### PR TITLE
bpo-2897: Make PyMemberDef part of stable ABI; deprecate structmember.h

### DIFF
--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -275,28 +275,30 @@ be read-only or read-write.  The structures in the table are defined as::
 For each entry in the table, a :term:`descriptor` will be constructed and added to the
 type which will be able to extract a value from the instance structure.  The
 :attr:`type` field should contain one of the type codes defined in the
-:file:`structmember.h` header; the value will be used to determine how to
+:file:`descrobject.h` header; the value will be used to determine how to
 convert Python values to and from C values.  The :attr:`flags` field is used to
 store flags which control how the attribute can be accessed.
 
-The following flag constants are defined in :file:`structmember.h`; they may be
-combined using bitwise-OR.
+The following flag constants are provided; they may be combined using
+bitwise-OR.
 
-+---------------------------+----------------------------------------------+
-| Constant                  | Meaning                                      |
-+===========================+==============================================+
-| :const:`READONLY`         | Never writable.                              |
-+---------------------------+----------------------------------------------+
-| :const:`READ_RESTRICTED`  | Not readable in restricted mode.             |
-+---------------------------+----------------------------------------------+
-| :const:`WRITE_RESTRICTED` | Not writable in restricted mode.             |
-+---------------------------+----------------------------------------------+
-| :const:`RESTRICTED`       | Not readable or writable in restricted mode. |
-+---------------------------+----------------------------------------------+
++-----------------------------+--------------------------------------------+
+| Constant                    | Meaning                                    |
++=============================+============================================+
+| :const:`PY_READONLY`        | Never writable.                            |
++-----------------------------+--------------------------------------------+
+| :const:`PY_READ_RESTRICTED` | Reading raises an audit event.             |
++-----------------------------+--------------------------------------------+
 
 .. index::
-   single: READONLY
-   single: READ_RESTRICTED
+   single: PY_READONLY
+   single: PY_READ_RESTRICTED
+
+The :const:`WRITE_RESTRICTED` and :const:`RESTRICTED` flags are deprecated. They
+are provided in the deprecated header :file:`structmember.h` for backward
+compatibility and ignored in Python 3.x.
+
+.. index::
    single: WRITE_RESTRICTED
    single: RESTRICTED
 

--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -238,13 +238,6 @@ adds these capabilities:
 
 This version of the module has a number of changes.
 
-We've added an extra include::
-
-   #include <structmember.h>
-
-This include provides declarations that we use to handle attributes, as
-described a bit later.
-
 The  :class:`Custom` type now has three data attributes in its C struct,
 *first*, *last*, and *number*.  The *first* and *last* variables are Python
 strings containing first and last names.  The *number* attribute is a C integer.

--- a/Doc/includes/custom2.c
+++ b/Doc/includes/custom2.c
@@ -1,6 +1,5 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
 
 typedef struct {
     PyObject_HEAD

--- a/Doc/includes/custom3.c
+++ b/Doc/includes/custom3.c
@@ -1,6 +1,5 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
 
 typedef struct {
     PyObject_HEAD

--- a/Doc/includes/custom4.c
+++ b/Doc/includes/custom4.c
@@ -1,6 +1,5 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
 
 typedef struct {
     PyObject_HEAD

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -49,7 +49,7 @@
 #endif
 #endif
 
-/* For size_t? */
+/* For size_t, offsetof */
 #ifdef HAVE_STDDEF_H
 #include <stddef.h>
 #endif

--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -16,6 +16,60 @@ typedef struct PyGetSetDef {
     void *closure;
 } PyGetSetDef;
 
+/* Interface to map C struct members to Python object attributes */
+
+/* An array of PyMemberDef structures defines the name, type and offset
+   of selected members of a C structure.  These can be read by
+   PyMember_GetOne() and set by PyMember_SetOne() (except if their READONLY
+   flag is set).  The array must be terminated with an entry whose name
+   pointer is NULL. */
+
+typedef struct PyMemberDef {
+    const char *name;
+    int type;
+    Py_ssize_t offset;
+    int flags;
+    const char *doc;
+} PyMemberDef;
+
+/* PyMemberDef Types */
+#define T_SHORT     0
+#define T_INT       1
+#define T_LONG      2
+#define T_FLOAT     3
+#define T_DOUBLE    4
+#define T_STRING    5
+#define T_OBJECT    6
+/* XXX the ordering here is weird for binary compatibility */
+#define T_CHAR      7   /* 1-character string */
+#define T_BYTE      8   /* 8-bit signed int */
+/* unsigned variants: */
+#define T_UBYTE     9
+#define T_USHORT    10
+#define T_UINT      11
+#define T_ULONG     12
+
+/* Added by Jack: strings contained in the structure */
+#define T_STRING_INPLACE    13
+
+/* Added by Lillo: bools contained in the structure (assumed char) */
+#define T_BOOL      14
+
+#define T_OBJECT_EX 16  /* Like T_OBJECT, but raises AttributeError
+                           when the value is NULL, instead of
+                           converting to None. */
+#define T_LONGLONG      17
+#define T_ULONGLONG     18
+
+#define T_PYSSIZET      19      /* Py_ssize_t */
+#define T_NONE          20      /* Value is always None */
+
+
+/* PyMemberDef Flags */
+#define PY_READONLY        1
+#define PY_READ_RESTRICTED 2
+
+
 #ifndef Py_LIMITED_API
 typedef PyObject *(*wrapperfunc)(PyObject *self, PyObject *args,
                                  void *wrapped);
@@ -99,6 +153,10 @@ PyAPI_FUNC(PyObject *) PyDescr_NewWrapper(PyTypeObject *,
 PyAPI_FUNC(PyObject *) PyDictProxy_New(PyObject *);
 PyAPI_FUNC(PyObject *) PyWrapper_New(PyObject *, PyObject *);
 
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyObject *) PyMember_GetOne(const char *, struct PyMemberDef *);
+PyAPI_FUNC(int) PyMember_SetOne(char *, struct PyMemberDef *, PyObject *);
+#endif
 
 PyAPI_DATA(PyTypeObject) PyProperty_Type;
 #ifdef __cplusplus

--- a/Include/structmember.h
+++ b/Include/structmember.h
@@ -1,72 +1,17 @@
+/* Deprecated header.  `PyMemberDef`, `PyMember_GetOne` and `PyMember_SetOne`
+ * were moved to `descrobject.h`. */
+
 #ifndef Py_STRUCTMEMBER_H
 #define Py_STRUCTMEMBER_H
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-/* Interface to map C struct members to Python object attributes */
-
-#include <stddef.h> /* For offsetof */
-
-/* An array of PyMemberDef structures defines the name, type and offset
-   of selected members of a C structure.  These can be read by
-   PyMember_GetOne() and set by PyMember_SetOne() (except if their READONLY
-   flag is set).  The array must be terminated with an entry whose name
-   pointer is NULL. */
-
-typedef struct PyMemberDef {
-    const char *name;
-    int type;
-    Py_ssize_t offset;
-    int flags;
-    const char *doc;
-} PyMemberDef;
-
-/* Types */
-#define T_SHORT     0
-#define T_INT       1
-#define T_LONG      2
-#define T_FLOAT     3
-#define T_DOUBLE    4
-#define T_STRING    5
-#define T_OBJECT    6
-/* XXX the ordering here is weird for binary compatibility */
-#define T_CHAR      7   /* 1-character string */
-#define T_BYTE      8   /* 8-bit signed int */
-/* unsigned variants: */
-#define T_UBYTE     9
-#define T_USHORT    10
-#define T_UINT      11
-#define T_ULONG     12
-
-/* Added by Jack: strings contained in the structure */
-#define T_STRING_INPLACE    13
-
-/* Added by Lillo: bools contained in the structure (assumed char) */
-#define T_BOOL      14
-
-#define T_OBJECT_EX 16  /* Like T_OBJECT, but raises AttributeError
-                           when the value is NULL, instead of
-                           converting to None. */
-#define T_LONGLONG      17
-#define T_ULONGLONG     18
-
-#define T_PYSSIZET      19      /* Py_ssize_t */
-#define T_NONE          20      /* Value is always None */
-
-
-/* Flags */
-#define READONLY            1
-#define READ_RESTRICTED     2
+/* The following names are provided for backward compatibility. */
+#define READONLY            PY_READONLY
+#define READ_RESTRICTED     PY_READ_RESTRICTED
 #define PY_WRITE_RESTRICTED 4
 #define RESTRICTED          (READ_RESTRICTED | PY_WRITE_RESTRICTED)
-
-
-/* Current API, use this */
-PyAPI_FUNC(PyObject *) PyMember_GetOne(const char *, struct PyMemberDef *);
-PyAPI_FUNC(int) PyMember_SetOne(char *, struct PyMemberDef *, PyObject *);
-
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/C API/2020-05-27-11-20-08.bpo-2897.do2KO9.rst
+++ b/Misc/NEWS.d/next/C API/2020-05-27-11-20-08.bpo-2897.do2KO9.rst
@@ -1,0 +1,3 @@
+PyMemberDef is available in Python.h and part of the stable ABI now.
+READONLY was renamed to PY_READONLY and READ_RESTRICTED to
+PY_READ_RESTRICTED. The structmember.h header was deprecated.

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -3,7 +3,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #include <bzlib.h>
 #include <stdio.h>
@@ -674,10 +673,10 @@ PyDoc_STRVAR(BZ2Decompressor_needs_input_doc,
 
 static PyMemberDef BZ2Decompressor_members[] = {
     {"eof", T_BOOL, offsetof(BZ2Decompressor, eof),
-     READONLY, BZ2Decompressor_eof__doc__},
+     PY_READONLY, BZ2Decompressor_eof__doc__},
     {"unused_data", T_OBJECT_EX, offsetof(BZ2Decompressor, unused_data),
-     READONLY, BZ2Decompressor_unused_data__doc__},
-    {"needs_input", T_BOOL, offsetof(BZ2Decompressor, needs_input), READONLY,
+     PY_READONLY, BZ2Decompressor_unused_data__doc__},
+    {"needs_input", T_BOOL, offsetof(BZ2Decompressor, needs_input), PY_READONLY,
      BZ2Decompressor_needs_input_doc},
     {NULL}
 };

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #ifdef STDC_HEADERS
 #include <stddef.h>

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -11,7 +11,6 @@ module instead.
 #define MODULE_VERSION "1.0"
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 #include <stdbool.h>
 
 
@@ -299,9 +298,9 @@ dialect_check_quoting(int quoting)
 #define D_OFF(x) offsetof(DialectObj, x)
 
 static struct PyMemberDef Dialect_memberlist[] = {
-    { "skipinitialspace",   T_BOOL, D_OFF(skipinitialspace), READONLY },
-    { "doublequote",        T_BOOL, D_OFF(doublequote), READONLY },
-    { "strict",             T_BOOL, D_OFF(strict), READONLY },
+    { "skipinitialspace",   T_BOOL, D_OFF(skipinitialspace), PY_READONLY },
+    { "doublequote",        T_BOOL, D_OFF(doublequote), PY_READONLY },
+    { "strict",             T_BOOL, D_OFF(strict), PY_READONLY },
     { NULL }
 };
 
@@ -895,8 +894,8 @@ static struct PyMethodDef Reader_methods[] = {
 #define R_OFF(x) offsetof(ReaderObj, x)
 
 static struct PyMemberDef Reader_memberlist[] = {
-    { "dialect", T_OBJECT, R_OFF(dialect), READONLY },
-    { "line_num", T_ULONG, R_OFF(line_num), READONLY },
+    { "dialect", T_OBJECT, R_OFF(dialect), PY_READONLY },
+    { "line_num", T_ULONG, R_OFF(line_num), PY_READONLY },
     { NULL }
 };
 
@@ -1293,7 +1292,7 @@ static struct PyMethodDef Writer_methods[] = {
 #define W_OFF(x) offsetof(WriterObj, x)
 
 static struct PyMemberDef Writer_memberlist[] = {
-    { "dialect", T_OBJECT, W_OFF(dialect), READONLY },
+    { "dialect", T_OBJECT, W_OFF(dialect), PY_READONLY },
     { NULL }
 };
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -102,7 +102,6 @@ bytes(cdata)
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #include <ffi.h>
 #ifdef MS_WIN32
@@ -2787,13 +2786,13 @@ PyCData_dealloc(PyObject *self)
 
 static PyMemberDef PyCData_members[] = {
     { "_b_base_", T_OBJECT,
-      offsetof(CDataObject, b_base), READONLY,
+      offsetof(CDataObject, b_base), PY_READONLY,
       "the base object" },
     { "_b_needsfree_", T_INT,
-      offsetof(CDataObject, b_needsfree), READONLY,
+      offsetof(CDataObject, b_needsfree), PY_READONLY,
       "whether the object owns the memory or not" },
     { "_objects", T_OBJECT,
-      offsetof(CDataObject, b_objects), READONLY,
+      offsetof(CDataObject, b_objects), PY_READONLY,
       "internal objects tree (NEVER CHANGE THIS OBJECT!)"},
     { NULL },
 };

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -55,7 +55,6 @@
  */
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #ifdef MS_WIN32
 #include <windows.h>
@@ -563,7 +562,7 @@ PyCArg_repr(PyCArgObject *self)
 
 static PyMemberDef PyCArgType_members[] = {
     { "_obj", T_OBJECT,
-      offsetof(PyCArgObject, obj), READONLY,
+      offsetof(PyCArgObject, obj), PY_READONLY,
       "the wrapped object" },
     { NULL },
 };

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -9,7 +9,6 @@
 
 #include "Python.h"
 #include "datetime.h"
-#include "structmember.h"         // PyMemberDef
 
 #include <time.h>
 
@@ -2653,13 +2652,13 @@ delta_reduce(PyDateTime_Delta* self, PyObject *Py_UNUSED(ignored))
 
 static PyMemberDef delta_members[] = {
 
-    {"days",         T_INT, OFFSET(days),         READONLY,
+    {"days",         T_INT, OFFSET(days),         PY_READONLY,
      PyDoc_STR("Number of days.")},
 
-    {"seconds",      T_INT, OFFSET(seconds),      READONLY,
+    {"seconds",      T_INT, OFFSET(seconds),      PY_READONLY,
      PyDoc_STR("Number of seconds (>= 0 and less than 1 day).")},
 
-    {"microseconds", T_INT, OFFSET(microseconds), READONLY,
+    {"microseconds", T_INT, OFFSET(microseconds), PY_READONLY,
      PyDoc_STR("Number of microseconds (>= 0 and less than 1 second).")},
     {NULL}
 };

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -14,7 +14,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 /* -------------------------------------------------------------------- */
 /* configuration */
@@ -4136,8 +4135,8 @@ _elementtree_XMLParser__setevents_impl(XMLParserObject *self,
 }
 
 static PyMemberDef xmlparser_members[] = {
-    {"entity", T_OBJECT, offsetof(XMLParserObject, entity), READONLY, NULL},
-    {"target", T_OBJECT, offsetof(XMLParserObject, target), READONLY, NULL},
+    {"entity", T_OBJECT, offsetof(XMLParserObject, entity), PY_READONLY, NULL},
+    {"target", T_OBJECT, offsetof(XMLParserObject, target), PY_READONLY, NULL},
     {NULL}
 };
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1,7 +1,6 @@
 #include "Python.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_tupleobject.h"
-#include "structmember.h"         // PyMemberDef
 
 /* _functools module written and maintained
    by Hye-Shik Chang <perky@FreeBSD.org>
@@ -286,11 +285,11 @@ PyDoc_STRVAR(partial_doc,
 
 #define OFF(x) offsetof(partialobject, x)
 static PyMemberDef partial_memberlist[] = {
-    {"func",            T_OBJECT,       OFF(fn),        READONLY,
+    {"func",            T_OBJECT,       OFF(fn),        PY_READONLY,
      "function object to use in future partial calls"},
-    {"args",            T_OBJECT,       OFF(args),      READONLY,
+    {"args",            T_OBJECT,       OFF(args),      PY_READONLY,
      "tuple of arguments to future partial calls"},
-    {"keywords",        T_OBJECT,       OFF(kw),        READONLY,
+    {"keywords",        T_OBJECT,       OFF(kw),        PY_READONLY,
      "dictionary of keyword arguments to future partial calls"},
     {NULL}  /* Sentinel */
 };

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -10,7 +10,6 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"         // PyMemberDef
 #include "_iomodule.h"
 
 /*[clinic input]
@@ -2403,7 +2402,7 @@ static PyMethodDef bufferedreader_methods[] = {
 };
 
 static PyMemberDef bufferedreader_members[] = {
-    {"raw", T_OBJECT, offsetof(buffered, raw), READONLY},
+    {"raw", T_OBJECT, offsetof(buffered, raw), PY_READONLY},
     {"_finalizing", T_BOOL, offsetof(buffered, finalizing), 0},
     {NULL}
 };
@@ -2489,7 +2488,7 @@ static PyMethodDef bufferedwriter_methods[] = {
 };
 
 static PyMemberDef bufferedwriter_members[] = {
-    {"raw", T_OBJECT, offsetof(buffered, raw), READONLY},
+    {"raw", T_OBJECT, offsetof(buffered, raw), PY_READONLY},
     {"_finalizing", T_BOOL, offsetof(buffered, finalizing), 0},
     {NULL}
 };
@@ -2660,7 +2659,7 @@ static PyMethodDef bufferedrandom_methods[] = {
 };
 
 static PyMemberDef bufferedrandom_members[] = {
-    {"raw", T_OBJECT, offsetof(buffered, raw), READONLY},
+    {"raw", T_OBJECT, offsetof(buffered, raw), PY_READONLY},
     {"_finalizing", T_BOOL, offsetof(buffered, finalizing), 0},
     {NULL}
 };

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -3,7 +3,6 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"         // PyMemberDef
 #include <stdbool.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -11,7 +11,6 @@
 #include "pycore_interp.h"        // PyInterpreterState.fs_codec
 #include "pycore_object.h"
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
-#include "structmember.h"         // PyMemberDef
 #include "_iomodule.h"
 
 /*[clinic input]
@@ -3253,10 +3252,10 @@ static PyMethodDef textiowrapper_methods[] = {
 };
 
 static PyMemberDef textiowrapper_members[] = {
-    {"encoding", T_OBJECT, offsetof(textio, encoding), READONLY},
-    {"buffer", T_OBJECT, offsetof(textio, buffer), READONLY},
-    {"line_buffering", T_BOOL, offsetof(textio, line_buffering), READONLY},
-    {"write_through", T_BOOL, offsetof(textio, write_through), READONLY},
+    {"encoding", T_OBJECT, offsetof(textio, encoding), PY_READONLY},
+    {"buffer", T_OBJECT, offsetof(textio, buffer), PY_READONLY},
+    {"line_buffering", T_BOOL, offsetof(textio, line_buffering), PY_READONLY},
+    {"write_through", T_BOOL, offsetof(textio, write_through), PY_READONLY},
     {"_finalizing", T_BOOL, offsetof(textio, finalizing), 0},
     {NULL}
 };

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -12,7 +12,6 @@
 
 #ifdef MS_WINDOWS
 
-#include "structmember.h"         // PyMemberDef
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -9,7 +9,6 @@
 #endif
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 #include "pycore_accu.h"
 
 typedef struct {
@@ -38,12 +37,12 @@ typedef struct _PyScannerObject {
 } PyScannerObject;
 
 static PyMemberDef scanner_members[] = {
-    {"strict", T_BOOL, offsetof(PyScannerObject, strict), READONLY, "strict"},
-    {"object_hook", T_OBJECT, offsetof(PyScannerObject, object_hook), READONLY, "object_hook"},
-    {"object_pairs_hook", T_OBJECT, offsetof(PyScannerObject, object_pairs_hook), READONLY},
-    {"parse_float", T_OBJECT, offsetof(PyScannerObject, parse_float), READONLY, "parse_float"},
-    {"parse_int", T_OBJECT, offsetof(PyScannerObject, parse_int), READONLY, "parse_int"},
-    {"parse_constant", T_OBJECT, offsetof(PyScannerObject, parse_constant), READONLY, "parse_constant"},
+    {"strict", T_BOOL, offsetof(PyScannerObject, strict), PY_READONLY, "strict"},
+    {"object_hook", T_OBJECT, offsetof(PyScannerObject, object_hook), PY_READONLY, "object_hook"},
+    {"object_pairs_hook", T_OBJECT, offsetof(PyScannerObject, object_pairs_hook), PY_READONLY},
+    {"parse_float", T_OBJECT, offsetof(PyScannerObject, parse_float), PY_READONLY, "parse_float"},
+    {"parse_int", T_OBJECT, offsetof(PyScannerObject, parse_int), PY_READONLY, "parse_int"},
+    {"parse_constant", T_OBJECT, offsetof(PyScannerObject, parse_constant), PY_READONLY, "parse_constant"},
     {NULL}
 };
 
@@ -62,14 +61,14 @@ typedef struct _PyEncoderObject {
 } PyEncoderObject;
 
 static PyMemberDef encoder_members[] = {
-    {"markers", T_OBJECT, offsetof(PyEncoderObject, markers), READONLY, "markers"},
-    {"default", T_OBJECT, offsetof(PyEncoderObject, defaultfn), READONLY, "default"},
-    {"encoder", T_OBJECT, offsetof(PyEncoderObject, encoder), READONLY, "encoder"},
-    {"indent", T_OBJECT, offsetof(PyEncoderObject, indent), READONLY, "indent"},
-    {"key_separator", T_OBJECT, offsetof(PyEncoderObject, key_separator), READONLY, "key_separator"},
-    {"item_separator", T_OBJECT, offsetof(PyEncoderObject, item_separator), READONLY, "item_separator"},
-    {"sort_keys", T_BOOL, offsetof(PyEncoderObject, sort_keys), READONLY, "sort_keys"},
-    {"skipkeys", T_BOOL, offsetof(PyEncoderObject, skipkeys), READONLY, "skipkeys"},
+    {"markers", T_OBJECT, offsetof(PyEncoderObject, markers), PY_READONLY, "markers"},
+    {"default", T_OBJECT, offsetof(PyEncoderObject, defaultfn), PY_READONLY, "default"},
+    {"encoder", T_OBJECT, offsetof(PyEncoderObject, encoder), PY_READONLY, "encoder"},
+    {"indent", T_OBJECT, offsetof(PyEncoderObject, indent), PY_READONLY, "indent"},
+    {"key_separator", T_OBJECT, offsetof(PyEncoderObject, key_separator), PY_READONLY, "key_separator"},
+    {"item_separator", T_OBJECT, offsetof(PyEncoderObject, item_separator), PY_READONLY, "item_separator"},
+    {"sort_keys", T_BOOL, offsetof(PyEncoderObject, sort_keys), PY_READONLY, "sort_keys"},
+    {"skipkeys", T_BOOL, offsetof(PyEncoderObject, skipkeys), PY_READONLY, "skipkeys"},
     {NULL}
 };
 

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -8,7 +8,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #include <stdarg.h>
 #include <string.h>
@@ -1246,14 +1245,14 @@ PyDoc_STRVAR(Decompressor_unused_data_doc,
 "Data found after the end of the compressed stream.");
 
 static PyMemberDef Decompressor_members[] = {
-    {"check", T_INT, offsetof(Decompressor, check), READONLY,
+    {"check", T_INT, offsetof(Decompressor, check), PY_READONLY,
      Decompressor_check_doc},
-    {"eof", T_BOOL, offsetof(Decompressor, eof), READONLY,
+    {"eof", T_BOOL, offsetof(Decompressor, eof), PY_READONLY,
      Decompressor_eof_doc},
-    {"needs_input", T_BOOL, offsetof(Decompressor, needs_input), READONLY,
+    {"needs_input", T_BOOL, offsetof(Decompressor, needs_input), PY_READONLY,
      Decompressor_needs_input_doc},
-    {"unused_data", T_OBJECT_EX, offsetof(Decompressor, unused_data), READONLY,
-     Decompressor_unused_data_doc},
+    {"unused_data", T_OBJECT_EX, offsetof(Decompressor, unused_data),
+     PY_READONLY, Decompressor_unused_data_doc},
     {NULL}
 };
 

--- a/Modules/_multiprocessing/multiprocessing.h
+++ b/Modules/_multiprocessing/multiprocessing.h
@@ -4,7 +4,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
 #include "pythread.h"
 
 /*

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -613,13 +613,13 @@ static PyMethodDef semlock_methods[] = {
  */
 
 static PyMemberDef semlock_members[] = {
-    {"handle", T_SEM_HANDLE, offsetof(SemLockObject, handle), READONLY,
+    {"handle", T_SEM_HANDLE, offsetof(SemLockObject, handle), PY_READONLY,
      ""},
-    {"kind", T_INT, offsetof(SemLockObject, kind), READONLY,
+    {"kind", T_INT, offsetof(SemLockObject, kind), PY_READONLY,
      ""},
-    {"maxvalue", T_INT, offsetof(SemLockObject, maxvalue), READONLY,
+    {"maxvalue", T_INT, offsetof(SemLockObject, maxvalue), PY_READONLY,
      ""},
-    {"name", T_STRING, offsetof(SemLockObject, name), READONLY,
+    {"name", T_STRING, offsetof(SemLockObject, name), PY_READONLY,
      ""},
     {NULL}
 };

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -9,7 +9,6 @@
 #endif
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 PyDoc_STRVAR(pickle_module_doc,
 "Optimized C implementation for the Python pickle module.");

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -23,7 +23,6 @@
 
 #include "cache.h"
 #include "module.h"
-#include "structmember.h"         // PyMemberDef
 #include "connection.h"
 #include "statement.h"
 #include "cursor.h"
@@ -1815,16 +1814,16 @@ static PyMethodDef connection_methods[] = {
 
 static struct PyMemberDef connection_members[] =
 {
-    {"Warning", T_OBJECT, offsetof(pysqlite_Connection, Warning), READONLY},
-    {"Error", T_OBJECT, offsetof(pysqlite_Connection, Error), READONLY},
-    {"InterfaceError", T_OBJECT, offsetof(pysqlite_Connection, InterfaceError), READONLY},
-    {"DatabaseError", T_OBJECT, offsetof(pysqlite_Connection, DatabaseError), READONLY},
-    {"DataError", T_OBJECT, offsetof(pysqlite_Connection, DataError), READONLY},
-    {"OperationalError", T_OBJECT, offsetof(pysqlite_Connection, OperationalError), READONLY},
-    {"IntegrityError", T_OBJECT, offsetof(pysqlite_Connection, IntegrityError), READONLY},
-    {"InternalError", T_OBJECT, offsetof(pysqlite_Connection, InternalError), READONLY},
-    {"ProgrammingError", T_OBJECT, offsetof(pysqlite_Connection, ProgrammingError), READONLY},
-    {"NotSupportedError", T_OBJECT, offsetof(pysqlite_Connection, NotSupportedError), READONLY},
+    {"Warning", T_OBJECT, offsetof(pysqlite_Connection, Warning), PY_READONLY},
+    {"Error", T_OBJECT, offsetof(pysqlite_Connection, Error), PY_READONLY},
+    {"InterfaceError", T_OBJECT, offsetof(pysqlite_Connection, InterfaceError), PY_READONLY},
+    {"DatabaseError", T_OBJECT, offsetof(pysqlite_Connection, DatabaseError), PY_READONLY},
+    {"DataError", T_OBJECT, offsetof(pysqlite_Connection, DataError), PY_READONLY},
+    {"OperationalError", T_OBJECT, offsetof(pysqlite_Connection, OperationalError), PY_READONLY},
+    {"IntegrityError", T_OBJECT, offsetof(pysqlite_Connection, IntegrityError), PY_READONLY},
+    {"InternalError", T_OBJECT, offsetof(pysqlite_Connection, InternalError), PY_READONLY},
+    {"ProgrammingError", T_OBJECT, offsetof(pysqlite_Connection, ProgrammingError), PY_READONLY},
+    {"NotSupportedError", T_OBJECT, offsetof(pysqlite_Connection, NotSupportedError), PY_READONLY},
     {"row_factory", T_OBJECT, offsetof(pysqlite_Connection, row_factory)},
     {"text_factory", T_OBJECT, offsetof(pysqlite_Connection, text_factory)},
     {NULL}

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -26,7 +26,6 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pythread.h"
-#include "structmember.h"
 
 #include "cache.h"
 #include "module.h"

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -892,11 +892,13 @@ static PyMethodDef cursor_methods[] = {
 
 static struct PyMemberDef cursor_members[] =
 {
-    {"connection", T_OBJECT, offsetof(pysqlite_Cursor, connection), READONLY},
-    {"description", T_OBJECT, offsetof(pysqlite_Cursor, description), READONLY},
+    {"connection", T_OBJECT, offsetof(pysqlite_Cursor, connection),
+     PY_READONLY},
+    {"description", T_OBJECT, offsetof(pysqlite_Cursor, description),
+     PY_READONLY},
     {"arraysize", T_INT, offsetof(pysqlite_Cursor, arraysize), 0},
-    {"lastrowid", T_OBJECT, offsetof(pysqlite_Cursor, lastrowid), READONLY},
-    {"rowcount", T_LONG, offsetof(pysqlite_Cursor, rowcount), READONLY},
+    {"lastrowid", T_OBJECT, offsetof(pysqlite_Cursor, lastrowid), PY_READONLY},
+    {"rowcount", T_LONG, offsetof(pysqlite_Cursor, rowcount), PY_READONLY},
     {"row_factory", T_OBJECT, offsetof(pysqlite_Cursor, row_factory), 0},
     {NULL}
 };

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -41,7 +41,6 @@ static const char copyright[] =
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #include "sre.h"
 
@@ -2581,11 +2580,11 @@ static PyGetSetDef pattern_getset[] = {
 
 #define PAT_OFF(x) offsetof(PatternObject, x)
 static PyMemberDef pattern_members[] = {
-    {"pattern",    T_OBJECT,    PAT_OFF(pattern),       READONLY,
+    {"pattern",    T_OBJECT,    PAT_OFF(pattern),       PY_READONLY,
      "The pattern string from which the RE object was compiled."},
-    {"flags",      T_INT,       PAT_OFF(flags),         READONLY,
+    {"flags",      T_INT,       PAT_OFF(flags),         PY_READONLY,
      "The regex matching flags."},
-    {"groups",     T_PYSSIZET,  PAT_OFF(groups),        READONLY,
+    {"groups",     T_PYSSIZET,  PAT_OFF(groups),        PY_READONLY,
      "The number of capturing groups in the pattern."},
     {NULL}  /* Sentinel */
 };
@@ -2656,13 +2655,13 @@ static PyGetSetDef match_getset[] = {
 
 #define MATCH_OFF(x) offsetof(MatchObject, x)
 static PyMemberDef match_members[] = {
-    {"string",  T_OBJECT,   MATCH_OFF(string),  READONLY,
+    {"string",  T_OBJECT,   MATCH_OFF(string),  PY_READONLY,
      "The string passed to match() or search()."},
-    {"re",      T_OBJECT,   MATCH_OFF(pattern), READONLY,
+    {"re",      T_OBJECT,   MATCH_OFF(pattern), PY_READONLY,
      "The regular expression object."},
-    {"pos",     T_PYSSIZET, MATCH_OFF(pos),     READONLY,
+    {"pos",     T_PYSSIZET, MATCH_OFF(pos),     PY_READONLY,
      "The index into the string at which the RE engine started looking for a match."},
-    {"endpos",  T_PYSSIZET, MATCH_OFF(endpos),  READONLY,
+    {"endpos",  T_PYSSIZET, MATCH_OFF(endpos),  PY_READONLY,
      "The index into the string beyond which the RE engine will not go."},
     {NULL}
 };
@@ -2710,7 +2709,7 @@ static PyMethodDef scanner_methods[] = {
 
 #define SCAN_OFF(x) offsetof(ScannerObject, x)
 static PyMemberDef scanner_members[] = {
-    {"pattern", T_OBJECT, SCAN_OFF(pattern), READONLY},
+    {"pattern", T_OBJECT, SCAN_OFF(pattern), PY_READONLY},
     {NULL}  /* Sentinel */
 };
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -6,7 +6,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 #include <ctype.h>
 
 /*[clinic input]
@@ -2036,7 +2035,7 @@ static struct PyMethodDef s_methods[] = {
 };
 
 static PyMemberDef s_members[] = {
-    {"__weaklistoffset__", T_PYSSIZET, offsetof(PyStructObject, weakreflist), READONLY},
+    {"__weaklistoffset__", T_PYSSIZET, offsetof(PyStructObject, weakreflist), PY_READONLY},
     {NULL}  /* sentinel */
 };
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -20,7 +20,6 @@
 #include "Python.h"
 #include "datetime.h"
 #include "marshal.h"
-#include "structmember.h"         // PyMemberDef
 #include <float.h>
 #include <signal.h>
 
@@ -6397,7 +6396,7 @@ static PyGetSetDef heapctypewithdict_getsetlist[] = {
 
 static struct PyMemberDef heapctypewithdict_members[] = {
     {"dictobj", T_OBJECT, offsetof(HeapCTypeWithDictObject, dict)},
-    {"__dictoffset__", T_PYSSIZET, offsetof(HeapCTypeWithDictObject, dict), READONLY},
+    {"__dictoffset__", T_PYSSIZET, offsetof(HeapCTypeWithDictObject, dict), PY_READONLY},
     {NULL} /* Sentinel */
 };
 
@@ -6418,7 +6417,7 @@ static PyType_Spec HeapCTypeWithDict_spec = {
 
 static struct PyMemberDef heapctypewithnegativedict_members[] = {
     {"dictobj", T_OBJECT, offsetof(HeapCTypeWithDictObject, dict)},
-    {"__dictoffset__", T_PYSSIZET, -(Py_ssize_t)sizeof(void*), READONLY},
+    {"__dictoffset__", T_PYSSIZET, -(Py_ssize_t)sizeof(void*), PY_READONLY},
     {NULL} /* Sentinel */
 };
 
@@ -6445,7 +6444,7 @@ typedef struct {
 static struct PyMemberDef heapctypewithweakref_members[] = {
     {"weakreflist", T_OBJECT, offsetof(HeapCTypeWithWeakrefObject, weakreflist)},
     {"__weaklistoffset__", T_PYSSIZET,
-      offsetof(HeapCTypeWithWeakrefObject, weakreflist), READONLY},
+      offsetof(HeapCTypeWithWeakrefObject, weakreflist), PY_READONLY},
     {NULL} /* Sentinel */
 };
 
@@ -6573,7 +6572,7 @@ ContainerNoGC_dealloc(ContainerNoGCobject *self)
 }
 
 static PyMemberDef ContainerNoGC_members[] = {
-    {"value", T_OBJECT, offsetof(ContainerNoGCobject, value), READONLY,
+    {"value", T_OBJECT, offsetof(ContainerNoGCobject, value), PY_READONLY,
      PyDoc_STR("a container value for test purposes")},
     {0}
 };

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -35,7 +35,6 @@
 /* See http://www.python.org/2.4/license for licensing details. */
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #define WINDOWS_LEAN_AND_MEAN
 #include "windows.h"
@@ -300,7 +299,7 @@ static PyMethodDef overlapped_methods[] = {
 static PyMemberDef overlapped_members[] = {
     {"event", T_HANDLE,
      offsetof(OverlappedObject, overlapped) + offsetof(OVERLAPPED, hEvent),
-     READONLY, "overlapped event handle"},
+     PY_READONLY, "overlapped event handle"},
     {NULL}
 };
 

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "structmember.h"
 
 #include <ctype.h>
 #include <stddef.h>
@@ -2566,7 +2565,7 @@ static PyMemberDef zoneinfo_members[] = {
     {.name = "key",
      .offset = offsetof(PyZoneInfo_ZoneInfo, key),
      .type = T_OBJECT_EX,
-     .flags = READONLY,
+     .flags = PY_READONLY,
      .doc = NULL},
     {NULL}, /* Sentinel */
 };

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -6,7 +6,6 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 #include "multibytecodec.h"
 #include "clinic/multibytecodec.c.h"
 
@@ -1645,7 +1644,7 @@ static struct PyMethodDef mbstreamreader_methods[] = {
 static PyMemberDef mbstreamreader_members[] = {
     {"stream",          T_OBJECT,
                     offsetof(MultibyteStreamReaderObject, stream),
-                    READONLY, NULL},
+                    PY_READONLY, NULL},
     {NULL,}
 };
 
@@ -1959,7 +1958,7 @@ static struct PyMethodDef mbstreamwriter_methods[] = {
 static PyMemberDef mbstreamwriter_members[] = {
     {"stream",          T_OBJECT,
                     offsetof(MultibyteStreamWriterObject, stream),
-                    READONLY, NULL},
+                    PY_READONLY, NULL},
     {NULL,}
 };
 

--- a/Modules/ossaudiodev.c
+++ b/Modules/ossaudiodev.c
@@ -19,7 +19,6 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
@@ -920,7 +919,7 @@ static PyMethodDef oss_mixer_methods[] = {
 };
 
 static PyMemberDef oss_members[] = {
-    {"name", T_STRING, offsetof(oss_audio_t, devicename), READONLY, NULL},
+    {"name", T_STRING, offsetof(oss_audio_t, devicename), PY_READONLY, NULL},
     {NULL}
 };
 

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -8,7 +8,6 @@
    Check itemsize */
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #define WINDOWS_LEAN_AND_MEAN
 #include <winsock2.h>
@@ -1742,10 +1741,10 @@ static PyMethodDef Overlapped_methods[] = {
 static PyMemberDef Overlapped_members[] = {
     {"error", T_ULONG,
      offsetof(OverlappedObject, error),
-     READONLY, "Error from last operation"},
+     PY_READONLY, "Error from last operation"},
     {"event", T_HANDLE,
      offsetof(OverlappedObject, overlapped) + offsetof(OVERLAPPED, hEvent),
-     READONLY, "Overlapped event handle"},
+     PY_READONLY, "Overlapped event handle"},
     {NULL}
 };
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -35,7 +35,6 @@
 #include "pycore_ceval.h"         // _PyEval_ReInitThreads()
 #include "pycore_import.h"        // _PyImport_ReInitLock()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
-#include "structmember.h"         // PyMemberDef
 #ifndef MS_WINDOWS
 #  include "posixmodule.h"
 #else
@@ -13048,9 +13047,9 @@ os_DirEntry___fspath___impl(DirEntry *self)
 }
 
 static PyMemberDef DirEntry_members[] = {
-    {"name", T_OBJECT_EX, offsetof(DirEntry, name), READONLY,
+    {"name", T_OBJECT_EX, offsetof(DirEntry, name), PY_READONLY,
      "the entry's base filename, relative to scandir() \"path\" argument"},
-    {"path", T_OBJECT_EX, offsetof(DirEntry, path), READONLY,
+    {"path", T_OBJECT_EX, offsetof(DirEntry, path), PY_READONLY,
      "the entry's full path name; equivalent to os.path.join(scandir_path, entry.name)"},
     {NULL}
 };

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1,7 +1,6 @@
 #include "Python.h"
 #include <ctype.h>
 
-#include "structmember.h"         // PyMemberDef
 #include "frameobject.h"
 #include "expat.h"
 
@@ -1415,7 +1414,7 @@ xmlparse_specified_attributes_setter(xmlparseobject *self, PyObject *v, void *cl
 }
 
 static PyMemberDef xmlparse_members[] = {
-    {"intern", T_OBJECT, offsetof(xmlparseobject, intern), READONLY, NULL},
+    {"intern", T_OBJECT, offsetof(xmlparseobject, intern), PY_READONLY, NULL},
     {NULL}
 };
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -9,7 +9,6 @@
 #endif
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #ifdef HAVE_SYS_DEVPOLL_H
 #include <sys/resource.h>

--- a/Modules/sha256module.c
+++ b/Modules/sha256module.c
@@ -18,7 +18,6 @@
 
 #include "Python.h"
 #include "pycore_byteswap.h"      // _Py_bswap32()
-#include "structmember.h"         // PyMemberDef
 #include "hashlib.h"
 #include "pystrhex.h"
 
@@ -513,7 +512,7 @@ static PyGetSetDef SHA_getseters[] = {
 };
 
 static PyMemberDef SHA_members[] = {
-    {"digest_size", T_INT, offsetof(SHAobject, digestsize), READONLY, NULL},
+    {"digest_size", T_INT, offsetof(SHAobject, digestsize), PY_READONLY, NULL},
     {NULL}  /* Sentinel */
 };
 

--- a/Modules/sha512module.c
+++ b/Modules/sha512module.c
@@ -18,7 +18,6 @@
 
 #include "Python.h"
 #include "pycore_byteswap.h"      // _Py_bswap32()
-#include "structmember.h"         // PyMemberDef
 #include "hashlib.h"
 #include "pystrhex.h"
 
@@ -570,7 +569,7 @@ static PyGetSetDef SHA_getseters[] = {
 };
 
 static PyMemberDef SHA_members[] = {
-    {"digest_size", T_INT, offsetof(SHAobject, digestsize), READONLY, NULL},
+    {"digest_size", T_INT, offsetof(SHAobject, digestsize), PY_READONLY, NULL},
     {NULL}  /* Sentinel */
 };
 

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -101,7 +101,6 @@ Local naming conventions:
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 #ifdef _Py_MEMORY_SANITIZER
 # include <sanitizer/msan_interface.h>
@@ -5017,9 +5016,9 @@ static PyMethodDef sock_methods[] = {
 
 /* SockObject members */
 static PyMemberDef sock_memberlist[] = {
-       {"family", T_INT, offsetof(PySocketSockObject, sock_family), READONLY, "the socket family"},
-       {"type", T_INT, offsetof(PySocketSockObject, sock_type), READONLY, "the socket type"},
-       {"proto", T_INT, offsetof(PySocketSockObject, sock_proto), READONLY, "the socket protocol"},
+       {"family", T_INT, offsetof(PySocketSockObject, sock_family), PY_READONLY, "the socket family"},
+       {"type", T_INT, offsetof(PySocketSockObject, sock_type), PY_READONLY, "the socket type"},
+       {"proto", T_INT, offsetof(PySocketSockObject, sock_proto), PY_READONLY, "the socket protocol"},
        {0},
 };
 

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -17,7 +17,6 @@
 
 #include "Python.h"
 #include "ucnhash.h"
-#include "structmember.h"         // PyMemberDef
 
 #include <stdbool.h>
 
@@ -86,7 +85,7 @@ typedef struct previous_version {
 #define get_old_record(self, v)    ((((PreviousDBVersion*)self)->getrecord)(v))
 
 static PyMemberDef DB_members[] = {
-        {"unidata_version", T_STRING, offsetof(PreviousDBVersion, name), READONLY},
+        {"unidata_version", T_STRING, offsetof(PreviousDBVersion, name), PY_READONLY},
         {NULL}
 };
 

--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 PyDoc_STRVAR(xxsubtype__doc__,
 "xxsubtype is an example module showing how to subtype builtin types from C.\n"
@@ -186,7 +185,7 @@ spamdict_init(spamdictobject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyMemberDef spamdict_members[] = {
-    {"state", T_INT, offsetof(spamdictobject, state), READONLY,
+    {"state", T_INT, offsetof(spamdictobject, state), PY_READONLY,
      PyDoc_STR("an int variable for demonstration purposes")},
     {0}
 };

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -6,7 +6,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 #include "zlib.h"
 
 
@@ -1194,9 +1193,9 @@ static PyMethodDef Decomp_methods[] =
 
 #define COMP_OFF(x) offsetof(compobject, x)
 static PyMemberDef Decomp_members[] = {
-    {"unused_data",     T_OBJECT, COMP_OFF(unused_data), READONLY},
-    {"unconsumed_tail", T_OBJECT, COMP_OFF(unconsumed_tail), READONLY},
-    {"eof",             T_BOOL,   COMP_OFF(eof), READONLY},
+    {"unused_data",     T_OBJECT, COMP_OFF(unused_data), PY_READONLY},
+    {"unconsumed_tail", T_OBJECT, COMP_OFF(unconsumed_tail), PY_READONLY},
+    {"eof",             T_BOOL,   COMP_OFF(eof), PY_READONLY},
     {NULL},
 };
 

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -4,7 +4,6 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "structmember.h"         // PyMemberDef
 
 #define TP_DESCR_GET(t) ((t)->tp_descr_get)
 
@@ -144,9 +143,9 @@ static PyMethodDef method_methods[] = {
 #define MO_OFF(x) offsetof(PyMethodObject, x)
 
 static PyMemberDef method_memberlist[] = {
-    {"__func__", T_OBJECT, MO_OFF(im_func), READONLY,
+    {"__func__", T_OBJECT, MO_OFF(im_func), PY_READONLY,
      "the function (or other callable) implementing a method"},
-    {"__self__", T_OBJECT, MO_OFF(im_self), READONLY,
+    {"__self__", T_OBJECT, MO_OFF(im_self), PY_READONLY,
      "the instance to which a method is bound"},
     {NULL}      /* Sentinel */
 };
@@ -399,7 +398,7 @@ PyInstanceMethod_Function(PyObject *im)
 #define IMO_OFF(x) offsetof(PyInstanceMethodObject, x)
 
 static PyMemberDef instancemethod_memberlist[] = {
-    {"__func__", T_OBJECT, IMO_OFF(func), READONLY,
+    {"__func__", T_OBJECT, IMO_OFF(func), PY_READONLY,
      "the function (or other callable) implementing a method"},
     {NULL}      /* Sentinel */
 };

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -3,7 +3,6 @@
 #include "Python.h"
 #include "code.h"
 #include "opcode.h"
-#include "structmember.h"         // PyMemberDef
 #include "pycore_code.h"
 #include "pycore_interp.h"        // PyInterpreterState.co_extra_freefuncs
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
@@ -373,22 +372,22 @@ failed:
 #define OFF(x) offsetof(PyCodeObject, x)
 
 static PyMemberDef code_memberlist[] = {
-    {"co_argcount",     T_INT,          OFF(co_argcount),        READONLY},
-    {"co_posonlyargcount",      T_INT,  OFF(co_posonlyargcount), READONLY},
-    {"co_kwonlyargcount",       T_INT,  OFF(co_kwonlyargcount),  READONLY},
-    {"co_nlocals",      T_INT,          OFF(co_nlocals),         READONLY},
-    {"co_stacksize",T_INT,              OFF(co_stacksize),       READONLY},
-    {"co_flags",        T_INT,          OFF(co_flags),           READONLY},
-    {"co_code",         T_OBJECT,       OFF(co_code),            READONLY},
-    {"co_consts",       T_OBJECT,       OFF(co_consts),          READONLY},
-    {"co_names",        T_OBJECT,       OFF(co_names),           READONLY},
-    {"co_varnames",     T_OBJECT,       OFF(co_varnames),        READONLY},
-    {"co_freevars",     T_OBJECT,       OFF(co_freevars),        READONLY},
-    {"co_cellvars",     T_OBJECT,       OFF(co_cellvars),        READONLY},
-    {"co_filename",     T_OBJECT,       OFF(co_filename),        READONLY},
-    {"co_name",         T_OBJECT,       OFF(co_name),            READONLY},
-    {"co_firstlineno", T_INT,           OFF(co_firstlineno),     READONLY},
-    {"co_lnotab",       T_OBJECT,       OFF(co_lnotab),          READONLY},
+    {"co_argcount",     T_INT,          OFF(co_argcount),        PY_READONLY},
+    {"co_posonlyargcount",      T_INT,  OFF(co_posonlyargcount), PY_READONLY},
+    {"co_kwonlyargcount",       T_INT,  OFF(co_kwonlyargcount),  PY_READONLY},
+    {"co_nlocals",      T_INT,          OFF(co_nlocals),         PY_READONLY},
+    {"co_stacksize",T_INT,              OFF(co_stacksize),       PY_READONLY},
+    {"co_flags",        T_INT,          OFF(co_flags),           PY_READONLY},
+    {"co_code",         T_OBJECT,       OFF(co_code),            PY_READONLY},
+    {"co_consts",       T_OBJECT,       OFF(co_consts),          PY_READONLY},
+    {"co_names",        T_OBJECT,       OFF(co_names),           PY_READONLY},
+    {"co_varnames",     T_OBJECT,       OFF(co_varnames),        PY_READONLY},
+    {"co_freevars",     T_OBJECT,       OFF(co_freevars),        PY_READONLY},
+    {"co_cellvars",     T_OBJECT,       OFF(co_cellvars),        PY_READONLY},
+    {"co_filename",     T_OBJECT,       OFF(co_filename),        PY_READONLY},
+    {"co_name",         T_OBJECT,       OFF(co_name),            PY_READONLY},
+    {"co_firstlineno", T_INT,           OFF(co_firstlineno),     PY_READONLY},
+    {"co_lnotab",       T_OBJECT,       OFF(co_lnotab),          PY_READONLY},
     {NULL}      /* Sentinel */
 };
 

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -6,7 +6,6 @@
 /* Submitted by Jim Hugunin */
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 /*[clinic input]
 class complex "PyComplexObject *" "&PyComplex_Type"
@@ -741,9 +740,9 @@ static PyMethodDef complex_methods[] = {
 };
 
 static PyMemberDef complex_members[] = {
-    {"real", T_DOUBLE, offsetof(PyComplexObject, cval.real), READONLY,
+    {"real", T_DOUBLE, offsetof(PyComplexObject, cval.real), PY_READONLY,
      "the real part of a complex number"},
-    {"imag", T_DOUBLE, offsetof(PyComplexObject, cval.imag), READONLY,
+    {"imag", T_DOUBLE, offsetof(PyComplexObject, cval.imag), PY_READONLY,
      "the imaginary part of a complex number"},
     {0},
 };

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -5,7 +5,6 @@
 #include "pycore_object.h"
 #include "pycore_pystate.h"      // _PyThreadState_GET()
 #include "pycore_tupleobject.h"
-#include "structmember.h"         // PyMemberDef
 
 _Py_IDENTIFIER(getattr);
 
@@ -164,7 +163,7 @@ member_get(PyMemberDescrObject *descr, PyObject *obj, PyObject *type)
     if (descr_check((PyDescrObject *)descr, obj, &res))
         return res;
 
-    if (descr->d_member->flags & READ_RESTRICTED) {
+    if (descr->d_member->flags & PY_READ_RESTRICTED) {
         if (PySys_Audit("object.__getattr__", "Os",
             obj ? obj : Py_None, descr->d_member->name) < 0) {
             return NULL;
@@ -620,8 +619,8 @@ static PyMethodDef descr_methods[] = {
 };
 
 static PyMemberDef descr_members[] = {
-    {"__objclass__", T_OBJECT, offsetof(PyDescrObject, d_type), READONLY},
-    {"__name__", T_OBJECT, offsetof(PyDescrObject, d_name), READONLY},
+    {"__objclass__", T_OBJECT, offsetof(PyDescrObject, d_type), PY_READONLY},
+    {"__name__", T_OBJECT, offsetof(PyDescrObject, d_name), PY_READONLY},
     {0}
 };
 
@@ -1328,7 +1327,7 @@ static PyMethodDef wrapper_methods[] = {
 };
 
 static PyMemberDef wrapper_members[] = {
-    {"__self__", T_OBJECT, offsetof(wrapperobject, self), READONLY},
+    {"__self__", T_OBJECT, offsetof(wrapperobject, self), PY_READONLY},
     {0}
 };
 
@@ -1497,9 +1496,9 @@ static PyObject * property_copy(PyObject *, PyObject *, PyObject *,
                                   PyObject *);
 
 static PyMemberDef property_members[] = {
-    {"fget", T_OBJECT, offsetof(propertyobject, prop_get), READONLY},
-    {"fset", T_OBJECT, offsetof(propertyobject, prop_set), READONLY},
-    {"fdel", T_OBJECT, offsetof(propertyobject, prop_del), READONLY},
+    {"fget", T_OBJECT, offsetof(propertyobject, prop_get), PY_READONLY},
+    {"fset", T_OBJECT, offsetof(propertyobject, prop_set), PY_READONLY},
+    {"fdel", T_OBJECT, offsetof(propertyobject, prop_del), PY_READONLY},
     {"__doc__",  T_OBJECT, offsetof(propertyobject, prop_doc), 0},
     {0}
 };

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -8,7 +8,6 @@
 #include <Python.h>
 #include "pycore_initconfig.h"
 #include "pycore_object.h"
-#include "structmember.h"         // PyMemberDef
 #include "osdefs.h"               // SEP
 
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -7,16 +7,15 @@
 #include "code.h"
 #include "frameobject.h"
 #include "opcode.h"
-#include "structmember.h"         // PyMemberDef
 
 #define OFF(x) offsetof(PyFrameObject, x)
 
 static PyMemberDef frame_memberlist[] = {
-    {"f_back",          T_OBJECT,       OFF(f_back),      READONLY},
-    {"f_code",          T_OBJECT,       OFF(f_code),      READONLY},
-    {"f_builtins",      T_OBJECT,       OFF(f_builtins),  READONLY},
-    {"f_globals",       T_OBJECT,       OFF(f_globals),   READONLY},
-    {"f_lasti",         T_INT,          OFF(f_lasti),     READONLY},
+    {"f_back",          T_OBJECT,       OFF(f_back),      PY_READONLY},
+    {"f_code",          T_OBJECT,       OFF(f_code),      PY_READONLY},
+    {"f_builtins",      T_OBJECT,       OFF(f_builtins),  PY_READONLY},
+    {"f_globals",       T_OBJECT,       OFF(f_globals),   PY_READONLY},
+    {"f_lasti",         T_INT,          OFF(f_lasti),     PY_READONLY},
     {"f_trace_lines",   T_BOOL,         OFF(f_trace_lines), 0},
     {"f_trace_opcodes", T_BOOL,         OFF(f_trace_opcodes), 0},
     {NULL}      /* Sentinel */

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -5,7 +5,6 @@
 #include "pycore_object.h"
 #include "pycore_tupleobject.h"
 #include "code.h"
-#include "structmember.h"         // PyMemberDef
 
 PyObject *
 PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname)
@@ -237,9 +236,9 @@ PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
 #define OFF(x) offsetof(PyFunctionObject, x)
 
 static PyMemberDef func_memberlist[] = {
-    {"__closure__",   T_OBJECT,     OFF(func_closure), READONLY},
+    {"__closure__",   T_OBJECT,     OFF(func_closure), PY_READONLY},
     {"__doc__",       T_OBJECT,     OFF(func_doc), 0},
-    {"__globals__",   T_OBJECT,     OFF(func_globals), READONLY},
+    {"__globals__",   T_OBJECT,     OFF(func_globals), PY_READONLY},
     {"__module__",    T_OBJECT,     OFF(func_module), 0},
     {NULL}  /* Sentinel */
 };
@@ -760,7 +759,7 @@ cm_init(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyMemberDef cm_memberlist[] = {
-    {"__func__", T_OBJECT, offsetof(classmethod, cm_callable), READONLY},
+    {"__func__", T_OBJECT, offsetof(classmethod, cm_callable), PY_READONLY},
     {NULL}  /* Sentinel */
 };
 
@@ -942,7 +941,7 @@ sm_init(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyMemberDef sm_memberlist[] = {
-    {"__func__", T_OBJECT, offsetof(staticmethod, sm_callable), READONLY},
+    {"__func__", T_OBJECT, offsetof(staticmethod, sm_callable), PY_READONLY},
     {NULL}  /* Sentinel */
 };
 

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -2,7 +2,6 @@
 
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"         // PyMemberDef
 
 typedef struct {
     PyObject_HEAD
@@ -496,8 +495,8 @@ static PyMethodDef ga_methods[] = {
 };
 
 static PyMemberDef ga_members[] = {
-    {"__origin__", T_OBJECT, offsetof(gaobject, origin), READONLY},
-    {"__args__", T_OBJECT, offsetof(gaobject, args), READONLY},
+    {"__origin__", T_OBJECT, offsetof(gaobject, origin), PY_READONLY},
+    {"__args__", T_OBJECT, offsetof(gaobject, args), PY_READONLY},
     {0}
 };
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -6,7 +6,6 @@
 #include "pycore_pyerrors.h"      // _PyErr_ClearExcState()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "frameobject.h"
-#include "structmember.h"         // PyMemberDef
 #include "opcode.h"
 
 static PyObject *gen_close(PyGenObject *, PyObject *);
@@ -701,9 +700,9 @@ static PyGetSetDef gen_getsetlist[] = {
 };
 
 static PyMemberDef gen_memberlist[] = {
-    {"gi_frame",     T_OBJECT, offsetof(PyGenObject, gi_frame),    READONLY},
-    {"gi_running",   T_BOOL,   offsetof(PyGenObject, gi_running),  READONLY},
-    {"gi_code",      T_OBJECT, offsetof(PyGenObject, gi_code),     READONLY},
+    {"gi_frame",   T_OBJECT, offsetof(PyGenObject, gi_frame),   PY_READONLY},
+    {"gi_running", T_BOOL,   offsetof(PyGenObject, gi_running), PY_READONLY},
+    {"gi_code",    T_OBJECT, offsetof(PyGenObject, gi_code),    PY_READONLY},
     {NULL}      /* Sentinel */
 };
 
@@ -921,10 +920,10 @@ static PyGetSetDef coro_getsetlist[] = {
 };
 
 static PyMemberDef coro_memberlist[] = {
-    {"cr_frame",     T_OBJECT, offsetof(PyCoroObject, cr_frame),    READONLY},
-    {"cr_running",   T_BOOL,   offsetof(PyCoroObject, cr_running),  READONLY},
-    {"cr_code",      T_OBJECT, offsetof(PyCoroObject, cr_code),     READONLY},
-    {"cr_origin",    T_OBJECT, offsetof(PyCoroObject, cr_origin),   READONLY},
+    {"cr_frame",   T_OBJECT, offsetof(PyCoroObject, cr_frame),   PY_READONLY},
+    {"cr_running", T_BOOL,   offsetof(PyCoroObject, cr_running), PY_READONLY},
+    {"cr_code",    T_OBJECT, offsetof(PyCoroObject, cr_code),    PY_READONLY},
+    {"cr_origin",  T_OBJECT, offsetof(PyCoroObject, cr_origin),  PY_READONLY},
     {NULL}      /* Sentinel */
 };
 
@@ -1318,10 +1317,10 @@ static PyGetSetDef async_gen_getsetlist[] = {
 };
 
 static PyMemberDef async_gen_memberlist[] = {
-    {"ag_frame",   T_OBJECT, offsetof(PyAsyncGenObject, ag_frame),   READONLY},
+    {"ag_frame",   T_OBJECT, offsetof(PyAsyncGenObject, ag_frame), PY_READONLY},
     {"ag_running", T_BOOL,   offsetof(PyAsyncGenObject, ag_running_async),
-        READONLY},
-    {"ag_code",    T_OBJECT, offsetof(PyAsyncGenObject, ag_code),    READONLY},
+     PY_READONLY},
+    {"ag_code",    T_OBJECT, offsetof(PyAsyncGenObject, ag_code),  PY_READONLY},
     {NULL}      /* Sentinel */
 };
 

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -6,7 +6,6 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "structmember.h"         // PyMemberDef
 
 /* undefine macro trampoline to PyCFunction_NewEx */
 #undef PyCFunction_New

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -4,7 +4,6 @@
 #include "Python.h"
 #include "pycore_interp.h"        // PyInterpreterState.importlib
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
-#include "structmember.h"         // PyMemberDef
 
 static Py_ssize_t max_module_number;
 
@@ -22,7 +21,7 @@ typedef struct {
 } PyModuleObject;
 
 static PyMemberDef module_members[] = {
-    {"__dict__", T_OBJECT, offsetof(PyModuleObject, md_dict), READONLY},
+    {"__dict__", T_OBJECT, offsetof(PyModuleObject, md_dict), PY_READONLY},
     {0}
 };
 

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -1,7 +1,6 @@
 // namespace object implementation
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 
 typedef struct {
@@ -11,7 +10,7 @@ typedef struct {
 
 
 static PyMemberDef namespace_members[] = {
-    {"__dict__", T_OBJECT, offsetof(_PyNamespaceObject, ns_dict), READONLY},
+    {"__dict__", T_OBJECT, offsetof(_PyNamespaceObject, ns_dict), PY_READONLY},
     {NULL}
 };
 

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -3,7 +3,6 @@
 #include "Python.h"
 #include "pycore_abstract.h"   // _PyIndex_Check()
 #include "pycore_tupleobject.h"
-#include "structmember.h"         // PyMemberDef
 
 /* Support objects whose length is > PY_SSIZE_T_MAX.
 
@@ -689,9 +688,9 @@ static PyMethodDef range_methods[] = {
 };
 
 static PyMemberDef range_members[] = {
-    {"start",   T_OBJECT_EX,    offsetof(rangeobject, start),   READONLY},
-    {"stop",    T_OBJECT_EX,    offsetof(rangeobject, stop),    READONLY},
-    {"step",    T_OBJECT_EX,    offsetof(rangeobject, step),    READONLY},
+    {"start",   T_OBJECT_EX,    offsetof(rangeobject, start),   PY_READONLY},
+    {"stop",    T_OBJECT_EX,    offsetof(rangeobject, stop),    PY_READONLY},
+    {"step",    T_OBJECT_EX,    offsetof(rangeobject, step),    PY_READONLY},
     {0}
 };
 

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -16,7 +16,6 @@ this type and there is exactly one in existence.
 #include "Python.h"
 #include "pycore_abstract.h"      // _PyIndex_Check()
 #include "pycore_object.h"
-#include "structmember.h"         // PyMemberDef
 
 static PyObject *
 ellipsis_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
@@ -341,9 +340,9 @@ slice_repr(PySliceObject *r)
 }
 
 static PyMemberDef slice_members[] = {
-    {"start", T_OBJECT, offsetof(PySliceObject, start), READONLY},
-    {"stop", T_OBJECT, offsetof(PySliceObject, stop), READONLY},
-    {"step", T_OBJECT, offsetof(PySliceObject, step), READONLY},
+    {"start", T_OBJECT, offsetof(PySliceObject, start), PY_READONLY},
+    {"stop", T_OBJECT, offsetof(PySliceObject, stop), PY_READONLY},
+    {"step", T_OBJECT, offsetof(PySliceObject, step), PY_READONLY},
     {0}
 };
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -10,7 +10,6 @@
 #include "Python.h"
 #include "pycore_tupleobject.h"
 #include "pycore_object.h"
-#include "structmember.h"         // PyMemberDef
 
 static const char visible_length_key[] = "n_sequence_fields";
 static const char real_length_key[] = "n_fields";
@@ -375,7 +374,7 @@ initialize_members(PyStructSequence_Desc *desc, PyMemberDef* members,
         members[k].type = T_OBJECT;
         members[k].offset = offsetof(PyStructSequence, ob_item)
           + i * sizeof(PyObject*);
-        members[k].flags = READONLY;
+        members[k].flags = PY_READONLY;
         members[k].doc = desc->fields[i].doc;
         k++;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7,7 +7,6 @@
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "frameobject.h"
-#include "structmember.h"         // PyMemberDef
 
 #include <ctype.h>
 
@@ -412,15 +411,17 @@ assign_version_tag(PyTypeObject *type)
 
 
 static PyMemberDef type_members[] = {
-    {"__basicsize__", T_PYSSIZET, offsetof(PyTypeObject,tp_basicsize),READONLY},
-    {"__itemsize__", T_PYSSIZET, offsetof(PyTypeObject, tp_itemsize), READONLY},
-    {"__flags__", T_ULONG, offsetof(PyTypeObject, tp_flags), READONLY},
+    {"__basicsize__", T_PYSSIZET, offsetof(PyTypeObject,tp_basicsize),
+     PY_READONLY},
+    {"__itemsize__", T_PYSSIZET, offsetof(PyTypeObject, tp_itemsize),
+     PY_READONLY},
+    {"__flags__", T_ULONG, offsetof(PyTypeObject, tp_flags), PY_READONLY},
     {"__weakrefoffset__", T_PYSSIZET,
-     offsetof(PyTypeObject, tp_weaklistoffset), READONLY},
-    {"__base__", T_OBJECT, offsetof(PyTypeObject, tp_base), READONLY},
+     offsetof(PyTypeObject, tp_weaklistoffset), PY_READONLY},
+    {"__base__", T_OBJECT, offsetof(PyTypeObject, tp_base), PY_READONLY},
     {"__dictoffset__", T_PYSSIZET,
-     offsetof(PyTypeObject, tp_dictoffset), READONLY},
-    {"__mro__", T_OBJECT, offsetof(PyTypeObject, tp_mro), READONLY},
+     offsetof(PyTypeObject, tp_dictoffset), PY_READONLY},
+    {"__mro__", T_OBJECT, offsetof(PyTypeObject, tp_mro), PY_READONLY},
     {0}
 };
 
@@ -1153,7 +1154,7 @@ clear_slots(PyTypeObject *type, PyObject *self)
     n = Py_SIZE(type);
     mp = PyHeapType_GET_MEMBERS((PyHeapTypeObject *)type);
     for (i = 0; i < n; i++, mp++) {
-        if (mp->type == T_OBJECT_EX && !(mp->flags & READONLY)) {
+        if (mp->type == T_OBJECT_EX && !(mp->flags & PY_READONLY)) {
             char *addr = (char *)self + mp->offset;
             PyObject *obj = *(PyObject **)addr;
             if (obj != NULL) {
@@ -2905,19 +2906,19 @@ PyType_FromModuleAndSpec(PyObject *module, PyType_Spec *spec, PyObject *bases)
                 if (strcmp(memb->name, "__weaklistoffset__") == 0) {
                     // The PyMemberDef must be a Py_ssize_t and readonly
                     assert(memb->type == T_PYSSIZET);
-                    assert(memb->flags == READONLY);
+                    assert(memb->flags == PY_READONLY);
                     weaklistoffset = memb->offset;
                 }
                 if (strcmp(memb->name, "__dictoffset__") == 0) {
                     // The PyMemberDef must be a Py_ssize_t and readonly
                     assert(memb->type == T_PYSSIZET);
-                    assert(memb->flags == READONLY);
+                    assert(memb->flags == PY_READONLY);
                     dictoffset = memb->offset;
                 }
                 if (strcmp(memb->name, "__vectorcalloffset__") == 0) {
                     // The PyMemberDef must be a Py_ssize_t and readonly
                     assert(memb->type == T_PYSSIZET);
-                    assert(memb->flags == READONLY);
+                    assert(memb->flags == PY_READONLY);
                     vectorcalloffset = memb->offset;
                 }
             }
@@ -7831,11 +7832,11 @@ typedef struct {
 } superobject;
 
 static PyMemberDef super_members[] = {
-    {"__thisclass__", T_OBJECT, offsetof(superobject, type), READONLY,
+    {"__thisclass__", T_OBJECT, offsetof(superobject, type), PY_READONLY,
      "the class invoking super()"},
-    {"__self__",  T_OBJECT, offsetof(superobject, obj), READONLY,
+    {"__self__",  T_OBJECT, offsetof(superobject, obj), PY_READONLY,
      "the instance invoking super(); may be None"},
-    {"__self_class__", T_OBJECT, offsetof(superobject, obj_type), READONLY,
+    {"__self_class__", T_OBJECT, offsetof(superobject, obj_type), PY_READONLY,
      "the type of the instance invoking super(); may be None"},
     {0}
 };

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -1,6 +1,5 @@
 #include "Python.h"
 #include "pycore_object.h"        // _PyObject_GET_WEAKREFS_LISTPTR()
-#include "structmember.h"         // PyMemberDef
 
 
 #define GET_WEAKREFS_LISTPTR(o) \
@@ -358,7 +357,8 @@ weakref___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 
 
 static PyMemberDef weakref_members[] = {
-    {"__callback__", T_OBJECT, offsetof(PyWeakReference, wr_callback), READONLY},
+    {"__callback__", T_OBJECT, offsetof(PyWeakReference, wr_callback),
+     PY_READONLY},
     {NULL} /* Sentinel */
 };
 

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -14,7 +14,6 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 #include <windows.h>
 
 static BOOL PyHKEY_AsHKEY(PyObject *ob, HKEY *pRes, BOOL bNoneOK);
@@ -346,7 +345,7 @@ static struct PyMethodDef PyHKEY_methods[] = {
 
 #define OFF(e) offsetof(PyHKEYObject, e)
 static PyMemberDef PyHKEY_memberlist[] = {
-    {"handle",      T_INT,      OFF(hkey), READONLY},
+    {"handle",      T_INT,      OFF(hkey), PY_READONLY},
     {NULL}    /* Sentinel */
 };
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -770,7 +770,7 @@ ast_type_reduce(PyObject *self, PyObject *unused)
 }
 
 static PyMemberDef ast_type_members[] = {
-    {"__dictoffset__", T_PYSSIZET, offsetof(AST_object, dict), READONLY},
+    {"__dictoffset__", T_PYSSIZET, offsetof(AST_object, dict), PY_READONLY},
     {NULL}  /* Sentinel */
 };
 
@@ -1429,7 +1429,6 @@ def write_source(f, mod):
     f.write('\n')
     f.write('#include "Python.h"\n')
     f.write('#include "%s-ast.h"\n' % mod.name)
-    f.write('#include "structmember.h"         // PyMemberDef\n')
     f.write('\n')
 
     generate_module_def(f, mod)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -4,7 +4,6 @@
 
 #include "Python.h"
 #include "Python-ast.h"
-#include "structmember.h"         // PyMemberDef
 
 typedef struct {
     int initialized;
@@ -1206,7 +1205,7 @@ ast_type_reduce(PyObject *self, PyObject *unused)
 }
 
 static PyMemberDef ast_type_members[] = {
-    {"__dictoffset__", T_PYSSIZET, offsetof(AST_object, dict), READONLY},
+    {"__dictoffset__", T_PYSSIZET, offsetof(AST_object, dict), PY_READONLY},
     {NULL}  /* Sentinel */
 };
 

--- a/Python/context.c
+++ b/Python/context.c
@@ -6,7 +6,6 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "structmember.h"         // PyMemberDef
 
 
 #define CONTEXT_FREELIST_MAXLEN 255
@@ -1025,7 +1024,7 @@ _contextvars_ContextVar_reset(PyContextVar *self, PyObject *token)
 
 
 static PyMemberDef PyContextVar_members[] = {
-    {"name", T_OBJECT, offsetof(PyContextVar, var_name), READONLY},
+    {"name", T_OBJECT, offsetof(PyContextVar, var_name), PY_READONLY},
     {NULL}
 };
 

--- a/Python/structmember.c
+++ b/Python/structmember.c
@@ -2,7 +2,6 @@
 /* Map C struct members to Python object attributes */
 
 #include "Python.h"
-#include "structmember.h"         // PyMemberDef
 
 PyObject *
 PyMember_GetOne(const char *addr, PyMemberDef *l)
@@ -103,7 +102,7 @@ PyMember_SetOne(char *addr, PyMemberDef *l, PyObject *v)
 
     addr += l->offset;
 
-    if ((l->flags & READONLY))
+    if ((l->flags & PY_READONLY))
     {
         PyErr_SetString(PyExc_AttributeError, "readonly attribute");
         return -1;

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -2,7 +2,6 @@
 #include "pycore_pystate.h"   // _PyThreadState_GET()
 #include "symtable.h"
 #undef Yield   /* undefine macro conflicting with <winbase.h> */
-#include "structmember.h"         // PyMemberDef
 
 /* error strings used for warnings */
 #define GLOBAL_PARAM \
@@ -134,14 +133,14 @@ ste_dealloc(PySTEntryObject *ste)
 #define OFF(x) offsetof(PySTEntryObject, x)
 
 static PyMemberDef ste_memberlist[] = {
-    {"id",       T_OBJECT, OFF(ste_id), READONLY},
-    {"name",     T_OBJECT, OFF(ste_name), READONLY},
-    {"symbols",  T_OBJECT, OFF(ste_symbols), READONLY},
-    {"varnames", T_OBJECT, OFF(ste_varnames), READONLY},
-    {"children", T_OBJECT, OFF(ste_children), READONLY},
-    {"nested",   T_INT,    OFF(ste_nested), READONLY},
-    {"type",     T_INT,    OFF(ste_type), READONLY},
-    {"lineno",   T_INT,    OFF(ste_lineno), READONLY},
+    {"id",       T_OBJECT, OFF(ste_id), PY_READONLY},
+    {"name",     T_OBJECT, OFF(ste_name), PY_READONLY},
+    {"symbols",  T_OBJECT, OFF(ste_symbols), PY_READONLY},
+    {"varnames", T_OBJECT, OFF(ste_varnames), PY_READONLY},
+    {"children", T_OBJECT, OFF(ste_children), PY_READONLY},
+    {"nested",   T_INT,    OFF(ste_nested), PY_READONLY},
+    {"type",     T_INT,    OFF(ste_type), PY_READONLY},
+    {"lineno",   T_INT,    OFF(ste_lineno), PY_READONLY},
     {NULL}
 };
 

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -5,7 +5,6 @@
 
 #include "code.h"
 #include "frameobject.h"          // PyFrame_GetBack()
-#include "structmember.h"         // PyMemberDef
 #include "osdefs.h"               // SEP
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
@@ -147,9 +146,9 @@ static PyMethodDef tb_methods[] = {
 };
 
 static PyMemberDef tb_memberlist[] = {
-    {"tb_frame",        T_OBJECT,       OFF(tb_frame),  READONLY},
-    {"tb_lasti",        T_INT,          OFF(tb_lasti),  READONLY},
-    {"tb_lineno",       T_INT,          OFF(tb_lineno), READONLY},
+    {"tb_frame",        T_OBJECT,       OFF(tb_frame),  PY_READONLY},
+    {"tb_lasti",        T_INT,          OFF(tb_lasti),  PY_READONLY},
+    {"tb_lineno",       T_INT,          OFF(tb_lineno), PY_READONLY},
     {NULL}      /* Sentinel */
 };
 

--- a/configure
+++ b/configure
@@ -7956,7 +7956,7 @@ fi
 for ac_header in asm/types.h crypt.h conio.h direct.h dlfcn.h errno.h \
 fcntl.h grp.h \
 ieeefp.h io.h langinfo.h libintl.h process.h pthread.h \
-sched.h shadow.h signal.h stropts.h termios.h \
+sched.h shadow.h signal.h stddef.h stropts.h termios.h \
 utime.h \
 poll.h sys/devpoll.h sys/epoll.h sys/poll.h \
 sys/audioio.h sys/xattr.h sys/bsdtty.h sys/event.h sys/file.h sys/ioctl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -2173,7 +2173,7 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS(asm/types.h crypt.h conio.h direct.h dlfcn.h errno.h \
 fcntl.h grp.h \
 ieeefp.h io.h langinfo.h libintl.h process.h pthread.h \
-sched.h shadow.h signal.h stropts.h termios.h \
+sched.h shadow.h signal.h stddef.h stropts.h termios.h \
 utime.h \
 poll.h sys/devpoll.h sys/epoll.h sys/poll.h \
 sys/audioio.h sys/xattr.h sys/bsdtty.h sys/event.h sys/file.h sys/ioctl.h \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1025,6 +1025,9 @@
    void fprintf(FILE *, char *, ...);) *and* <stdarg.h> */
 #undef HAVE_STDARG_PROTOTYPES
 
+/* Define to 1 if you have the <stddef.h> header file. */
+#undef HAVE_STDDEF_H
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 


### PR DESCRIPTION
Move PyMemberDef and related flags from structmember.h to descrobject.h.
Rename READONLY to PY_READONLY and READ_RESTRICTED to
PY_READ_RESTRICTED. This makes the structure part of the stable ABI.

Move PyMember_GetOne and PyMemberSetOne as well but do not make them
part of the stable ABI yet.

Document that structmember.h is deprecated, change examples and
documentation and add definitions for READONLY, READ_RESTRICTED,
PY_WRITE_RESTRICTED and RESTRICTED to it for backwards compatibility.

Add check for stddef.h to configure.ac because we need to include it for
offsetof and Python.h does not pass the HAVE_STDDEF_H check without it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-2897](https://bugs.python.org/issue2897) -->
https://bugs.python.org/issue2897
<!-- /issue-number -->
