### PR TITLE
bpo-39026: Allow relative include paths

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-#include "cpython/initconfig.h"
+#include "initconfig.h"
 
 PyAPI_FUNC(int) _PyInterpreterState_RequiresIDRef(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_RequireIDRef(PyInterpreterState *, int);


### PR DESCRIPTION
Prior to this change, the following would fail to compile with gcc main.c

    #include "include/python3.9/Python.h"
    int main() {}

The compiler would complain that cpython/initconfig.h didn't exist.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39026](https://bugs.python.org/issue39026) -->
https://bugs.python.org/issue39026
<!-- /issue-number -->
