### PR TITLE
Fix peg_generator compiler warnings under MSVC

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -32,10 +32,6 @@
                || c == '_'\
                || (c >= 128))
 
-extern char *PyOS_Readline(FILE *, FILE *, const char *);
-/* Return malloc'ed string including trailing \n;
-   empty malloc'ed string for EOF;
-   NULL if interrupted */
 
 /* Don't ever change this -- it would break the portability of Python code */
 #define TABSIZE 8

--- a/Tools/peg_generator/peg_extension/peg_extension.c
+++ b/Tools/peg_generator/peg_extension/peg_extension.c
@@ -96,21 +96,21 @@ error:
 }
 
 static PyObject *
-clear_memo_stats()
+clear_memo_stats(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
 {
     _PyPegen_clear_memo_statistics();
     Py_RETURN_NONE;
 }
 
 static PyObject *
-get_memo_stats()
+get_memo_stats(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
 {
     return _PyPegen_get_memo_statistics();
 }
 
 // TODO: Write to Python's sys.stdout instead of C's stdout.
 static PyObject *
-dump_memo_stats()
+dump_memo_stats(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
 {
     PyObject *list = _PyPegen_get_memo_statistics();
     if (list == NULL) {
@@ -124,7 +124,7 @@ dump_memo_stats()
             break;
         }
         if (count > 0) {
-            printf("%4ld %9ld\n", i, count);
+            printf("%4zd %9ld\n", i, count);
         }
     }
     Py_DECREF(list);


### PR DESCRIPTION
This fixes the following warnings:

```
Tools\peg_generator\peg_extension\peg_extension.c(127): warning C4477: 'printf' : format string '%4ld' requires an argument of type 'long', but variadic argument 1 has type 'Py_ssize_t'
Tools\peg_generator\peg_extension\peg_extension.c(137): warning C4113: 'PyObject *(__cdecl *)()' differs in parameter lists from 'PyCFunction'
Tools\peg_generator\peg_extension\peg_extension.c(138): warning C4113: 'PyObject *(__cdecl *)()' differs in parameter lists from 'PyCFunction'
Tools\peg_generator\peg_extension\peg_extension.c(139): warning C4113: 'PyObject *(__cdecl *)()' differs in parameter lists from 'PyCFunction'

Parser\tokenizer.c(35): warning C4273: 'PyOS_Readline': inconsistent dll linkage
include\pythonrun.h(184): note: see previous definition of 'PyOS_Readline'
```

The changes to `peg_extension.c` are pretty simple.

----

For the tokenizer.c change, looking through the blame, it looks like `PyOS_Readline` was extern'd so it could be included in both the old C `pgen` executable and the interpreter:

* When it was added: https://github.com/python/cpython/commit/f4b1a64a215443ac839c1453b1233860bccfdee6
* Before Pablo removed the C version of `pgen` in [bpo-35808](https://bugs.python.org/issue35808), we still used to link with `tokenizer.o` and `myreadline.o`: https://github.com/python/cpython/blob/3.7/Makefile.pre.in#L311)

Unfortunately right now this causes a warning due when building the `peg_generator` module since it uses tokenizer.c as a source file. This causes a mismatch between the extern'd `PyOS_Readline` and the `PyAPI_FUNC`'d version of the functions. 

Since we're building an extension, this causes [pyport.h to set the function as a `__declspec(dllimport)`](https://github.com/python/cpython/blob/master/Include/pyport.h#L657-L672) which doesn't match the extern definition without the import declaration. See the page on the warning for more details: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4273?view=vs-2019

As far as I know, the only supported way of using tokenizer.c is with a Python runtime (since the `#ifndef PGEN` guards were removed) so this extern should be safe to remove now.