### PR TITLE
bpo-40707: Document that Popen.communicate sets the returncode attribute

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -738,7 +738,7 @@ Instances of the :class:`Popen` class have the following methods:
 .. method:: Popen.communicate(input=None, timeout=None)
 
    Interact with process: Send data to stdin.  Read data from stdout and stderr,
-   until end-of-file is reached.  Wait for process to terminate and set
+   until end-of-file is reached.  Wait for process to terminate and set the
    :attr:`~Popen.returncode` attribute.  The optional *input* argument should be
    data to be sent to the child process, or ``None``, if no data should be sent
    to the child.  If streams were opened in text mode, *input* must be a string.

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -738,7 +738,7 @@ Instances of the :class:`Popen` class have the following methods:
 .. method:: Popen.communicate(input=None, timeout=None)
 
    Interact with process: Send data to stdin.  Read data from stdout and stderr,
-   until end-of-file is reached.  Wait for process to terminate.  Set
+   until end-of-file is reached.  Wait for process to terminate and set
    :attr:`~Popen.returncode` attribute.  The optional *input* argument should be
    data to be sent to the child process, or ``None``, if no data should be sent
    to the child.  If streams were opened in text mode, *input* must be a string.

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -738,10 +738,11 @@ Instances of the :class:`Popen` class have the following methods:
 .. method:: Popen.communicate(input=None, timeout=None)
 
    Interact with process: Send data to stdin.  Read data from stdout and stderr,
-   until end-of-file is reached.  Wait for process to terminate.  The optional
-   *input* argument should be data to be sent to the child process, or
-   ``None``, if no data should be sent to the child.  If streams were opened in
-   text mode, *input* must be a string.  Otherwise, it must be bytes.
+   until end-of-file is reached.  Wait for process to terminate.  Set
+   :attr:`~Popen.returncode` attribute.  The optional *input* argument should be
+   data to be sent to the child process, or ``None``, if no data should be sent
+   to the child.  If streams were opened in text mode, *input* must be a string.
+   Otherwise, it must be bytes.
 
    :meth:`communicate` returns a tuple ``(stdout_data, stderr_data)``.
    The data will be strings if streams were opened in text mode; otherwise,


### PR DESCRIPTION
This pull request fixes [issue 40707](https://bugs.python.org/issue40707) by documenting that the `subprocess.Popen.communicate()` method sets the `returncode` attribute.

<!-- issue-number: [bpo-40707](https://bugs.python.org/issue40707) -->
https://bugs.python.org/issue40707
<!-- /issue-number -->
