### PR TITLE
bpo-40609: _Py_hashtable_t values become void*

### DIFF
--- a/Include/internal/pycore_hashtable.h
+++ b/Include/internal/pycore_hashtable.h
@@ -31,19 +31,8 @@ typedef struct {
 
     Py_uhash_t key_hash;
     void *key;
-    /* data (data_size bytes) follows */
+    void *value;
 } _Py_hashtable_entry_t;
-
-#define _Py_HASHTABLE_ENTRY_PDATA(ENTRY) \
-        ((const void *)((char *)(ENTRY) \
-                        + sizeof(_Py_hashtable_entry_t)))
-
-#define _Py_HASHTABLE_ENTRY_READ_DATA(TABLE, ENTRY, DATA) \
-    do { \
-        assert(sizeof(DATA) == (TABLE)->data_size); \
-        memcpy(&(DATA), _Py_HASHTABLE_ENTRY_PDATA((ENTRY)), \
-                  sizeof(DATA)); \
-    } while (0)
 
 
 /* _Py_hashtable: prototypes */
@@ -55,12 +44,8 @@ typedef struct _Py_hashtable_t _Py_hashtable_t;
 typedef Py_uhash_t (*_Py_hashtable_hash_func) (const void *key);
 typedef int (*_Py_hashtable_compare_func) (const void *key1, const void *key2);
 typedef void (*_Py_hashtable_destroy_func) (void *key);
-typedef void (*_Py_hashtable_value_destroy_func) (_Py_hashtable_t *ht,
-                                                  _Py_hashtable_entry_t *entry);
 typedef _Py_hashtable_entry_t* (*_Py_hashtable_get_entry_func)(_Py_hashtable_t *ht,
                                                                const void *key);
-typedef int (*_Py_hashtable_get_func) (_Py_hashtable_t *ht,
-                                       const void *key, void *data);
 
 typedef struct {
     /* allocate a memory block */
@@ -76,14 +61,12 @@ struct _Py_hashtable_t {
     size_t num_buckets;
     size_t entries; /* Total number of entries in the table. */
     _Py_slist_t *buckets;
-    size_t data_size;
 
-    _Py_hashtable_get_func get_func;
     _Py_hashtable_get_entry_func get_entry_func;
     _Py_hashtable_hash_func hash_func;
     _Py_hashtable_compare_func compare_func;
     _Py_hashtable_destroy_func key_destroy_func;
-    _Py_hashtable_value_destroy_func value_destroy_func;
+    _Py_hashtable_destroy_func value_destroy_func;
     _Py_hashtable_allocator_t alloc;
 };
 
@@ -96,17 +79,14 @@ PyAPI_FUNC(int) _Py_hashtable_compare_direct(
     const void *key2);
 
 PyAPI_FUNC(_Py_hashtable_t *) _Py_hashtable_new(
-    size_t data_size,
     _Py_hashtable_hash_func hash_func,
     _Py_hashtable_compare_func compare_func);
 
 PyAPI_FUNC(_Py_hashtable_t *) _Py_hashtable_new_full(
-    size_t data_size,
-    size_t init_size,
     _Py_hashtable_hash_func hash_func,
     _Py_hashtable_compare_func compare_func,
     _Py_hashtable_destroy_func key_destroy_func,
-    _Py_hashtable_value_destroy_func value_destroy_func,
+    _Py_hashtable_destroy_func value_destroy_func,
     _Py_hashtable_allocator_t *allocator);
 
 PyAPI_FUNC(void) _Py_hashtable_destroy(_Py_hashtable_t *ht);
@@ -114,8 +94,8 @@ PyAPI_FUNC(void) _Py_hashtable_destroy(_Py_hashtable_t *ht);
 PyAPI_FUNC(void) _Py_hashtable_clear(_Py_hashtable_t *ht);
 
 typedef int (*_Py_hashtable_foreach_func) (_Py_hashtable_t *ht,
-                                           _Py_hashtable_entry_t *entry,
-                                           void *arg);
+                                           const void *key, const void *value,
+                                           void *user_data);
 
 /* Call func() on each entry of the hashtable.
    Iteration stops if func() result is non-zero, in this case it's the result
@@ -123,68 +103,42 @@ typedef int (*_Py_hashtable_foreach_func) (_Py_hashtable_t *ht,
 PyAPI_FUNC(int) _Py_hashtable_foreach(
     _Py_hashtable_t *ht,
     _Py_hashtable_foreach_func func,
-    void *arg);
+    void *user_data);
 
-PyAPI_FUNC(size_t) _Py_hashtable_size(_Py_hashtable_t *ht);
+PyAPI_FUNC(size_t) _Py_hashtable_size(const _Py_hashtable_t *ht);
 
 /* Add a new entry to the hash. The key must not be present in the hash table.
-   Return 0 on success, -1 on memory error.
-
-   Don't call directly this function,
-   but use _Py_HASHTABLE_SET() and _Py_HASHTABLE_SET_NODATA() macros */
+   Return 0 on success, -1 on memory error. */
 PyAPI_FUNC(int) _Py_hashtable_set(
     _Py_hashtable_t *ht,
     const void *key,
-    size_t data_size,
-    const void *data);
-
-#define _Py_HASHTABLE_SET(TABLE, KEY, DATA) \
-    _Py_hashtable_set(TABLE, (KEY), sizeof(DATA), &(DATA))
-
-#define _Py_HASHTABLE_SET_NODATA(TABLE, KEY) \
-    _Py_hashtable_set(TABLE, (KEY), 0, NULL)
+    void *value);
 
 
 /* Get an entry.
-   Return NULL if the key does not exist.
-
-   Don't call directly this function, but use _Py_HASHTABLE_GET_ENTRY()
-   macro */
+   Return NULL if the key does not exist. */
 static inline _Py_hashtable_entry_t *
 _Py_hashtable_get_entry(_Py_hashtable_t *ht, const void *key)
 {
     return ht->get_entry_func(ht, key);
 }
 
-#define _Py_HASHTABLE_GET_ENTRY(TABLE, KEY) \
-    _Py_hashtable_get_entry(TABLE, (const void *)(KEY))
+
+/* Get value from an entry.
+   Return NULL if the entry is not found.
+
+   Use _Py_hashtable_get_entry() to distinguish entry value equal to NULL
+   and entry not found. */
+extern void *_Py_hashtable_get(_Py_hashtable_t *ht, const void *key);
 
 
-/* Get data from an entry. Copy entry data into data and return 1 if the entry
-   exists, return 0 if the entry does not exist.
-
-   Don't call directly this function, but use _Py_HASHTABLE_GET() macro */
-static inline int
-_Py_hashtable_get(_Py_hashtable_t *ht, const void *key,
-                  size_t data_size, void *data)
-{
-    assert(data_size == ht->data_size);
-    return ht->get_func(ht, key, data);
-}
-
-#define _Py_HASHTABLE_GET(TABLE, KEY, DATA) \
-    _Py_hashtable_get(TABLE, (KEY), sizeof(DATA), &(DATA))
-
-
-/* Don't call directly this function, but use _Py_HASHTABLE_POP() macro */
-PyAPI_FUNC(int) _Py_hashtable_pop(
+// Remove a key and its associated value without calling key and value destroy
+// functions.
+// Return the removed value if the key was found.
+// Return NULL if the key was not found.
+PyAPI_FUNC(void*) _Py_hashtable_steal(
     _Py_hashtable_t *ht,
-    const void *key,
-    size_t data_size,
-    void *data);
-
-#define _Py_HASHTABLE_POP(TABLE, KEY, DATA) \
-    _Py_hashtable_pop(TABLE, (KEY), sizeof(DATA), &(DATA))
+    const void *key);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
_Py_hashtable_t values become regular "void *" pointers.

* Add _Py_hashtable_entry_t.data member
* Remove _Py_hashtable_t.data_size member
* Remove _Py_hashtable_t.get_func member. It is no longer needed
  to specialize _Py_hashtable_get() for a specific value size, since
  all entries now have the same size (void*).
* Remove the following macros:

  * _Py_HASHTABLE_GET()
  * _Py_HASHTABLE_SET()
  * _Py_HASHTABLE_SET_NODATA()
  * _Py_HASHTABLE_POP()

* Rename _Py_hashtable_pop() to _Py_hashtable_steal()
* _Py_hashtable_foreach() callback now gets key and value rather than
  entry.
* Remove _Py_hashtable_value_destroy_func type. value_destroy_func
  callback now only has a single parameter: data (void*).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40609](https://bugs.python.org/issue40609) -->
https://bugs.python.org/issue40609
<!-- /issue-number -->
