### PR TITLE
bpo-38787: Fix Argument Clinic defining_class_converter

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -724,7 +724,7 @@ class CLanguage(Language):
 
         parser_prototype_def_class = normalize_snippet("""
             static PyObject *
-            {c_basename}({self_type}{self_name}, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+            {c_basename}({self_type}{self_name}, PyTypeObject *{defining_class_name}, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
         """)
 
         # parser_body_fields remembers the fields passed in to the
@@ -1305,7 +1305,8 @@ class CLanguage(Language):
         template_dict['docstring'] = self.docstring_for_c_string(f)
 
         template_dict['self_name'] = template_dict['self_type'] = template_dict['self_type_check'] = ''
-        f_self.converter.set_template_dict(template_dict)
+        for converter in converters:
+            converter.set_template_dict(template_dict)
 
         f.return_converter.render(f, data)
         template_dict['impl_return_type'] = f.return_converter.type
@@ -2697,6 +2698,10 @@ class CConverter(metaclass=CConverterAutoRegister):
                 {paramname} = {cast}{argname};
                 """.format(argname=argname, paramname=self.name, cast=cast)
         return None
+
+    def set_template_dict(self, template_dict):
+        pass
+
 
 type_checks = {
     '&PyLong_Type': ('PyLong_Check', 'int'),


### PR DESCRIPTION
Don't hardcode defining_class parameter name to "cls":

* Define CConverter.set_template_dict(): do nothing by default
* CLanguage.render_function() now calls set_template_dict() on all
  converters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38787](https://bugs.python.org/issue38787) -->
https://bugs.python.org/issue38787
<!-- /issue-number -->
