### PR TITLE
bpo-40575: Avoid unnecessary overhead in _PyDict_GetItemIdWithError()

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1488,12 +1488,11 @@ PyDict_GetItemWithError(PyObject *op, PyObject *key)
 PyObject *
 _PyDict_GetItemIdWithError(PyObject *dp, struct _Py_Identifier *key)
 {
-    Py_hash_t hash;
     PyObject *kv;
     kv = _PyUnicode_FromId(key); /* borrowed */
     if (kv == NULL)
         return NULL;
-    hash = ((PyASCIIObject *) kv)->hash;
+    Py_hash_t hash = ((PyASCIIObject *) kv)->hash;
     assert (hash != -1);  /* interned strings have their hash value initialised */
     return _PyDict_GetItem_KnownHash(dp, kv, hash);
 }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1488,11 +1488,14 @@ PyDict_GetItemWithError(PyObject *op, PyObject *key)
 PyObject *
 _PyDict_GetItemIdWithError(PyObject *dp, struct _Py_Identifier *key)
 {
+    Py_hash_t hash;
     PyObject *kv;
     kv = _PyUnicode_FromId(key); /* borrowed */
     if (kv == NULL)
         return NULL;
-    return PyDict_GetItemWithError(dp, kv);
+    hash = ((PyASCIIObject *) kv)->hash;
+    assert (hash != -1);  /* interned strings have their hash value initialised */
+    return _PyDict_GetItem_KnownHash(dp, kv, hash);
 }
 
 PyObject *


### PR DESCRIPTION
Call _PyDict_GetItem_KnownHash() instead of the more generic PyDict_GetItemWithError(),
since we already know the hash of interned strings.

I think this is not worth a News entry – I can't even prove that it makes any performance difference at all. It's just too obvious a change to not make it, IMHO.

<!-- issue-number: [bpo-40575](https://bugs.python.org/issue40575) -->
https://bugs.python.org/issue40575
<!-- /issue-number -->
