### PR TITLE
bpo-40730: Remove redundant 'to'

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -605,7 +605,7 @@ Optimizations
 
      sums = [s for s in [0] for x in data for s in [s + x]]
 
-  Unlike to the ``:=`` operator this idiom does not leak a variable to the
+  Unlike the ``:=`` operator this idiom does not leak a variable to the
   outer scope.
 
   (Contributed by Serhiy Storchaka in :issue:`32856`.)


### PR DESCRIPTION
@ericvsmith I guess it is correct to merge it into master and not 3.9 directly?

<!-- issue-number: [bpo-40730](https://bugs.python.org/issue40730) -->
https://bugs.python.org/issue40730
<!-- /issue-number -->


Automerge-Triggered-By: @ericvsmith