### PR TITLE
bpo-40536: Add zoneinfo.available_timezones

### DIFF
--- a/Doc/library/zoneinfo.rst
+++ b/Doc/library/zoneinfo.rst
@@ -337,6 +337,29 @@ pickled in an environment with a different version of the time zone data.
 Functions
 ---------
 
+.. function:: available_timezones()
+
+    Get a set containing all the valid keys for IANA time zones available
+    anywhere on the time zone path. This is recalculated on every call to the
+    function.
+
+    This function only includes canonical zone names and does not include
+    "special" zones such as those under the ``posix/`` and ``right/``
+    directories, or the ``posixrules`` zone.
+
+    .. caution::
+
+        This function may open a large number of files, as the best way to
+        determine if a file on the time zone path is a valid time zone is to
+        read the "magic string" at the beginning.
+
+    .. note::
+
+        These values are not designed to be exposed to end-users; for user
+        facing elements, applications should use something like CLDR (the
+        Unicode Common Locale Data Repository) to get more user-friendly
+        strings. See also the cautionary note on :attr:`ZoneInfo.key`.
+
 .. function:: reset_tzpath(to=None)
 
     Sets or resets the time zone search path (:data:`TZPATH`) for the module.

--- a/Lib/test/test_zoneinfo/_support.py
+++ b/Lib/test/test_zoneinfo/_support.py
@@ -73,7 +73,7 @@ class ZoneInfoTestBase(unittest.TestCase):
                 if not modname.startswith("tzdata"):
                     continue
 
-                if len(modname) > 6 and modname[7] != ".":
+                if modname.split(".", 1)[0] != "tzdata":  # pragma: nocover
                     continue
 
                 tzdata_modules[modname] = sys.modules.pop(modname)

--- a/Lib/test/test_zoneinfo/_support.py
+++ b/Lib/test/test_zoneinfo/_support.py
@@ -66,11 +66,38 @@ class ZoneInfoTestBase(unittest.TestCase):
         super().setUpClass()
 
     @contextlib.contextmanager
-    def tzpath_context(self, tzpath, lock=TZPATH_LOCK):
+    def tzpath_context(self, tzpath, block_tzdata=True, lock=TZPATH_LOCK):
+        def pop_tzdata_modules():
+            tzdata_modules = {}
+            for modname in list(sys.modules):
+                if not modname.startswith("tzdata"):
+                    continue
+
+                if len(modname) > 6 and modname[7] != ".":
+                    continue
+
+                tzdata_modules[modname] = sys.modules.pop(modname)
+
+            return tzdata_modules
+
         with lock:
+            if block_tzdata:
+                # In order to fully exclude tzdata from the path, we need to
+                # clear the sys.modules cache of all its contents — setting the
+                # root package to None is not enough to block direct access of
+                # already-imported submodules (though it will prevent new
+                # imports of submodules).
+                tzdata_modules = pop_tzdata_modules()
+                sys.modules["tzdata"] = None
+
             old_path = self.module.TZPATH
             try:
                 self.module.reset_tzpath(tzpath)
                 yield
             finally:
+                if block_tzdata:
+                    sys.modules.pop("tzdata")
+                    for modname, module in tzdata_modules.items():
+                        sys.modules[modname] = module
+
                 self.module.reset_tzpath(old_path)

--- a/Lib/test/test_zoneinfo/_support.py
+++ b/Lib/test/test_zoneinfo/_support.py
@@ -70,9 +70,6 @@ class ZoneInfoTestBase(unittest.TestCase):
         def pop_tzdata_modules():
             tzdata_modules = {}
             for modname in list(sys.modules):
-                if not modname.startswith("tzdata"):
-                    continue
-
                 if modname.split(".", 1)[0] != "tzdata":  # pragma: nocover
                     continue
 

--- a/Lib/zoneinfo/__init__.py
+++ b/Lib/zoneinfo/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     "ZoneInfo",
     "reset_tzpath",
+    "available_timezones",
     "TZPATH",
     "ZoneInfoNotFoundError",
     "InvalidTZPathWarning",
@@ -15,6 +16,7 @@ except ImportError:  # pragma: nocover
     from ._zoneinfo import ZoneInfo
 
 reset_tzpath = _tzpath.reset_tzpath
+available_timezones = _tzpath.available_timezones
 InvalidTZPathWarning = _tzpath.InvalidTZPathWarning
 
 

--- a/Misc/NEWS.d/next/Library/2020-05-17-14-00-12.bpo-40536.FCpoRA.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-17-14-00-12.bpo-40536.FCpoRA.rst
@@ -1,0 +1,2 @@
+Added the :func:`~zoneinfo.available_timezones` function to the
+:mod:`zoneinfo` module. Patch by Paul Ganssle.


### PR DESCRIPTION
This was not specified in the PEP, but it will likely be a frequently requested feature if it's not included.

@ambv Given the uncertainty about the stability of this feature (we didn't have a lot of time to design it and it ends up being slightly a more complicated UI problem than one would think), please let me know ASAP if you'd like to exclude this from the beta period and push it to 3.10.

<!-- issue-number: [bpo-40536](https://bugs.python.org/issue40536) -->
https://bugs.python.org/issue40536
<!-- /issue-number -->
