### PR TITLE
bpo-40674: Deprecate urllib.request.urlretrieve() and cleanup()

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1349,6 +1349,8 @@ some point in the future.
 
 .. function:: urlretrieve(url, filename=None, reporthook=None, data=None)
 
+   .. deprecated:: 3.10
+
    Copy a network object denoted by a URL to a local file. If the URL
    points to a local file, the object will not be copied unless filename is supplied.
    Return a tuple ``(filename, headers)`` where *filename* is the
@@ -1395,6 +1397,8 @@ some point in the future.
    to assume that the download was successful.
 
 .. function:: urlcleanup()
+
+   .. deprecated:: 3.10
 
    Cleans up temporary files that may have been left behind by previous
    calls to :func:`urlretrieve`.

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -220,7 +220,9 @@ def clear_caches():
     except KeyError:
         pass
     else:
-        urllib_request.urlcleanup()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            urllib_request.urlcleanup()
 
     try:
         linecache = sys.modules['linecache']

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -234,6 +234,12 @@ def urlretrieve(url, filename=None, reporthook=None, data=None):
     Returns a tuple containing the path to the newly created
     data file as well as the resulting HTTPMessage object.
     """
+    warnings.warn(
+        "urlretrieve() is deprecated and will be removed in a future version.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+
     url_type, path = _splittype(url)
 
     with contextlib.closing(urlopen(url, data)) as fp:
@@ -283,6 +289,12 @@ def urlretrieve(url, filename=None, reporthook=None, data=None):
 
 def urlcleanup():
     """Clean up temporary files from urlretrieve calls."""
+    warnings.warn(
+        "urlcleanup() is deprecated and will be removed in a future version.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+
     for temp_file in _url_tempfiles:
         try:
             os.unlink(temp_file)

--- a/Misc/NEWS.d/next/Library/2020-05-19-00-41-07.bpo-40674.Rn8mC-.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-19-00-41-07.bpo-40674.Rn8mC-.rst
@@ -1,0 +1,2 @@
+:func:`urllib.request.urlretrieve()` and :func:`urllib.request.urlcleanup()`
+are now deprecated.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40674](https://bugs.python.org/issue40674) -->
https://bugs.python.org/issue40674
<!-- /issue-number -->
