### PR TITLE
bpo-40650: Include winsock2.h in pytime.c, instead of a full windows.h

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-05-17-00-08-13.bpo-40650.4euMtU.rst
+++ b/Misc/NEWS.d/next/Windows/2020-05-17-00-08-13.bpo-40650.4euMtU.rst
@@ -1,0 +1,1 @@
+Include winsock2.h in pytime.c for timeval.

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1,6 +1,6 @@
 #include "Python.h"
 #ifdef MS_WINDOWS
-#include <windows.h>
+#include <winsock2.h>         /* struct timeval */
 #endif
 
 #if defined(__APPLE__)


### PR DESCRIPTION
Python/pytime.c only needs struct timeval from windows.h. It can be changed to winsock2.h for better compiling performance. Picking winsock2.h instead of winsock.h is because the 2 version works with desktop apps and UWP apps.

<!-- issue-number: [bpo-40650](https://bugs.python.org/issue40650) -->
https://bugs.python.org/issue40650
<!-- /issue-number -->
