### PR TITLE
bpo-40552 Add 'users' variable in code sample (tutorial 4.2).

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -70,6 +70,9 @@ Code that modifies a collection while iterating over that same collection can
 be tricky to get right.  Instead, it is usually more straight-forward to loop
 over a copy of the collection or to create a new collection::
 
+    # Create a sample collection
+    users = {'Hans': 'active', 'Éléonore': 'inactive', '景太郎': 'active'}
+
     # Strategy:  Iterate over a copy
     for user, status in users.copy().items():
         if status == 'inactive':

--- a/Misc/NEWS.d/next/Documentation/2020-05-09-12-10-31.bpo-40552._0uB73.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-05-09-12-10-31.bpo-40552._0uB73.rst
@@ -1,0 +1,2 @@
+Fix in tutorial section 4.2.
+Code snippet is now correct.


### PR DESCRIPTION
Previoulsy, running the sample code in the 4.2 section from tutorial would yield:

`NameError: name 'users' is not defined`

I've defined a 'users' variable and the code runs as expected:

```
>>> active_users
{'Hans': 'active', '景太郎': 'active'}
```


<!-- issue-number: [bpo-40552](https://bugs.python.org/issue40552) -->
https://bugs.python.org/issue40552
<!-- /issue-number -->
