### PR TITLE
bpo-40780: Fix failure of _Py_dg_dtoa to remove trailing zeros

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -484,6 +484,17 @@ class FormatTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             format(c, ".%sf" % (INT_MAX + 1))
 
+    def test_g_format_has_no_trailing_zeros(self):
+        # regression test for bugs.python.org/issue40780
+        self.assertEqual("%.3g" % 1505, "1.5e+03")
+        self.assertEqual("%#.3g" % 1505, "1.50e+03")
+
+        self.assertEqual(format(1505, ".3g"), "1.5e+03")
+        self.assertEqual(format(1505, "#.3g"), "1.50e+03")
+
+        self.assertEqual(format(12300050, ".6g"), "1.23e+07")
+        self.assertEqual(format(12300050, "#.6g"), "1.23000e+07")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -486,14 +486,14 @@ class FormatTest(unittest.TestCase):
 
     def test_g_format_has_no_trailing_zeros(self):
         # regression test for bugs.python.org/issue40780
-        self.assertEqual("%.3g" % 1505, "1.5e+03")
-        self.assertEqual("%#.3g" % 1505, "1.50e+03")
+        self.assertEqual("%.3g" % 1505.0, "1.5e+03")
+        self.assertEqual("%#.3g" % 1505.0, "1.50e+03")
 
-        self.assertEqual(format(1505, ".3g"), "1.5e+03")
-        self.assertEqual(format(1505, "#.3g"), "1.50e+03")
+        self.assertEqual(format(1505.0, ".3g"), "1.5e+03")
+        self.assertEqual(format(1505.0, "#.3g"), "1.50e+03")
 
-        self.assertEqual(format(12300050, ".6g"), "1.23e+07")
-        self.assertEqual(format(12300050, "#.6g"), "1.23000e+07")
+        self.assertEqual(format(12300050.0, ".6g"), "1.23e+07")
+        self.assertEqual(format(12300050.0, "#.6g"), "1.23000e+07")
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-26-17-43-58.bpo-40780.3Ckdgm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-26-17-43-58.bpo-40780.3Ckdgm.rst
@@ -1,0 +1,2 @@
+Fix a corner case where g-style string formatting of a float failed to
+remove trailing zeros.

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -64,6 +64,9 @@
  *  7. _Py_dg_strtod has been modified so that it doesn't accept strings with
  *     leading whitespace.
  *
+ *  8. A corner case where _Py_dg_dtoa didn't strip trailing zeros has been
+ *     fixed. (bugs.python.org/issue40780)
+ *
  ***************************************************************/
 
 /* Please send bug reports for the original dtoa.c code to David M. Gay (dmg
@@ -2563,17 +2566,13 @@ _Py_dg_dtoa(double dd, int mode, int ndigits,
                         }
                     ++*s++;
                 }
-                /* This branch was missing from the original dtoa.c, leading
-                   to surplus trailing zeros in some cases.
-                   See bugs.python.org/issue40780. */
                 else {
-                    /* At the beginning of the for loop we have 10**k <= d; it
-                       follows that on the first iteration, ds <= dval(&u), and
-                       so the first digit written to s is nonzero and it's safe
-                       to strip trailing zeros. */
-                    assert(k_check == 0);
-                    while(*--s == '0');
-                    s++;
+                    /* Strip trailing zeros. This branch was missing from the
+                       original dtoa.c, leading to surplus trailing zeros in
+                       some cases. See bugs.python.org/issue40780. */
+                    while (s > s0 && s[-1] == '0') {
+                        --s;
+                    }
                 }
                 break;
             }

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -2567,6 +2567,11 @@ _Py_dg_dtoa(double dd, int mode, int ndigits,
                    to surplus trailing zeros in some cases.
                    See bugs.python.org/issue40780. */
                 else {
+                    /* At the beginning of the for loop we have 10**k <= d; it
+                       follows that on the first iteration, ds <= dval(&u), and
+                       so the first digit written to s is nonzero and it's safe
+                       to strip trailing zeros. */
+                    assert(k_check == 0);
                     while(*--s == '0');
                     s++;
                 }

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -2563,6 +2563,13 @@ _Py_dg_dtoa(double dd, int mode, int ndigits,
                         }
                     ++*s++;
                 }
+                /* This branch was missing from the original dtoa.c, leading
+                   to surplus trailing zeros in some cases.
+                   See bugs.python.org/issue40780. */
+                else {
+                    while(*--s == '0');
+                    s++;
+                }
                 break;
             }
         }


### PR DESCRIPTION
The `dtoa.c` code underlying string formatting wasn't stripping trailing zeros in some cases where it should have been. This PR fixes that.

~Making this a draft PR for now; I still need to add regression tests.~ EDIT: tests added

<!-- issue-number: [bpo-40780](https://bugs.python.org/issue40780) -->
https://bugs.python.org/issue40780
<!-- /issue-number -->
