### PR TITLE
bpo-40334: Generate comments in the parser code to improve debugging

### DIFF
--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -678,9 +678,9 @@ file_rule(Parser *p)
         void *a;
         Token * endmarker_var;
         if (
-            (a = statements_rule(p), 1)
+            (a = statements_rule(p), 1)  // statements?
             &&
-            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))
+            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))  // token='ENDMARKER'
         )
         {
             res = _PyPegen_make_module ( p , a );
@@ -709,7 +709,7 @@ interactive_rule(Parser *p)
     { // statement_newline
         asdl_seq* a;
         if (
-            (a = statement_newline_rule(p))
+            (a = statement_newline_rule(p))  // statement_newline
         )
         {
             res = Interactive ( a , p -> arena );
@@ -740,11 +740,11 @@ eval_rule(Parser *p)
         expr_ty a;
         Token * endmarker_var;
         if (
-            (a = expressions_rule(p))
+            (a = expressions_rule(p))  // expressions
             &&
-            (_loop0_1_var = _loop0_1_rule(p))
+            (_loop0_1_var = _loop0_1_rule(p))  // NEWLINE*
             &&
-            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))
+            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))  // token='ENDMARKER'
         )
         {
             res = Expression ( a , p -> arena );
@@ -779,19 +779,19 @@ func_type_rule(Parser *p)
         Token * literal_1;
         Token * literal_2;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = type_expressions_rule(p), 1)
+            (a = type_expressions_rule(p), 1)  // type_expressions?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
             &&
-            (literal_2 = _PyPegen_expect_token(p, 51))
+            (literal_2 = _PyPegen_expect_token(p, 51))  // token='->'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
             &&
-            (_loop0_2_var = _loop0_2_rule(p))
+            (_loop0_2_var = _loop0_2_rule(p))  // NEWLINE*
             &&
-            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))
+            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))  // token='ENDMARKER'
         )
         {
             res = FunctionType ( a , b , p -> arena );
@@ -820,7 +820,7 @@ fstring_rule(Parser *p)
     { // star_expressions
         expr_ty star_expressions_var;
         if (
-            (star_expressions_var = star_expressions_rule(p))
+            (star_expressions_var = star_expressions_rule(p))  // star_expressions
         )
         {
             res = star_expressions_var;
@@ -858,19 +858,19 @@ type_expressions_rule(Parser *p)
         Token * literal_2;
         Token * literal_3;
         if (
-            (a = _gather_3_rule(p))
+            (a = _gather_3_rule(p))  // ','.expression+
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (literal_1 = _PyPegen_expect_token(p, 16))
+            (literal_1 = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
             &&
-            (literal_2 = _PyPegen_expect_token(p, 12))
+            (literal_2 = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (literal_3 = _PyPegen_expect_token(p, 35))
+            (literal_3 = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (c = expression_rule(p))
+            (c = expression_rule(p))  // expression
         )
         {
             res = _PyPegen_seq_append_to_end ( p , CHECK ( _PyPegen_seq_append_to_end ( p , a , b ) ) , c );
@@ -888,13 +888,13 @@ type_expressions_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = _gather_5_rule(p))
+            (a = _gather_5_rule(p))  // ','.expression+
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (literal_1 = _PyPegen_expect_token(p, 16))
+            (literal_1 = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             res = _PyPegen_seq_append_to_end ( p , a , b );
@@ -912,13 +912,13 @@ type_expressions_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = _gather_7_rule(p))
+            (a = _gather_7_rule(p))  // ','.expression+
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (literal_1 = _PyPegen_expect_token(p, 35))
+            (literal_1 = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             res = _PyPegen_seq_append_to_end ( p , a , b );
@@ -937,15 +937,15 @@ type_expressions_rule(Parser *p)
         Token * literal_1;
         Token * literal_2;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (literal_1 = _PyPegen_expect_token(p, 12))
+            (literal_1 = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (literal_2 = _PyPegen_expect_token(p, 35))
+            (literal_2 = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             res = _PyPegen_seq_append_to_end ( p , CHECK ( _PyPegen_singleton_seq ( p , a ) ) , b );
@@ -961,9 +961,9 @@ type_expressions_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             res = _PyPegen_singleton_seq ( p , a );
@@ -979,9 +979,9 @@ type_expressions_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             res = _PyPegen_singleton_seq ( p , a );
@@ -996,7 +996,7 @@ type_expressions_rule(Parser *p)
     { // ','.expression+
         asdl_seq * _gather_9_var;
         if (
-            (_gather_9_var = _gather_9_rule(p))
+            (_gather_9_var = _gather_9_rule(p))  // ','.expression+
         )
         {
             res = _gather_9_var;
@@ -1021,7 +1021,7 @@ statements_rule(Parser *p)
     { // statement+
         asdl_seq * a;
         if (
-            (a = _loop1_11_rule(p))
+            (a = _loop1_11_rule(p))  // statement+
         )
         {
             res = _PyPegen_seq_flatten ( p , a );
@@ -1050,7 +1050,7 @@ statement_rule(Parser *p)
     { // compound_stmt
         stmt_ty a;
         if (
-            (a = compound_stmt_rule(p))
+            (a = compound_stmt_rule(p))  // compound_stmt
         )
         {
             res = _PyPegen_singleton_seq ( p , a );
@@ -1065,7 +1065,7 @@ statement_rule(Parser *p)
     { // simple_stmt
         asdl_seq* simple_stmt_var;
         if (
-            (simple_stmt_var = simple_stmt_rule(p))
+            (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
         )
         {
             res = simple_stmt_var;
@@ -1099,9 +1099,9 @@ statement_newline_rule(Parser *p)
         stmt_ty a;
         Token * newline_var;
         if (
-            (a = compound_stmt_rule(p))
+            (a = compound_stmt_rule(p))  // compound_stmt
             &&
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
             res = _PyPegen_singleton_seq ( p , a );
@@ -1116,7 +1116,7 @@ statement_newline_rule(Parser *p)
     { // simple_stmt
         asdl_seq* simple_stmt_var;
         if (
-            (simple_stmt_var = simple_stmt_rule(p))
+            (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
         )
         {
             res = simple_stmt_var;
@@ -1127,7 +1127,7 @@ statement_newline_rule(Parser *p)
     { // NEWLINE
         Token * newline_var;
         if (
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1150,7 +1150,7 @@ statement_newline_rule(Parser *p)
     { // $
         Token * endmarker_var;
         if (
-            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))
+            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))  // token='ENDMARKER'
         )
         {
             res = _PyPegen_interactive_exit ( p );
@@ -1180,11 +1180,11 @@ simple_stmt_rule(Parser *p)
         stmt_ty a;
         Token * newline_var;
         if (
-            (a = small_stmt_rule(p))
+            (a = small_stmt_rule(p))  // small_stmt
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 13)
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 13)  // token=';'
             &&
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
             res = _PyPegen_singleton_seq ( p , a );
@@ -1202,11 +1202,11 @@ simple_stmt_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_12_rule(p))
+            (a = _gather_12_rule(p))  // ';'.small_stmt+
             &&
-            (opt_var = _PyPegen_expect_token(p, 13), 1)
+            (opt_var = _PyPegen_expect_token(p, 13), 1)  // ';'?
             &&
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
             res = a;
@@ -1258,7 +1258,7 @@ small_stmt_rule(Parser *p)
     { // assignment
         stmt_ty assignment_var;
         if (
-            (assignment_var = assignment_rule(p))
+            (assignment_var = assignment_rule(p))  // assignment
         )
         {
             res = assignment_var;
@@ -1269,7 +1269,7 @@ small_stmt_rule(Parser *p)
     { // star_expressions
         expr_ty e;
         if (
-            (e = star_expressions_rule(p))
+            (e = star_expressions_rule(p))  // star_expressions
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1292,9 +1292,9 @@ small_stmt_rule(Parser *p)
     { // &'return' return_stmt
         stmt_ty return_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 500)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 500)  // token='return'
             &&
-            (return_stmt_var = return_stmt_rule(p))
+            (return_stmt_var = return_stmt_rule(p))  // return_stmt
         )
         {
             res = return_stmt_var;
@@ -1307,7 +1307,7 @@ small_stmt_rule(Parser *p)
         if (
             _PyPegen_lookahead(1, _tmp_14_rule, p)
             &&
-            (import_stmt_var = import_stmt_rule(p))
+            (import_stmt_var = import_stmt_rule(p))  // import_stmt
         )
         {
             res = import_stmt_var;
@@ -1318,9 +1318,9 @@ small_stmt_rule(Parser *p)
     { // &'raise' raise_stmt
         stmt_ty raise_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 501)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 501)  // token='raise'
             &&
-            (raise_stmt_var = raise_stmt_rule(p))
+            (raise_stmt_var = raise_stmt_rule(p))  // raise_stmt
         )
         {
             res = raise_stmt_var;
@@ -1331,7 +1331,7 @@ small_stmt_rule(Parser *p)
     { // 'pass'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 502))
+            (keyword = _PyPegen_expect_token(p, 502))  // token='pass'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1354,9 +1354,9 @@ small_stmt_rule(Parser *p)
     { // &'del' del_stmt
         stmt_ty del_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 503)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 503)  // token='del'
             &&
-            (del_stmt_var = del_stmt_rule(p))
+            (del_stmt_var = del_stmt_rule(p))  // del_stmt
         )
         {
             res = del_stmt_var;
@@ -1367,9 +1367,9 @@ small_stmt_rule(Parser *p)
     { // &'yield' yield_stmt
         stmt_ty yield_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 504)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 504)  // token='yield'
             &&
-            (yield_stmt_var = yield_stmt_rule(p))
+            (yield_stmt_var = yield_stmt_rule(p))  // yield_stmt
         )
         {
             res = yield_stmt_var;
@@ -1380,9 +1380,9 @@ small_stmt_rule(Parser *p)
     { // &'assert' assert_stmt
         stmt_ty assert_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 505)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 505)  // token='assert'
             &&
-            (assert_stmt_var = assert_stmt_rule(p))
+            (assert_stmt_var = assert_stmt_rule(p))  // assert_stmt
         )
         {
             res = assert_stmt_var;
@@ -1393,7 +1393,7 @@ small_stmt_rule(Parser *p)
     { // 'break'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 506))
+            (keyword = _PyPegen_expect_token(p, 506))  // token='break'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1416,7 +1416,7 @@ small_stmt_rule(Parser *p)
     { // 'continue'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 507))
+            (keyword = _PyPegen_expect_token(p, 507))  // token='continue'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1439,9 +1439,9 @@ small_stmt_rule(Parser *p)
     { // &'global' global_stmt
         stmt_ty global_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 508)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 508)  // token='global'
             &&
-            (global_stmt_var = global_stmt_rule(p))
+            (global_stmt_var = global_stmt_rule(p))  // global_stmt
         )
         {
             res = global_stmt_var;
@@ -1452,9 +1452,9 @@ small_stmt_rule(Parser *p)
     { // &'nonlocal' nonlocal_stmt
         stmt_ty nonlocal_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 509)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 509)  // token='nonlocal'
             &&
-            (nonlocal_stmt_var = nonlocal_stmt_rule(p))
+            (nonlocal_stmt_var = nonlocal_stmt_rule(p))  // nonlocal_stmt
         )
         {
             res = nonlocal_stmt_var;
@@ -1489,7 +1489,7 @@ compound_stmt_rule(Parser *p)
         if (
             _PyPegen_lookahead(1, _tmp_15_rule, p)
             &&
-            (function_def_var = function_def_rule(p))
+            (function_def_var = function_def_rule(p))  // function_def
         )
         {
             res = function_def_var;
@@ -1500,9 +1500,9 @@ compound_stmt_rule(Parser *p)
     { // &'if' if_stmt
         stmt_ty if_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 510)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 510)  // token='if'
             &&
-            (if_stmt_var = if_stmt_rule(p))
+            (if_stmt_var = if_stmt_rule(p))  // if_stmt
         )
         {
             res = if_stmt_var;
@@ -1515,7 +1515,7 @@ compound_stmt_rule(Parser *p)
         if (
             _PyPegen_lookahead(1, _tmp_16_rule, p)
             &&
-            (class_def_var = class_def_rule(p))
+            (class_def_var = class_def_rule(p))  // class_def
         )
         {
             res = class_def_var;
@@ -1528,7 +1528,7 @@ compound_stmt_rule(Parser *p)
         if (
             _PyPegen_lookahead(1, _tmp_17_rule, p)
             &&
-            (with_stmt_var = with_stmt_rule(p))
+            (with_stmt_var = with_stmt_rule(p))  // with_stmt
         )
         {
             res = with_stmt_var;
@@ -1541,7 +1541,7 @@ compound_stmt_rule(Parser *p)
         if (
             _PyPegen_lookahead(1, _tmp_18_rule, p)
             &&
-            (for_stmt_var = for_stmt_rule(p))
+            (for_stmt_var = for_stmt_rule(p))  // for_stmt
         )
         {
             res = for_stmt_var;
@@ -1552,9 +1552,9 @@ compound_stmt_rule(Parser *p)
     { // &'try' try_stmt
         stmt_ty try_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 511)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 511)  // token='try'
             &&
-            (try_stmt_var = try_stmt_rule(p))
+            (try_stmt_var = try_stmt_rule(p))  // try_stmt
         )
         {
             res = try_stmt_var;
@@ -1565,9 +1565,9 @@ compound_stmt_rule(Parser *p)
     { // &'while' while_stmt
         stmt_ty while_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 512)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 512)  // token='while'
             &&
-            (while_stmt_var = while_stmt_rule(p))
+            (while_stmt_var = while_stmt_rule(p))  // while_stmt
         )
         {
             res = while_stmt_var;
@@ -1608,13 +1608,13 @@ assignment_rule(Parser *p)
         void *c;
         Token * literal;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
             &&
-            (c = _tmp_19_rule(p), 1)
+            (c = _tmp_19_rule(p), 1)  // ['=' annotated_rhs]
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1640,13 +1640,13 @@ assignment_rule(Parser *p)
         void *c;
         Token * literal;
         if (
-            (a = _tmp_20_rule(p))
+            (a = _tmp_20_rule(p))  // '(' inside_paren_ann_assign_target ')' | ann_assign_subscript_attribute_target
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
             &&
-            (c = _tmp_21_rule(p), 1)
+            (c = _tmp_21_rule(p), 1)  // ['=' annotated_rhs]
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1671,11 +1671,11 @@ assignment_rule(Parser *p)
         void *b;
         void *tc;
         if (
-            (a = _loop1_22_rule(p))
+            (a = _loop1_22_rule(p))  // ((star_targets '='))+
             &&
-            (b = _tmp_23_rule(p))
+            (b = _tmp_23_rule(p))  // yield_expr | star_expressions
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1700,11 +1700,11 @@ assignment_rule(Parser *p)
         AugOperator* b;
         void *c;
         if (
-            (a = target_rule(p))
+            (a = target_rule(p))  // target
             &&
-            (b = augassign_rule(p))
+            (b = augassign_rule(p))  // augassign
             &&
-            (c = _tmp_24_rule(p))
+            (c = _tmp_24_rule(p))  // yield_expr | star_expressions
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1727,7 +1727,7 @@ assignment_rule(Parser *p)
     { // invalid_assignment
         void *invalid_assignment_var;
         if (
-            (invalid_assignment_var = invalid_assignment_rule(p))
+            (invalid_assignment_var = invalid_assignment_rule(p))  // invalid_assignment
         )
         {
             res = invalid_assignment_var;
@@ -1765,7 +1765,7 @@ augassign_rule(Parser *p)
     { // '+='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 36))
+            (literal = _PyPegen_expect_token(p, 36))  // token='+='
         )
         {
             res = _PyPegen_augoperator ( p , Add );
@@ -1780,7 +1780,7 @@ augassign_rule(Parser *p)
     { // '-='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 37))
+            (literal = _PyPegen_expect_token(p, 37))  // token='-='
         )
         {
             res = _PyPegen_augoperator ( p , Sub );
@@ -1795,7 +1795,7 @@ augassign_rule(Parser *p)
     { // '*='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 38))
+            (literal = _PyPegen_expect_token(p, 38))  // token='*='
         )
         {
             res = _PyPegen_augoperator ( p , Mult );
@@ -1810,7 +1810,7 @@ augassign_rule(Parser *p)
     { // '@='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 50))
+            (literal = _PyPegen_expect_token(p, 50))  // token='@='
         )
         {
             res = CHECK_VERSION ( 5 , "The '@' operator is" , _PyPegen_augoperator ( p , MatMult ) );
@@ -1825,7 +1825,7 @@ augassign_rule(Parser *p)
     { // '/='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 39))
+            (literal = _PyPegen_expect_token(p, 39))  // token='/='
         )
         {
             res = _PyPegen_augoperator ( p , Div );
@@ -1840,7 +1840,7 @@ augassign_rule(Parser *p)
     { // '%='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 40))
+            (literal = _PyPegen_expect_token(p, 40))  // token='%='
         )
         {
             res = _PyPegen_augoperator ( p , Mod );
@@ -1855,7 +1855,7 @@ augassign_rule(Parser *p)
     { // '&='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 41))
+            (literal = _PyPegen_expect_token(p, 41))  // token='&='
         )
         {
             res = _PyPegen_augoperator ( p , BitAnd );
@@ -1870,7 +1870,7 @@ augassign_rule(Parser *p)
     { // '|='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 42))
+            (literal = _PyPegen_expect_token(p, 42))  // token='|='
         )
         {
             res = _PyPegen_augoperator ( p , BitOr );
@@ -1885,7 +1885,7 @@ augassign_rule(Parser *p)
     { // '^='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 43))
+            (literal = _PyPegen_expect_token(p, 43))  // token='^='
         )
         {
             res = _PyPegen_augoperator ( p , BitXor );
@@ -1900,7 +1900,7 @@ augassign_rule(Parser *p)
     { // '<<='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 44))
+            (literal = _PyPegen_expect_token(p, 44))  // token='<<='
         )
         {
             res = _PyPegen_augoperator ( p , LShift );
@@ -1915,7 +1915,7 @@ augassign_rule(Parser *p)
     { // '>>='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 45))
+            (literal = _PyPegen_expect_token(p, 45))  // token='>>='
         )
         {
             res = _PyPegen_augoperator ( p , RShift );
@@ -1930,7 +1930,7 @@ augassign_rule(Parser *p)
     { // '**='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 46))
+            (literal = _PyPegen_expect_token(p, 46))  // token='**='
         )
         {
             res = _PyPegen_augoperator ( p , Pow );
@@ -1945,7 +1945,7 @@ augassign_rule(Parser *p)
     { // '//='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 48))
+            (literal = _PyPegen_expect_token(p, 48))  // token='//='
         )
         {
             res = _PyPegen_augoperator ( p , FloorDiv );
@@ -1983,9 +1983,9 @@ global_stmt_rule(Parser *p)
         asdl_seq * a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 508))
+            (keyword = _PyPegen_expect_token(p, 508))  // token='global'
             &&
-            (a = _gather_25_rule(p))
+            (a = _gather_25_rule(p))  // ','.NAME+
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2031,9 +2031,9 @@ nonlocal_stmt_rule(Parser *p)
         asdl_seq * a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 509))
+            (keyword = _PyPegen_expect_token(p, 509))  // token='nonlocal'
             &&
-            (a = _gather_27_rule(p))
+            (a = _gather_27_rule(p))  // ','.NAME+
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2078,7 +2078,7 @@ yield_stmt_rule(Parser *p)
     { // yield_expr
         expr_ty y;
         if (
-            (y = yield_expr_rule(p))
+            (y = yield_expr_rule(p))  // yield_expr
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2125,11 +2125,11 @@ assert_stmt_rule(Parser *p)
         void *b;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 505))
+            (keyword = _PyPegen_expect_token(p, 505))  // token='assert'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (b = _tmp_29_rule(p), 1)
+            (b = _tmp_29_rule(p), 1)  // [',' expression]
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2175,9 +2175,9 @@ del_stmt_rule(Parser *p)
         asdl_seq* a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 503))
+            (keyword = _PyPegen_expect_token(p, 503))  // token='del'
             &&
-            (a = del_targets_rule(p))
+            (a = del_targets_rule(p))  // del_targets
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2214,7 +2214,7 @@ import_stmt_rule(Parser *p)
     { // import_name
         stmt_ty import_name_var;
         if (
-            (import_name_var = import_name_rule(p))
+            (import_name_var = import_name_rule(p))  // import_name
         )
         {
             res = import_name_var;
@@ -2225,7 +2225,7 @@ import_stmt_rule(Parser *p)
     { // import_from
         stmt_ty import_from_var;
         if (
-            (import_from_var = import_from_rule(p))
+            (import_from_var = import_from_rule(p))  // import_from
         )
         {
             res = import_from_var;
@@ -2259,9 +2259,9 @@ import_name_rule(Parser *p)
         asdl_seq* a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 513))
+            (keyword = _PyPegen_expect_token(p, 513))  // token='import'
             &&
-            (a = dotted_as_names_rule(p))
+            (a = dotted_as_names_rule(p))  // dotted_as_names
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2312,15 +2312,15 @@ import_from_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (keyword = _PyPegen_expect_token(p, 514))
+            (keyword = _PyPegen_expect_token(p, 514))  // token='from'
             &&
-            (a = _loop0_30_rule(p))
+            (a = _loop0_30_rule(p))  // (('.' | '...'))*
             &&
-            (b = dotted_name_rule(p))
+            (b = dotted_name_rule(p))  // dotted_name
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 513))
+            (keyword_1 = _PyPegen_expect_token(p, 513))  // token='import'
             &&
-            (c = import_from_targets_rule(p))
+            (c = import_from_targets_rule(p))  // import_from_targets
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2346,13 +2346,13 @@ import_from_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (keyword = _PyPegen_expect_token(p, 514))
+            (keyword = _PyPegen_expect_token(p, 514))  // token='from'
             &&
-            (a = _loop1_31_rule(p))
+            (a = _loop1_31_rule(p))  // (('.' | '...'))+
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 513))
+            (keyword_1 = _PyPegen_expect_token(p, 513))  // token='import'
             &&
-            (b = import_from_targets_rule(p))
+            (b = import_from_targets_rule(p))  // import_from_targets
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2393,13 +2393,13 @@ import_from_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = import_from_as_names_rule(p))
+            (a = import_from_as_names_rule(p))  // import_from_as_names
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = a;
@@ -2414,7 +2414,7 @@ import_from_targets_rule(Parser *p)
     { // import_from_as_names
         asdl_seq* import_from_as_names_var;
         if (
-            (import_from_as_names_var = import_from_as_names_rule(p))
+            (import_from_as_names_var = import_from_as_names_rule(p))  // import_from_as_names
         )
         {
             res = import_from_as_names_var;
@@ -2425,7 +2425,7 @@ import_from_targets_rule(Parser *p)
     { // '*'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
         )
         {
             res = _PyPegen_singleton_seq ( p , CHECK ( _PyPegen_alias_for_star ( p ) ) );
@@ -2454,7 +2454,7 @@ import_from_as_names_rule(Parser *p)
     { // ','.import_from_as_name+
         asdl_seq * a;
         if (
-            (a = _gather_32_rule(p))
+            (a = _gather_32_rule(p))  // ','.import_from_as_name+
         )
         {
             res = a;
@@ -2484,9 +2484,9 @@ import_from_as_name_rule(Parser *p)
         expr_ty a;
         void *b;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
             &&
-            (b = _tmp_34_rule(p), 1)
+            (b = _tmp_34_rule(p), 1)  // ['as' NAME]
         )
         {
             res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
@@ -2515,7 +2515,7 @@ dotted_as_names_rule(Parser *p)
     { // ','.dotted_as_name+
         asdl_seq * a;
         if (
-            (a = _gather_35_rule(p))
+            (a = _gather_35_rule(p))  // ','.dotted_as_name+
         )
         {
             res = a;
@@ -2545,9 +2545,9 @@ dotted_as_name_rule(Parser *p)
         expr_ty a;
         void *b;
         if (
-            (a = dotted_name_rule(p))
+            (a = dotted_name_rule(p))  // dotted_name
             &&
-            (b = _tmp_37_rule(p), 1)
+            (b = _tmp_37_rule(p), 1)  // ['as' NAME]
         )
         {
             res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
@@ -2603,11 +2603,11 @@ dotted_name_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = dotted_name_rule(p))
+            (a = dotted_name_rule(p))  // dotted_name
             &&
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
             &&
-            (b = _PyPegen_name_token(p))
+            (b = _PyPegen_name_token(p))  // NAME
         )
         {
             res = _PyPegen_join_names_with_dot ( p , a , b );
@@ -2622,7 +2622,7 @@ dotted_name_raw(Parser *p)
     { // NAME
         expr_ty name_var;
         if (
-            (name_var = _PyPegen_name_token(p))
+            (name_var = _PyPegen_name_token(p))  // NAME
         )
         {
             res = name_var;
@@ -2661,15 +2661,15 @@ if_stmt_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 510))
+            (keyword = _PyPegen_expect_token(p, 510))  // token='if'
             &&
-            (a = named_expression_rule(p))
+            (a = named_expression_rule(p))  // named_expression
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (c = elif_stmt_rule(p))
+            (c = elif_stmt_rule(p))  // elif_stmt
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2696,15 +2696,15 @@ if_stmt_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 510))
+            (keyword = _PyPegen_expect_token(p, 510))  // token='if'
             &&
-            (a = named_expression_rule(p))
+            (a = named_expression_rule(p))  // named_expression
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (c = else_block_rule(p), 1)
+            (c = else_block_rule(p), 1)  // else_block?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2755,15 +2755,15 @@ elif_stmt_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 515))
+            (keyword = _PyPegen_expect_token(p, 515))  // token='elif'
             &&
-            (a = named_expression_rule(p))
+            (a = named_expression_rule(p))  // named_expression
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (c = elif_stmt_rule(p))
+            (c = elif_stmt_rule(p))  // elif_stmt
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2790,15 +2790,15 @@ elif_stmt_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 515))
+            (keyword = _PyPegen_expect_token(p, 515))  // token='elif'
             &&
-            (a = named_expression_rule(p))
+            (a = named_expression_rule(p))  // named_expression
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (c = else_block_rule(p), 1)
+            (c = else_block_rule(p), 1)  // else_block?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2837,11 +2837,11 @@ else_block_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 516))
+            (keyword = _PyPegen_expect_token(p, 516))  // token='else'
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             res = b;
@@ -2882,15 +2882,15 @@ while_stmt_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 512))
+            (keyword = _PyPegen_expect_token(p, 512))  // token='while'
             &&
-            (a = named_expression_rule(p))
+            (a = named_expression_rule(p))  // named_expression
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (c = else_block_rule(p), 1)
+            (c = else_block_rule(p), 1)  // else_block?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2944,21 +2944,21 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (keyword = _PyPegen_expect_token(p, 517))
+            (keyword = _PyPegen_expect_token(p, 517))  // token='for'
             &&
-            (t = star_targets_rule(p))
+            (t = star_targets_rule(p))  // star_targets
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 518))
+            (keyword_1 = _PyPegen_expect_token(p, 518))  // token='in'
             &&
-            (ex = star_expressions_rule(p))
+            (ex = star_expressions_rule(p))  // star_expressions
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (el = else_block_rule(p), 1)
+            (el = else_block_rule(p), 1)  // else_block?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2989,23 +2989,23 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
-            (keyword = _PyPegen_expect_token(p, 517))
+            (keyword = _PyPegen_expect_token(p, 517))  // token='for'
             &&
-            (t = star_targets_rule(p))
+            (t = star_targets_rule(p))  // star_targets
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 518))
+            (keyword_1 = _PyPegen_expect_token(p, 518))  // token='in'
             &&
-            (ex = star_expressions_rule(p))
+            (ex = star_expressions_rule(p))  // star_expressions
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (el = else_block_rule(p), 1)
+            (el = else_block_rule(p), 1)  // else_block?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3061,19 +3061,19 @@ with_stmt_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (keyword = _PyPegen_expect_token(p, 519))
+            (keyword = _PyPegen_expect_token(p, 519))  // token='with'
             &&
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = _gather_38_rule(p))
+            (a = _gather_38_rule(p))  // ','.with_item+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
             &&
-            (literal_2 = _PyPegen_expect_token(p, 11))
+            (literal_2 = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3100,15 +3100,15 @@ with_stmt_rule(Parser *p)
         Token * literal;
         void *tc;
         if (
-            (keyword = _PyPegen_expect_token(p, 519))
+            (keyword = _PyPegen_expect_token(p, 519))  // token='with'
             &&
-            (a = _gather_40_rule(p))
+            (a = _gather_40_rule(p))  // ','.with_item+
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3139,21 +3139,21 @@ with_stmt_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
-            (keyword = _PyPegen_expect_token(p, 519))
+            (keyword = _PyPegen_expect_token(p, 519))  // token='with'
             &&
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = _gather_42_rule(p))
+            (a = _gather_42_rule(p))  // ','.with_item+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
             &&
-            (literal_2 = _PyPegen_expect_token(p, 11))
+            (literal_2 = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3181,17 +3181,17 @@ with_stmt_rule(Parser *p)
         Token * literal;
         void *tc;
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
-            (keyword = _PyPegen_expect_token(p, 519))
+            (keyword = _PyPegen_expect_token(p, 519))  // token='with'
             &&
-            (a = _gather_44_rule(p))
+            (a = _gather_44_rule(p))  // ','.with_item+
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3229,9 +3229,9 @@ with_item_rule(Parser *p)
         expr_ty e;
         void *o;
         if (
-            (e = expression_rule(p))
+            (e = expression_rule(p))  // expression
             &&
-            (o = _tmp_46_rule(p), 1)
+            (o = _tmp_46_rule(p), 1)  // ['as' target]
         )
         {
             res = _Py_withitem ( e , o , p -> arena );
@@ -3273,13 +3273,13 @@ try_stmt_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 511))
+            (keyword = _PyPegen_expect_token(p, 511))  // token='try'
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (f = finally_block_rule(p))
+            (f = finally_block_rule(p))  // finally_block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3307,17 +3307,17 @@ try_stmt_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 511))
+            (keyword = _PyPegen_expect_token(p, 511))  // token='try'
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
             &&
-            (ex = _loop1_47_rule(p))
+            (ex = _loop1_47_rule(p))  // except_block+
             &&
-            (el = else_block_rule(p), 1)
+            (el = else_block_rule(p), 1)  // else_block?
             &&
-            (f = finally_block_rule(p), 1)
+            (f = finally_block_rule(p), 1)  // finally_block?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3366,15 +3366,15 @@ except_block_rule(Parser *p)
         Token * literal;
         void *t;
         if (
-            (keyword = _PyPegen_expect_token(p, 520))
+            (keyword = _PyPegen_expect_token(p, 520))  // token='except'
             &&
-            (e = expression_rule(p))
+            (e = expression_rule(p))  // expression
             &&
-            (t = _tmp_48_rule(p), 1)
+            (t = _tmp_48_rule(p), 1)  // ['as' target]
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3399,11 +3399,11 @@ except_block_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 520))
+            (keyword = _PyPegen_expect_token(p, 520))  // token='except'
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3442,11 +3442,11 @@ finally_block_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 521))
+            (keyword = _PyPegen_expect_token(p, 521))  // token='finally'
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (a = block_rule(p))
+            (a = block_rule(p))  // block
         )
         {
             res = a;
@@ -3484,9 +3484,9 @@ return_stmt_rule(Parser *p)
         void *a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 500))
+            (keyword = _PyPegen_expect_token(p, 500))  // token='return'
             &&
-            (a = star_expressions_rule(p), 1)
+            (a = star_expressions_rule(p), 1)  // star_expressions?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3533,11 +3533,11 @@ raise_stmt_rule(Parser *p)
         void *b;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 501))
+            (keyword = _PyPegen_expect_token(p, 501))  // token='raise'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (b = _tmp_49_rule(p), 1)
+            (b = _tmp_49_rule(p), 1)  // ['from' expression]
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3560,7 +3560,7 @@ raise_stmt_rule(Parser *p)
     { // 'raise'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 501))
+            (keyword = _PyPegen_expect_token(p, 501))  // token='raise'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3598,9 +3598,9 @@ function_def_rule(Parser *p)
         asdl_seq* d;
         stmt_ty f;
         if (
-            (d = decorators_rule(p))
+            (d = decorators_rule(p))  // decorators
             &&
-            (f = function_def_raw_rule(p))
+            (f = function_def_raw_rule(p))  // function_def_raw
         )
         {
             res = _PyPegen_function_def_decorators ( p , d , f );
@@ -3615,7 +3615,7 @@ function_def_rule(Parser *p)
     { // function_def_raw
         stmt_ty function_def_raw_var;
         if (
-            (function_def_raw_var = function_def_raw_rule(p))
+            (function_def_raw_var = function_def_raw_rule(p))  // function_def_raw
         )
         {
             res = function_def_raw_var;
@@ -3658,23 +3658,23 @@ function_def_raw_rule(Parser *p)
         void *params;
         void *tc;
         if (
-            (keyword = _PyPegen_expect_token(p, 522))
+            (keyword = _PyPegen_expect_token(p, 522))  // token='def'
             &&
-            (n = _PyPegen_name_token(p))
+            (n = _PyPegen_name_token(p))  // NAME
             &&
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (params = params_rule(p), 1)
+            (params = params_rule(p), 1)  // params?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
             &&
-            (a = _tmp_50_rule(p), 1)
+            (a = _tmp_50_rule(p), 1)  // ['->' expression]
             &&
-            (literal_2 = _PyPegen_expect_token(p, 11))
+            (literal_2 = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (tc = func_type_comment_rule(p), 1)
+            (tc = func_type_comment_rule(p), 1)  // func_type_comment?
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3706,25 +3706,25 @@ function_def_raw_rule(Parser *p)
         void *params;
         void *tc;
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
-            (keyword = _PyPegen_expect_token(p, 522))
+            (keyword = _PyPegen_expect_token(p, 522))  // token='def'
             &&
-            (n = _PyPegen_name_token(p))
+            (n = _PyPegen_name_token(p))  // NAME
             &&
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (params = params_rule(p), 1)
+            (params = params_rule(p), 1)  // params?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
             &&
-            (a = _tmp_51_rule(p), 1)
+            (a = _tmp_51_rule(p), 1)  // ['->' expression]
             &&
-            (literal_2 = _PyPegen_expect_token(p, 11))
+            (literal_2 = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (tc = func_type_comment_rule(p), 1)
+            (tc = func_type_comment_rule(p), 1)  // func_type_comment?
             &&
-            (b = block_rule(p))
+            (b = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3765,9 +3765,9 @@ func_type_comment_rule(Parser *p)
         Token * newline_var;
         Token * t;
         if (
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
             &&
-            (t = _PyPegen_expect_token(p, TYPE_COMMENT))
+            (t = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
             &&
             _PyPegen_lookahead(1, _tmp_52_rule, p)
         )
@@ -3784,7 +3784,7 @@ func_type_comment_rule(Parser *p)
     { // invalid_double_type_comments
         void *invalid_double_type_comments_var;
         if (
-            (invalid_double_type_comments_var = invalid_double_type_comments_rule(p))
+            (invalid_double_type_comments_var = invalid_double_type_comments_rule(p))  // invalid_double_type_comments
         )
         {
             res = invalid_double_type_comments_var;
@@ -3795,7 +3795,7 @@ func_type_comment_rule(Parser *p)
     { // TYPE_COMMENT
         Token * type_comment_var;
         if (
-            (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))
+            (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
         )
         {
             res = type_comment_var;
@@ -3820,7 +3820,7 @@ params_rule(Parser *p)
     { // invalid_parameters
         void *invalid_parameters_var;
         if (
-            (invalid_parameters_var = invalid_parameters_rule(p))
+            (invalid_parameters_var = invalid_parameters_rule(p))  // invalid_parameters
         )
         {
             res = invalid_parameters_var;
@@ -3831,7 +3831,7 @@ params_rule(Parser *p)
     { // parameters
         arguments_ty parameters_var;
         if (
-            (parameters_var = parameters_rule(p))
+            (parameters_var = parameters_rule(p))  // parameters
         )
         {
             res = parameters_var;
@@ -3864,13 +3864,13 @@ parameters_rule(Parser *p)
         asdl_seq * c;
         void *d;
         if (
-            (a = slash_no_default_rule(p))
+            (a = slash_no_default_rule(p))  // slash_no_default
             &&
-            (b = _loop0_53_rule(p))
+            (b = _loop0_53_rule(p))  // param_no_default*
             &&
-            (c = _loop0_54_rule(p))
+            (c = _loop0_54_rule(p))  // param_with_default*
             &&
-            (d = star_etc_rule(p), 1)
+            (d = star_etc_rule(p), 1)  // star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -3887,11 +3887,11 @@ parameters_rule(Parser *p)
         asdl_seq * b;
         void *c;
         if (
-            (a = slash_with_default_rule(p))
+            (a = slash_with_default_rule(p))  // slash_with_default
             &&
-            (b = _loop0_55_rule(p))
+            (b = _loop0_55_rule(p))  // param_with_default*
             &&
-            (c = star_etc_rule(p), 1)
+            (c = star_etc_rule(p), 1)  // star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -3908,11 +3908,11 @@ parameters_rule(Parser *p)
         asdl_seq * b;
         void *c;
         if (
-            (a = _loop1_56_rule(p))
+            (a = _loop1_56_rule(p))  // param_no_default+
             &&
-            (b = _loop0_57_rule(p))
+            (b = _loop0_57_rule(p))  // param_with_default*
             &&
-            (c = star_etc_rule(p), 1)
+            (c = star_etc_rule(p), 1)  // star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -3928,9 +3928,9 @@ parameters_rule(Parser *p)
         asdl_seq * a;
         void *b;
         if (
-            (a = _loop1_58_rule(p))
+            (a = _loop1_58_rule(p))  // param_with_default+
             &&
-            (b = star_etc_rule(p), 1)
+            (b = star_etc_rule(p), 1)  // star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -3945,7 +3945,7 @@ parameters_rule(Parser *p)
     { // star_etc
         StarEtc* a;
         if (
-            (a = star_etc_rule(p))
+            (a = star_etc_rule(p))  // star_etc
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , NULL , a );
@@ -3976,11 +3976,11 @@ slash_no_default_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = _loop1_59_rule(p))
+            (a = _loop1_59_rule(p))  // param_no_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            (literal_1 = _PyPegen_expect_token(p, 12))
+            (literal_1 = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             res = a;
@@ -3996,11 +3996,11 @@ slash_no_default_rule(Parser *p)
         asdl_seq * a;
         Token * literal;
         if (
-            (a = _loop1_60_rule(p))
+            (a = _loop1_60_rule(p))  // param_no_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)  // token=')'
         )
         {
             res = a;
@@ -4034,13 +4034,13 @@ slash_with_default_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = _loop0_61_rule(p))
+            (a = _loop0_61_rule(p))  // param_no_default*
             &&
-            (b = _loop1_62_rule(p))
+            (b = _loop1_62_rule(p))  // param_with_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            (literal_1 = _PyPegen_expect_token(p, 12))
+            (literal_1 = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             res = _PyPegen_slash_with_default ( p , a , b );
@@ -4057,13 +4057,13 @@ slash_with_default_rule(Parser *p)
         asdl_seq * b;
         Token * literal;
         if (
-            (a = _loop0_63_rule(p))
+            (a = _loop0_63_rule(p))  // param_no_default*
             &&
-            (b = _loop1_64_rule(p))
+            (b = _loop1_64_rule(p))  // param_with_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)  // token=')'
         )
         {
             res = _PyPegen_slash_with_default ( p , a , b );
@@ -4099,13 +4099,13 @@ star_etc_rule(Parser *p)
         void *c;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = param_no_default_rule(p))
+            (a = param_no_default_rule(p))  // param_no_default
             &&
-            (b = _loop0_65_rule(p))
+            (b = _loop0_65_rule(p))  // param_maybe_default*
             &&
-            (c = kwds_rule(p), 1)
+            (c = kwds_rule(p), 1)  // kwds?
         )
         {
             res = _PyPegen_star_etc ( p , a , b , c );
@@ -4123,13 +4123,13 @@ star_etc_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (literal_1 = _PyPegen_expect_token(p, 12))
+            (literal_1 = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (b = _loop1_66_rule(p))
+            (b = _loop1_66_rule(p))  // param_maybe_default+
             &&
-            (c = kwds_rule(p), 1)
+            (c = kwds_rule(p), 1)  // kwds?
         )
         {
             res = _PyPegen_star_etc ( p , NULL , b , c );
@@ -4144,7 +4144,7 @@ star_etc_rule(Parser *p)
     { // kwds
         arg_ty a;
         if (
-            (a = kwds_rule(p))
+            (a = kwds_rule(p))  // kwds
         )
         {
             res = _PyPegen_star_etc ( p , NULL , NULL , a );
@@ -4159,7 +4159,7 @@ star_etc_rule(Parser *p)
     { // invalid_star_etc
         void *invalid_star_etc_var;
         if (
-            (invalid_star_etc_var = invalid_star_etc_rule(p))
+            (invalid_star_etc_var = invalid_star_etc_rule(p))  // invalid_star_etc
         )
         {
             res = invalid_star_etc_var;
@@ -4185,9 +4185,9 @@ kwds_rule(Parser *p)
         arg_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (a = param_no_default_rule(p))
+            (a = param_no_default_rule(p))  // param_no_default
         )
         {
             res = a;
@@ -4218,11 +4218,11 @@ param_no_default_rule(Parser *p)
         Token * literal;
         void *tc;
         if (
-            (a = param_rule(p))
+            (a = param_rule(p))  // param
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
         )
         {
             res = _PyPegen_add_type_comment_to_arg ( p , a , tc );
@@ -4238,11 +4238,11 @@ param_no_default_rule(Parser *p)
         arg_ty a;
         void *tc;
         if (
-            (a = param_rule(p))
+            (a = param_rule(p))  // param
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)  // token=')'
         )
         {
             res = _PyPegen_add_type_comment_to_arg ( p , a , tc );
@@ -4274,13 +4274,13 @@ param_with_default_rule(Parser *p)
         Token * literal;
         void *tc;
         if (
-            (a = param_rule(p))
+            (a = param_rule(p))  // param
             &&
-            (c = default_rule(p))
+            (c = default_rule(p))  // default
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , tc );
@@ -4297,13 +4297,13 @@ param_with_default_rule(Parser *p)
         expr_ty c;
         void *tc;
         if (
-            (a = param_rule(p))
+            (a = param_rule(p))  // param
             &&
-            (c = default_rule(p))
+            (c = default_rule(p))  // default
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)  // token=')'
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , tc );
@@ -4337,13 +4337,13 @@ param_maybe_default_rule(Parser *p)
         Token * literal;
         void *tc;
         if (
-            (a = param_rule(p))
+            (a = param_rule(p))  // param
             &&
-            (c = default_rule(p), 1)
+            (c = default_rule(p), 1)  // default?
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , tc );
@@ -4360,13 +4360,13 @@ param_maybe_default_rule(Parser *p)
         void *c;
         void *tc;
         if (
-            (a = param_rule(p))
+            (a = param_rule(p))  // param
             &&
-            (c = default_rule(p), 1)
+            (c = default_rule(p), 1)  // default?
             &&
-            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)  // TYPE_COMMENT?
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)  // token=')'
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , tc );
@@ -4404,9 +4404,9 @@ param_rule(Parser *p)
         expr_ty a;
         void *b;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
             &&
-            (b = annotation_rule(p), 1)
+            (b = annotation_rule(p), 1)  // annotation?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4444,9 +4444,9 @@ annotation_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             res = a;
@@ -4476,9 +4476,9 @@ default_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             res = a;
@@ -4507,7 +4507,7 @@ decorators_rule(Parser *p)
     { // (('@' named_expression NEWLINE))+
         asdl_seq * a;
         if (
-            (a = _loop1_67_rule(p))
+            (a = _loop1_67_rule(p))  // (('@' named_expression NEWLINE))+
         )
         {
             res = a;
@@ -4537,9 +4537,9 @@ class_def_rule(Parser *p)
         asdl_seq* a;
         stmt_ty b;
         if (
-            (a = decorators_rule(p))
+            (a = decorators_rule(p))  // decorators
             &&
-            (b = class_def_raw_rule(p))
+            (b = class_def_raw_rule(p))  // class_def_raw
         )
         {
             res = _PyPegen_class_def_decorators ( p , a , b );
@@ -4554,7 +4554,7 @@ class_def_rule(Parser *p)
     { // class_def_raw
         stmt_ty class_def_raw_var;
         if (
-            (class_def_raw_var = class_def_raw_rule(p))
+            (class_def_raw_var = class_def_raw_rule(p))  // class_def_raw
         )
         {
             res = class_def_raw_var;
@@ -4591,15 +4591,15 @@ class_def_raw_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 523))
+            (keyword = _PyPegen_expect_token(p, 523))  // token='class'
             &&
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
             &&
-            (b = _tmp_68_rule(p), 1)
+            (b = _tmp_68_rule(p), 1)  // ['(' arguments? ')']
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (c = block_rule(p))
+            (c = block_rule(p))  // block
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4641,13 +4641,13 @@ block_rule(Parser *p)
         Token * indent_var;
         Token * newline_var;
         if (
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
             &&
-            (indent_var = _PyPegen_expect_token(p, INDENT))
+            (indent_var = _PyPegen_expect_token(p, INDENT))  // token='INDENT'
             &&
-            (a = statements_rule(p))
+            (a = statements_rule(p))  // statements
             &&
-            (dedent_var = _PyPegen_expect_token(p, DEDENT))
+            (dedent_var = _PyPegen_expect_token(p, DEDENT))  // token='DEDENT'
         )
         {
             res = a;
@@ -4662,7 +4662,7 @@ block_rule(Parser *p)
     { // simple_stmt
         asdl_seq* simple_stmt_var;
         if (
-            (simple_stmt_var = simple_stmt_rule(p))
+            (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
         )
         {
             res = simple_stmt_var;
@@ -4673,7 +4673,7 @@ block_rule(Parser *p)
     { // invalid_block
         void *invalid_block_var;
         if (
-            (invalid_block_var = invalid_block_rule(p))
+            (invalid_block_var = invalid_block_rule(p))  // invalid_block
         )
         {
             res = invalid_block_var;
@@ -4701,9 +4701,9 @@ expressions_list_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_69_rule(p))
+            (a = _gather_69_rule(p))  // ','.star_expression+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             res = a;
@@ -4746,11 +4746,11 @@ star_expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = star_expression_rule(p))
+            (a = star_expression_rule(p))  // star_expression
             &&
-            (b = _loop1_71_rule(p))
+            (b = _loop1_71_rule(p))  // ((',' star_expression))+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4774,9 +4774,9 @@ star_expressions_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (a = star_expression_rule(p))
+            (a = star_expression_rule(p))  // star_expression
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4799,7 +4799,7 @@ star_expressions_rule(Parser *p)
     { // star_expression
         expr_ty star_expression_var;
         if (
-            (star_expression_var = star_expression_rule(p))
+            (star_expression_var = star_expression_rule(p))  // star_expression
         )
         {
             res = star_expression_var;
@@ -4835,9 +4835,9 @@ star_expression_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4860,7 +4860,7 @@ star_expression_rule(Parser *p)
     { // expression
         expr_ty expression_var;
         if (
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
         )
         {
             res = expression_var;
@@ -4888,9 +4888,9 @@ star_named_expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_72_rule(p))
+            (a = _gather_72_rule(p))  // ','.star_named_expression+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             res = a;
@@ -4928,9 +4928,9 @@ star_named_expression_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4953,7 +4953,7 @@ star_named_expression_rule(Parser *p)
     { // named_expression
         expr_ty named_expression_var;
         if (
-            (named_expression_var = named_expression_rule(p))
+            (named_expression_var = named_expression_rule(p))  // named_expression
         )
         {
             res = named_expression_var;
@@ -4988,11 +4988,11 @@ named_expression_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
             &&
-            (literal = _PyPegen_expect_token(p, 53))
+            (literal = _PyPegen_expect_token(p, 53))  // token=':='
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5015,9 +5015,9 @@ named_expression_rule(Parser *p)
     { // expression !':='
         expr_ty expression_var;
         if (
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 53)
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 53)  // token=':='
         )
         {
             res = expression_var;
@@ -5028,7 +5028,7 @@ named_expression_rule(Parser *p)
     { // invalid_named_expression
         void *invalid_named_expression_var;
         if (
-            (invalid_named_expression_var = invalid_named_expression_rule(p))
+            (invalid_named_expression_var = invalid_named_expression_rule(p))  // invalid_named_expression
         )
         {
             res = invalid_named_expression_var;
@@ -5053,7 +5053,7 @@ annotated_rhs_rule(Parser *p)
     { // yield_expr
         expr_ty yield_expr_var;
         if (
-            (yield_expr_var = yield_expr_rule(p))
+            (yield_expr_var = yield_expr_rule(p))  // yield_expr
         )
         {
             res = yield_expr_var;
@@ -5064,7 +5064,7 @@ annotated_rhs_rule(Parser *p)
     { // star_expressions
         expr_ty star_expressions_var;
         if (
-            (star_expressions_var = star_expressions_rule(p))
+            (star_expressions_var = star_expressions_rule(p))  // star_expressions
         )
         {
             res = star_expressions_var;
@@ -5100,11 +5100,11 @@ expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (b = _loop1_74_rule(p))
+            (b = _loop1_74_rule(p))  // ((',' expression))+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5128,9 +5128,9 @@ expressions_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5153,7 +5153,7 @@ expressions_rule(Parser *p)
     { // expression
         expr_ty expression_var;
         if (
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
         )
         {
             res = expression_var;
@@ -5192,15 +5192,15 @@ expression_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (a = disjunction_rule(p))
+            (a = disjunction_rule(p))  // disjunction
             &&
-            (keyword = _PyPegen_expect_token(p, 510))
+            (keyword = _PyPegen_expect_token(p, 510))  // token='if'
             &&
-            (b = disjunction_rule(p))
+            (b = disjunction_rule(p))  // disjunction
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 516))
+            (keyword_1 = _PyPegen_expect_token(p, 516))  // token='else'
             &&
-            (c = expression_rule(p))
+            (c = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5223,7 +5223,7 @@ expression_rule(Parser *p)
     { // disjunction
         expr_ty disjunction_var;
         if (
-            (disjunction_var = disjunction_rule(p))
+            (disjunction_var = disjunction_rule(p))  // disjunction
         )
         {
             res = disjunction_var;
@@ -5234,7 +5234,7 @@ expression_rule(Parser *p)
     { // lambdef
         expr_ty lambdef_var;
         if (
-            (lambdef_var = lambdef_rule(p))
+            (lambdef_var = lambdef_rule(p))  // lambdef
         )
         {
             res = lambdef_var;
@@ -5271,13 +5271,13 @@ lambdef_rule(Parser *p)
         Token * keyword;
         Token * literal;
         if (
-            (keyword = _PyPegen_expect_token(p, 524))
+            (keyword = _PyPegen_expect_token(p, 524))  // token='lambda'
             &&
-            (a = lambda_parameters_rule(p), 1)
+            (a = lambda_parameters_rule(p), 1)  // lambda_parameters?
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5322,13 +5322,13 @@ lambda_parameters_rule(Parser *p)
         asdl_seq * c;
         void *d;
         if (
-            (a = lambda_slash_no_default_rule(p))
+            (a = lambda_slash_no_default_rule(p))  // lambda_slash_no_default
             &&
-            (b = _loop0_75_rule(p))
+            (b = _loop0_75_rule(p))  // lambda_param_no_default*
             &&
-            (c = _loop0_76_rule(p))
+            (c = _loop0_76_rule(p))  // lambda_param_with_default*
             &&
-            (d = lambda_star_etc_rule(p), 1)
+            (d = lambda_star_etc_rule(p), 1)  // lambda_star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -5345,11 +5345,11 @@ lambda_parameters_rule(Parser *p)
         asdl_seq * b;
         void *c;
         if (
-            (a = lambda_slash_with_default_rule(p))
+            (a = lambda_slash_with_default_rule(p))  // lambda_slash_with_default
             &&
-            (b = _loop0_77_rule(p))
+            (b = _loop0_77_rule(p))  // lambda_param_with_default*
             &&
-            (c = lambda_star_etc_rule(p), 1)
+            (c = lambda_star_etc_rule(p), 1)  // lambda_star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -5366,11 +5366,11 @@ lambda_parameters_rule(Parser *p)
         asdl_seq * b;
         void *c;
         if (
-            (a = _loop1_78_rule(p))
+            (a = _loop1_78_rule(p))  // lambda_param_no_default+
             &&
-            (b = _loop0_79_rule(p))
+            (b = _loop0_79_rule(p))  // lambda_param_with_default*
             &&
-            (c = lambda_star_etc_rule(p), 1)
+            (c = lambda_star_etc_rule(p), 1)  // lambda_star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -5386,9 +5386,9 @@ lambda_parameters_rule(Parser *p)
         asdl_seq * a;
         void *b;
         if (
-            (a = _loop1_80_rule(p))
+            (a = _loop1_80_rule(p))  // lambda_param_with_default+
             &&
-            (b = lambda_star_etc_rule(p), 1)
+            (b = lambda_star_etc_rule(p), 1)  // lambda_star_etc?
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -5403,7 +5403,7 @@ lambda_parameters_rule(Parser *p)
     { // lambda_star_etc
         StarEtc* a;
         if (
-            (a = lambda_star_etc_rule(p))
+            (a = lambda_star_etc_rule(p))  // lambda_star_etc
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , NULL , a );
@@ -5436,11 +5436,11 @@ lambda_slash_no_default_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = _loop1_81_rule(p))
+            (a = _loop1_81_rule(p))  // lambda_param_no_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            (literal_1 = _PyPegen_expect_token(p, 12))
+            (literal_1 = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             res = a;
@@ -5456,11 +5456,11 @@ lambda_slash_no_default_rule(Parser *p)
         asdl_seq * a;
         Token * literal;
         if (
-            (a = _loop1_82_rule(p))
+            (a = _loop1_82_rule(p))  // lambda_param_no_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)  // token=':'
         )
         {
             res = a;
@@ -5494,13 +5494,13 @@ lambda_slash_with_default_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = _loop0_83_rule(p))
+            (a = _loop0_83_rule(p))  // lambda_param_no_default*
             &&
-            (b = _loop1_84_rule(p))
+            (b = _loop1_84_rule(p))  // lambda_param_with_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            (literal_1 = _PyPegen_expect_token(p, 12))
+            (literal_1 = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             res = _PyPegen_slash_with_default ( p , a , b );
@@ -5517,13 +5517,13 @@ lambda_slash_with_default_rule(Parser *p)
         asdl_seq * b;
         Token * literal;
         if (
-            (a = _loop0_85_rule(p))
+            (a = _loop0_85_rule(p))  // lambda_param_no_default*
             &&
-            (b = _loop1_86_rule(p))
+            (b = _loop1_86_rule(p))  // lambda_param_with_default+
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)  // token=':'
         )
         {
             res = _PyPegen_slash_with_default ( p , a , b );
@@ -5559,13 +5559,13 @@ lambda_star_etc_rule(Parser *p)
         void *c;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = lambda_param_no_default_rule(p))
+            (a = lambda_param_no_default_rule(p))  // lambda_param_no_default
             &&
-            (b = _loop0_87_rule(p))
+            (b = _loop0_87_rule(p))  // lambda_param_maybe_default*
             &&
-            (c = lambda_kwds_rule(p), 1)
+            (c = lambda_kwds_rule(p), 1)  // lambda_kwds?
         )
         {
             res = _PyPegen_star_etc ( p , a , b , c );
@@ -5583,13 +5583,13 @@ lambda_star_etc_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (literal_1 = _PyPegen_expect_token(p, 12))
+            (literal_1 = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (b = _loop1_88_rule(p))
+            (b = _loop1_88_rule(p))  // lambda_param_maybe_default+
             &&
-            (c = lambda_kwds_rule(p), 1)
+            (c = lambda_kwds_rule(p), 1)  // lambda_kwds?
         )
         {
             res = _PyPegen_star_etc ( p , NULL , b , c );
@@ -5604,7 +5604,7 @@ lambda_star_etc_rule(Parser *p)
     { // lambda_kwds
         arg_ty a;
         if (
-            (a = lambda_kwds_rule(p))
+            (a = lambda_kwds_rule(p))  // lambda_kwds
         )
         {
             res = _PyPegen_star_etc ( p , NULL , NULL , a );
@@ -5619,7 +5619,7 @@ lambda_star_etc_rule(Parser *p)
     { // invalid_lambda_star_etc
         void *invalid_lambda_star_etc_var;
         if (
-            (invalid_lambda_star_etc_var = invalid_lambda_star_etc_rule(p))
+            (invalid_lambda_star_etc_var = invalid_lambda_star_etc_rule(p))  // invalid_lambda_star_etc
         )
         {
             res = invalid_lambda_star_etc_var;
@@ -5645,9 +5645,9 @@ lambda_kwds_rule(Parser *p)
         arg_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (a = lambda_param_no_default_rule(p))
+            (a = lambda_param_no_default_rule(p))  // lambda_param_no_default
         )
         {
             res = a;
@@ -5677,9 +5677,9 @@ lambda_param_no_default_rule(Parser *p)
         arg_ty a;
         Token * literal;
         if (
-            (a = lambda_param_rule(p))
+            (a = lambda_param_rule(p))  // lambda_param
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             res = a;
@@ -5694,9 +5694,9 @@ lambda_param_no_default_rule(Parser *p)
     { // lambda_param &':'
         arg_ty a;
         if (
-            (a = lambda_param_rule(p))
+            (a = lambda_param_rule(p))  // lambda_param
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)  // token=':'
         )
         {
             res = a;
@@ -5727,11 +5727,11 @@ lambda_param_with_default_rule(Parser *p)
         expr_ty c;
         Token * literal;
         if (
-            (a = lambda_param_rule(p))
+            (a = lambda_param_rule(p))  // lambda_param
             &&
-            (c = default_rule(p))
+            (c = default_rule(p))  // default
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , NULL );
@@ -5747,11 +5747,11 @@ lambda_param_with_default_rule(Parser *p)
         arg_ty a;
         expr_ty c;
         if (
-            (a = lambda_param_rule(p))
+            (a = lambda_param_rule(p))  // lambda_param
             &&
-            (c = default_rule(p))
+            (c = default_rule(p))  // default
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)  // token=':'
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , NULL );
@@ -5782,11 +5782,11 @@ lambda_param_maybe_default_rule(Parser *p)
         void *c;
         Token * literal;
         if (
-            (a = lambda_param_rule(p))
+            (a = lambda_param_rule(p))  // lambda_param
             &&
-            (c = default_rule(p), 1)
+            (c = default_rule(p), 1)  // default?
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , NULL );
@@ -5802,11 +5802,11 @@ lambda_param_maybe_default_rule(Parser *p)
         arg_ty a;
         void *c;
         if (
-            (a = lambda_param_rule(p))
+            (a = lambda_param_rule(p))  // lambda_param
             &&
-            (c = default_rule(p), 1)
+            (c = default_rule(p), 1)  // default?
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 11)  // token=':'
         )
         {
             res = _PyPegen_name_default_pair ( p , a , c , NULL );
@@ -5843,7 +5843,7 @@ lambda_param_rule(Parser *p)
     { // NAME
         expr_ty a;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5891,9 +5891,9 @@ disjunction_rule(Parser *p)
         expr_ty a;
         asdl_seq * b;
         if (
-            (a = conjunction_rule(p))
+            (a = conjunction_rule(p))  // conjunction
             &&
-            (b = _loop1_89_rule(p))
+            (b = _loop1_89_rule(p))  // (('or' conjunction))+
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5916,7 +5916,7 @@ disjunction_rule(Parser *p)
     { // conjunction
         expr_ty conjunction_var;
         if (
-            (conjunction_var = conjunction_rule(p))
+            (conjunction_var = conjunction_rule(p))  // conjunction
         )
         {
             res = conjunction_var;
@@ -5953,9 +5953,9 @@ conjunction_rule(Parser *p)
         expr_ty a;
         asdl_seq * b;
         if (
-            (a = inversion_rule(p))
+            (a = inversion_rule(p))  // inversion
             &&
-            (b = _loop1_90_rule(p))
+            (b = _loop1_90_rule(p))  // (('and' inversion))+
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5978,7 +5978,7 @@ conjunction_rule(Parser *p)
     { // inversion
         expr_ty inversion_var;
         if (
-            (inversion_var = inversion_rule(p))
+            (inversion_var = inversion_rule(p))  // inversion
         )
         {
             res = inversion_var;
@@ -6015,9 +6015,9 @@ inversion_rule(Parser *p)
         expr_ty a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 525))
+            (keyword = _PyPegen_expect_token(p, 525))  // token='not'
             &&
-            (a = inversion_rule(p))
+            (a = inversion_rule(p))  // inversion
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -6040,7 +6040,7 @@ inversion_rule(Parser *p)
     { // comparison
         expr_ty comparison_var;
         if (
-            (comparison_var = comparison_rule(p))
+            (comparison_var = comparison_rule(p))  // comparison
         )
         {
             res = comparison_var;
@@ -6075,9 +6075,9 @@ comparison_rule(Parser *p)
         expr_ty a;
         asdl_seq * b;
         if (
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
             &&
-            (b = _loop1_91_rule(p))
+            (b = _loop1_91_rule(p))  // compare_op_bitwise_or_pair+
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -6100,7 +6100,7 @@ comparison_rule(Parser *p)
     { // bitwise_or
         expr_ty bitwise_or_var;
         if (
-            (bitwise_or_var = bitwise_or_rule(p))
+            (bitwise_or_var = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = bitwise_or_var;
@@ -6135,7 +6135,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // eq_bitwise_or
         CmpopExprPair* eq_bitwise_or_var;
         if (
-            (eq_bitwise_or_var = eq_bitwise_or_rule(p))
+            (eq_bitwise_or_var = eq_bitwise_or_rule(p))  // eq_bitwise_or
         )
         {
             res = eq_bitwise_or_var;
@@ -6146,7 +6146,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // noteq_bitwise_or
         CmpopExprPair* noteq_bitwise_or_var;
         if (
-            (noteq_bitwise_or_var = noteq_bitwise_or_rule(p))
+            (noteq_bitwise_or_var = noteq_bitwise_or_rule(p))  // noteq_bitwise_or
         )
         {
             res = noteq_bitwise_or_var;
@@ -6157,7 +6157,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // lte_bitwise_or
         CmpopExprPair* lte_bitwise_or_var;
         if (
-            (lte_bitwise_or_var = lte_bitwise_or_rule(p))
+            (lte_bitwise_or_var = lte_bitwise_or_rule(p))  // lte_bitwise_or
         )
         {
             res = lte_bitwise_or_var;
@@ -6168,7 +6168,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // lt_bitwise_or
         CmpopExprPair* lt_bitwise_or_var;
         if (
-            (lt_bitwise_or_var = lt_bitwise_or_rule(p))
+            (lt_bitwise_or_var = lt_bitwise_or_rule(p))  // lt_bitwise_or
         )
         {
             res = lt_bitwise_or_var;
@@ -6179,7 +6179,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // gte_bitwise_or
         CmpopExprPair* gte_bitwise_or_var;
         if (
-            (gte_bitwise_or_var = gte_bitwise_or_rule(p))
+            (gte_bitwise_or_var = gte_bitwise_or_rule(p))  // gte_bitwise_or
         )
         {
             res = gte_bitwise_or_var;
@@ -6190,7 +6190,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // gt_bitwise_or
         CmpopExprPair* gt_bitwise_or_var;
         if (
-            (gt_bitwise_or_var = gt_bitwise_or_rule(p))
+            (gt_bitwise_or_var = gt_bitwise_or_rule(p))  // gt_bitwise_or
         )
         {
             res = gt_bitwise_or_var;
@@ -6201,7 +6201,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // notin_bitwise_or
         CmpopExprPair* notin_bitwise_or_var;
         if (
-            (notin_bitwise_or_var = notin_bitwise_or_rule(p))
+            (notin_bitwise_or_var = notin_bitwise_or_rule(p))  // notin_bitwise_or
         )
         {
             res = notin_bitwise_or_var;
@@ -6212,7 +6212,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // in_bitwise_or
         CmpopExprPair* in_bitwise_or_var;
         if (
-            (in_bitwise_or_var = in_bitwise_or_rule(p))
+            (in_bitwise_or_var = in_bitwise_or_rule(p))  // in_bitwise_or
         )
         {
             res = in_bitwise_or_var;
@@ -6223,7 +6223,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // isnot_bitwise_or
         CmpopExprPair* isnot_bitwise_or_var;
         if (
-            (isnot_bitwise_or_var = isnot_bitwise_or_rule(p))
+            (isnot_bitwise_or_var = isnot_bitwise_or_rule(p))  // isnot_bitwise_or
         )
         {
             res = isnot_bitwise_or_var;
@@ -6234,7 +6234,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
     { // is_bitwise_or
         CmpopExprPair* is_bitwise_or_var;
         if (
-            (is_bitwise_or_var = is_bitwise_or_rule(p))
+            (is_bitwise_or_var = is_bitwise_or_rule(p))  // is_bitwise_or
         )
         {
             res = is_bitwise_or_var;
@@ -6260,9 +6260,9 @@ eq_bitwise_or_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 27))
+            (literal = _PyPegen_expect_token(p, 27))  // token='=='
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , Eq , a );
@@ -6292,9 +6292,9 @@ noteq_bitwise_or_rule(Parser *p)
         void *_tmp_92_var;
         expr_ty a;
         if (
-            (_tmp_92_var = _tmp_92_rule(p))
+            (_tmp_92_var = _tmp_92_rule(p))  // '!='
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , NotEq , a );
@@ -6324,9 +6324,9 @@ lte_bitwise_or_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 29))
+            (literal = _PyPegen_expect_token(p, 29))  // token='<='
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , LtE , a );
@@ -6356,9 +6356,9 @@ lt_bitwise_or_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 20))
+            (literal = _PyPegen_expect_token(p, 20))  // token='<'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , Lt , a );
@@ -6388,9 +6388,9 @@ gte_bitwise_or_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 30))
+            (literal = _PyPegen_expect_token(p, 30))  // token='>='
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , GtE , a );
@@ -6420,9 +6420,9 @@ gt_bitwise_or_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 21))
+            (literal = _PyPegen_expect_token(p, 21))  // token='>'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , Gt , a );
@@ -6453,11 +6453,11 @@ notin_bitwise_or_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (keyword = _PyPegen_expect_token(p, 525))
+            (keyword = _PyPegen_expect_token(p, 525))  // token='not'
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 518))
+            (keyword_1 = _PyPegen_expect_token(p, 518))  // token='in'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , NotIn , a );
@@ -6487,9 +6487,9 @@ in_bitwise_or_rule(Parser *p)
         expr_ty a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 518))
+            (keyword = _PyPegen_expect_token(p, 518))  // token='in'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , In , a );
@@ -6520,11 +6520,11 @@ isnot_bitwise_or_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (keyword = _PyPegen_expect_token(p, 526))
+            (keyword = _PyPegen_expect_token(p, 526))  // token='is'
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 525))
+            (keyword_1 = _PyPegen_expect_token(p, 525))  // token='not'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , IsNot , a );
@@ -6554,9 +6554,9 @@ is_bitwise_or_rule(Parser *p)
         expr_ty a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 526))
+            (keyword = _PyPegen_expect_token(p, 526))  // token='is'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_cmpop_expr_pair ( p , Is , a );
@@ -6620,11 +6620,11 @@ bitwise_or_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
             &&
-            (literal = _PyPegen_expect_token(p, 18))
+            (literal = _PyPegen_expect_token(p, 18))  // token='|'
             &&
-            (b = bitwise_xor_rule(p))
+            (b = bitwise_xor_rule(p))  // bitwise_xor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -6647,7 +6647,7 @@ bitwise_or_raw(Parser *p)
     { // bitwise_xor
         expr_ty bitwise_xor_var;
         if (
-            (bitwise_xor_var = bitwise_xor_rule(p))
+            (bitwise_xor_var = bitwise_xor_rule(p))  // bitwise_xor
         )
         {
             res = bitwise_xor_var;
@@ -6707,11 +6707,11 @@ bitwise_xor_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = bitwise_xor_rule(p))
+            (a = bitwise_xor_rule(p))  // bitwise_xor
             &&
-            (literal = _PyPegen_expect_token(p, 32))
+            (literal = _PyPegen_expect_token(p, 32))  // token='^'
             &&
-            (b = bitwise_and_rule(p))
+            (b = bitwise_and_rule(p))  // bitwise_and
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -6734,7 +6734,7 @@ bitwise_xor_raw(Parser *p)
     { // bitwise_and
         expr_ty bitwise_and_var;
         if (
-            (bitwise_and_var = bitwise_and_rule(p))
+            (bitwise_and_var = bitwise_and_rule(p))  // bitwise_and
         )
         {
             res = bitwise_and_var;
@@ -6794,11 +6794,11 @@ bitwise_and_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = bitwise_and_rule(p))
+            (a = bitwise_and_rule(p))  // bitwise_and
             &&
-            (literal = _PyPegen_expect_token(p, 19))
+            (literal = _PyPegen_expect_token(p, 19))  // token='&'
             &&
-            (b = shift_expr_rule(p))
+            (b = shift_expr_rule(p))  // shift_expr
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -6821,7 +6821,7 @@ bitwise_and_raw(Parser *p)
     { // shift_expr
         expr_ty shift_expr_var;
         if (
-            (shift_expr_var = shift_expr_rule(p))
+            (shift_expr_var = shift_expr_rule(p))  // shift_expr
         )
         {
             res = shift_expr_var;
@@ -6881,11 +6881,11 @@ shift_expr_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = shift_expr_rule(p))
+            (a = shift_expr_rule(p))  // shift_expr
             &&
-            (literal = _PyPegen_expect_token(p, 33))
+            (literal = _PyPegen_expect_token(p, 33))  // token='<<'
             &&
-            (b = sum_rule(p))
+            (b = sum_rule(p))  // sum
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -6910,11 +6910,11 @@ shift_expr_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = shift_expr_rule(p))
+            (a = shift_expr_rule(p))  // shift_expr
             &&
-            (literal = _PyPegen_expect_token(p, 34))
+            (literal = _PyPegen_expect_token(p, 34))  // token='>>'
             &&
-            (b = sum_rule(p))
+            (b = sum_rule(p))  // sum
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -6937,7 +6937,7 @@ shift_expr_raw(Parser *p)
     { // sum
         expr_ty sum_var;
         if (
-            (sum_var = sum_rule(p))
+            (sum_var = sum_rule(p))  // sum
         )
         {
             res = sum_var;
@@ -6997,11 +6997,11 @@ sum_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = sum_rule(p))
+            (a = sum_rule(p))  // sum
             &&
-            (literal = _PyPegen_expect_token(p, 14))
+            (literal = _PyPegen_expect_token(p, 14))  // token='+'
             &&
-            (b = term_rule(p))
+            (b = term_rule(p))  // term
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7026,11 +7026,11 @@ sum_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = sum_rule(p))
+            (a = sum_rule(p))  // sum
             &&
-            (literal = _PyPegen_expect_token(p, 15))
+            (literal = _PyPegen_expect_token(p, 15))  // token='-'
             &&
-            (b = term_rule(p))
+            (b = term_rule(p))  // term
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7053,7 +7053,7 @@ sum_raw(Parser *p)
     { // term
         expr_ty term_var;
         if (
-            (term_var = term_rule(p))
+            (term_var = term_rule(p))  // term
         )
         {
             res = term_var;
@@ -7119,11 +7119,11 @@ term_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = term_rule(p))
+            (a = term_rule(p))  // term
             &&
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (b = factor_rule(p))
+            (b = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7148,11 +7148,11 @@ term_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = term_rule(p))
+            (a = term_rule(p))  // term
             &&
-            (literal = _PyPegen_expect_token(p, 17))
+            (literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
-            (b = factor_rule(p))
+            (b = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7177,11 +7177,11 @@ term_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = term_rule(p))
+            (a = term_rule(p))  // term
             &&
-            (literal = _PyPegen_expect_token(p, 47))
+            (literal = _PyPegen_expect_token(p, 47))  // token='//'
             &&
-            (b = factor_rule(p))
+            (b = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7206,11 +7206,11 @@ term_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = term_rule(p))
+            (a = term_rule(p))  // term
             &&
-            (literal = _PyPegen_expect_token(p, 24))
+            (literal = _PyPegen_expect_token(p, 24))  // token='%'
             &&
-            (b = factor_rule(p))
+            (b = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7235,11 +7235,11 @@ term_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = term_rule(p))
+            (a = term_rule(p))  // term
             &&
-            (literal = _PyPegen_expect_token(p, 49))
+            (literal = _PyPegen_expect_token(p, 49))  // token='@'
             &&
-            (b = factor_rule(p))
+            (b = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7262,7 +7262,7 @@ term_raw(Parser *p)
     { // factor
         expr_ty factor_var;
         if (
-            (factor_var = factor_rule(p))
+            (factor_var = factor_rule(p))  // factor
         )
         {
             res = factor_var;
@@ -7298,9 +7298,9 @@ factor_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 14))
+            (literal = _PyPegen_expect_token(p, 14))  // token='+'
             &&
-            (a = factor_rule(p))
+            (a = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7324,9 +7324,9 @@ factor_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 15))
+            (literal = _PyPegen_expect_token(p, 15))  // token='-'
             &&
-            (a = factor_rule(p))
+            (a = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7350,9 +7350,9 @@ factor_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 31))
+            (literal = _PyPegen_expect_token(p, 31))  // token='~'
             &&
-            (a = factor_rule(p))
+            (a = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7375,7 +7375,7 @@ factor_rule(Parser *p)
     { // power
         expr_ty power_var;
         if (
-            (power_var = power_rule(p))
+            (power_var = power_rule(p))  // power
         )
         {
             res = power_var;
@@ -7411,11 +7411,11 @@ power_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = await_primary_rule(p))
+            (a = await_primary_rule(p))  // await_primary
             &&
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (b = factor_rule(p))
+            (b = factor_rule(p))  // factor
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7438,7 +7438,7 @@ power_rule(Parser *p)
     { // await_primary
         expr_ty await_primary_var;
         if (
-            (await_primary_var = await_primary_rule(p))
+            (await_primary_var = await_primary_rule(p))  // await_primary
         )
         {
             res = await_primary_var;
@@ -7474,9 +7474,9 @@ await_primary_rule(Parser *p)
         expr_ty a;
         Token * await_var;
         if (
-            (await_var = _PyPegen_expect_token(p, AWAIT))
+            (await_var = _PyPegen_expect_token(p, AWAIT))  // token='AWAIT'
             &&
-            (a = primary_rule(p))
+            (a = primary_rule(p))  // primary
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7499,7 +7499,7 @@ await_primary_rule(Parser *p)
     { // primary
         expr_ty primary_var;
         if (
-            (primary_var = primary_rule(p))
+            (primary_var = primary_rule(p))  // primary
         )
         {
             res = primary_var;
@@ -7565,11 +7565,11 @@ primary_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = primary_rule(p))
+            (a = primary_rule(p))  // primary
             &&
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
             &&
-            (b = _PyPegen_name_token(p))
+            (b = _PyPegen_name_token(p))  // NAME
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7593,9 +7593,9 @@ primary_raw(Parser *p)
         expr_ty a;
         expr_ty b;
         if (
-            (a = primary_rule(p))
+            (a = primary_rule(p))  // primary
             &&
-            (b = genexp_rule(p))
+            (b = genexp_rule(p))  // genexp
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7621,13 +7621,13 @@ primary_raw(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = primary_rule(p))
+            (a = primary_rule(p))  // primary
             &&
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (b = arguments_rule(p), 1)
+            (b = arguments_rule(p), 1)  // arguments?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7653,13 +7653,13 @@ primary_raw(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = primary_rule(p))
+            (a = primary_rule(p))  // primary
             &&
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (b = slices_rule(p))
+            (b = slices_rule(p))  // slices
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7682,7 +7682,7 @@ primary_raw(Parser *p)
     { // atom
         expr_ty atom_var;
         if (
-            (atom_var = atom_rule(p))
+            (atom_var = atom_rule(p))  // atom
         )
         {
             res = atom_var;
@@ -7715,9 +7715,9 @@ slices_rule(Parser *p)
     { // slice !','
         expr_ty a;
         if (
-            (a = slice_rule(p))
+            (a = slice_rule(p))  // slice
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 12)
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 12)  // token=','
         )
         {
             res = a;
@@ -7734,9 +7734,9 @@ slices_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_93_rule(p))
+            (a = _gather_93_rule(p))  // ','.slice+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7784,13 +7784,13 @@ slice_rule(Parser *p)
         void *c;
         Token * literal;
         if (
-            (a = expression_rule(p), 1)
+            (a = expression_rule(p), 1)  // expression?
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = expression_rule(p), 1)
+            (b = expression_rule(p), 1)  // expression?
             &&
-            (c = _tmp_95_rule(p), 1)
+            (c = _tmp_95_rule(p), 1)  // [':' expression?]
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7813,7 +7813,7 @@ slice_rule(Parser *p)
     { // expression
         expr_ty a;
         if (
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             res = a;
@@ -7861,7 +7861,7 @@ atom_rule(Parser *p)
     { // NAME
         expr_ty name_var;
         if (
-            (name_var = _PyPegen_name_token(p))
+            (name_var = _PyPegen_name_token(p))  // NAME
         )
         {
             res = name_var;
@@ -7872,7 +7872,7 @@ atom_rule(Parser *p)
     { // 'True'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 527))
+            (keyword = _PyPegen_expect_token(p, 527))  // token='True'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7895,7 +7895,7 @@ atom_rule(Parser *p)
     { // 'False'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 528))
+            (keyword = _PyPegen_expect_token(p, 528))  // token='False'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7918,7 +7918,7 @@ atom_rule(Parser *p)
     { // 'None'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 529))
+            (keyword = _PyPegen_expect_token(p, 529))  // token='None'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7941,7 +7941,7 @@ atom_rule(Parser *p)
     { // '__new_parser__'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 530))
+            (keyword = _PyPegen_expect_token(p, 530))  // token='__new_parser__'
         )
         {
             res = RAISE_SYNTAX_ERROR ( "You found it!" );
@@ -7958,7 +7958,7 @@ atom_rule(Parser *p)
         if (
             _PyPegen_lookahead(1, _PyPegen_string_token, p)
             &&
-            (strings_var = strings_rule(p))
+            (strings_var = strings_rule(p))  // strings
         )
         {
             res = strings_var;
@@ -7969,7 +7969,7 @@ atom_rule(Parser *p)
     { // NUMBER
         expr_ty number_var;
         if (
-            (number_var = _PyPegen_number_token(p))
+            (number_var = _PyPegen_number_token(p))  // NUMBER
         )
         {
             res = number_var;
@@ -7980,9 +7980,9 @@ atom_rule(Parser *p)
     { // &'(' (tuple | group | genexp)
         void *_tmp_96_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)  // token='('
             &&
-            (_tmp_96_var = _tmp_96_rule(p))
+            (_tmp_96_var = _tmp_96_rule(p))  // tuple | group | genexp
         )
         {
             res = _tmp_96_var;
@@ -7993,9 +7993,9 @@ atom_rule(Parser *p)
     { // &'[' (list | listcomp)
         void *_tmp_97_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)  // token='['
             &&
-            (_tmp_97_var = _tmp_97_rule(p))
+            (_tmp_97_var = _tmp_97_rule(p))  // list | listcomp
         )
         {
             res = _tmp_97_var;
@@ -8006,9 +8006,9 @@ atom_rule(Parser *p)
     { // &'{' (dict | set | dictcomp | setcomp)
         void *_tmp_98_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)  // token='{'
             &&
-            (_tmp_98_var = _tmp_98_rule(p))
+            (_tmp_98_var = _tmp_98_rule(p))  // dict | set | dictcomp | setcomp
         )
         {
             res = _tmp_98_var;
@@ -8019,7 +8019,7 @@ atom_rule(Parser *p)
     { // '...'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 52))
+            (literal = _PyPegen_expect_token(p, 52))  // token='...'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8058,7 +8058,7 @@ strings_rule(Parser *p)
     { // STRING+
         asdl_seq * a;
         if (
-            (a = _loop1_99_rule(p))
+            (a = _loop1_99_rule(p))  // STRING+
         )
         {
             res = _PyPegen_concatenate_strings ( p , a );
@@ -8098,11 +8098,11 @@ list_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (a = star_named_expressions_rule(p), 1)
+            (a = star_named_expressions_rule(p), 1)  // star_named_expressions?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8150,13 +8150,13 @@ listcomp_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (a = named_expression_rule(p))
+            (a = named_expression_rule(p))  // named_expression
             &&
-            (b = for_if_clauses_rule(p))
+            (b = for_if_clauses_rule(p))  // for_if_clauses
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8179,7 +8179,7 @@ listcomp_rule(Parser *p)
     { // invalid_comprehension
         void *invalid_comprehension_var;
         if (
-            (invalid_comprehension_var = invalid_comprehension_rule(p))
+            (invalid_comprehension_var = invalid_comprehension_rule(p))  // invalid_comprehension
         )
         {
             res = invalid_comprehension_var;
@@ -8214,11 +8214,11 @@ tuple_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = _tmp_100_rule(p), 1)
+            (a = _tmp_100_rule(p), 1)  // [star_named_expression ',' star_named_expressions?]
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8257,11 +8257,11 @@ group_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = _tmp_101_rule(p))
+            (a = _tmp_101_rule(p))  // yield_expr | named_expression
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = a;
@@ -8301,13 +8301,13 @@ genexp_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (b = for_if_clauses_rule(p))
+            (b = for_if_clauses_rule(p))  // for_if_clauses
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8330,7 +8330,7 @@ genexp_rule(Parser *p)
     { // invalid_comprehension
         void *invalid_comprehension_var;
         if (
-            (invalid_comprehension_var = invalid_comprehension_rule(p))
+            (invalid_comprehension_var = invalid_comprehension_rule(p))  // invalid_comprehension
         )
         {
             res = invalid_comprehension_var;
@@ -8365,11 +8365,11 @@ set_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 25))
+            (literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
-            (a = expressions_list_rule(p))
+            (a = expressions_list_rule(p))  // expressions_list
             &&
-            (literal_1 = _PyPegen_expect_token(p, 26))
+            (literal_1 = _PyPegen_expect_token(p, 26))  // token='}'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8417,13 +8417,13 @@ setcomp_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 25))
+            (literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (b = for_if_clauses_rule(p))
+            (b = for_if_clauses_rule(p))  // for_if_clauses
             &&
-            (literal_1 = _PyPegen_expect_token(p, 26))
+            (literal_1 = _PyPegen_expect_token(p, 26))  // token='}'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8446,7 +8446,7 @@ setcomp_rule(Parser *p)
     { // invalid_comprehension
         void *invalid_comprehension_var;
         if (
-            (invalid_comprehension_var = invalid_comprehension_rule(p))
+            (invalid_comprehension_var = invalid_comprehension_rule(p))  // invalid_comprehension
         )
         {
             res = invalid_comprehension_var;
@@ -8481,11 +8481,11 @@ dict_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 25))
+            (literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
-            (a = kvpairs_rule(p), 1)
+            (a = kvpairs_rule(p), 1)  // kvpairs?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 26))
+            (literal_1 = _PyPegen_expect_token(p, 26))  // token='}'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8533,13 +8533,13 @@ dictcomp_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 25))
+            (literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
-            (a = kvpair_rule(p))
+            (a = kvpair_rule(p))  // kvpair
             &&
-            (b = for_if_clauses_rule(p))
+            (b = for_if_clauses_rule(p))  // for_if_clauses
             &&
-            (literal_1 = _PyPegen_expect_token(p, 26))
+            (literal_1 = _PyPegen_expect_token(p, 26))  // token='}'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8578,9 +8578,9 @@ kvpairs_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_102_rule(p))
+            (a = _gather_102_rule(p))  // ','.kvpair+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             res = a;
@@ -8610,9 +8610,9 @@ kvpair_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (a = bitwise_or_rule(p))
+            (a = bitwise_or_rule(p))  // bitwise_or
         )
         {
             res = _PyPegen_key_value_pair ( p , NULL , a );
@@ -8629,11 +8629,11 @@ kvpair_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             res = _PyPegen_key_value_pair ( p , a , b );
@@ -8662,7 +8662,7 @@ for_if_clauses_rule(Parser *p)
     { // for_if_clause+
         asdl_seq * _loop1_104_var;
         if (
-            (_loop1_104_var = _loop1_104_rule(p))
+            (_loop1_104_var = _loop1_104_rule(p))  // for_if_clause+
         )
         {
             res = _loop1_104_var;
@@ -8694,17 +8694,17 @@ for_if_clause_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
-            (keyword = _PyPegen_expect_token(p, 517))
+            (keyword = _PyPegen_expect_token(p, 517))  // token='for'
             &&
-            (a = star_targets_rule(p))
+            (a = star_targets_rule(p))  // star_targets
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 518))
+            (keyword_1 = _PyPegen_expect_token(p, 518))  // token='in'
             &&
-            (b = disjunction_rule(p))
+            (b = disjunction_rule(p))  // disjunction
             &&
-            (c = _loop0_105_rule(p))
+            (c = _loop0_105_rule(p))  // (('if' disjunction))*
         )
         {
             res = CHECK_VERSION ( 6 , "Async comprehensions are" , _Py_comprehension ( a , b , c , 1 , p -> arena ) );
@@ -8723,15 +8723,15 @@ for_if_clause_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (keyword = _PyPegen_expect_token(p, 517))
+            (keyword = _PyPegen_expect_token(p, 517))  // token='for'
             &&
-            (a = star_targets_rule(p))
+            (a = star_targets_rule(p))  // star_targets
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 518))
+            (keyword_1 = _PyPegen_expect_token(p, 518))  // token='in'
             &&
-            (b = disjunction_rule(p))
+            (b = disjunction_rule(p))  // disjunction
             &&
-            (c = _loop0_106_rule(p))
+            (c = _loop0_106_rule(p))  // (('if' disjunction))*
         )
         {
             res = _Py_comprehension ( a , b , c , 0 , p -> arena );
@@ -8770,11 +8770,11 @@ yield_expr_rule(Parser *p)
         Token * keyword;
         Token * keyword_1;
         if (
-            (keyword = _PyPegen_expect_token(p, 504))
+            (keyword = _PyPegen_expect_token(p, 504))  // token='yield'
             &&
-            (keyword_1 = _PyPegen_expect_token(p, 514))
+            (keyword_1 = _PyPegen_expect_token(p, 514))  // token='from'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8798,9 +8798,9 @@ yield_expr_rule(Parser *p)
         void *a;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 504))
+            (keyword = _PyPegen_expect_token(p, 504))  // token='yield'
             &&
-            (a = star_expressions_rule(p), 1)
+            (a = star_expressions_rule(p), 1)  // star_expressions?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8841,11 +8841,11 @@ arguments_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = args_rule(p))
+            (a = args_rule(p))  // args
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
             &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)  // token=')'
         )
         {
             res = a;
@@ -8860,7 +8860,7 @@ arguments_rule(Parser *p)
     { // incorrect_arguments
         void *incorrect_arguments_var;
         if (
-            (incorrect_arguments_var = incorrect_arguments_rule(p))
+            (incorrect_arguments_var = incorrect_arguments_rule(p))  // incorrect_arguments
         )
         {
             res = incorrect_arguments_var;
@@ -8895,9 +8895,9 @@ args_rule(Parser *p)
         expr_ty a;
         void *b;
         if (
-            (a = starred_expression_rule(p))
+            (a = starred_expression_rule(p))  // starred_expression
             &&
-            (b = _tmp_107_rule(p), 1)
+            (b = _tmp_107_rule(p), 1)  // [',' args]
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8920,7 +8920,7 @@ args_rule(Parser *p)
     { // kwargs
         asdl_seq* a;
         if (
-            (a = kwargs_rule(p))
+            (a = kwargs_rule(p))  // kwargs
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8944,9 +8944,9 @@ args_rule(Parser *p)
         expr_ty a;
         void *b;
         if (
-            (a = named_expression_rule(p))
+            (a = named_expression_rule(p))  // named_expression
             &&
-            (b = _tmp_108_rule(p), 1)
+            (b = _tmp_108_rule(p), 1)  // [',' args]
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8988,11 +8988,11 @@ kwargs_rule(Parser *p)
         asdl_seq * b;
         Token * literal;
         if (
-            (a = _gather_109_rule(p))
+            (a = _gather_109_rule(p))  // ','.kwarg_or_starred+
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (b = _gather_111_rule(p))
+            (b = _gather_111_rule(p))  // ','.kwarg_or_double_starred+
         )
         {
             res = _PyPegen_join_sequences ( p , a , b );
@@ -9007,7 +9007,7 @@ kwargs_rule(Parser *p)
     { // ','.kwarg_or_starred+
         asdl_seq * _gather_113_var;
         if (
-            (_gather_113_var = _gather_113_rule(p))
+            (_gather_113_var = _gather_113_rule(p))  // ','.kwarg_or_starred+
         )
         {
             res = _gather_113_var;
@@ -9018,7 +9018,7 @@ kwargs_rule(Parser *p)
     { // ','.kwarg_or_double_starred+
         asdl_seq * _gather_115_var;
         if (
-            (_gather_115_var = _gather_115_rule(p))
+            (_gather_115_var = _gather_115_rule(p))  // ','.kwarg_or_double_starred+
         )
         {
             res = _gather_115_var;
@@ -9052,9 +9052,9 @@ starred_expression_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9101,11 +9101,11 @@ kwarg_or_starred_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
             &&
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9128,7 +9128,7 @@ kwarg_or_starred_rule(Parser *p)
     { // starred_expression
         expr_ty a;
         if (
-            (a = starred_expression_rule(p))
+            (a = starred_expression_rule(p))  // starred_expression
         )
         {
             res = _PyPegen_keyword_or_starred ( p , a , 0 );
@@ -9167,11 +9167,11 @@ kwarg_or_double_starred_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
             &&
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
             &&
-            (b = expression_rule(p))
+            (b = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9195,9 +9195,9 @@ kwarg_or_double_starred_rule(Parser *p)
         expr_ty a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
             &&
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9242,9 +9242,9 @@ star_targets_rule(Parser *p)
     { // star_target !','
         expr_ty a;
         if (
-            (a = star_target_rule(p))
+            (a = star_target_rule(p))  // star_target
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 12)
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 12)  // token=','
         )
         {
             res = a;
@@ -9262,11 +9262,11 @@ star_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = star_target_rule(p))
+            (a = star_target_rule(p))  // star_target
             &&
-            (b = _loop0_117_rule(p))
+            (b = _loop0_117_rule(p))  // ((',' star_target))*
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9305,9 +9305,9 @@ star_targets_seq_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_118_rule(p))
+            (a = _gather_118_rule(p))  // ','.star_target+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             res = a;
@@ -9351,9 +9351,9 @@ star_target_rule(Parser *p)
         void *a;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (a = _tmp_120_rule(p))
+            (a = _tmp_120_rule(p))  // !'*' star_target
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9378,11 +9378,11 @@ star_target_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
             &&
-            (b = _PyPegen_name_token(p))
+            (b = _PyPegen_name_token(p))  // NAME
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -9410,13 +9410,13 @@ star_target_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (b = slices_rule(p))
+            (b = slices_rule(p))  // slices
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -9441,7 +9441,7 @@ star_target_rule(Parser *p)
     { // star_atom
         expr_ty star_atom_var;
         if (
-            (star_atom_var = star_atom_rule(p))
+            (star_atom_var = star_atom_rule(p))  // star_atom
         )
         {
             res = star_atom_var;
@@ -9479,7 +9479,7 @@ star_atom_rule(Parser *p)
     { // NAME
         expr_ty a;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
         )
         {
             res = _PyPegen_set_expr_context ( p , a , Store );
@@ -9496,11 +9496,11 @@ star_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = star_target_rule(p))
+            (a = star_target_rule(p))  // star_target
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = _PyPegen_set_expr_context ( p , a , Store );
@@ -9517,11 +9517,11 @@ star_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = star_targets_seq_rule(p), 1)
+            (a = star_targets_seq_rule(p), 1)  // star_targets_seq?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9546,11 +9546,11 @@ star_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (a = star_targets_seq_rule(p), 1)
+            (a = star_targets_seq_rule(p), 1)  // star_targets_seq?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9590,7 +9590,7 @@ inside_paren_ann_assign_target_rule(Parser *p)
     { // ann_assign_subscript_attribute_target
         expr_ty ann_assign_subscript_attribute_target_var;
         if (
-            (ann_assign_subscript_attribute_target_var = ann_assign_subscript_attribute_target_rule(p))
+            (ann_assign_subscript_attribute_target_var = ann_assign_subscript_attribute_target_rule(p))  // ann_assign_subscript_attribute_target
         )
         {
             res = ann_assign_subscript_attribute_target_var;
@@ -9601,7 +9601,7 @@ inside_paren_ann_assign_target_rule(Parser *p)
     { // NAME
         expr_ty a;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
         )
         {
             res = _PyPegen_set_expr_context ( p , a , Store );
@@ -9618,11 +9618,11 @@ inside_paren_ann_assign_target_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = inside_paren_ann_assign_target_rule(p))
+            (a = inside_paren_ann_assign_target_rule(p))  // inside_paren_ann_assign_target
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = a;
@@ -9663,11 +9663,11 @@ ann_assign_subscript_attribute_target_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
             &&
-            (b = _PyPegen_name_token(p))
+            (b = _PyPegen_name_token(p))  // NAME
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -9695,13 +9695,13 @@ ann_assign_subscript_attribute_target_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (b = slices_rule(p))
+            (b = slices_rule(p))  // slices
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -9742,9 +9742,9 @@ del_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_121_rule(p))
+            (a = _gather_121_rule(p))  // ','.del_target+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             res = a;
@@ -9788,11 +9788,11 @@ del_target_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
             &&
-            (b = _PyPegen_name_token(p))
+            (b = _PyPegen_name_token(p))  // NAME
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -9820,13 +9820,13 @@ del_target_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (b = slices_rule(p))
+            (b = slices_rule(p))  // slices
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -9851,7 +9851,7 @@ del_target_rule(Parser *p)
     { // del_t_atom
         expr_ty del_t_atom_var;
         if (
-            (del_t_atom_var = del_t_atom_rule(p))
+            (del_t_atom_var = del_t_atom_rule(p))  // del_t_atom
         )
         {
             res = del_t_atom_var;
@@ -9885,7 +9885,7 @@ del_t_atom_rule(Parser *p)
     { // NAME
         expr_ty a;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
         )
         {
             res = _PyPegen_set_expr_context ( p , a , Del );
@@ -9902,11 +9902,11 @@ del_t_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = del_target_rule(p))
+            (a = del_target_rule(p))  // del_target
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = _PyPegen_set_expr_context ( p , a , Del );
@@ -9923,11 +9923,11 @@ del_t_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = del_targets_rule(p), 1)
+            (a = del_targets_rule(p), 1)  // del_targets?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9952,11 +9952,11 @@ del_t_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (a = del_targets_rule(p), 1)
+            (a = del_targets_rule(p), 1)  // del_targets?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9995,9 +9995,9 @@ targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_123_rule(p))
+            (a = _gather_123_rule(p))  // ','.target+
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
         {
             res = a;
@@ -10041,11 +10041,11 @@ target_rule(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
             &&
-            (b = _PyPegen_name_token(p))
+            (b = _PyPegen_name_token(p))  // NAME
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -10073,13 +10073,13 @@ target_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (b = slices_rule(p))
+            (b = slices_rule(p))  // slices
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
             &&
             _PyPegen_lookahead(0, t_lookahead_rule, p)
         )
@@ -10104,7 +10104,7 @@ target_rule(Parser *p)
     { // t_atom
         expr_ty t_atom_var;
         if (
-            (t_atom_var = t_atom_rule(p))
+            (t_atom_var = t_atom_rule(p))  // t_atom
         )
         {
             res = t_atom_var;
@@ -10170,11 +10170,11 @@ t_primary_raw(Parser *p)
         expr_ty b;
         Token * literal;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
             &&
-            (b = _PyPegen_name_token(p))
+            (b = _PyPegen_name_token(p))  // NAME
             &&
             _PyPegen_lookahead(1, t_lookahead_rule, p)
         )
@@ -10202,13 +10202,13 @@ t_primary_raw(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (b = slices_rule(p))
+            (b = slices_rule(p))  // slices
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
             &&
             _PyPegen_lookahead(1, t_lookahead_rule, p)
         )
@@ -10234,9 +10234,9 @@ t_primary_raw(Parser *p)
         expr_ty a;
         expr_ty b;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (b = genexp_rule(p))
+            (b = genexp_rule(p))  // genexp
             &&
             _PyPegen_lookahead(1, t_lookahead_rule, p)
         )
@@ -10264,13 +10264,13 @@ t_primary_raw(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (a = t_primary_rule(p))
+            (a = t_primary_rule(p))  // t_primary
             &&
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (b = arguments_rule(p), 1)
+            (b = arguments_rule(p), 1)  // arguments?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
             &&
             _PyPegen_lookahead(1, t_lookahead_rule, p)
         )
@@ -10295,7 +10295,7 @@ t_primary_raw(Parser *p)
     { // atom &t_lookahead
         expr_ty a;
         if (
-            (a = atom_rule(p))
+            (a = atom_rule(p))  // atom
             &&
             _PyPegen_lookahead(1, t_lookahead_rule, p)
         )
@@ -10326,7 +10326,7 @@ t_lookahead_rule(Parser *p)
     { // '('
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
         )
         {
             res = literal;
@@ -10337,7 +10337,7 @@ t_lookahead_rule(Parser *p)
     { // '['
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
         )
         {
             res = literal;
@@ -10348,7 +10348,7 @@ t_lookahead_rule(Parser *p)
     { // '.'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
         )
         {
             res = literal;
@@ -10381,7 +10381,7 @@ t_atom_rule(Parser *p)
     { // NAME
         expr_ty a;
         if (
-            (a = _PyPegen_name_token(p))
+            (a = _PyPegen_name_token(p))  // NAME
         )
         {
             res = _PyPegen_set_expr_context ( p , a , Store );
@@ -10398,11 +10398,11 @@ t_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = target_rule(p))
+            (a = target_rule(p))  // target
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = _PyPegen_set_expr_context ( p , a , Store );
@@ -10419,11 +10419,11 @@ t_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (b = targets_rule(p), 1)
+            (b = targets_rule(p), 1)  // targets?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -10448,11 +10448,11 @@ t_atom_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
-            (b = targets_rule(p), 1)
+            (b = targets_rule(p), 1)  // targets?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 10))
+            (literal_1 = _PyPegen_expect_token(p, 10))  // token=']'
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -10494,11 +10494,11 @@ incorrect_arguments_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (args_var = args_rule(p))
+            (args_var = args_rule(p))  // args
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (literal_1 = _PyPegen_expect_token(p, 16))
+            (literal_1 = _PyPegen_expect_token(p, 16))  // token='*'
         )
         {
             res = RAISE_SYNTAX_ERROR ( "iterable argument unpacking follows keyword argument unpacking" );
@@ -10517,13 +10517,13 @@ incorrect_arguments_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
             &&
-            (for_if_clauses_var = for_if_clauses_rule(p))
+            (for_if_clauses_var = for_if_clauses_rule(p))  // for_if_clauses
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (opt_var = _tmp_125_rule(p), 1)
+            (opt_var = _tmp_125_rule(p), 1)  // [args | expression for_if_clauses]
         )
         {
             res = RAISE_SYNTAX_ERROR ( "Generator expression must be parenthesized" );
@@ -10540,11 +10540,11 @@ incorrect_arguments_rule(Parser *p)
         expr_ty args_var;
         Token * literal;
         if (
-            (a = args_rule(p))
+            (a = args_rule(p))  // args
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (args_var = args_rule(p))
+            (args_var = args_rule(p))  // args
         )
         {
             res = _PyPegen_arguments_parsing_error ( p , a );
@@ -10575,11 +10575,11 @@ invalid_named_expression_rule(Parser *p)
         expr_ty expression_var;
         Token * literal;
         if (
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (literal = _PyPegen_expect_token(p, 53))
+            (literal = _PyPegen_expect_token(p, 53))  // token=':='
             &&
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
         )
         {
             res = RAISE_SYNTAX_ERROR ( "cannot use assignment expressions with %s" , _PyPegen_get_expr_name ( a ) );
@@ -10613,9 +10613,9 @@ invalid_assignment_rule(Parser *p)
         expr_ty list_var;
         Token * literal;
         if (
-            (list_var = list_rule(p))
+            (list_var = list_rule(p))  // list
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
         )
         {
             res = RAISE_SYNTAX_ERROR ( "only single target (not list) can be annotated" );
@@ -10631,9 +10631,9 @@ invalid_assignment_rule(Parser *p)
         Token * literal;
         expr_ty tuple_var;
         if (
-            (tuple_var = tuple_rule(p))
+            (tuple_var = tuple_rule(p))  // tuple
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
         )
         {
             res = RAISE_SYNTAX_ERROR ( "only single target (not tuple) can be annotated" );
@@ -10652,13 +10652,13 @@ invalid_assignment_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
             &&
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (expression_var_1 = expression_rule(p))
+            (expression_var_1 = expression_rule(p))  // expression
             &&
-            (opt_var = _tmp_126_rule(p), 1)
+            (opt_var = _tmp_126_rule(p), 1)  // ['=' annotated_rhs]
         )
         {
             res = RAISE_SYNTAX_ERROR ( "illegal target for annotation" );
@@ -10675,11 +10675,11 @@ invalid_assignment_rule(Parser *p)
         void *_tmp_128_var;
         expr_ty a;
         if (
-            (a = expression_rule(p))
+            (a = expression_rule(p))  // expression
             &&
-            (_tmp_127_var = _tmp_127_rule(p))
+            (_tmp_127_var = _tmp_127_rule(p))  // '=' | augassign
             &&
-            (_tmp_128_var = _tmp_128_rule(p))
+            (_tmp_128_var = _tmp_128_rule(p))  // yield_expr | star_expressions
         )
         {
             res = RAISE_SYNTAX_ERROR_NO_COL_OFFSET ( "cannot assign to %s" , _PyPegen_get_expr_name ( a ) );
@@ -10708,9 +10708,9 @@ invalid_block_rule(Parser *p)
     { // NEWLINE !INDENT
         Token * newline_var;
         if (
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, INDENT)
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, INDENT)  // token=INDENT
         )
         {
             res = RAISE_INDENTATION_ERROR ( "expected an indented block" );
@@ -10742,13 +10742,13 @@ invalid_comprehension_rule(Parser *p)
         asdl_seq* for_if_clauses_var;
         Token * literal;
         if (
-            (_tmp_129_var = _tmp_129_rule(p))
+            (_tmp_129_var = _tmp_129_rule(p))  // '[' | '(' | '{'
             &&
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
             &&
-            (for_if_clauses_var = for_if_clauses_rule(p))
+            (for_if_clauses_var = for_if_clauses_rule(p))  // for_if_clauses
         )
         {
             res = RAISE_SYNTAX_ERROR ( "iterable unpacking cannot be used in comprehension" );
@@ -10780,11 +10780,11 @@ invalid_parameters_rule(Parser *p)
         void *_tmp_131_var;
         arg_ty param_no_default_var;
         if (
-            (_loop0_130_var = _loop0_130_rule(p))
+            (_loop0_130_var = _loop0_130_rule(p))  // param_no_default*
             &&
-            (_tmp_131_var = _tmp_131_rule(p))
+            (_tmp_131_var = _tmp_131_rule(p))  // slash_with_default | param_with_default+
             &&
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = RAISE_SYNTAX_ERROR ( "non-default argument follows default argument" );
@@ -10814,9 +10814,9 @@ invalid_star_etc_rule(Parser *p)
         void *_tmp_132_var;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (_tmp_132_var = _tmp_132_rule(p))
+            (_tmp_132_var = _tmp_132_rule(p))  // ')' | ',' (')' | '**')
         )
         {
             res = RAISE_SYNTAX_ERROR ( "named arguments must follow bare *" );
@@ -10846,9 +10846,9 @@ invalid_lambda_star_etc_rule(Parser *p)
         void *_tmp_133_var;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 16))
+            (literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (_tmp_133_var = _tmp_133_rule(p))
+            (_tmp_133_var = _tmp_133_rule(p))  // ':' | ',' (':' | '**')
         )
         {
             res = RAISE_SYNTAX_ERROR ( "named arguments must follow bare *" );
@@ -10881,15 +10881,15 @@ invalid_double_type_comments_rule(Parser *p)
         Token * type_comment_var;
         Token * type_comment_var_1;
         if (
-            (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))
+            (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
             &&
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
             &&
-            (type_comment_var_1 = _PyPegen_expect_token(p, TYPE_COMMENT))
+            (type_comment_var_1 = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
             &&
-            (newline_var_1 = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var_1 = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
             &&
-            (indent_var = _PyPegen_expect_token(p, INDENT))
+            (indent_var = _PyPegen_expect_token(p, INDENT))  // token='INDENT'
         )
         {
             res = RAISE_SYNTAX_ERROR ( "Cannot have two type comments on def" );
@@ -10926,7 +10926,7 @@ _loop0_1_rule(Parser *p)
     { // NEWLINE
         Token * newline_var;
         while (
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
             res = newline_var;
@@ -10975,7 +10975,7 @@ _loop0_2_rule(Parser *p)
     { // NEWLINE
         Token * newline_var;
         while (
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
             res = newline_var;
@@ -11025,9 +11025,9 @@ _loop0_4_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
         )
         {
             res = elem;
@@ -11074,9 +11074,9 @@ _gather_3_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
             &&
-            (seq = _loop0_4_rule(p))
+            (seq = _loop0_4_rule(p))  // _loop0_4
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11110,9 +11110,9 @@ _loop0_6_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
         )
         {
             res = elem;
@@ -11159,9 +11159,9 @@ _gather_5_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
             &&
-            (seq = _loop0_6_rule(p))
+            (seq = _loop0_6_rule(p))  // _loop0_6
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11195,9 +11195,9 @@ _loop0_8_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
         )
         {
             res = elem;
@@ -11244,9 +11244,9 @@ _gather_7_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
             &&
-            (seq = _loop0_8_rule(p))
+            (seq = _loop0_8_rule(p))  // _loop0_8
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11280,9 +11280,9 @@ _loop0_10_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
         )
         {
             res = elem;
@@ -11329,9 +11329,9 @@ _gather_9_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = expression_rule(p))
+            (elem = expression_rule(p))  // expression
             &&
-            (seq = _loop0_10_rule(p))
+            (seq = _loop0_10_rule(p))  // _loop0_10
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11364,7 +11364,7 @@ _loop1_11_rule(Parser *p)
     { // statement
         asdl_seq* statement_var;
         while (
-            (statement_var = statement_rule(p))
+            (statement_var = statement_rule(p))  // statement
         )
         {
             res = statement_var;
@@ -11418,9 +11418,9 @@ _loop0_13_rule(Parser *p)
         stmt_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 13))
+            (literal = _PyPegen_expect_token(p, 13))  // token=';'
             &&
-            (elem = small_stmt_rule(p))
+            (elem = small_stmt_rule(p))  // small_stmt
         )
         {
             res = elem;
@@ -11467,9 +11467,9 @@ _gather_12_rule(Parser *p)
         stmt_ty elem;
         asdl_seq * seq;
         if (
-            (elem = small_stmt_rule(p))
+            (elem = small_stmt_rule(p))  // small_stmt
             &&
-            (seq = _loop0_13_rule(p))
+            (seq = _loop0_13_rule(p))  // _loop0_13
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11494,7 +11494,7 @@ _tmp_14_rule(Parser *p)
     { // 'import'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 513))
+            (keyword = _PyPegen_expect_token(p, 513))  // token='import'
         )
         {
             res = keyword;
@@ -11505,7 +11505,7 @@ _tmp_14_rule(Parser *p)
     { // 'from'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 514))
+            (keyword = _PyPegen_expect_token(p, 514))  // token='from'
         )
         {
             res = keyword;
@@ -11530,7 +11530,7 @@ _tmp_15_rule(Parser *p)
     { // 'def'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 522))
+            (keyword = _PyPegen_expect_token(p, 522))  // token='def'
         )
         {
             res = keyword;
@@ -11541,7 +11541,7 @@ _tmp_15_rule(Parser *p)
     { // '@'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 49))
+            (literal = _PyPegen_expect_token(p, 49))  // token='@'
         )
         {
             res = literal;
@@ -11552,7 +11552,7 @@ _tmp_15_rule(Parser *p)
     { // ASYNC
         Token * async_var;
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
         )
         {
             res = async_var;
@@ -11577,7 +11577,7 @@ _tmp_16_rule(Parser *p)
     { // 'class'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 523))
+            (keyword = _PyPegen_expect_token(p, 523))  // token='class'
         )
         {
             res = keyword;
@@ -11588,7 +11588,7 @@ _tmp_16_rule(Parser *p)
     { // '@'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 49))
+            (literal = _PyPegen_expect_token(p, 49))  // token='@'
         )
         {
             res = literal;
@@ -11613,7 +11613,7 @@ _tmp_17_rule(Parser *p)
     { // 'with'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 519))
+            (keyword = _PyPegen_expect_token(p, 519))  // token='with'
         )
         {
             res = keyword;
@@ -11624,7 +11624,7 @@ _tmp_17_rule(Parser *p)
     { // ASYNC
         Token * async_var;
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
         )
         {
             res = async_var;
@@ -11649,7 +11649,7 @@ _tmp_18_rule(Parser *p)
     { // 'for'
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 517))
+            (keyword = _PyPegen_expect_token(p, 517))  // token='for'
         )
         {
             res = keyword;
@@ -11660,7 +11660,7 @@ _tmp_18_rule(Parser *p)
     { // ASYNC
         Token * async_var;
         if (
-            (async_var = _PyPegen_expect_token(p, ASYNC))
+            (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
         )
         {
             res = async_var;
@@ -11686,9 +11686,9 @@ _tmp_19_rule(Parser *p)
         expr_ty d;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
             &&
-            (d = annotated_rhs_rule(p))
+            (d = annotated_rhs_rule(p))  // annotated_rhs
         )
         {
             res = d;
@@ -11719,11 +11719,11 @@ _tmp_20_rule(Parser *p)
         Token * literal;
         Token * literal_1;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (b = inside_paren_ann_assign_target_rule(p))
+            (b = inside_paren_ann_assign_target_rule(p))  // inside_paren_ann_assign_target
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = b;
@@ -11738,7 +11738,7 @@ _tmp_20_rule(Parser *p)
     { // ann_assign_subscript_attribute_target
         expr_ty ann_assign_subscript_attribute_target_var;
         if (
-            (ann_assign_subscript_attribute_target_var = ann_assign_subscript_attribute_target_rule(p))
+            (ann_assign_subscript_attribute_target_var = ann_assign_subscript_attribute_target_rule(p))  // ann_assign_subscript_attribute_target
         )
         {
             res = ann_assign_subscript_attribute_target_var;
@@ -11764,9 +11764,9 @@ _tmp_21_rule(Parser *p)
         expr_ty d;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
             &&
-            (d = annotated_rhs_rule(p))
+            (d = annotated_rhs_rule(p))  // annotated_rhs
         )
         {
             res = d;
@@ -11803,7 +11803,7 @@ _loop1_22_rule(Parser *p)
     { // (star_targets '=')
         void *_tmp_134_var;
         while (
-            (_tmp_134_var = _tmp_134_rule(p))
+            (_tmp_134_var = _tmp_134_rule(p))  // star_targets '='
         )
         {
             res = _tmp_134_var;
@@ -11848,7 +11848,7 @@ _tmp_23_rule(Parser *p)
     { // yield_expr
         expr_ty yield_expr_var;
         if (
-            (yield_expr_var = yield_expr_rule(p))
+            (yield_expr_var = yield_expr_rule(p))  // yield_expr
         )
         {
             res = yield_expr_var;
@@ -11859,7 +11859,7 @@ _tmp_23_rule(Parser *p)
     { // star_expressions
         expr_ty star_expressions_var;
         if (
-            (star_expressions_var = star_expressions_rule(p))
+            (star_expressions_var = star_expressions_rule(p))  // star_expressions
         )
         {
             res = star_expressions_var;
@@ -11884,7 +11884,7 @@ _tmp_24_rule(Parser *p)
     { // yield_expr
         expr_ty yield_expr_var;
         if (
-            (yield_expr_var = yield_expr_rule(p))
+            (yield_expr_var = yield_expr_rule(p))  // yield_expr
         )
         {
             res = yield_expr_var;
@@ -11895,7 +11895,7 @@ _tmp_24_rule(Parser *p)
     { // star_expressions
         expr_ty star_expressions_var;
         if (
-            (star_expressions_var = star_expressions_rule(p))
+            (star_expressions_var = star_expressions_rule(p))  // star_expressions
         )
         {
             res = star_expressions_var;
@@ -11929,9 +11929,9 @@ _loop0_26_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _PyPegen_name_token(p))
+            (elem = _PyPegen_name_token(p))  // NAME
         )
         {
             res = elem;
@@ -11978,9 +11978,9 @@ _gather_25_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = _PyPegen_name_token(p))
+            (elem = _PyPegen_name_token(p))  // NAME
             &&
-            (seq = _loop0_26_rule(p))
+            (seq = _loop0_26_rule(p))  // _loop0_26
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12014,9 +12014,9 @@ _loop0_28_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = _PyPegen_name_token(p))
+            (elem = _PyPegen_name_token(p))  // NAME
         )
         {
             res = elem;
@@ -12063,9 +12063,9 @@ _gather_27_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = _PyPegen_name_token(p))
+            (elem = _PyPegen_name_token(p))  // NAME
             &&
-            (seq = _loop0_28_rule(p))
+            (seq = _loop0_28_rule(p))  // _loop0_28
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12091,9 +12091,9 @@ _tmp_29_rule(Parser *p)
         Token * literal;
         expr_ty z;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (z = expression_rule(p))
+            (z = expression_rule(p))  // expression
         )
         {
             res = z;
@@ -12130,7 +12130,7 @@ _loop0_30_rule(Parser *p)
     { // ('.' | '...')
         void *_tmp_135_var;
         while (
-            (_tmp_135_var = _tmp_135_rule(p))
+            (_tmp_135_var = _tmp_135_rule(p))  // '.' | '...'
         )
         {
             res = _tmp_135_var;
@@ -12179,7 +12179,7 @@ _loop1_31_rule(Parser *p)
     { // ('.' | '...')
         void *_tmp_136_var;
         while (
-            (_tmp_136_var = _tmp_136_rule(p))
+            (_tmp_136_var = _tmp_136_rule(p))  // '.' | '...'
         )
         {
             res = _tmp_136_var;
@@ -12233,9 +12233,9 @@ _loop0_33_rule(Parser *p)
         alias_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = import_from_as_name_rule(p))
+            (elem = import_from_as_name_rule(p))  // import_from_as_name
         )
         {
             res = elem;
@@ -12282,9 +12282,9 @@ _gather_32_rule(Parser *p)
         alias_ty elem;
         asdl_seq * seq;
         if (
-            (elem = import_from_as_name_rule(p))
+            (elem = import_from_as_name_rule(p))  // import_from_as_name
             &&
-            (seq = _loop0_33_rule(p))
+            (seq = _loop0_33_rule(p))  // _loop0_33
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12310,9 +12310,9 @@ _tmp_34_rule(Parser *p)
         Token * keyword;
         expr_ty z;
         if (
-            (keyword = _PyPegen_expect_token(p, 531))
+            (keyword = _PyPegen_expect_token(p, 531))  // token='as'
             &&
-            (z = _PyPegen_name_token(p))
+            (z = _PyPegen_name_token(p))  // NAME
         )
         {
             res = z;
@@ -12350,9 +12350,9 @@ _loop0_36_rule(Parser *p)
         alias_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = dotted_as_name_rule(p))
+            (elem = dotted_as_name_rule(p))  // dotted_as_name
         )
         {
             res = elem;
@@ -12399,9 +12399,9 @@ _gather_35_rule(Parser *p)
         alias_ty elem;
         asdl_seq * seq;
         if (
-            (elem = dotted_as_name_rule(p))
+            (elem = dotted_as_name_rule(p))  // dotted_as_name
             &&
-            (seq = _loop0_36_rule(p))
+            (seq = _loop0_36_rule(p))  // _loop0_36
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12427,9 +12427,9 @@ _tmp_37_rule(Parser *p)
         Token * keyword;
         expr_ty z;
         if (
-            (keyword = _PyPegen_expect_token(p, 531))
+            (keyword = _PyPegen_expect_token(p, 531))  // token='as'
             &&
-            (z = _PyPegen_name_token(p))
+            (z = _PyPegen_name_token(p))  // NAME
         )
         {
             res = z;
@@ -12467,9 +12467,9 @@ _loop0_39_rule(Parser *p)
         withitem_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
         )
         {
             res = elem;
@@ -12516,9 +12516,9 @@ _gather_38_rule(Parser *p)
         withitem_ty elem;
         asdl_seq * seq;
         if (
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
             &&
-            (seq = _loop0_39_rule(p))
+            (seq = _loop0_39_rule(p))  // _loop0_39
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12552,9 +12552,9 @@ _loop0_41_rule(Parser *p)
         withitem_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
         )
         {
             res = elem;
@@ -12601,9 +12601,9 @@ _gather_40_rule(Parser *p)
         withitem_ty elem;
         asdl_seq * seq;
         if (
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
             &&
-            (seq = _loop0_41_rule(p))
+            (seq = _loop0_41_rule(p))  // _loop0_41
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12637,9 +12637,9 @@ _loop0_43_rule(Parser *p)
         withitem_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
         )
         {
             res = elem;
@@ -12686,9 +12686,9 @@ _gather_42_rule(Parser *p)
         withitem_ty elem;
         asdl_seq * seq;
         if (
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
             &&
-            (seq = _loop0_43_rule(p))
+            (seq = _loop0_43_rule(p))  // _loop0_43
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12722,9 +12722,9 @@ _loop0_45_rule(Parser *p)
         withitem_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
         )
         {
             res = elem;
@@ -12771,9 +12771,9 @@ _gather_44_rule(Parser *p)
         withitem_ty elem;
         asdl_seq * seq;
         if (
-            (elem = with_item_rule(p))
+            (elem = with_item_rule(p))  // with_item
             &&
-            (seq = _loop0_45_rule(p))
+            (seq = _loop0_45_rule(p))  // _loop0_45
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12799,9 +12799,9 @@ _tmp_46_rule(Parser *p)
         Token * keyword;
         expr_ty t;
         if (
-            (keyword = _PyPegen_expect_token(p, 531))
+            (keyword = _PyPegen_expect_token(p, 531))  // token='as'
             &&
-            (t = target_rule(p))
+            (t = target_rule(p))  // target
         )
         {
             res = t;
@@ -12838,7 +12838,7 @@ _loop1_47_rule(Parser *p)
     { // except_block
         excepthandler_ty except_block_var;
         while (
-            (except_block_var = except_block_rule(p))
+            (except_block_var = except_block_rule(p))  // except_block
         )
         {
             res = except_block_var;
@@ -12884,9 +12884,9 @@ _tmp_48_rule(Parser *p)
         Token * keyword;
         expr_ty z;
         if (
-            (keyword = _PyPegen_expect_token(p, 531))
+            (keyword = _PyPegen_expect_token(p, 531))  // token='as'
             &&
-            (z = target_rule(p))
+            (z = target_rule(p))  // target
         )
         {
             res = z;
@@ -12916,9 +12916,9 @@ _tmp_49_rule(Parser *p)
         Token * keyword;
         expr_ty z;
         if (
-            (keyword = _PyPegen_expect_token(p, 514))
+            (keyword = _PyPegen_expect_token(p, 514))  // token='from'
             &&
-            (z = expression_rule(p))
+            (z = expression_rule(p))  // expression
         )
         {
             res = z;
@@ -12948,9 +12948,9 @@ _tmp_50_rule(Parser *p)
         Token * literal;
         expr_ty z;
         if (
-            (literal = _PyPegen_expect_token(p, 51))
+            (literal = _PyPegen_expect_token(p, 51))  // token='->'
             &&
-            (z = expression_rule(p))
+            (z = expression_rule(p))  // expression
         )
         {
             res = z;
@@ -12980,9 +12980,9 @@ _tmp_51_rule(Parser *p)
         Token * literal;
         expr_ty z;
         if (
-            (literal = _PyPegen_expect_token(p, 51))
+            (literal = _PyPegen_expect_token(p, 51))  // token='->'
             &&
-            (z = expression_rule(p))
+            (z = expression_rule(p))  // expression
         )
         {
             res = z;
@@ -13012,9 +13012,9 @@ _tmp_52_rule(Parser *p)
         Token * indent_var;
         Token * newline_var;
         if (
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
             &&
-            (indent_var = _PyPegen_expect_token(p, INDENT))
+            (indent_var = _PyPegen_expect_token(p, INDENT))  // token='INDENT'
         )
         {
             res = _PyPegen_dummy_name(p, newline_var, indent_var);
@@ -13047,7 +13047,7 @@ _loop0_53_rule(Parser *p)
     { // param_no_default
         arg_ty param_no_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = param_no_default_var;
@@ -13096,7 +13096,7 @@ _loop0_54_rule(Parser *p)
     { // param_with_default
         NameDefaultPair* param_with_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))  // param_with_default
         )
         {
             res = param_with_default_var;
@@ -13145,7 +13145,7 @@ _loop0_55_rule(Parser *p)
     { // param_with_default
         NameDefaultPair* param_with_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))  // param_with_default
         )
         {
             res = param_with_default_var;
@@ -13194,7 +13194,7 @@ _loop1_56_rule(Parser *p)
     { // param_no_default
         arg_ty param_no_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = param_no_default_var;
@@ -13247,7 +13247,7 @@ _loop0_57_rule(Parser *p)
     { // param_with_default
         NameDefaultPair* param_with_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))  // param_with_default
         )
         {
             res = param_with_default_var;
@@ -13296,7 +13296,7 @@ _loop1_58_rule(Parser *p)
     { // param_with_default
         NameDefaultPair* param_with_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))  // param_with_default
         )
         {
             res = param_with_default_var;
@@ -13349,7 +13349,7 @@ _loop1_59_rule(Parser *p)
     { // param_no_default
         arg_ty param_no_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = param_no_default_var;
@@ -13402,7 +13402,7 @@ _loop1_60_rule(Parser *p)
     { // param_no_default
         arg_ty param_no_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = param_no_default_var;
@@ -13455,7 +13455,7 @@ _loop0_61_rule(Parser *p)
     { // param_no_default
         arg_ty param_no_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = param_no_default_var;
@@ -13504,7 +13504,7 @@ _loop1_62_rule(Parser *p)
     { // param_with_default
         NameDefaultPair* param_with_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))  // param_with_default
         )
         {
             res = param_with_default_var;
@@ -13557,7 +13557,7 @@ _loop0_63_rule(Parser *p)
     { // param_no_default
         arg_ty param_no_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = param_no_default_var;
@@ -13606,7 +13606,7 @@ _loop1_64_rule(Parser *p)
     { // param_with_default
         NameDefaultPair* param_with_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))  // param_with_default
         )
         {
             res = param_with_default_var;
@@ -13659,7 +13659,7 @@ _loop0_65_rule(Parser *p)
     { // param_maybe_default
         NameDefaultPair* param_maybe_default_var;
         while (
-            (param_maybe_default_var = param_maybe_default_rule(p))
+            (param_maybe_default_var = param_maybe_default_rule(p))  // param_maybe_default
         )
         {
             res = param_maybe_default_var;
@@ -13708,7 +13708,7 @@ _loop1_66_rule(Parser *p)
     { // param_maybe_default
         NameDefaultPair* param_maybe_default_var;
         while (
-            (param_maybe_default_var = param_maybe_default_rule(p))
+            (param_maybe_default_var = param_maybe_default_rule(p))  // param_maybe_default
         )
         {
             res = param_maybe_default_var;
@@ -13761,7 +13761,7 @@ _loop1_67_rule(Parser *p)
     { // ('@' named_expression NEWLINE)
         void *_tmp_137_var;
         while (
-            (_tmp_137_var = _tmp_137_rule(p))
+            (_tmp_137_var = _tmp_137_rule(p))  // '@' named_expression NEWLINE
         )
         {
             res = _tmp_137_var;
@@ -13808,11 +13808,11 @@ _tmp_68_rule(Parser *p)
         Token * literal_1;
         void *z;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (z = arguments_rule(p), 1)
+            (z = arguments_rule(p), 1)  // arguments?
             &&
-            (literal_1 = _PyPegen_expect_token(p, 8))
+            (literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = z;
@@ -13850,9 +13850,9 @@ _loop0_70_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = star_expression_rule(p))
+            (elem = star_expression_rule(p))  // star_expression
         )
         {
             res = elem;
@@ -13899,9 +13899,9 @@ _gather_69_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = star_expression_rule(p))
+            (elem = star_expression_rule(p))  // star_expression
             &&
-            (seq = _loop0_70_rule(p))
+            (seq = _loop0_70_rule(p))  // _loop0_70
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13934,7 +13934,7 @@ _loop1_71_rule(Parser *p)
     { // (',' star_expression)
         void *_tmp_138_var;
         while (
-            (_tmp_138_var = _tmp_138_rule(p))
+            (_tmp_138_var = _tmp_138_rule(p))  // ',' star_expression
         )
         {
             res = _tmp_138_var;
@@ -13988,9 +13988,9 @@ _loop0_73_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = star_named_expression_rule(p))
+            (elem = star_named_expression_rule(p))  // star_named_expression
         )
         {
             res = elem;
@@ -14037,9 +14037,9 @@ _gather_72_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = star_named_expression_rule(p))
+            (elem = star_named_expression_rule(p))  // star_named_expression
             &&
-            (seq = _loop0_73_rule(p))
+            (seq = _loop0_73_rule(p))  // _loop0_73
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14072,7 +14072,7 @@ _loop1_74_rule(Parser *p)
     { // (',' expression)
         void *_tmp_139_var;
         while (
-            (_tmp_139_var = _tmp_139_rule(p))
+            (_tmp_139_var = _tmp_139_rule(p))  // ',' expression
         )
         {
             res = _tmp_139_var;
@@ -14125,7 +14125,7 @@ _loop0_75_rule(Parser *p)
     { // lambda_param_no_default
         arg_ty lambda_param_no_default_var;
         while (
-            (lambda_param_no_default_var = lambda_param_no_default_rule(p))
+            (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
         )
         {
             res = lambda_param_no_default_var;
@@ -14174,7 +14174,7 @@ _loop0_76_rule(Parser *p)
     { // lambda_param_with_default
         NameDefaultPair* lambda_param_with_default_var;
         while (
-            (lambda_param_with_default_var = lambda_param_with_default_rule(p))
+            (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
         )
         {
             res = lambda_param_with_default_var;
@@ -14223,7 +14223,7 @@ _loop0_77_rule(Parser *p)
     { // lambda_param_with_default
         NameDefaultPair* lambda_param_with_default_var;
         while (
-            (lambda_param_with_default_var = lambda_param_with_default_rule(p))
+            (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
         )
         {
             res = lambda_param_with_default_var;
@@ -14272,7 +14272,7 @@ _loop1_78_rule(Parser *p)
     { // lambda_param_no_default
         arg_ty lambda_param_no_default_var;
         while (
-            (lambda_param_no_default_var = lambda_param_no_default_rule(p))
+            (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
         )
         {
             res = lambda_param_no_default_var;
@@ -14325,7 +14325,7 @@ _loop0_79_rule(Parser *p)
     { // lambda_param_with_default
         NameDefaultPair* lambda_param_with_default_var;
         while (
-            (lambda_param_with_default_var = lambda_param_with_default_rule(p))
+            (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
         )
         {
             res = lambda_param_with_default_var;
@@ -14374,7 +14374,7 @@ _loop1_80_rule(Parser *p)
     { // lambda_param_with_default
         NameDefaultPair* lambda_param_with_default_var;
         while (
-            (lambda_param_with_default_var = lambda_param_with_default_rule(p))
+            (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
         )
         {
             res = lambda_param_with_default_var;
@@ -14427,7 +14427,7 @@ _loop1_81_rule(Parser *p)
     { // lambda_param_no_default
         arg_ty lambda_param_no_default_var;
         while (
-            (lambda_param_no_default_var = lambda_param_no_default_rule(p))
+            (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
         )
         {
             res = lambda_param_no_default_var;
@@ -14480,7 +14480,7 @@ _loop1_82_rule(Parser *p)
     { // lambda_param_no_default
         arg_ty lambda_param_no_default_var;
         while (
-            (lambda_param_no_default_var = lambda_param_no_default_rule(p))
+            (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
         )
         {
             res = lambda_param_no_default_var;
@@ -14533,7 +14533,7 @@ _loop0_83_rule(Parser *p)
     { // lambda_param_no_default
         arg_ty lambda_param_no_default_var;
         while (
-            (lambda_param_no_default_var = lambda_param_no_default_rule(p))
+            (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
         )
         {
             res = lambda_param_no_default_var;
@@ -14582,7 +14582,7 @@ _loop1_84_rule(Parser *p)
     { // lambda_param_with_default
         NameDefaultPair* lambda_param_with_default_var;
         while (
-            (lambda_param_with_default_var = lambda_param_with_default_rule(p))
+            (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
         )
         {
             res = lambda_param_with_default_var;
@@ -14635,7 +14635,7 @@ _loop0_85_rule(Parser *p)
     { // lambda_param_no_default
         arg_ty lambda_param_no_default_var;
         while (
-            (lambda_param_no_default_var = lambda_param_no_default_rule(p))
+            (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
         )
         {
             res = lambda_param_no_default_var;
@@ -14684,7 +14684,7 @@ _loop1_86_rule(Parser *p)
     { // lambda_param_with_default
         NameDefaultPair* lambda_param_with_default_var;
         while (
-            (lambda_param_with_default_var = lambda_param_with_default_rule(p))
+            (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
         )
         {
             res = lambda_param_with_default_var;
@@ -14737,7 +14737,7 @@ _loop0_87_rule(Parser *p)
     { // lambda_param_maybe_default
         NameDefaultPair* lambda_param_maybe_default_var;
         while (
-            (lambda_param_maybe_default_var = lambda_param_maybe_default_rule(p))
+            (lambda_param_maybe_default_var = lambda_param_maybe_default_rule(p))  // lambda_param_maybe_default
         )
         {
             res = lambda_param_maybe_default_var;
@@ -14786,7 +14786,7 @@ _loop1_88_rule(Parser *p)
     { // lambda_param_maybe_default
         NameDefaultPair* lambda_param_maybe_default_var;
         while (
-            (lambda_param_maybe_default_var = lambda_param_maybe_default_rule(p))
+            (lambda_param_maybe_default_var = lambda_param_maybe_default_rule(p))  // lambda_param_maybe_default
         )
         {
             res = lambda_param_maybe_default_var;
@@ -14839,7 +14839,7 @@ _loop1_89_rule(Parser *p)
     { // ('or' conjunction)
         void *_tmp_140_var;
         while (
-            (_tmp_140_var = _tmp_140_rule(p))
+            (_tmp_140_var = _tmp_140_rule(p))  // 'or' conjunction
         )
         {
             res = _tmp_140_var;
@@ -14892,7 +14892,7 @@ _loop1_90_rule(Parser *p)
     { // ('and' inversion)
         void *_tmp_141_var;
         while (
-            (_tmp_141_var = _tmp_141_rule(p))
+            (_tmp_141_var = _tmp_141_rule(p))  // 'and' inversion
         )
         {
             res = _tmp_141_var;
@@ -14945,7 +14945,7 @@ _loop1_91_rule(Parser *p)
     { // compare_op_bitwise_or_pair
         CmpopExprPair* compare_op_bitwise_or_pair_var;
         while (
-            (compare_op_bitwise_or_pair_var = compare_op_bitwise_or_pair_rule(p))
+            (compare_op_bitwise_or_pair_var = compare_op_bitwise_or_pair_rule(p))  // compare_op_bitwise_or_pair
         )
         {
             res = compare_op_bitwise_or_pair_var;
@@ -14990,7 +14990,7 @@ _tmp_92_rule(Parser *p)
     { // '!='
         Token * tok;
         if (
-            (tok = _PyPegen_expect_token(p, 28))
+            (tok = _PyPegen_expect_token(p, 28))  // token='!='
         )
         {
             res = _PyPegen_check_barry_as_flufl ( p ) ? NULL : tok;
@@ -15028,9 +15028,9 @@ _loop0_94_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = slice_rule(p))
+            (elem = slice_rule(p))  // slice
         )
         {
             res = elem;
@@ -15077,9 +15077,9 @@ _gather_93_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = slice_rule(p))
+            (elem = slice_rule(p))  // slice
             &&
-            (seq = _loop0_94_rule(p))
+            (seq = _loop0_94_rule(p))  // _loop0_94
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15105,9 +15105,9 @@ _tmp_95_rule(Parser *p)
         void *d;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
-            (d = expression_rule(p), 1)
+            (d = expression_rule(p), 1)  // expression?
         )
         {
             res = d;
@@ -15136,7 +15136,7 @@ _tmp_96_rule(Parser *p)
     { // tuple
         expr_ty tuple_var;
         if (
-            (tuple_var = tuple_rule(p))
+            (tuple_var = tuple_rule(p))  // tuple
         )
         {
             res = tuple_var;
@@ -15147,7 +15147,7 @@ _tmp_96_rule(Parser *p)
     { // group
         expr_ty group_var;
         if (
-            (group_var = group_rule(p))
+            (group_var = group_rule(p))  // group
         )
         {
             res = group_var;
@@ -15158,7 +15158,7 @@ _tmp_96_rule(Parser *p)
     { // genexp
         expr_ty genexp_var;
         if (
-            (genexp_var = genexp_rule(p))
+            (genexp_var = genexp_rule(p))  // genexp
         )
         {
             res = genexp_var;
@@ -15183,7 +15183,7 @@ _tmp_97_rule(Parser *p)
     { // list
         expr_ty list_var;
         if (
-            (list_var = list_rule(p))
+            (list_var = list_rule(p))  // list
         )
         {
             res = list_var;
@@ -15194,7 +15194,7 @@ _tmp_97_rule(Parser *p)
     { // listcomp
         expr_ty listcomp_var;
         if (
-            (listcomp_var = listcomp_rule(p))
+            (listcomp_var = listcomp_rule(p))  // listcomp
         )
         {
             res = listcomp_var;
@@ -15219,7 +15219,7 @@ _tmp_98_rule(Parser *p)
     { // dict
         expr_ty dict_var;
         if (
-            (dict_var = dict_rule(p))
+            (dict_var = dict_rule(p))  // dict
         )
         {
             res = dict_var;
@@ -15230,7 +15230,7 @@ _tmp_98_rule(Parser *p)
     { // set
         expr_ty set_var;
         if (
-            (set_var = set_rule(p))
+            (set_var = set_rule(p))  // set
         )
         {
             res = set_var;
@@ -15241,7 +15241,7 @@ _tmp_98_rule(Parser *p)
     { // dictcomp
         expr_ty dictcomp_var;
         if (
-            (dictcomp_var = dictcomp_rule(p))
+            (dictcomp_var = dictcomp_rule(p))  // dictcomp
         )
         {
             res = dictcomp_var;
@@ -15252,7 +15252,7 @@ _tmp_98_rule(Parser *p)
     { // setcomp
         expr_ty setcomp_var;
         if (
-            (setcomp_var = setcomp_rule(p))
+            (setcomp_var = setcomp_rule(p))  // setcomp
         )
         {
             res = setcomp_var;
@@ -15285,7 +15285,7 @@ _loop1_99_rule(Parser *p)
     { // STRING
         expr_ty string_var;
         while (
-            (string_var = _PyPegen_string_token(p))
+            (string_var = _PyPegen_string_token(p))  // STRING
         )
         {
             res = string_var;
@@ -15332,11 +15332,11 @@ _tmp_100_rule(Parser *p)
         expr_ty y;
         void *z;
         if (
-            (y = star_named_expression_rule(p))
+            (y = star_named_expression_rule(p))  // star_named_expression
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (z = star_named_expressions_rule(p), 1)
+            (z = star_named_expressions_rule(p), 1)  // star_named_expressions?
         )
         {
             res = _PyPegen_seq_insert_in_front ( p , y , z );
@@ -15365,7 +15365,7 @@ _tmp_101_rule(Parser *p)
     { // yield_expr
         expr_ty yield_expr_var;
         if (
-            (yield_expr_var = yield_expr_rule(p))
+            (yield_expr_var = yield_expr_rule(p))  // yield_expr
         )
         {
             res = yield_expr_var;
@@ -15376,7 +15376,7 @@ _tmp_101_rule(Parser *p)
     { // named_expression
         expr_ty named_expression_var;
         if (
-            (named_expression_var = named_expression_rule(p))
+            (named_expression_var = named_expression_rule(p))  // named_expression
         )
         {
             res = named_expression_var;
@@ -15410,9 +15410,9 @@ _loop0_103_rule(Parser *p)
         KeyValuePair* elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = kvpair_rule(p))
+            (elem = kvpair_rule(p))  // kvpair
         )
         {
             res = elem;
@@ -15459,9 +15459,9 @@ _gather_102_rule(Parser *p)
         KeyValuePair* elem;
         asdl_seq * seq;
         if (
-            (elem = kvpair_rule(p))
+            (elem = kvpair_rule(p))  // kvpair
             &&
-            (seq = _loop0_103_rule(p))
+            (seq = _loop0_103_rule(p))  // _loop0_103
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15494,7 +15494,7 @@ _loop1_104_rule(Parser *p)
     { // for_if_clause
         comprehension_ty for_if_clause_var;
         while (
-            (for_if_clause_var = for_if_clause_rule(p))
+            (for_if_clause_var = for_if_clause_rule(p))  // for_if_clause
         )
         {
             res = for_if_clause_var;
@@ -15547,7 +15547,7 @@ _loop0_105_rule(Parser *p)
     { // ('if' disjunction)
         void *_tmp_142_var;
         while (
-            (_tmp_142_var = _tmp_142_rule(p))
+            (_tmp_142_var = _tmp_142_rule(p))  // 'if' disjunction
         )
         {
             res = _tmp_142_var;
@@ -15596,7 +15596,7 @@ _loop0_106_rule(Parser *p)
     { // ('if' disjunction)
         void *_tmp_143_var;
         while (
-            (_tmp_143_var = _tmp_143_rule(p))
+            (_tmp_143_var = _tmp_143_rule(p))  // 'if' disjunction
         )
         {
             res = _tmp_143_var;
@@ -15638,9 +15638,9 @@ _tmp_107_rule(Parser *p)
         expr_ty c;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (c = args_rule(p))
+            (c = args_rule(p))  // args
         )
         {
             res = c;
@@ -15670,9 +15670,9 @@ _tmp_108_rule(Parser *p)
         expr_ty c;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (c = args_rule(p))
+            (c = args_rule(p))  // args
         )
         {
             res = c;
@@ -15710,9 +15710,9 @@ _loop0_110_rule(Parser *p)
         KeywordOrStarred* elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = kwarg_or_starred_rule(p))
+            (elem = kwarg_or_starred_rule(p))  // kwarg_or_starred
         )
         {
             res = elem;
@@ -15759,9 +15759,9 @@ _gather_109_rule(Parser *p)
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
-            (elem = kwarg_or_starred_rule(p))
+            (elem = kwarg_or_starred_rule(p))  // kwarg_or_starred
             &&
-            (seq = _loop0_110_rule(p))
+            (seq = _loop0_110_rule(p))  // _loop0_110
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15795,9 +15795,9 @@ _loop0_112_rule(Parser *p)
         KeywordOrStarred* elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = kwarg_or_double_starred_rule(p))
+            (elem = kwarg_or_double_starred_rule(p))  // kwarg_or_double_starred
         )
         {
             res = elem;
@@ -15844,9 +15844,9 @@ _gather_111_rule(Parser *p)
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
-            (elem = kwarg_or_double_starred_rule(p))
+            (elem = kwarg_or_double_starred_rule(p))  // kwarg_or_double_starred
             &&
-            (seq = _loop0_112_rule(p))
+            (seq = _loop0_112_rule(p))  // _loop0_112
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15880,9 +15880,9 @@ _loop0_114_rule(Parser *p)
         KeywordOrStarred* elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = kwarg_or_starred_rule(p))
+            (elem = kwarg_or_starred_rule(p))  // kwarg_or_starred
         )
         {
             res = elem;
@@ -15929,9 +15929,9 @@ _gather_113_rule(Parser *p)
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
-            (elem = kwarg_or_starred_rule(p))
+            (elem = kwarg_or_starred_rule(p))  // kwarg_or_starred
             &&
-            (seq = _loop0_114_rule(p))
+            (seq = _loop0_114_rule(p))  // _loop0_114
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15965,9 +15965,9 @@ _loop0_116_rule(Parser *p)
         KeywordOrStarred* elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = kwarg_or_double_starred_rule(p))
+            (elem = kwarg_or_double_starred_rule(p))  // kwarg_or_double_starred
         )
         {
             res = elem;
@@ -16014,9 +16014,9 @@ _gather_115_rule(Parser *p)
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
-            (elem = kwarg_or_double_starred_rule(p))
+            (elem = kwarg_or_double_starred_rule(p))  // kwarg_or_double_starred
             &&
-            (seq = _loop0_116_rule(p))
+            (seq = _loop0_116_rule(p))  // _loop0_116
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -16049,7 +16049,7 @@ _loop0_117_rule(Parser *p)
     { // (',' star_target)
         void *_tmp_144_var;
         while (
-            (_tmp_144_var = _tmp_144_rule(p))
+            (_tmp_144_var = _tmp_144_rule(p))  // ',' star_target
         )
         {
             res = _tmp_144_var;
@@ -16099,9 +16099,9 @@ _loop0_119_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = star_target_rule(p))
+            (elem = star_target_rule(p))  // star_target
         )
         {
             res = elem;
@@ -16148,9 +16148,9 @@ _gather_118_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = star_target_rule(p))
+            (elem = star_target_rule(p))  // star_target
             &&
-            (seq = _loop0_119_rule(p))
+            (seq = _loop0_119_rule(p))  // _loop0_119
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -16175,9 +16175,9 @@ _tmp_120_rule(Parser *p)
     { // !'*' star_target
         expr_ty star_target_var;
         if (
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 16)
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 16)  // token='*'
             &&
-            (star_target_var = star_target_rule(p))
+            (star_target_var = star_target_rule(p))  // star_target
         )
         {
             res = star_target_var;
@@ -16211,9 +16211,9 @@ _loop0_122_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = del_target_rule(p))
+            (elem = del_target_rule(p))  // del_target
         )
         {
             res = elem;
@@ -16260,9 +16260,9 @@ _gather_121_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = del_target_rule(p))
+            (elem = del_target_rule(p))  // del_target
             &&
-            (seq = _loop0_122_rule(p))
+            (seq = _loop0_122_rule(p))  // _loop0_122
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -16296,9 +16296,9 @@ _loop0_124_rule(Parser *p)
         expr_ty elem;
         Token * literal;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (elem = target_rule(p))
+            (elem = target_rule(p))  // target
         )
         {
             res = elem;
@@ -16345,9 +16345,9 @@ _gather_123_rule(Parser *p)
         expr_ty elem;
         asdl_seq * seq;
         if (
-            (elem = target_rule(p))
+            (elem = target_rule(p))  // target
             &&
-            (seq = _loop0_124_rule(p))
+            (seq = _loop0_124_rule(p))  // _loop0_124
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -16372,7 +16372,7 @@ _tmp_125_rule(Parser *p)
     { // args
         expr_ty args_var;
         if (
-            (args_var = args_rule(p))
+            (args_var = args_rule(p))  // args
         )
         {
             res = args_var;
@@ -16384,9 +16384,9 @@ _tmp_125_rule(Parser *p)
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
         if (
-            (expression_var = expression_rule(p))
+            (expression_var = expression_rule(p))  // expression
             &&
-            (for_if_clauses_var = for_if_clauses_rule(p))
+            (for_if_clauses_var = for_if_clauses_rule(p))  // for_if_clauses
         )
         {
             res = _PyPegen_dummy_name(p, expression_var, for_if_clauses_var);
@@ -16412,9 +16412,9 @@ _tmp_126_rule(Parser *p)
         expr_ty annotated_rhs_var;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
             &&
-            (annotated_rhs_var = annotated_rhs_rule(p))
+            (annotated_rhs_var = annotated_rhs_rule(p))  // annotated_rhs
         )
         {
             res = _PyPegen_dummy_name(p, literal, annotated_rhs_var);
@@ -16439,7 +16439,7 @@ _tmp_127_rule(Parser *p)
     { // '='
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
         )
         {
             res = literal;
@@ -16450,7 +16450,7 @@ _tmp_127_rule(Parser *p)
     { // augassign
         AugOperator* augassign_var;
         if (
-            (augassign_var = augassign_rule(p))
+            (augassign_var = augassign_rule(p))  // augassign
         )
         {
             res = augassign_var;
@@ -16475,7 +16475,7 @@ _tmp_128_rule(Parser *p)
     { // yield_expr
         expr_ty yield_expr_var;
         if (
-            (yield_expr_var = yield_expr_rule(p))
+            (yield_expr_var = yield_expr_rule(p))  // yield_expr
         )
         {
             res = yield_expr_var;
@@ -16486,7 +16486,7 @@ _tmp_128_rule(Parser *p)
     { // star_expressions
         expr_ty star_expressions_var;
         if (
-            (star_expressions_var = star_expressions_rule(p))
+            (star_expressions_var = star_expressions_rule(p))  // star_expressions
         )
         {
             res = star_expressions_var;
@@ -16511,7 +16511,7 @@ _tmp_129_rule(Parser *p)
     { // '['
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 9))
+            (literal = _PyPegen_expect_token(p, 9))  // token='['
         )
         {
             res = literal;
@@ -16522,7 +16522,7 @@ _tmp_129_rule(Parser *p)
     { // '('
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 7))
+            (literal = _PyPegen_expect_token(p, 7))  // token='('
         )
         {
             res = literal;
@@ -16533,7 +16533,7 @@ _tmp_129_rule(Parser *p)
     { // '{'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 25))
+            (literal = _PyPegen_expect_token(p, 25))  // token='{'
         )
         {
             res = literal;
@@ -16566,7 +16566,7 @@ _loop0_130_rule(Parser *p)
     { // param_no_default
         arg_ty param_no_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))  // param_no_default
         )
         {
             res = param_no_default_var;
@@ -16607,7 +16607,7 @@ _tmp_131_rule(Parser *p)
     { // slash_with_default
         SlashWithDefault* slash_with_default_var;
         if (
-            (slash_with_default_var = slash_with_default_rule(p))
+            (slash_with_default_var = slash_with_default_rule(p))  // slash_with_default
         )
         {
             res = slash_with_default_var;
@@ -16618,7 +16618,7 @@ _tmp_131_rule(Parser *p)
     { // param_with_default+
         asdl_seq * _loop1_145_var;
         if (
-            (_loop1_145_var = _loop1_145_rule(p))
+            (_loop1_145_var = _loop1_145_rule(p))  // param_with_default+
         )
         {
             res = _loop1_145_var;
@@ -16643,7 +16643,7 @@ _tmp_132_rule(Parser *p)
     { // ')'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 8))
+            (literal = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = literal;
@@ -16655,9 +16655,9 @@ _tmp_132_rule(Parser *p)
         void *_tmp_146_var;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (_tmp_146_var = _tmp_146_rule(p))
+            (_tmp_146_var = _tmp_146_rule(p))  // ')' | '**'
         )
         {
             res = _PyPegen_dummy_name(p, literal, _tmp_146_var);
@@ -16682,7 +16682,7 @@ _tmp_133_rule(Parser *p)
     { // ':'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
         )
         {
             res = literal;
@@ -16694,9 +16694,9 @@ _tmp_133_rule(Parser *p)
         void *_tmp_147_var;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (_tmp_147_var = _tmp_147_rule(p))
+            (_tmp_147_var = _tmp_147_rule(p))  // ':' | '**'
         )
         {
             res = _PyPegen_dummy_name(p, literal, _tmp_147_var);
@@ -16722,9 +16722,9 @@ _tmp_134_rule(Parser *p)
         Token * literal;
         expr_ty z;
         if (
-            (z = star_targets_rule(p))
+            (z = star_targets_rule(p))  // star_targets
             &&
-            (literal = _PyPegen_expect_token(p, 22))
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
         )
         {
             res = z;
@@ -16753,7 +16753,7 @@ _tmp_135_rule(Parser *p)
     { // '.'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
         )
         {
             res = literal;
@@ -16764,7 +16764,7 @@ _tmp_135_rule(Parser *p)
     { // '...'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 52))
+            (literal = _PyPegen_expect_token(p, 52))  // token='...'
         )
         {
             res = literal;
@@ -16789,7 +16789,7 @@ _tmp_136_rule(Parser *p)
     { // '.'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 23))
+            (literal = _PyPegen_expect_token(p, 23))  // token='.'
         )
         {
             res = literal;
@@ -16800,7 +16800,7 @@ _tmp_136_rule(Parser *p)
     { // '...'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 52))
+            (literal = _PyPegen_expect_token(p, 52))  // token='...'
         )
         {
             res = literal;
@@ -16827,11 +16827,11 @@ _tmp_137_rule(Parser *p)
         Token * literal;
         Token * newline_var;
         if (
-            (literal = _PyPegen_expect_token(p, 49))
+            (literal = _PyPegen_expect_token(p, 49))  // token='@'
             &&
-            (f = named_expression_rule(p))
+            (f = named_expression_rule(p))  // named_expression
             &&
-            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
             res = f;
@@ -16861,9 +16861,9 @@ _tmp_138_rule(Parser *p)
         expr_ty c;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (c = star_expression_rule(p))
+            (c = star_expression_rule(p))  // star_expression
         )
         {
             res = c;
@@ -16893,9 +16893,9 @@ _tmp_139_rule(Parser *p)
         expr_ty c;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (c = expression_rule(p))
+            (c = expression_rule(p))  // expression
         )
         {
             res = c;
@@ -16925,9 +16925,9 @@ _tmp_140_rule(Parser *p)
         expr_ty c;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 532))
+            (keyword = _PyPegen_expect_token(p, 532))  // token='or'
             &&
-            (c = conjunction_rule(p))
+            (c = conjunction_rule(p))  // conjunction
         )
         {
             res = c;
@@ -16957,9 +16957,9 @@ _tmp_141_rule(Parser *p)
         expr_ty c;
         Token * keyword;
         if (
-            (keyword = _PyPegen_expect_token(p, 533))
+            (keyword = _PyPegen_expect_token(p, 533))  // token='and'
             &&
-            (c = inversion_rule(p))
+            (c = inversion_rule(p))  // inversion
         )
         {
             res = c;
@@ -16989,9 +16989,9 @@ _tmp_142_rule(Parser *p)
         Token * keyword;
         expr_ty z;
         if (
-            (keyword = _PyPegen_expect_token(p, 510))
+            (keyword = _PyPegen_expect_token(p, 510))  // token='if'
             &&
-            (z = disjunction_rule(p))
+            (z = disjunction_rule(p))  // disjunction
         )
         {
             res = z;
@@ -17021,9 +17021,9 @@ _tmp_143_rule(Parser *p)
         Token * keyword;
         expr_ty z;
         if (
-            (keyword = _PyPegen_expect_token(p, 510))
+            (keyword = _PyPegen_expect_token(p, 510))  // token='if'
             &&
-            (z = disjunction_rule(p))
+            (z = disjunction_rule(p))  // disjunction
         )
         {
             res = z;
@@ -17053,9 +17053,9 @@ _tmp_144_rule(Parser *p)
         expr_ty c;
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (c = star_target_rule(p))
+            (c = star_target_rule(p))  // star_target
         )
         {
             res = c;
@@ -17092,7 +17092,7 @@ _loop1_145_rule(Parser *p)
     { // param_with_default
         NameDefaultPair* param_with_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))  // param_with_default
         )
         {
             res = param_with_default_var;
@@ -17137,7 +17137,7 @@ _tmp_146_rule(Parser *p)
     { // ')'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 8))
+            (literal = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
             res = literal;
@@ -17148,7 +17148,7 @@ _tmp_146_rule(Parser *p)
     { // '**'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
         )
         {
             res = literal;
@@ -17173,7 +17173,7 @@ _tmp_147_rule(Parser *p)
     { // ':'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 11))
+            (literal = _PyPegen_expect_token(p, 11))  // token=':'
         )
         {
             res = literal;
@@ -17184,7 +17184,7 @@ _tmp_147_rule(Parser *p)
     { // '**'
         Token * literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 35))  // token='**'
         )
         {
             res = literal;

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -68,6 +68,7 @@ class FunctionCall:
     return_type: Optional[str] = None
     nodetype: Optional[NodeTypes] = None
     force_true: bool = False
+    comment: Optional[str] = None
 
     def __str__(self) -> str:
         parts = []
@@ -78,6 +79,8 @@ class FunctionCall:
             parts.append(", 1")
         if self.assigned_variable:
             parts = ["(", self.assigned_variable, " = ", *parts, ")"]
+        if self.comment:
+            parts.append(f"  // {self.comment}")
         return "".join(parts)
 
 
@@ -103,6 +106,7 @@ class CCallMakerVisitor(GrammarVisitor):
             arguments=["p", self.keyword_cache[keyword]],
             return_type="Token *",
             nodetype=NodeTypes.KEYWORD,
+            comment=f"token='{keyword}'",
         )
 
     def visit_NameLeaf(self, node: NameLeaf) -> FunctionCall:
@@ -115,6 +119,7 @@ class CCallMakerVisitor(GrammarVisitor):
                     arguments=["p"],
                     nodetype=BASE_NODETYPES[name],
                     return_type="expr_ty",
+                    comment=name,
                 )
             return FunctionCall(
                 assigned_variable=f"{name.lower()}_var",
@@ -122,6 +127,7 @@ class CCallMakerVisitor(GrammarVisitor):
                 arguments=["p", name],
                 nodetype=NodeTypes.GENERIC_TOKEN,
                 return_type="Token *",
+                comment=f"token='{name}'",
             )
 
         type = None
@@ -134,6 +140,7 @@ class CCallMakerVisitor(GrammarVisitor):
             function=f"{name}_rule",
             arguments=["p"],
             return_type=type,
+            comment=f"{node}"
         )
 
     def visit_StringLeaf(self, node: StringLeaf) -> FunctionCall:
@@ -149,6 +156,7 @@ class CCallMakerVisitor(GrammarVisitor):
                 arguments=["p", type],
                 nodetype=NodeTypes.GENERIC_TOKEN,
                 return_type="Token *",
+                comment=f"token='{val}'",
             )
 
     def visit_Rhs(self, node: Rhs) -> FunctionCall:
@@ -168,6 +176,7 @@ class CCallMakerVisitor(GrammarVisitor):
             name = self.gen.name_node(node)
             self.cache[node] = FunctionCall(
                 assigned_variable=f"{name}_var", function=f"{name}_rule", arguments=["p"],
+                comment=f"{node}"
             )
         return self.cache[node]
 
@@ -190,6 +199,7 @@ class CCallMakerVisitor(GrammarVisitor):
                 function=f"_PyPegen_lookahead_with_int",
                 arguments=[positive, call.function, *call.arguments],
                 return_type="int",
+                comment=f"token={node.node}",
             )
         else:
             return FunctionCall(
@@ -211,6 +221,7 @@ class CCallMakerVisitor(GrammarVisitor):
             function=call.function,
             arguments=call.arguments,
             force_true=True,
+            comment=f"{node}"
         )
 
     def visit_Repeat0(self, node: Repeat0) -> FunctionCall:
@@ -222,6 +233,7 @@ class CCallMakerVisitor(GrammarVisitor):
             function=f"{name}_rule",
             arguments=["p"],
             return_type="asdl_seq *",
+            comment=f"{node}",
         )
         return self.cache[node]
 
@@ -234,6 +246,7 @@ class CCallMakerVisitor(GrammarVisitor):
             function=f"{name}_rule",
             arguments=["p"],
             return_type="asdl_seq *",
+            comment=f"{node}",
         )
         return self.cache[node]
 
@@ -246,6 +259,7 @@ class CCallMakerVisitor(GrammarVisitor):
             function=f"{name}_rule",
             arguments=["p"],
             return_type="asdl_seq *",
+            comment=f"{node}",
         )
         return self.cache[node]
 


### PR DESCRIPTION
I missed these comments when debugging recently (especially useful in the temporary rules) :)

Check the generate code in the diff to see how they look like.

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
