### PR TITLE
bpo-40291: Mention socket.CAN_J1939 in What's New

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -530,6 +530,9 @@ The :mod:`socket` module now exports the :data:`~socket.CAN_RAW_JOIN_FILTERS`
 constant on Linux 4.1 and greater.
 (Contributed by Stefan Tatschner and Zackery Spytz in :issue:`25780`.)
 
+The socket module now supports the :data:`~socket.CAN_J1939` protocol on
+platforms that support it.  (Contributed by Karl Ding in :issue:`40291`.)
+
 time
 ----
 


### PR DESCRIPTION
This mentions the new CAN_J1939 implementation in the What's New
documentation for Python 3.9

<!-- issue-number: [bpo-40291](https://bugs.python.org/issue40291) -->
https://bugs.python.org/issue40291
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum