### PR TITLE
bpo-40334: Error message for invalid default args in function call

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -548,10 +548,12 @@ kwarg_or_starred[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
         _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
     | a=starred_expression { _PyPegen_keyword_or_starred(p, a, 0) }
+    | invalid_kwarg
 kwarg_or_double_starred[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
         _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
     | '**' a=expression { _PyPegen_keyword_or_starred(p, CHECK(_Py_keyword(NULL, a, EXTRA)), 1) }
+    | invalid_kwarg
 
 # NOTE: star_targets may contain *bitwise_or, targets may not.
 star_targets[expr_ty]:
@@ -620,6 +622,8 @@ incorrect_arguments:
     | expression for_if_clauses ',' [args | expression for_if_clauses] {
         RAISE_SYNTAX_ERROR("Generator expression must be parenthesized") }
     | a=args ',' args { _PyPegen_arguments_parsing_error(p, a) }
+invalid_kwarg:
+    | expression '=' { RAISE_SYNTAX_ERROR("expression cannot contain assignment, perhaps you meant \"==\"?") }
 invalid_named_expression:
     | a=expression ':=' expression {
         RAISE_SYNTAX_ERROR("cannot use assignment expressions with %s", _PyPegen_get_expr_name(a)) }

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -242,16 +242,16 @@ class ExceptionTests(unittest.TestCase):
         check('from __future__ import doesnt_exist', 1, 1)
         check('from __future__ import braces', 1, 1)
         check('x=1\nfrom __future__ import division', 2, 1)
+        check('(yield i) = 2', 1, 1)
         check('def f(*):\n  pass', 1, 7 if support.use_old_parser() else 8)
+        check('foo(1=2)', 1, 5 if support.use_old_parser() else 6)
 
     @support.skip_if_new_parser("Pegen column offsets might be different")
     def testSyntaxErrorOffsetCustom(self):
         self.check('for 1 in []: pass', 1, 5)
         self.check('[*x for x in xs]', 1, 2)
         self.check('def f():\n  x, y: int', 2, 3)
-        self.check('(yield i) = 2', 1, 1)
         self.check('foo(x for x in range(10), 100)', 1, 5)
-        self.check('foo(1=2)', 1, 5)
 
     @cpython_only
     def testSettingException(self):

--- a/Lib/test/test_peg_parser.py
+++ b/Lib/test/test_peg_parser.py
@@ -609,6 +609,9 @@ FAIL_SPECIALIZED_MESSAGE_CASES = [
     ("lambda *: pass", "named arguments must follow bare *"),
     ("lambda *,: pass", "named arguments must follow bare *"),
     ("lambda *, **a: pass", "named arguments must follow bare *"),
+    ("f(g()=2", "expression cannot contain assignment, perhaps you meant \"==\"?"),
+    ("f(a, b, *c, d.e=2", "expression cannot contain assignment, perhaps you meant \"==\"?"),
+    ("f(*a, **b, c=0, d[1]=3)", "expression cannot contain assignment, perhaps you meant \"==\"?"),
 ]
 
 GOOD_BUT_FAIL_TEST_CASES = [

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -210,161 +210,162 @@ static KeywordToken *reserved_keywords[] = {
 #define t_lookahead_type 1139
 #define t_atom_type 1140
 #define incorrect_arguments_type 1141
-#define invalid_named_expression_type 1142
-#define invalid_assignment_type 1143
-#define invalid_block_type 1144
-#define invalid_comprehension_type 1145
-#define invalid_parameters_type 1146
-#define invalid_star_etc_type 1147
-#define invalid_lambda_star_etc_type 1148
-#define invalid_double_type_comments_type 1149
-#define _loop0_1_type 1150
-#define _loop0_2_type 1151
-#define _loop0_4_type 1152
-#define _gather_3_type 1153
-#define _loop0_6_type 1154
-#define _gather_5_type 1155
-#define _loop0_8_type 1156
-#define _gather_7_type 1157
-#define _loop0_10_type 1158
-#define _gather_9_type 1159
-#define _loop1_11_type 1160
-#define _loop0_13_type 1161
-#define _gather_12_type 1162
-#define _tmp_14_type 1163
-#define _tmp_15_type 1164
-#define _tmp_16_type 1165
-#define _tmp_17_type 1166
-#define _tmp_18_type 1167
-#define _tmp_19_type 1168
-#define _tmp_20_type 1169
-#define _tmp_21_type 1170
-#define _loop1_22_type 1171
-#define _tmp_23_type 1172
-#define _tmp_24_type 1173
-#define _loop0_26_type 1174
-#define _gather_25_type 1175
-#define _loop0_28_type 1176
-#define _gather_27_type 1177
-#define _tmp_29_type 1178
-#define _loop0_30_type 1179
-#define _loop1_31_type 1180
-#define _loop0_33_type 1181
-#define _gather_32_type 1182
-#define _tmp_34_type 1183
-#define _loop0_36_type 1184
-#define _gather_35_type 1185
-#define _tmp_37_type 1186
-#define _loop0_39_type 1187
-#define _gather_38_type 1188
-#define _loop0_41_type 1189
-#define _gather_40_type 1190
-#define _loop0_43_type 1191
-#define _gather_42_type 1192
-#define _loop0_45_type 1193
-#define _gather_44_type 1194
-#define _tmp_46_type 1195
-#define _loop1_47_type 1196
-#define _tmp_48_type 1197
-#define _tmp_49_type 1198
-#define _tmp_50_type 1199
-#define _tmp_51_type 1200
-#define _tmp_52_type 1201
-#define _loop0_53_type 1202
-#define _loop0_54_type 1203
-#define _loop0_55_type 1204
-#define _loop1_56_type 1205
-#define _loop0_57_type 1206
-#define _loop1_58_type 1207
-#define _loop1_59_type 1208
-#define _loop1_60_type 1209
-#define _loop0_61_type 1210
-#define _loop1_62_type 1211
-#define _loop0_63_type 1212
-#define _loop1_64_type 1213
-#define _loop0_65_type 1214
-#define _loop1_66_type 1215
-#define _loop1_67_type 1216
-#define _tmp_68_type 1217
-#define _loop0_70_type 1218
-#define _gather_69_type 1219
-#define _loop1_71_type 1220
-#define _loop0_73_type 1221
-#define _gather_72_type 1222
-#define _loop1_74_type 1223
-#define _loop0_75_type 1224
-#define _loop0_76_type 1225
-#define _loop0_77_type 1226
-#define _loop1_78_type 1227
-#define _loop0_79_type 1228
-#define _loop1_80_type 1229
-#define _loop1_81_type 1230
-#define _loop1_82_type 1231
-#define _loop0_83_type 1232
-#define _loop1_84_type 1233
-#define _loop0_85_type 1234
-#define _loop1_86_type 1235
-#define _loop0_87_type 1236
-#define _loop1_88_type 1237
-#define _loop1_89_type 1238
-#define _loop1_90_type 1239
-#define _loop1_91_type 1240
-#define _tmp_92_type 1241
-#define _loop0_94_type 1242
-#define _gather_93_type 1243
-#define _tmp_95_type 1244
-#define _tmp_96_type 1245
-#define _tmp_97_type 1246
-#define _tmp_98_type 1247
-#define _loop1_99_type 1248
-#define _tmp_100_type 1249
-#define _tmp_101_type 1250
-#define _loop0_103_type 1251
-#define _gather_102_type 1252
-#define _loop1_104_type 1253
-#define _loop0_105_type 1254
-#define _loop0_106_type 1255
-#define _tmp_107_type 1256
-#define _tmp_108_type 1257
-#define _loop0_110_type 1258
-#define _gather_109_type 1259
-#define _loop0_112_type 1260
-#define _gather_111_type 1261
-#define _loop0_114_type 1262
-#define _gather_113_type 1263
-#define _loop0_116_type 1264
-#define _gather_115_type 1265
-#define _loop0_117_type 1266
-#define _loop0_119_type 1267
-#define _gather_118_type 1268
-#define _tmp_120_type 1269
-#define _loop0_122_type 1270
-#define _gather_121_type 1271
-#define _loop0_124_type 1272
-#define _gather_123_type 1273
-#define _tmp_125_type 1274
-#define _tmp_126_type 1275
-#define _tmp_127_type 1276
-#define _tmp_128_type 1277
-#define _tmp_129_type 1278
-#define _loop0_130_type 1279
-#define _tmp_131_type 1280
-#define _tmp_132_type 1281
-#define _tmp_133_type 1282
-#define _tmp_134_type 1283
-#define _tmp_135_type 1284
-#define _tmp_136_type 1285
-#define _tmp_137_type 1286
-#define _tmp_138_type 1287
-#define _tmp_139_type 1288
-#define _tmp_140_type 1289
-#define _tmp_141_type 1290
-#define _tmp_142_type 1291
-#define _tmp_143_type 1292
-#define _tmp_144_type 1293
-#define _loop1_145_type 1294
-#define _tmp_146_type 1295
-#define _tmp_147_type 1296
+#define invalid_kwarg_type 1142
+#define invalid_named_expression_type 1143
+#define invalid_assignment_type 1144
+#define invalid_block_type 1145
+#define invalid_comprehension_type 1146
+#define invalid_parameters_type 1147
+#define invalid_star_etc_type 1148
+#define invalid_lambda_star_etc_type 1149
+#define invalid_double_type_comments_type 1150
+#define _loop0_1_type 1151
+#define _loop0_2_type 1152
+#define _loop0_4_type 1153
+#define _gather_3_type 1154
+#define _loop0_6_type 1155
+#define _gather_5_type 1156
+#define _loop0_8_type 1157
+#define _gather_7_type 1158
+#define _loop0_10_type 1159
+#define _gather_9_type 1160
+#define _loop1_11_type 1161
+#define _loop0_13_type 1162
+#define _gather_12_type 1163
+#define _tmp_14_type 1164
+#define _tmp_15_type 1165
+#define _tmp_16_type 1166
+#define _tmp_17_type 1167
+#define _tmp_18_type 1168
+#define _tmp_19_type 1169
+#define _tmp_20_type 1170
+#define _tmp_21_type 1171
+#define _loop1_22_type 1172
+#define _tmp_23_type 1173
+#define _tmp_24_type 1174
+#define _loop0_26_type 1175
+#define _gather_25_type 1176
+#define _loop0_28_type 1177
+#define _gather_27_type 1178
+#define _tmp_29_type 1179
+#define _loop0_30_type 1180
+#define _loop1_31_type 1181
+#define _loop0_33_type 1182
+#define _gather_32_type 1183
+#define _tmp_34_type 1184
+#define _loop0_36_type 1185
+#define _gather_35_type 1186
+#define _tmp_37_type 1187
+#define _loop0_39_type 1188
+#define _gather_38_type 1189
+#define _loop0_41_type 1190
+#define _gather_40_type 1191
+#define _loop0_43_type 1192
+#define _gather_42_type 1193
+#define _loop0_45_type 1194
+#define _gather_44_type 1195
+#define _tmp_46_type 1196
+#define _loop1_47_type 1197
+#define _tmp_48_type 1198
+#define _tmp_49_type 1199
+#define _tmp_50_type 1200
+#define _tmp_51_type 1201
+#define _tmp_52_type 1202
+#define _loop0_53_type 1203
+#define _loop0_54_type 1204
+#define _loop0_55_type 1205
+#define _loop1_56_type 1206
+#define _loop0_57_type 1207
+#define _loop1_58_type 1208
+#define _loop1_59_type 1209
+#define _loop1_60_type 1210
+#define _loop0_61_type 1211
+#define _loop1_62_type 1212
+#define _loop0_63_type 1213
+#define _loop1_64_type 1214
+#define _loop0_65_type 1215
+#define _loop1_66_type 1216
+#define _loop1_67_type 1217
+#define _tmp_68_type 1218
+#define _loop0_70_type 1219
+#define _gather_69_type 1220
+#define _loop1_71_type 1221
+#define _loop0_73_type 1222
+#define _gather_72_type 1223
+#define _loop1_74_type 1224
+#define _loop0_75_type 1225
+#define _loop0_76_type 1226
+#define _loop0_77_type 1227
+#define _loop1_78_type 1228
+#define _loop0_79_type 1229
+#define _loop1_80_type 1230
+#define _loop1_81_type 1231
+#define _loop1_82_type 1232
+#define _loop0_83_type 1233
+#define _loop1_84_type 1234
+#define _loop0_85_type 1235
+#define _loop1_86_type 1236
+#define _loop0_87_type 1237
+#define _loop1_88_type 1238
+#define _loop1_89_type 1239
+#define _loop1_90_type 1240
+#define _loop1_91_type 1241
+#define _tmp_92_type 1242
+#define _loop0_94_type 1243
+#define _gather_93_type 1244
+#define _tmp_95_type 1245
+#define _tmp_96_type 1246
+#define _tmp_97_type 1247
+#define _tmp_98_type 1248
+#define _loop1_99_type 1249
+#define _tmp_100_type 1250
+#define _tmp_101_type 1251
+#define _loop0_103_type 1252
+#define _gather_102_type 1253
+#define _loop1_104_type 1254
+#define _loop0_105_type 1255
+#define _loop0_106_type 1256
+#define _tmp_107_type 1257
+#define _tmp_108_type 1258
+#define _loop0_110_type 1259
+#define _gather_109_type 1260
+#define _loop0_112_type 1261
+#define _gather_111_type 1262
+#define _loop0_114_type 1263
+#define _gather_113_type 1264
+#define _loop0_116_type 1265
+#define _gather_115_type 1266
+#define _loop0_117_type 1267
+#define _loop0_119_type 1268
+#define _gather_118_type 1269
+#define _tmp_120_type 1270
+#define _loop0_122_type 1271
+#define _gather_121_type 1272
+#define _loop0_124_type 1273
+#define _gather_123_type 1274
+#define _tmp_125_type 1275
+#define _tmp_126_type 1276
+#define _tmp_127_type 1277
+#define _tmp_128_type 1278
+#define _tmp_129_type 1279
+#define _loop0_130_type 1280
+#define _tmp_131_type 1281
+#define _tmp_132_type 1282
+#define _tmp_133_type 1283
+#define _tmp_134_type 1284
+#define _tmp_135_type 1285
+#define _tmp_136_type 1286
+#define _tmp_137_type 1287
+#define _tmp_138_type 1288
+#define _tmp_139_type 1289
+#define _tmp_140_type 1290
+#define _tmp_141_type 1291
+#define _tmp_142_type 1292
+#define _tmp_143_type 1293
+#define _tmp_144_type 1294
+#define _loop1_145_type 1295
+#define _tmp_146_type 1296
+#define _tmp_147_type 1297
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -508,6 +509,7 @@ static expr_ty t_primary_rule(Parser *p);
 static void *t_lookahead_rule(Parser *p);
 static expr_ty t_atom_rule(Parser *p);
 static void *incorrect_arguments_rule(Parser *p);
+static void *invalid_kwarg_rule(Parser *p);
 static void *invalid_named_expression_rule(Parser *p);
 static void *invalid_assignment_rule(Parser *p);
 static void *invalid_block_rule(Parser *p);
@@ -9079,7 +9081,7 @@ starred_expression_rule(Parser *p)
     return res;
 }
 
-// kwarg_or_starred: NAME '=' expression | starred_expression
+// kwarg_or_starred: NAME '=' expression | starred_expression | invalid_kwarg
 static KeywordOrStarred*
 kwarg_or_starred_rule(Parser *p)
 {
@@ -9140,12 +9142,23 @@ kwarg_or_starred_rule(Parser *p)
         }
         p->mark = mark;
     }
+    { // invalid_kwarg
+        void *invalid_kwarg_var;
+        if (
+            (invalid_kwarg_var = invalid_kwarg_rule(p))  // invalid_kwarg
+        )
+        {
+            res = invalid_kwarg_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
     res = NULL;
   done:
     return res;
 }
 
-// kwarg_or_double_starred: NAME '=' expression | '**' expression
+// kwarg_or_double_starred: NAME '=' expression | '**' expression | invalid_kwarg
 static KeywordOrStarred*
 kwarg_or_double_starred_rule(Parser *p)
 {
@@ -9213,6 +9226,17 @@ kwarg_or_double_starred_rule(Parser *p)
                 p->error_indicator = 1;
                 return NULL;
             }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // invalid_kwarg
+        void *invalid_kwarg_var;
+        if (
+            (invalid_kwarg_var = invalid_kwarg_rule(p))  // invalid_kwarg
+        )
+        {
+            res = invalid_kwarg_var;
             goto done;
         }
         p->mark = mark;
@@ -10548,6 +10572,38 @@ incorrect_arguments_rule(Parser *p)
         )
         {
             res = _PyPegen_arguments_parsing_error ( p , a );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// invalid_kwarg: expression '='
+static void *
+invalid_kwarg_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // expression '='
+        expr_ty expression_var;
+        Token * literal;
+        if (
+            (expression_var = expression_rule(p))  // expression
+            &&
+            (literal = _PyPegen_expect_token(p, 22))  // token='='
+        )
+        {
+            res = RAISE_SYNTAX_ERROR ( "expression cannot contain assignment, perhaps you meant \"==\"?" );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;


### PR DESCRIPTION
When parsing something like `f(g()=2)`, where the name of a default arg
is not a NAME, but an arbitrary expression, a spacialised error message
is output.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
