### PR TITLE
bpo-40679: use a function's qualname in error messages

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -8,7 +8,6 @@ import struct
 import collections
 import itertools
 import gc
-import re
 
 
 class FunctionCalls(unittest.TestCase):
@@ -363,45 +362,10 @@ class PythonClass:
     def static_method():
         return "staticmethod"
 
-    @staticmethod
-    def positional_only(arg, /):
-        return arg
-
 
 PYTHON_INSTANCE = PythonClass()
 
 NULL_OR_EMPTY = object()
-
-
-@cpython_only
-class TestErrorMessagesUseQualifiedName(unittest.TestCase):
-
-    def test_missing_arguments(self):
-        msg = "PythonClass.method() missing 1 required positional argument: 'arg2'"
-        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
-            PYTHON_INSTANCE.method("arg1")
-
-    def test_too_many_positional(self):
-        msg = "PythonClass.static_method() takes 0 positional arguments but 1 was given"
-        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
-            PythonClass.static_method("oops it's an arg")
-
-    def test_positional_only_passed_as_keyword(self):
-        msg = "PythonClass.positional_only() got some positional-only arguments passed as keyword arguments: 'arg'"
-        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
-            PythonClass.positional_only(arg="x")
-
-    def test_unexpected_keyword(self):
-        msg = "PythonClass.method() got an unexpected keyword argument 'bad'"
-        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
-            PYTHON_INSTANCE.method(bad="x")
-
-    def test_multiple_values(self):
-        kwargs = {"arg1":2, "arg2":3}
-        msg = "PythonClass.method() got multiple values for argument 'arg1'"
-        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
-            PYTHON_INSTANCE.method("arg1", "arg2", arg1="oops")
-
 
 class FastCallTests(unittest.TestCase):
     """Test calling using various callables from C

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -8,6 +8,7 @@ import struct
 import collections
 import itertools
 import gc
+import contextlib
 
 
 class FunctionCalls(unittest.TestCase):
@@ -663,6 +664,53 @@ class TestPEP590(unittest.TestCase):
                 self.assertEqual(expected, vectorcall(func, args, kwargs))
                 self.assertEqual(expected, meth(*args1, **kwargs))
                 self.assertEqual(expected, wrapped(*args, **kwargs))
+
+
+class A:
+    def method(self, x, y):
+        return x + y
+
+    @staticmethod
+    def static_method():
+        pass
+
+    @staticmethod
+    def positional_only(arg, /):
+        pass
+
+@cpython_only
+class TestErrorMessagesUseQualifiedName(unittest.TestCase):
+
+    @contextlib.contextmanager
+    def check_raises_exact(self, message, exception_type=TypeError):
+        with self.assertRaises(exception_type) as cm:
+            yield
+        self.assertEqual(str(cm.exception), message)
+
+    def test_missing_arguments(self):
+        msg = "A.method() missing 1 required positional argument: 'y'"
+        with self.check_raises_exact(msg):
+            A().method("x")
+
+    def test_too_many_positional(self):
+        msg = "A.static_method() takes 0 positional arguments but 1 was given"
+        with self.check_raises_exact(msg):
+            A.static_method("oops it's an arg")
+
+    def test_positional_only_passed_as_keyword(self):
+        msg = "A.positional_only() got some positional-only arguments passed as keyword arguments: 'arg'"
+        with self.check_raises_exact(msg):
+            A.positional_only(arg="x")
+
+    def test_unexpected_keyword(self):
+        msg = "A.method() got an unexpected keyword argument 'bad'"
+        with self.check_raises_exact(msg):
+            A().method(bad="x")
+
+    def test_multiple_values(self):
+        msg = "A.method() got multiple values for argument 'x'"
+        with self.check_raises_exact(msg):
+            A().method("x", "y", x="oops")
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -667,11 +667,11 @@ class TestPEP590(unittest.TestCase):
 
 
 class A:
-    def method(self, x, y):
-        return x + y
+    def method_two_args(self, x, y):
+        pass
 
     @staticmethod
-    def static_method():
+    def static_no_args():
         pass
 
     @staticmethod
@@ -682,35 +682,35 @@ class A:
 class TestErrorMessagesUseQualifiedName(unittest.TestCase):
 
     @contextlib.contextmanager
-    def check_raises_exact(self, message, exception_type=TypeError):
-        with self.assertRaises(exception_type) as cm:
+    def check_raises_type_error(self, message):
+        with self.assertRaises(TypeError) as cm:
             yield
         self.assertEqual(str(cm.exception), message)
 
     def test_missing_arguments(self):
-        msg = "A.method() missing 1 required positional argument: 'y'"
-        with self.check_raises_exact(msg):
-            A().method("x")
+        msg = "A.method_two_args() missing 1 required positional argument: 'y'"
+        with self.check_raises_type_error(msg):
+            A().method_two_args("x")
 
     def test_too_many_positional(self):
-        msg = "A.static_method() takes 0 positional arguments but 1 was given"
-        with self.check_raises_exact(msg):
-            A.static_method("oops it's an arg")
+        msg = "A.static_no_args() takes 0 positional arguments but 1 was given"
+        with self.check_raises_type_error(msg):
+            A.static_no_args("oops it's an arg")
 
     def test_positional_only_passed_as_keyword(self):
         msg = "A.positional_only() got some positional-only arguments passed as keyword arguments: 'arg'"
-        with self.check_raises_exact(msg):
+        with self.check_raises_type_error(msg):
             A.positional_only(arg="x")
 
     def test_unexpected_keyword(self):
-        msg = "A.method() got an unexpected keyword argument 'bad'"
-        with self.check_raises_exact(msg):
-            A().method(bad="x")
+        msg = "A.method_two_args() got an unexpected keyword argument 'bad'"
+        with self.check_raises_type_error(msg):
+            A().method_two_args(bad="x")
 
     def test_multiple_values(self):
-        msg = "A.method() got multiple values for argument 'x'"
-        with self.check_raises_exact(msg):
-            A().method("x", "y", x="oops")
+        msg = "A.method_two_args() got multiple values for argument 'x'"
+        with self.check_raises_type_error(msg):
+            A().method_two_args("x", "y", x="oops")
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -8,6 +8,7 @@ import struct
 import collections
 import itertools
 import gc
+import re
 
 
 class FunctionCalls(unittest.TestCase):
@@ -362,10 +363,45 @@ class PythonClass:
     def static_method():
         return "staticmethod"
 
+    @staticmethod
+    def positional_only(arg, /):
+        return arg
+
 
 PYTHON_INSTANCE = PythonClass()
 
 NULL_OR_EMPTY = object()
+
+
+@cpython_only
+class TestErrorMessagesUseQualifiedName(unittest.TestCase):
+
+    def test_missing_arguments(self):
+        msg = "PythonClass.method() missing 1 required positional argument: 'arg2'"
+        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
+            PYTHON_INSTANCE.method("arg1")
+
+    def test_too_many_positional(self):
+        msg = "PythonClass.static_method() takes 0 positional arguments but 1 was given"
+        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
+            PythonClass.static_method("oops it's an arg")
+
+    def test_positional_only_passed_as_keyword(self):
+        msg = "PythonClass.positional_only() got some positional-only arguments passed as keyword arguments: 'arg'"
+        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
+            PythonClass.positional_only(arg="x")
+
+    def test_unexpected_keyword(self):
+        msg = "PythonClass.method() got an unexpected keyword argument 'bad'"
+        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
+            PYTHON_INSTANCE.method(bad="x")
+
+    def test_multiple_values(self):
+        kwargs = {"arg1":2, "arg2":3}
+        msg = "PythonClass.method() got multiple values for argument 'arg1'"
+        with self.assertRaisesRegex(TypeError, "^"+re.escape(msg)+"$"):
+            PYTHON_INSTANCE.method("arg1", "arg2", arg1="oops")
+
 
 class FastCallTests(unittest.TestCase):
     """Test calling using various callables from C

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -500,6 +500,50 @@ Same with keyword only args:
       ...
     TypeError: f() missing 5 required keyword-only arguments: 'a', 'b', 'c', 'd', and 'e'
 
+Test that functions are referred to by their __qualname__s:
+
+    >>> class A:
+    ...     def method(self, x, y):
+    ...         pass
+    ...     def method_noarg(self):
+    ...         pass
+    ...     @classmethod
+    ...     def class_method(cls):
+    ...         pass
+    ...     @staticmethod
+    ...     def static_method():
+    ...         pass
+    ...     @staticmethod
+    ...     def positional_only(arg, /):
+    ...         pass
+
+    >>> a_object = A()
+
+    >>> a_object.method("x")
+    Traceback (most recent call last):
+      ...
+    TypeError: A.method() missing 1 required positional argument: 'y'
+
+    >>> A.static_method("oops it's an argument")
+    Traceback (most recent call last):
+      ...
+    TypeError: A.static_method() takes 0 positional arguments but 1 was given
+
+    >>> A.positional_only(arg="x")
+    Traceback (most recent call last):
+      ...
+    TypeError: A.positional_only() got some positional-only arguments passed as keyword arguments: 'arg'
+
+    >>> a_object.method(bad='x')
+    Traceback (most recent call last):
+      ...
+    TypeError: A.method() got an unexpected keyword argument 'bad'
+
+    >>> a_object.method("x", "y", x="oops")
+    Traceback (most recent call last):
+      ...
+    TypeError: A.method() got multiple values for argument 'x'
+
 """
 
 import sys

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -505,11 +505,6 @@ Test that functions are referred to by their __qualname__s:
     >>> class A:
     ...     def method(self, x, y):
     ...         pass
-    ...     def method_noarg(self):
-    ...         pass
-    ...     @classmethod
-    ...     def class_method(cls):
-    ...         pass
     ...     @staticmethod
     ...     def static_method():
     ...         pass

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -500,45 +500,6 @@ Same with keyword only args:
       ...
     TypeError: f() missing 5 required keyword-only arguments: 'a', 'b', 'c', 'd', and 'e'
 
-Test that functions are referred to by their __qualname__s:
-
-    >>> class A:
-    ...     def method(self, x, y):
-    ...         pass
-    ...     @staticmethod
-    ...     def static_method():
-    ...         pass
-    ...     @staticmethod
-    ...     def positional_only(arg, /):
-    ...         pass
-
-    >>> a_object = A()
-
-    >>> a_object.method("x")
-    Traceback (most recent call last):
-      ...
-    TypeError: A.method() missing 1 required positional argument: 'y'
-
-    >>> A.static_method("oops it's an argument")
-    Traceback (most recent call last):
-      ...
-    TypeError: A.static_method() takes 0 positional arguments but 1 was given
-
-    >>> A.positional_only(arg="x")
-    Traceback (most recent call last):
-      ...
-    TypeError: A.positional_only() got some positional-only arguments passed as keyword arguments: 'arg'
-
-    >>> a_object.method(bad='x')
-    Traceback (most recent call last):
-      ...
-    TypeError: A.method() got an unexpected keyword argument 'bad'
-
-    >>> a_object.method("x", "y", x="oops")
-    Traceback (most recent call last):
-      ...
-    TypeError: A.method() got multiple values for argument 'x'
-
 """
 
 import sys

--- a/Lib/test/test_keywordonlyarg.py
+++ b/Lib/test/test_keywordonlyarg.py
@@ -63,7 +63,8 @@ class KeywordOnlyArgTestCase(unittest.TestCase):
             pass
         with self.assertRaises(TypeError) as exc:
             f(1, 2, 3)
-        expected = "f() takes from 1 to 2 positional arguments but 3 were given"
+        expected = (f"{f.__qualname__}() takes from 1 to 2 "
+                    "positional arguments but 3 were given")
         self.assertEqual(str(exc.exception), expected)
 
     def testSyntaxErrorForFunctionCall(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
@@ -1,1 +1,1 @@
-Certain error messages about passing too few or too many arguments now inclue the function's :term:`qualified name`.
+Certain :exc:`TypeError` messages about missing or extra arguments now include the function's :term:`qualified name`.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
@@ -1,0 +1,1 @@
+Error messages about invalid arguments now refer to a function by its ``__qualname__``.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
@@ -1,1 +1,1 @@
-Certain error messages about too few or too many arguments now refer to a function by its :term:`qualified name`.
+Certain error messages about passing too few or too many arguments now inclue the function's :term:`qualified name`.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
@@ -1,1 +1,1 @@
-Error messages about invalid arguments now refer to a function by its ``__qualname__``.
+Certain error messages about too few or too many arguments now refer to a function by its :term:`qualified name`.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-19-19-39-49.bpo-40679.SVzz9p.rst
@@ -1,1 +1,2 @@
-Certain :exc:`TypeError` messages about missing or extra arguments now include the function's :term:`qualified name`.
+Certain :exc:`TypeError` messages about missing or extra arguments now include the function's
+:term:`qualified name`.  Patch by Dennis Sweeney.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3875,7 +3875,7 @@ exit_eval_frame:
 
 static void
 format_missing(PyThreadState *tstate, const char *kind,
-               PyCodeObject *co, PyObject *names)
+               PyCodeObject *co, PyObject *names, PyObject *qualname)
 {
     int err;
     Py_ssize_t len = PyList_GET_SIZE(names);
@@ -3928,7 +3928,7 @@ format_missing(PyThreadState *tstate, const char *kind,
         return;
     _PyErr_Format(tstate, PyExc_TypeError,
                   "%U() missing %i required %s argument%s: %U",
-                  co->co_name,
+                  qualname,
                   len,
                   kind,
                   len == 1 ? "" : "s",
@@ -3939,7 +3939,7 @@ format_missing(PyThreadState *tstate, const char *kind,
 static void
 missing_arguments(PyThreadState *tstate, PyCodeObject *co,
                   Py_ssize_t missing, Py_ssize_t defcount,
-                  PyObject **fastlocals)
+                  PyObject **fastlocals, PyObject *qualname)
 {
     Py_ssize_t i, j = 0;
     Py_ssize_t start, end;
@@ -3971,14 +3971,14 @@ missing_arguments(PyThreadState *tstate, PyCodeObject *co,
         }
     }
     assert(j == missing);
-    format_missing(tstate, kind, co, missing_names);
+    format_missing(tstate, kind, co, missing_names, qualname);
     Py_DECREF(missing_names);
 }
 
 static void
 too_many_positional(PyThreadState *tstate, PyCodeObject *co,
                     Py_ssize_t given, Py_ssize_t defcount,
-                    PyObject **fastlocals)
+                    PyObject **fastlocals, PyObject *qualname)
 {
     int plural;
     Py_ssize_t kwonly_given = 0;
@@ -4022,7 +4022,7 @@ too_many_positional(PyThreadState *tstate, PyCodeObject *co,
     }
     _PyErr_Format(tstate, PyExc_TypeError,
                   "%U() takes %U positional argument%s but %zd%U %s given",
-                  co->co_name,
+                  qualname,
                   sig,
                   plural ? "s" : "",
                   given,
@@ -4034,7 +4034,8 @@ too_many_positional(PyThreadState *tstate, PyCodeObject *co,
 
 static int
 positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
-                                  Py_ssize_t kwcount, PyObject* const* kwnames)
+                                  Py_ssize_t kwcount, PyObject* const* kwnames,
+                                  PyObject *qualname)
 {
     int posonly_conflicts = 0;
     PyObject* posonly_names = PyList_New(0);
@@ -4079,7 +4080,7 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
         _PyErr_Format(tstate, PyExc_TypeError,
                       "%U() got some positional-only arguments passed"
                       " as keyword arguments: '%U'",
-                      co->co_name, error_names);
+                      qualname, error_names);
         Py_DECREF(error_names);
         goto fail;
     }
@@ -4180,7 +4181,7 @@ _PyEval_EvalCode(PyThreadState *tstate,
         if (keyword == NULL || !PyUnicode_Check(keyword)) {
             _PyErr_Format(tstate, PyExc_TypeError,
                           "%U() keywords must be strings",
-                          co->co_name);
+                          qualname);
             goto fail;
         }
 
@@ -4211,14 +4212,14 @@ _PyEval_EvalCode(PyThreadState *tstate,
 
             if (co->co_posonlyargcount
                 && positional_only_passed_as_keyword(tstate, co,
-                                                     kwcount, kwnames))
+                                                     kwcount, kwnames, qualname))
             {
                 goto fail;
             }
 
             _PyErr_Format(tstate, PyExc_TypeError,
                           "%U() got an unexpected keyword argument '%S'",
-                          co->co_name, keyword);
+                          qualname, keyword);
             goto fail;
         }
 
@@ -4231,7 +4232,7 @@ _PyEval_EvalCode(PyThreadState *tstate,
         if (GETLOCAL(j) != NULL) {
             _PyErr_Format(tstate, PyExc_TypeError,
                           "%U() got multiple values for argument '%S'",
-                          co->co_name, keyword);
+                          qualname, keyword);
             goto fail;
         }
         Py_INCREF(value);
@@ -4240,7 +4241,7 @@ _PyEval_EvalCode(PyThreadState *tstate,
 
     /* Check the number of positional arguments */
     if ((argcount > co->co_argcount) && !(co->co_flags & CO_VARARGS)) {
-        too_many_positional(tstate, co, argcount, defcount, fastlocals);
+        too_many_positional(tstate, co, argcount, defcount, fastlocals, qualname);
         goto fail;
     }
 
@@ -4254,7 +4255,7 @@ _PyEval_EvalCode(PyThreadState *tstate,
             }
         }
         if (missing) {
-            missing_arguments(tstate, co, missing, defcount, fastlocals);
+            missing_arguments(tstate, co, missing, defcount, fastlocals, qualname);
             goto fail;
         }
         if (n > m)
@@ -4292,7 +4293,7 @@ _PyEval_EvalCode(PyThreadState *tstate,
             missing++;
         }
         if (missing) {
-            missing_arguments(tstate, co, missing, -1, fastlocals);
+            missing_arguments(tstate, co, missing, -1, fastlocals, qualname);
             goto fail;
         }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40679](https://bugs.python.org/issue40679) -->
https://bugs.python.org/issue40679
<!-- /issue-number -->
