### PR TITLE
bpo-40725: Restore missing column of digits

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -628,48 +628,48 @@ Here's a summary of performance improvements from Python 3.4 through Python 3.9:
 
 .. code-block:: none
 
-    Python version                      3.4     3.5     3.6     3.7     3.8    3.9
-    --------------                      ---     ---     ---     ---     ---    ---
+    Python version                       3.4     3.5     3.6     3.7     3.8    3.9
+    --------------                       ---     ---     ---     ---     ---    ---
 
     Variable and attribute read access:
-        read_local                      7.1     7.1     5.4     5.1     3.9    4.0
-        read_nonlocal                   7.1     8.1     5.8     5.4     4.4    4.8
-        read_global                     5.5    19.0    14.3    13.6     7.6    7.7
-        read_builtin                    1.1    21.6    18.5    19.0     7.5    7.7
-        read_classvar_from_class        5.6    26.5    20.7    19.5    18.4   18.6
-        read_classvar_from_instance     2.8    23.5    18.8    17.1    16.4   20.1
-        read_instancevar                2.4    33.1    28.0    26.3    25.4   27.7
-        read_instancevar_slots          7.8    31.3    20.8    20.8    20.2   24.5
-        read_namedtuple                 3.8    57.5    45.0    46.8    18.4   23.2
-        read_boundmethod                7.6    37.9    29.6    26.9    27.7   45.9
+        read_local                       7.1     7.1     5.4     5.1     3.9    4.0
+        read_nonlocal                    7.1     8.1     5.8     5.4     4.4    4.8
+        read_global                     15.5    19.0    14.3    13.6     7.6    7.7
+        read_builtin                    21.1    21.6    18.5    19.0     7.5    7.7
+        read_classvar_from_class        25.6    26.5    20.7    19.5    18.4   18.6
+        read_classvar_from_instance     22.8    23.5    18.8    17.1    16.4   20.1
+        read_instancevar                32.4    33.1    28.0    26.3    25.4   27.7
+        read_instancevar_slots          27.8    31.3    20.8    20.8    20.2   24.5
+        read_namedtuple                 73.8    57.5    45.0    46.8    18.4   23.2
+        read_boundmethod                37.6    37.9    29.6    26.9    27.7   45.9
 
     Variable and attribute write access:
-        write_local                     8.7     9.3     5.5     5.3     4.3    4.2
-        write_nonlocal                  0.5    11.1     5.6     5.5     4.7    4.9
-        write_global                    9.7    21.2    18.0    18.0    15.8   17.2
-        write_classvar                  2.9    96.0   104.6   102.1    39.2   43.2
-        write_instancevar               4.6    45.8    40.0    38.9    35.5   40.7
-        write_instancevar_slots         5.6    36.1    27.3    26.6    25.7   27.7
+        write_local                      8.7     9.3     5.5     5.3     4.3    4.2
+        write_nonlocal                  10.5    11.1     5.6     5.5     4.7    4.9
+        write_global                    19.7    21.2    18.0    18.0    15.8   17.2
+        write_classvar                  92.9    96.0   104.6   102.1    39.2   43.2
+        write_instancevar               44.6    45.8    40.0    38.9    35.5   40.7
+        write_instancevar_slots         35.6    36.1    27.3    26.6    25.7   27.7
 
     Data structure read access:
-        read_list                       4.2    24.5    20.8    20.8    19.0   21.1
-        read_deque                      4.7    25.5    20.2    20.6    19.8   21.6
-        read_dict                       4.3    25.7    22.3    23.0    21.0   22.5
-        read_strdict                    2.6    24.3    19.5    21.2    18.9   21.6
+        read_list                       24.2    24.5    20.8    20.8    19.0   21.1
+        read_deque                      24.7    25.5    20.2    20.6    19.8   21.6
+        read_dict                       24.3    25.7    22.3    23.0    21.0   22.5
+        read_strdict                    22.6    24.3    19.5    21.2    18.9   21.6
 
     Data structure write access:
-        write_list                      7.1    28.5    22.5    21.6    20.0   21.6
-        write_deque                     8.7    30.1    22.7    21.8    23.5   23.2
-        write_dict                      1.4    33.3    29.3    29.2    24.7   27.8
-        write_strdict                   8.4    29.9    27.5    25.2    23.1   29.8
+        write_list                      27.1    28.5    22.5    21.6    20.0   21.6
+        write_deque                     28.7    30.1    22.7    21.8    23.5   23.2
+        write_dict                      31.4    33.3    29.3    29.2    24.7   27.8
+        write_strdict                   28.4    29.9    27.5    25.2    23.1   29.8
 
     Stack (or queue) operations:
-        list_append_pop                13.4   112.7    75.4    74.2    50.8   53.9
-        deque_append_pop                3.5    57.0    49.4    49.2    42.5   45.5
-        deque_append_popleft            3.7    57.3    49.7    49.7    42.8   45.5
+        list_append_pop                 93.4   112.7    75.4    74.2    50.8   53.9
+        deque_append_pop                43.5    57.0    49.4    49.2    42.5   45.5
+        deque_append_popleft            43.7    57.3    49.7    49.7    42.8   45.5
 
     Timing loop:
-        loop_overhead                   0.5     0.6     0.4     0.3     0.3    0.3
+        loop_overhead                    0.5     0.6     0.4     0.3     0.3    0.3
 
 These results were generated from the variable access benchmark script at:
 ``Tools/scripts/var_access_benchmark.py``. The benchmark script displays timings


### PR DESCRIPTION
One column of digits was omitted from the table of timings

<!-- issue-number: [bpo-40725](https://bugs.python.org/issue40725) -->
https://bugs.python.org/issue40725
<!-- /issue-number -->
