### PR TITLE
bpo-38632: respect SOURCE_DATE_EPOCH when building .tar sdists

### DIFF
--- a/Lib/distutils/tests/test_archive_util.py
+++ b/Lib/distutils/tests/test_archive_util.py
@@ -306,6 +306,24 @@ class ArchiveUtilTestCase(support.TempdirManager,
         self.assertEqual(os.path.basename(res), 'archive.tar')
         self.assertEqual(self._tarinfo(res), self._created_files)
 
+    def test_make_archive_tar_source_date_epoch(self):
+        ORIGINAL_SDE = os.environ.get('SOURCE_DATE_EPOCH')
+        try:
+            os.environ['SOURCE_DATE_EPOCH'] = '1337'
+            base_dir =  self._create_files()
+            base_name = os.path.join(self.mkdtemp() , 'archive')
+            res = make_archive(base_name, 'tar', base_dir, 'dist')
+
+            archive = tarfile.open(res,mode='r')
+            for item in archive:
+                self.assertLessEqual(item.mtime, 1337)
+        finally:
+            archive.close()
+            if ORIGINAL_SDE is None:
+                del os.environ['SOURCE_DATE_EPOCH']
+            else:
+                os.environ['SOURCE_DATE_EPOCH'] = ORIGINAL_SDE
+
     @unittest.skipUnless(ZLIB_SUPPORT, 'Need zlib support to run')
     def test_make_archive_gztar(self):
         base_dir =  self._create_files()

--- a/Misc/NEWS.d/next/Library/2020-05-23-12-05-15.bpo-38632.nFTEqW.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-23-12-05-15.bpo-38632.nFTEqW.rst
@@ -1,0 +1,5 @@
+Partial support for ``SOURCE_DATE_EPOCH`` environment variable for sdists
+has been added in distutils. When the ``SOURCE_DATE_EPOCH`` environment
+variable is set, the ``mtime`` of the files in an sdist tar archive will not
+be later than ``SOURCE_DATE_EPOCH``. This is a firs step to simplify getting
+byte identical reproducibility of source dists.


### PR DESCRIPTION
This currently only affects .tar as compression may also add some
variability, Gzip for example adds current timestamp.

With this I am able without further modification to do reproducible
build bytes of bytes of IPython with no source code changes in IPython
itself.

Adding reproducibility to other format will need to be on a per-format
basis, which currently is tough as distutils seem to shell out to do the
compression. I can do some refactor and do in process tar and
compressing – which should be faster/more robust, but will be another
pull request.


<!-- issue-number: [bpo-38632](https://bugs.python.org/issue38632) -->
https://bugs.python.org/issue38632
<!-- /issue-number -->
