### PR TITLE
bpo-40614: Respect feature version for f-string debug expressions

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -654,6 +654,11 @@ class AST_Tests(unittest.TestCase):
         expressions[0] = f"expr = {ast.expr.__subclasses__()[0].__doc__}"
         self.assertCountEqual(ast.expr.__doc__.split("\n"), expressions)
 
+    def test_issue40614_feature_version(self):
+        ast.parse('f"{x=}"', feature_version=(3, 8))
+        with self.assertRaises(SyntaxError) as e:
+            ast.parse('f"{x=}"', feature_version=(3, 7))
+
 
 class ASTHelpers_Test(unittest.TestCase):
     maxDiff = None

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -656,7 +656,7 @@ class AST_Tests(unittest.TestCase):
 
     def test_issue40614_feature_version(self):
         ast.parse('f"{x=}"', feature_version=(3, 8))
-        with self.assertRaises(SyntaxError) as e:
+        with self.assertRaises(SyntaxError):
             ast.parse('f"{x=}"', feature_version=(3, 7))
 
 

--- a/Misc/NEWS.d/next/Library/2020-05-18-22-41-02.bpo-40614.8j3kmq.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-18-22-41-02.bpo-40614.8j3kmq.rst
@@ -1,0 +1,1 @@
+:func:`ast.parse` will not parse self documenting expressions in f-strings when passed `feature_version` less than `(3, 8)`.

--- a/Misc/NEWS.d/next/Library/2020-05-18-22-41-02.bpo-40614.8j3kmq.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-18-22-41-02.bpo-40614.8j3kmq.rst
@@ -1,1 +1,1 @@
-:func:`ast.parse` will not parse self documenting expressions in f-strings when passed ``feature_version`` less than ``(3, 8)``.
+:func:`ast.parse` will not parse self documenting expressions in f-strings when passed ``feature_version`` is less than ``(3, 8)``.

--- a/Misc/NEWS.d/next/Library/2020-05-18-22-41-02.bpo-40614.8j3kmq.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-18-22-41-02.bpo-40614.8j3kmq.rst
@@ -1,1 +1,1 @@
-:func:`ast.parse` will not parse self documenting expressions in f-strings when passed `feature_version` less than `(3, 8)`.
+:func:`ast.parse` will not parse self documenting expressions in f-strings when passed ``feature_version`` less than ``(3, 8)``.

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -931,6 +931,11 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
     /* Check for =, which puts the text value of the expression in
        expr_text. */
     if (**str == '=') {
+        if (p->feature_version < 8) {
+            RAISE_SYNTAX_ERROR("f-string: self documenting expressions are "
+                               "only supported in Python 3.8 and greater");
+            goto error;
+        }
         *str += 1;
 
         /* Skip over ASCII whitespace.  No need to test for end of string

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -5069,6 +5069,12 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
     /* Check for =, which puts the text value of the expression in
        expr_text. */
     if (**str == '=') {
+        if (c->c_feature_version < 8) {
+            ast_error(c, n,
+                      "f-string: self documenting expressions are "
+                      "only supported in Python 3.8 and greater");
+            goto error;
+        }
         *str += 1;
 
         /* Skip over ASCII whitespace.  No need to test for end of string


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40614](https://bugs.python.org/issue40614) -->
https://bugs.python.org/issue40614
<!-- /issue-number -->
