### PR TITLE
bpo-40585: Normalize errors messages in codeop when comparing them

### DIFF
--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -93,13 +93,10 @@ def _maybe_compile(compiler, source, filename, symbol):
     except SyntaxError as e:
         err2 = e
 
-    def normalize_error(err):
-        return repr(err).replace("\\n", "")
-
     try:
         if code:
             return code
-        if not code1 and normalize_error(err1) == normalize_error(err2):
+        if not code1 and repr(err1) == repr(err2):
             raise err1
     finally:
         err1 = err2 = None

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -93,10 +93,13 @@ def _maybe_compile(compiler, source, filename, symbol):
     except SyntaxError as e:
         err2 = e
 
+    def normalize_error(err):
+        return repr(err).replace("\\n", "")
+
     try:
         if code:
             return code
-        if not code1 and repr(err1) == repr(err2):
+        if not code1 and normalize_error(err1) == normalize_error(err2):
             raise err1
     finally:
         err1 = err2 = None

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -288,6 +288,15 @@ class CodeopTests(unittest.TestCase):
 
         ai("[i for i in range(10)] = (1, 2, 3)")
 
+    def test_invalid_exec(self):
+        ai = self.assertInvalid
+        ai("raise = 4", symbol="exec")
+        ai('def a-b', symbol='exec')
+        ai('await?', symbol='exec')
+        ai('=!=', symbol='exec')
+        ai('a await raise b', symbol='exec')
+        ai('a await raise b?+1', symbol='exec')
+
     def test_filename(self):
         self.assertEqual(compile_command("a = 1\n", "abc").co_filename,
                          compile("a = 1\n", "abc", 'single').co_filename)

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-11-00-19-42.bpo-40585.yusknY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-11-00-19-42.bpo-40585.yusknY.rst
@@ -1,0 +1,2 @@
+Fixed a bug when using :func:`codeop.compile_command` that was causing
+exceptions to be swallowed with the new parser. Patch by Pablo Galindo

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -310,8 +310,12 @@ get_error_line(char *buffer, int is_file)
         newline = strchr(buffer, '\n');
     }
 
+    while (newline && *newline == '\n') {
+        newline -= 1;
+    }
+
     if (newline) {
-        return PyUnicode_DecodeUTF8(buffer, newline - buffer, "replace");
+        return PyUnicode_DecodeUTF8(buffer, newline - buffer + 1, "replace");
     }
     else {
         return PyUnicode_DecodeUTF8(buffer, strlen(buffer), "replace");

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -310,12 +310,12 @@ get_error_line(char *buffer, int is_file)
         newline = strchr(buffer, '\n');
     }
 
-    while (newline && *newline == '\n') {
-        newline -= 1;
+    while (is_file && newline > buffer && newline[-1] == '\n') {
+        --newline;
     }
 
     if (newline) {
-        return PyUnicode_DecodeUTF8(buffer, newline - buffer + 1, "replace");
+        return PyUnicode_DecodeUTF8(buffer, newline - buffer, "replace");
     }
     else {
         return PyUnicode_DecodeUTF8(buffer, strlen(buffer), "replace");

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -310,8 +310,10 @@ get_error_line(char *buffer, int is_file)
         newline = strchr(buffer, '\n');
     }
 
-    while (is_file && newline > buffer && newline[-1] == '\n') {
-        --newline;
+    if (is_file) {
+        while (newline > buffer && newline[-1] == '\n') {
+            --newline;
+        }
     }
 
     if (newline) {


### PR DESCRIPTION
With the new parser, the error message contains always the trailing
newlines, causing the naive comparison of the repr of the error messages
in codeop to fail.


<!-- issue-number: [bpo-40585](https://bugs.python.org/issue40585) -->
https://bugs.python.org/issue40585
<!-- /issue-number -->
