### PR TITLE
bpo-40334: Correctly generate C parser when assigned var is None

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -391,6 +391,13 @@ class TestCParser(TempdirManager, unittest.TestCase):
         self.assertTrue("SOME SUBHEADER" in parser_source)
         self.assertTrue("SOME TRAILER" in parser_source)
 
+    def test_multiple_lookahead(self) -> None:
+        grammar_source = 'start: !"(" NEWLINE+ !")"'
+        grammar = parse_string(grammar_source, GrammarParser)
+        parser_source = generate_c_parser_source(grammar)
+
+        self.assertNotIn("int None_1", parser_source)
+
     def test_error_in_rules(self) -> None:
         grammar_source = """
         start: expr+ NEWLINE? ENDMARKER

--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -391,13 +391,6 @@ class TestCParser(TempdirManager, unittest.TestCase):
         self.assertTrue("SOME SUBHEADER" in parser_source)
         self.assertTrue("SOME TRAILER" in parser_source)
 
-    def test_multiple_lookahead(self) -> None:
-        grammar_source = 'start: !"(" NEWLINE+ !")"'
-        grammar = parse_string(grammar_source, GrammarParser)
-        parser_source = generate_c_parser_source(grammar)
-
-        self.assertNotIn("int None_1", parser_source)
-
     def test_error_in_rules(self) -> None:
         grammar_source = """
         start: expr+ NEWLINE? ENDMARKER

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -722,4 +722,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
 
     def add_var(self, node: NamedItem) -> Tuple[Optional[str], Optional[str]]:
         call = self.callmakervisitor.visit(node.item)
-        return self.dedupe(node.name if node.name else call.assigned_variable), call.return_type
+        name = node.name if node.name else call.assigned_variable
+        if name is not None:
+            name = self.dedupe(name)
+        return name, call.return_type


### PR DESCRIPTION
When there are 2 negative lookaheads in a same rule, let's say
`!"(" blabla "," !")"`, there will the 2 `FunctionCall`'s where
assigned value is None. Currently when the `add_var` is called
the first one will be ignored (since it will be returned as same
from dedupe because there aren't any `None` named variables in
locals, but when the second lookahead's var is sent to dedupe it
will be returned as `None_1` and this wont be ignored by the
declaration generator in the `visit_Alt`. This patch adds an explicit
check to `add_var` to distinguish whether if there is a variable or not.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
