### PR TITLE
bpo-40611: Adds MAP_POPULATE to the mmap library

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -358,5 +358,5 @@ MAP_* Constants
 
     These are the various flags that can be passed to :meth:`mmap.mmap`. Note that some options might not be present on some systems.
 
-    .. versionchanged:: 3.8
+    .. versionchanged:: 3.10
       Add MAP_POPULATE

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -81,7 +81,9 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
    private copy-on-write mapping, so changes to the contents of the mmap
    object will be private to this process, and :const:`MAP_SHARED` creates a
    mapping that's shared with all other processes mapping the same areas of
-   the file.  The default value is :const:`MAP_SHARED`. Some systems have additional possible flags with the full list specified in :ref:`MAP_* constants <map-constants>`.
+   the file.  The default value is :const:`MAP_SHARED`. Some systems have 
+   additional possible flags with the full list specified in 
+   :ref:`MAP_* constants <map-constants>`.
 
    *prot*, if specified, gives the desired memory protection; the two most
    useful values are :const:`PROT_READ` and :const:`PROT_WRITE`, to specify
@@ -359,4 +361,4 @@ MAP_* Constants
     These are the various flags that can be passed to :meth:`mmap.mmap`. Note that some options might not be present on some systems.
 
     .. versionchanged:: 3.10
-      Add MAP_POPULATE
+       Added MAP_POPULATE constant.

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -81,7 +81,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
    private copy-on-write mapping, so changes to the contents of the mmap
    object will be private to this process, and :const:`MAP_SHARED` creates a
    mapping that's shared with all other processes mapping the same areas of
-   the file.  The default value is :const:`MAP_SHARED`.
+   the file.  The default value is :const:`MAP_SHARED`. Some systems have additional possible flags with the full list specified in :ref:`MAP_* constants <map-constants>`.
 
    *prot*, if specified, gives the desired memory protection; the two most
    useful values are :const:`PROT_READ` and :const:`PROT_WRITE`, to specify
@@ -342,3 +342,21 @@ MADV_* Constants
    Availability: Systems with the madvise() system call.
 
    .. versionadded:: 3.8
+
+.. _map-constants:
+
+MAP_* Constants
++++++++++++++++
+
+.. data:: MAP_SHARED
+          MAP_PRIVATE
+          MAP_DENYWRITE
+          MAP_EXECUTABLE
+          MAP_ANON
+          MAP_ANONYMOUS
+          MAP_POPULATE
+
+    These are the various flags that can be passed to :meth:`mmap.mmap`. Note that some options might not be present on some systems.
+
+    .. versionchanged:: 3.8
+      Add MAP_POPULATE

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -81,8 +81,8 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
    private copy-on-write mapping, so changes to the contents of the mmap
    object will be private to this process, and :const:`MAP_SHARED` creates a
    mapping that's shared with all other processes mapping the same areas of
-   the file.  The default value is :const:`MAP_SHARED`. Some systems have 
-   additional possible flags with the full list specified in 
+   the file.  The default value is :const:`MAP_SHARED`. Some systems have
+   additional possible flags with the full list specified in
    :ref:`MAP_* constants <map-constants>`.
 
    *prot*, if specified, gives the desired memory protection; the two most

--- a/Misc/NEWS.d/next/Library/2020-05-13-16-28-33.bpo-40611.ZCk0_c.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-13-16-28-33.bpo-40611.ZCk0_c.rst
@@ -1,1 +1,1 @@
-MAP_POPULATE has now been added to the list of exported mmap flags.
+:data:`~mmap.MAP_POPULATE` constant has now been added to the list of exported :mod:`mmap` module flags.

--- a/Misc/NEWS.d/next/Library/2020-05-13-16-28-33.bpo-40611.ZCk0_c.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-13-16-28-33.bpo-40611.ZCk0_c.rst
@@ -1,0 +1,1 @@
+MAP_POPULATE has now been added to the list of exported mmap flags.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1574,6 +1574,9 @@ PyInit_mmap(void)
     setint(dict, "MAP_ANON", MAP_ANONYMOUS);
     setint(dict, "MAP_ANONYMOUS", MAP_ANONYMOUS);
 #endif
+#ifdef MAP_POPULATE
+    setint(dict, "MAP_POPULATE", MAP_POPULATE);
+#endif
 
     setint(dict, "PAGESIZE", (long)my_getpagesize());
 


### PR DESCRIPTION
This commit adds MAP_POPULATE to the mmap library. MAP_POPULATE is an incredibly useful flag that enables much more efficient IO on linux systems. Currently it is possible to manually pass MAP_POPULATE in using a hardcoded constant, but this change makes it easier by adding it to the set of flags that mmap exposes. 


<!-- issue-number: [bpo-40611](https://bugs.python.org/issue40611) -->
https://bugs.python.org/issue40611
<!-- /issue-number -->
