### PR TITLE
bpo-30064: Fix asyncio loop.sock_* race condition issue

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-05-25-11-52-23.bpo-30064.6CICsH.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-25-11-52-23.bpo-30064.6CICsH.rst
@@ -1,0 +1,1 @@
+Fix asyncio ``loop.sock_*`` race condition issue


### PR DESCRIPTION
<!-- issue-number: [bpo-30064](https://bugs.python.org/issue30064) -->
https://bugs.python.org/issue30064
<!-- /issue-number -->

This is reproducible by a `cancel()` followed directly by a retry:

```python
done, pending = await asyncio.wait([loop.sock_recv(sock, 1024)], timeout=0.1)
if done:
    data = await done.pop()
else:
    pending.pop().cancel()
    data = await loop.sock_recv(sock, 1024)
```

This issue applies to all the `loop.sock_*` methods. Without this PR, users could work it around by adding a `sleep(0)`:

```python
done, pending = await asyncio.wait([loop.sock_recv(sock, 1024)], timeout=0.1)
if done:
    data = await done.pop()
else:
    pending.pop().cancel()
    await asyncio.sleep(0)  # <---- this ensures that the right reader is removed
    data = await loop.sock_recv(sock, 1024)
```
