### PR TITLE
bpo-40599: Improve error messages with expected keywords

### DIFF
--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -72,6 +72,8 @@ typedef struct {
     int feature_version;
     growable_comment_array type_ignore_comments;
     Token *known_err_token;
+    int last_err_line;
+    PyObject* err_tokens;
 } Parser;
 
 typedef struct {


### PR DESCRIPTION
The current errors are due to tests that don't expect the extra information in the error messages.

<!-- issue-number: [bpo-40599](https://bugs.python.org/issue40599) -->
https://bugs.python.org/issue40599
<!-- /issue-number -->
