### PR TITLE
[3.8] bpo-39959: Do not use resource_tracker for shared_memory

### DIFF
--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -112,10 +112,6 @@ class SharedMemory:
             except OSError:
                 self.unlink()
                 raise
-
-            from .resource_tracker import register
-            register(self._name, "shared_memory")
-
         else:
 
             # Windows Named Shared Memory
@@ -234,9 +230,7 @@ class SharedMemory:
         called once (and only once) across all processes which have access
         to the shared memory block."""
         if _USE_POSIX and self._name:
-            from .resource_tracker import unregister
             _posixshmem.shm_unlink(self._name)
-            unregister(self._name, "shared_memory")
 
 
 _encoding = "utf8"

--- a/Misc/NEWS.d/next/Library/2020-05-16-21-31-41.bpo-39959.1TTyew.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-16-21-31-41.bpo-39959.1TTyew.rst
@@ -1,0 +1,1 @@
+Drop use of resource_tracker in "multiprocessing.shared_memory.SharedMemory"


### PR DESCRIPTION
This PR aims to fix the issue with "multiprocessing.shared_memory.SharedMemory" class registering open shared memory with resource_tracker, causing shared memory clean up after any of the connecting processes exit. The idea is not to use the resource_tracker at all and let the user be responsible for shared memory clean up. This allows shared memory to persist even if either the creating or any other reading processes have long exited. 

https://bugs.python.org/issue39959

**shm.py**



```
from multiprocessing import shared_memory
import struct
import sys

def connect_shm(name):
    shm_r = shared_memory.SharedMemory(name)
    print("Attached to shared memory")
    print(struct.unpack("i", bytes(shm_r.buf[0:4])))

    shm_r.close()

def create_shm(name, spin=False):
    shm_c = shared_memory.SharedMemory(name=name, create=True, size=4096*5)

    print("Created shared memory")

    buf = shm_c.buf

    buf[0:4] = struct.pack("i", 4096)

    shm_c.close()

if __name__ == "__main__":
    mode = sys.argv[1]

    name = "test"

    if mode == "-create":
        create_shm(name, True)
    elif mode == "-attach":
        connect_shm(name)
```

```
python3.8 shm.py -create
python3.7 shm.py -attach
```

- Before this change

> resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown

- After this change

> Created shared memory

> Attached to shared memory
> (4096,)



<!-- issue-number: [bpo-39959](https://bugs.python.org/issue39959) -->
https://bugs.python.org/issue39959
<!-- /issue-number -->
