### PR TITLE
bpo-40584: Update PyType_FromModuleAndSpec to process  tp_vectorcall_offset

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -424,9 +424,11 @@ Accessing attributes of extension types
 
    Heap allocated types (created using :c:func:`PyType_FromSpec` or similar),
    ``PyMemberDef`` may contain definitions for the special members
-   ``__dictoffset__`` and ``__weaklistoffset__``, corresponding to
-   :c:member:`~PyTypeObject.tp_dictoffset` and
-   :c:member:`~PyTypeObject.tp_weaklistoffset` in type objects.
+   ``__dictoffset__``, ``__weaklistoffset__`` and ``__vectorcalloffset__``,
+   corresponding to
+   :c:member:`~PyTypeObject.tp_dictoffset`,
+   :c:member:`~PyTypeObject.tp_weaklistoffset` and
+   :c:member:`~PyTypeObject.tp_vectorcall_offset` in type objects.
    These must be defined with ``T_PYSSIZET`` and ``READONLY``, for example::
 
       static PyMemberDef spam_type_members[] = {

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -228,6 +228,7 @@ The following functions and structs are used to create
       * :c:member:`~PyTypeObject.tp_dictoffset`
         (see :ref:`PyMemberDef <pymemberdef-offsets>`)
       * :c:member:`~PyTypeObject.tp_vectorcall_offset`
+        (see :ref:`PyMemberDef <pymemberdef-offsets>`)
       * :c:member:`~PyBufferProcs.bf_getbuffer`
       * :c:member:`~PyBufferProcs.bf_releasebuffer`
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2979,7 +2979,7 @@ PyType_FromModuleAndSpec(PyObject *module, PyType_Spec *spec, PyObject *bases)
                     // The PyMemberDef must be a Py_ssize_t and readonly
                     assert(memb->type == T_PYSSIZET);
                     assert(memb->flags == READONLY);
-                    dictoffset = memb->offset;
+                    vectorcalloffset = memb->offset;
                 }
             }
         }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2954,10 +2954,10 @@ PyType_FromModuleAndSpec(PyObject *module, PyType_Spec *spec, PyObject *bases)
     PyTypeObject *type, *base;
 
     const PyType_Slot *slot;
-    Py_ssize_t nmembers, weaklistoffset, dictoffset;
+    Py_ssize_t nmembers, weaklistoffset, dictoffset, vectorcalloffset;
     char *res_start;
 
-    nmembers = weaklistoffset = dictoffset = 0;
+    nmembers = weaklistoffset = dictoffset = vectorcalloffset = 0;
     for (slot = spec->slots; slot->slot; slot++) {
         if (slot->slot == Py_tp_members) {
             nmembers = 0;
@@ -2970,6 +2970,12 @@ PyType_FromModuleAndSpec(PyObject *module, PyType_Spec *spec, PyObject *bases)
                     weaklistoffset = memb->offset;
                 }
                 if (strcmp(memb->name, "__dictoffset__") == 0) {
+                    // The PyMemberDef must be a Py_ssize_t and readonly
+                    assert(memb->type == T_PYSSIZET);
+                    assert(memb->flags == READONLY);
+                    dictoffset = memb->offset;
+                }
+                if (strcmp(memb->name, "__vectorcalloffset__") == 0) {
                     // The PyMemberDef must be a Py_ssize_t and readonly
                     assert(memb->type == T_PYSSIZET);
                     assert(memb->flags == READONLY);
@@ -3121,6 +3127,10 @@ PyType_FromModuleAndSpec(PyObject *module, PyType_Spec *spec, PyObject *bases)
            subtype_dealloc will call the base type's tp_dealloc, if
            necessary. */
         type->tp_dealloc = subtype_dealloc;
+    }
+
+    if (vectorcalloffset) {
+        type->tp_vectorcall_offset = vectorcalloffset;
     }
 
     if (PyType_Ready(type) < 0)


### PR DESCRIPTION


<!-- issue-number: [bpo-40584](https://bugs.python.org/issue40584) -->
https://bugs.python.org/issue40584
<!-- /issue-number -->
