### PR TITLE
bpo-38323: Temporarily skip close_kill_running() for MultiLoopWatcher in test_asyncio

### DIFF
--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -462,7 +462,7 @@ class SubprocessMixin:
     def test_close_kill_running(self):
         if isinstance(asyncio.get_child_watcher(),
                       asyncio.MultiLoopChildWatcher):
-            raise unittest.SkipTest("Temporary skip until bpo-38323 is fixed")
+            self.skipTest("Temporary skip until bpo-38323 is fixed")
 
         async def kill_running():
             create = self.loop.subprocess_exec(asyncio.SubprocessProtocol,

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -460,9 +460,10 @@ class SubprocessMixin:
             test_utils.run_briefly(self.loop)
 
     def test_close_kill_running(self):
-        if isinstance(asyncio.get_child_watcher(),
-                      asyncio.MultiLoopChildWatcher):
-            self.skipTest("Temporary skip until bpo-38323 is fixed")
+        if sys.platform != "win32":
+            if isinstance(asyncio.get_child_watcher(),
+                          asyncio.MultiLoopChildWatcher):
+                self.skipTest("Temporary skip until bpo-38323 is fixed")
 
         async def kill_running():
             create = self.loop.subprocess_exec(asyncio.SubprocessProtocol,

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -460,10 +460,9 @@ class SubprocessMixin:
             test_utils.run_briefly(self.loop)
 
     def test_close_kill_running(self):
-        if sys.platform != "win32":
-            if isinstance(asyncio.get_child_watcher(),
-                          asyncio.MultiLoopChildWatcher):
-                self.skipTest("Temporary skip until bpo-38323 is fixed")
+        if (sys.platform != "win32" and
+                self.Watcher == asyncio.MultiLoopChildWatcher):
+            self.skipTest("Temporary skip until bpo-38323 is fixed")
 
         async def kill_running():
             create = self.loop.subprocess_exec(asyncio.SubprocessProtocol,

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -461,7 +461,7 @@ class SubprocessMixin:
 
     def test_close_kill_running(self):
         if isinstance(asyncio.get_child_watcher(),
-                      unix_events.MultiLoopChildWatcher):
+                      asyncio.MultiLoopChildWatcher):
             raise unittest.SkipTest("Temporary skip until bpo-38323 is fixed")
 
         async def kill_running():

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -460,6 +460,9 @@ class SubprocessMixin:
             test_utils.run_briefly(self.loop)
 
     def test_close_kill_running(self):
+        if isinstance(asyncio.get_child_watcher(),
+                      unix_events.MultiLoopChildWatcher):
+            raise unittest.SkipTest("Temporary skip until bpo-38323 is fixed")
 
         async def kill_running():
             create = self.loop.subprocess_exec(asyncio.SubprocessProtocol,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Note that `@unittest.skipIf()` is not an option here because the child watcher is not set until after `setUp()` in the mixin.

<!-- issue-number: [bpo-38323](https://bugs.python.org/issue38323) -->
https://bugs.python.org/issue38323
<!-- /issue-number -->
