### PR TITLE
bpo-40559: Add Py_DECREF to _asynciomodule.c:task_step_impl()

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-05-05-08-12-51.bpo-40559.112wwa.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-05-08-12-51.bpo-40559.112wwa.rst
@@ -1,0 +1,1 @@
+Fix possible memory leak in the C implementation of :class:`asyncio.Task`.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2638,6 +2638,10 @@ task_step_impl(TaskObj *task, PyObject *exc)
     coro = task->task_coro;
     if (coro == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "uninitialized Task object");
+        if (clear_exc) {
+            /* We created 'exc' during this call */
+            Py_DECREF(exc);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
This adds a missing `Py_DECREF`. The code comment is a duplication of the same comment that appears 15 lines later.

This seems like a pretty obscure code path ([as also mentioned in the original issue](https://bugs.python.org/issue31185)), so I'm not sure if a test is worth it.

<!-- issue-number: [bpo-40559](https://bugs.python.org/issue40559) -->
https://bugs.python.org/issue40559
<!-- /issue-number -->
