### PR TITLE
bpo-34790: add version of removal of explicit passing of coros to `asyncio.wait`'s documentation

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -575,7 +575,7 @@ Waiting Primitives
           if task in done:
               # Everything will work as expected now.
 
-   .. deprecated:: 3.8
+   .. deprecated-removed:: 3.8 3.11
 
       Passing coroutine objects to ``wait()`` directly is
       deprecated.

--- a/Misc/NEWS.d/next/Documentation/2020-05-08-20-18-55.bpo-34790.t6kW_1.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-05-08-20-18-55.bpo-34790.t6kW_1.rst
@@ -1,0 +1,1 @@
+Add version of removal for explicit passing of coros to `asyncio.wait()`'s documentation


### PR DESCRIPTION
#16977 didn't include the update to `asyncio.wait()` docs

<!-- issue-number: [bpo-34790](https://bugs.python.org/issue34790) -->
https://bugs.python.org/issue34790
<!-- /issue-number -->
