### PR TITLE
Fixed syntax error in asyncio/queues.py

### DIFF
--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -71,7 +71,7 @@ class Queue:
                 break
 
     def __repr__(self):
-        return f'<{type(self).__name__} at {id(self):#x} {self._format()}>'
+        return f'<{type(self).__name__} at {id(self)} - {self._format()}>'
 
     def __str__(self):
         return f'<{type(self).__name__} {self._format()}>'


### PR DESCRIPTION
There was a small syntax error in queues.py pushed in commit [6370f345e1d5829e1fba59cd695c8b82c5a8c620](https://github.com/python/cpython/commit/6370f345e1d5829e1fba59cd695c8b82c5a8c620).