### PR TITLE
bpo-40334: Support suppressing of multiple optional variables in Pegen

### DIFF
--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -694,8 +694,8 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
                 if v == "_cut_var":
                     v += " = 0"  # cut_var must be initialized
                 self.print(f"{var_type}{v};")
-                if v == "_opt_var":
-                    self.print("UNUSED(_opt_var); // Silence compiler warnings")
+                if v.startswith("_opt_var"):
+                    self.print(f"UNUSED({v}); // Silence compiler warnings")
 
             with self.local_variable_context():
                 if is_loop:


### PR DESCRIPTION
C generator would produce `_opt_var_1`, `_opt_var_2` etc. for multiple optional variables in the same context. This patch makes the C generator to support multiple optional variables.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
