### PR TITLE
bpo-40334: Reproduce error message for type comments on bare '*'

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -661,6 +661,7 @@ invalid_parameters:
         RAISE_SYNTAX_ERROR("non-default argument follows default argument") }
 invalid_star_etc:
     | '*' (')' | ',' (')' | '**')) { RAISE_SYNTAX_ERROR("named arguments must follow bare *") }
+    | '*' ',' TYPE_COMMENT { RAISE_SYNTAX_ERROR("bare * has associated type comment") }
 invalid_lambda_star_etc:
     | '*' (':' | ',' (':' | '**')) { RAISE_SYNTAX_ERROR("named arguments must follow bare *") }
 invalid_double_type_comments:

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -178,6 +178,16 @@ SyntaxError: invalid syntax
 Traceback (most recent call last):
 SyntaxError: invalid syntax
 
+>>> import ast; ast.parse('''
+... def f(
+...     *, # type: int
+...     a, # type: int
+... ):
+...     pass
+... ''', type_comments=True)
+Traceback (most recent call last):
+SyntaxError: bare * has associated type comment
+
 
 From ast_for_funcdef():
 

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -10991,7 +10991,7 @@ invalid_parameters_rule(Parser *p)
     return _res;
 }
 
-// invalid_star_etc: '*' (')' | ',' (')' | '**'))
+// invalid_star_etc: '*' (')' | ',' (')' | '**')) | '*' ',' TYPE_COMMENT
 static void *
 invalid_star_etc_rule(Parser *p)
 {
@@ -11010,6 +11010,27 @@ invalid_star_etc_rule(Parser *p)
         )
         {
             _res = RAISE_SYNTAX_ERROR ( "named arguments must follow bare *" );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+    }
+    { // '*' ',' TYPE_COMMENT
+        Token * _literal;
+        Token * _literal_1;
+        Token * a;
+        if (
+            (_literal = _PyPegen_expect_token(p, 16))  // token='*'
+            &&
+            (_literal_1 = _PyPegen_expect_token(p, 12))  // token=','
+            &&
+            (a = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
+        )
+        {
+            _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "bare * has associated type comment" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -11021,16 +11021,16 @@ invalid_star_etc_rule(Parser *p)
     { // '*' ',' TYPE_COMMENT
         Token * _literal;
         Token * _literal_1;
-        Token * a;
+        Token * type_comment_var;
         if (
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
             (_literal_1 = _PyPegen_expect_token(p, 12))  // token=','
             &&
-            (a = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
+            (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
         )
         {
-            _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "bare * has associated type comment" );
+            _res = RAISE_SYNTAX_ERROR ( "bare * has associated type comment" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -431,25 +431,6 @@ error:
     return NULL;
 }
 
-void *_PyPegen_arguments_parsing_error(Parser *p, expr_ty e) {
-    int kwarg_unpacking = 0;
-    for (Py_ssize_t i = 0, l = asdl_seq_LEN(e->v.Call.keywords); i < l; i++) {
-        keyword_ty keyword = asdl_seq_GET(e->v.Call.keywords, i);
-        if (!keyword->arg) {
-            kwarg_unpacking = 1;
-        }
-    }
-
-    const char *msg = NULL;
-    if (kwarg_unpacking) {
-        msg = "positional argument follows keyword argument unpacking";
-    } else {
-        msg = "positional argument follows keyword argument";
-    }
-
-    return RAISE_SYNTAX_ERROR(msg);
-}
-
 #if 0
 static const char *
 token_name(int type)
@@ -2099,4 +2080,23 @@ _PyPegen_get_invalid_target(expr_ty e)
         default:
             return e;
     }
+}
+
+void *_PyPegen_arguments_parsing_error(Parser *p, expr_ty e) {
+    int kwarg_unpacking = 0;
+    for (Py_ssize_t i = 0, l = asdl_seq_LEN(e->v.Call.keywords); i < l; i++) {
+        keyword_ty keyword = asdl_seq_GET(e->v.Call.keywords, i);
+        if (!keyword->arg) {
+            kwarg_unpacking = 1;
+        }
+    }
+
+    const char *msg = NULL;
+    if (kwarg_unpacking) {
+        msg = "positional argument follows keyword argument unpacking";
+    } else {
+        msg = "positional argument follows keyword argument";
+    }
+
+    return RAISE_SYNTAX_ERROR(msg);
 }

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -256,13 +256,13 @@ asdl_seq *_PyPegen_seq_extract_starred_exprs(Parser *, asdl_seq *);
 asdl_seq *_PyPegen_seq_delete_starred_exprs(Parser *, asdl_seq *);
 expr_ty _PyPegen_concatenate_strings(Parser *p, asdl_seq *);
 asdl_seq *_PyPegen_join_sequences(Parser *, asdl_seq *, asdl_seq *);
-void *_PyPegen_arguments_parsing_error(Parser *, expr_ty);
 int _PyPegen_check_barry_as_flufl(Parser *);
 mod_ty _PyPegen_make_module(Parser *, asdl_seq *);
 
 // Error reporting helpers
-
 expr_ty _PyPegen_get_invalid_target(expr_ty e);
+void *_PyPegen_arguments_parsing_error(Parser *, expr_ty);
+
 
 void *_PyPegen_parse(Parser *);
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
