### PR TITLE
bpo-40653: Move _dirnameW out of #ifdef HAVE_SYMLINK/#endif

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-05-17-03-33-00.bpo-40653.WI8UGn.rst
+++ b/Misc/NEWS.d/next/Build/2020-05-17-03-33-00.bpo-40653.WI8UGn.rst
@@ -1,0 +1,1 @@
+Move _dirnameW out of HAVE_SYMLINK to fix a potential compiling issue.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8156,8 +8156,6 @@ os_readlink_impl(PyObject *module, path_t *path, int dir_fd)
 }
 #endif /* defined(HAVE_READLINK) || defined(MS_WINDOWS) */
 
-#ifdef HAVE_SYMLINK
-
 #if defined(MS_WINDOWS)
 
 /* Remove the last portion of the path - return 0 on success */
@@ -8179,6 +8177,12 @@ _dirnameW(WCHAR *path)
     *ptr = 0;
     return 0;
 }
+
+#endif
+
+#ifdef HAVE_SYMLINK
+
+#if defined(MS_WINDOWS)
 
 /* Is this path absolute? */
 static int


### PR DESCRIPTION
_dirnameW is used in os__getdiskusage_impl, which is outside HAVE_SYMLINK. So if HAVE_SYMLINK is not defined (e.g., on UWP), it'll have compiling issues. Move _dirnameW out to fix this problem.

<!-- issue-number: [bpo-40653](https://bugs.python.org/issue40653) -->
https://bugs.python.org/issue40653
<!-- /issue-number -->
