### PR TITLE
bpo-40688: Use the correct parser in the peg_generator scripts

### DIFF
--- a/Modules/_peg_parser.c
+++ b/Modules/_peg_parser.c
@@ -61,21 +61,19 @@ _Py_compile_string(PyObject *self, PyObject *args, PyObject *kwds)
 
     mod_ty mod = _run_parser(the_string, mode, &flags, arena, oldparser);
     if (mod == NULL) {
-        goto error;
+        PyArena_Free(arena);
+        return NULL;
     }
 
     PyObject *filename = PyUnicode_DecodeFSDefault("<string>");
     if (filename == NULL) {
-        goto error;
+        PyArena_Free(arena);
+        return NULL;
     }
     PyCodeObject *result = PyAST_CompileObject(mod, filename, &flags, -1, arena);
     Py_XDECREF(filename);
     PyArena_Free(arena);
     return (PyObject *)result;
-
-error:
-    PyArena_Free(arena);
-    return NULL;
 }
 
 PyObject *
@@ -106,16 +104,13 @@ _Py_parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 
     mod_ty mod = _run_parser(the_string, mode, &flags, arena, oldparser);
     if (mod == NULL) {
-        goto error;
+        PyArena_Free(arena);
+        return NULL;
     }
 
     PyObject *result = PyAST_mod2obj(mod);
     PyArena_Free(arena);
     return result;
-
-error:
-    PyArena_Free(arena);
-    return NULL;
 }
 
 static PyMethodDef ParseMethods[] = {
@@ -123,13 +118,13 @@ static PyMethodDef ParseMethods[] = {
         "parse_string",
         (PyCFunction)(void (*)(void))_Py_parse_string,
         METH_VARARGS|METH_KEYWORDS,
-        "Parse a string."
+        "Parse a string, return an AST."
     },
     {
         "compile_string",
         (PyCFunction)(void (*)(void))_Py_compile_string,
         METH_VARARGS|METH_KEYWORDS,
-        "Compile a string to bytecode."
+        "Compile a string, return a code object."
     },
     {NULL, NULL, 0, NULL} /* Sentinel */
 };

--- a/Modules/_peg_parser.c
+++ b/Modules/_peg_parser.c
@@ -1,7 +1,7 @@
 #include <Python.h>
 #include "pegen_interface.h"
 
-int
+static int
 _mode_str_to_int(char *mode_str)
 {
     int mode;
@@ -20,7 +20,7 @@ _mode_str_to_int(char *mode_str)
     return mode;
 }
 
-mod_ty
+static mod_ty
 _run_parser(char *str, int mode, PyCompilerFlags *flags, PyArena *arena, int oldparser)
 {
     mod_ty mod;

--- a/Tools/peg_generator/Makefile
+++ b/Tools/peg_generator/Makefile
@@ -83,8 +83,8 @@ time_old_compile: venv data/xxl.py
 time_old_parse: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl parse
 
-time_peg_dir:
-	$(PYTHON) scripts/test_parse_directory.py \
+time_peg_dir: venv
+	$(VENVPYTHON) scripts/test_parse_directory.py \
 		--grammar-file $(GRAMMAR) \
 		--tokens-file $(TOKENS) \
 		-d $(TESTDIR) \
@@ -93,8 +93,8 @@ time_peg_dir:
 		--exclude "*/failset/**" \
 		--exclude "*/failset/**/*"
 
-time_stdlib: $(CPYTHON)
-	$(PYTHON) scripts/test_parse_directory.py \
+time_stdlib: $(CPYTHON) venv
+	$(VENVPYTHON) scripts/test_parse_directory.py \
 		--grammar-file $(GRAMMAR) \
 		--tokens-file $(TOKENS) \
 		-d $(CPYTHON) \

--- a/Tools/peg_generator/Makefile
+++ b/Tools/peg_generator/Makefile
@@ -69,18 +69,18 @@ stats: peg_extension/parse.c data/xxl.py
 
 time: time_compile
 
-time_compile: venv peg_extension/parse.c data/xxl.py
+time_compile: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl compile
 
-time_parse: venv peg_extension/parse.c data/xxl.py
+time_parse: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl parse
 
 time_stdlib: time_stdlib_compile
 
-time_stdlib_compile: venv peg_extension/parse.c data/xxl.py
+time_stdlib_compile: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl compile
 
-time_stdlib_parse: venv peg_extension/parse.c data/xxl.py
+time_stdlib_parse: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl parse
 
 test_local:

--- a/Tools/peg_generator/Makefile
+++ b/Tools/peg_generator/Makefile
@@ -75,9 +75,6 @@ time_compile: venv peg_extension/parse.c data/xxl.py
 time_parse: venv peg_extension/parse.c data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl parse
 
-time_check: venv peg_extension/parse.c data/xxl.py
-	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl check
-
 time_stdlib: time_stdlib_compile
 
 time_stdlib_compile: venv peg_extension/parse.c data/xxl.py

--- a/Tools/peg_generator/Makefile
+++ b/Tools/peg_generator/Makefile
@@ -75,15 +75,15 @@ time_compile: venv data/xxl.py
 time_parse: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=xxl parse
 
-time_stdlib: time_stdlib_compile
+time_old: time_old_compile
 
-time_stdlib_compile: venv data/xxl.py
+time_old_compile: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl compile
 
-time_stdlib_parse: venv data/xxl.py
+time_old_parse: venv data/xxl.py
 	$(VENVPYTHON) scripts/benchmark.py --parser=cpython --target=xxl parse
 
-test_local:
+time_peg_dir:
 	$(PYTHON) scripts/test_parse_directory.py \
 		--grammar-file $(GRAMMAR) \
 		--tokens-file $(TOKENS) \
@@ -93,7 +93,7 @@ test_local:
 		--exclude "*/failset/**" \
 		--exclude "*/failset/**/*"
 
-test_global: $(CPYTHON)
+time_stdlib: $(CPYTHON)
 	$(PYTHON) scripts/test_parse_directory.py \
 		--grammar-file $(GRAMMAR) \
 		--tokens-file $(TOKENS) \
@@ -109,9 +109,6 @@ mypy: regen-metaparser
 
 format-python:
 	black pegen scripts
-
-bench: venv
-	$(VENVPYTHON) scripts/benchmark.py --parser=pegen --target=stdlib check
 
 format: format-python
 

--- a/Tools/peg_generator/scripts/benchmark.py
+++ b/Tools/peg_generator/scripts/benchmark.py
@@ -89,7 +89,6 @@ def run_benchmark_xxl(subcommand, parser, source):
 
 def run_benchmark_stdlib(subcommand, parser):
     modes = {"compile": 2, "parse": 1, "check": 0}
-    extension = None
     for _ in range(3):
         parse_directory(
             "../../Lib",

--- a/Tools/peg_generator/scripts/benchmark.py
+++ b/Tools/peg_generator/scripts/benchmark.py
@@ -87,7 +87,6 @@ def run_benchmark_xxl(subcommand, parser, source):
 
 
 def run_benchmark_stdlib(subcommand, parser):
-    modes = {"compile": 2, "parse": 1, "check": 0}
     for _ in range(3):
         parse_directory(
             "../../Lib",
@@ -98,7 +97,7 @@ def run_benchmark_stdlib(subcommand, parser):
             skip_actions=False,
             tree_arg=0,
             short=True,
-            mode=modes[subcommand],
+            mode=2 if subcommand == "compile" else 1,
             parser=parser,
         )
 

--- a/Tools/peg_generator/scripts/benchmark.py
+++ b/Tools/peg_generator/scripts/benchmark.py
@@ -68,7 +68,7 @@ def time_compile(source, parser):
             oldparser=True,
         )
     else:
-        return compile(source, "xxl.py", "exec")
+        return _peg_parser.compile_string(source)
 
 
 @benchmark
@@ -76,7 +76,7 @@ def time_parse(source, parser):
     if parser == "cpython":
         return _peg_parser.parse_string(source, oldparser=True)
     else:
-        return ast.parse(source)
+        return _peg_parser.parse_string(source)
 
 
 def run_benchmark_xxl(subcommand, parser, source):
@@ -98,7 +98,6 @@ def run_benchmark_stdlib(subcommand, parser):
             skip_actions=False,
             tree_arg=0,
             short=True,
-            extension=None,
             mode=modes[subcommand],
             parser=parser,
         )

--- a/Tools/peg_generator/scripts/benchmark.py
+++ b/Tools/peg_generator/scripts/benchmark.py
@@ -6,6 +6,8 @@ import sys
 import os
 from time import time
 
+import _peg_parser
+
 try:
     import memory_profiler
 except ModuleNotFoundError:
@@ -14,8 +16,6 @@ except ModuleNotFoundError:
     sys.exit(1)
 
 sys.path.insert(0, os.getcwd())
-from peg_extension import parse
-from pegen.build import build_c_parser_and_generator
 from scripts.test_parse_directory import parse_directory
 
 argparser = argparse.ArgumentParser(
@@ -41,9 +41,6 @@ command_compile = subcommands.add_parser(
     "compile", help="Benchmark parsing and compiling to bytecode"
 )
 command_parse = subcommands.add_parser("parse", help="Benchmark parsing and generating an ast.AST")
-command_check = subcommands.add_parser(
-    "check", help="Benchmark parsing and throwing the tree away"
-)
 
 
 def benchmark(func):
@@ -66,22 +63,21 @@ def benchmark(func):
 @benchmark
 def time_compile(source, parser):
     if parser == "cpython":
-        return compile(source, os.path.join("data", "xxl.py"), "exec")
+        return _peg_parser.parse_string(
+            source,
+            oldparser=True,
+            bytecode=True,
+        )
     else:
-        return parse.parse_string(source, mode=2)
+        return compile(source, "xxl.py", "exec")
 
 
 @benchmark
 def time_parse(source, parser):
     if parser == "cpython":
-        return ast.parse(source, os.path.join("data", "xxl.py"), "exec")
+        return _peg_parser.parse_string(source, oldparser=True)
     else:
-        return parse.parse_string(source, mode=1)
-
-
-@benchmark
-def time_check(source):
-    return parse.parse_string(source, mode=0)
+        return ast.parse(source)
 
 
 def run_benchmark_xxl(subcommand, parser, source):
@@ -89,21 +85,11 @@ def run_benchmark_xxl(subcommand, parser, source):
         time_compile(source, parser)
     elif subcommand == "parse":
         time_parse(source, parser)
-    elif subcommand == "check":
-        time_check(source)
 
 
 def run_benchmark_stdlib(subcommand, parser):
     modes = {"compile": 2, "parse": 1, "check": 0}
     extension = None
-    if parser == "pegen":
-        extension = build_c_parser_and_generator(
-            "../../Grammar/python.gram",
-            "../../Grammar/Tokens",
-            "peg_extension/parse.c",
-            compile_extension=True,
-            skip_actions=False,
-        )
     for _ in range(3):
         parse_directory(
             "../../Lib",
@@ -113,7 +99,7 @@ def run_benchmark_stdlib(subcommand, parser):
             skip_actions=False,
             tree_arg=0,
             short=True,
-            extension=extension,
+            extension=None,
             mode=modes[subcommand],
             parser=parser,
         )
@@ -127,8 +113,6 @@ def main():
 
     if subcommand is None:
         argparser.error("A benchmark to run is required")
-    if subcommand == "check" and parser == "cpython":
-        argparser.error("Cannot use check target with the CPython parser")
 
     if target == "xxl":
         with open(os.path.join("data", "xxl.py"), "r") as f:

--- a/Tools/peg_generator/scripts/benchmark.py
+++ b/Tools/peg_generator/scripts/benchmark.py
@@ -63,10 +63,9 @@ def benchmark(func):
 @benchmark
 def time_compile(source, parser):
     if parser == "cpython":
-        return _peg_parser.parse_string(
+        return _peg_parser.compile_string(
             source,
             oldparser=True,
-            bytecode=True,
         )
     else:
         return compile(source, "xxl.py", "exec")
@@ -93,6 +92,7 @@ def run_benchmark_stdlib(subcommand, parser):
         parse_directory(
             "../../Lib",
             "../../Grammar/python.gram",
+            "../../Grammar/Tokens",
             verbose=False,
             excluded_files=["*/bad*", "*/lib2to3/tests/data/*",],
             skip_actions=False,

--- a/Tools/peg_generator/scripts/show_parse.py
+++ b/Tools/peg_generator/scripts/show_parse.py
@@ -30,6 +30,8 @@ import os
 import sys
 import tempfile
 
+import _peg_parser
+
 from typing import List
 
 sys.path.insert(0, os.getcwd())
@@ -72,7 +74,7 @@ def diff_trees(a: ast.AST, b: ast.AST, verbose: bool = False) -> List[str]:
 
 
 def show_parse(source: str, verbose: bool = False) -> str:
-    tree = ast.parse(source)
+    tree = _peg_parser.parse_string(source, oldparser=True)
     return format_tree(tree, verbose).rstrip("\n")
 
 
@@ -90,17 +92,11 @@ def main() -> None:
         sep = " "
     program = sep.join(args.program)
     if args.grammar_file:
-        sys.path.insert(0, os.curdir)
-        from pegen.build import build_parser_and_generator
-
-        build_parser_and_generator(args.grammar_file, "peg_parser/parse.c", compile_extension=True)
-        from pegen.parse import parse_string  # type: ignore[import]
-
-        tree = parse_string(program, mode=1)
+        tree = ast.parse(program)
 
         if args.diff:
             a = tree
-            b = ast.parse(program)
+            b = _peg_parser.parse_string(program, oldparser=True)
             diff = diff_trees(a, b, args.verbose)
             if diff:
                 for line in diff:
@@ -111,8 +107,8 @@ def main() -> None:
             print(f"# Parsed using {args.grammar_file}")
             print(format_tree(tree, args.verbose))
     else:
-        tree = ast.parse(program)
-        print("# Parse using ast.parse()")
+        tree = _peg_parser.parse_string(program, oldparser=True)
+        print("# Parse using the old parser")
         print(format_tree(tree, args.verbose))
 
 

--- a/Tools/peg_generator/scripts/show_parse.py
+++ b/Tools/peg_generator/scripts/show_parse.py
@@ -92,7 +92,7 @@ def main() -> None:
         sep = " "
     program = sep.join(args.program)
     if args.grammar_file:
-        tree = ast.parse(program)
+        tree = _peg_parser.parse_string(program)
 
         if args.diff:
             a = tree

--- a/Tools/peg_generator/scripts/test_parse_directory.py
+++ b/Tools/peg_generator/scripts/test_parse_directory.py
@@ -175,13 +175,13 @@ def parse_directory(
                         if mode == 2
                         else _peg_parser.parse_string
                     )
-                    tree = peg_parser_func(
+                    result = peg_parser_func(
                         source,
                         mode="exec",
                         oldparser=True,
                     )
                 if tree_arg:
-                    trees[file] = tree
+                    trees[file] = result
                 if not short:
                     report_status(succeeded=True, file=file, verbose=verbose)
             except Exception as error:

--- a/Tools/peg_generator/scripts/test_parse_directory.py
+++ b/Tools/peg_generator/scripts/test_parse_directory.py
@@ -120,7 +120,6 @@ def parse_directory(
     skip_actions: bool,
     tree_arg: int,
     short: bool,
-    extension: Any,
     mode: int,
     parser: str,
 ) -> int:
@@ -162,23 +161,15 @@ def parse_directory(
             try:
                 if tree_arg:
                     mode = 1
-                if parser == "pegen":
-                    compile(
+                if mode == 2:
+                    result = _peg_parser.compile_string(
                         source,
-                        file,
-                        "exec",
-                        flags=ast.PyCF_ONLY_AST if mode == 1 else 0
+                        oldparser=parser == "cpython",
                     )
                 else:
-                    peg_parser_func = (
-                        _peg_parser.compile_string
-                        if mode == 2
-                        else _peg_parser.parse_string
-                    )
-                    result = peg_parser_func(
+                    result = _peg_parser.parse_string(
                         source,
-                        mode="exec",
-                        oldparser=True,
+                        oldparser=parser == "cpython"
                     )
                 if tree_arg:
                     trees[file] = result
@@ -259,7 +250,6 @@ def main() -> None:
             skip_actions,
             tree,
             short,
-            None,
             0,
             "pegen",
         )

--- a/Tools/peg_generator/scripts/test_parse_directory.py
+++ b/Tools/peg_generator/scripts/test_parse_directory.py
@@ -142,6 +142,9 @@ def parse_directory(
             "A grammar file or a tokens file was not provided - attempting to use existing parser from stdlib...\n"
         )
 
+    if tree_arg:
+        assert mode == 1, "Mode should be 1 (parse), when comparing the generated trees"
+
     # For a given directory, traverse files and attempt to parse each one
     # - Output success/failure for each file
     errors = 0
@@ -161,8 +164,6 @@ def parse_directory(
             with tokenize.open(file) as f:
                 source = f.read()
             try:
-                if tree_arg:
-                    mode = 1
                 t0 = time.time()
                 if mode == 2:
                     result = _peg_parser.compile_string(
@@ -246,6 +247,7 @@ def main() -> None:
     skip_actions = args.skip_actions
     tree = args.tree
     short = args.short
+    mode = 1 if args.tree else 2
     sys.exit(
         parse_directory(
             directory,
@@ -256,7 +258,7 @@ def main() -> None:
             skip_actions,
             tree,
             short,
-            1,
+            mode,
             "pegen",
         )
     )

--- a/Tools/peg_generator/scripts/test_parse_directory.py
+++ b/Tools/peg_generator/scripts/test_parse_directory.py
@@ -170,11 +170,15 @@ def parse_directory(
                         flags=ast.PyCF_ONLY_AST if mode == 1 else 0
                     )
                 else:
-                    tree = _peg_parser.parse_string(
+                    peg_parser_func = (
+                        _peg_parser.compile_string
+                        if mode == 2
+                        else _peg_parser.parse_string
+                    )
+                    tree = peg_parser_func(
                         source,
                         mode="exec",
                         oldparser=True,
-                        bytecode=mode == 2,
                     )
                 if tree_arg:
                     trees[file] = tree

--- a/Tools/peg_generator/scripts/test_pypi_packages.py
+++ b/Tools/peg_generator/scripts/test_pypi_packages.py
@@ -72,7 +72,6 @@ def run_tests(dirname: str, tree: int) -> int:
         skip_actions=False,
         tree_arg=tree,
         short=True,
-        extension=None,
         mode=1,
         parser="pegen",
     )

--- a/Tools/peg_generator/scripts/test_pypi_packages.py
+++ b/Tools/peg_generator/scripts/test_pypi_packages.py
@@ -54,7 +54,7 @@ def find_dirname(package_name: str) -> str:
     assert False  # This is to fix mypy, should never be reached
 
 
-def run_tests(dirname: str, tree: int, extension: Any) -> int:
+def run_tests(dirname: str, tree: int) -> int:
     return test_parse_directory.parse_directory(
         dirname,
         HERE / ".." / ".." / ".." / "Grammar" / "python.gram",
@@ -72,7 +72,7 @@ def run_tests(dirname: str, tree: int, extension: Any) -> int:
         skip_actions=False,
         tree_arg=tree,
         short=True,
-        extension=extension,
+        extension=None,
         mode=1,
         parser="pegen",
     )
@@ -81,13 +81,6 @@ def run_tests(dirname: str, tree: int, extension: Any) -> int:
 def main() -> None:
     args = argparser.parse_args()
     tree = args.tree
-
-    extension = build.build_c_parser_and_generator(
-        HERE / ".." / ".." / ".." / "Grammar" / "python.gram",
-        HERE / ".." / ".." / ".." / "Grammar" / "Tokens",
-        "peg_extension/parse.c",
-        compile_extension=True,
-    )
 
     for package in get_packages():
         print(f"Extracting files from {package}... ", end="")
@@ -100,7 +93,7 @@ def main() -> None:
 
         print(f"Trying to parse all python files ... ")
         dirname = find_dirname(package)
-        status = run_tests(dirname, tree, extension)
+        status = run_tests(dirname, tree)
         if status == 0:
             shutil.rmtree(dirname)
         else:


### PR DESCRIPTION
The scripts in `Tools/peg_generator/scripts` mostly assume that
`ast.parse` and `compile` use the old parser, since this was the
state of things, while we were developing them. They need to be
updated to always use the correct parser. `_peg_parser` is being
extended to support both parsing and compiling with both parsers.

Also deleted the `parse_file` function from the `_peg_parser` extension
module, since it wasn't up-to-date with all the things `parse_string`
supported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40688](https://bugs.python.org/issue40688) -->
https://bugs.python.org/issue40688
<!-- /issue-number -->
