### PR TITLE
[3.8] bpo-25872: Fix KeyError in linecache when multithreaded (GH-18007)

### DIFF
--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -73,10 +73,10 @@ def checkcache(filename=None):
         try:
             stat = os.stat(fullname)
         except OSError:
-            del cache[filename]
+            cache.pop(filename, None)
             continue
         if size != stat.st_size or mtime != stat.st_mtime:
-            del cache[filename]
+            cache.pop(filename, None)
 
 
 def updatecache(filename, module_globals=None):
@@ -86,7 +86,7 @@ def updatecache(filename, module_globals=None):
 
     if filename in cache:
         if len(cache[filename]) != 1:
-            del cache[filename]
+            cache.pop(filename, None)
     if not filename or (filename.startswith('<') and filename.endswith('>')):
         return []
 

--- a/Misc/NEWS.d/next/Library/2020-05-14-13-25-36.bpo-25872.5D5538.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-14-13-25-36.bpo-25872.5D5538.rst
@@ -1,0 +1,2 @@
+:mod:`linecache` could crash with a :exc:`KeyError` when accessed from multiple threads.
+Fix by Michael Graczyk.


### PR DESCRIPTION
Backporting to 3.8 and adding a NEWS item (I should have added one to the master branch -- oh well).

<!-- issue-number: [bpo-25872](https://bugs.python.org/issue25872) -->
https://bugs.python.org/issue25872
<!-- /issue-number -->


Automerge-Triggered-By: @csabella