### PR TITLE
bpo-38870: don't put unnecessary parantheses on class declarations

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -930,7 +930,7 @@ class _Unparser(NodeVisitor):
             self.fill("@")
             self.traverse(deco)
         self.fill("class " + node.name)
-        with self.delimit("(", ")"):
+        with self.delimit_if("(", ")", condition = node.bases or node.keywords):
             comma = False
             for e in node.bases:
                 if comma:

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -110,7 +110,7 @@ with f() as x, g() as y:
 
 docstring_prefixes = [
     "",
-    "class foo():\n    ",
+    "class foo:\n    ",
     "def foo():\n    ",
     "async def foo():\n    ",
 ]
@@ -366,6 +366,19 @@ class CosmeticTestCase(ASTTestCase):
         self.check_src_roundtrip("yield from x")
         self.check_src_roundtrip("call((yield x))")
         self.check_src_roundtrip("return x + (yield x)")
+
+
+    def test_class_bases_and_keywords(self):
+        self.check_src_roundtrip("class X:\n    pass")
+        self.check_src_roundtrip("class X(A):\n    pass")
+        self.check_src_roundtrip("class X(A, B, C, D):\n    pass")
+        self.check_src_roundtrip("class X(x=y):\n    pass")
+        self.check_src_roundtrip("class X(metaclass=z):\n    pass")
+        self.check_src_roundtrip("class X(x=y, z=d):\n    pass")
+        self.check_src_roundtrip("class X(A, x=y):\n    pass")
+        self.check_src_roundtrip("class X(A, **kw):\n    pass")
+        self.check_src_roundtrip("class X(*args):\n    pass")
+        self.check_src_roundtrip("class X(*args, **kwargs):\n    pass")
 
     def test_docstrings(self):
         docstrings = (


### PR DESCRIPTION
current:
```py
>>> ast.unparse(ast.parse("class Type: pass"))
'class Type():\n    pass'
```

after this PR:
```py
>>> ast.unparse(ast.parse("class Type: pass"))
'class Type:\n    pass'
>>> ast.unparse(ast.parse("class Type(BaseType): pass"))
'class Type(BaseType):\n    pass'
```

<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
