### PR TITLE
bpo-38870: invalid escape sequence

### DIFF
--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -330,7 +330,7 @@ class UnparseTestCase(ASTTestCase):
             '\r\\r\t\\t\n\\n',
             '""">>> content = \"\"\"blabla\"\"\" <<<"""',
             r'foo\n\x00',
-            '🐍⛎𩸽üéş^\X\BB\N{LONG RIGHTWARDS SQUIGGLE ARROW}'
+            '🐍⛎𩸽üéş^\N{LONG RIGHTWARDS SQUIGGLE ARROW}'
 
         )
         for docstring in docstrings:


### PR DESCRIPTION
`/home/isidentical/cpython/cpython/Lib/test/test_unparse.py:333: DeprecationWarning: invalid escape sequence \X`


<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal