### PR TITLE
bpo-40608: restore protection against double-deallocate issue for subclasses of classes that use trashcan

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -395,6 +395,16 @@ class CAPITest(unittest.TestCase):
             del L
             self.assertEqual(PyList.num, 0)
 
+    def test_subclass_of_base_that_uses_old_macros(self):
+        class Daisy(_testcapi.OldTrashcanMacros):
+            pass
+
+        DEPTH=150
+        daisyChain = Daisy()
+        for x in range(DEPTH):
+            daisyChain = (Daisy(), daisyChain, Daisy())
+        daisyChain = None
+
     def test_subclass_of_heap_gc_ctype_with_tpdealloc_decrefs_once(self):
         class HeapGcCTypeSubclass(_testcapi.HeapGcCType):
             def __init__(self):

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -6011,6 +6011,67 @@ static PyTypeObject MyList_Type = {
     MyList_new,                                 /* tp_new */
 };
 
+/* create baseclass using the old trashcan macros (Py_TRASHCAN_SAFE_BEGIN/END) to test backwards compatibility */
+
+typedef struct {
+    PyObject_HEAD
+} OldTrashcanMacros;
+
+static PyObject* OldTrashcanMacros_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
+{
+    OldTrashcanMacros *self;
+    self = (OldTrashcanMacros*)type->tp_alloc(type, 0);
+    return (PyObject*)self;
+}
+
+static void OldTrashcanMacros_dealloc(OldTrashcanMacros* self)
+{
+    PyObject_GC_UnTrack(self);
+    Py_TRASHCAN_SAFE_BEGIN(self)
+    Py_TYPE(self)->tp_free((PyObject*)self);
+    Py_TRASHCAN_SAFE_END(self)
+}
+
+PyTypeObject OldTrashcanMacros_Type = {
+    PyVarObject_HEAD_INIT(NULL,0)
+    "OldTrashcanMacros",                   /* tp_name */
+    (sizeof(OldTrashcanMacros)),           /* tp_basicsize */
+    0,                                     /* tp_itemsize */
+    (destructor)OldTrashcanMacros_dealloc, /* tp-dealloc */
+    0,                                     /* tp_print */
+    0,                                     /* tp_getattr */
+    0,                                     /* tp_setattr */
+    0,                                     /* tp_compare */
+    0,                                     /* tp_repr */
+    0,                                     /* tp_as_number */
+    0,                                     /* tp_as_sequence */
+    0,                                     /* tp_as_mapping */
+    0,                                     /* tp_hash */
+    0,                                     /* tp_call */
+    0,                                     /* tp_str */
+    0,                                     /* tp_getattro */
+    0,                                     /* tp_setattro */
+    0,                                     /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /* tp_flags */
+    "Old Trashcan Macros Test",            /* tp_doc */
+    0,                                     /* tp_traverse */
+    0,                                     /* tp_clear */
+    0,                                     /* tp_richcompare */
+    0,                                     /* tp_weaklistoffset */
+    0,                                     /* tp_iter */
+    0,                                     /* tp_iternext */
+    0,                                     /* tp_methods */
+    0,                                     /* tp_members */
+    0,                                     /* tp_getset */
+    0,                                     /* tp_base */
+    0,                                     /* tp_dict */
+    0,                                     /* tp_descr_get */
+    0,                                     /* tp_descr_set */
+    0,                                     /* tp_dictoffset */
+    0,                                     /* tp_init */
+    0,                                     /* tp_alloc */
+    OldTrashcanMacros_new,                 /* tp_new */
+};
 
 /* Test PEP 560 */
 
@@ -6640,6 +6701,11 @@ PyInit__testcapi(void)
         return NULL;
     Py_INCREF(&MyList_Type);
     PyModule_AddObject(m, "MyList", (PyObject *)&MyList_Type);
+
+    if (PyType_Ready(&OldTrashcanMacros_Type) < 0)
+        return NULL;
+    Py_INCREF(&OldTrashcanMacros_Type);
+    PyModule_AddObject(m, "OldTrashcanMacros", (PyObject*)&OldTrashcanMacros_Type);
 
     if (PyType_Ready(&MethodDescriptorBase_Type) < 0)
         return NULL;


### PR DESCRIPTION
Added a unit test that segfaults in python 3.8 and reversed the changes in typeobject.c that caused this segfault.

The segfault occurs with the old trashcan macros (Py_TRASHCAN_SAFE_BEGIN/END) and can be avoided by using the new ones (Py_TRASHCAN_BEGIN/END). The purpose of this change is to prevent segfaults in old code, it can be reversed once the old macros are removed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40608](https://bugs.python.org/issue40608) -->
https://bugs.python.org/issue40608
<!-- /issue-number -->
