### PR TITLE
bpo-40055: Fix warnings filters in test_distutils

### DIFF
--- a/Lib/distutils/tests/__init__.py
+++ b/Lib/distutils/tests/__init__.py
@@ -15,6 +15,7 @@ by import rather than matching pre-defined names.
 import os
 import sys
 import unittest
+import warnings
 from test.support import run_unittest
 
 
@@ -22,6 +23,7 @@ here = os.path.dirname(__file__) or os.curdir
 
 
 def test_suite():
+    old_filters = warnings.filters[:]
     suite = unittest.TestSuite()
     for fn in os.listdir(here):
         if fn.startswith("test") and fn.endswith(".py"):
@@ -29,6 +31,10 @@ def test_suite():
             __import__(modname)
             module = sys.modules[modname]
             suite.addTest(module.test_suite())
+    # bpo-40055: Save/restore warnings filters to leave them unchanged.
+    # Importing tests imports docutils which imports pkg_resources which adds a
+    # warnings filter.
+    warnings.filters[:] = old_filters
     return suite
 
 

--- a/Misc/NEWS.d/next/Tests/2020-05-15-01-21-44.bpo-40055.Xp4aP9.rst
+++ b/Misc/NEWS.d/next/Tests/2020-05-15-01-21-44.bpo-40055.Xp4aP9.rst
@@ -1,0 +1,3 @@
+distutils.tests now saves/restores warnings filters to leave them unchanged.
+Importing tests imports docutils which imports pkg_resources which adds a
+warnings filter.


### PR DESCRIPTION
distutils.tests now imports distutils.command.check early and
saves/restores warnings filters. pkg_resources, imported by docutils,
adds a warning filter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40055](https://bugs.python.org/issue40055) -->
https://bugs.python.org/issue40055
<!-- /issue-number -->
