### PR TITLE
bpo-40651: Bugfix of the `LRU` implementation based on `OrderedDict` in the collections document

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1161,6 +1161,8 @@ variants of :func:`functools.lru_cache`::
             return value
 
         def __setitem__(self, key, value):
+            if key in self:
+                self.move_to_end(key)
             super().__setitem__(key, value)
             if len(self) > self.maxsize:
                 oldest = next(iter(self))


### PR DESCRIPTION
[bpo-40651](https://bugs.python.org/issue40651): Bugfix of the `LRU` implementation based on `OrderedDict` in the `collections` module documents.

It didn't consider the calls to `__setitem__` method as usage.

<!-- issue-number: [bpo-40651](https://bugs.python.org/issue40651) -->
https://bugs.python.org/issue40651
<!-- /issue-number -->
