### PR TITLE
bpo-38112: Document that compileall.compile_[dir,file] also accept multiple opt levels

### DIFF
--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -181,7 +181,8 @@ Public functions
    coexist.
 
    *optimize* specifies the optimization level for the compiler.  It is passed to
-   the built-in :func:`compile` function.
+   the built-in :func:`compile` function. Accepts also a sequence of optimization
+   levels which lead to multiple compilations of one :file:`.py` file in one call.
 
    The argument *workers* specifies how many workers are used to
    compile files in parallel. The default is to not use multiple workers.
@@ -256,7 +257,8 @@ Public functions
    coexist.
 
    *optimize* specifies the optimization level for the compiler.  It is passed to
-   the built-in :func:`compile` function.
+   the built-in :func:`compile` function. Accepts also a sequence of optimization
+   levels which lead to multiple compilations of one :file:`.py` file in one call.
 
    *invalidation_mode* should be a member of the
    :class:`py_compile.PycInvalidationMode` enum and controls how the generated


### PR DESCRIPTION
Functions compile_dir and compile_file accept also a sequence of optimization levels to compile for.

Cc: @vstinner 

<!-- issue-number: [bpo-38112](https://bugs.python.org/issue38112) -->
https://bugs.python.org/issue38112
<!-- /issue-number -->
