### PR TITLE
bpo-31904: fix fifo test cases for VxWorks RTOS

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1933,7 +1933,7 @@ class TestPosixSpawnP(unittest.TestCase, _PosixSpawnMixin):
 class TestPosixWeaklinking(unittest.TestCase):
     # These test cases verify that weak linking support on macOS works
     # as expected. These cases only test new behaviour introduced by weak linking,
-    # regular behaviour is tested by the normal test cases. 
+    # regular behaviour is tested by the normal test cases.
     #
     # See the section on Weak Linking in Mac/README.txt for more information.
     def setUp(self):

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -647,6 +647,7 @@ class PosixTester(unittest.TestCase):
         else:
             fifo_path = os_helper.TESTFN
         os_helper.unlink(fifo_path)
+        self.addCleanup(os_helper.unlink, fifo_path)
         try:
             posix.mkfifo(fifo_path, stat.S_IRUSR | stat.S_IWUSR)
         except PermissionError as e:

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -642,12 +642,16 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'mkfifo'), "don't have mkfifo()")
     def test_mkfifo(self):
-        os_helper.unlink(os_helper.TESTFN)
+        if sys.platform == "vxworks":
+            fifo_path = os.path.join("/fifos/", os_helper.TESTFN)
+        else:
+            fifo_path = os_helper.TESTFN
+        os_helper.unlink(fifo_path)
         try:
-            posix.mkfifo(os_helper.TESTFN, stat.S_IRUSR | stat.S_IWUSR)
+            posix.mkfifo(fifo_path, stat.S_IRUSR | stat.S_IWUSR)
         except PermissionError as e:
             self.skipTest('posix.mkfifo(): %s' % e)
-        self.assertTrue(stat.S_ISFIFO(posix.stat(os_helper.TESTFN).st_mode))
+        self.assertTrue(stat.S_ISFIFO(posix.stat(fifo_path).st_mode))
 
     @unittest.skipUnless(hasattr(posix, 'mknod') and hasattr(stat, 'S_IFIFO'),
                          "don't have mknod()/S_IFIFO")

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -173,11 +173,17 @@ class TestFilemode:
 
     @unittest.skipUnless(hasattr(os, 'mkfifo'), 'os.mkfifo not available')
     def test_fifo(self):
+        if sys.platform == "vxworks":
+            fifo_path = os.path.join("/fifos/", TESTFN)
+        else:
+            fifo_path = TESTFN
         try:
-            os.mkfifo(TESTFN, 0o700)
+            os.mkfifo(fifo_path, 0o700)
         except PermissionError as e:
             self.skipTest('os.mkfifo(): %s' % e)
-        st_mode, modestr = self.get_mode()
+        st_mode, modestr = self.get_mode(fifo_path)
+        if sys.platform == "vxworks":
+            os.remove(fifo_path)
         self.assertEqual(modestr, 'prwx------')
         self.assertS_IS("FIFO", st_mode)
 

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import socket
 import sys
+from test.support import os_helper
 from test.support import socket_helper
 from test.support.import_helper import import_fresh_module
 from test.support.os_helper import TESTFN
@@ -181,9 +182,8 @@ class TestFilemode:
             os.mkfifo(fifo_path, 0o700)
         except PermissionError as e:
             self.skipTest('os.mkfifo(): %s' % e)
+        self.addCleanup(os_helper.unlink, fifo_path)
         st_mode, modestr = self.get_mode(fifo_path)
-        if sys.platform == "vxworks":
-            os.remove(fifo_path)
         self.assertEqual(modestr, 'prwx------')
         self.assertS_IS("FIFO", st_mode)
 

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -178,11 +178,11 @@ class TestFilemode:
             fifo_path = os.path.join("/fifos/", TESTFN)
         else:
             fifo_path = TESTFN
+        self.addCleanup(os_helper.unlink, fifo_path)
         try:
             os.mkfifo(fifo_path, 0o700)
         except PermissionError as e:
             self.skipTest('os.mkfifo(): %s' % e)
-        self.addCleanup(os_helper.unlink, fifo_path)
         st_mode, modestr = self.get_mode(fifo_path)
         self.assertEqual(modestr, 'prwx------')
         self.assertS_IS("FIFO", st_mode)

--- a/Misc/NEWS.d/next/Tests/2020-05-20-14-28-48.bpo-31904.yJik6k.rst
+++ b/Misc/NEWS.d/next/Tests/2020-05-20-14-28-48.bpo-31904.yJik6k.rst
@@ -1,0 +1,1 @@
+Fix fifo test cases for VxWorks RTOS.


### PR DESCRIPTION
In VxWork RTOS, FIFO must be created under directory "/fifos/". So tuned related test cases accordingly.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
