### PR TITLE
bpo-40661: Fix segfault when parsing invalid input

### DIFF
--- a/Lib/test/test_peg_parser.py
+++ b/Lib/test/test_peg_parser.py
@@ -591,7 +591,7 @@ FAIL_TEST_CASES = [
     ("f-string_single_closing_brace", "f'}'"),
     ("from_import_invalid", "from import import a"),
     ("from_import_trailing_comma", "from a import b,"),
-    ("import_very_complex", "import äˆ ð£„¯ð¢·žð±‹á”€ð””ð‘©±å®ä±¬ð©¾\nð—¶½"),
+    ("import_non_ascii_syntax_error", "import ä £"),
     # This test case checks error paths involving tokens with uninitialized
     # values of col_offset and end_col_offset.
     ("invalid indentation",

--- a/Lib/test/test_peg_parser.py
+++ b/Lib/test/test_peg_parser.py
@@ -591,6 +591,7 @@ FAIL_TEST_CASES = [
     ("f-string_single_closing_brace", "f'}'"),
     ("from_import_invalid", "from import import a"),
     ("from_import_trailing_comma", "from a import b,"),
+    ("import_very_complex", "import äˆ ð£„¯ð¢·žð±‹á”€ð””ð‘©±å®ä±¬ð©¾\nð—¶½"),
     # This test case checks error paths involving tokens with uninitialized
     # values of col_offset and end_col_offset.
     ("invalid indentation",

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -659,6 +659,9 @@ Corner-cases that used to crash:
     Traceback (most recent call last):
     SyntaxError: cannot assign to __debug__
 
+    >>> import ä £
+    Traceback (most recent call last):
+    SyntaxError: invalid character '£' (U+00A3)
 """
 
 import re

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -677,6 +677,9 @@ static void *_tmp_148_rule(Parser *p);
 static mod_ty
 file_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // statements? $
@@ -709,6 +712,9 @@ file_rule(Parser *p)
 static mod_ty
 interactive_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // statement_newline
@@ -738,6 +744,9 @@ interactive_rule(Parser *p)
 static mod_ty
 eval_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // expressions NEWLINE* $
@@ -773,6 +782,9 @@ eval_rule(Parser *p)
 static mod_ty
 func_type_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // '(' type_expressions? ')' '->' expression NEWLINE* $
@@ -820,6 +832,9 @@ func_type_rule(Parser *p)
 static expr_ty
 fstring_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // star_expressions
@@ -852,6 +867,9 @@ fstring_rule(Parser *p)
 static asdl_seq*
 type_expressions_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.expression+ ',' '*' expression ',' '**' expression
@@ -1039,6 +1057,9 @@ type_expressions_rule(Parser *p)
 static asdl_seq*
 statements_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // statement+
@@ -1068,6 +1089,9 @@ statements_rule(Parser *p)
 static asdl_seq*
 statement_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // compound_stmt
@@ -1111,6 +1135,9 @@ statement_rule(Parser *p)
 static asdl_seq*
 statement_newline_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -1209,6 +1236,9 @@ statement_newline_rule(Parser *p)
 static asdl_seq*
 simple_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // small_stmt !';' NEWLINE
@@ -1281,6 +1311,9 @@ simple_stmt_rule(Parser *p)
 static stmt_ty
 small_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     if (_PyPegen_is_memoized(p, small_stmt_type, &_res))
         return _res;
@@ -1556,6 +1589,9 @@ small_stmt_rule(Parser *p)
 static stmt_ty
 compound_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // &('def' | '@' | ASYNC) function_def
@@ -1684,6 +1720,9 @@ compound_stmt_rule(Parser *p)
 static stmt_ty
 assignment_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -1864,6 +1903,9 @@ assignment_rule(Parser *p)
 static AugOperator*
 augassign_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     AugOperator* _res = NULL;
     int _mark = p->mark;
     { // '+='
@@ -2109,6 +2151,9 @@ augassign_rule(Parser *p)
 static stmt_ty
 global_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2157,6 +2202,9 @@ global_stmt_rule(Parser *p)
 static stmt_ty
 nonlocal_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2205,6 +2253,9 @@ nonlocal_stmt_rule(Parser *p)
 static stmt_ty
 yield_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2250,6 +2301,9 @@ yield_stmt_rule(Parser *p)
 static stmt_ty
 assert_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2301,6 +2355,9 @@ assert_stmt_rule(Parser *p)
 static stmt_ty
 del_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2349,6 +2406,9 @@ del_stmt_rule(Parser *p)
 static stmt_ty
 import_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // import_name
@@ -2388,6 +2448,9 @@ import_stmt_rule(Parser *p)
 static stmt_ty
 import_name_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2438,6 +2501,9 @@ import_name_rule(Parser *p)
 static stmt_ty
 import_from_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2530,6 +2596,9 @@ import_from_rule(Parser *p)
 static asdl_seq*
 import_from_targets_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // '(' import_from_as_names ','? ')'
@@ -2601,6 +2670,9 @@ import_from_targets_rule(Parser *p)
 static asdl_seq*
 import_from_as_names_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.import_from_as_name+
@@ -2630,6 +2702,9 @@ import_from_as_names_rule(Parser *p)
 static alias_ty
 import_from_as_name_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     alias_ty _res = NULL;
     int _mark = p->mark;
     { // NAME ['as' NAME]
@@ -2662,6 +2737,9 @@ import_from_as_name_rule(Parser *p)
 static asdl_seq*
 dotted_as_names_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.dotted_as_name+
@@ -2691,6 +2769,9 @@ dotted_as_names_rule(Parser *p)
 static alias_ty
 dotted_as_name_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     alias_ty _res = NULL;
     int _mark = p->mark;
     { // dotted_name ['as' NAME]
@@ -2748,6 +2829,9 @@ dotted_name_rule(Parser *p)
 static expr_ty
 dotted_name_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // dotted_name '.' NAME
@@ -2799,6 +2883,9 @@ dotted_name_raw(Parser *p)
 static stmt_ty
 if_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2896,6 +2983,9 @@ if_stmt_rule(Parser *p)
 static stmt_ty
 elif_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2991,6 +3081,9 @@ elif_stmt_rule(Parser *p)
 static asdl_seq*
 else_block_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // 'else' ':' block
@@ -3026,6 +3119,9 @@ else_block_rule(Parser *p)
 static stmt_ty
 while_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3085,6 +3181,9 @@ while_stmt_rule(Parser *p)
 static stmt_ty
 for_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3205,6 +3304,9 @@ for_stmt_rule(Parser *p)
 static stmt_ty
 with_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3396,6 +3498,9 @@ with_stmt_rule(Parser *p)
 static withitem_ty
 with_item_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     withitem_ty _res = NULL;
     int _mark = p->mark;
     { // expression ['as' target]
@@ -3430,6 +3535,9 @@ with_item_rule(Parser *p)
 static stmt_ty
 try_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3525,6 +3633,9 @@ try_stmt_rule(Parser *p)
 static excepthandler_ty
 except_block_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     excepthandler_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3614,6 +3725,9 @@ except_block_rule(Parser *p)
 static asdl_seq*
 finally_block_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // 'finally' ':' block
@@ -3649,6 +3763,9 @@ finally_block_rule(Parser *p)
 static stmt_ty
 return_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3697,6 +3814,9 @@ return_stmt_rule(Parser *p)
 static stmt_ty
 raise_stmt_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3774,6 +3894,9 @@ raise_stmt_rule(Parser *p)
 static stmt_ty
 function_def_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // decorators function_def_raw
@@ -3822,6 +3945,9 @@ function_def_rule(Parser *p)
 static stmt_ty
 function_def_raw_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3947,6 +4073,9 @@ function_def_raw_rule(Parser *p)
 static Token*
 func_type_comment_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     Token* _res = NULL;
     int _mark = p->mark;
     { // NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
@@ -4009,6 +4138,9 @@ func_type_comment_rule(Parser *p)
 static arguments_ty
 params_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // invalid_parameters
@@ -4053,6 +4185,9 @@ params_rule(Parser *p)
 static arguments_ty
 parameters_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // slash_no_default param_no_default* param_with_default* star_etc?
@@ -4178,6 +4313,9 @@ parameters_rule(Parser *p)
 static asdl_seq*
 slash_no_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // param_no_default+ '/' ','
@@ -4238,6 +4376,9 @@ slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 slash_with_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     SlashWithDefault* _res = NULL;
     int _mark = p->mark;
     { // param_no_default* param_with_default+ '/' ','
@@ -4306,6 +4447,9 @@ slash_with_default_rule(Parser *p)
 static StarEtc*
 star_etc_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     StarEtc* _res = NULL;
     int _mark = p->mark;
     { // '*' param_no_default param_maybe_default* kwds?
@@ -4403,6 +4547,9 @@ star_etc_rule(Parser *p)
 static arg_ty
 kwds_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // '**' param_no_default
@@ -4435,6 +4582,9 @@ kwds_rule(Parser *p)
 static arg_ty
 param_no_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // param ',' TYPE_COMMENT?
@@ -4493,6 +4643,9 @@ param_no_default_rule(Parser *p)
 static NameDefaultPair*
 param_with_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // param default ',' TYPE_COMMENT?
@@ -4559,6 +4712,9 @@ param_with_default_rule(Parser *p)
 static NameDefaultPair*
 param_maybe_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // param default? ',' TYPE_COMMENT?
@@ -4623,6 +4779,9 @@ param_maybe_default_rule(Parser *p)
 static arg_ty
 param_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -4671,6 +4830,9 @@ param_rule(Parser *p)
 static expr_ty
 annotation_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // ':' expression
@@ -4703,6 +4865,9 @@ annotation_rule(Parser *p)
 static expr_ty
 default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // '=' expression
@@ -4735,6 +4900,9 @@ default_rule(Parser *p)
 static asdl_seq*
 decorators_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // (('@' named_expression NEWLINE))+
@@ -4764,6 +4932,9 @@ decorators_rule(Parser *p)
 static stmt_ty
 class_def_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // decorators class_def_raw
@@ -4810,6 +4981,9 @@ class_def_rule(Parser *p)
 static stmt_ty
 class_def_raw_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -4867,6 +5041,9 @@ class_def_raw_rule(Parser *p)
 static asdl_seq*
 block_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     if (_PyPegen_is_memoized(p, block_type, &_res))
         return _res;
@@ -4936,6 +5113,9 @@ block_rule(Parser *p)
 static asdl_seq*
 expressions_list_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_expression+ ','?
@@ -4972,6 +5152,9 @@ expressions_list_rule(Parser *p)
 static expr_ty
 star_expressions_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5067,6 +5250,9 @@ star_expressions_rule(Parser *p)
 static expr_ty
 star_expression_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, star_expression_type, &_res))
         return _res;
@@ -5132,6 +5318,9 @@ star_expression_rule(Parser *p)
 static asdl_seq*
 star_named_expressions_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_named_expression+ ','?
@@ -5165,6 +5354,9 @@ star_named_expressions_rule(Parser *p)
 static expr_ty
 star_named_expression_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5227,6 +5419,9 @@ star_named_expression_rule(Parser *p)
 static expr_ty
 named_expression_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5308,6 +5503,9 @@ named_expression_rule(Parser *p)
 static expr_ty
 annotated_rhs_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // yield_expr
@@ -5347,6 +5545,9 @@ annotated_rhs_rule(Parser *p)
 static expr_ty
 expressions_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5442,6 +5643,9 @@ expressions_rule(Parser *p)
 static expr_ty
 expression_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, expression_type, &_res))
         return _res;
@@ -5530,6 +5734,9 @@ expression_rule(Parser *p)
 static expr_ty
 lambdef_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5589,6 +5796,9 @@ lambdef_rule(Parser *p)
 static arguments_ty
 lambda_parameters_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* lambda_star_etc?
@@ -5716,6 +5926,9 @@ lambda_parameters_rule(Parser *p)
 static asdl_seq*
 lambda_slash_no_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default+ '/' ','
@@ -5776,6 +5989,9 @@ lambda_slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 lambda_slash_with_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     SlashWithDefault* _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default* lambda_param_with_default+ '/' ','
@@ -5844,6 +6060,9 @@ lambda_slash_with_default_rule(Parser *p)
 static StarEtc*
 lambda_star_etc_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     StarEtc* _res = NULL;
     int _mark = p->mark;
     { // '*' lambda_param_no_default lambda_param_maybe_default* lambda_kwds?
@@ -5941,6 +6160,9 @@ lambda_star_etc_rule(Parser *p)
 static arg_ty
 lambda_kwds_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // '**' lambda_param_no_default
@@ -5973,6 +6195,9 @@ lambda_kwds_rule(Parser *p)
 static arg_ty
 lambda_param_no_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // lambda_param ','
@@ -6025,6 +6250,9 @@ lambda_param_no_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_with_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // lambda_param default ','
@@ -6083,6 +6311,9 @@ lambda_param_with_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_maybe_default_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // lambda_param default? ','
@@ -6141,6 +6372,9 @@ lambda_param_maybe_default_rule(Parser *p)
 static arg_ty
 lambda_param_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -6186,6 +6420,9 @@ lambda_param_rule(Parser *p)
 static expr_ty
 disjunction_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, disjunction_type, &_res))
         return _res;
@@ -6251,6 +6488,9 @@ disjunction_rule(Parser *p)
 static expr_ty
 conjunction_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, conjunction_type, &_res))
         return _res;
@@ -6316,6 +6556,9 @@ conjunction_rule(Parser *p)
 static expr_ty
 inversion_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, inversion_type, &_res))
         return _res;
@@ -6381,6 +6624,9 @@ inversion_rule(Parser *p)
 static expr_ty
 comparison_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -6453,6 +6699,9 @@ comparison_rule(Parser *p)
 static CmpopExprPair*
 compare_op_bitwise_or_pair_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // eq_bitwise_or
@@ -6604,6 +6853,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
 static CmpopExprPair*
 eq_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '==' bitwise_or
@@ -6636,6 +6888,9 @@ eq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 noteq_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // ('!=') bitwise_or
@@ -6668,6 +6923,9 @@ noteq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lte_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '<=' bitwise_or
@@ -6700,6 +6958,9 @@ lte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lt_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '<' bitwise_or
@@ -6732,6 +6993,9 @@ lt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gte_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '>=' bitwise_or
@@ -6764,6 +7028,9 @@ gte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gt_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '>' bitwise_or
@@ -6796,6 +7063,9 @@ gt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 notin_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'not' 'in' bitwise_or
@@ -6831,6 +7101,9 @@ notin_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 in_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'in' bitwise_or
@@ -6863,6 +7136,9 @@ in_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 isnot_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'is' 'not' bitwise_or
@@ -6898,6 +7174,9 @@ isnot_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 is_bitwise_or_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'is' bitwise_or
@@ -6955,6 +7234,9 @@ bitwise_or_rule(Parser *p)
 static expr_ty
 bitwise_or_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7045,6 +7327,9 @@ bitwise_xor_rule(Parser *p)
 static expr_ty
 bitwise_xor_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7135,6 +7420,9 @@ bitwise_and_rule(Parser *p)
 static expr_ty
 bitwise_and_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7225,6 +7513,9 @@ shift_expr_rule(Parser *p)
 static expr_ty
 shift_expr_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7347,6 +7638,9 @@ sum_rule(Parser *p)
 static expr_ty
 sum_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7475,6 +7769,9 @@ term_rule(Parser *p)
 static expr_ty
 term_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7668,6 +7965,9 @@ term_raw(Parser *p)
 static expr_ty
 factor_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, factor_type, &_res))
         return _res;
@@ -7791,6 +8091,9 @@ factor_rule(Parser *p)
 static expr_ty
 power_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7856,6 +8159,9 @@ power_rule(Parser *p)
 static expr_ty
 await_primary_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, await_primary_type, &_res))
         return _res;
@@ -7951,6 +8257,9 @@ primary_rule(Parser *p)
 static expr_ty
 primary_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8115,6 +8424,9 @@ primary_raw(Parser *p)
 static expr_ty
 slices_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8184,6 +8496,9 @@ slices_rule(Parser *p)
 static expr_ty
 slice_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8267,6 +8582,9 @@ slice_rule(Parser *p)
 static expr_ty
 atom_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8500,6 +8818,9 @@ atom_rule(Parser *p)
 static expr_ty
 strings_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, strings_type, &_res))
         return _res;
@@ -8532,6 +8853,9 @@ strings_rule(Parser *p)
 static expr_ty
 list_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8583,6 +8907,9 @@ list_rule(Parser *p)
 static expr_ty
 listcomp_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8651,6 +8978,9 @@ listcomp_rule(Parser *p)
 static expr_ty
 tuple_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8702,6 +9032,9 @@ tuple_rule(Parser *p)
 static expr_ty
 group_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // '(' (yield_expr | named_expression) ')'
@@ -8737,6 +9070,9 @@ group_rule(Parser *p)
 static expr_ty
 genexp_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8805,6 +9141,9 @@ genexp_rule(Parser *p)
 static expr_ty
 set_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8856,6 +9195,9 @@ set_rule(Parser *p)
 static expr_ty
 setcomp_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8924,6 +9266,9 @@ setcomp_rule(Parser *p)
 static expr_ty
 dict_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8975,6 +9320,9 @@ dict_rule(Parser *p)
 static expr_ty
 dictcomp_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9029,6 +9377,9 @@ dictcomp_rule(Parser *p)
 static asdl_seq*
 kvpairs_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.kvpair+ ','?
@@ -9062,6 +9413,9 @@ kvpairs_rule(Parser *p)
 static KeyValuePair*
 kvpair_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     KeyValuePair* _res = NULL;
     int _mark = p->mark;
     { // '**' bitwise_or
@@ -9118,6 +9472,9 @@ kvpair_rule(Parser *p)
 static asdl_seq*
 for_if_clauses_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // for_if_clause+
@@ -9145,6 +9502,9 @@ for_if_clauses_rule(Parser *p)
 static comprehension_ty
 for_if_clause_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     comprehension_ty _res = NULL;
     int _mark = p->mark;
     { // ASYNC 'for' star_targets 'in' disjunction (('if' disjunction))*
@@ -9219,6 +9579,9 @@ for_if_clause_rule(Parser *p)
 static expr_ty
 yield_expr_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9299,6 +9662,9 @@ yield_expr_rule(Parser *p)
 static expr_ty
 arguments_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, arguments_type, &_res))
         return _res;
@@ -9351,6 +9717,9 @@ arguments_rule(Parser *p)
 static expr_ty
 args_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9457,6 +9826,9 @@ args_rule(Parser *p)
 static asdl_seq*
 kwargs_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+
@@ -9520,6 +9892,9 @@ kwargs_rule(Parser *p)
 static expr_ty
 starred_expression_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9568,6 +9943,9 @@ starred_expression_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_starred_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     KeywordOrStarred* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9651,6 +10029,9 @@ kwarg_or_starred_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_double_starred_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     KeywordOrStarred* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9745,6 +10126,9 @@ kwarg_or_double_starred_rule(Parser *p)
 static expr_ty
 star_targets_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9817,6 +10201,9 @@ star_targets_rule(Parser *p)
 static asdl_seq*
 star_targets_seq_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_target+ ','?
@@ -9854,6 +10241,9 @@ star_targets_seq_rule(Parser *p)
 static expr_ty
 star_target_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, star_target_type, &_res))
         return _res;
@@ -9994,6 +10384,9 @@ star_target_rule(Parser *p)
 static expr_ty
 star_atom_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -10119,6 +10512,9 @@ star_atom_rule(Parser *p)
 static expr_ty
 single_target_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // single_subscript_attribute_target
@@ -10188,6 +10584,9 @@ single_target_rule(Parser *p)
 static expr_ty
 single_subscript_attribute_target_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -10278,6 +10677,9 @@ single_subscript_attribute_target_rule(Parser *p)
 static asdl_seq*
 del_targets_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.del_target+ ','?
@@ -10314,6 +10716,9 @@ del_targets_rule(Parser *p)
 static expr_ty
 del_target_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, del_target_type, &_res))
         return _res;
@@ -10426,6 +10831,9 @@ del_target_rule(Parser *p)
 static expr_ty
 del_t_atom_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -10567,6 +10975,9 @@ del_t_atom_rule(Parser *p)
 static void *
 del_target_end_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
@@ -10648,6 +11059,9 @@ del_target_end_rule(Parser *p)
 static asdl_seq*
 targets_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.target+ ','?
@@ -10684,6 +11098,9 @@ targets_rule(Parser *p)
 static expr_ty
 target_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, target_type, &_res))
         return _res;
@@ -10821,6 +11238,9 @@ t_primary_rule(Parser *p)
 static expr_ty
 t_primary_raw(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -10999,6 +11419,9 @@ t_primary_raw(Parser *p)
 static void *
 t_lookahead_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '('
@@ -11052,6 +11475,9 @@ t_lookahead_rule(Parser *p)
 static expr_ty
 t_atom_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -11180,6 +11606,9 @@ t_atom_rule(Parser *p)
 static void *
 incorrect_arguments_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // args ',' '*'
@@ -11267,6 +11696,9 @@ incorrect_arguments_rule(Parser *p)
 static void *
 invalid_kwarg_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression '='
@@ -11299,6 +11731,9 @@ invalid_kwarg_rule(Parser *p)
 static void *
 invalid_named_expression_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression ':=' expression
@@ -11340,6 +11775,9 @@ invalid_named_expression_rule(Parser *p)
 static void *
 invalid_assignment_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // list ':'
@@ -11496,6 +11934,9 @@ invalid_assignment_rule(Parser *p)
 static void *
 invalid_block_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // NEWLINE !INDENT
@@ -11527,6 +11968,9 @@ invalid_block_rule(Parser *p)
 static void *
 invalid_comprehension_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ('[' | '(' | '{') starred_expression for_if_clauses
@@ -11563,6 +12007,9 @@ invalid_comprehension_rule(Parser *p)
 static void *
 invalid_parameters_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // param_no_default* (slash_with_default | param_with_default+) param_no_default
@@ -11598,6 +12045,9 @@ invalid_parameters_rule(Parser *p)
 static void *
 invalid_star_etc_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '*' (')' | ',' (')' | '**'))
@@ -11630,6 +12080,9 @@ invalid_star_etc_rule(Parser *p)
 static void *
 invalid_lambda_star_etc_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '*' (':' | ',' (':' | '**'))
@@ -11662,6 +12115,9 @@ invalid_lambda_star_etc_rule(Parser *p)
 static void *
 invalid_double_type_comments_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
@@ -11703,6 +12159,9 @@ invalid_double_type_comments_rule(Parser *p)
 static void *
 invalid_del_target_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_expression &del_target_end
@@ -11910,6 +12369,9 @@ _loop0_4_rule(Parser *p)
 static asdl_seq *
 _gather_3_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_4
@@ -12002,6 +12464,9 @@ _loop0_6_rule(Parser *p)
 static asdl_seq *
 _gather_5_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_6
@@ -12094,6 +12559,9 @@ _loop0_8_rule(Parser *p)
 static asdl_seq *
 _gather_7_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_8
@@ -12186,6 +12654,9 @@ _loop0_10_rule(Parser *p)
 static asdl_seq *
 _gather_9_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_10
@@ -12338,6 +12809,9 @@ _loop0_13_rule(Parser *p)
 static asdl_seq *
 _gather_12_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // small_stmt _loop0_13
@@ -12366,6 +12840,9 @@ _gather_12_rule(Parser *p)
 static void *
 _tmp_14_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'import'
@@ -12405,6 +12882,9 @@ _tmp_14_rule(Parser *p)
 static void *
 _tmp_15_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'def'
@@ -12458,6 +12938,9 @@ _tmp_15_rule(Parser *p)
 static void *
 _tmp_16_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'class'
@@ -12497,6 +12980,9 @@ _tmp_16_rule(Parser *p)
 static void *
 _tmp_17_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'with'
@@ -12536,6 +13022,9 @@ _tmp_17_rule(Parser *p)
 static void *
 _tmp_18_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'for'
@@ -12575,6 +13064,9 @@ _tmp_18_rule(Parser *p)
 static void *
 _tmp_19_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
@@ -12607,6 +13099,9 @@ _tmp_19_rule(Parser *p)
 static void *
 _tmp_20_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' single_target ')'
@@ -12656,6 +13151,9 @@ _tmp_20_rule(Parser *p)
 static void *
 _tmp_21_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
@@ -12748,6 +13246,9 @@ _loop1_22_rule(Parser *p)
 static void *
 _tmp_23_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
@@ -12787,6 +13288,9 @@ _tmp_23_rule(Parser *p)
 static void *
 _tmp_24_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
@@ -12890,6 +13394,9 @@ _loop0_26_rule(Parser *p)
 static asdl_seq *
 _gather_25_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // NAME _loop0_26
@@ -12982,6 +13489,9 @@ _loop0_28_rule(Parser *p)
 static asdl_seq *
 _gather_27_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // NAME _loop0_28
@@ -13010,6 +13520,9 @@ _gather_27_rule(Parser *p)
 static void *
 _tmp_29_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' expression
@@ -13222,6 +13735,9 @@ _loop0_33_rule(Parser *p)
 static asdl_seq *
 _gather_32_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // import_from_as_name _loop0_33
@@ -13250,6 +13766,9 @@ _gather_32_rule(Parser *p)
 static void *
 _tmp_34_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
@@ -13346,6 +13865,9 @@ _loop0_36_rule(Parser *p)
 static asdl_seq *
 _gather_35_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // dotted_as_name _loop0_36
@@ -13374,6 +13896,9 @@ _gather_35_rule(Parser *p)
 static void *
 _tmp_37_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
@@ -13470,6 +13995,9 @@ _loop0_39_rule(Parser *p)
 static asdl_seq *
 _gather_38_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_39
@@ -13562,6 +14090,9 @@ _loop0_41_rule(Parser *p)
 static asdl_seq *
 _gather_40_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_41
@@ -13654,6 +14185,9 @@ _loop0_43_rule(Parser *p)
 static asdl_seq *
 _gather_42_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_43
@@ -13746,6 +14280,9 @@ _loop0_45_rule(Parser *p)
 static asdl_seq *
 _gather_44_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_45
@@ -13774,6 +14311,9 @@ _gather_44_rule(Parser *p)
 static void *
 _tmp_46_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' target
@@ -13866,6 +14406,9 @@ _loop1_47_rule(Parser *p)
 static void *
 _tmp_48_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
@@ -13898,6 +14441,9 @@ _tmp_48_rule(Parser *p)
 static void *
 _tmp_49_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'from' expression
@@ -13930,6 +14476,9 @@ _tmp_49_rule(Parser *p)
 static void *
 _tmp_50_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '->' expression
@@ -13962,6 +14511,9 @@ _tmp_50_rule(Parser *p)
 static void *
 _tmp_51_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '->' expression
@@ -13994,6 +14546,9 @@ _tmp_51_rule(Parser *p)
 static void *
 _tmp_52_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // NEWLINE INDENT
@@ -14894,6 +15449,9 @@ _loop1_67_rule(Parser *p)
 static void *
 _tmp_68_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' arguments? ')'
@@ -14993,6 +15551,9 @@ _loop0_70_rule(Parser *p)
 static asdl_seq *
 _gather_69_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_expression _loop0_70
@@ -15145,6 +15706,9 @@ _loop0_73_rule(Parser *p)
 static asdl_seq *
 _gather_72_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_named_expression _loop0_73
@@ -16225,6 +16789,9 @@ _loop1_91_rule(Parser *p)
 static void *
 _tmp_92_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '!='
@@ -16318,6 +16885,9 @@ _loop0_94_rule(Parser *p)
 static asdl_seq *
 _gather_93_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // slice _loop0_94
@@ -16346,6 +16916,9 @@ _gather_93_rule(Parser *p)
 static void *
 _tmp_95_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':' expression?
@@ -16378,6 +16951,9 @@ _tmp_95_rule(Parser *p)
 static void *
 _tmp_96_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // tuple
@@ -16431,6 +17007,9 @@ _tmp_96_rule(Parser *p)
 static void *
 _tmp_97_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // list
@@ -16470,6 +17049,9 @@ _tmp_97_rule(Parser *p)
 static void *
 _tmp_98_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // dict
@@ -16597,6 +17179,9 @@ _loop1_99_rule(Parser *p)
 static void *
 _tmp_100_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_named_expression ',' star_named_expressions?
@@ -16632,6 +17217,9 @@ _tmp_100_rule(Parser *p)
 static void *
 _tmp_101_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
@@ -16735,6 +17323,9 @@ _loop0_103_rule(Parser *p)
 static asdl_seq *
 _gather_102_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kvpair _loop0_103
@@ -16935,6 +17526,9 @@ _loop0_106_rule(Parser *p)
 static void *
 _tmp_107_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' args
@@ -16967,6 +17561,9 @@ _tmp_107_rule(Parser *p)
 static void *
 _tmp_108_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' args
@@ -17063,6 +17660,9 @@ _loop0_110_rule(Parser *p)
 static asdl_seq *
 _gather_109_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_starred _loop0_110
@@ -17155,6 +17755,9 @@ _loop0_112_rule(Parser *p)
 static asdl_seq *
 _gather_111_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_double_starred _loop0_112
@@ -17247,6 +17850,9 @@ _loop0_114_rule(Parser *p)
 static asdl_seq *
 _gather_113_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_starred _loop0_114
@@ -17339,6 +17945,9 @@ _loop0_116_rule(Parser *p)
 static asdl_seq *
 _gather_115_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_double_starred _loop0_116
@@ -17487,6 +18096,9 @@ _loop0_119_rule(Parser *p)
 static asdl_seq *
 _gather_118_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_target _loop0_119
@@ -17515,6 +18127,9 @@ _gather_118_rule(Parser *p)
 static void *
 _tmp_120_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // !'*' star_target
@@ -17606,6 +18221,9 @@ _loop0_122_rule(Parser *p)
 static asdl_seq *
 _gather_121_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // del_target _loop0_122
@@ -17698,6 +18316,9 @@ _loop0_124_rule(Parser *p)
 static asdl_seq *
 _gather_123_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // target _loop0_124
@@ -17726,6 +18347,9 @@ _gather_123_rule(Parser *p)
 static void *
 _tmp_125_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // args
@@ -17824,6 +18448,9 @@ _loop0_126_rule(Parser *p)
 static void *
 _tmp_127_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
@@ -17852,6 +18479,9 @@ _tmp_127_rule(Parser *p)
 static void *
 _tmp_128_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
@@ -17891,6 +18521,9 @@ _tmp_128_rule(Parser *p)
 static void *
 _tmp_129_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
@@ -17930,6 +18563,9 @@ _tmp_129_rule(Parser *p)
 static void *
 _tmp_130_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '['
@@ -18039,6 +18675,9 @@ _loop0_131_rule(Parser *p)
 static void *
 _tmp_132_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // slash_with_default
@@ -18078,6 +18717,9 @@ _tmp_132_rule(Parser *p)
 static void *
 _tmp_133_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
@@ -18120,6 +18762,9 @@ _tmp_133_rule(Parser *p)
 static void *
 _tmp_134_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':'
@@ -18162,6 +18807,9 @@ _tmp_134_rule(Parser *p)
 static void *
 _tmp_135_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_targets '='
@@ -18194,6 +18842,9 @@ _tmp_135_rule(Parser *p)
 static void *
 _tmp_136_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
@@ -18233,6 +18884,9 @@ _tmp_136_rule(Parser *p)
 static void *
 _tmp_137_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
@@ -18272,6 +18926,9 @@ _tmp_137_rule(Parser *p)
 static void *
 _tmp_138_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '@' named_expression NEWLINE
@@ -18307,6 +18964,9 @@ _tmp_138_rule(Parser *p)
 static void *
 _tmp_139_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' star_expression
@@ -18339,6 +18999,9 @@ _tmp_139_rule(Parser *p)
 static void *
 _tmp_140_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' expression
@@ -18371,6 +19034,9 @@ _tmp_140_rule(Parser *p)
 static void *
 _tmp_141_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'or' conjunction
@@ -18403,6 +19069,9 @@ _tmp_141_rule(Parser *p)
 static void *
 _tmp_142_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'and' inversion
@@ -18435,6 +19104,9 @@ _tmp_142_rule(Parser *p)
 static void *
 _tmp_143_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'if' disjunction
@@ -18467,6 +19139,9 @@ _tmp_143_rule(Parser *p)
 static void *
 _tmp_144_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'if' disjunction
@@ -18499,6 +19174,9 @@ _tmp_144_rule(Parser *p)
 static void *
 _tmp_145_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' star_target
@@ -18591,6 +19269,9 @@ _loop1_146_rule(Parser *p)
 static void *
 _tmp_147_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
@@ -18630,6 +19311,9 @@ _tmp_147_rule(Parser *p)
 static void *
 _tmp_148_rule(Parser *p)
 {
+    if (p->error_indicator) {
+        return NULL;
+    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':'

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -677,12 +677,12 @@ static void *_tmp_148_rule(Parser *p);
 static mod_ty
 file_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // statements? $
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *a;
         Token * endmarker_var;
         if (
@@ -709,12 +709,12 @@ file_rule(Parser *p)
 static mod_ty
 interactive_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // statement_newline
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* a;
         if (
             (a = statement_newline_rule(p))  // statement_newline
@@ -738,12 +738,12 @@ interactive_rule(Parser *p)
 static mod_ty
 eval_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // expressions NEWLINE* $
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * _loop0_1_var;
         expr_ty a;
         Token * endmarker_var;
@@ -773,12 +773,12 @@ eval_rule(Parser *p)
 static mod_ty
 func_type_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     mod_ty _res = NULL;
     int _mark = p->mark;
     { // '(' type_expressions? ')' '->' expression NEWLINE* $
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         Token * _literal_2;
@@ -820,12 +820,12 @@ func_type_rule(Parser *p)
 static expr_ty
 fstring_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // star_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_expressions_var;
         if (
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
@@ -852,12 +852,12 @@ fstring_rule(Parser *p)
 static asdl_seq*
 type_expressions_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.expression+ ',' '*' expression ',' '**' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         Token * _literal_2;
@@ -891,6 +891,9 @@ type_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // ','.expression+ ',' '*' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * a;
@@ -915,6 +918,9 @@ type_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // ','.expression+ ',' '**' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * a;
@@ -939,6 +945,9 @@ type_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // '*' expression ',' '**' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         Token * _literal_2;
@@ -966,6 +975,9 @@ type_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // '*' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -984,6 +996,9 @@ type_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // '**' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -1002,6 +1017,9 @@ type_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // ','.expression+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * _gather_9_var;
         if (
             (_gather_9_var = _gather_9_rule(p))  // ','.expression+
@@ -1021,12 +1039,12 @@ type_expressions_rule(Parser *p)
 static asdl_seq*
 statements_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // statement+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         if (
             (a = _loop1_11_rule(p))  // statement+
@@ -1050,12 +1068,12 @@ statements_rule(Parser *p)
 static asdl_seq*
 statement_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // compound_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty a;
         if (
             (a = compound_stmt_rule(p))  // compound_stmt
@@ -1071,6 +1089,9 @@ statement_rule(Parser *p)
         p->mark = _mark;
     }
     { // simple_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* simple_stmt_var;
         if (
             (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
@@ -1090,9 +1111,6 @@ statement_rule(Parser *p)
 static asdl_seq*
 statement_newline_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -1104,6 +1122,9 @@ statement_newline_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // compound_stmt NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty a;
         Token * newline_var;
         if (
@@ -1122,6 +1143,9 @@ statement_newline_rule(Parser *p)
         p->mark = _mark;
     }
     { // simple_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* simple_stmt_var;
         if (
             (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
@@ -1133,6 +1157,9 @@ statement_newline_rule(Parser *p)
         p->mark = _mark;
     }
     { // NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
@@ -1156,6 +1183,9 @@ statement_newline_rule(Parser *p)
         p->mark = _mark;
     }
     { // $
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * endmarker_var;
         if (
             (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))  // token='ENDMARKER'
@@ -1179,12 +1209,12 @@ statement_newline_rule(Parser *p)
 static asdl_seq*
 simple_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // small_stmt !';' NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty a;
         Token * newline_var;
         if (
@@ -1205,6 +1235,9 @@ simple_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // ';'.small_stmt+ ';'? NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -1248,9 +1281,6 @@ simple_stmt_rule(Parser *p)
 static stmt_ty
 small_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     if (_PyPegen_is_memoized(p, small_stmt_type, &_res))
         return _res;
@@ -1264,6 +1294,9 @@ small_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // assignment
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty assignment_var;
         if (
             (assignment_var = assignment_rule(p))  // assignment
@@ -1275,6 +1308,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty e;
         if (
             (e = star_expressions_rule(p))  // star_expressions
@@ -1298,6 +1334,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'return' return_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty return_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 500)  // token='return'
@@ -1311,6 +1350,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &('import' | 'from') import_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty import_stmt_var;
         if (
             _PyPegen_lookahead(1, _tmp_14_rule, p)
@@ -1324,6 +1366,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'raise' raise_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty raise_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 501)  // token='raise'
@@ -1337,6 +1382,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'pass'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 502))  // token='pass'
@@ -1360,6 +1408,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'del' del_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty del_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 503)  // token='del'
@@ -1373,6 +1424,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'yield' yield_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty yield_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 504)  // token='yield'
@@ -1386,6 +1440,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'assert' assert_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty assert_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 505)  // token='assert'
@@ -1399,6 +1456,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'break'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 506))  // token='break'
@@ -1422,6 +1482,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'continue'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 507))  // token='continue'
@@ -1445,6 +1508,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'global' global_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty global_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 508)  // token='global'
@@ -1458,6 +1524,9 @@ small_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'nonlocal' nonlocal_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty nonlocal_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 509)  // token='nonlocal'
@@ -1487,12 +1556,12 @@ small_stmt_rule(Parser *p)
 static stmt_ty
 compound_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // &('def' | '@' | ASYNC) function_def
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty function_def_var;
         if (
             _PyPegen_lookahead(1, _tmp_15_rule, p)
@@ -1506,6 +1575,9 @@ compound_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'if' if_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty if_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 510)  // token='if'
@@ -1519,6 +1591,9 @@ compound_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &('class' | '@') class_def
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty class_def_var;
         if (
             _PyPegen_lookahead(1, _tmp_16_rule, p)
@@ -1532,6 +1607,9 @@ compound_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &('with' | ASYNC) with_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty with_stmt_var;
         if (
             _PyPegen_lookahead(1, _tmp_17_rule, p)
@@ -1545,6 +1623,9 @@ compound_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &('for' | ASYNC) for_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty for_stmt_var;
         if (
             _PyPegen_lookahead(1, _tmp_18_rule, p)
@@ -1558,6 +1639,9 @@ compound_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'try' try_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty try_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 511)  // token='try'
@@ -1571,6 +1655,9 @@ compound_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'while' while_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty while_stmt_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 512)  // token='while'
@@ -1597,9 +1684,6 @@ compound_stmt_rule(Parser *p)
 static stmt_ty
 assignment_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -1611,6 +1695,9 @@ assignment_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME ':' expression ['=' annotated_rhs]
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -1643,6 +1730,9 @@ assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // ('(' single_target ')' | single_subscript_attribute_target) ':' expression ['=' annotated_rhs]
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *a;
         expr_ty b;
@@ -1675,6 +1765,9 @@ assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // ((star_targets '='))+ (yield_expr | star_expressions) TYPE_COMMENT?
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         void *b;
         void *tc;
@@ -1704,6 +1797,9 @@ assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // single_target augassign (yield_expr | star_expressions)
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         AugOperator* b;
         void *c;
@@ -1733,6 +1829,9 @@ assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_assignment
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_assignment_var;
         if (
             (invalid_assignment_var = invalid_assignment_rule(p))  // invalid_assignment
@@ -1765,12 +1864,12 @@ assignment_rule(Parser *p)
 static AugOperator*
 augassign_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     AugOperator* _res = NULL;
     int _mark = p->mark;
     { // '+='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 36))  // token='+='
@@ -1786,6 +1885,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '-='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 37))  // token='-='
@@ -1801,6 +1903,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '*='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 38))  // token='*='
@@ -1816,6 +1921,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '@='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 50))  // token='@='
@@ -1831,6 +1939,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '/='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 39))  // token='/='
@@ -1846,6 +1957,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '%='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 40))  // token='%='
@@ -1861,6 +1975,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '&='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 41))  // token='&='
@@ -1876,6 +1993,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '|='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 42))  // token='|='
@@ -1891,6 +2011,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '^='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 43))  // token='^='
@@ -1906,6 +2029,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '<<='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 44))  // token='<<='
@@ -1921,6 +2047,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '>>='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 45))  // token='>>='
@@ -1936,6 +2065,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '**='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 46))  // token='**='
@@ -1951,6 +2083,9 @@ augassign_rule(Parser *p)
         p->mark = _mark;
     }
     { // '//='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 48))  // token='//='
@@ -1974,9 +2109,6 @@ augassign_rule(Parser *p)
 static stmt_ty
 global_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -1988,6 +2120,9 @@ global_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'global' ','.NAME+
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         asdl_seq * a;
         if (
@@ -2022,9 +2157,6 @@ global_stmt_rule(Parser *p)
 static stmt_ty
 nonlocal_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2036,6 +2168,9 @@ nonlocal_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'nonlocal' ','.NAME+
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         asdl_seq * a;
         if (
@@ -2070,9 +2205,6 @@ nonlocal_stmt_rule(Parser *p)
 static stmt_ty
 yield_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2084,6 +2216,9 @@ yield_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // yield_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty y;
         if (
             (y = yield_expr_rule(p))  // yield_expr
@@ -2115,9 +2250,6 @@ yield_stmt_rule(Parser *p)
 static stmt_ty
 assert_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2129,6 +2261,9 @@ assert_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'assert' expression [',' expression]
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty a;
         void *b;
@@ -2166,9 +2301,6 @@ assert_stmt_rule(Parser *p)
 static stmt_ty
 del_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2180,6 +2312,9 @@ del_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'del' del_targets
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         asdl_seq* a;
         if (
@@ -2214,12 +2349,12 @@ del_stmt_rule(Parser *p)
 static stmt_ty
 import_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // import_name
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty import_name_var;
         if (
             (import_name_var = import_name_rule(p))  // import_name
@@ -2231,6 +2366,9 @@ import_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // import_from
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty import_from_var;
         if (
             (import_from_var = import_from_rule(p))  // import_from
@@ -2250,9 +2388,6 @@ import_stmt_rule(Parser *p)
 static stmt_ty
 import_name_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2264,6 +2399,9 @@ import_name_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'import' dotted_as_names
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         asdl_seq* a;
         if (
@@ -2300,9 +2438,6 @@ import_name_rule(Parser *p)
 static stmt_ty
 import_from_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2314,6 +2449,9 @@ import_from_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'from' (('.' | '...'))* dotted_name 'import' import_from_targets
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         asdl_seq * a;
@@ -2349,6 +2487,9 @@ import_from_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'from' (('.' | '...'))+ 'import' import_from_targets
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         asdl_seq * a;
@@ -2389,12 +2530,12 @@ import_from_rule(Parser *p)
 static asdl_seq*
 import_from_targets_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // '(' import_from_as_names ','? ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *_opt_var;
@@ -2420,6 +2561,9 @@ import_from_targets_rule(Parser *p)
         p->mark = _mark;
     }
     { // import_from_as_names
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* import_from_as_names_var;
         if (
             (import_from_as_names_var = import_from_as_names_rule(p))  // import_from_as_names
@@ -2431,6 +2575,9 @@ import_from_targets_rule(Parser *p)
         p->mark = _mark;
     }
     { // '*'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
@@ -2454,12 +2601,12 @@ import_from_targets_rule(Parser *p)
 static asdl_seq*
 import_from_as_names_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.import_from_as_name+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         if (
             (a = _gather_32_rule(p))  // ','.import_from_as_name+
@@ -2483,12 +2630,12 @@ import_from_as_names_rule(Parser *p)
 static alias_ty
 import_from_as_name_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     alias_ty _res = NULL;
     int _mark = p->mark;
     { // NAME ['as' NAME]
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         void *b;
         if (
@@ -2515,12 +2662,12 @@ import_from_as_name_rule(Parser *p)
 static asdl_seq*
 dotted_as_names_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.dotted_as_name+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         if (
             (a = _gather_35_rule(p))  // ','.dotted_as_name+
@@ -2544,12 +2691,12 @@ dotted_as_names_rule(Parser *p)
 static alias_ty
 dotted_as_name_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     alias_ty _res = NULL;
     int _mark = p->mark;
     { // dotted_name ['as' NAME]
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         void *b;
         if (
@@ -2601,12 +2748,12 @@ dotted_name_rule(Parser *p)
 static expr_ty
 dotted_name_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // dotted_name '.' NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -2628,6 +2775,9 @@ dotted_name_raw(Parser *p)
         p->mark = _mark;
     }
     { // NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty name_var;
         if (
             (name_var = _PyPegen_name_token(p))  // NAME
@@ -2649,9 +2799,6 @@ dotted_name_raw(Parser *p)
 static stmt_ty
 if_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2663,6 +2810,9 @@ if_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'if' named_expression ':' block elif_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         expr_ty a;
@@ -2698,6 +2848,9 @@ if_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'if' named_expression ':' block else_block?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         expr_ty a;
@@ -2743,9 +2896,6 @@ if_stmt_rule(Parser *p)
 static stmt_ty
 elif_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2757,6 +2907,9 @@ elif_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'elif' named_expression ':' block elif_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         expr_ty a;
@@ -2792,6 +2945,9 @@ elif_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'elif' named_expression ':' block else_block?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         expr_ty a;
@@ -2835,12 +2991,12 @@ elif_stmt_rule(Parser *p)
 static asdl_seq*
 else_block_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // 'else' ':' block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq* b;
@@ -2870,9 +3026,6 @@ else_block_rule(Parser *p)
 static stmt_ty
 while_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2884,6 +3037,9 @@ while_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'while' named_expression ':' block else_block?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         expr_ty a;
@@ -2929,9 +3085,6 @@ while_stmt_rule(Parser *p)
 static stmt_ty
 for_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -2943,6 +3096,9 @@ for_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         Token * _literal;
@@ -2987,6 +3143,9 @@ for_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // ASYNC 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         Token * _literal;
@@ -3046,9 +3205,6 @@ for_stmt_rule(Parser *p)
 static stmt_ty
 with_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3060,6 +3216,9 @@ with_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'with' '(' ','.with_item+ ','? ')' ':' block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         Token * _literal_1;
@@ -3102,6 +3261,9 @@ with_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'with' ','.with_item+ ':' TYPE_COMMENT? block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq * a;
@@ -3137,6 +3299,9 @@ with_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // ASYNC 'with' '(' ','.with_item+ ','? ')' ':' block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         Token * _literal_1;
@@ -3182,6 +3347,9 @@ with_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq * a;
@@ -3228,12 +3396,12 @@ with_stmt_rule(Parser *p)
 static withitem_ty
 with_item_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     withitem_ty _res = NULL;
     int _mark = p->mark;
     { // expression ['as' target]
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty e;
         void *o;
         if (
@@ -3262,9 +3430,6 @@ with_item_rule(Parser *p)
 static stmt_ty
 try_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3276,6 +3441,9 @@ try_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'try' ':' block finally_block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq* b;
@@ -3308,6 +3476,9 @@ try_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'try' ':' block except_block+ else_block? finally_block?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq* b;
@@ -3354,9 +3525,6 @@ try_stmt_rule(Parser *p)
 static excepthandler_ty
 except_block_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     excepthandler_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3368,6 +3536,9 @@ except_block_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'except' expression ['as' NAME] ':' block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq* b;
@@ -3403,6 +3574,9 @@ except_block_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'except' ':' block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq* b;
@@ -3440,12 +3614,12 @@ except_block_rule(Parser *p)
 static asdl_seq*
 finally_block_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // 'finally' ':' block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         asdl_seq* a;
@@ -3475,9 +3649,6 @@ finally_block_rule(Parser *p)
 static stmt_ty
 return_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3489,6 +3660,9 @@ return_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'return' star_expressions?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         void *a;
         if (
@@ -3523,9 +3697,6 @@ return_stmt_rule(Parser *p)
 static stmt_ty
 raise_stmt_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3537,6 +3708,9 @@ raise_stmt_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'raise' expression ['from' expression]
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty a;
         void *b;
@@ -3566,6 +3740,9 @@ raise_stmt_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'raise'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 501))  // token='raise'
@@ -3597,12 +3774,12 @@ raise_stmt_rule(Parser *p)
 static stmt_ty
 function_def_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // decorators function_def_raw
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* d;
         stmt_ty f;
         if (
@@ -3621,6 +3798,9 @@ function_def_rule(Parser *p)
         p->mark = _mark;
     }
     { // function_def_raw
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty function_def_raw_var;
         if (
             (function_def_raw_var = function_def_raw_rule(p))  // function_def_raw
@@ -3642,9 +3822,6 @@ function_def_rule(Parser *p)
 static stmt_ty
 function_def_raw_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -3656,6 +3833,9 @@ function_def_raw_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         Token * _literal_1;
@@ -3703,6 +3883,9 @@ function_def_raw_rule(Parser *p)
         p->mark = _mark;
     }
     { // ASYNC 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         Token * _literal_1;
@@ -3764,12 +3947,12 @@ function_def_raw_rule(Parser *p)
 static Token*
 func_type_comment_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     Token* _res = NULL;
     int _mark = p->mark;
     { // NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * newline_var;
         Token * t;
         if (
@@ -3790,6 +3973,9 @@ func_type_comment_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_double_type_comments
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_double_type_comments_var;
         if (
             (invalid_double_type_comments_var = invalid_double_type_comments_rule(p))  // invalid_double_type_comments
@@ -3801,6 +3987,9 @@ func_type_comment_rule(Parser *p)
         p->mark = _mark;
     }
     { // TYPE_COMMENT
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * type_comment_var;
         if (
             (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))  // token='TYPE_COMMENT'
@@ -3820,12 +4009,12 @@ func_type_comment_rule(Parser *p)
 static arguments_ty
 params_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // invalid_parameters
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_parameters_var;
         if (
             (invalid_parameters_var = invalid_parameters_rule(p))  // invalid_parameters
@@ -3837,6 +4026,9 @@ params_rule(Parser *p)
         p->mark = _mark;
     }
     { // parameters
+        if (p->error_indicator) {
+            return NULL;
+        }
         arguments_ty parameters_var;
         if (
             (parameters_var = parameters_rule(p))  // parameters
@@ -3861,12 +4053,12 @@ params_rule(Parser *p)
 static arguments_ty
 parameters_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // slash_no_default param_no_default* param_with_default* star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* a;
         asdl_seq * b;
         asdl_seq * c;
@@ -3891,6 +4083,9 @@ parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // slash_with_default param_with_default* star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         SlashWithDefault* a;
         asdl_seq * b;
         void *c;
@@ -3912,6 +4107,9 @@ parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // param_no_default+ param_with_default* star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         asdl_seq * b;
         void *c;
@@ -3933,6 +4131,9 @@ parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // param_with_default+ star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         void *b;
         if (
@@ -3951,6 +4152,9 @@ parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_etc
+        if (p->error_indicator) {
+            return NULL;
+        }
         StarEtc* a;
         if (
             (a = star_etc_rule(p))  // star_etc
@@ -3974,12 +4178,12 @@ parameters_rule(Parser *p)
 static asdl_seq*
 slash_no_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // param_no_default+ '/' ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * a;
@@ -4001,6 +4205,9 @@ slash_no_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // param_no_default+ '/' &')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         asdl_seq * a;
         if (
@@ -4031,12 +4238,12 @@ slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 slash_with_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     SlashWithDefault* _res = NULL;
     int _mark = p->mark;
     { // param_no_default* param_with_default+ '/' ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * a;
@@ -4061,6 +4268,9 @@ slash_with_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // param_no_default* param_with_default+ '/' &')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         asdl_seq * a;
         asdl_seq * b;
@@ -4096,12 +4306,12 @@ slash_with_default_rule(Parser *p)
 static StarEtc*
 star_etc_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     StarEtc* _res = NULL;
     int _mark = p->mark;
     { // '*' param_no_default param_maybe_default* kwds?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         asdl_seq * b;
@@ -4126,6 +4336,9 @@ star_etc_rule(Parser *p)
         p->mark = _mark;
     }
     { // '*' ',' param_maybe_default+ kwds?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * b;
@@ -4150,6 +4363,9 @@ star_etc_rule(Parser *p)
         p->mark = _mark;
     }
     { // kwds
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         if (
             (a = kwds_rule(p))  // kwds
@@ -4165,6 +4381,9 @@ star_etc_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_star_etc
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_star_etc_var;
         if (
             (invalid_star_etc_var = invalid_star_etc_rule(p))  // invalid_star_etc
@@ -4184,12 +4403,12 @@ star_etc_rule(Parser *p)
 static arg_ty
 kwds_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // '**' param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         if (
@@ -4216,12 +4435,12 @@ kwds_rule(Parser *p)
 static arg_ty
 param_no_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // param ',' TYPE_COMMENT?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         void *tc;
@@ -4243,6 +4462,9 @@ param_no_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // param TYPE_COMMENT? &')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         void *tc;
         if (
@@ -4271,12 +4493,12 @@ param_no_default_rule(Parser *p)
 static NameDefaultPair*
 param_with_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // param default ',' TYPE_COMMENT?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         expr_ty c;
@@ -4301,6 +4523,9 @@ param_with_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // param default TYPE_COMMENT? &')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         expr_ty c;
         void *tc;
@@ -4334,12 +4559,12 @@ param_with_default_rule(Parser *p)
 static NameDefaultPair*
 param_maybe_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // param default? ',' TYPE_COMMENT?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         void *c;
@@ -4364,6 +4589,9 @@ param_maybe_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // param default? TYPE_COMMENT? &')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         void *c;
         void *tc;
@@ -4395,9 +4623,6 @@ param_maybe_default_rule(Parser *p)
 static arg_ty
 param_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -4409,6 +4634,9 @@ param_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME annotation?
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         void *b;
         if (
@@ -4443,12 +4671,12 @@ param_rule(Parser *p)
 static expr_ty
 annotation_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // ':' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -4475,12 +4703,12 @@ annotation_rule(Parser *p)
 static expr_ty
 default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // '=' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -4507,12 +4735,12 @@ default_rule(Parser *p)
 static asdl_seq*
 decorators_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // (('@' named_expression NEWLINE))+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         if (
             (a = _loop1_67_rule(p))  // (('@' named_expression NEWLINE))+
@@ -4536,12 +4764,12 @@ decorators_rule(Parser *p)
 static stmt_ty
 class_def_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     { // decorators class_def_raw
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* a;
         stmt_ty b;
         if (
@@ -4560,6 +4788,9 @@ class_def_rule(Parser *p)
         p->mark = _mark;
     }
     { // class_def_raw
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty class_def_raw_var;
         if (
             (class_def_raw_var = class_def_raw_rule(p))  // class_def_raw
@@ -4579,9 +4810,6 @@ class_def_rule(Parser *p)
 static stmt_ty
 class_def_raw_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     stmt_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -4593,6 +4821,9 @@ class_def_raw_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'class' NAME ['(' arguments? ')'] ':' block
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         expr_ty a;
@@ -4636,14 +4867,14 @@ class_def_raw_rule(Parser *p)
 static asdl_seq*
 block_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     if (_PyPegen_is_memoized(p, block_type, &_res))
         return _res;
     int _mark = p->mark;
     { // NEWLINE INDENT statements DEDENT
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* a;
         Token * dedent_var;
         Token * indent_var;
@@ -4668,6 +4899,9 @@ block_rule(Parser *p)
         p->mark = _mark;
     }
     { // simple_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* simple_stmt_var;
         if (
             (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
@@ -4679,6 +4913,9 @@ block_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_block
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_block_var;
         if (
             (invalid_block_var = invalid_block_rule(p))  // invalid_block
@@ -4699,12 +4936,12 @@ block_rule(Parser *p)
 static asdl_seq*
 expressions_list_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_expression+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -4735,9 +4972,6 @@ expressions_list_rule(Parser *p)
 static expr_ty
 star_expressions_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -4749,6 +4983,9 @@ star_expressions_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // star_expression ((',' star_expression))+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
@@ -4779,6 +5016,9 @@ star_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expression ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -4805,6 +5045,9 @@ star_expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_expression_var;
         if (
             (star_expression_var = star_expression_rule(p))  // star_expression
@@ -4824,9 +5067,6 @@ star_expressions_rule(Parser *p)
 static expr_ty
 star_expression_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, star_expression_type, &_res))
         return _res;
@@ -4840,6 +5080,9 @@ star_expression_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -4866,6 +5109,9 @@ star_expression_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty expression_var;
         if (
             (expression_var = expression_rule(p))  // expression
@@ -4886,12 +5132,12 @@ star_expression_rule(Parser *p)
 static asdl_seq*
 star_named_expressions_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_named_expression+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -4919,9 +5165,6 @@ star_named_expressions_rule(Parser *p)
 static expr_ty
 star_named_expression_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -4933,6 +5176,9 @@ star_named_expression_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -4959,6 +5205,9 @@ star_named_expression_rule(Parser *p)
         p->mark = _mark;
     }
     { // named_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty named_expression_var;
         if (
             (named_expression_var = named_expression_rule(p))  // named_expression
@@ -4978,9 +5227,6 @@ star_named_expression_rule(Parser *p)
 static expr_ty
 named_expression_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -4992,6 +5238,9 @@ named_expression_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME ':=' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -5021,6 +5270,9 @@ named_expression_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression !':='
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty expression_var;
         if (
             (expression_var = expression_rule(p))  // expression
@@ -5034,6 +5286,9 @@ named_expression_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_named_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_named_expression_var;
         if (
             (invalid_named_expression_var = invalid_named_expression_rule(p))  // invalid_named_expression
@@ -5053,12 +5308,12 @@ named_expression_rule(Parser *p)
 static expr_ty
 annotated_rhs_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // yield_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty yield_expr_var;
         if (
             (yield_expr_var = yield_expr_rule(p))  // yield_expr
@@ -5070,6 +5325,9 @@ annotated_rhs_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_expressions_var;
         if (
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
@@ -5089,9 +5347,6 @@ annotated_rhs_rule(Parser *p)
 static expr_ty
 expressions_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5103,6 +5358,9 @@ expressions_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // expression ((',' expression))+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
@@ -5133,6 +5391,9 @@ expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -5159,6 +5420,9 @@ expressions_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty expression_var;
         if (
             (expression_var = expression_rule(p))  // expression
@@ -5178,9 +5442,6 @@ expressions_rule(Parser *p)
 static expr_ty
 expression_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, expression_type, &_res))
         return _res;
@@ -5194,6 +5455,9 @@ expression_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // disjunction 'if' disjunction 'else' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         expr_ty a;
@@ -5229,6 +5493,9 @@ expression_rule(Parser *p)
         p->mark = _mark;
     }
     { // disjunction
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty disjunction_var;
         if (
             (disjunction_var = disjunction_rule(p))  // disjunction
@@ -5240,6 +5507,9 @@ expression_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambdef
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty lambdef_var;
         if (
             (lambdef_var = lambdef_rule(p))  // lambdef
@@ -5260,9 +5530,6 @@ expression_rule(Parser *p)
 static expr_ty
 lambdef_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5274,6 +5541,9 @@ lambdef_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'lambda' lambda_parameters? ':' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _literal;
         void *a;
@@ -5319,12 +5589,12 @@ lambdef_rule(Parser *p)
 static arguments_ty
 lambda_parameters_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arguments_ty _res = NULL;
     int _mark = p->mark;
     { // lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* lambda_star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* a;
         asdl_seq * b;
         asdl_seq * c;
@@ -5349,6 +5619,9 @@ lambda_parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_slash_with_default lambda_param_with_default* lambda_star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         SlashWithDefault* a;
         asdl_seq * b;
         void *c;
@@ -5370,6 +5643,9 @@ lambda_parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_param_no_default+ lambda_param_with_default* lambda_star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         asdl_seq * b;
         void *c;
@@ -5391,6 +5667,9 @@ lambda_parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_param_with_default+ lambda_star_etc?
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         void *b;
         if (
@@ -5409,6 +5688,9 @@ lambda_parameters_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_star_etc
+        if (p->error_indicator) {
+            return NULL;
+        }
         StarEtc* a;
         if (
             (a = lambda_star_etc_rule(p))  // lambda_star_etc
@@ -5434,12 +5716,12 @@ lambda_parameters_rule(Parser *p)
 static asdl_seq*
 lambda_slash_no_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default+ '/' ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * a;
@@ -5461,6 +5743,9 @@ lambda_slash_no_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_param_no_default+ '/' &':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         asdl_seq * a;
         if (
@@ -5491,12 +5776,12 @@ lambda_slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 lambda_slash_with_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     SlashWithDefault* _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default* lambda_param_with_default+ '/' ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * a;
@@ -5521,6 +5806,9 @@ lambda_slash_with_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_param_no_default* lambda_param_with_default+ '/' &':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         asdl_seq * a;
         asdl_seq * b;
@@ -5556,12 +5844,12 @@ lambda_slash_with_default_rule(Parser *p)
 static StarEtc*
 lambda_star_etc_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     StarEtc* _res = NULL;
     int _mark = p->mark;
     { // '*' lambda_param_no_default lambda_param_maybe_default* lambda_kwds?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         asdl_seq * b;
@@ -5586,6 +5874,9 @@ lambda_star_etc_rule(Parser *p)
         p->mark = _mark;
     }
     { // '*' ',' lambda_param_maybe_default+ lambda_kwds?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * b;
@@ -5610,6 +5901,9 @@ lambda_star_etc_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_kwds
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         if (
             (a = lambda_kwds_rule(p))  // lambda_kwds
@@ -5625,6 +5919,9 @@ lambda_star_etc_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_lambda_star_etc
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_lambda_star_etc_var;
         if (
             (invalid_lambda_star_etc_var = invalid_lambda_star_etc_rule(p))  // invalid_lambda_star_etc
@@ -5644,12 +5941,12 @@ lambda_star_etc_rule(Parser *p)
 static arg_ty
 lambda_kwds_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // '**' lambda_param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         if (
@@ -5676,12 +5973,12 @@ lambda_kwds_rule(Parser *p)
 static arg_ty
 lambda_param_no_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     { // lambda_param ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         if (
@@ -5700,6 +5997,9 @@ lambda_param_no_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_param &':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         if (
             (a = lambda_param_rule(p))  // lambda_param
@@ -5725,12 +6025,12 @@ lambda_param_no_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_with_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // lambda_param default ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         expr_ty c;
@@ -5752,6 +6052,9 @@ lambda_param_with_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_param default &':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         expr_ty c;
         if (
@@ -5780,12 +6083,12 @@ lambda_param_with_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_maybe_default_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     NameDefaultPair* _res = NULL;
     int _mark = p->mark;
     { // lambda_param default? ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         arg_ty a;
         void *c;
@@ -5807,6 +6110,9 @@ lambda_param_maybe_default_rule(Parser *p)
         p->mark = _mark;
     }
     { // lambda_param default? &':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty a;
         void *c;
         if (
@@ -5835,9 +6141,6 @@ lambda_param_maybe_default_rule(Parser *p)
 static arg_ty
 lambda_param_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     arg_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -5849,6 +6152,9 @@ lambda_param_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = _PyPegen_name_token(p))  // NAME
@@ -5880,9 +6186,6 @@ lambda_param_rule(Parser *p)
 static expr_ty
 disjunction_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, disjunction_type, &_res))
         return _res;
@@ -5896,6 +6199,9 @@ disjunction_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // conjunction (('or' conjunction))+
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         asdl_seq * b;
         if (
@@ -5922,6 +6228,9 @@ disjunction_rule(Parser *p)
         p->mark = _mark;
     }
     { // conjunction
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty conjunction_var;
         if (
             (conjunction_var = conjunction_rule(p))  // conjunction
@@ -5942,9 +6251,6 @@ disjunction_rule(Parser *p)
 static expr_ty
 conjunction_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, conjunction_type, &_res))
         return _res;
@@ -5958,6 +6264,9 @@ conjunction_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // inversion (('and' inversion))+
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         asdl_seq * b;
         if (
@@ -5984,6 +6293,9 @@ conjunction_rule(Parser *p)
         p->mark = _mark;
     }
     { // inversion
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty inversion_var;
         if (
             (inversion_var = inversion_rule(p))  // inversion
@@ -6004,9 +6316,6 @@ conjunction_rule(Parser *p)
 static expr_ty
 inversion_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, inversion_type, &_res))
         return _res;
@@ -6020,6 +6329,9 @@ inversion_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'not' inversion
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty a;
         if (
@@ -6046,6 +6358,9 @@ inversion_rule(Parser *p)
         p->mark = _mark;
     }
     { // comparison
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty comparison_var;
         if (
             (comparison_var = comparison_rule(p))  // comparison
@@ -6066,9 +6381,6 @@ inversion_rule(Parser *p)
 static expr_ty
 comparison_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -6080,6 +6392,9 @@ comparison_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_or compare_op_bitwise_or_pair+
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         asdl_seq * b;
         if (
@@ -6106,6 +6421,9 @@ comparison_rule(Parser *p)
         p->mark = _mark;
     }
     { // bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty bitwise_or_var;
         if (
             (bitwise_or_var = bitwise_or_rule(p))  // bitwise_or
@@ -6135,12 +6453,12 @@ comparison_rule(Parser *p)
 static CmpopExprPair*
 compare_op_bitwise_or_pair_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // eq_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* eq_bitwise_or_var;
         if (
             (eq_bitwise_or_var = eq_bitwise_or_rule(p))  // eq_bitwise_or
@@ -6152,6 +6470,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // noteq_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* noteq_bitwise_or_var;
         if (
             (noteq_bitwise_or_var = noteq_bitwise_or_rule(p))  // noteq_bitwise_or
@@ -6163,6 +6484,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // lte_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* lte_bitwise_or_var;
         if (
             (lte_bitwise_or_var = lte_bitwise_or_rule(p))  // lte_bitwise_or
@@ -6174,6 +6498,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // lt_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* lt_bitwise_or_var;
         if (
             (lt_bitwise_or_var = lt_bitwise_or_rule(p))  // lt_bitwise_or
@@ -6185,6 +6512,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // gte_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* gte_bitwise_or_var;
         if (
             (gte_bitwise_or_var = gte_bitwise_or_rule(p))  // gte_bitwise_or
@@ -6196,6 +6526,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // gt_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* gt_bitwise_or_var;
         if (
             (gt_bitwise_or_var = gt_bitwise_or_rule(p))  // gt_bitwise_or
@@ -6207,6 +6540,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // notin_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* notin_bitwise_or_var;
         if (
             (notin_bitwise_or_var = notin_bitwise_or_rule(p))  // notin_bitwise_or
@@ -6218,6 +6554,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // in_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* in_bitwise_or_var;
         if (
             (in_bitwise_or_var = in_bitwise_or_rule(p))  // in_bitwise_or
@@ -6229,6 +6568,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // isnot_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* isnot_bitwise_or_var;
         if (
             (isnot_bitwise_or_var = isnot_bitwise_or_rule(p))  // isnot_bitwise_or
@@ -6240,6 +6582,9 @@ compare_op_bitwise_or_pair_rule(Parser *p)
         p->mark = _mark;
     }
     { // is_bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* is_bitwise_or_var;
         if (
             (is_bitwise_or_var = is_bitwise_or_rule(p))  // is_bitwise_or
@@ -6259,12 +6604,12 @@ compare_op_bitwise_or_pair_rule(Parser *p)
 static CmpopExprPair*
 eq_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '==' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -6291,12 +6636,12 @@ eq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 noteq_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // ('!=') bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_92_var;
         expr_ty a;
         if (
@@ -6323,12 +6668,12 @@ noteq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lte_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '<=' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -6355,12 +6700,12 @@ lte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lt_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '<' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -6387,12 +6732,12 @@ lt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gte_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '>=' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -6419,12 +6764,12 @@ gte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gt_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // '>' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -6451,12 +6796,12 @@ gt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 notin_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'not' 'in' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         expr_ty a;
@@ -6486,12 +6831,12 @@ notin_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 in_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'in' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty a;
         if (
@@ -6518,12 +6863,12 @@ in_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 isnot_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'is' 'not' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         expr_ty a;
@@ -6553,12 +6898,12 @@ isnot_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 is_bitwise_or_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     CmpopExprPair* _res = NULL;
     int _mark = p->mark;
     { // 'is' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty a;
         if (
@@ -6610,9 +6955,6 @@ bitwise_or_rule(Parser *p)
 static expr_ty
 bitwise_or_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -6624,6 +6966,9 @@ bitwise_or_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_or '|' bitwise_xor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -6653,6 +6998,9 @@ bitwise_or_raw(Parser *p)
         p->mark = _mark;
     }
     { // bitwise_xor
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty bitwise_xor_var;
         if (
             (bitwise_xor_var = bitwise_xor_rule(p))  // bitwise_xor
@@ -6697,9 +7045,6 @@ bitwise_xor_rule(Parser *p)
 static expr_ty
 bitwise_xor_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -6711,6 +7056,9 @@ bitwise_xor_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_xor '^' bitwise_and
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -6740,6 +7088,9 @@ bitwise_xor_raw(Parser *p)
         p->mark = _mark;
     }
     { // bitwise_and
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty bitwise_and_var;
         if (
             (bitwise_and_var = bitwise_and_rule(p))  // bitwise_and
@@ -6784,9 +7135,6 @@ bitwise_and_rule(Parser *p)
 static expr_ty
 bitwise_and_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -6798,6 +7146,9 @@ bitwise_and_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // bitwise_and '&' shift_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -6827,6 +7178,9 @@ bitwise_and_raw(Parser *p)
         p->mark = _mark;
     }
     { // shift_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty shift_expr_var;
         if (
             (shift_expr_var = shift_expr_rule(p))  // shift_expr
@@ -6871,9 +7225,6 @@ shift_expr_rule(Parser *p)
 static expr_ty
 shift_expr_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -6885,6 +7236,9 @@ shift_expr_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // shift_expr '<<' sum
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -6914,6 +7268,9 @@ shift_expr_raw(Parser *p)
         p->mark = _mark;
     }
     { // shift_expr '>>' sum
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -6943,6 +7300,9 @@ shift_expr_raw(Parser *p)
         p->mark = _mark;
     }
     { // sum
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty sum_var;
         if (
             (sum_var = sum_rule(p))  // sum
@@ -6987,9 +7347,6 @@ sum_rule(Parser *p)
 static expr_ty
 sum_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7001,6 +7358,9 @@ sum_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // sum '+' term
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7030,6 +7390,9 @@ sum_raw(Parser *p)
         p->mark = _mark;
     }
     { // sum '-' term
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7059,6 +7422,9 @@ sum_raw(Parser *p)
         p->mark = _mark;
     }
     { // term
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty term_var;
         if (
             (term_var = term_rule(p))  // term
@@ -7109,9 +7475,6 @@ term_rule(Parser *p)
 static expr_ty
 term_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7123,6 +7486,9 @@ term_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // term '*' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7152,6 +7518,9 @@ term_raw(Parser *p)
         p->mark = _mark;
     }
     { // term '/' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7181,6 +7550,9 @@ term_raw(Parser *p)
         p->mark = _mark;
     }
     { // term '//' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7210,6 +7582,9 @@ term_raw(Parser *p)
         p->mark = _mark;
     }
     { // term '%' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7239,6 +7614,9 @@ term_raw(Parser *p)
         p->mark = _mark;
     }
     { // term '@' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7268,6 +7646,9 @@ term_raw(Parser *p)
         p->mark = _mark;
     }
     { // factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty factor_var;
         if (
             (factor_var = factor_rule(p))  // factor
@@ -7287,9 +7668,6 @@ term_raw(Parser *p)
 static expr_ty
 factor_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, factor_type, &_res))
         return _res;
@@ -7303,6 +7681,9 @@ factor_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '+' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -7329,6 +7710,9 @@ factor_rule(Parser *p)
         p->mark = _mark;
     }
     { // '-' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -7355,6 +7739,9 @@ factor_rule(Parser *p)
         p->mark = _mark;
     }
     { // '~' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -7381,6 +7768,9 @@ factor_rule(Parser *p)
         p->mark = _mark;
     }
     { // power
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty power_var;
         if (
             (power_var = power_rule(p))  // power
@@ -7401,9 +7791,6 @@ factor_rule(Parser *p)
 static expr_ty
 power_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7415,6 +7802,9 @@ power_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // await_primary '**' factor
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7444,6 +7834,9 @@ power_rule(Parser *p)
         p->mark = _mark;
     }
     { // await_primary
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty await_primary_var;
         if (
             (await_primary_var = await_primary_rule(p))  // await_primary
@@ -7463,9 +7856,6 @@ power_rule(Parser *p)
 static expr_ty
 await_primary_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, await_primary_type, &_res))
         return _res;
@@ -7479,6 +7869,9 @@ await_primary_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // AWAIT primary
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         Token * await_var;
         if (
@@ -7505,6 +7898,9 @@ await_primary_rule(Parser *p)
         p->mark = _mark;
     }
     { // primary
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty primary_var;
         if (
             (primary_var = primary_rule(p))  // primary
@@ -7555,9 +7951,6 @@ primary_rule(Parser *p)
 static expr_ty
 primary_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7569,6 +7962,9 @@ primary_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // primary '.' NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -7598,6 +7994,9 @@ primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // primary genexp
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         expr_ty b;
         if (
@@ -7624,6 +8023,9 @@ primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // primary '(' arguments? ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -7656,6 +8058,9 @@ primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // primary '[' slices ']'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -7688,6 +8093,9 @@ primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // atom
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty atom_var;
         if (
             (atom_var = atom_rule(p))  // atom
@@ -7707,9 +8115,6 @@ primary_raw(Parser *p)
 static expr_ty
 slices_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7721,6 +8126,9 @@ slices_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // slice !','
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = slice_rule(p))  // slice
@@ -7738,6 +8146,9 @@ slices_rule(Parser *p)
         p->mark = _mark;
     }
     { // ','.slice+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -7773,9 +8184,6 @@ slices_rule(Parser *p)
 static expr_ty
 slice_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7787,6 +8195,9 @@ slice_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // expression? ':' expression? [':' expression?]
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *a;
         void *b;
@@ -7819,6 +8230,9 @@ slice_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = expression_rule(p))  // expression
@@ -7853,9 +8267,6 @@ slice_rule(Parser *p)
 static expr_ty
 atom_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -7867,6 +8278,9 @@ atom_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty name_var;
         if (
             (name_var = _PyPegen_name_token(p))  // NAME
@@ -7878,6 +8292,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'True'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 527))  // token='True'
@@ -7901,6 +8318,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'False'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 528))  // token='False'
@@ -7924,6 +8344,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'None'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 529))  // token='None'
@@ -7947,6 +8370,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '__new_parser__'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 530))  // token='__new_parser__'
@@ -7962,6 +8388,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // &STRING strings
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty strings_var;
         if (
             _PyPegen_lookahead(1, _PyPegen_string_token, p)
@@ -7975,6 +8404,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // NUMBER
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty number_var;
         if (
             (number_var = _PyPegen_number_token(p))  // NUMBER
@@ -7986,6 +8418,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'(' (tuple | group | genexp)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_96_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)  // token='('
@@ -7999,6 +8434,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'[' (list | listcomp)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_97_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)  // token='['
@@ -8012,6 +8450,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // &'{' (dict | set | dictcomp | setcomp)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_98_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)  // token='{'
@@ -8025,6 +8466,9 @@ atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '...'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 52))  // token='...'
@@ -8056,14 +8500,14 @@ atom_rule(Parser *p)
 static expr_ty
 strings_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, strings_type, &_res))
         return _res;
     int _mark = p->mark;
     { // STRING+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * a;
         if (
             (a = _loop1_99_rule(p))  // STRING+
@@ -8088,9 +8532,6 @@ strings_rule(Parser *p)
 static expr_ty
 list_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8102,6 +8543,9 @@ list_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '[' star_named_expressions? ']'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -8139,9 +8583,6 @@ list_rule(Parser *p)
 static expr_ty
 listcomp_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8153,6 +8594,9 @@ listcomp_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '[' named_expression for_if_clauses ']'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -8185,6 +8629,9 @@ listcomp_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_comprehension
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_comprehension_var;
         if (
             (invalid_comprehension_var = invalid_comprehension_rule(p))  // invalid_comprehension
@@ -8204,9 +8651,6 @@ listcomp_rule(Parser *p)
 static expr_ty
 tuple_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8218,6 +8662,9 @@ tuple_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '(' [star_named_expression ',' star_named_expressions?] ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -8255,12 +8702,12 @@ tuple_rule(Parser *p)
 static expr_ty
 group_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // '(' (yield_expr | named_expression) ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -8290,9 +8737,6 @@ group_rule(Parser *p)
 static expr_ty
 genexp_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8304,6 +8748,9 @@ genexp_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '(' expression for_if_clauses ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -8336,6 +8783,9 @@ genexp_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_comprehension
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_comprehension_var;
         if (
             (invalid_comprehension_var = invalid_comprehension_rule(p))  // invalid_comprehension
@@ -8355,9 +8805,6 @@ genexp_rule(Parser *p)
 static expr_ty
 set_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8369,6 +8816,9 @@ set_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' expressions_list '}'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq* a;
@@ -8406,9 +8856,6 @@ set_rule(Parser *p)
 static expr_ty
 setcomp_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8420,6 +8867,9 @@ setcomp_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' expression for_if_clauses '}'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -8452,6 +8902,9 @@ setcomp_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_comprehension
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_comprehension_var;
         if (
             (invalid_comprehension_var = invalid_comprehension_rule(p))  // invalid_comprehension
@@ -8471,9 +8924,6 @@ setcomp_rule(Parser *p)
 static expr_ty
 dict_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8485,6 +8935,9 @@ dict_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' kvpairs? '}'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -8522,9 +8975,6 @@ dict_rule(Parser *p)
 static expr_ty
 dictcomp_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8536,6 +8986,9 @@ dictcomp_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '{' kvpair for_if_clauses '}'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         KeyValuePair* a;
@@ -8576,12 +9029,12 @@ dictcomp_rule(Parser *p)
 static asdl_seq*
 kvpairs_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.kvpair+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -8609,12 +9062,12 @@ kvpairs_rule(Parser *p)
 static KeyValuePair*
 kvpair_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     KeyValuePair* _res = NULL;
     int _mark = p->mark;
     { // '**' bitwise_or
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -8633,6 +9086,9 @@ kvpair_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression ':' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -8662,12 +9118,12 @@ kvpair_rule(Parser *p)
 static asdl_seq*
 for_if_clauses_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // for_if_clause+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * _loop1_104_var;
         if (
             (_loop1_104_var = _loop1_104_rule(p))  // for_if_clause+
@@ -8689,12 +9145,12 @@ for_if_clauses_rule(Parser *p)
 static comprehension_ty
 for_if_clause_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     comprehension_ty _res = NULL;
     int _mark = p->mark;
     { // ASYNC 'for' star_targets 'in' disjunction (('if' disjunction))*
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         expr_ty a;
@@ -8725,6 +9181,9 @@ for_if_clause_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'for' star_targets 'in' disjunction (('if' disjunction))*
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         expr_ty a;
@@ -8760,9 +9219,6 @@ for_if_clause_rule(Parser *p)
 static expr_ty
 yield_expr_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8774,6 +9230,9 @@ yield_expr_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // 'yield' 'from' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         Token * _keyword_1;
         expr_ty a;
@@ -8803,6 +9262,9 @@ yield_expr_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'yield' star_expressions?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         void *a;
         if (
@@ -8837,14 +9299,14 @@ yield_expr_rule(Parser *p)
 static expr_ty
 arguments_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, arguments_type, &_res))
         return _res;
     int _mark = p->mark;
     { // args ','? &')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
@@ -8866,6 +9328,9 @@ arguments_rule(Parser *p)
         p->mark = _mark;
     }
     { // incorrect_arguments
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *incorrect_arguments_var;
         if (
             (incorrect_arguments_var = incorrect_arguments_rule(p))  // incorrect_arguments
@@ -8886,9 +9351,6 @@ arguments_rule(Parser *p)
 static expr_ty
 args_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -8900,6 +9362,9 @@ args_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // starred_expression [',' args]
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         void *b;
         if (
@@ -8926,6 +9391,9 @@ args_rule(Parser *p)
         p->mark = _mark;
     }
     { // kwargs
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* a;
         if (
             (a = kwargs_rule(p))  // kwargs
@@ -8949,6 +9417,9 @@ args_rule(Parser *p)
         p->mark = _mark;
     }
     { // named_expression [',' args]
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         void *b;
         if (
@@ -8986,12 +9457,12 @@ args_rule(Parser *p)
 static asdl_seq*
 kwargs_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         asdl_seq * a;
         asdl_seq * b;
@@ -9013,6 +9484,9 @@ kwargs_rule(Parser *p)
         p->mark = _mark;
     }
     { // ','.kwarg_or_starred+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * _gather_113_var;
         if (
             (_gather_113_var = _gather_113_rule(p))  // ','.kwarg_or_starred+
@@ -9024,6 +9498,9 @@ kwargs_rule(Parser *p)
         p->mark = _mark;
     }
     { // ','.kwarg_or_double_starred+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * _gather_115_var;
         if (
             (_gather_115_var = _gather_115_rule(p))  // ','.kwarg_or_double_starred+
@@ -9043,9 +9520,6 @@ kwargs_rule(Parser *p)
 static expr_ty
 starred_expression_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9057,6 +9531,9 @@ starred_expression_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -9091,9 +9568,6 @@ starred_expression_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_starred_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     KeywordOrStarred* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9105,6 +9579,9 @@ kwarg_or_starred_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME '=' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -9134,6 +9611,9 @@ kwarg_or_starred_rule(Parser *p)
         p->mark = _mark;
     }
     { // starred_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = starred_expression_rule(p))  // starred_expression
@@ -9149,6 +9629,9 @@ kwarg_or_starred_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_kwarg
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_kwarg_var;
         if (
             (invalid_kwarg_var = invalid_kwarg_rule(p))  // invalid_kwarg
@@ -9168,9 +9651,6 @@ kwarg_or_starred_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_double_starred_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     KeywordOrStarred* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9182,6 +9662,9 @@ kwarg_or_double_starred_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME '=' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -9211,6 +9694,9 @@ kwarg_or_double_starred_rule(Parser *p)
         p->mark = _mark;
     }
     { // '**' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -9237,6 +9723,9 @@ kwarg_or_double_starred_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_kwarg
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_kwarg_var;
         if (
             (invalid_kwarg_var = invalid_kwarg_rule(p))  // invalid_kwarg
@@ -9256,9 +9745,6 @@ kwarg_or_double_starred_rule(Parser *p)
 static expr_ty
 star_targets_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9270,6 +9756,9 @@ star_targets_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // star_target !','
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = star_target_rule(p))  // star_target
@@ -9287,6 +9776,9 @@ star_targets_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_target ((',' star_target))* ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
@@ -9325,12 +9817,12 @@ star_targets_rule(Parser *p)
 static asdl_seq*
 star_targets_seq_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_target+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -9362,9 +9854,6 @@ star_targets_seq_rule(Parser *p)
 static expr_ty
 star_target_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, star_target_type, &_res))
         return _res;
@@ -9378,6 +9867,9 @@ star_target_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // '*' (!'*' star_target)
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *a;
         if (
@@ -9404,6 +9896,9 @@ star_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // t_primary '.' NAME !t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -9435,6 +9930,9 @@ star_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // t_primary '[' slices ']' !t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -9469,6 +9967,9 @@ star_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_atom
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_atom_var;
         if (
             (star_atom_var = star_atom_rule(p))  // star_atom
@@ -9493,9 +9994,6 @@ star_target_rule(Parser *p)
 static expr_ty
 star_atom_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9507,6 +10005,9 @@ star_atom_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = _PyPegen_name_token(p))  // NAME
@@ -9522,6 +10023,9 @@ star_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '(' star_target ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -9543,6 +10047,9 @@ star_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '(' star_targets_seq? ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -9572,6 +10079,9 @@ star_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '[' star_targets_seq? ']'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -9609,12 +10119,12 @@ star_atom_rule(Parser *p)
 static expr_ty
 single_target_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     { // single_subscript_attribute_target
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty single_subscript_attribute_target_var;
         if (
             (single_subscript_attribute_target_var = single_subscript_attribute_target_rule(p))  // single_subscript_attribute_target
@@ -9626,6 +10136,9 @@ single_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = _PyPegen_name_token(p))  // NAME
@@ -9641,6 +10154,9 @@ single_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // '(' single_target ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -9672,9 +10188,6 @@ single_target_rule(Parser *p)
 static expr_ty
 single_subscript_attribute_target_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9686,6 +10199,9 @@ single_subscript_attribute_target_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME !t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -9717,6 +10233,9 @@ single_subscript_attribute_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // t_primary '[' slices ']' !t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -9759,12 +10278,12 @@ single_subscript_attribute_target_rule(Parser *p)
 static asdl_seq*
 del_targets_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.del_target+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -9795,9 +10314,6 @@ del_targets_rule(Parser *p)
 static expr_ty
 del_target_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, del_target_type, &_res))
         return _res;
@@ -9811,6 +10327,9 @@ del_target_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME &del_target_end
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -9842,6 +10361,9 @@ del_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // t_primary '[' slices ']' &del_target_end
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -9876,6 +10398,9 @@ del_target_rule(Parser *p)
         p->mark = _mark;
     }
     { // del_t_atom
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty del_t_atom_var;
         if (
             (del_t_atom_var = del_t_atom_rule(p))  // del_t_atom
@@ -9901,9 +10426,6 @@ del_target_rule(Parser *p)
 static expr_ty
 del_t_atom_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -9915,6 +10437,9 @@ del_t_atom_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME &del_target_end
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = _PyPegen_name_token(p))  // NAME
@@ -9932,6 +10457,9 @@ del_t_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '(' del_target ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -9953,6 +10481,9 @@ del_t_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '(' del_targets? ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -9982,6 +10513,9 @@ del_t_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '[' del_targets? ']'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *a;
@@ -10011,6 +10545,9 @@ del_t_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // invalid_del_target
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *invalid_del_target_var;
         if (
             (invalid_del_target_var = invalid_del_target_rule(p))  // invalid_del_target
@@ -10030,12 +10567,12 @@ del_t_atom_rule(Parser *p)
 static void *
 del_target_end_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 8))  // token=')'
@@ -10047,6 +10584,9 @@ del_target_end_rule(Parser *p)
         p->mark = _mark;
     }
     { // ']'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 10))  // token=']'
@@ -10058,6 +10598,9 @@ del_target_end_rule(Parser *p)
         p->mark = _mark;
     }
     { // ','
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
@@ -10069,6 +10612,9 @@ del_target_end_rule(Parser *p)
         p->mark = _mark;
     }
     { // ';'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 13))  // token=';'
@@ -10080,6 +10626,9 @@ del_target_end_rule(Parser *p)
         p->mark = _mark;
     }
     { // NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
@@ -10099,12 +10648,12 @@ del_target_end_rule(Parser *p)
 static asdl_seq*
 targets_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.target+ ','?
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         asdl_seq * a;
@@ -10135,9 +10684,6 @@ targets_rule(Parser *p)
 static expr_ty
 target_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     if (_PyPegen_is_memoized(p, target_type, &_res))
         return _res;
@@ -10151,6 +10697,9 @@ target_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME !t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -10182,6 +10731,9 @@ target_rule(Parser *p)
         p->mark = _mark;
     }
     { // t_primary '[' slices ']' !t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -10216,6 +10768,9 @@ target_rule(Parser *p)
         p->mark = _mark;
     }
     { // t_atom
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty t_atom_var;
         if (
             (t_atom_var = t_atom_rule(p))  // t_atom
@@ -10266,9 +10821,6 @@ t_primary_rule(Parser *p)
 static expr_ty
 t_primary_raw(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -10280,6 +10832,9 @@ t_primary_raw(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // t_primary '.' NAME &t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty b;
@@ -10311,6 +10866,9 @@ t_primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // t_primary '[' slices ']' &t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -10345,6 +10903,9 @@ t_primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // t_primary genexp &t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         expr_ty b;
         if (
@@ -10373,6 +10934,9 @@ t_primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // t_primary '(' arguments? ')' &t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -10407,6 +10971,9 @@ t_primary_raw(Parser *p)
         p->mark = _mark;
     }
     { // atom &t_lookahead
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = atom_rule(p))  // atom
@@ -10432,12 +10999,12 @@ t_primary_raw(Parser *p)
 static void *
 t_lookahead_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '('
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
@@ -10449,6 +11016,9 @@ t_lookahead_rule(Parser *p)
         p->mark = _mark;
     }
     { // '['
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 9))  // token='['
@@ -10460,6 +11030,9 @@ t_lookahead_rule(Parser *p)
         p->mark = _mark;
     }
     { // '.'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 23))  // token='.'
@@ -10479,9 +11052,6 @@ t_lookahead_rule(Parser *p)
 static expr_ty
 t_atom_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     expr_ty _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
@@ -10493,6 +11063,9 @@ t_atom_rule(Parser *p)
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
     { // NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = _PyPegen_name_token(p))  // NAME
@@ -10508,6 +11081,9 @@ t_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '(' target ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
@@ -10529,6 +11105,9 @@ t_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '(' targets? ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *b;
@@ -10558,6 +11137,9 @@ t_atom_rule(Parser *p)
         p->mark = _mark;
     }
     { // '[' targets? ']'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *b;
@@ -10598,12 +11180,12 @@ t_atom_rule(Parser *p)
 static void *
 incorrect_arguments_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // args ',' '*'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty args_var;
@@ -10625,6 +11207,9 @@ incorrect_arguments_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression for_if_clauses ',' [args | expression for_if_clauses]
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
@@ -10650,6 +11235,9 @@ incorrect_arguments_rule(Parser *p)
         p->mark = _mark;
     }
     { // args ',' args
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty args_var;
@@ -10679,12 +11267,12 @@ incorrect_arguments_rule(Parser *p)
 static void *
 invalid_kwarg_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression '='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -10711,12 +11299,12 @@ invalid_kwarg_rule(Parser *p)
 static void *
 invalid_named_expression_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // expression ':=' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         expr_ty expression_var;
@@ -10752,12 +11340,12 @@ invalid_named_expression_rule(Parser *p)
 static void *
 invalid_assignment_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // list ':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -10776,6 +11364,9 @@ invalid_assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // tuple ':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty a;
         if (
@@ -10794,6 +11385,9 @@ invalid_assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_named_expression ',' star_named_expressions* ':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         asdl_seq * _loop0_126_var;
@@ -10818,6 +11412,9 @@ invalid_assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression ':' expression ['=' annotated_rhs]
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
@@ -10843,6 +11440,9 @@ invalid_assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions '=' (yield_expr | star_expressions)
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *_tmp_128_var;
         expr_ty a;
@@ -10864,6 +11464,9 @@ invalid_assignment_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions augassign (yield_expr | star_expressions)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_129_var;
         expr_ty a;
         AugOperator* augassign_var;
@@ -10893,12 +11496,12 @@ invalid_assignment_rule(Parser *p)
 static void *
 invalid_block_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // NEWLINE !INDENT
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
@@ -10924,12 +11527,12 @@ invalid_block_rule(Parser *p)
 static void *
 invalid_comprehension_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ('[' | '(' | '{') starred_expression for_if_clauses
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_130_var;
         expr_ty a;
         asdl_seq* for_if_clauses_var;
@@ -10960,12 +11563,12 @@ invalid_comprehension_rule(Parser *p)
 static void *
 invalid_parameters_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // param_no_default* (slash_with_default | param_with_default+) param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * _loop0_131_var;
         void *_tmp_132_var;
         arg_ty param_no_default_var;
@@ -10995,12 +11598,12 @@ invalid_parameters_rule(Parser *p)
 static void *
 invalid_star_etc_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '*' (')' | ',' (')' | '**'))
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *_tmp_133_var;
         if (
@@ -11027,12 +11630,12 @@ invalid_star_etc_rule(Parser *p)
 static void *
 invalid_lambda_star_etc_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '*' (':' | ',' (':' | '**'))
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *_tmp_134_var;
         if (
@@ -11059,12 +11662,12 @@ invalid_lambda_star_etc_rule(Parser *p)
 static void *
 invalid_double_type_comments_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * indent_var;
         Token * newline_var;
         Token * newline_var_1;
@@ -11100,12 +11703,12 @@ invalid_double_type_comments_rule(Parser *p)
 static void *
 invalid_del_target_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_expression &del_target_end
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty a;
         if (
             (a = star_expression_rule(p))  // star_expression
@@ -11146,6 +11749,9 @@ _loop0_1_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * newline_var;
         while (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
@@ -11199,6 +11805,9 @@ _loop0_2_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * newline_var;
         while (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
@@ -11252,6 +11861,9 @@ _loop0_4_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -11298,12 +11910,12 @@ _loop0_4_rule(Parser *p)
 static asdl_seq *
 _gather_3_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_4
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -11341,6 +11953,9 @@ _loop0_6_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -11387,12 +12002,12 @@ _loop0_6_rule(Parser *p)
 static asdl_seq *
 _gather_5_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_6
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -11430,6 +12045,9 @@ _loop0_8_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -11476,12 +12094,12 @@ _loop0_8_rule(Parser *p)
 static asdl_seq *
 _gather_7_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_8
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -11519,6 +12137,9 @@ _loop0_10_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -11565,12 +12186,12 @@ _loop0_10_rule(Parser *p)
 static asdl_seq *
 _gather_9_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // expression _loop0_10
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -11608,6 +12229,9 @@ _loop1_11_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // statement
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* statement_var;
         while (
             (statement_var = statement_rule(p))  // statement
@@ -11665,6 +12289,9 @@ _loop0_13_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ';' small_stmt
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         stmt_ty elem;
         while (
@@ -11711,12 +12338,12 @@ _loop0_13_rule(Parser *p)
 static asdl_seq *
 _gather_12_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // small_stmt _loop0_13
+        if (p->error_indicator) {
+            return NULL;
+        }
         stmt_ty elem;
         asdl_seq * seq;
         if (
@@ -11739,12 +12366,12 @@ _gather_12_rule(Parser *p)
 static void *
 _tmp_14_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'import'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 513))  // token='import'
@@ -11756,6 +12383,9 @@ _tmp_14_rule(Parser *p)
         p->mark = _mark;
     }
     { // 'from'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 514))  // token='from'
@@ -11775,12 +12405,12 @@ _tmp_14_rule(Parser *p)
 static void *
 _tmp_15_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'def'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 522))  // token='def'
@@ -11792,6 +12422,9 @@ _tmp_15_rule(Parser *p)
         p->mark = _mark;
     }
     { // '@'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 49))  // token='@'
@@ -11803,6 +12436,9 @@ _tmp_15_rule(Parser *p)
         p->mark = _mark;
     }
     { // ASYNC
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * async_var;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
@@ -11822,12 +12458,12 @@ _tmp_15_rule(Parser *p)
 static void *
 _tmp_16_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'class'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 523))  // token='class'
@@ -11839,6 +12475,9 @@ _tmp_16_rule(Parser *p)
         p->mark = _mark;
     }
     { // '@'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 49))  // token='@'
@@ -11858,12 +12497,12 @@ _tmp_16_rule(Parser *p)
 static void *
 _tmp_17_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'with'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 519))  // token='with'
@@ -11875,6 +12514,9 @@ _tmp_17_rule(Parser *p)
         p->mark = _mark;
     }
     { // ASYNC
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * async_var;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
@@ -11894,12 +12536,12 @@ _tmp_17_rule(Parser *p)
 static void *
 _tmp_18_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'for'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         if (
             (_keyword = _PyPegen_expect_token(p, 517))  // token='for'
@@ -11911,6 +12553,9 @@ _tmp_18_rule(Parser *p)
         p->mark = _mark;
     }
     { // ASYNC
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * async_var;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
@@ -11930,12 +12575,12 @@ _tmp_18_rule(Parser *p)
 static void *
 _tmp_19_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty d;
         if (
@@ -11962,12 +12607,12 @@ _tmp_19_rule(Parser *p)
 static void *
 _tmp_20_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' single_target ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         expr_ty b;
@@ -11989,6 +12634,9 @@ _tmp_20_rule(Parser *p)
         p->mark = _mark;
     }
     { // single_subscript_attribute_target
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty single_subscript_attribute_target_var;
         if (
             (single_subscript_attribute_target_var = single_subscript_attribute_target_rule(p))  // single_subscript_attribute_target
@@ -12008,12 +12656,12 @@ _tmp_20_rule(Parser *p)
 static void *
 _tmp_21_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty d;
         if (
@@ -12055,6 +12703,9 @@ _loop1_22_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // (star_targets '=')
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_135_var;
         while (
             (_tmp_135_var = _tmp_135_rule(p))  // star_targets '='
@@ -12097,12 +12748,12 @@ _loop1_22_rule(Parser *p)
 static void *
 _tmp_23_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty yield_expr_var;
         if (
             (yield_expr_var = yield_expr_rule(p))  // yield_expr
@@ -12114,6 +12765,9 @@ _tmp_23_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_expressions_var;
         if (
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
@@ -12133,12 +12787,12 @@ _tmp_23_rule(Parser *p)
 static void *
 _tmp_24_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty yield_expr_var;
         if (
             (yield_expr_var = yield_expr_rule(p))  // yield_expr
@@ -12150,6 +12804,9 @@ _tmp_24_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_expressions_var;
         if (
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
@@ -12184,6 +12841,9 @@ _loop0_26_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -12230,12 +12890,12 @@ _loop0_26_rule(Parser *p)
 static asdl_seq *
 _gather_25_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // NAME _loop0_26
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -12273,6 +12933,9 @@ _loop0_28_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -12319,12 +12982,12 @@ _loop0_28_rule(Parser *p)
 static asdl_seq *
 _gather_27_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // NAME _loop0_28
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -12347,12 +13010,12 @@ _gather_27_rule(Parser *p)
 static void *
 _tmp_29_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty z;
         if (
@@ -12394,6 +13057,9 @@ _loop0_30_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ('.' | '...')
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_136_var;
         while (
             (_tmp_136_var = _tmp_136_rule(p))  // '.' | '...'
@@ -12447,6 +13113,9 @@ _loop1_31_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ('.' | '...')
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_137_var;
         while (
             (_tmp_137_var = _tmp_137_rule(p))  // '.' | '...'
@@ -12504,6 +13173,9 @@ _loop0_33_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' import_from_as_name
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         alias_ty elem;
         while (
@@ -12550,12 +13222,12 @@ _loop0_33_rule(Parser *p)
 static asdl_seq *
 _gather_32_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // import_from_as_name _loop0_33
+        if (p->error_indicator) {
+            return NULL;
+        }
         alias_ty elem;
         asdl_seq * seq;
         if (
@@ -12578,12 +13250,12 @@ _gather_32_rule(Parser *p)
 static void *
 _tmp_34_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty z;
         if (
@@ -12625,6 +13297,9 @@ _loop0_36_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' dotted_as_name
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         alias_ty elem;
         while (
@@ -12671,12 +13346,12 @@ _loop0_36_rule(Parser *p)
 static asdl_seq *
 _gather_35_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // dotted_as_name _loop0_36
+        if (p->error_indicator) {
+            return NULL;
+        }
         alias_ty elem;
         asdl_seq * seq;
         if (
@@ -12699,12 +13374,12 @@ _gather_35_rule(Parser *p)
 static void *
 _tmp_37_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty z;
         if (
@@ -12746,6 +13421,9 @@ _loop0_39_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' with_item
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         withitem_ty elem;
         while (
@@ -12792,12 +13470,12 @@ _loop0_39_rule(Parser *p)
 static asdl_seq *
 _gather_38_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_39
+        if (p->error_indicator) {
+            return NULL;
+        }
         withitem_ty elem;
         asdl_seq * seq;
         if (
@@ -12835,6 +13513,9 @@ _loop0_41_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' with_item
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         withitem_ty elem;
         while (
@@ -12881,12 +13562,12 @@ _loop0_41_rule(Parser *p)
 static asdl_seq *
 _gather_40_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_41
+        if (p->error_indicator) {
+            return NULL;
+        }
         withitem_ty elem;
         asdl_seq * seq;
         if (
@@ -12924,6 +13605,9 @@ _loop0_43_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' with_item
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         withitem_ty elem;
         while (
@@ -12970,12 +13654,12 @@ _loop0_43_rule(Parser *p)
 static asdl_seq *
 _gather_42_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_43
+        if (p->error_indicator) {
+            return NULL;
+        }
         withitem_ty elem;
         asdl_seq * seq;
         if (
@@ -13013,6 +13697,9 @@ _loop0_45_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' with_item
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         withitem_ty elem;
         while (
@@ -13059,12 +13746,12 @@ _loop0_45_rule(Parser *p)
 static asdl_seq *
 _gather_44_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // with_item _loop0_45
+        if (p->error_indicator) {
+            return NULL;
+        }
         withitem_ty elem;
         asdl_seq * seq;
         if (
@@ -13087,12 +13774,12 @@ _gather_44_rule(Parser *p)
 static void *
 _tmp_46_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' target
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty t;
         if (
@@ -13134,6 +13821,9 @@ _loop1_47_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // except_block
+        if (p->error_indicator) {
+            return NULL;
+        }
         excepthandler_ty except_block_var;
         while (
             (except_block_var = except_block_rule(p))  // except_block
@@ -13176,12 +13866,12 @@ _loop1_47_rule(Parser *p)
 static void *
 _tmp_48_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'as' NAME
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty z;
         if (
@@ -13208,12 +13898,12 @@ _tmp_48_rule(Parser *p)
 static void *
 _tmp_49_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'from' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty z;
         if (
@@ -13240,12 +13930,12 @@ _tmp_49_rule(Parser *p)
 static void *
 _tmp_50_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '->' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty z;
         if (
@@ -13272,12 +13962,12 @@ _tmp_50_rule(Parser *p)
 static void *
 _tmp_51_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '->' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty z;
         if (
@@ -13304,12 +13994,12 @@ _tmp_51_rule(Parser *p)
 static void *
 _tmp_52_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // NEWLINE INDENT
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * indent_var;
         Token * newline_var;
         if (
@@ -13347,6 +14037,9 @@ _loop0_53_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty param_no_default_var;
         while (
             (param_no_default_var = param_no_default_rule(p))  // param_no_default
@@ -13400,6 +14093,9 @@ _loop0_54_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_with_default_var;
         while (
             (param_with_default_var = param_with_default_rule(p))  // param_with_default
@@ -13453,6 +14149,9 @@ _loop0_55_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_with_default_var;
         while (
             (param_with_default_var = param_with_default_rule(p))  // param_with_default
@@ -13506,6 +14205,9 @@ _loop1_56_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty param_no_default_var;
         while (
             (param_no_default_var = param_no_default_rule(p))  // param_no_default
@@ -13563,6 +14265,9 @@ _loop0_57_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_with_default_var;
         while (
             (param_with_default_var = param_with_default_rule(p))  // param_with_default
@@ -13616,6 +14321,9 @@ _loop1_58_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_with_default_var;
         while (
             (param_with_default_var = param_with_default_rule(p))  // param_with_default
@@ -13673,6 +14381,9 @@ _loop1_59_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty param_no_default_var;
         while (
             (param_no_default_var = param_no_default_rule(p))  // param_no_default
@@ -13730,6 +14441,9 @@ _loop1_60_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty param_no_default_var;
         while (
             (param_no_default_var = param_no_default_rule(p))  // param_no_default
@@ -13787,6 +14501,9 @@ _loop0_61_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty param_no_default_var;
         while (
             (param_no_default_var = param_no_default_rule(p))  // param_no_default
@@ -13840,6 +14557,9 @@ _loop1_62_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_with_default_var;
         while (
             (param_with_default_var = param_with_default_rule(p))  // param_with_default
@@ -13897,6 +14617,9 @@ _loop0_63_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty param_no_default_var;
         while (
             (param_no_default_var = param_no_default_rule(p))  // param_no_default
@@ -13950,6 +14673,9 @@ _loop1_64_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_with_default_var;
         while (
             (param_with_default_var = param_with_default_rule(p))  // param_with_default
@@ -14007,6 +14733,9 @@ _loop0_65_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_maybe_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_maybe_default_var;
         while (
             (param_maybe_default_var = param_maybe_default_rule(p))  // param_maybe_default
@@ -14060,6 +14789,9 @@ _loop1_66_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_maybe_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_maybe_default_var;
         while (
             (param_maybe_default_var = param_maybe_default_rule(p))  // param_maybe_default
@@ -14117,6 +14849,9 @@ _loop1_67_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ('@' named_expression NEWLINE)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_138_var;
         while (
             (_tmp_138_var = _tmp_138_rule(p))  // '@' named_expression NEWLINE
@@ -14159,12 +14894,12 @@ _loop1_67_rule(Parser *p)
 static void *
 _tmp_68_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '(' arguments? ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         Token * _literal_1;
         void *z;
@@ -14209,6 +14944,9 @@ _loop0_70_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' star_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -14255,12 +14993,12 @@ _loop0_70_rule(Parser *p)
 static asdl_seq *
 _gather_69_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_expression _loop0_70
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -14298,6 +15036,9 @@ _loop1_71_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // (',' star_expression)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_139_var;
         while (
             (_tmp_139_var = _tmp_139_rule(p))  // ',' star_expression
@@ -14355,6 +15096,9 @@ _loop0_73_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' star_named_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -14401,12 +15145,12 @@ _loop0_73_rule(Parser *p)
 static asdl_seq *
 _gather_72_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_named_expression _loop0_73
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -14444,6 +15188,9 @@ _loop1_74_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // (',' expression)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_140_var;
         while (
             (_tmp_140_var = _tmp_140_rule(p))  // ',' expression
@@ -14501,6 +15248,9 @@ _loop0_75_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty lambda_param_no_default_var;
         while (
             (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
@@ -14554,6 +15304,9 @@ _loop0_76_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_with_default_var;
         while (
             (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
@@ -14607,6 +15360,9 @@ _loop0_77_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_with_default_var;
         while (
             (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
@@ -14660,6 +15416,9 @@ _loop1_78_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty lambda_param_no_default_var;
         while (
             (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
@@ -14717,6 +15476,9 @@ _loop0_79_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_with_default_var;
         while (
             (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
@@ -14770,6 +15532,9 @@ _loop1_80_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_with_default_var;
         while (
             (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
@@ -14827,6 +15592,9 @@ _loop1_81_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty lambda_param_no_default_var;
         while (
             (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
@@ -14884,6 +15652,9 @@ _loop1_82_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty lambda_param_no_default_var;
         while (
             (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
@@ -14941,6 +15712,9 @@ _loop0_83_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty lambda_param_no_default_var;
         while (
             (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
@@ -14994,6 +15768,9 @@ _loop1_84_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_with_default_var;
         while (
             (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
@@ -15051,6 +15828,9 @@ _loop0_85_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty lambda_param_no_default_var;
         while (
             (lambda_param_no_default_var = lambda_param_no_default_rule(p))  // lambda_param_no_default
@@ -15104,6 +15884,9 @@ _loop1_86_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_with_default_var;
         while (
             (lambda_param_with_default_var = lambda_param_with_default_rule(p))  // lambda_param_with_default
@@ -15161,6 +15944,9 @@ _loop0_87_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_maybe_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_maybe_default_var;
         while (
             (lambda_param_maybe_default_var = lambda_param_maybe_default_rule(p))  // lambda_param_maybe_default
@@ -15214,6 +16000,9 @@ _loop1_88_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // lambda_param_maybe_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* lambda_param_maybe_default_var;
         while (
             (lambda_param_maybe_default_var = lambda_param_maybe_default_rule(p))  // lambda_param_maybe_default
@@ -15271,6 +16060,9 @@ _loop1_89_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ('or' conjunction)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_141_var;
         while (
             (_tmp_141_var = _tmp_141_rule(p))  // 'or' conjunction
@@ -15328,6 +16120,9 @@ _loop1_90_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ('and' inversion)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_142_var;
         while (
             (_tmp_142_var = _tmp_142_rule(p))  // 'and' inversion
@@ -15385,6 +16180,9 @@ _loop1_91_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // compare_op_bitwise_or_pair
+        if (p->error_indicator) {
+            return NULL;
+        }
         CmpopExprPair* compare_op_bitwise_or_pair_var;
         while (
             (compare_op_bitwise_or_pair_var = compare_op_bitwise_or_pair_rule(p))  // compare_op_bitwise_or_pair
@@ -15427,12 +16225,12 @@ _loop1_91_rule(Parser *p)
 static void *
 _tmp_92_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '!='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * tok;
         if (
             (tok = _PyPegen_expect_token(p, 28))  // token='!='
@@ -15471,6 +16269,9 @@ _loop0_94_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' slice
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -15517,12 +16318,12 @@ _loop0_94_rule(Parser *p)
 static asdl_seq *
 _gather_93_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // slice _loop0_94
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -15545,12 +16346,12 @@ _gather_93_rule(Parser *p)
 static void *
 _tmp_95_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':' expression?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *d;
         if (
@@ -15577,12 +16378,12 @@ _tmp_95_rule(Parser *p)
 static void *
 _tmp_96_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // tuple
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty tuple_var;
         if (
             (tuple_var = tuple_rule(p))  // tuple
@@ -15594,6 +16395,9 @@ _tmp_96_rule(Parser *p)
         p->mark = _mark;
     }
     { // group
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty group_var;
         if (
             (group_var = group_rule(p))  // group
@@ -15605,6 +16409,9 @@ _tmp_96_rule(Parser *p)
         p->mark = _mark;
     }
     { // genexp
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty genexp_var;
         if (
             (genexp_var = genexp_rule(p))  // genexp
@@ -15624,12 +16431,12 @@ _tmp_96_rule(Parser *p)
 static void *
 _tmp_97_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // list
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty list_var;
         if (
             (list_var = list_rule(p))  // list
@@ -15641,6 +16448,9 @@ _tmp_97_rule(Parser *p)
         p->mark = _mark;
     }
     { // listcomp
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty listcomp_var;
         if (
             (listcomp_var = listcomp_rule(p))  // listcomp
@@ -15660,12 +16470,12 @@ _tmp_97_rule(Parser *p)
 static void *
 _tmp_98_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // dict
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty dict_var;
         if (
             (dict_var = dict_rule(p))  // dict
@@ -15677,6 +16487,9 @@ _tmp_98_rule(Parser *p)
         p->mark = _mark;
     }
     { // set
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty set_var;
         if (
             (set_var = set_rule(p))  // set
@@ -15688,6 +16501,9 @@ _tmp_98_rule(Parser *p)
         p->mark = _mark;
     }
     { // dictcomp
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty dictcomp_var;
         if (
             (dictcomp_var = dictcomp_rule(p))  // dictcomp
@@ -15699,6 +16515,9 @@ _tmp_98_rule(Parser *p)
         p->mark = _mark;
     }
     { // setcomp
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty setcomp_var;
         if (
             (setcomp_var = setcomp_rule(p))  // setcomp
@@ -15733,6 +16552,9 @@ _loop1_99_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // STRING
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty string_var;
         while (
             (string_var = _PyPegen_string_token(p))  // STRING
@@ -15775,12 +16597,12 @@ _loop1_99_rule(Parser *p)
 static void *
 _tmp_100_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_named_expression ',' star_named_expressions?
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty y;
         void *z;
@@ -15810,12 +16632,12 @@ _tmp_100_rule(Parser *p)
 static void *
 _tmp_101_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty yield_expr_var;
         if (
             (yield_expr_var = yield_expr_rule(p))  // yield_expr
@@ -15827,6 +16649,9 @@ _tmp_101_rule(Parser *p)
         p->mark = _mark;
     }
     { // named_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty named_expression_var;
         if (
             (named_expression_var = named_expression_rule(p))  // named_expression
@@ -15861,6 +16686,9 @@ _loop0_103_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' kvpair
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         KeyValuePair* elem;
         while (
@@ -15907,12 +16735,12 @@ _loop0_103_rule(Parser *p)
 static asdl_seq *
 _gather_102_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kvpair _loop0_103
+        if (p->error_indicator) {
+            return NULL;
+        }
         KeyValuePair* elem;
         asdl_seq * seq;
         if (
@@ -15950,6 +16778,9 @@ _loop1_104_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // for_if_clause
+        if (p->error_indicator) {
+            return NULL;
+        }
         comprehension_ty for_if_clause_var;
         while (
             (for_if_clause_var = for_if_clause_rule(p))  // for_if_clause
@@ -16007,6 +16838,9 @@ _loop0_105_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ('if' disjunction)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_143_var;
         while (
             (_tmp_143_var = _tmp_143_rule(p))  // 'if' disjunction
@@ -16060,6 +16894,9 @@ _loop0_106_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ('if' disjunction)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_144_var;
         while (
             (_tmp_144_var = _tmp_144_rule(p))  // 'if' disjunction
@@ -16098,12 +16935,12 @@ _loop0_106_rule(Parser *p)
 static void *
 _tmp_107_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' args
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty c;
         if (
@@ -16130,12 +16967,12 @@ _tmp_107_rule(Parser *p)
 static void *
 _tmp_108_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' args
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty c;
         if (
@@ -16177,6 +17014,9 @@ _loop0_110_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' kwarg_or_starred
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         KeywordOrStarred* elem;
         while (
@@ -16223,12 +17063,12 @@ _loop0_110_rule(Parser *p)
 static asdl_seq *
 _gather_109_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_starred _loop0_110
+        if (p->error_indicator) {
+            return NULL;
+        }
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
@@ -16266,6 +17106,9 @@ _loop0_112_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' kwarg_or_double_starred
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         KeywordOrStarred* elem;
         while (
@@ -16312,12 +17155,12 @@ _loop0_112_rule(Parser *p)
 static asdl_seq *
 _gather_111_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_double_starred _loop0_112
+        if (p->error_indicator) {
+            return NULL;
+        }
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
@@ -16355,6 +17198,9 @@ _loop0_114_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' kwarg_or_starred
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         KeywordOrStarred* elem;
         while (
@@ -16401,12 +17247,12 @@ _loop0_114_rule(Parser *p)
 static asdl_seq *
 _gather_113_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_starred _loop0_114
+        if (p->error_indicator) {
+            return NULL;
+        }
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
@@ -16444,6 +17290,9 @@ _loop0_116_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' kwarg_or_double_starred
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         KeywordOrStarred* elem;
         while (
@@ -16490,12 +17339,12 @@ _loop0_116_rule(Parser *p)
 static asdl_seq *
 _gather_115_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // kwarg_or_double_starred _loop0_116
+        if (p->error_indicator) {
+            return NULL;
+        }
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
@@ -16533,6 +17382,9 @@ _loop0_117_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // (',' star_target)
+        if (p->error_indicator) {
+            return NULL;
+        }
         void *_tmp_145_var;
         while (
             (_tmp_145_var = _tmp_145_rule(p))  // ',' star_target
@@ -16586,6 +17438,9 @@ _loop0_119_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' star_target
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -16632,12 +17487,12 @@ _loop0_119_rule(Parser *p)
 static asdl_seq *
 _gather_118_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // star_target _loop0_119
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -16660,12 +17515,12 @@ _gather_118_rule(Parser *p)
 static void *
 _tmp_120_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // !'*' star_target
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_target_var;
         if (
             _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 16)  // token='*'
@@ -16702,6 +17557,9 @@ _loop0_122_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' del_target
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -16748,12 +17606,12 @@ _loop0_122_rule(Parser *p)
 static asdl_seq *
 _gather_121_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // del_target _loop0_122
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -16791,6 +17649,9 @@ _loop0_124_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // ',' target
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty elem;
         while (
@@ -16837,12 +17698,12 @@ _loop0_124_rule(Parser *p)
 static asdl_seq *
 _gather_123_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     asdl_seq * _res = NULL;
     int _mark = p->mark;
     { // target _loop0_124
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty elem;
         asdl_seq * seq;
         if (
@@ -16865,12 +17726,12 @@ _gather_123_rule(Parser *p)
 static void *
 _tmp_125_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // args
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty args_var;
         if (
             (args_var = args_rule(p))  // args
@@ -16882,6 +17743,9 @@ _tmp_125_rule(Parser *p)
         p->mark = _mark;
     }
     { // expression for_if_clauses
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
         if (
@@ -16919,6 +17783,9 @@ _loop0_126_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // star_named_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq* star_named_expressions_var;
         while (
             (star_named_expressions_var = star_named_expressions_rule(p))  // star_named_expressions
@@ -16957,12 +17824,12 @@ _loop0_126_rule(Parser *p)
 static void *
 _tmp_127_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '=' annotated_rhs
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty annotated_rhs_var;
         if (
@@ -16985,12 +17852,12 @@ _tmp_127_rule(Parser *p)
 static void *
 _tmp_128_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty yield_expr_var;
         if (
             (yield_expr_var = yield_expr_rule(p))  // yield_expr
@@ -17002,6 +17869,9 @@ _tmp_128_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_expressions_var;
         if (
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
@@ -17021,12 +17891,12 @@ _tmp_128_rule(Parser *p)
 static void *
 _tmp_129_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // yield_expr
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty yield_expr_var;
         if (
             (yield_expr_var = yield_expr_rule(p))  // yield_expr
@@ -17038,6 +17908,9 @@ _tmp_129_rule(Parser *p)
         p->mark = _mark;
     }
     { // star_expressions
+        if (p->error_indicator) {
+            return NULL;
+        }
         expr_ty star_expressions_var;
         if (
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
@@ -17057,12 +17930,12 @@ _tmp_129_rule(Parser *p)
 static void *
 _tmp_130_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '['
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 9))  // token='['
@@ -17074,6 +17947,9 @@ _tmp_130_rule(Parser *p)
         p->mark = _mark;
     }
     { // '('
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
@@ -17085,6 +17961,9 @@ _tmp_130_rule(Parser *p)
         p->mark = _mark;
     }
     { // '{'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 25))  // token='{'
@@ -17119,6 +17998,9 @@ _loop0_131_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_no_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         arg_ty param_no_default_var;
         while (
             (param_no_default_var = param_no_default_rule(p))  // param_no_default
@@ -17157,12 +18039,12 @@ _loop0_131_rule(Parser *p)
 static void *
 _tmp_132_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // slash_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         SlashWithDefault* slash_with_default_var;
         if (
             (slash_with_default_var = slash_with_default_rule(p))  // slash_with_default
@@ -17174,6 +18056,9 @@ _tmp_132_rule(Parser *p)
         p->mark = _mark;
     }
     { // param_with_default+
+        if (p->error_indicator) {
+            return NULL;
+        }
         asdl_seq * _loop1_146_var;
         if (
             (_loop1_146_var = _loop1_146_rule(p))  // param_with_default+
@@ -17193,12 +18078,12 @@ _tmp_132_rule(Parser *p)
 static void *
 _tmp_133_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 8))  // token=')'
@@ -17210,6 +18095,9 @@ _tmp_133_rule(Parser *p)
         p->mark = _mark;
     }
     { // ',' (')' | '**')
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *_tmp_147_var;
         if (
@@ -17232,12 +18120,12 @@ _tmp_133_rule(Parser *p)
 static void *
 _tmp_134_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
@@ -17249,6 +18137,9 @@ _tmp_134_rule(Parser *p)
         p->mark = _mark;
     }
     { // ',' (':' | '**')
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         void *_tmp_148_var;
         if (
@@ -17271,12 +18162,12 @@ _tmp_134_rule(Parser *p)
 static void *
 _tmp_135_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // star_targets '='
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty z;
         if (
@@ -17303,12 +18194,12 @@ _tmp_135_rule(Parser *p)
 static void *
 _tmp_136_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 23))  // token='.'
@@ -17320,6 +18211,9 @@ _tmp_136_rule(Parser *p)
         p->mark = _mark;
     }
     { // '...'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 52))  // token='...'
@@ -17339,12 +18233,12 @@ _tmp_136_rule(Parser *p)
 static void *
 _tmp_137_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '.'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 23))  // token='.'
@@ -17356,6 +18250,9 @@ _tmp_137_rule(Parser *p)
         p->mark = _mark;
     }
     { // '...'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 52))  // token='...'
@@ -17375,12 +18272,12 @@ _tmp_137_rule(Parser *p)
 static void *
 _tmp_138_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // '@' named_expression NEWLINE
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty f;
         Token * newline_var;
@@ -17410,12 +18307,12 @@ _tmp_138_rule(Parser *p)
 static void *
 _tmp_139_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' star_expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty c;
         if (
@@ -17442,12 +18339,12 @@ _tmp_139_rule(Parser *p)
 static void *
 _tmp_140_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' expression
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty c;
         if (
@@ -17474,12 +18371,12 @@ _tmp_140_rule(Parser *p)
 static void *
 _tmp_141_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'or' conjunction
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty c;
         if (
@@ -17506,12 +18403,12 @@ _tmp_141_rule(Parser *p)
 static void *
 _tmp_142_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'and' inversion
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty c;
         if (
@@ -17538,12 +18435,12 @@ _tmp_142_rule(Parser *p)
 static void *
 _tmp_143_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'if' disjunction
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty z;
         if (
@@ -17570,12 +18467,12 @@ _tmp_143_rule(Parser *p)
 static void *
 _tmp_144_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // 'if' disjunction
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _keyword;
         expr_ty z;
         if (
@@ -17602,12 +18499,12 @@ _tmp_144_rule(Parser *p)
 static void *
 _tmp_145_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ',' star_target
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         expr_ty c;
         if (
@@ -17649,6 +18546,9 @@ _loop1_146_rule(Parser *p)
     ssize_t _children_capacity = 1;
     ssize_t _n = 0;
     { // param_with_default
+        if (p->error_indicator) {
+            return NULL;
+        }
         NameDefaultPair* param_with_default_var;
         while (
             (param_with_default_var = param_with_default_rule(p))  // param_with_default
@@ -17691,12 +18591,12 @@ _loop1_146_rule(Parser *p)
 static void *
 _tmp_147_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ')'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 8))  // token=')'
@@ -17708,6 +18608,9 @@ _tmp_147_rule(Parser *p)
         p->mark = _mark;
     }
     { // '**'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 35))  // token='**'
@@ -17727,12 +18630,12 @@ _tmp_147_rule(Parser *p)
 static void *
 _tmp_148_rule(Parser *p)
 {
-    if (p->error_indicator) {
-        return NULL;
-    }
     void * _res = NULL;
     int _mark = p->mark;
     { // ':'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
@@ -17744,6 +18647,9 @@ _tmp_148_rule(Parser *p)
         p->mark = _mark;
     }
     { // '**'
+        if (p->error_indicator) {
+            return NULL;
+        }
         Token * _literal;
         if (
             (_literal = _PyPegen_expect_token(p, 35))  // token='**'

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -433,6 +433,12 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.print("int _end_col_offset = _token->end_col_offset;")
         self.print("UNUSED(_end_col_offset); // Only used by EXTRA macro")
 
+    def _check_for_errors(self) -> None:
+        self.print("if (p->error_indicator) {")
+        with self.indent():
+            self.print("return NULL;")
+        self.print("}")
+
     def _set_up_rule_memoization(self, node: Rule, result_type: str) -> None:
         self.print("{")
         with self.indent():
@@ -468,6 +474,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         memoize = self._should_memoize(node)
 
         with self.indent():
+            self._check_for_errors()
             self.print(f"{result_type} _res = NULL;")
             if memoize:
                 self.print(f"if (_PyPegen_is_memoized(p, {node.name}_type, &_res))")
@@ -496,10 +503,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         is_repeat1 = node.name.startswith("_loop1")
 
         with self.indent():
-            self.print("if (p->error_indicator) {")
-            with self.indent():
-                self.print("return NULL;")
-            self.print("}")
+            self._check_for_errors()
             self.print("void *_res = NULL;")
             if memoize:
                 self.print(f"if (_PyPegen_is_memoized(p, {node.name}_type, &_res))")
@@ -683,10 +687,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
     ) -> None:
         self.print(f"{{ // {node}")
         with self.indent():
-            self.print("if (p->error_indicator) {")
-            with self.indent():
-                self.print("return NULL;")
-            self.print("}")
+            self._check_for_errors()
             # Prepare variable declarations for the alternative
             vars = self.collect_vars(node)
             for v, var_type in sorted(item for item in vars.items() if item[0] is not None):

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -468,10 +468,6 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         memoize = self._should_memoize(node)
 
         with self.indent():
-            self.print("if (p->error_indicator) {")
-            with self.indent():
-                self.print("return NULL;")
-            self.print("}")
             self.print(f"{result_type} _res = NULL;")
             if memoize:
                 self.print(f"if (_PyPegen_is_memoized(p, {node.name}_type, &_res))")
@@ -687,6 +683,10 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
     ) -> None:
         self.print(f"{{ // {node}")
         with self.indent():
+            self.print("if (p->error_indicator) {")
+            with self.indent():
+                self.print("return NULL;")
+            self.print("}")
             # Prepare variable declarations for the alternative
             vars = self.collect_vars(node)
             for v, var_type in sorted(item for item in vars.items() if item[0] is not None):


### PR DESCRIPTION
Fix segfaults when parsing very complex invalid input, like
`import äˆ ð£„¯ð¢·žð±‹á”€ð””ð‘©±å®ä±¬ð©¾\nð—¶½`.

Initially reported by @pablogsal.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40661](https://bugs.python.org/issue40661) -->
https://bugs.python.org/issue40661
<!-- /issue-number -->
