### PR TITLE
bpo-38870: Do not seperate factor prefixes

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1190,10 +1190,10 @@ class _Unparser(NodeVisitor):
 
     unop = {"Invert": "~", "Not": "not", "UAdd": "+", "USub": "-"}
     unop_precedence = {
-        "~": _Precedence.FACTOR,
         "not": _Precedence.NOT,
+        "~": _Precedence.FACTOR,
         "+": _Precedence.FACTOR,
-        "-": _Precedence.FACTOR
+        "-": _Precedence.FACTOR,
     }
 
     def visit_UnaryOp(self, node):
@@ -1201,7 +1201,10 @@ class _Unparser(NodeVisitor):
         operator_precedence = self.unop_precedence[operator]
         with self.require_parens(operator_precedence, node):
             self.write(operator)
-            self.write(" ")
+            # factor prefixes (+, -, ~) shouldn't be seperated
+            # from the value they belong, (e.g: +1 instead of + 1)
+            if operator_precedence is not _Precedence.FACTOR:
+                self.write(" ")
             self.set_precedence(operator_precedence, node.operand)
             self.traverse(node.operand)
 

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -347,7 +347,7 @@ class CosmeticTestCase(ASTTestCase):
         self.check_src_roundtrip("(1 + 2) / 3")
         self.check_src_roundtrip("(1 + 2) * 3 + 4 * (5 + 2)")
         self.check_src_roundtrip("(1 + 2) * 3 + 4 * (5 + 2) ** 2")
-        self.check_src_roundtrip("~ x")
+        self.check_src_roundtrip("~x")
         self.check_src_roundtrip("x and y")
         self.check_src_roundtrip("x and y and z")
         self.check_src_roundtrip("x and (y and x)")
@@ -400,6 +400,12 @@ class CosmeticTestCase(ASTTestCase):
                 src = f"{prefix}{negative}"
                 self.check_ast_roundtrip(src)
                 self.check_src_dont_roundtrip(src)
+
+    def test_unary_op_factor(self):
+        for prefix in ("+", "-", "~"):
+            self.check_src_roundtrip(f"{prefix}1")
+        for prefix in ("not",):
+            self.check_src_roundtrip(f"{prefix} 1")
 
 class DirectoryTestCase(ASTTestCase):
     """Test roundtrip behaviour on all files in Lib and Lib/test."""


### PR DESCRIPTION
```py
>>> ast.unparse(ast.parse("+value"))
'+ value'
>>> ast.unparse(ast.parse("+value / -EPSILON"))
'+ value / - EPSILON'
```

with this PR
```py
>>> ast.unparse(ast.parse("+value"))
'+value'
>>> ast.unparse(ast.parse("+value / -EPSILON"))
'+value / -EPSILON'
>>> ast.unparse(ast.parse("option = not congig.option"))
'option = not congig.option'
```

<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
