### PR TITLE
bpo-40544: Set the validate field in logging Formatter with fileConfig

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -113,9 +113,7 @@ def _create_formatters(cp):
         dfs = cp.get(sectname, "datefmt", raw=True, fallback=None)
         stl = cp.get(sectname, "style", raw=True, fallback='%')
         vldstr = cp.get(sectname, "validate", raw=True, fallback="True")
-        vld = True
-        if vldstr == "False":
-            vld = False
+        vld = (vldstr != "False")
         c = logging.Formatter
         class_name = cp[sectname].get("class")
         if class_name:

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -112,11 +112,15 @@ def _create_formatters(cp):
         fs = cp.get(sectname, "format", raw=True, fallback=None)
         dfs = cp.get(sectname, "datefmt", raw=True, fallback=None)
         stl = cp.get(sectname, "style", raw=True, fallback='%')
+        vldstr = cp.get(sectname, "validate", raw=True, fallback="True")
+        vld = True
+        if vldstr == "False":
+            vld = False
         c = logging.Formatter
         class_name = cp[sectname].get("class")
         if class_name:
             c = _resolve(class_name)
-        f = c(fs, dfs, stl)
+        f = c(fs, dfs, stl, vld)
         formatters[form] = f
     return formatters
 


### PR DESCRIPTION
https://bugs.python.org/issue40544
This PR fixes python 3.8 bug that caused because of the add of the `validate` param (default: True) in `logging.Formatter`, it causing it to throws ValueError exception if the `format` param is not one of the 3 styles.
There was no way to set `validate` field when using `logging.config.fileConfig`, which breaks the code to users who want to upgrade to 3.8.

<!-- issue-number: [bpo-40544](https://bugs.python.org/issue40544) -->
https://bugs.python.org/issue40544
<!-- /issue-number -->
