### PR TITLE
bpo-40589: Add versionchanged note for shutil.rmtree and path-like objs

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -321,6 +321,9 @@ Directory and files operations
       Added a symlink attack resistant version that is used automatically
       if platform supports fd-based functions.
 
+   .. versionchanged:: 3.6
+      The *path* parameter can now be a :term:`path-like object`.
+
    .. versionchanged:: 3.8
       On Windows, will no longer delete the contents of a directory junction
       before removing the junction.


### PR DESCRIPTION


<!-- issue-number: [bpo-40589](https://bugs.python.org/issue40589) -->
https://bugs.python.org/issue40589
<!-- /issue-number -->
