### PR TITLE
[WIP] bpo-39465: Mark _Py_Identifier.object as atomic

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -45,7 +45,10 @@ PyAPI_FUNC(Py_ssize_t) _Py_GetRefTotal(void);
 typedef struct _Py_Identifier {
     struct _Py_Identifier *next;
     const char* string;
-    PyObject *object;
+    // bpo-39465: _PyUnicode_FromId() can be called by multiple threads
+    // running in different interpreters. Use an atomic variable rather
+    // than a lock for better parallelism.
+    _Atomic PyObject *object;
 } _Py_Identifier;
 
 #define _Py_static_string_init(value) { .next = NULL, .string = value, .object = NULL }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2275,18 +2275,24 @@ PyUnicode_FromString(const char *u)
 PyObject *
 _PyUnicode_FromId(_Py_Identifier *id)
 {
-    if (!id->object) {
-        id->object = PyUnicode_DecodeUTF8Stateful(id->string,
-                                                  strlen(id->string),
-                                                  NULL, NULL);
-        if (!id->object)
-            return NULL;
-        PyUnicode_InternInPlace(&id->object);
-        assert(!id->next);
-        id->next = static_strings;
-        static_strings = id;
+    if (id->object) {
+        return (PyObject *)id->object;
     }
-    return id->object;
+
+    PyObject *object;
+    object = PyUnicode_DecodeUTF8Stateful(id->string,
+                                          strlen(id->string),
+                                          NULL, NULL);
+    if (!object) {
+        return NULL;
+    }
+
+    PyUnicode_InternInPlace(&object);
+    id->object = (_Atomic PyObject *)object;
+    assert(!id->next);
+    id->next = static_strings;
+    static_strings = id;
+    return object;
 }
 
 static void


### PR DESCRIPTION
This PR is basically a test to check if C compilers used by CPython
support C11 _Atomic specifier.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39465](https://bugs.python.org/issue39465) -->
https://bugs.python.org/issue39465
<!-- /issue-number -->
