### PR TITLE
bpo-40570: Improve compatibility of uname_result with late-bound .platform

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -798,9 +798,10 @@ class uname_result(
         )
 
     def __getitem__(self, key):
-        if key == 5:
-            return self.processor
-        return super().__getitem__(key)
+        return tuple(iter(self))[key]
+
+    def __len__(self):
+        return len(tuple(iter(self)))
 
 
 _uname_cache = None

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -154,11 +154,18 @@ class PlatformTest(unittest.TestCase):
         res = platform.uname()
         self.assertTrue(any(res))
         self.assertEqual(res[0], res.system)
+        self.assertEqual(res[-6], res.system)
         self.assertEqual(res[1], res.node)
+        self.assertEqual(res[-5], res.node)
         self.assertEqual(res[2], res.release)
+        self.assertEqual(res[-4], res.release)
         self.assertEqual(res[3], res.version)
+        self.assertEqual(res[-3], res.version)
         self.assertEqual(res[4], res.machine)
+        self.assertEqual(res[-2], res.machine)
         self.assertEqual(res[5], res.processor)
+        self.assertEqual(res[-1], res.processor)
+        self.assertEqual(len(res), 6)
 
     @unittest.skipIf(sys.platform in ['win32', 'OpenVMS'], "uname -p not used")
     def test_uname_processor(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -167,6 +167,14 @@ class PlatformTest(unittest.TestCase):
         self.assertEqual(res[-1], res.processor)
         self.assertEqual(len(res), 6)
 
+    def test_uname_cast_to_tuple(self):
+        res = platform.uname()
+        expected = (
+            res.system, res.node, res.release, res.version, res.machine,
+            res.processor,
+        )
+        self.assertEqual(tuple(res), expected)
+
     @unittest.skipIf(sys.platform in ['win32', 'OpenVMS'], "uname -p not used")
     def test_uname_processor(self):
         """


### PR DESCRIPTION


<!-- issue-number: [bpo-40570](https://bugs.python.org/issue40570) -->
https://bugs.python.org/issue40570
<!-- /issue-number -->


Automerge-Triggered-By: @jaraco