### PR TITLE
3.10 whatsnew needs to use blurb-produced changelog

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -47,7 +47,7 @@
 
 This article explains the new features in Python 3.10, compared to 3.9.
 
-For full details, see the :source:`Misc/NEWS` file.
+For full details, see the :ref:`changelog <changelog>`.
 
 .. note::
 


### PR DESCRIPTION
Because the change to use blurb happened after the start of the release, we always pick up the last release's incorrect template for whatsnew.  (I'll add a note to PEP 101 to break the cycle!)