### PR TITLE
[3.8] bpo-35714: Reject null characters in struct format strings (GH-16928)

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -652,7 +652,6 @@ class StructTest(unittest.TestCase):
         s2 = struct.Struct(s.format.encode())
         self.assertEqual(s2.format, s.format)
 
-
     def test_issue35714(self):
         # Embedded null characters should not be allowed in format strings.
         for s in '\0', '2\0i', b'\0':

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -653,6 +653,14 @@ class StructTest(unittest.TestCase):
         self.assertEqual(s2.format, s.format)
 
 
+    def test_issue35714(self):
+        # Embedded null characters should not be allowed in format strings.
+        for s in '\0', '2\0i', b'\0':
+            with self.assertRaisesRegex(struct.error,
+                                        'embedded null character'):
+                struct.calcsize(s)
+
+
 class UnpackIteratorTest(unittest.TestCase):
     """
     Tests for iterative unpacking (struct.Struct.iter_unpack).

--- a/Misc/NEWS.d/next/Library/2019-10-25-23-45-49.bpo-35714.fw3xb7.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-25-23-45-49.bpo-35714.fw3xb7.rst
@@ -1,0 +1,2 @@
+:exc:`struct.error` is now raised if there is a null character in a
+:mod:`struct` format string.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1285,6 +1285,11 @@ prepare_s(PyStructObject *self)
     size_t ncodes;
 
     fmt = PyBytes_AS_STRING(self->s_format);
+    if (strlen(fmt) != (size_t)PyBytes_GET_SIZE(self->s_format)) {
+        PyErr_SetString(_structmodulestate_global->StructError,
+                        "embedded null character");
+        return -1;
+    }
 
     f = whichtable(&fmt);
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1286,8 +1286,7 @@ prepare_s(PyStructObject *self)
 
     fmt = PyBytes_AS_STRING(self->s_format);
     if (strlen(fmt) != (size_t)PyBytes_GET_SIZE(self->s_format)) {
-        PyErr_SetString(_structmodulestate_global->StructError,
-                        "embedded null character");
+        PyErr_SetString(StructError, "embedded null character");
         return -1;
     }
 


### PR DESCRIPTION
struct.error is now raised if there is a null character in a struct
format string.
(cherry picked from commit 3f59b55)

<!-- issue-number: [bpo-35714](https://bugs.python.org/issue35714) -->
https://bugs.python.org/issue35714
<!-- /issue-number -->
