### PR TITLE
bpo-40626: Support HDF5 in mimetypes

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -448,6 +448,7 @@ def _default_mime_types():
         '.dvi'    : 'application/x-dvi',
         '.gtar'   : 'application/x-gtar',
         '.hdf'    : 'application/x-hdf',
+        '.h5'     : 'application/x-hdf5',
         '.latex'  : 'application/x-latex',
         '.mif'    : 'application/x-mif',
         '.cdf'    : 'application/x-netcdf',

--- a/Misc/NEWS.d/next/Library/2020-05-18-17-29-30.bpo-40626.NeZufF.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-18-17-29-30.bpo-40626.NeZufF.rst
@@ -1,1 +1,1 @@
-Add h5 file extension as MIME Type application/x-hdf5, as per HDF Group recommendation for HDF5 formatted data files.
+Add h5 file extension as MIME Type application/x-hdf5, as per HDF Group recommendation for HDF5 formatted data files. Patch contributed by Mark Schwab.

--- a/Misc/NEWS.d/next/Library/2020-05-18-17-29-30.bpo-40626.NeZufF.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-18-17-29-30.bpo-40626.NeZufF.rst
@@ -1,0 +1,1 @@
+Add h5 file extension as MIME Type application/x-hdf5, as per HDF Group recommendation for HDF5 formatted data files.


### PR DESCRIPTION
Could you update the types to include the newer version of hdf... hdf5 with .h5 file extension?
See 'Recommendations' section for mime types from the HDF group here:  https://www.hdfgroup.org/2018/06/citations-for-hdf-data-and-software/

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40626](https://bugs.python.org/issue40626) -->
https://bugs.python.org/issue40626
<!-- /issue-number -->
