### PR TITLE
bpo-39580: add check for CLI installation on macOS

### DIFF
--- a/Mac/BuildScript/scripts/postflight.documentation
+++ b/Mac/BuildScript/scripts/postflight.documentation
@@ -12,7 +12,9 @@ SHARE_DOCDIR_TO_FWK="../../.."
 # make link in /Applications/Python m.n/ for Finder users
 if [ -d "${APPDIR}" ]; then
     ln -fhs "${FWK_DOCDIR}/index.html" "${APPDIR}/Python Documentation.html"
-    open "${APPDIR}" || true  # open the applications folder
+    if [ "${COMMAND_LINE_INSTALL}" != 1 ]; then
+        open "${APPDIR}" || true  # open the applications folder
+    fi
 fi
 
 # make share/doc link in framework for command line users

--- a/Misc/NEWS.d/next/macOS/2020-06-25-06-09-00.bpo-39580.N_vJ9h.rst
+++ b/Misc/NEWS.d/next/macOS/2020-06-25-06-09-00.bpo-39580.N_vJ9h.rst
@@ -1,0 +1,2 @@
+Avoid opening Finder window if running installer from the command line.
+Patch contributed by Rick Heil.


### PR DESCRIPTION
Adds a simple check for whether or not the package is being installed in the GUI or using installer on the command line. This addresses an issue where CLI-based software management tools (such as Munki) unexpectedly open Finder windows into a GUI session during installation runs.

https://bugs.python.org/issue39580

<!-- issue-number: [bpo-39580](https://bugs.python.org/issue39580) -->
https://bugs.python.org/issue39580
<!-- /issue-number -->
