### PR TITLE
bpo-40636: Clarify the zip built-in docstring.

### DIFF
--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -669,7 +669,7 @@ plain ol' Python and is guaranteed to be available.
     True
     >>> real_tests = [t for t in tests if len(t.examples) > 0]
     >>> len(real_tests) # objects that actually have doctests
-    12
+    13
     >>> for t in real_tests:
     ...     print('{}  {}'.format(len(t.examples), t.name))
     ...
@@ -685,6 +685,7 @@ plain ol' Python and is guaranteed to be available.
     2  builtins.int.bit_length
     5  builtins.memoryview.hex
     1  builtins.oct
+    1  builtins.zip
 
 Note here that 'bin', 'oct', and 'hex' are functions; 'float.as_integer_ratio',
 'float.hex', and 'int.bit_length' are methods; 'float.fromhex' is a classmethod,

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2649,9 +2649,14 @@ static PyMethodDef zip_methods[] = {
 };
 
 PyDoc_STRVAR(zip_doc,
-"zip(*iterables) --> zip object\n\
+"zip(*iterables) --> An iterable zip object that yields tuples.\n\
 \n\
-Return a zip object whose .__next__() method returns a tuple where\n\
+Upon any of the input iterables being exhausted, the zip stops.\n\
+\n\
+   >>> list(zip('abcdefg', range(3), range(4)))\n\
+   [('a', 0, 0), ('b', 1, 1), ('c', 2, 2)]\n\
+\n\
+Returns a zip object whose .__next__() method returns a tuple where\n\
 the i-th element comes from the i-th iterable argument.  The .__next__()\n\
 method continues until the shortest iterable in the argument sequence\n\
 is exhausted and then it raises StopIteration.");

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2651,8 +2651,6 @@ static PyMethodDef zip_methods[] = {
 PyDoc_STRVAR(zip_doc,
 "zip(*iterables) --> A zip object yielding tuples until an input is exhausted.\n\
 \n\
-Upon any of the input iterables being exhausted, the zipping stops.\n\
-\n\
    >>> list(zip('abcdefg', range(3), range(4)))\n\
    [('a', 0, 0), ('b', 1, 1), ('c', 2, 2)]\n\
 \n\

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2654,7 +2654,7 @@ PyDoc_STRVAR(zip_doc,
    >>> list(zip('abcdefg', range(3), range(4)))\n\
    [('a', 0, 0), ('b', 1, 1), ('c', 2, 2)]\n\
 \n\
-The zip object yields n-length tuples where n is the number of iterables\n\
+The zip object yields n-length tuples, where n is the number of iterables\n\
 passed as positional arguments to zip().  The i-th element in every tuple\n\
 comes from the i-th iterable argument to zip().  This continues until the\n\
 shortest iterable in the argument iterables is exhausted.");

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2649,17 +2649,17 @@ static PyMethodDef zip_methods[] = {
 };
 
 PyDoc_STRVAR(zip_doc,
-"zip(*iterables) --> An iterable zip object that yields tuples.\n\
+"zip(*iterables) --> A zip object yielding tuples until an input is exhausted.\n\
 \n\
-Upon any of the input iterables being exhausted, the zip stops.\n\
+Upon any of the input iterables being exhausted, the zipping stops.\n\
 \n\
    >>> list(zip('abcdefg', range(3), range(4)))\n\
    [('a', 0, 0), ('b', 1, 1), ('c', 2, 2)]\n\
 \n\
-Returns a zip object whose .__next__() method returns a tuple where\n\
-the i-th element comes from the i-th iterable argument.  The .__next__()\n\
-method continues until the shortest iterable in the argument sequence\n\
-is exhausted and then it raises StopIteration.");
+The zip object yields n-length tuples where n is the number of iterables\n\
+passed as positional arguments to zip().  The i-th element in every tuple\n\
+comes from the i-th iterable argument to zip().  This continues until the\n\
+shortest iterable in the argument sequences is exhausted.");
 
 PyTypeObject PyZip_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2657,7 +2657,7 @@ PyDoc_STRVAR(zip_doc,
 The zip object yields n-length tuples, where n is the number of iterables\n\
 passed as positional arguments to zip().  The i-th element in every tuple\n\
 comes from the i-th iterable argument to zip().  This continues until the\n\
-shortest iterable in the argument iterables is exhausted.");
+shortest argument is exhausted.");
 
 PyTypeObject PyZip_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2659,7 +2659,7 @@ Upon any of the input iterables being exhausted, the zipping stops.\n\
 The zip object yields n-length tuples where n is the number of iterables\n\
 passed as positional arguments to zip().  The i-th element in every tuple\n\
 comes from the i-th iterable argument to zip().  This continues until the\n\
-shortest iterable in the argument sequences is exhausted.");
+shortest iterable in the argument iterables is exhausted.");
 
 PyTypeObject PyZip_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)


### PR DESCRIPTION
This puts much simpler text up front along with an example.

As it was, the zip built-in docstring was technically correct.  But too
technical for the reader who shouldn't _need_ to know about `__next__` and
`StopIteration` as most people do not need to understand the internal
implementation details of the iterator protocol in their daily life.

This is a documentation only change, intended to be backported to 3.8; it is
only tangentially related to PEP-618 which might offer new behavior options
in the future.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40636](https://bugs.python.org/issue40636) -->
https://bugs.python.org/issue40636
<!-- /issue-number -->
