### PR TITLE
bpo-40752: Implement PurePath.__len__

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1020,6 +1020,10 @@ class PurePath(object):
                 return False
         return True
 
+    def __len__(self):
+        return len(str(self))
+
+
 # Can't subclass os.PathLike from PurePath and keep the constructor
 # optimizations in PurePath._parse_args().
 os.PathLike.register(PurePath)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2300,6 +2300,14 @@ class _BasePathTest(object):
     def test_complex_symlinks_relative_dot_dot(self):
         self._check_complex_symlinks(os.path.join('dirA', '..'))
 
+    def test_len(self):
+        p = self.cls(BASE)
+        assert len(p) == len(str(p))
+        assert len(p / 'foofoo') == len(p) + 7
+
+
+
+
 
 class PathTest(_BasePathTest, unittest.TestCase):
     cls = pathlib.Path

--- a/Misc/NEWS.d/next/Library/2020-05-24-11-06-44.bpo-40752.y3Kyrq.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-24-11-06-44.bpo-40752.y3Kyrq.rst
@@ -1,0 +1,1 @@
+Implement :meth:`PurePath.__len__`.


### PR DESCRIPTION
Today I wrote a script and did this: 

```python
sorted(paths, key=lambda path: len(str(path)), reverse=True)
```

But it would have been nicer if I could do this: 

```python
sorted(paths, key=len, reverse=True)
```

So I implemented `PurePath.__len__`.

<!-- issue-number: [bpo-40752](https://bugs.python.org/issue40752) -->
https://bugs.python.org/issue40752
<!-- /issue-number -->
