### PR TITLE
bpo-40613: Remove compiler warning from _xxsubinterpretersmodule

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -329,6 +329,7 @@ _objsnapshot_clear(_objsnapshot *osn)
 //    PyMem_Free(osn);
 //}
 
+#ifndef NDEBUG
 static int
 _objsnapshot_is_clear(_objsnapshot *osn)
 {
@@ -336,6 +337,7 @@ _objsnapshot_is_clear(_objsnapshot *osn)
         && _rawstring_is_clear(&osn->modname)
         && _rawstring_is_clear(&osn->clsname);
 }
+#endif
 
 static void
 _objsnapshot_summarize(_objsnapshot *osn, _rawstring *rawbuf, const char *msg)
@@ -597,6 +599,7 @@ _tbsnapshot_free(_tbsnapshot *tbs)
     PyMem_Free(tbs);
 }
 
+#ifndef NDEBUG
 static int
 _tbsnapshot_is_clear(_tbsnapshot *tbs)
 {
@@ -604,6 +607,7 @@ _tbsnapshot_is_clear(_tbsnapshot *tbs)
         && _rawstring_is_clear(&tbs->tbs_funcname)
         && _rawstring_is_clear(&tbs->tbs_filename);
 }
+#endif
 
 static int
 _tbsnapshot_from_pytb(_tbsnapshot *tbs, PyTracebackObject *pytb)
@@ -748,6 +752,7 @@ _excsnapshot_free(_excsnapshot *es)
     PyMem_Free(es);
 }
 
+#ifndef NDEBUG
 static int
 _excsnapshot_is_clear(_excsnapshot *es)
 {
@@ -758,6 +763,7 @@ _excsnapshot_is_clear(_excsnapshot *es)
         && es->es_msg == NULL
         && _objsnapshot_is_clear(&es->es_object);
 }
+#endif
 
 static PyObject *
 _excsnapshot_get_exc_naive(_excsnapshot *es)
@@ -1085,6 +1091,7 @@ _sharedexception_free(_sharedexception *she)
     PyMem_Free(she);
 }
 
+#ifndef NDEBUG
 static int
 _sharedexception_is_clear(_sharedexception *she)
 {
@@ -1092,6 +1099,7 @@ _sharedexception_is_clear(_sharedexception *she)
         && _excsnapshot_is_clear(&she->snapshot)
         && _rawstring_is_clear(&she->msg);
 }
+#endif
 
 static PyObject *
 _sharedexception_get_cause(_sharedexception *sharedexc)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40613](https://bugs.python.org/issue40613) -->
https://bugs.python.org/issue40613
<!-- /issue-number -->
