### PR TITLE
bpo-40677: Define IO_REPARSE_TAG_APPEXECLINK for old Windows SDK

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-05-19-04-11-12.bpo-40677.qQbLW8.rst
+++ b/Misc/NEWS.d/next/Windows/2020-05-19-04-11-12.bpo-40677.qQbLW8.rst
@@ -1,0 +1,1 @@
+Manually define IO_REPARSE_TAG_APPEXECLINK in case some old Windows SDK doesn't have it.

--- a/Modules/_stat.c
+++ b/Modules/_stat.c
@@ -40,6 +40,10 @@ typedef unsigned short mode_t;
 #  define FILE_ATTRIBUTE_NO_SCRUB_DATA 0x20000
 #endif
 
+#ifndef IO_REPARSE_TAG_APPEXECLINK
+#  define IO_REPARSE_TAG_APPEXECLINK 0x8000001BL
+#endif
+
 #endif /* MS_WINDOWS */
 
 /* From Python's stat.py */


### PR DESCRIPTION
Manually define IO_REPARSE_TAG_APPEXECLINK in case some old Windows SDK doesn't have it.

<!-- issue-number: [bpo-40677](https://bugs.python.org/issue40677) -->
https://bugs.python.org/issue40677
<!-- /issue-number -->
