### PR TITLE
bpo-40791: Make compare_digest more constant-time.

### DIFF
--- a/Misc/NEWS.d/next/Security/2020-05-28-06-06-47.bpo-40791.QGZClX.rst
+++ b/Misc/NEWS.d/next/Security/2020-05-28-06-06-47.bpo-40791.QGZClX.rst
@@ -1,0 +1,1 @@
+Add ``volatile`` to the accumulator variable in ``hmac.compare_digest``, making constant-time-defeating optimizations less likely.

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -735,7 +735,7 @@ _tscmp(const unsigned char *a, const unsigned char *b,
     volatile const unsigned char *left;
     volatile const unsigned char *right;
     Py_ssize_t i;
-    unsigned char result;
+    volatile unsigned char result;
 
     /* loop count depends on length of b */
     length = len_b;


### PR DESCRIPTION
The existing volatile `left`/`right` pointers guarantee that the reads will all occur, but does not guarantee that they will be _used_. So a compiler can still short-circuit the loop, saving e.g. the overhead of doing the xors and especially the overhead of the data dependency between `result` and the reads. That would change performance depending on where the first unequal byte occurs. This change removes that optimization.

(This is change 1 from https://bugs.python.org/issue40791 .)

<!-- issue-number: [bpo-40791](https://bugs.python.org/issue40791) -->
https://bugs.python.org/issue40791
<!-- /issue-number -->
