### PR TITLE
bpo-40602: _Py_hashtable_new() uses PyMem_Malloc()

### DIFF
--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -149,11 +149,12 @@ _Py_hashtable_new_full(size_t key_size, size_t data_size,
     _Py_hashtable_allocator_t alloc;
 
     if (allocator == NULL) {
-        alloc.malloc = PyMem_RawMalloc;
-        alloc.free = PyMem_RawFree;
+        alloc.malloc = PyMem_Malloc;
+        alloc.free = PyMem_Free;
     }
-    else
+    else {
         alloc = *allocator;
+    }
 
     ht = (_Py_hashtable_t *)alloc.malloc(sizeof(_Py_hashtable_t));
     if (ht == NULL)


### PR DESCRIPTION
_Py_hashtable_new() now uses PyMem_Malloc/PyMem_Free allocator by
default, rather than PyMem_RawMalloc/PyMem_RawFree.

PyMem_Malloc is faster than PyMem_RawMalloc for memory blocks smaller
than or equal to 512 bytes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40602](https://bugs.python.org/issue40602) -->
https://bugs.python.org/issue40602
<!-- /issue-number -->
