### PR TITLE
gh-78612: Docs does not eval allows code object as argument

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -459,7 +459,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: eval(expression[, globals[, locals]])
 
    The arguments are a string or a compiled code object, optionally along
-   with globals and locals.  If provided; globals must be a dictionary,
+   with globals and locals.  If provided, globals must be a dictionary and
    locals can be any mapping object.
 
    The *expression* argument is parsed and evaluated as a Python expression

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -458,7 +458,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: eval(expression[, globals[, locals]])
 
-   The arguments are a string or compiled code object, optionally along
+   The arguments are a string or a compiled code object, optionally along
    with globals and locals.  If provided; globals must be a dictionary,
    locals can be any mapping object.
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -458,9 +458,9 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: eval(expression[, globals[, locals]])
 
-   The arguments are a string and optional globals and locals.  If provided,
-   *globals* must be a dictionary.  If provided, *locals* can be any mapping
-   object.
+   The arguments are a string or compiled code object, optionally along
+   with globals and locals.  If provided; globals must be a dictionary,
+   locals can be any mapping object.
 
    The *expression* argument is parsed and evaluated as a Python expression
    (technically speaking, a condition list) using the *globals* and *locals*


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-34431](https://bugs.python.org/issue34431) -->
https://bugs.python.org/issue34431
<!-- /issue-number -->


<!-- gh-issue-number: gh-78612 -->
* Issue: gh-78612
<!-- /gh-issue-number -->
