### PR TITLE
gh-84752: [_xxsubinterpreters] Add a way to request basic operations in another interpreter.

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -198,6 +198,8 @@ PyAPI_FUNC(const PyConfig*) _Py_GetConfig(void);
 /* cross-interpreter operations */
 
 PyAPI_FUNC(int) _Py_DECREF_in_interpreter(PyInterpreterState *, PyObject *);
+PyAPI_FUNC(int) _PyBuffer_Release_in_interpreter(PyInterpreterState *,
+                                                 Py_buffer *);
 
 /* cross-interpreter data */
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -195,6 +195,10 @@ PyAPI_FUNC(const PyConfig*) _PyInterpreterState_GetConfig(PyInterpreterState *in
 PyAPI_FUNC(const PyConfig*) _Py_GetConfig(void);
 
 
+/* cross-interpreter operations */
+
+PyAPI_FUNC(int) _Py_DECREF_in_interpreter(PyInterpreterState *, PyObject *);
+
 /* cross-interpreter data */
 
 struct _xid;

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -200,6 +200,9 @@ PyAPI_FUNC(const PyConfig*) _Py_GetConfig(void);
 PyAPI_FUNC(int) _Py_DECREF_in_interpreter(PyInterpreterState *, PyObject *);
 PyAPI_FUNC(int) _PyBuffer_Release_in_interpreter(PyInterpreterState *,
                                                  Py_buffer *);
+typedef void (*_deallocfunc)(void *);
+PyAPI_FUNC(int) _PyMem_Free_in_interpreter(PyInterpreterState *, void *,
+                                           _deallocfunc);
 
 /* cross-interpreter data */
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -201,8 +201,8 @@ PyAPI_FUNC(int) _Py_DECREF_in_interpreter(PyInterpreterState *, PyObject *);
 PyAPI_FUNC(int) _PyBuffer_Release_in_interpreter(PyInterpreterState *,
                                                  Py_buffer *);
 typedef void (*_deallocfunc)(void *);
-PyAPI_FUNC(int) _PyMem_Free_in_interpreter(PyInterpreterState *, void *,
-                                           _deallocfunc);
+PyAPI_FUNC(int) _PyMem_Free_in_interpreter(PyInterpreterState *, void *);
+PyAPI_FUNC(int) _PyMem_RawFree_in_interpreter(PyInterpreterState *, void *);
 
 /* cross-interpreter data */
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -23,7 +23,13 @@ struct _Py_parser_state {
 struct _pending_call {
     int (*func)(void *);
     void *arg;
+    struct _pending_call *next;
 };
+
+// We technically do not need this limit around any longer since we
+// moved from a circular queue to a linked list.  However, having a
+// size limit is still a good idea so we keep the one we already had.
+#define NPENDINGCALLS 32
 
 struct _pending_calls {
     PyThread_type_lock lock;
@@ -33,10 +39,9 @@ struct _pending_calls {
        thread state.
        Guarded by the GIL. */
     int async_exc;
-#define NPENDINGCALLS 32
-    struct _pending_call calls[NPENDINGCALLS];
-    int first;
-    int last;
+    int ncalls;
+    struct _pending_call *head;
+    struct _pending_call *last;
 };
 
 struct _ceval_state {

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -20,6 +20,11 @@ struct _Py_parser_state {
     } listnode;
 };
 
+struct _pending_call {
+    int (*func)(void *);
+    void *arg;
+};
+
 struct _pending_calls {
     PyThread_type_lock lock;
     /* Request for running pending calls. */
@@ -29,10 +34,7 @@ struct _pending_calls {
        Guarded by the GIL. */
     int async_exc;
 #define NPENDINGCALLS 32
-    struct {
-        int (*func)(void *);
-        void *arg;
-    } calls[NPENDINGCALLS];
+    struct _pending_call calls[NPENDINGCALLS];
     int first;
     int last;
 };

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -28,7 +28,8 @@ struct _pending_call {
 
 // We technically do not need this limit around any longer since we
 // moved from a circular queue to a linked list.  However, having a
-// size limit is still a good idea so we keep the one we already had.
+// size limit is still a good idea so we keep the one we already had,
+// for now.  We will increase the limit (or drop it) later.
 #define NPENDINGCALLS 32
 
 struct _pending_calls {

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -510,17 +510,21 @@ class IsRunningTests(TestBase):
 class InterpreterIDTests(TestBase):
 
     def test_with_int(self):
-        id = interpreters.InterpreterID(10, force=True)
+        orig = interpreters.create()
+        value = int(orig)
+        interpid = interpreters.InterpreterID(value)
 
-        self.assertEqual(int(id), 10)
+        self.assertEqual(int(interpid), value)
 
     def test_coerce_id(self):
+        interpid = interpreters.create()
+        value = int(interpid)
         class Int(str):
             def __index__(self):
-                return 10
+                return value
 
-        id = interpreters.InterpreterID(Int(), force=True)
-        self.assertEqual(int(id), 10)
+        id = interpreters.InterpreterID(Int())
+        self.assertEqual(int(id), value)
 
     def test_bad_id(self):
         self.assertRaises(TypeError, interpreters.InterpreterID, object())
@@ -531,39 +535,66 @@ class InterpreterIDTests(TestBase):
         self.assertRaises(OverflowError, interpreters.InterpreterID, 2**64)
 
     def test_does_not_exist(self):
-        id = interpreters.channel_create()
+        interpid = interpreters.create()
+        does_not_exist = int(interpid) + 1
         with self.assertRaises(RuntimeError):
-            interpreters.InterpreterID(int(id) + 1)  # unforced
+            interpreters.InterpreterID(does_not_exist)
+
+#    def test_cannot_be_instantiated(self):
+#        interpid = interpreters.create()
+#        does_not_exist = int(interpid) + 1
+#        with self.assertRaises(TypeError):
+#            interpreters.InterpreterID(interpid)
+#        with self.assertRaises(TypeError):
+#            interpreters.InterpreterID(does_not_exist)
+
+    def test_int(self):
+        interpid = interpreters.create()
+        self.assertNotIsInstance(interpid, int)
+        with self.assertRaises(TypeError):
+            interpid + 1
+        with self.assertRaises(TypeError):
+            interpid - 1
+        with self.assertRaises(TypeError):
+            1 + interpid
+        with self.assertRaises(TypeError):
+            1 - interpid
 
     def test_str(self):
-        id = interpreters.InterpreterID(10, force=True)
-        self.assertEqual(str(id), '10')
+        interpid = interpreters.create()
+        value = int(interpid)
+        self.assertEqual(str(interpid), str(value))
 
     def test_repr(self):
-        id = interpreters.InterpreterID(10, force=True)
-        self.assertEqual(repr(id), 'InterpreterID(10)')
+        interpid = interpreters.create()
+        value = int(interpid)
+        self.assertEqual(repr(interpid), f'InterpreterID({value})')
 
     def test_equality(self):
         id1 = interpreters.create()
-        id2 = interpreters.InterpreterID(int(id1))
-        id3 = interpreters.create()
+        id2 = int(id1)
+        id3 = interpreters.InterpreterID(int(id1))
+        id4 = interpreters.create()
 
         self.assertTrue(id1 == id1)
         self.assertTrue(id1 == id2)
-        self.assertTrue(id1 == int(id1))
-        self.assertTrue(int(id1) == id1)
-        self.assertTrue(id1 == float(int(id1)))
-        self.assertTrue(float(int(id1)) == id1)
-        self.assertFalse(id1 == float(int(id1)) + 0.1)
-        self.assertFalse(id1 == str(int(id1)))
+        self.assertTrue(id2 == id1)
+        self.assertTrue(id1 == id3)
+        self.assertTrue(str(id1) == str(id2))
+        self.assertTrue(id1 == float(id2))
+        self.assertTrue(float(id2) == id1)
+        self.assertFalse(id1 == float(id2) + 0.1)
+        self.assertFalse(id1 == str(id2))
         self.assertFalse(id1 == 2**1000)
         self.assertFalse(id1 == float('inf'))
         self.assertFalse(id1 == 'spam')
-        self.assertFalse(id1 == id3)
+        self.assertFalse(id1 == id4)
+        self.assertIsNot(id1, id3)
 
         self.assertFalse(id1 != id1)
         self.assertFalse(id1 != id2)
-        self.assertTrue(id1 != id3)
+        self.assertFalse(id1 != id3)
+        self.assertTrue(id1 != id4)
 
 
 class CreateTests(TestBase):

--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -583,7 +583,8 @@ class TestSendRecv(TestBase):
         obj = r.recv()
 
         self.assertEqual(obj, orig)
-        self.assertIsNot(obj, orig)
+        # When going back to the same interpreter we get the same object.
+        self.assertIs(obj, orig)
 
     def test_send_recv_same_interpreter(self):
         interp = interpreters.create()
@@ -594,7 +595,8 @@ class TestSendRecv(TestBase):
             s.send_nowait(orig)
             obj = r.recv()
             assert obj == orig, 'expected: obj == orig'
-            assert obj is not orig, 'expected: obj is not orig'
+            # When going back to the same interpreter we get the same object.
+            assert obj is orig, 'expected: obj is orig'
             """))
 
     @unittest.skip('broken (see BPO-...)')
@@ -641,7 +643,8 @@ class TestSendRecv(TestBase):
         obj = r.recv()
 
         self.assertEqual(obj, orig)
-        self.assertIsNot(obj, orig)
+        # When going back to the same interpreter we get the same object.
+        self.assertIs(obj, orig)
 
     def test_send_recv_nowait_main(self):
         r, s = interpreters.create_channel()
@@ -650,7 +653,8 @@ class TestSendRecv(TestBase):
         obj = r.recv_nowait()
 
         self.assertEqual(obj, orig)
-        self.assertIsNot(obj, orig)
+        # When going back to the same interpreter we get the same object.
+        self.assertIs(obj, orig)
 
     def test_send_recv_nowait_main_with_default(self):
         r, _ = interpreters.create_channel()
@@ -668,7 +672,7 @@ class TestSendRecv(TestBase):
             obj = r.recv_nowait()
             assert obj == orig, 'expected: obj == orig'
             # When going back to the same interpreter we get the same object.
-            assert obj is not orig, 'expected: obj is not orig'
+            assert obj is orig, 'expected: obj is orig'
             """))
 
     @unittest.skip('broken (see BPO-...)')

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-08-13-08-47.bpo-40572.CcNQnm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-08-13-08-47.bpo-40572.CcNQnm.rst
@@ -1,0 +1,3 @@
+Add a way to queue various operations in one interpreter to run safely in
+another.  This includes moving the pending calls from a circular queue to a
+linked list, to allow for a more flexible queue.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-08-13-08-47.bpo-40572.CcNQnm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-08-13-08-47.bpo-40572.CcNQnm.rst
@@ -1,3 +1,5 @@
-Add a way to queue various operations in one interpreter to run safely in
-another.  This includes moving the pending calls from a circular queue to a
-linked list, to allow for a more flexible queue.
+Allow one interpreter to request specific low-level (memory-related)
+operations to happen in another interpreter at some point in the future.
+This includes a new "private" C-API function for each operation, as well
+as moving the pending calls from a circular queue to a linked list
+(to allow for a more flexible queue).

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1508,6 +1508,13 @@ _PyBuffer_Release_in_interpreter(PyInterpreterState *interp, Py_buffer *view)
     return _PyEval_AddPendingCall(interp, _release_pybuf, view);
 }
 
+int
+_PyMem_Free_in_interpreter(PyInterpreterState *interp, void *data,
+                           _deallocfunc dealloc)
+{
+    return _PyEval_AddPendingCall(interp, (int (*)(void *))dealloc, data);
+}
+
 /* cross-interpreter data */
 
 crossinterpdatafunc _PyCrossInterpreterData_Lookup(PyObject *);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1495,6 +1495,19 @@ _Py_DECREF_in_interpreter(PyInterpreterState *interp, PyObject *obj)
     return _PyEval_AddPendingCall(interp, _decref_pyobj, obj);
 }
 
+static int
+_release_pybuf(void *view)
+{
+    PyBuffer_Release((Py_buffer *)view);
+    return 0;
+}
+
+int
+_PyBuffer_Release_in_interpreter(PyInterpreterState *interp, Py_buffer *view)
+{
+    return _PyEval_AddPendingCall(interp, _release_pybuf, view);
+}
+
 /* cross-interpreter data */
 
 crossinterpdatafunc _PyCrossInterpreterData_Lookup(PyObject *);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1482,6 +1482,19 @@ _call_in_interpreter(struct _gilstate_runtime_state *gilstate,
     }
 }
 
+static int
+_decref_pyobj(void *obj)
+{
+    Py_DECREF(obj);
+    return 0;
+}
+
+int
+_Py_DECREF_in_interpreter(PyInterpreterState *interp, PyObject *obj)
+{
+    return _PyEval_AddPendingCall(interp, _decref_pyobj, obj);
+}
+
 /* cross-interpreter data */
 
 crossinterpdatafunc _PyCrossInterpreterData_Lookup(PyObject *);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1635,7 +1635,7 @@ _PyCrossInterpreterData_Release(_PyCrossInterpreterData *data)
         } else if (data->free == PyMem_RawFree) {
             _PyMem_RawFree_in_interpreter(interp, data->data);
         } else {
-            // We only worry about the PyMem_* deallocators.
+            // We only worry about special-casing the PyMem_* deallocators.
             data->free(data->data);
         }
     }
@@ -1645,7 +1645,7 @@ _PyCrossInterpreterData_Release(_PyCrossInterpreterData *data)
     // Note that we do not free "data" itself.  That should be done by
     // the caller after this completes.  That implies that the memory
     // for "data" is either owned by the calling interpreter or
-    // on the heap.
+    // on the stack.
 }
 
 PyObject *

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -480,6 +480,9 @@ _PyInterpreterState_IDInitref(PyInterpreterState *interp)
     if (interp->id_mutex != NULL) {
         return 0;
     }
+    if (interp == PyInterpreterState_Main()) {
+        return 0;
+    }
     interp->id_mutex = PyThread_allocate_lock();
     if (interp->id_mutex == NULL) {
         PyErr_SetString(PyExc_RuntimeError,


### PR DESCRIPTION
In this PR we cover `Py_DECREF()`, `PyMem_Free()`, `PyMem_RawFree()`, and `PyBuffer_Release()`.  We also change the "pending calls" queue from a circular buffer to a linked list, to give us flexibility in handling more pending calls.

Note that, once the GIL is per-interpreter, we will need to ensure that these operations are properly handled when the target interpreter is finalized.  I'm working on a separate fix for that case.

<!-- issue-number: [bpo-40572](https://bugs.python.org/issue40572) -->
https://bugs.python.org/issue40572
<!-- /issue-number -->

<!-- gh-issue-number: gh-84752 -->
* Issue: gh-84752
<!-- /gh-issue-number -->
