### PR TITLE
bpo-38964: Print correct filename on a SyntaxError in an fstring

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1051,11 +1051,11 @@ non-important content
     def test_filename_in_syntaxerror(self):
         # see issue 38964
         with temp_cwd() as cwd:
-            filename = os.path.join(cwd, 't.py')
-            with open(filename, 'w') as f:
+            file_path = os.path.join(cwd, 't.py')
+            with open(file_path, 'w') as f:
                 f.write('f"{a b}"') # This generates a SyntaxError
-            _, _, stderr = assert_python_failure(filename)
-        self.assertIn(filename, stderr.decode('utf-8'))
+            _, _, stderr = assert_python_failure(file_path)
+        self.assertIn(file_path, stderr.decode('utf-8'))
 
     def test_loop(self):
         for i in range(1000):

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -8,9 +8,12 @@
 # Unicode identifiers in tests is allowed by PEP 3131.
 
 import ast
+import os
 import types
 import decimal
 import unittest
+from test.support import temp_cwd
+from test.support.script_helper import assert_python_failure
 
 a_global = 'global variable'
 
@@ -1043,6 +1046,15 @@ non-important content
                             [r"f'{1000:j}'",
                              r"f'{1000:j}'",
                             ])
+
+    def test_filename_in_syntaxerror(self):
+        # see issue 38964
+        with temp_cwd() as cwd:
+            filename = os.path.join(cwd, 't.py')
+            with open(filename, 'w') as f:
+                f.write('f"{a b}"') # This generates a SyntaxError
+            _, _, stderr = assert_python_failure(filename)
+        self.assertIn(filename, stderr.decode('utf-8'))
 
     def test_loop(self):
         for i in range(1000):

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -12,7 +12,7 @@ import os
 import types
 import decimal
 import unittest
-from test.support import temp_cwd
+from test.support import temp_cwd, use_old_parser
 from test.support.script_helper import assert_python_failure
 
 a_global = 'global variable'
@@ -1047,6 +1047,7 @@ non-important content
                              r"f'{1000:j}'",
                             ])
 
+    @unittest.skipIf(use_old_parser(), "This is not supported by the old parser")
     def test_filename_in_syntaxerror(self):
         # see issue 38964
         with temp_cwd() as cwd:

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1047,7 +1047,7 @@ non-important content
                              r"f'{1000:j}'",
                             ])
 
-    @unittest.skipIf(use_old_parser(), "This is not supported by the old parser")
+    @unittest.skipIf(use_old_parser(), "The old parser only supports <fstring> as the filename")
     def test_filename_in_syntaxerror(self):
         # see issue 38964
         with temp_cwd() as cwd:

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-25-21-49-11.bpo-38964.lrml90.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-25-21-49-11.bpo-38964.lrml90.rst
@@ -1,0 +1,1 @@
+When there's a :exc:`SyntaxError` in the expression part of an fstring, the filename attribute of the :exc:`SyntaxError` gets correctly set to the name of the file the fstring resides in.

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -606,11 +606,8 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
     if (tok == NULL) {
         return NULL;
     }
-    tok->filename = PyUnicode_FromString("<fstring>");
-    if (!tok->filename) {
-        PyTokenizer_Free(tok);
-        return NULL;
-    }
+    Py_INCREF(p->tok->filename);
+    tok->filename = p->tok->filename;
 
     Parser *p2 = _PyPegen_Parser_New(tok, Py_fstring_input, p->flags, p->feature_version,
                                      NULL, p->arena);


### PR DESCRIPTION
When a `SyntaxError` in the expression part of an fstring is found,
the filename attribute of the `SyntaxError` is always `<fstring>`.
With this PR it gets changed to always have the name of the file
the fstring resides in.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38964](https://bugs.python.org/issue38964) -->
https://bugs.python.org/issue38964
<!-- /issue-number -->
