### PR TITLE
bpo-40753: Remove Python 2 compatibility code from pathlib

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -53,7 +53,7 @@ def _is_wildcard_pattern(pat):
     return "*" in pat or "?" in pat or "[" in pat
 
 
-class _Flavour(object):
+class _Flavour:
     """A flavour implements a particular (platform-specific) set of path
     semantics."""
 
@@ -636,7 +636,7 @@ class _PathParents(Sequence):
         return "<{}.parents>".format(self._pathcls.__name__)
 
 
-class PurePath(object):
+class PurePath:
     """Base class for manipulating paths without I/O.
 
     PurePath represents a filesystem path and offers operations which

--- a/Misc/NEWS.d/next/Library/2020-05-24-11-52-26.bpo-40753.B4M24P.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-24-11-52-26.bpo-40753.B4M24P.rst
@@ -1,0 +1,1 @@
+Remove Python 2 compatibility code from :mod:`pathlib`.


### PR DESCRIPTION
No need to inherit from object anymore.

<!-- issue-number: [bpo-40753](https://bugs.python.org/issue40753) -->
https://bugs.python.org/issue40753
<!-- /issue-number -->
