### PR TITLE
Revert "move a dot outside double quotes"

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -35,7 +35,8 @@ on efficient attribute extraction for output formatting and manipulation.
 Aware and Naive Objects
 -----------------------
 
-Date and time objects may be categorized as "aware" or "naive."
+Date and time objects may be categorized as "aware" or "naive" depending on
+whether or not they include timezone information.
 
 With sufficient knowledge of applicable algorithmic and political time
 adjustments, such as time zone and daylight saving time information,

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -35,7 +35,7 @@ on efficient attribute extraction for output formatting and manipulation.
 Aware and Naive Objects
 -----------------------
 
-Date and time objects may be categorized as "aware" or "naive".
+Date and time objects may be categorized as "aware" or "naive."
 
 With sufficient knowledge of applicable algorithmic and political time
 adjustments, such as time zone and daylight saving time information,


### PR DESCRIPTION
As seen in #20007, contrary to what one would expect, in American English, dots go into quotes.
see https://www.thepunctuationguide.com/quotation-marks.html.

Reverts python/cpython#20007