### PR TITLE
bpo-31033: Use _PyErr_ChainStackItem() inside gen_send_ex().

### DIFF
--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -203,16 +203,8 @@ gen_send_ex(PyGenObject *gen, PyObject *arg, int exc, int closing)
     assert(f->f_back == NULL);
     f->f_back = tstate->frame;
 
-    _PyErr_StackItem *gi_exc_state = &gen->gi_exc_state;
-    if (exc && gi_exc_state->exc_type != NULL &&
-        gi_exc_state->exc_type != Py_None)
-    {
-        Py_INCREF(gi_exc_state->exc_type);
-        Py_XINCREF(gi_exc_state->exc_value);
-        Py_XINCREF(gi_exc_state->exc_traceback);
-        _PyErr_ChainExceptions(gi_exc_state->exc_type,
-                               gi_exc_state->exc_value,
-                               gi_exc_state->exc_traceback);
+    if (exc) {
+        _PyErr_ChainStackItem(&gen->gi_exc_state);
     }
 
     gen->gi_running = 1;


### PR DESCRIPTION
This is a tiny refactoring follow-up to PR #19951 / [bpo-31033](https://bugs.python.org/issue31033).

`_PyErr_ChainStackItem()` was just added in PR #19951, so it can now be used in `genobject.c`.

(This isn't needed for [bpo-31033](https://bugs.python.org/issue31033). I'm linking it only because it's related.)

<!-- issue-number: [bpo-31033](https://bugs.python.org/issue31033) -->
https://bugs.python.org/issue31033
<!-- /issue-number -->
