### PR TITLE
bpo-40640: Tutorial for Continue missing ... line

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -211,6 +211,7 @@ iteration of the loop::
     ...         print("Found an even number", num)
     ...         continue
     ...     print("Found a number", num)
+    ...
     Found an even number 2
     Found a number 3
     Found an even number 4


### PR DESCRIPTION
In the even/not-even example for Continue, the results appear to
start without the "for" loop having been closed by entering a
return with no input. Add the return, designated by ... with no
following text.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40640](https://bugs.python.org/issue40640) -->
https://bugs.python.org/issue40640
<!-- /issue-number -->
