### PR TITLE
[3.9] bpo-40246: Fix test_fstring when run with the old parser

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -11,6 +11,7 @@ import ast
 import types
 import decimal
 import unittest
+from test.support import use_old_parser
 
 a_global = 'global variable'
 
@@ -864,7 +865,12 @@ non-important content
                              "Bf''",
                              "BF''",]
         double_quote_cases = [case.replace("'", '"') for case in single_quote_cases]
-        self.assertAllRaise(SyntaxError, 'unexpected EOF while parsing',
+        error_msg = (
+            'invalid syntax'
+            if use_old_parser()
+            else 'unexpected EOF while parsing'
+        )
+        self.assertAllRaise(SyntaxError, error_msg,
                             single_quote_cases + double_quote_cases)
 
     def test_leading_trailing_spaces(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40246](https://bugs.python.org/issue40246) -->
https://bugs.python.org/issue40246
<!-- /issue-number -->
