### PR TITLE
bpo-32309: Add support for contextvars in asyncio.to_thread()

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -610,7 +610,9 @@ Running in Threads
    Asynchronously run function *func* in a separate thread.
 
    Any \*args and \*\*kwargs supplied for this function are directly passed
-   to *func*.
+   to *func*. Also, the current :class:`contextvars.Context` is propogated,
+   allowing context variables from the main thread to be accessed in the
+   separate thread.
 
    Return an :class:`asyncio.Future` which represents the eventual result of
    *func*.
@@ -656,6 +658,8 @@ Running in Threads
       to make IO-bound functions non-blocking. However, for extension modules
       that release the GIL or alternative Python implementations that don't
       have one, `asyncio.to_thread()` can also be used for CPU-bound functions.
+
+   .. versionadded:: 3.9
 
 
 Scheduling From Other Threads

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -611,7 +611,7 @@ Running in Threads
 
    Any \*args and \*\*kwargs supplied for this function are directly passed
    to *func*. Also, the current :class:`contextvars.Context` is propogated,
-   allowing context variables from the main thread to be accessed in the
+   allowing context variables from the event loop thread to be accessed in the
    separate thread.
 
    Return an :class:`asyncio.Future` which represents the eventual result of

--- a/Lib/test/test_asyncio/test_threads.py
+++ b/Lib/test/test_asyncio/test_threads.py
@@ -3,6 +3,7 @@
 import asyncio
 import unittest
 
+from contextvars import ContextVar
 from unittest import mock
 from test.test_asyncio import utils as test_utils
 
@@ -73,6 +74,19 @@ class ToThreadTests(test_utils.TestCase):
 
         self.loop.run_until_complete(main())
         func.assert_called_once_with('test', something=True)
+
+    def test_to_thread_contextvars(self):
+        test_ctx = ContextVar('test_ctx')
+
+        def get_ctx():
+            return test_ctx.get()
+
+        async def main():
+            test_ctx.set('parrot')
+            return await asyncio.to_thread(get_ctx)
+
+        result = self.loop.run_until_complete(main())
+        self.assertEqual(result, 'parrot')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows contextvars from the main thread to be accessed in the separate thread used in `asyncio.to_thread()`. See the [discussion](https://github.com/python/cpython/pull/20143#discussion_r427808225) in GH-20143 for context.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32309](https://bugs.python.org/issue32309) -->
https://bugs.python.org/issue32309
<!-- /issue-number -->


Automerge-Triggered-By: @aeros