### PR TITLE
bpo-33187: Document 3.9 changes to xml.etree.ElementInclude.include

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -817,7 +817,7 @@ Functions
 
 
 .. function:: xml.etree.ElementInclude.include( elem, loader=None, base_url=None, \
-                                                max_depth=DEFAULT_MAX_INCLUSION_DEPTH)
+                                                max_depth=6)
 
    This function expands XInclude directives.  *elem* is the root element.  *loader* is
    an optional resource loader.  If omitted, it defaults to :func:`default_loader`.

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -823,8 +823,8 @@ Functions
    an optional resource loader.  If omitted, it defaults to :func:`default_loader`.
    If given, it should be a callable that implements the same interface as
    :func:`default_loader`.  *base_url* is base URL of the original file, to resolve
-   relative include file references. *max_depth* is the maximum number of recursive
-   inclusions. Limited to reduce the risk of malicious content explosion. Pass a
+   relative include file references.  *max_depth* is the maximum number of recursive
+   inclusions.  Limited to reduce the risk of malicious content explosion. Pass a
    negative value to disable the limitation.
 
    Returns the expanded resource.  If the parse mode is

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -816,15 +816,24 @@ Functions
    loader fails, it can return None or raise an exception.
 
 
-.. function:: xml.etree.ElementInclude.include( elem, loader=None)
+.. function:: xml.etree.ElementInclude.include( elem, loader=None, base_url=None, \
+                                                max_depth=DEFAULT_MAX_INCLUSION_DEPTH)
 
    This function expands XInclude directives.  *elem* is the root element.  *loader* is
    an optional resource loader.  If omitted, it defaults to :func:`default_loader`.
    If given, it should be a callable that implements the same interface as
-   :func:`default_loader`.  Returns the expanded resource.  If the parse mode is
+   :func:`default_loader`.  *base_url* is base URL of the original file, to resolve
+   relative include file references. *max_depth* is the maximum number of recursive
+   inclusions. Limited to reduce the risk of malicious content explosion. Pass a
+   negative value to disable the limitation.
+
+   Returns the expanded resource.  If the parse mode is
    ``"xml"``, this is an ElementTree instance.  If the parse mode is "text",
    this is a Unicode string.  If the loader fails, it can return None or
    raise an exception.
+
+   .. versionadded:: 3.9
+      The *base_url* and *max_depth* parameters.
 
 
 .. _elementtree-element-objects:


### PR DESCRIPTION
Looks like the merging of [bpo-33187](https://bugs.python.org/issue33187) and [bpo-20928](https://bugs.python.org/issue20928) was racy, resulting in
this change going undocumented.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33187](https://bugs.python.org/issue33187) -->
https://bugs.python.org/issue33187
<!-- /issue-number -->
