### PR TITLE
bpo-40756: Default second argument of LoggerAdapter.__init__ to None

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1751,7 +1751,7 @@ class LoggerAdapter(object):
     information in logging output.
     """
 
-    def __init__(self, logger, extra):
+    def __init__(self, logger, extra=None):
         """
         Initialize the adapter with a logger and a dict-like object which
         provides contextual information. This constructor signature allows

--- a/Misc/NEWS.d/next/Library/2020-05-24-11-06-37.bpo-40756.7ZH83z.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-24-11-06-37.bpo-40756.7ZH83z.rst
@@ -1,0 +1,2 @@
+The second argument (extra) of ``LoggerAdapter.__init__`` now defaults to
+None.


### PR DESCRIPTION
The 'extra' argument is not always used by custom logger adapters. For
example:

```python
class IndentAdapter(logging.LoggerAdapter):
    def process(self, msg, kwargs):
        indent = kwargs.pop(indent, 1)
        return ' ' * indent + msg, kwargs
```

It is cleaner and friendlier to default the 'extra' argument to None
instead of either forcing the subclasses of LoggerAdapter to pass a None
value directly or to override the constructor.

This change is backward compatible because existing calls to
`LoggerAdapter.__init__` are already passing a value for the second
argument.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40756](https://bugs.python.org/issue40756) -->
https://bugs.python.org/issue40756
<!-- /issue-number -->


Automerge-Triggered-By: @vsajip