### PR TITLE
bpo-40602: Add _Py_HashPointerRaw() function

### DIFF
--- a/Include/pyhash.h
+++ b/Include/pyhash.h
@@ -9,6 +9,8 @@ extern "C" {
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(Py_hash_t) _Py_HashDouble(double);
 PyAPI_FUNC(Py_hash_t) _Py_HashPointer(const void*);
+// Similar to _Py_HashPointer(), but don't replace -1 with -2
+PyAPI_FUNC(Py_hash_t) _Py_HashPointerRaw(const void*);
 PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void*, Py_ssize_t);
 #endif
 

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -109,7 +109,7 @@ _Py_hashtable_hash_ptr(struct _Py_hashtable_t *ht, const void *pkey)
 {
     void *key;
     _Py_HASHTABLE_READ_KEY(ht, pkey, key);
-    return (Py_uhash_t)_Py_HashPointer(key);
+    return (Py_uhash_t)_Py_HashPointerRaw(key);
 }
 
 

--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -129,16 +129,22 @@ _Py_HashDouble(double v)
 }
 
 Py_hash_t
-_Py_HashPointer(const void *p)
+_Py_HashPointerRaw(const void *p)
 {
-    Py_hash_t x;
     size_t y = (size_t)p;
     /* bottom 3 or 4 bits are likely to be 0; rotate y by 4 to avoid
        excessive hash collisions for dicts and sets */
     y = (y >> 4) | (y << (8 * SIZEOF_VOID_P - 4));
-    x = (Py_hash_t)y;
-    if (x == -1)
+    return (Py_hash_t)y;
+}
+
+Py_hash_t
+_Py_HashPointer(const void *p)
+{
+    Py_hash_t x = _Py_HashPointerRaw(p);
+    if (x == -1) {
         x = -2;
+    }
     return x;
 }
 


### PR DESCRIPTION
Add a new _Py_HashPointerRaw() function which avoids replacing -1
with -2 to micro-optimize hash table using pointer keys: using
_Py_hashtable_hash_ptr() hash function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40602](https://bugs.python.org/issue40602) -->
https://bugs.python.org/issue40602
<!-- /issue-number -->
