### PR TITLE
bpo-40849: Expose X509_V_FLAG_PARTIAL_CHAIN ssl flag

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -642,6 +642,17 @@ Constants
 
    .. versionadded:: 3.4.4
 
+.. data:: VERIFY_X509_PARTIAL_CHAIN
+
+   Possible value for :attr:`SSLContext.verify_flags`. It instructs OpenSSL to
+   accept intermediate CAs in the trust store to be treated as trust-anchors,
+   in the same way as the self-signed root CA certificates. This makes it
+   possible to trust certificates issued by an intermediate CA without having
+   to trust its ancestor root CA.
+
+  .. versionadded::3.8.4
+
+
 .. class:: VerifyFlags
 
    :class:`enum.IntFlag` collection of VERIFY_* constants.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -650,7 +650,7 @@ Constants
    possible to trust certificates issued by an intermediate CA without having
    to trust its ancestor root CA.
 
-  .. versionadded::3.8.4
+   .. versionadded:: 3.10
 
 
 .. class:: VerifyFlags

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -153,6 +153,7 @@ Michel Van den Bergh
 Julian Berman
 Brice Berna
 Olivier Bernard
+Vivien Bernet-Rollande
 Maxwell Bernstein
 Eric Beser
 Steven Bethard

--- a/Misc/NEWS.d/next/Library/2020-06-02-21-32-33.bpo-40849.zpeKx3.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-02-21-32-33.bpo-40849.zpeKx3.rst
@@ -1,0 +1,1 @@
+Expose X509_V_FLAG_PARTIAL_CHAIN ssl flag

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6112,6 +6112,11 @@ PyInit__ssl(void)
                             X509_V_FLAG_TRUSTED_FIRST);
 #endif
 
+#ifdef X509_V_FLAG_PARTIAL_CHAIN
+    PyModule_AddIntConstant(m, "VERIFY_X509_PARTIAL_CHAIN",
+                            X509_V_FLAG_PARTIAL_CHAIN);
+#endif
+
     /* Alert Descriptions from ssl.h */
     /* note RESERVED constants no longer intended for use have been removed */
     /* http://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-6 */


### PR DESCRIPTION
This short PR exposes an openssl flag that  wasn't exposed. I've also updated to doc to reflect the change. It's heavily inspired by 990fcaac3c428569697f62a80fd95ab4d4b93151.

<!-- issue-number: [bpo-40849](https://bugs.python.org/issue40849) -->
https://bugs.python.org/issue40849
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran