### PR TITLE
bpo-40662:  add test for ast.get_source_segment with missing line/col…

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -332,6 +332,8 @@ def get_source_segment(source, node, *, padded=False):
     be padded with spaces to match its original position.
     """
     try:
+        if node.end_lineno is None or node.end_col_offset is None:
+            return None
         lineno = node.lineno - 1
         end_lineno = node.end_lineno - 1
         col_offset = node.col_offset

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1851,6 +1851,17 @@ class EndPositionTests(unittest.TestCase):
         cdef = ast.parse(s).body[0]
         self.assertEqual(ast.get_source_segment(s, cdef.body[0], padded=True), s_method)
 
+    def test_source_segment_missing_info(self):
+        s = 'v = 1\r\nw = 1\nx = 1\n\ry = 1\r\n'
+        v, w, x, y = ast.parse(s).body
+        del v.lineno
+        del w.end_lineno
+        del x.col_offset
+        del y.end_col_offset
+        self.assertIsNone(ast.get_source_segment(s, v))
+        self.assertIsNone(ast.get_source_segment(s, w))
+        self.assertIsNone(ast.get_source_segment(s, x))
+        self.assertIsNone(ast.get_source_segment(s, y))
 
 class NodeVisitorTests(unittest.TestCase):
     def test_old_constant_nodes(self):

--- a/Misc/NEWS.d/next/Library/2020-05-18-12-56-45.bpo-40662.dfornR.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-18-12-56-45.bpo-40662.dfornR.rst
@@ -1,1 +1,1 @@
-Fixed ast.get_source_segment() for ast nodes that have incomplete location information. Added the missing unit test.
+Fixed :func:`ast.get_source_segment` for ast nodes that have incomplete location information. Patch by Irit Katriel.

--- a/Misc/NEWS.d/next/Library/2020-05-18-12-56-45.bpo-40662.dfornR.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-18-12-56-45.bpo-40662.dfornR.rst
@@ -1,0 +1,1 @@
+Fixed ast.get_source_segment() for ast nodes that have incomplete location information. Added the missing unit test.


### PR DESCRIPTION
Added a unit test for ast.get_source_segment() on a node that has incomplete location information, expecting None as per the docstring. Added a possible fix to the code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40662](https://bugs.python.org/issue40662) -->
https://bugs.python.org/issue40662
<!-- /issue-number -->
