### PR TITLE
bpo-38872: Document exec symbol for codeop.compile_command

### DIFF
--- a/Doc/library/code.rst
+++ b/Doc/library/code.rst
@@ -56,8 +56,8 @@ build applications which provide an interactive interpreter prompt.
 
    *source* is the source string; *filename* is the optional filename from which
    source was read, defaulting to ``'<input>'``; and *symbol* is the optional
-   grammar start symbol, which should be either ``'single'`` (the default) or
-   ``'eval'``.
+   grammar start symbol, which should be either ``'single'`` (the default), ``'eval'``
+   or ``'exec'``.
 
    Returns a code object (the same as ``compile(source, filename, symbol)``) if the
    command is complete and valid; ``None`` if the command is incomplete; raises

--- a/Doc/library/code.rst
+++ b/Doc/library/code.rst
@@ -56,7 +56,7 @@ build applications which provide an interactive interpreter prompt.
 
    *source* is the source string; *filename* is the optional filename from which
    source was read, defaulting to ``'<input>'``; and *symbol* is the optional
-   grammar start symbol, which should be either ``'single'`` (the default), ``'eval'``
+   grammar start symbol, which should be ``'single'`` (the default), ``'eval'``
    or ``'exec'``.
 
    Returns a code object (the same as ``compile(source, filename, symbol)``) if the

--- a/Doc/library/codeop.rst
+++ b/Doc/library/codeop.rst
@@ -43,8 +43,11 @@ To do just the former:
    :exc:`OverflowError` or :exc:`ValueError` if there is an invalid literal.
 
    The *symbol* argument determines whether *source* is compiled as a statement
-   (``'single'``, the default) or as an :term:`expression` (``'eval'``).  Any
-   other value will cause :exc:`ValueError` to  be raised.
+   (``'single'``, the default), as a sequence of statements (``'exec'``) or
+   as an :term:`expression` (``'eval'``).  Any other value will
+   cause :exc:`ValueError` to  be raised. If *symbol* is ``'single'`` and *source*
+   is an expression, executing the resulting code object will print a representation
+   of the object the expression evaluates to unless it evaluates to ``None``.
 
    .. note::
 

--- a/Doc/library/codeop.rst
+++ b/Doc/library/codeop.rst
@@ -45,9 +45,7 @@ To do just the former:
    The *symbol* argument determines whether *source* is compiled as a statement
    (``'single'``, the default), as a sequence of statements (``'exec'``) or
    as an :term:`expression` (``'eval'``).  Any other value will
-   cause :exc:`ValueError` to  be raised. If *symbol* is ``'single'`` and *source*
-   is an expression, executing the resulting code object will print a representation
-   of the object the expression evaluates to unless it evaluates to ``None``.
+   cause :exc:`ValueError` to  be raised.
 
    .. note::
 

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -112,7 +112,8 @@ def compile_command(source, filename="<input>", symbol="single"):
     source -- the source string; may contain \n characters
     filename -- optional filename from which source was read; default
                 "<input>"
-    symbol -- optional grammar start symbol; "single" (default) or "eval"
+    symbol -- optional grammar start symbol; "single" (default), "exec"
+              or "eval"
 
     Return value / exceptions raised:
 


### PR DESCRIPTION
Original author :  Андрей Беньковский, abenkovskii@gmail.com .

<!-- issue-number: [bpo-38872](https://bugs.python.org/issue38872) -->
https://bugs.python.org/issue38872
<!-- /issue-number -->
