### PR TITLE
bpo-39301: State that floor division is used for right shift operations

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -434,12 +434,10 @@ Notes:
    Negative shift counts are illegal and cause a :exc:`ValueError` to be raised.
 
 (2)
-   A left shift by *n* bits is equivalent to multiplication by ``pow(2, n)``
-   without overflow check.
+   A left shift by *n* bits is equivalent to multiplication by ``pow(2, n)``.
 
 (3)
-   A right shift by *n* bits is equivalent to floor division by ``pow(2, n)``
-   without overflow check.
+   A right shift by *n* bits is equivalent to floor division by ``pow(2, n)``.
 
 (4)
    Performing these calculations with at least one extra sign extension bit in

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -438,8 +438,8 @@ Notes:
    without overflow check.
 
 (3)
-   A right shift by *n* bits is equivalent to division by ``pow(2, n)`` without
-   overflow check.
+   A right shift by *n* bits is equivalent to floor division by ``pow(2, n)``
+   without overflow check.
 
 (4)
    Performing these calculations with at least one extra sign extension bit in


### PR DESCRIPTION


<!-- issue-number: [bpo-39301](https://bugs.python.org/issue39301) -->
https://bugs.python.org/issue39301
<!-- /issue-number -->
