### PR TITLE
bpo-37129: Add os.RWF_APPEND flag for os.pwritev

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9778,6 +9778,7 @@ The flags argument contains a bitwise OR of zero or more of the following flags:
 
 - RWF_DSYNC
 - RWF_SYNC
+- RWF_APPEND
 
 Using non-zero flags requires Linux 4.7 or newer.
 [clinic start generated code]*/
@@ -14513,6 +14514,9 @@ all_ins(PyObject *m)
 #endif
 #ifdef RWF_NOWAIT
     if (PyModule_AddIntConstant(m, "RWF_NOWAIT", RWF_NOWAIT)) return -1;
+#endif
+#ifdef RWF_APPEND
+    if (PyModule_AddIntConstant(m, "RWF_APPEND", RWF_APPEND)) return -1;
 #endif
 
 /* constants for posix_spawn */


### PR DESCRIPTION
Recreating https://bugs.python.org/issue37129

<!-- issue-number: [bpo-37129](https://bugs.python.org/issue37129) -->
https://bugs.python.org/issue37129
<!-- /issue-number -->
