### PR TITLE
bpo-40705: Fix use-after-free in _zoneinfo's module_free

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2490,6 +2490,7 @@ new_weak_cache()
 static int
 initialize_caches()
 {
+    // TODO: Move to a PyModule_GetState / PEP 573 based caching system.
     if (TIMEDELTA_CACHE == NULL) {
         TIMEDELTA_CACHE = PyDict_New();
     }
@@ -2603,14 +2604,16 @@ module_free()
 
     xdecref_ttinfo(&NO_TTINFO);
 
-    Py_XDECREF(TIMEDELTA_CACHE);
-    if (!Py_REFCNT(TIMEDELTA_CACHE)) {
-        TIMEDELTA_CACHE = NULL;
+    if (TIMEDELTA_CACHE != NULL && Py_REFCNT(TIMEDELTA_CACHE) > 1) {
+        Py_DECREF(TIMEDELTA_CACHE);
+    } else {
+        Py_CLEAR(TIMEDELTA_CACHE);
     }
 
-    Py_XDECREF(ZONEINFO_WEAK_CACHE);
-    if (!Py_REFCNT(ZONEINFO_WEAK_CACHE)) {
-        ZONEINFO_WEAK_CACHE = NULL;
+    if (ZONEINFO_WEAK_CACHE != NULL && Py_REFCNT(ZONEINFO_WEAK_CACHE) > 1) {
+        Py_DECREF(ZONEINFO_WEAK_CACHE);
+    } else {
+        Py_CLEAR(ZONEINFO_WEAK_CACHE);
     }
 
     strong_cache_free(ZONEINFO_STRONG_CACHE);


### PR DESCRIPTION
`initialize_caches` currently seems to be designed to account for being called twice but it's only callee is the `Py_mod_exec`. This might have been future planning for heap allocated types but I'll wait for a response from @pganssle on their intentions with this code there. Until then this seems like a straight-forward fix.

Couldn't really think of an easy way to test this since it doesn't seem like there's a codepath where a reference to `TIMEDELTA_CACHE` or `ZONEINFO_WEAK_CACHE` could be held by someone outside the module.

<!-- issue-number: [bpo-40705](https://bugs.python.org/issue40705) -->
https://bugs.python.org/issue40705
<!-- /issue-number -->
