### PR TITLE
bpo-40669: Make memory_profiler optional for running PEG benchmarks

### DIFF
--- a/Tools/peg_generator/scripts/benchmark.py
+++ b/Tools/peg_generator/scripts/benchmark.py
@@ -6,7 +6,11 @@ import sys
 import os
 from time import time
 
-import memory_profiler
+MEMORY_BENCHMARKS = True
+try:
+    import memory_profiler
+except ModuleNotFoundError:
+    MEMORY_BENCHMARKS = False
 
 sys.path.insert(0, os.getcwd())
 from peg_extension import parse
@@ -43,16 +47,17 @@ command_check = subcommands.add_parser(
 
 def benchmark(func):
     def wrapper(*args):
+        print(f"{func.__name__}")
         times = list()
         for _ in range(3):
             start = time()
             result = func(*args)
             end = time()
             times.append(end - start)
-        memory = memory_profiler.memory_usage((func, args))
-        print(f"{func.__name__}")
         print(f"\tTime: {sum(times)/3:.3f} seconds on an average of 3 runs")
-        print(f"\tMemory: {max(memory)} MiB on an average of 3 runs")
+        if MEMORY_BENCHMARKS:
+            memory = memory_profiler.memory_usage((func, args))
+            print(f"\tMemory: {max(memory)} MiB on an average of 3 runs")
         return result
 
     return wrapper


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40669](https://bugs.python.org/issue40669) -->
https://bugs.python.org/issue40669
<!-- /issue-number -->
