### PR TITLE
bpo-40548: Always run GitHub action, even on doc PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,19 @@
 name: Tests
 
+# bpo-40548: "paths-ignore" is not used to skip documentation-only PRs, because
+# it prevents to mark a job as mandatory. A PR cannot be merged if a job is
+# mandatory but not scheduled because of "paths-ignore".
 on:
   push:
     branches:
     - master
     - 3.8
     - 3.7
-    paths-ignore:
-    - 'Doc/**'
-    - 'Misc/**'
-    - '**/*.md'
-    - '**/*.rst'
   pull_request:
     branches:
     - master
     - 3.8
     - 3.7
-    paths-ignore:
-    - 'Doc/**'
-    - 'Misc/**'
-    - '**/*.md'
-    - '**/*.rst'
 
 jobs:
   build_win32:


### PR DESCRIPTION
Always run GitHub action jobs, even on documentation-only pull
requests. So it will be possible to make a GitHub action job, like
the Windows (64-bit) job, mandatory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40548](https://bugs.python.org/issue40548) -->
https://bugs.python.org/issue40548
<!-- /issue-number -->
