### PR TITLE
bpo-40767: Allow pure Wayland to get default XDG web browser

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -545,7 +545,7 @@ def register_standard_browsers():
                 register(browser, None, BackgroundBrowser(browser))
     else:
         # Prefer X browsers if present
-        if os.environ.get("DISPLAY"):
+        if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
             try:
                 cmd = "xdg-settings get default-web-browser".split()
                 raw_result = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)

--- a/Misc/NEWS.d/next/Library/2020-05-27-21-27-01.bpo-40767.L5MnVV.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-27-21-27-01.bpo-40767.L5MnVV.rst
@@ -1,0 +1,3 @@
+:mod:`webbrowser` now properly finds the default browser in pure Wayland
+systems by checking the WAYLAND_DISPLAY environment variable. Patch
+contributed by Jérémy Attali.


### PR DESCRIPTION
Would be nice to backport to python 3.7+. I don't think it's worth the hassle to backport this all the way down to 3.10. But I'll let the maintainers decide.

This is hard to test because the test setup already includes this [environment variable](https://github.com/python/cpython/blob/master/Lib/test/pythoninfo.py#L292)

Let me know if something doesn't match the PR guidelines. This is my first PR in the python source code.

<!-- issue-number: [bpo-40767](https://bugs.python.org/issue40767) -->
https://bugs.python.org/issue40767
<!-- /issue-number -->


Automerge-Triggered-By: @orsenthil