### PR TITLE
bpo-40645: Deprecated internal details of hmac.HMAC (GH-20132)

### DIFF
--- a/Doc/library/hmac.rst
+++ b/Doc/library/hmac.rst
@@ -114,6 +114,12 @@ A hash object has the following attributes:
    .. versionadded:: 3.4
 
 
+.. deprecated:: 3.9
+
+   The undocumented attributes ``HMAC.digest_cons``, ``HMAC.inner``, and
+   ``HMAC.outer`` are internal implementation details and will be removed in
+   Python 3.10.
+
 This module also provides the following helper function:
 
 .. function:: compare_digest(a, b)

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -409,11 +409,11 @@ class CopyTestCase(unittest.TestCase):
         # Testing if attributes are of same type.
         h1 = hmac.HMAC(b"key", digestmod="sha256")
         h2 = h1.copy()
-        self.assertTrue(h1.digest_cons == h2.digest_cons,
+        self.assertTrue(h1._digest_cons == h2._digest_cons,
             "digest constructors don't match.")
-        self.assertEqual(type(h1.inner), type(h2.inner),
+        self.assertEqual(type(h1._inner), type(h2._inner),
             "Types of inner don't match.")
-        self.assertEqual(type(h1.outer), type(h2.outer),
+        self.assertEqual(type(h1._outer), type(h2._outer),
             "Types of outer don't match.")
 
     @hashlib_helper.requires_hashdigest('sha256')
@@ -423,10 +423,21 @@ class CopyTestCase(unittest.TestCase):
         h2 = h1.copy()
         # Using id() in case somebody has overridden __eq__/__ne__.
         self.assertTrue(id(h1) != id(h2), "No real copy of the HMAC instance.")
-        self.assertTrue(id(h1.inner) != id(h2.inner),
+        self.assertTrue(id(h1._inner) != id(h2._inner),
             "No real copy of the attribute 'inner'.")
-        self.assertTrue(id(h1.outer) != id(h2.outer),
+        self.assertTrue(id(h1._outer) != id(h2._outer),
             "No real copy of the attribute 'outer'.")
+        self.assertEqual(h1._inner, h1.inner)
+        self.assertEqual(h1._outer, h1.outer)
+        self.assertEqual(h1._digest_cons, h1.digest_cons)
+
+    @hashlib_helper.requires_hashdigest('sha256')
+    def test_properties(self):
+        # deprecated properties
+        h1 = hmac.HMAC(b"key", digestmod="sha256")
+        self.assertEqual(h1._inner, h1.inner)
+        self.assertEqual(h1._outer, h1.outer)
+        self.assertEqual(h1._digest_cons, h1.digest_cons)
 
     @hashlib_helper.requires_hashdigest('sha256')
     def test_equality(self):

--- a/Misc/NEWS.d/next/Library/2020-05-16-19-34-38.bpo-40645.7ibMt-.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-16-19-34-38.bpo-40645.7ibMt-.rst
@@ -1,0 +1,3 @@
+The :class:`hmac.HMAC` exposes internal implementation details. The
+attributes ``digest_cons``, ``inner``, and ``outer`` are deprecated and will
+be removed in the future.


### PR DESCRIPTION
The :class:`hmac.HMAC` exposes internal implementation details. The
attributes ``digest_cons``, ``inner``, and ``outer`` are deprecated and will
be removed in the future.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40645](https://bugs.python.org/issue40645) -->
https://bugs.python.org/issue40645
<!-- /issue-number -->


Automerge-Triggered-By: @tiran