### PR TITLE
bpo-40521: Add PyInterpreterState.unicode

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -51,6 +51,19 @@ struct _ceval_state {
 #endif
 };
 
+/* fs_codec.encoding is initialized to NULL.
+   Later, it is set to a non-NULL string by _PyUnicode_InitEncodings(). */
+struct _Py_unicode_fs_codec {
+    char *encoding;   // Filesystem encoding (encoded to UTF-8)
+    int utf8;         // encoding=="utf-8"?
+    char *errors;     // Filesystem errors (encoded to UTF-8)
+    _Py_error_handler error_handler;
+};
+
+struct _Py_unicode_state {
+    struct _Py_unicode_fs_codec fs_codec;
+};
+
 
 /* interpreter state */
 
@@ -97,14 +110,7 @@ struct _is {
     PyObject *codec_error_registry;
     int codecs_initialized;
 
-    /* fs_codec.encoding is initialized to NULL.
-       Later, it is set to a non-NULL string by _PyUnicode_InitEncodings(). */
-    struct {
-        char *encoding;   /* Filesystem encoding (encoded to UTF-8) */
-        int utf8;         /* encoding=="utf-8"? */
-        char *errors;     /* Filesystem errors (encoded to UTF-8) */
-        _Py_error_handler error_handler;
-    } fs_codec;
+    struct _Py_unicode_state unicode;
 
     PyConfig config;
 #ifdef HAVE_DLOPEN

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1007,7 +1007,7 @@ io_check_errors(PyObject *errors)
 
     /* Avoid calling PyCodec_LookupError() before the codec registry is ready:
        before_PyUnicode_InitEncodings() is called. */
-    if (!interp->fs_codec.encoding) {
+    if (!interp->unicode.fs_codec.encoding) {
         return 0;
     }
 


### PR DESCRIPTION
Move PyInterpreterState.fs_codec into a new
PyInterpreterState.unicode structure.

Give a name to the fs_codec structure and use this structure in
unicodeobject.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
