### PR TITLE
bpo-31203: Expose IP_PKTINFO in the socket module

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -371,6 +371,9 @@ Constants
    .. versionchanged:: 3.7
       ``TCP_NOTSENT_LOWAT`` was added.
 
+   .. versionchanged:: 3.9
+      ``IP_PKTINFO`` was added.
+
       On Windows, ``TCP_KEEPIDLE``, ``TCP_KEEPINTVL`` appear if run-time Windows
       supports.
 

--- a/Misc/NEWS.d/next/Library/2020-05-10-17-03-36.bpo-31203.y8JmfZ.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-10-17-03-36.bpo-31203.y8JmfZ.rst
@@ -1,0 +1,1 @@
+Expose :data:`socket.IP_PKTINFO` in the :mod:`socket` module.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8096,6 +8096,9 @@ PyInit__socket(void)
 #ifdef  IP_TRANSPARENT
     PyModule_AddIntMacro(m, IP_TRANSPARENT);
 #endif
+#ifdef  IP_PKTINFO
+    PyModule_AddIntMacro(m, IP_PKTINFO);
+#endif
 
     /* IPv6 [gs]etsockopt options, defined in RFC2553 */
 #ifdef  IPV6_JOIN_GROUP


### PR DESCRIPTION
Co-Authored-By: Florian Hedtstück <fhedtstueck@posteo.de>



<!-- issue-number: [bpo-31203](https://bugs.python.org/issue31203) -->
https://bugs.python.org/issue31203
<!-- /issue-number -->
