### PR TITLE
bpo-5846: Deprecate obsolete methods makeSuite, findTestCases, and getTestCaseNames in unittest

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1830,6 +1830,9 @@ Loading and running tests
       Return a sorted sequence of method names found within *testCaseClass*;
       this should be a subclass of :class:`TestCase`.
 
+      .. deprecated:: 3.10
+         Scheduled for removal in Python 3.12.
+
 
    .. method:: discover(start_dir, pattern='test*.py', top_level_dir=None)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -365,6 +365,10 @@ Deprecated
   scheduled for removal in Python 3.12.
   (Contributed by Erlend E. Aasland in :issue:`42264`.)
 
+* :meth:`unittest.makeSuite`, :meth:`unittest.findTestCases`, and :meth:`unittest.getTestCaseNames`
+  are now deprecated, scheduled for removal in Python 3.12.
+  (Contributed by Erlend E. Aasland in :issue:`5846`.)
+
 
 Removed
 =======

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1077,7 +1077,7 @@ def run_unittest(*classes):
         elif isinstance(cls, valid_types):
             suite.addTest(cls)
         else:
-            suite.addTest(unittest.makeSuite(cls))
+            suite.addTest(unittest.TestLoader().loadTestsFromTestCase(cls))
     _filter_suite(suite, match_test)
     _run_suite(suite)
 

--- a/Lib/unittest/__init__.py
+++ b/Lib/unittest/__init__.py
@@ -52,6 +52,7 @@ __all__ = ['TestResult', 'TestCase', 'IsolatedAsyncioTestCase', 'TestSuite',
            'addModuleCleanup']
 
 # Expose obsolete functions for backwards compatibility
+# Issue 5846: Deprecated in Python 3.10, scheduled for removal in Python 3.12.
 __all__.extend(['getTestCaseNames', 'makeSuite', 'findTestCases'])
 
 __unittest = True

--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -503,15 +503,31 @@ def _makeLoader(prefix, sortUsing, suiteClass=None, testNamePatterns=None):
         loader.suiteClass = suiteClass
     return loader
 
+# Issue 5846: getTestCaseNames, makeSuite, and findTestCases are deprecated as
+#             of Python 3.10, scheduled for removal in Python 3.12.
 def getTestCaseNames(testCaseClass, prefix, sortUsing=util.three_way_cmp, testNamePatterns=None):
+    warnings.warn(
+        "getTestCaseNames() is deprecated and will be removed in Python 3.12.",
+        DeprecationWarning, stacklevel=2
+    )
     return _makeLoader(prefix, sortUsing, testNamePatterns=testNamePatterns).getTestCaseNames(testCaseClass)
 
 def makeSuite(testCaseClass, prefix='test', sortUsing=util.three_way_cmp,
               suiteClass=suite.TestSuite):
+    warnings.warn(
+        "makeSuite() is deprecated and will be removed in Python 3.12. "
+        "Please use loadTestsFromTestCase() instead.",
+        DeprecationWarning, stacklevel=2
+    )
     return _makeLoader(prefix, sortUsing, suiteClass).loadTestsFromTestCase(
         testCaseClass)
 
 def findTestCases(module, prefix='test', sortUsing=util.three_way_cmp,
                   suiteClass=suite.TestSuite):
+    warnings.warn(
+        "findTestCases() is deprecated and will be removed in Python 3.12. "
+        "Please use loadTestsFromModule() instead.",
+        DeprecationWarning, stacklevel=2
+    )
     return _makeLoader(prefix, sortUsing, suiteClass).loadTestsFromModule(\
         module)

--- a/Misc/NEWS.d/next/Library/2020-05-25-23-58-29.bpo-5846.O9BIfm.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-25-23-58-29.bpo-5846.O9BIfm.rst
@@ -1,0 +1,4 @@
+:meth:`unittest.findTestCases`, :meth:`unittest.makeSuite`, and
+:meth:`unittest.getTestCaseNames` are now deprecated, scheduled for removal in
+Python 3.12.
+Patch by Erlend E. Aasland.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-5846](https://bugs.python.org/issue5846) -->
https://bugs.python.org/issue5846
<!-- /issue-number -->
