### PR TITLE
bpo-40723: Make IDLE autocomplete test run without __main__.__file__

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,8 +3,7 @@ Released on 2020-10-05?
 ======================================
 
 
-bpo-40723: Make autocomplete test run without `__main__.__file__`
-as `__file__` is not defined if run as `__main__`.
+bpo-40723: Make test_idle pass when run after import.
 
 bpo-38689: IDLE will no longer freeze when inspect.signature fails
 when fetching a calltip.

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2020-10-05?
 ======================================
 
 
+bpo-40723: Make autocomplete test run without `__main__.__file__`
+as `__file__` is not defined if run as `__main__`.
+
 bpo-38689: IDLE will no longer freeze when inspect.signature fails
 when fetching a calltip.
 

--- a/Lib/idlelib/idle_test/test_autocomplete.py
+++ b/Lib/idlelib/idle_test/test_autocomplete.py
@@ -227,7 +227,7 @@ class AutoCompleteTest(unittest.TestCase):
         acp = self.autocomplete
         small, large = acp.fetch_completions(
                 '', ac.ATTRS)
-        if __main__.__file__ != ac.__file__:
+        if hasattr(__main__, '__file__') and __main__.__file__ != ac.__file__:
             self.assertNotIn('AutoComplete', small)  # See issue 36405.
 
         # Test attributes

--- a/Misc/NEWS.d/next/IDLE/2020-05-24-06-19-43.bpo-40723.AJLd4U.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-05-24-06-19-43.bpo-40723.AJLd4U.rst
@@ -1,0 +1,1 @@
+Make test_idle pass when run after import.


### PR DESCRIPTION
Apply the fix suggested by @terryjreedy in the corresponding issue's discussion (https://bugs.python.org/issue40723).

<!-- issue-number: [bpo-40723](https://bugs.python.org/issue40723) -->
https://bugs.python.org/issue40723
<!-- /issue-number -->
