### PR TITLE
bpo-40334: Do not show error caret if RAISE_SYNTAX_ERROR_NO_COL_OFFSE…

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -620,7 +620,7 @@ t_atom[expr_ty]:
 incorrect_arguments:
     | args ',' '*' { RAISE_SYNTAX_ERROR("iterable argument unpacking follows keyword argument unpacking") }
     | expression for_if_clauses ',' [args | expression for_if_clauses] {
-        RAISE_SYNTAX_ERROR("Generator expression must be parenthesized") }
+        RAISE_SYNTAX_ERROR_NO_COL_OFFSET("Generator expression must be parenthesized") }
     | a=args ',' args { _PyPegen_arguments_parsing_error(p, a) }
 invalid_kwarg:
     | expression '=' { RAISE_SYNTAX_ERROR("expression cannot contain assignment, perhaps you meant \"==\"?") }

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -10550,7 +10550,7 @@ incorrect_arguments_rule(Parser *p)
             (opt_var = _tmp_125_rule(p), 1)  // [args | expression for_if_clauses]
         )
         {
-            res = RAISE_SYNTAX_ERROR ( "Generator expression must be parenthesized" );
+            res = RAISE_SYNTAX_ERROR_NO_COL_OFFSET ( "Generator expression must be parenthesized" );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -413,7 +413,7 @@ _PyPegen_raise_error(Parser *p, PyObject *errtype, int with_col_number, const ch
         }
         col_number = byte_offset_to_character_offset(loc, col_offset);
     }
-    else if (!loc) {
+    else {
         Py_INCREF(Py_None);
         loc = Py_None;
     }


### PR DESCRIPTION
Before:

```python-traceback
>>> f(x for x in range(10),)
  File "<console>", line 1
    f(x for x in range(10),)
    ^
SyntaxError: Generator expression must be parenthesized
```

With this PR:

```python-traceback
>>> f(x for x in range(10),)
  File "<console>", line 1
SyntaxError: Generator expression must be parenthesized
```

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
