### PR TITLE
bpo-40596: Fix str.isidentifier() for non-canonicalized strings containing non-BMP characters on Windows.

### DIFF
--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -720,6 +720,13 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertFalse("©".isidentifier())
         self.assertFalse("0".isidentifier())
 
+    @support.cpython_only
+    def test_isidentifier_legacy(self):
+        import _testcapi
+        u = '𝖀𝖓𝖎𝖈𝖔𝖉𝖊'
+        self.assertTrue(u.isidentifier())
+        self.assertTrue(_testcapi.unicode_legacy_string(u).isidentifier())
+
     def test_isprintable(self):
         self.assertTrue("".isprintable())
         self.assertTrue(" ".isprintable())

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-11-20-53-52.bpo-40596.dwOH_X.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-11-20-53-52.bpo-40596.dwOH_X.rst
@@ -1,0 +1,2 @@
+Fixed :meth:`str.isidentifier` for non-canonicalized strings containing
+non-BMP characters on Windows.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2319,6 +2319,12 @@ valid_identifier(PyObject *s)
                      Py_TYPE(s)->tp_name);
         return 0;
     }
+    /* Since there is no way to return an error from PyUnicode_IsIdentifier()
+       we have to call PyUnicode_READY() to ensure that the string object is
+       in the "canonical" representation. */
+    if (PyUnicode_READY(s) < 0) {
+        return 0;
+    }
     if (!PyUnicode_IsIdentifier(s)) {
         PyErr_SetString(PyExc_TypeError,
                         "__slots__ must be identifiers");

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2320,8 +2320,7 @@ valid_identifier(PyObject *s)
         return 0;
     }
     /* Since there is no way to return an error from PyUnicode_IsIdentifier()
-       we have to call PyUnicode_READY() to ensure that the string object is
-       in the "canonical" representation. */
+       we have to call explicitly PyUnicode_READY(). */
     if (PyUnicode_READY(s) < 0) {
         return 0;
     }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12373,6 +12373,12 @@ static PyObject *
 unicode_isidentifier_impl(PyObject *self)
 /*[clinic end generated code: output=fe585a9666572905 input=2d807a104f21c0c5]*/
 {
+    /* Since there is no way to return an error from PyUnicode_IsIdentifier()
+       we have to call PyUnicode_READY() to ensure that the string object is
+       in the "canonical" representation. */
+    if (PyUnicode_READY(self) < 0) {
+        return NULL;
+    }
     return PyBool_FromLong(PyUnicode_IsIdentifier(self));
 }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12373,9 +12373,6 @@ static PyObject *
 unicode_isidentifier_impl(PyObject *self)
 /*[clinic end generated code: output=fe585a9666572905 input=2d807a104f21c0c5]*/
 {
-    /* Since there is no way to return an error from PyUnicode_IsIdentifier()
-       we have to call PyUnicode_READY() to ensure that the string object is
-       in the "canonical" representation. */
     if (PyUnicode_READY(self) < 0) {
         return NULL;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-40596](https://bugs.python.org/issue40596) -->
https://bugs.python.org/issue40596
<!-- /issue-number -->
