### PR TITLE
bpo-38787: Clarify docs for PyType_GetModule and warn against common mistake

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -122,7 +122,7 @@ Type Objects
    may not return the intended result.
    ``Py_TYPE(self)`` may be a *subclass* of the intended class, and subclasses
    are not necessarily defined in the same module as their superclass.
-   See :c:type:`PyCMethod` to get the defining class.
+   See :c:type:`PyCMethod` to get the class that defines the method.
 
    .. versionadded:: 3.9
 

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -117,7 +117,7 @@ Type Objects
    If no module is associated with the given type, sets :py:class:`TypeError`
    and returns ``NULL``.
 
-   This function is usually used to get the module in wich a method is defined.
+   This function is usually used to get the module in which a method is defined.
    Note that in such a method, ``PyType_GetModule(Py_TYPE(self))``
    may not return the intended result.
    ``Py_TYPE(self)`` may be a *subclass* of the intended class, and subclasses

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -117,6 +117,13 @@ Type Objects
    If no module is associated with the given type, sets :py:class:`TypeError`
    and returns ``NULL``.
 
+   This function is usually used to get the module in wich a method is defined.
+   Note that in such a method, ``PyType_GetModule(Py_TYPE(self))``
+   may not return the intended result.
+   ``Py_TYPE(self)`` may be a *subclass* of the intended class, and subclasses
+   are not necessarily defined in the same module as their superclass.
+   See :c:type:`PyCMethod` to get the defining class.
+
    .. versionadded:: 3.9
 
 .. c:function:: void* PyType_GetModuleState(PyTypeObject *type)
@@ -151,9 +158,12 @@ The following functions and structs are used to create
    If *bases* is ``NULL``, the *Py_tp_base* slot is used instead.
    If that also is ``NULL``, the new type derives from :class:`object`.
 
-   The *module* must be a module object or ``NULL``.
+   The *module* argument can be used to record the module in which the new
+   class is defined. It must be a module object or ``NULL``.
    If not ``NULL``, the module is associated with the new type and can later be
    retreived with :c:func:`PyType_GetModule`.
+   The associated module is not inherited by subclasses; it must be specified
+   for each class individually.
 
    This function calls :c:func:`PyType_Ready` on the new type.
 


### PR DESCRIPTION
This should make `PyType_GetModule`, and `PyType_FromModuleAndSpec`'s *module* argument clearer to people who didn't read the PEP.

Thanks @vstinner and @shihai1991 for asking clarifying questions. Hopefully this will help others.

<!-- issue-number: [bpo-38787](https://bugs.python.org/issue38787) -->
https://bugs.python.org/issue38787
<!-- /issue-number -->


Automerge-Triggered-By: @encukou