### PR TITLE
Fix the link to ncurses patch download in macos installer build script

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -302,7 +302,7 @@ def library_recipes():
                   "--libdir=/Library/Frameworks/Python.framework/Versions/%s/lib"%(getVersion(),),
               ],
               patchscripts=[
-                  ("ftp://invisible-island.net/ncurses//5.9/ncurses-5.9-20120616-patch.sh.bz2",
+                  ("ftp://ftp.invisible-island.net/ncurses//5.9/ncurses-5.9-20120616-patch.sh.bz2",
                    "f54bf02a349f96a7c4f0d00922f3a0d4"),
                    ],
               useLDFlags=False,


### PR DESCRIPTION
Reason: the link `ftp://invisible-island.net/ncurses//5.9/ncurses-5.9-20120616-patch.sh.bz2` is dead, which prevents `Mac/BuildScript/build-installer.py` from completing. Looks like the host of the FTP server was changed to `ftp.invisible-island.net`, thus this proposal.

Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>

Automerge-Triggered-By: @ned-deily