### PR TITLE
bpo-1294959: Try to clarify the meaning of platlibdir

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1141,8 +1141,7 @@ always available.
 .. data:: platlibdir
 
    Name of the platform-specific library directory. It is used to build the
-   path of platform-specific dynamic libraries and the path of the standard
-   library.
+   path of standard library and the paths of installed extension modules.
 
    It is equal to ``"lib"`` on most platforms. On Fedora and SuSE, it is equal
    to ``"lib64"`` on 64-bit platforms which gives the following ``sys.path``
@@ -1153,8 +1152,10 @@ always available.
    * ``/usr/lib64/pythonX.Y/lib-dynload/``:
      C extension modules of the standard library (like the :mod:`errno` module,
      the exact filename is platform specific)
-   * ``/usr/lib/pythonX.Y/site-packages`` (always use ``lib``, not
+   * ``/usr/lib/pythonX.Y/site-packages/`` (always use ``lib``, not
      :data:`sys.platlibdir`): Third-party modules
+   * ``/usr/lib64/pythonX.Y/site-packages/``:
+     C extension modules of third-party packages
 
    .. versionadded:: 3.9
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -552,10 +552,9 @@ sys
 ---
 
 Add a new :attr:`sys.platlibdir` attribute: name of the platform-specific
-library directory. It is used to build the path of platform-specific dynamic
-libraries and the path of the standard library. It is equal to ``"lib"`` on
-most platforms.  On Fedora and SuSE, it is equal to ``"lib64"`` on 64-bit
-platforms.
+library directory. It is used to build the path of standard library and the
+paths of installed extension modules. It is equal to ``"lib"`` on most
+platforms.  On Fedora and SuSE, it is equal to ``"lib64"`` on 64-bit platforms.
 (Contributed by Jan Matějek, Matěj Cepl, Charalampos Stratakis and Victor Stinner in :issue:`1294959`.)
 
 Previously, :attr:`sys.stderr` was block-buffered when non-interactive. Now

--- a/Misc/NEWS.d/3.9.0a5.rst
+++ b/Misc/NEWS.d/3.9.0a5.rst
@@ -990,7 +990,7 @@ modules are built.
 Add ``--with-platlibdir`` option to the configure script: name of the
 platform-specific library directory, stored in the new
 :attr:`sys.platlibdir` attribute. It is used to build the path of
-platform-specific dynamic libraries and the path of the standard library. It
+platform-specific extension modules and the path of the standard library. It
 is equal to ``"lib"`` on most platforms. On Fedora and SuSE, it is equal to
 ``"lib64"`` on 64-bit platforms. Patch by Jan Matějek, Matěj Cepl,
 Charalampos Stratakis and Victor Stinner.


### PR DESCRIPTION
Try to make the meaning of platlibdir clear.  The previous wording could
be misinterpreted to suggest that it will be used to find all shared
libraries on the system, and not just Python extensions.  Furthermore,
it was unclear whether it affects third-party (site-packages) extensions
or not.  The new wording tries to make its dual purpose clear,
and provide the additional example of extensions in site-packages.

<!-- issue-number: [bpo-1294959](https://bugs.python.org/issue1294959) -->
https://bugs.python.org/issue1294959
<!-- /issue-number -->
