### PR TITLE
bpo-30459: Cast the result of PyList_SET_ITEM() to void

### DIFF
--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -34,7 +34,7 @@ PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 #define _PyList_CAST(op) (assert(PyList_Check(op)), (PyListObject *)(op))
 
 #define PyList_GET_ITEM(op, i) (_PyList_CAST(op)->ob_item[i])
-#define PyList_SET_ITEM(op, i, v) (_PyList_CAST(op)->ob_item[i] = (v))
+#define PyList_SET_ITEM(op, i, v) ((void)(_PyList_CAST(op)->ob_item[i] = (v)))
 #define PyList_GET_SIZE(op)    Py_SIZE(_PyList_CAST(op))
 #define _PyList_ITEMS(op)      (_PyList_CAST(op)->ob_item)
 

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -27,7 +27,7 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 #define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
 
 /* Macro, *only* to be used to fill in brand new tuples */
-#define PyTuple_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
+#define PyTuple_SET_ITEM(op, i, v) ((void)(_PyTuple_CAST(op)->ob_item[i] = v))
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);
 

--- a/Misc/NEWS.d/next/C API/2020-05-06-23-54-57.bpo-30459.N9_Jai.rst
+++ b/Misc/NEWS.d/next/C API/2020-05-06-23-54-57.bpo-30459.N9_Jai.rst
@@ -1,0 +1,2 @@
+Cast the result of :c:func:`PyList_SET_ITEM` and :c:func:`PyTuple_SET_ITEM`
+to void.


### PR DESCRIPTION
Do the same for PyTuple_SET_ITEM().


<!-- issue-number: [bpo-30459](https://bugs.python.org/issue30459) -->
https://bugs.python.org/issue30459
<!-- /issue-number -->
