### PR TITLE
bpo-39481: remove generic classes from ipaddress/mmap

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -12,7 +12,6 @@ __version__ = '1.0'
 
 
 import functools
-import types
 
 IPV4LENGTH = 32
 IPV6LENGTH = 128
@@ -1125,8 +1124,6 @@ class _BaseNetwork(_IPAddressBase):
         return (self.network_address.is_loopback and
                 self.broadcast_address.is_loopback)
 
-    __class_getitem__ = classmethod(types.GenericAlias)
-
 class _BaseV4:
 
     """Base IPv4 object.
@@ -1445,8 +1442,6 @@ class IPv4Interface(IPv4Address):
     def with_hostmask(self):
         return '%s/%s' % (self._string_from_ip_int(self._ip),
                           self.hostmask)
-
-    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 class IPv4Network(_BaseV4, _BaseNetwork):
@@ -2155,8 +2150,6 @@ class IPv6Interface(IPv6Address):
     @property
     def is_loopback(self):
         return self._ip == 1 and self.network.is_loopback
-
-    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 class IPv6Network(_BaseV6, _BaseNetwork):

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -17,8 +17,6 @@ from ctypes import Array, LibraryLoader
 from difflib import SequenceMatcher
 from filecmp import dircmp
 from fileinput import FileInput
-from mmap import mmap
-from ipaddress import IPv4Network, IPv4Interface, IPv6Network, IPv6Interface
 from itertools import chain
 from http.cookies import Morsel
 from multiprocessing.managers import ValueProxy
@@ -49,7 +47,6 @@ class BaseTest(unittest.TestCase):
 
     def test_subscriptable(self):
         for t in (type, tuple, list, dict, set, frozenset, enumerate,
-                  mmap,
                   defaultdict, deque,
                   SequenceMatcher,
                   dircmp,
@@ -74,7 +71,6 @@ class BaseTest(unittest.TestCase):
                   Sequence, MutableSequence,
                   MappingProxyType, AsyncGeneratorType,
                   DirEntry,
-                  IPv4Network, IPv4Interface, IPv6Network, IPv6Interface,
                   chain,
                   TemporaryDirectory, SpooledTemporaryFile,
                   Queue, SimpleQueue,

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -816,8 +816,6 @@ static struct PyMethodDef mmap_object_methods[] = {
 #ifdef MS_WINDOWS
     {"__sizeof__",      (PyCFunction) mmap__sizeof__method,     METH_NOARGS},
 #endif
-    {"__class_getitem__",    (PyCFunction)Py_GenericAlias, METH_O|METH_CLASS,
-     PyDoc_STR("See PEP 585")},
     {NULL,         NULL}       /* sentinel */
 };
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->
