### PR TITLE
bpo-40683: Add zoneinfo to LIBSUBDIRS

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1429,6 +1429,7 @@ LIBSUBDIRS=	tkinter tkinter/test tkinter/test/test_tkinter \
 		test/test_importlib/source \
 		test/test_importlib/zipdata01 \
 		test/test_importlib/zipdata02 \
+		test/test_zoneinfo test/test_zoneinfo/data \
 		test/ziptestdata \
 		asyncio \
 		test/test_asyncio \
@@ -1450,7 +1451,8 @@ LIBSUBDIRS=	tkinter tkinter/test tkinter/test/test_tkinter \
 		multiprocessing multiprocessing/dummy \
 		unittest unittest/test unittest/test/testmock \
 		venv venv/scripts venv/scripts/common venv/scripts/posix \
-		curses pydoc_data
+		curses pydoc_data \
+		zoneinfo
 libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 	@for i in $(SCRIPTDIR) $(LIBDEST); \
 	do \

--- a/Misc/NEWS.d/next/Build/2020-05-19-10-54-08.bpo-40683.W8JHrr.rst
+++ b/Misc/NEWS.d/next/Build/2020-05-19-10-54-08.bpo-40683.W8JHrr.rst
@@ -1,0 +1,2 @@
+Fixed an issue where the :mod:`zoneinfo` module and its tests were not
+included when Python is installed with ``make``.


### PR DESCRIPTION
Without this, only the `_zoneinfo` module is getting installed, not the `zoneinfo` module. I believe this was not noticed earlier because `test.test_zoneinfo` was also not being installed.

With this fix, the tests are passing correctly locally:

```
$ TARGET_DIR=$(mktemp -d)
$ ./configure --prefix=$TARGET_DIR 1>/dev/null
$ make -j 1>/dev/null && make 1>/dev/null
$ $TARGET_DIR/bin/python3 -m test test_zoneinfo
0:00:00 load avg: 3.02 Run tests sequentially
0:00:00 load avg: 3.02 [1/1] test_zoneinfo

== Tests result: SUCCESS ==

1 test OK.

Total duration: 288 ms
Tests result: SUCCESS
```

<!-- issue-number: [bpo-40683](https://bugs.python.org/issue40683) -->
https://bugs.python.org/issue40683
<!-- /issue-number -->
