### PR TITLE
bpo-40545: Export _PyErr_GetTopmostException() function

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -75,7 +75,7 @@ typedef PyOSErrorObject PyWindowsErrorObject;
 /* Error handling definitions */
 
 PyAPI_FUNC(void) _PyErr_SetKeyError(PyObject *);
-_PyErr_StackItem *_PyErr_GetTopmostException(PyThreadState *tstate);
+PyAPI_FUNC(_PyErr_StackItem*) _PyErr_GetTopmostException(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, PyObject **);
 
 /* Context manipulation (PEP 3134) */

--- a/Misc/NEWS.d/next/C API/2020-05-07-11-41-13.bpo-40545.51DzF1.rst
+++ b/Misc/NEWS.d/next/C API/2020-05-07-11-41-13.bpo-40545.51DzF1.rst
@@ -1,0 +1,3 @@
+Declare ``_PyErr_GetTopmostException()`` with ``PyAPI_FUNC()`` to properly
+export the function in the C API. The function remains private (``_Py``)
+prefix.


### PR DESCRIPTION
Declare _PyErr_GetTopmostException() with PyAPI_FUNC() to properly
export the function in the C API. The function remains private
("_Py") prefix.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40545](https://bugs.python.org/issue40545) -->
https://bugs.python.org/issue40545
<!-- /issue-number -->
