### PR TITLE
bpo-40669: Install PEG benchmarking dependencies in a venv

### DIFF
--- a/Tools/peg_generator/.gitignore
+++ b/Tools/peg_generator/.gitignore
@@ -1,3 +1,4 @@
 peg_extension/parse.c
 data/xxl.py
+venv/
 @data

--- a/Tools/peg_generator/Makefile
+++ b/Tools/peg_generator/Makefile
@@ -5,7 +5,8 @@ endif
 ifeq ($(UNAME_S),Darwin)
 	PYTHON ?= ../../python.exe
 endif
-
+VENVDIR ?= ./venv
+VENVPYTHON ?= $(VENVDIR)/bin/python
 CPYTHON ?= ../../Lib
 MYPY ?= mypy
 
@@ -27,6 +28,7 @@ peg_extension/parse.c: $(GRAMMAR) $(TOKENS) pegen/*.py peg_extension/peg_extensi
 clean:
 	-rm -f peg_extension/*.o peg_extension/*.so peg_extension/parse.c
 	-rm -f data/xxl.py
+	-rm -rf $(VENVDIR)
 
 dump: peg_extension/parse.c
 	cat -n $(TESTFILE)
@@ -40,6 +42,12 @@ regen-metaparser: pegen/metagrammar.gram pegen/*.py
 # parse.c by the use of --compile-extension.
 
 .PHONY: test
+
+venv:
+	$(PYTHON) -m venv $(VENVDIR)
+	$(VENVPYTHON) -m pip install -U pip setuptools
+	$(VENVPYTHON) -m pip install -U memory_profiler
+	@echo "The venv has been created in the $(VENVDIR) directory"
 
 test: run
 
@@ -61,22 +69,22 @@ stats: peg_extension/parse.c data/xxl.py
 
 time: time_compile
 
-time_compile: peg_extension/parse.c data/xxl.py
-	$(PYTHON) scripts/benchmark.py --parser=pegen --target=xxl compile
+time_compile: venv peg_extension/parse.c data/xxl.py
+	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl compile
 
-time_parse: peg_extension/parse.c data/xxl.py
-	$(PYTHON) scripts/benchmark.py --parser=pegen --target=xxl parse
+time_parse: venv peg_extension/parse.c data/xxl.py
+	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl parse
 
-time_check: peg_extension/parse.c data/xxl.py
-	$(PYTHON) scripts/benchmark.py --parser=pegen --target=xxl check
+time_check: venv peg_extension/parse.c data/xxl.py
+	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl check
 
 time_stdlib: time_stdlib_compile
 
-time_stdlib_compile: data/xxl.py
-	$(PYTHON) scripts/benchmark.py --parser=cpython --target=xxl compile
+time_stdlib_compile: venv data/xxl.py
+	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl compile
 
-time_stdlib_parse: data/xxl.py
-	$(PYTHON) scripts/benchmark.py --parser=cpython --target=xxl parse
+time_stdlib_parse: venv data/xxl.py
+	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl parse
 
 test_local:
 	$(PYTHON) scripts/test_parse_directory.py \
@@ -105,8 +113,8 @@ mypy: regen-metaparser
 format-python:
 	black pegen scripts
 
-bench:
-	$(PYTHON) scripts/benchmark.py --parser=pegen --target=stdlib check
+bench: venv
+	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=stdlib check
 
 format: format-python
 

--- a/Tools/peg_generator/Makefile
+++ b/Tools/peg_generator/Makefile
@@ -80,10 +80,10 @@ time_check: venv peg_extension/parse.c data/xxl.py
 
 time_stdlib: time_stdlib_compile
 
-time_stdlib_compile: venv data/xxl.py
+time_stdlib_compile: venv peg_extension/parse.c data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl compile
 
-time_stdlib_parse: venv data/xxl.py
+time_stdlib_parse: venv peg_extension/parse.c data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl parse
 
 test_local:

--- a/Tools/peg_generator/scripts/benchmark.py
+++ b/Tools/peg_generator/scripts/benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.9
+#!/usr/bin/env python3
 
 import argparse
 import ast
@@ -6,7 +6,12 @@ import sys
 import os
 from time import time
 
-import memory_profiler
+try:
+    import memory_profiler
+except ModuleNotFoundError:
+    print("Please run `make venv` to create a virtual environment and install"
+          " all the dependencies, before running this script.")
+    sys.exit(1)
 
 sys.path.insert(0, os.getcwd())
 from peg_extension import parse


### PR DESCRIPTION
Create a `make venv` target, that creates a virtual environment
and installs the dependency in that venv. `make time` and all
the related targets are changed to use the virtual environment
python.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40669](https://bugs.python.org/issue40669) -->
https://bugs.python.org/issue40669
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal