### PR TITLE
bpo-40762: Fix writing bytes in csv

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -434,9 +434,10 @@ Writer Objects
 
 :class:`Writer` objects (:class:`DictWriter` instances and objects returned by
 the :func:`writer` function) have the following public methods.  A *row* must be
-an iterable of strings or numbers for :class:`Writer` objects and a dictionary
-mapping fieldnames to strings or numbers (by passing them through :func:`str`
-first) for :class:`DictWriter` objects.  Note that complex numbers are written
+an iterable of strings, numbers or bytes for :class:`Writer` objects and a dictionary
+mapping fieldnames to strings, numbers or bytes (by passing them through :func:`str`
+first) for :class:`DictWriter` objects. Note that bytes will be written according to
+the encoding scheme of the output file. Also note that complex numbers are written
 out surrounded by parens. This may cause some problems for other programs which
 read CSV files (assuming they support complex numbers at all).
 

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -230,6 +230,13 @@ class Test_Csv(unittest.TestCase):
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), 'a\r\n""\r\n')
 
+    def test_writerows_with_bytes(self):
+        with TemporaryFile("w+", newline='', encoding='iso-8859-1') as fileobj:
+            writer = csv.writer(fileobj)
+            writer.writerows([['a', b'\xc2'], [b'\xc2', 'c']])
+            fileobj.seek(0);
+            self.assertEqual(fileobj.read(), 'a,\xc2\r\n\xc2,c\r\n')
+
     @support.cpython_only
     def test_writerows_legacy_strings(self):
         import _testcapi

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -231,11 +231,16 @@ class Test_Csv(unittest.TestCase):
             self.assertEqual(fileobj.read(), 'a\r\n""\r\n')
 
     def test_writerows_with_bytes(self):
-        with TemporaryFile("w+", newline='', encoding='iso-8859-1') as fileobj:
+        with TemporaryFile("w+", newline='', encoding='latin-1') as fileobj:
             writer = csv.writer(fileobj)
             writer.writerows([['a', b'\xc2'], [b'\xc2', 'c']])
             fileobj.seek(0);
             self.assertEqual(fileobj.read(), 'a,\xc2\r\n\xc2,c\r\n')
+
+        with TemporaryFile("w+", newline='', encoding='utf-8') as fileobj:
+            writer = csv.writer(fileobj)
+            self.assertRaises(UnicodeDecodeError, writer.writerows, [['a', b'\xc2'], ['a', 'c']])
+
 
     @support.cpython_only
     def test_writerows_legacy_strings(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-25-07-25-29.bpo-40762.TkMFHk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-25-07-25-29.bpo-40762.TkMFHk.rst
@@ -1,0 +1,1 @@
+csv.Writer.writerow() now supports writing bytes as it is instead of writing them as b-prefixed strings. Uses encoding provided by the file object to write the bytes in the text mode. Incase the file object has no encoding attribute it falls back on using ``locale.getpreferredencoding`` to decide.


### PR DESCRIPTION
Changes how bytes are written in csv. Changes writing bytes as strings to writing them as bytes.

Ex. 
```
import csv
with open("abc.csv", "w", encoding="utf-8") as f:
   data = [b'A', b'A']
   w = csv.writer(f)
   w.writerow(data)
```
This code currently writes `b'A',b'A'` in `abc.csv`, i.e the b-prefixed string instead of the actual bytes, whereas the natural expectation is for the actual bytes to be written (i.e `A,A`) in `utf-8` or whatever encoding is specified in `open`. 

This un-natural behaviour has been covered in this [Pandas issue](https://github.com/pandas-dev/pandas/issues/9712) also.

<!-- issue-number: [bpo-40762](https://bugs.python.org/issue40762) -->
https://bugs.python.org/issue40762
<!-- /issue-number -->
