### PR TITLE
bpo-38870: fixing unhandled hexescape in docstrings at ast.unparse

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1095,8 +1095,7 @@ class _Unparser(NodeVisitor):
                 # \n and \t, because they are more likely to be unescaped
                 # in the source
                 return c
-            else:
-                return c.encode('unicode_escape').decode('ascii')
+            return c.encode('unicode_escape').decode('ascii')
 
         self.fill()
         if node.kind == "u":

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1088,6 +1088,16 @@ class _Unparser(NodeVisitor):
         self.write(node.id)
 
     def _write_docstring(self, node):
+        def esc_char(c):
+            if c in ("\n", "\t"):
+                # In the AST form, we don't know the author's intentation
+                # about how this should be displayed. We'll only escape
+                # \n and \t, because they are more likely to be unescaped
+                # in the source
+                return c
+            else:
+                return c.encode('unicode_escape').decode('ascii')
+
         self.fill()
         if node.kind == "u":
             self.write("u")
@@ -1095,11 +1105,10 @@ class _Unparser(NodeVisitor):
         value = node.value
         if value:
             # Preserve quotes in the docstring by escaping them
-            value = value.replace("\\", "\\\\")
-            value = value.replace('"""', '""\"')
-            value = value.replace("\r", "\\r")
+            value = "".join(map(esc_char, value))
             if value[-1] == '"':
                 value = value.replace('"', '\\"', -1)
+            value = value.replace('"""', '""\\"')
 
         self.write(f'"""{value}"""')
 

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -324,7 +324,11 @@ class UnparseTestCase(ASTTestCase):
             '\\t',
             '\n',
             '\\n',
-            '\r\\r\t\\t\n\\n'
+            '\r\\r\t\\t\n\\n',
+            '""">>> content = \"\"\"blabla\"\"\" <<<"""',
+            r'foo\n\x00'
+            '🐍⛎𩸽üéş^\X\BB\N{LONG RIGHTWARDS SQUIGGLE ARROW}'
+
         )
         for docstring in docstrings:
             # check as Module docstrings for easy testing

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -326,7 +326,7 @@ class UnparseTestCase(ASTTestCase):
             '\\n',
             '\r\\r\t\\t\n\\n',
             '""">>> content = \"\"\"blabla\"\"\" <<<"""',
-            r'foo\n\x00'
+            r'foo\n\x00',
             '🐍⛎𩸽üéş^\X\BB\N{LONG RIGHTWARDS SQUIGGLE ARROW}'
 
         )


### PR DESCRIPTION



<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
