### PR TITLE
Fix compiler warnings in _zoneinfo.c

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -36,8 +36,8 @@ typedef struct {
     PyObject *key;
     PyObject *file_repr;
     PyObject *weakreflist;
-    unsigned int num_transitions;
-    unsigned int num_ttinfos;
+    size_t num_transitions;
+    size_t num_ttinfos;
     int64_t *trans_list_utc;
     int64_t *trans_list_wall[2];
     _ttinfo **trans_ttinfos;  // References to the ttinfo for each transition
@@ -900,15 +900,15 @@ load_data(PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
         goto error;
     }
 
-    self->num_transitions = (size_t)num_transitions;
-    self->num_ttinfos = (size_t)num_ttinfos;
+    self->num_transitions = num_transitions;
+    self->num_ttinfos = num_ttinfos;
 
     // Load the transition indices and list
     self->trans_list_utc =
         PyMem_Malloc(self->num_transitions * sizeof(int64_t));
     trans_idx = PyMem_Malloc(self->num_transitions * sizeof(Py_ssize_t));
 
-    for (Py_ssize_t i = 0; i < self->num_transitions; ++i) {
+    for (size_t i = 0; i < self->num_transitions; ++i) {
         PyObject *num = PyTuple_GetItem(trans_utc, i);
         if (num == NULL) {
             goto error;
@@ -946,7 +946,7 @@ load_data(PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     if (utcoff == NULL || isdst == NULL) {
         goto error;
     }
-    for (Py_ssize_t i = 0; i < self->num_ttinfos; ++i) {
+    for (size_t i = 0; i < self->num_ttinfos; ++i) {
         PyObject *num = PyTuple_GetItem(utcoff_list, i);
         if (num == NULL) {
             goto error;
@@ -1737,13 +1737,13 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
     //   3. Mm.n.d: Specifying by month, week and day-of-week.
 
     if (*ptr == 'M') {
-        uint8_t month, week, day;
+        ssize_t month, week, day;
         ptr++;
         ssize_t tmp = parse_uint(ptr);
         if (tmp < 0) {
             return -1;
         }
-        month = (uint8_t)tmp;
+        month = tmp;
         ptr++;
         if (*ptr != '.') {
             tmp = parse_uint(ptr);
@@ -1756,7 +1756,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
             ptr++;
         }
 
-        uint8_t *values[2] = {&week, &day};
+        ssize_t *values[2] = {&week, &day};
         for (size_t i = 0; i < 2; ++i) {
             if (*ptr != '.') {
                 return -1;

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -117,14 +117,14 @@ ts_to_local(size_t *trans_idx, int64_t *trans_utc, long *utcoff,
 static int
 parse_tz_str(PyObject *tz_str_obj, _tzrule *out);
 
-static ssize_t
+static Py_ssize_t
 parse_abbr(const char *const p, PyObject **abbr);
-static ssize_t
+static Py_ssize_t
 parse_tz_delta(const char *const p, long *total_seconds);
-static ssize_t
+static Py_ssize_t
 parse_transition_time(const char *const p, int8_t *hour, int8_t *minute,
                       int8_t *second);
-static ssize_t
+static Py_ssize_t
 parse_transition_rule(const char *const p, TransitionRuleType **out);
 
 static _ttinfo *
@@ -1468,7 +1468,7 @@ parse_tz_str(PyObject *tz_str_obj, _tzrule *out)
     char *p = tz_str;
 
     // Read the `std` abbreviation, which must be at least 3 characters long.
-    ssize_t num_chars = parse_abbr(p, &std_abbr);
+    Py_ssize_t num_chars = parse_abbr(p, &std_abbr);
     if (num_chars < 1) {
         PyErr_Format(PyExc_ValueError, "Invalid STD format in %R", tz_str_obj);
         goto error;
@@ -1565,7 +1565,7 @@ error:
     return -1;
 }
 
-static ssize_t
+static Py_ssize_t
 parse_uint(const char *const p)
 {
     if (!isdigit(*p)) {
@@ -1576,7 +1576,7 @@ parse_uint(const char *const p)
 }
 
 /* Parse the STD and DST abbreviations from a TZ string. */
-static ssize_t
+static Py_ssize_t
 parse_abbr(const char *const p, PyObject **abbr)
 {
     const char *ptr = p;
@@ -1629,7 +1629,7 @@ parse_abbr(const char *const p, PyObject **abbr)
 }
 
 /* Parse a UTC offset from a TZ str. */
-static ssize_t
+static Py_ssize_t
 parse_tz_delta(const char *const p, long *total_seconds)
 {
     // From the POSIX spec:
@@ -1712,7 +1712,7 @@ complete:
 }
 
 /* Parse the date portion of a transition rule. */
-static ssize_t
+static Py_ssize_t
 parse_transition_rule(const char *const p, TransitionRuleType **out)
 {
     // The full transition rule indicates when to change back and forth between
@@ -1737,9 +1737,9 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
     //   3. Mm.n.d: Specifying by month, week and day-of-week.
 
     if (*ptr == 'M') {
-        ssize_t month, week, day;
+        Py_ssize_t month, week, day;
         ptr++;
-        ssize_t tmp = parse_uint(ptr);
+        Py_ssize_t tmp = parse_uint(ptr);
         if (tmp < 0) {
             return -1;
         }
@@ -1756,7 +1756,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
             ptr++;
         }
 
-        ssize_t *values[2] = {&week, &day};
+        Py_ssize_t *values[2] = {&week, &day};
         for (size_t i = 0; i < 2; ++i) {
             if (*ptr != '.') {
                 return -1;
@@ -1774,7 +1774,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
 
         if (*ptr == '/') {
             ptr++;
-            ssize_t num_chars =
+            Py_ssize_t num_chars =
                 parse_transition_time(ptr, &hour, &minute, &second);
             if (num_chars < 0) {
                 return -1;
@@ -1816,7 +1816,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
 
         if (*ptr == '/') {
             ptr++;
-            ssize_t num_chars =
+            Py_ssize_t num_chars =
                 parse_transition_time(ptr, &hour, &minute, &second);
             if (num_chars < 0) {
                 return -1;
@@ -1840,7 +1840,7 @@ parse_transition_rule(const char *const p, TransitionRuleType **out)
 }
 
 /* Parse the time portion of a transition rule (e.g. following an /) */
-static ssize_t
+static Py_ssize_t
 parse_transition_time(const char *const p, int8_t *hour, int8_t *minute,
                       int8_t *second)
 {


### PR DESCRIPTION
```
D:\a\cpython\cpython\Modules\_zoneinfo.c(903,52): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [D:\a\cpython\cpython\PCbuild\_zoneinfo.vcxproj]
D:\a\cpython\cpython\Modules\_zoneinfo.c(904,44): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data [D:\a\cpython\cpython\PCbuild\_zoneinfo.vcxproj]
D:\a\cpython\cpython\Modules\_zoneinfo.c(1772,31): warning C4244: '=': conversion from 'ssize_t' to 'uint8_t', possible loss of data [D:\a\cpython\cpython\PCbuild\_zoneinfo.vcxproj]
```