### PR TITLE
bpo-40655: Fix 'from x import *' which is bad programming practice from 'Lib/ctypes/test'

### DIFF
--- a/Lib/ctypes/_endian.py
+++ b/Lib/ctypes/_endian.py
@@ -1,5 +1,5 @@
 import sys
-from ctypes import *
+from ctypes import Array, Structure
 
 _array_type = type(Array)
 

--- a/Lib/ctypes/test/test_anon.py
+++ b/Lib/ctypes/test/test_anon.py
@@ -1,6 +1,6 @@
 import unittest
 import test.support
-from ctypes import *
+from ctypes import Structure, Union, c_int, sizeof
 
 class AnonTest(unittest.TestCase):
 

--- a/Lib/ctypes/test/test_array_in_pointer.py
+++ b/Lib/ctypes/test/test_array_in_pointer.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import POINTER, c_byte, cast, Structure
 from binascii import hexlify
 import re
 

--- a/Lib/ctypes/test/test_arrays.py
+++ b/Lib/ctypes/test/test_arrays.py
@@ -1,8 +1,10 @@
 import unittest
 from test.support import bigmemtest, _2G
 import sys
-from ctypes import *
-
+from ctypes import (
+    ARRAY, Array, Structure, addressof, c_byte, c_char, c_double, c_float,
+    c_int, c_long, c_longdouble, c_short, c_ubyte, c_uint, c_ulonglong,
+    c_ushort, c_wchar, create_string_buffer, create_unicode_buffer, sizeof)
 from ctypes.test import need_symbol
 
 formats = "bBhHiIlLqQfd"

--- a/Lib/ctypes/test/test_as_parameter.py
+++ b/Lib/ctypes/test/test_as_parameter.py
@@ -1,13 +1,15 @@
 import unittest
-from ctypes import *
+from ctypes import (
+    CDLL, CFUNCTYPE, POINTER, ArgumentError, Structure, byref, c_byte,
+    c_double, c_float, c_int, c_long, c_longlong, c_short, c_wchar, pointer)
 from ctypes.test import need_symbol
 import _ctypes_test
 
 dll = CDLL(_ctypes_test.__file__)
 
 try:
-    CALLBACK_FUNCTYPE = WINFUNCTYPE
-except NameError:
+    from ctypes import WINFUNCTYPE as CALLBACK_FUNCTYPE
+except ImportError:
     # fake to enable this test on Linux
     CALLBACK_FUNCTYPE = CFUNCTYPE
 

--- a/Lib/ctypes/test/test_bitfields.py
+++ b/Lib/ctypes/test/test_bitfields.py
@@ -1,4 +1,8 @@
-from ctypes import *
+from ctypes import (
+    CDLL, POINTER, BigEndianStructure, LittleEndianStructure, Structure,
+    alignment, byref, c_byte, c_char, c_char_p, c_int, c_long, c_longlong,
+    c_short, c_ubyte, c_uint, c_uint32, c_uint64, c_ulong, c_ulonglong,
+    c_ushort, c_void_p, c_wchar, sizeof)
 from ctypes.test import need_symbol
 import unittest
 import os

--- a/Lib/ctypes/test/test_buffers.py
+++ b/Lib/ctypes/test/test_buffers.py
@@ -1,4 +1,5 @@
-from ctypes import *
+from ctypes import (
+    c_char, c_wchar, create_string_buffer, create_unicode_buffer, sizeof)
 from ctypes.test import need_symbol
 import unittest
 

--- a/Lib/ctypes/test/test_bytes.py
+++ b/Lib/ctypes/test/test_bytes.py
@@ -1,7 +1,7 @@
 """Test where byte objects are accepted"""
 import unittest
 import sys
-from ctypes import *
+from ctypes import Structure, c_char, c_char_p, c_wchar, c_wchar_p
 
 class BytesTest(unittest.TestCase):
     def test_c_char(self):

--- a/Lib/ctypes/test/test_byteswap.py
+++ b/Lib/ctypes/test/test_byteswap.py
@@ -1,7 +1,10 @@
-import sys, unittest, struct, math, ctypes
+import sys, unittest, struct, math
 from binascii import hexlify
-
-from ctypes import *
+from ctypes import (
+    POINTER, BigEndianStructure, LittleEndianStructure, Structure,
+    _pointer_type_cache, c_byte, c_char, c_double, c_float, c_int, c_long,
+    c_longlong, c_short, c_ubyte, c_uint, c_uint32, c_ulong, c_ulonglong,
+    c_ushort, c_void_p, c_wchar, cast, sizeof)
 
 def bin(s):
     return hexlify(memoryview(s)).decode().upper()
@@ -229,7 +232,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(len(data), sizeof(TestStructure))
                 ptr = POINTER(TestStructure)
                 s = cast(data, ptr)[0]
-                del ctypes._pointer_type_cache[TestStructure]
+                del _pointer_type_cache[TestStructure]
                 self.assertEqual(s.point.x, 1)
                 self.assertEqual(s.point.y, 2)
 

--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -1,6 +1,13 @@
 import functools
 import unittest
-from ctypes import *
+from ctypes import (
+    CDLL, CFUNCTYPE, POINTER, Structure, c_byte, c_char, c_char_p, c_double,
+    c_float, c_int, c_long, c_longdouble, c_longlong, c_short, c_ubyte, c_uint,
+    c_ulong, c_ulonglong, c_ushort, py_object, sizeof)
+try:
+    from ctypes import WINFUNCTYPE
+except ImportError:
+    pass
 from ctypes.test import need_symbol
 import _ctypes_test
 
@@ -194,6 +201,7 @@ class SampleCallbacksTestCase(unittest.TestCase):
 
     @need_symbol('WINFUNCTYPE')
     def test_issue_8959_b(self):
+        from ctypes import windll
         from ctypes.wintypes import BOOL, HWND, LPARAM
         global windowCount
         windowCount = 0

--- a/Lib/ctypes/test/test_cast.py
+++ b/Lib/ctypes/test/test_cast.py
@@ -1,4 +1,6 @@
-from ctypes import *
+from ctypes import (
+    POINTER, Structure, Union, addressof, c_byte, c_char_p, c_int, c_short,
+    c_void_p, c_wchar_p, cast, sizeof)
 from ctypes.test import need_symbol
 import unittest
 import sys

--- a/Lib/ctypes/test/test_cfuncs.py
+++ b/Lib/ctypes/test/test_cfuncs.py
@@ -2,7 +2,9 @@
 # Byte order related?
 
 import unittest
-from ctypes import *
+from ctypes import (
+    CDLL, c_byte, c_char, c_double, c_float, c_int, c_long, c_longdouble,
+    c_longlong, c_short, c_ubyte, c_uint, c_ulong, c_ulonglong, c_ushort)
 from ctypes.test import need_symbol
 
 import _ctypes_test
@@ -192,8 +194,8 @@ class CFunctions(unittest.TestCase):
 # The following repeats the above tests with stdcall functions (where
 # they are available)
 try:
-    WinDLL
-except NameError:
+    from ctypes import WinDLL
+except ImportError:
     def stdcall_dll(*_): pass
 else:
     class stdcall_dll(WinDLL):

--- a/Lib/ctypes/test/test_checkretval.py
+++ b/Lib/ctypes/test/test_checkretval.py
@@ -1,13 +1,14 @@
 import unittest
 
-from ctypes import *
+from ctypes import CDLL, c_int
 from ctypes.test import need_symbol
 
 class CHECKED(c_int):
+
+    @staticmethod
     def _check_retval_(value):
         # Receives a CHECKED instance.
         return str(value.value)
-    _check_retval_ = staticmethod(_check_retval_)
 
 class Test(unittest.TestCase):
 
@@ -28,6 +29,7 @@ class Test(unittest.TestCase):
 
     @need_symbol('oledll')
     def test_oledll(self):
+        from ctypes import oledll
         self.assertRaises(OSError,
                               oledll.oleaut32.CreateTypeLib2,
                               0, None, None)

--- a/Lib/ctypes/test/test_delattr.py
+++ b/Lib/ctypes/test/test_delattr.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import Structure, c_char, c_int
 
 class X(Structure):
     _fields_ = [("foo", c_int)]

--- a/Lib/ctypes/test/test_errno.py
+++ b/Lib/ctypes/test/test_errno.py
@@ -1,7 +1,7 @@
 import unittest, os, errno
 import threading
 
-from ctypes import *
+from ctypes import CDLL, c_char_p, c_int, c_wchar_p, get_errno, set_errno
 from ctypes.util import find_library
 
 class Test(unittest.TestCase):
@@ -44,6 +44,7 @@ class Test(unittest.TestCase):
 
     @unittest.skipUnless(os.name == "nt", 'Test specific to Windows')
     def test_GetLastError(self):
+        from ctypes import WinDLL, get_last_error, set_last_error
         dll = WinDLL("kernel32", use_last_error=True)
         GetModuleHandle = dll.GetModuleHandleA
         GetModuleHandle.argtypes = [c_wchar_p]

--- a/Lib/ctypes/test/test_find.py
+++ b/Lib/ctypes/test/test_find.py
@@ -2,7 +2,7 @@ import unittest
 import os.path
 import sys
 import test.support
-from ctypes import *
+from ctypes import CDLL, RTLD_GLOBAL
 from ctypes.util import find_library
 
 # On some systems, loading the OpenGL libraries needs the RTLD_GLOBAL mode.

--- a/Lib/ctypes/test/test_frombuffer.py
+++ b/Lib/ctypes/test/test_frombuffer.py
@@ -1,4 +1,4 @@
-from ctypes import *
+from ctypes import Array, Structure, Union, c_char, c_int, sizeof
 import array
 import gc
 import unittest

--- a/Lib/ctypes/test/test_funcptr.py
+++ b/Lib/ctypes/test/test_funcptr.py
@@ -1,9 +1,10 @@
 import unittest
-from ctypes import *
-
+from ctypes import (
+    CDLL, CFUNCTYPE, Structure, c_char, c_char_p, c_int, c_long, c_uint,
+    c_voidp, sizeof)
 try:
-    WINFUNCTYPE
-except NameError:
+    from ctypes import WINFUNCTYPE
+except ImportError:
     # fake to enable this test on Linux
     WINFUNCTYPE = CFUNCTYPE
 
@@ -91,6 +92,7 @@ class CFuncPtrTestCase(unittest.TestCase):
 
         def NoNullHandle(value):
             if not value:
+                from ctypes import WinError
                 raise WinError()
             return value
 

--- a/Lib/ctypes/test/test_functions.py
+++ b/Lib/ctypes/test/test_functions.py
@@ -5,19 +5,23 @@ show how the type behave.
 Later...
 """
 
-from ctypes import *
+from ctypes import (
+    CDLL, CFUNCTYPE, POINTER, ArgumentError, Array, Structure, byref, c_byte,
+    c_char_p, c_double, c_float, c_int, c_long, c_longdouble, c_longlong,
+    c_short, c_wchar, pointer)
 from ctypes.test import need_symbol
 import sys, unittest
 
 try:
-    WINFUNCTYPE
-except NameError:
+    from ctypes import WINFUNCTYPE
+except ImportError:
     # fake to enable this test on Linux
     WINFUNCTYPE = CFUNCTYPE
 
 import _ctypes_test
 dll = CDLL(_ctypes_test.__file__)
 if sys.platform == "win32":
+    from ctypes import WinDLL
     windll = WinDLL(_ctypes_test.__file__)
 
 class POINT(Structure):

--- a/Lib/ctypes/test/test_incomplete.py
+++ b/Lib/ctypes/test/test_incomplete.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import POINTER, SetPointerType, Structure, c_char_p, pointer
 
 ################################################################
 #

--- a/Lib/ctypes/test/test_init.py
+++ b/Lib/ctypes/test/test_init.py
@@ -1,4 +1,4 @@
-from ctypes import *
+from ctypes import Structure, c_int
 import unittest
 
 class X(Structure):

--- a/Lib/ctypes/test/test_internals.py
+++ b/Lib/ctypes/test/test_internals.py
@@ -1,6 +1,6 @@
 # This tests the internal _objects attribute
 import unittest
-from ctypes import *
+from ctypes import POINTER, Structure, c_char_p, c_int
 from sys import getrefcount as grc
 
 # XXX This test must be reviewed for correctness!!!

--- a/Lib/ctypes/test/test_keeprefs.py
+++ b/Lib/ctypes/test/test_keeprefs.py
@@ -1,4 +1,4 @@
-from ctypes import *
+from ctypes import POINTER, Structure, c_char_p, c_int, pointer
 import unittest
 
 class SimpleTestCase(unittest.TestCase):

--- a/Lib/ctypes/test/test_libc.py
+++ b/Lib/ctypes/test/test_libc.py
@@ -1,6 +1,8 @@
 import unittest
 
-from ctypes import *
+from ctypes import (
+    CDLL, CFUNCTYPE, POINTER, c_char, c_double, c_int, c_size_t, c_void_p,
+    create_string_buffer, sizeof)
 import _ctypes_test
 
 lib = CDLL(_ctypes_test.__file__)

--- a/Lib/ctypes/test/test_loading.py
+++ b/Lib/ctypes/test/test_loading.py
@@ -1,11 +1,14 @@
-from ctypes import *
 import os
 import shutil
 import subprocess
 import sys
 import unittest
 import test.support
+from ctypes import CDLL, c_char_p, c_void_p, cdll
 from ctypes.util import find_library
+
+if os.name == "nt":
+    from ctypes import WinDLL, addressof, windll
 
 libc_name = None
 
@@ -59,13 +62,12 @@ class LoaderTest(unittest.TestCase):
             print(find_library("kernel32"))
             print(find_library("user32"))
 
-        if os.name == "nt":
-            windll.kernel32.GetModuleHandleW
-            windll["kernel32"].GetModuleHandleW
-            windll.LoadLibrary("kernel32").GetModuleHandleW
-            WinDLL("kernel32").GetModuleHandleW
-            # embedded null character
-            self.assertRaises(ValueError, windll.LoadLibrary, "kernel32\0")
+        windll.kernel32.GetModuleHandleW
+        windll["kernel32"].GetModuleHandleW
+        windll.LoadLibrary("kernel32").GetModuleHandleW
+        WinDLL("kernel32").GetModuleHandleW
+        # embedded null character
+        self.assertRaises(ValueError, windll.LoadLibrary, "kernel32\0")
 
     @unittest.skipUnless(os.name == "nt",
                          'test specific to Windows')

--- a/Lib/ctypes/test/test_memfunctions.py
+++ b/Lib/ctypes/test/test_memfunctions.py
@@ -1,7 +1,9 @@
 import sys
 from test import support
 import unittest
-from ctypes import *
+from ctypes import (
+    POINTER, c_byte, c_char_p, c_ubyte, c_wchar, cast, create_string_buffer,
+    create_unicode_buffer, memmove, memset, sizeof, string_at, wstring_at)
 from ctypes.test import need_symbol
 
 class MemFunctionsTest(unittest.TestCase):

--- a/Lib/ctypes/test/test_numbers.py
+++ b/Lib/ctypes/test/test_numbers.py
@@ -1,4 +1,7 @@
-from ctypes import *
+from ctypes import (
+    alignment, byref, c_bool, c_byte, c_double, c_float, c_int, c_long,
+    c_longdouble, c_longlong, c_short, c_ubyte, c_uint, c_ulong, c_ulonglong,
+    c_ushort, sizeof)
 import unittest
 import struct
 

--- a/Lib/ctypes/test/test_parameters.py
+++ b/Lib/ctypes/test/test_parameters.py
@@ -5,7 +5,6 @@ import test.support
 class SimpleTypesTestCase(unittest.TestCase):
 
     def setUp(self):
-        import ctypes
         try:
             from _ctypes import set_conversion_mode
         except ImportError:

--- a/Lib/ctypes/test/test_pep3118.py
+++ b/Lib/ctypes/test/test_pep3118.py
@@ -1,5 +1,9 @@
 import unittest
-from ctypes import *
+from ctypes import (
+    CFUNCTYPE, POINTER, BigEndianStructure, LittleEndianStructure, Structure,
+    Union, c_bool, c_byte, c_char, c_double, c_float, c_int, c_long,
+    c_longdouble, c_longlong, c_short, c_ubyte, c_uint, c_ulong, c_ulonglong,
+    c_ushort, py_object, sizeof)
 import re, sys
 
 if sys.byteorder == "little":

--- a/Lib/ctypes/test/test_pickling.py
+++ b/Lib/ctypes/test/test_pickling.py
@@ -1,6 +1,8 @@
 import unittest
 import pickle
-from ctypes import *
+from ctypes import (
+    CDLL, CFUNCTYPE, Structure, c_char, c_char_p, c_double, c_int, c_void_p,
+    c_wchar, c_wchar_p, pointer)
 import _ctypes_test
 dll = CDLL(_ctypes_test.__file__)
 

--- a/Lib/ctypes/test/test_pointers.py
+++ b/Lib/ctypes/test/test_pointers.py
@@ -1,6 +1,9 @@
 import unittest, sys
 
-from ctypes import *
+from ctypes import (
+    CDLL, CFUNCTYPE, POINTER, Structure, byref, c_byte, c_char_p, c_double,
+    c_float, c_int, c_long, c_longlong, c_short, c_ubyte, c_uint, c_ulong,
+    c_ulonglong, c_ushort, c_void_p, pointer, sizeof)
 import _ctypes_test
 
 ctype_types = [c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
@@ -193,6 +196,7 @@ class PointersTestCase(unittest.TestCase):
 
         # COM methods are boolean True:
         if sys.platform == "win32":
+            from ctypes import WINFUNCTYPE
             mth = WINFUNCTYPE(None)(42, "name", (), None)
             self.assertEqual(bool(mth), True)
 

--- a/Lib/ctypes/test/test_prototypes.py
+++ b/Lib/ctypes/test/test_prototypes.py
@@ -1,4 +1,7 @@
-from ctypes import *
+from ctypes import (
+    CDLL, CFUNCTYPE, POINTER, ArgumentError, addressof, byref, c_buffer,
+    c_char, c_char_p, c_double, c_int, c_long, c_longlong, c_short, c_void_p,
+    c_wchar, c_wchar_p, pointer, sizeof)
 from ctypes.test import need_symbol
 import unittest
 

--- a/Lib/ctypes/test/test_python_api.py
+++ b/Lib/ctypes/test/test_python_api.py
@@ -1,4 +1,6 @@
-from ctypes import *
+from ctypes import (
+    POINTER, c_buffer, c_char, c_char_p, c_int, c_long, c_size_t, py_object,
+    pythonapi, sizeof)
 import unittest, sys
 from test import support
 

--- a/Lib/ctypes/test/test_random_things.py
+++ b/Lib/ctypes/test/test_random_things.py
@@ -1,5 +1,9 @@
-from ctypes import *
-import unittest, sys
+import sys
+import unittest
+from ctypes import CFUNCTYPE, c_char_p, c_double, c_int, c_void_p
+
+if sys.platform == "win32":
+    from ctypes import windll
 
 def callback_func(arg):
     42 / arg

--- a/Lib/ctypes/test/test_repr.py
+++ b/Lib/ctypes/test/test_repr.py
@@ -1,4 +1,6 @@
-from ctypes import *
+from ctypes import (
+    c_bool, c_byte, c_char, c_double, c_float, c_int, c_long, c_longdouble,
+    c_longlong, c_short, c_ubyte, c_uint, c_ulong, c_ulonglong, c_ushort)
 import unittest
 
 subclasses = []

--- a/Lib/ctypes/test/test_returnfuncptrs.py
+++ b/Lib/ctypes/test/test_returnfuncptrs.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import CDLL, CFUNCTYPE, ArgumentError, c_char, c_char_p, c_void_p
 
 import _ctypes_test
 

--- a/Lib/ctypes/test/test_simplesubclasses.py
+++ b/Lib/ctypes/test/test_simplesubclasses.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import CFUNCTYPE, Structure, c_int
 
 class MyInt(c_int):
     def __eq__(self, other):

--- a/Lib/ctypes/test/test_sizes.py
+++ b/Lib/ctypes/test/test_sizes.py
@@ -1,6 +1,8 @@
 # Test specifically-sized containers.
 
-from ctypes import *
+from ctypes import (
+    c_int8, c_int16, c_int32, c_int64, c_size_t, c_ssize_t, c_uint8, c_uint16,
+    c_uint32, c_uint64, c_void_p, sizeof)
 
 import unittest
 

--- a/Lib/ctypes/test/test_slicing.py
+++ b/Lib/ctypes/test/test_slicing.py
@@ -1,5 +1,7 @@
 import unittest
-from ctypes import *
+from ctypes import (
+    CDLL, POINTER, c_byte, c_char, c_char_p, c_int, c_long, c_short, c_wchar,
+    sizeof)
 from ctypes.test import need_symbol
 
 import _ctypes_test

--- a/Lib/ctypes/test/test_stringptr.py
+++ b/Lib/ctypes/test/test_stringptr.py
@@ -1,6 +1,6 @@
 import unittest
 from test import support
-from ctypes import *
+from ctypes import CDLL, POINTER, Structure, c_buffer, c_char, c_char_p
 
 import _ctypes_test
 

--- a/Lib/ctypes/test/test_strings.py
+++ b/Lib/ctypes/test/test_strings.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import byref, c_buffer, c_char, c_wchar, sizeof
 from ctypes.test import need_symbol
 
 class StringArrayTestCase(unittest.TestCase):

--- a/Lib/ctypes/test/test_struct_fields.py
+++ b/Lib/ctypes/test/test_struct_fields.py
@@ -1,5 +1,5 @@
 import unittest
-from ctypes import *
+from ctypes import Structure, Union, c_int, sizeof
 
 class StructFieldsTestCase(unittest.TestCase):
     # Structure/Union classes must get 'finalized' sooner or

--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -1,7 +1,11 @@
 import platform
 import sys
 import unittest
-from ctypes import *
+from ctypes import (
+    CDLL, POINTER, Structure, Union, alignment, c_byte, c_char, c_double,
+    c_float, c_int, c_long, c_longlong, c_short, c_ubyte, c_uint, c_uint8,
+    c_uint16, c_uint32, c_ulong, c_ulonglong, c_ushort, c_void_p, c_wchar,
+    sizeof)
 from ctypes.test import need_symbol
 from struct import calcsize
 import _ctypes_test

--- a/Lib/ctypes/test/test_unaligned_structures.py
+++ b/Lib/ctypes/test/test_unaligned_structures.py
@@ -1,5 +1,7 @@
 import sys, unittest
-from ctypes import *
+from ctypes import (
+    BigEndianStructure, Structure, c_byte, c_double, c_float, c_int, c_long,
+    c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort)
 
 structures = []
 byteswapped_structures = []

--- a/Lib/ctypes/test/test_values.py
+++ b/Lib/ctypes/test/test_values.py
@@ -4,8 +4,8 @@ A testcase which accesses *values* in a dll.
 
 import unittest
 import sys
-from ctypes import *
-
+from ctypes import (
+    CDLL, POINTER, Structure, c_char_p, c_int, c_ubyte, pythonapi)
 import _ctypes_test
 
 class ValuesTestCase(unittest.TestCase):

--- a/Lib/ctypes/test/test_varsize_struct.py
+++ b/Lib/ctypes/test/test_varsize_struct.py
@@ -1,4 +1,4 @@
-from ctypes import *
+from ctypes import Structure, c_int, resize, sizeof
 import unittest
 
 class VarSizeTest(unittest.TestCase):

--- a/Lib/ctypes/test/test_win32.py
+++ b/Lib/ctypes/test/test_win32.py
@@ -1,10 +1,14 @@
 # Windows specific tests
 
-from ctypes import *
-import unittest, sys
+import _ctypes_test
+import sys
+import unittest
+from ctypes import (
+    CDLL, POINTER, Structure, byref, c_int, c_long, c_void_p, pointer, sizeof)
 from test import support
 
-import _ctypes_test
+if sys.platform == "win32":
+    from ctypes import FormatError, WinError, windll, c_char
 
 @unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 class FunctionCallTestCase(unittest.TestCase):

--- a/Lib/ctypes/test/test_wintypes.py
+++ b/Lib/ctypes/test/test_wintypes.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from ctypes import *
+from ctypes import POINTER, c_int16, cast
 
 @unittest.skipUnless(sys.platform.startswith('win'), 'Windows-only test')
 class WinTypesTest(unittest.TestCase):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40655](https://bugs.python.org/issue40655) -->
https://bugs.python.org/issue40655
<!-- /issue-number -->
