### PR TITLE
bpo-40550: Fix time-of-check/time-of-action issue in subprocess.Popen.send_signal.

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -2063,11 +2063,9 @@ class Popen(object):
             # and the kill() call.
             try:
                 os.kill(self.pid, sig)
-            except ProcessLookupError as e:
-                # supress the process not found error in case the race
-                # condition happens, see bpo-40550
-                if e.errno != errno.ESRCH:
-                    raise e
+            except ProcessLookupError:
+                # Supress the race condition error; bpo-40550.
+                pass
 
         def terminate(self):
             """Terminate the process with SIGTERM

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -2061,7 +2061,13 @@ class Popen(object):
             # The race condition can still happen if the race condition
             # described above happens between the returncode test
             # and the kill() call.
-            os.kill(self.pid, sig)
+            try:
+                os.kill(self.pid, sig)
+            except ProcessLookupError as e:
+                # supress the process not found error in case the race
+                # condition happens, see bpo-40550
+                if e.errno != errno.ESRCH:
+                    raise e
 
         def terminate(self):
             """Terminate the process with SIGTERM

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3145,6 +3145,19 @@ class POSIXProcessTestCase(BaseTestCase):
         # so Popen failed to read it and uses a default returncode instead.
         self.assertIsNotNone(proc.returncode)
 
+    def test_send_signal_race2(self):
+        # bpo-40550: the process might exist between the returncode check and
+        # the kill operation
+        p = subprocess.Popen([sys.executable, '-c', 'exit(1)'])
+
+        # wait for process to exit
+        while not p.returncode:
+            p.poll()
+
+        with mock.patch.object(p, 'poll', new=lambda: None):
+            p.returncode = None
+            p.send_signal(signal.SIGTERM)
+
     def test_communicate_repeated_call_after_stdout_close(self):
         proc = subprocess.Popen([sys.executable, '-c',
                                  'import os, time; os.close(1), time.sleep(2)'],

--- a/Misc/NEWS.d/next/Library/2020-05-08-21-30-54.bpo-40550.i7GWkb.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-08-21-30-54.bpo-40550.i7GWkb.rst
@@ -1,0 +1,1 @@
+Fix time-of-check/time-of-action issue in subprocess.Popen.send_signal.


### PR DESCRIPTION
All the implementation details have been explained the bug, please check it out.

<!-- issue-number: [bpo-40550](https://bugs.python.org/issue40550) -->
https://bugs.python.org/issue40550
<!-- /issue-number -->
