### PR TITLE
bpo-40570: Count the processor property in len(platform.uname())

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -802,6 +802,9 @@ class uname_result(
             return self.processor
         return super().__getitem__(key)
 
+    def __len__(self):
+        return super().__len__() + 1  # Add 1 for self.processor.
+
 
 _uname_cache = None
 

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -153,6 +153,7 @@ class PlatformTest(unittest.TestCase):
     def test_uname(self):
         res = platform.uname()
         self.assertTrue(any(res))
+        self.assertEqual(len(res), 6)
         self.assertEqual(res[0], res.system)
         self.assertEqual(res[1], res.node)
         self.assertEqual(res[2], res.release)


### PR DESCRIPTION
https://bugs.python.org/issue40570

This amends #12239 to preserve `len(platform.uname())`.

<!-- issue-number: [bpo-40570](https://bugs.python.org/issue40570) -->
https://bugs.python.org/issue40570
<!-- /issue-number -->
