### PR TITLE
bpo-40695: Limit hashlib builtin hash fallback

### DIFF
--- a/Lib/hashlib.py
+++ b/Lib/hashlib.py
@@ -127,8 +127,9 @@ def __get_openssl_constructor(name):
         # SHA3/shake are available in OpenSSL 1.1.1+
         f = getattr(_hashlib, 'openssl_' + name)
         # Allow the C module to raise ValueError.  The function will be
-        # defined but the hash not actually available thanks to OpenSSL.
-        f()
+        # defined but the hash not actually available.  Don't fall back to
+        # builtin if the current security policy blocks a digest, bpo#40695.
+        f(usedforsecurity=False)
         # Use the C function directly (very fast)
         return f
     except (AttributeError, ValueError):

--- a/Misc/NEWS.d/next/Library/2020-05-20-13-03-28.bpo-40695.lr4aIS.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-20-13-03-28.bpo-40695.lr4aIS.rst
@@ -1,0 +1,3 @@
+:mod:`hashlib` no longer falls back to builtin hash implementations when
+OpenSSL provides a hash digest and the algorithm is blocked by security
+policy.


### PR DESCRIPTION
:mod:`hashlib` no longer falls back to builtin hash implementations when
OpenSSL provides a hash digest and the algorithm is blocked by security
policy.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40695](https://bugs.python.org/issue40695) -->
https://bugs.python.org/issue40695
<!-- /issue-number -->


Automerge-Triggered-By: @tiran