### PR TITLE
Fix typo in multiprocessing.rst documentation

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2144,7 +2144,7 @@ with the :class:`Pool` class.
       or by calling :meth:`close` and :meth:`terminate` manually. Failure to do this
       can lead to the process hanging on finalization.
 
-      Note that is **not correct** to rely on the garbage colletor to destroy the pool
+      Note that it is **not correct** to rely on the garbage collector to destroy the pool
       as CPython does not assure that the finalizer of the pool will be called
       (see :meth:`object.__del__` for more information).
 


### PR DESCRIPTION
Fixes a typo: 
- `colletor` -> `collector`

Also fixes a couple of grammatical issues:
- `Note that is` -> `Note that it is`
~- Add comma between clauses~