### PR TITLE
bpo-35890: Use RegQueryInfoKeyW and CryptAcquireContextW for consistency

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-05-16-23-19-07.bpo-35890.oisoPR.rst
+++ b/Misc/NEWS.d/next/Windows/2020-05-16-23-19-07.bpo-35890.oisoPR.rst
@@ -1,1 +1,0 @@
-Fix API calling consistency of RegQueryInfoKeyW and CryptAcquireContextW.

--- a/Misc/NEWS.d/next/Windows/2020-05-16-23-19-07.bpo-35890.oisoPR.rst
+++ b/Misc/NEWS.d/next/Windows/2020-05-16-23-19-07.bpo-35890.oisoPR.rst
@@ -1,0 +1,1 @@
+Fix API calling consistency of RegQueryInfoKeyW and CryptAcquireContextW.

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -358,7 +358,7 @@ getpythonregpath(HKEY keyBase, int skipcore)
         goto done;
     }
     /* Find out how big our core buffer is, and how many subkeys we have */
-    rc = RegQueryInfoKey(newKey, NULL, NULL, NULL, &numKeys, NULL, NULL,
+    rc = RegQueryInfoKeyW(newKey, NULL, NULL, NULL, &numKeys, NULL, NULL,
                     NULL, NULL, &dataSize, NULL, NULL);
     if (rc!=ERROR_SUCCESS) {
         goto done;

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -1451,9 +1451,9 @@ winreg_QueryInfoKey_impl(PyObject *module, HKEY key)
     if (PySys_Audit("winreg.QueryInfoKey", "n", (Py_ssize_t)key) < 0) {
         return NULL;
     }
-    if ((rc = RegQueryInfoKey(key, NULL, NULL, 0, &nSubKeys, NULL, NULL,
-                              &nValues,  NULL,  NULL, NULL, &ft))
-                              != ERROR_SUCCESS) {
+    if ((rc = RegQueryInfoKeyW(key, NULL, NULL, 0, &nSubKeys, NULL, NULL,
+                               &nValues,  NULL,  NULL, NULL, &ft))
+                               != ERROR_SUCCESS) {
         return PyErr_SetFromWindowsErrWithFunction(rc, "RegQueryInfoKey");
     }
     li.LowPart = ft.dwLowDateTime;

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -38,8 +38,8 @@ static int
 win32_urandom_init(int raise)
 {
     /* Acquire context */
-    if (!CryptAcquireContext(&hCryptProv, NULL, NULL,
-                             PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+    if (!CryptAcquireContextW(&hCryptProv, NULL, NULL,
+                              PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
         goto error;
 
     return 0;


### PR DESCRIPTION
Explicitly use the wide version RegQueryInfoKeyW and CryptAcquireContextW. It consistent with most Win32 API calls in the code base.

<!-- issue-number: [bpo-35890](https://bugs.python.org/issue35890) -->
https://bugs.python.org/issue35890
<!-- /issue-number -->
