### PR TITLE
Update doc in logging 

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1391,7 +1391,7 @@ class QueueHandler(logging.Handler):
     def prepare(self, record):
         """
         Prepares a record for queuing. The object returned by this method is
-        enqueued.
+        ready to enqueue.
 
         The base implementation formats the record to merge the message
         and arguments, and removes unpickleable items from the record


### PR DESCRIPTION
The object returned by QueueHandler.prepare() is ready to enqueue instead of already enqueued.
