### PR TITLE
bpo-40669: Use requirements.pip when installing PEG dependencies

### DIFF
--- a/Tools/peg_generator/Makefile
+++ b/Tools/peg_generator/Makefile
@@ -46,7 +46,7 @@ regen-metaparser: pegen/metagrammar.gram pegen/*.py
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
 	$(VENVPYTHON) -m pip install -U pip setuptools
-	$(VENVPYTHON) -m pip install -U memory_profiler
+	$(VENVPYTHON) -m pip install -r requirements.pip
 	@echo "The venv has been created in the $(VENVDIR) directory"
 
 test: run


### PR DESCRIPTION


<!-- issue-number: [bpo-40669](https://bugs.python.org/issue40669) -->
https://bugs.python.org/issue40669
<!-- /issue-number -->
