### PR TITLE
bpo-40801: Add operator.as_float

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -107,6 +107,8 @@ The mathematical and bitwise operations are the most numerous:
    that conversion from a string or bytestring is not permitted. The result
    always has exact type :class:`float`.
 
+   .. versionadded:: 3.10
+
 
 .. function:: floordiv(a, b)
               __floordiv__(a, b)

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -103,7 +103,7 @@ The mathematical and bitwise operations are the most numerous:
 
 .. function:: as_float(a)
 
-   Return *a* converted to an float.  Equivalent to ``float(a)``, except
+   Return *a* converted to a float.  Equivalent to ``float(a)``, except
    that conversion from a string or bytestring is not permitted. The result
    always has exact type :class:`float`.
 

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -101,6 +101,13 @@ The mathematical and bitwise operations are the most numerous:
    Return the bitwise and of *a* and *b*.
 
 
+.. function:: as_float(a)
+
+   Return *a* converted to an float.  Equivalent to ``float(a)``, except
+   that conversion from a string or bytestring is not permitted. The result
+   always has exact type :class:`float`.
+
+
 .. function:: floordiv(a, b)
               __floordiv__(a, b)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -92,6 +92,13 @@ New Modules
 Improved Modules
 ================
 
+operator
+--------
+
+Added :func:`operator.as_float` to convert a numeric object to :class:`float`.
+This exposes to Python a conversion whose semantics exactly match Python's
+own implicit float conversions, for example as used in the :mod:`math` module.
+
 tracemalloc
 -----------
 

--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -80,6 +80,16 @@ def and_(a, b):
     "Same as a & b."
     return a & b
 
+def as_float(obj):
+    """
+    Convert something numeric to float.
+
+    Same as float(obj), but does not accept strings.
+    """
+    if isinstance(obj, (str, bytes, bytearray)):
+        raise TypeError("as_float argument must be numeric")
+    return float(obj)
+
 def floordiv(a, b):
     "Same as a // b."
     return a // b

--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -86,8 +86,20 @@ def as_float(obj):
 
     Same as float(obj), but does not accept strings.
     """
-    if isinstance(obj, (str, bytes, bytearray)):
-        raise TypeError("as_float argument must be numeric")
+    # Exclude strings and anything exposing the buffer interface.
+    bad_type = False
+    if isinstance(obj, str):
+        bad_type = True
+    else:
+        try:
+            memoryview(obj)
+            bad_type = True
+        except TypeError:
+            pass
+
+    if bad_type:
+        raise TypeError(f"must be real number, not {obj.__class__.__name__}")
+
     return float(obj)
 
 def floordiv(a, b):

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -562,7 +562,12 @@ class OperatorTestCase:
         self.assertIsFloatWithValue(operator.as_float(Confused()), 123.456)
 
         # Not convertible.
-        bad_values = ["123", b"123", bytearray(b"123"), None, 1j]
+        import array
+
+        bad_values = [
+            "123", b"123", bytearray(b"123"), None, 1j,
+            array.array('B', b"123.0"),
+        ]
         for bad_value in bad_values:
             with self.subTest(bad_value=bad_value):
                 with self.assertRaises(TypeError):

--- a/Misc/NEWS.d/next/Library/2020-05-28-11-54-56.bpo-40801.CFOWc1.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-28-11-54-56.bpo-40801.CFOWc1.rst
@@ -1,0 +1,6 @@
+Add a new :func:`operator.as_float` function for converting an arbitrary
+Python numeric object to :class:`float`. This is a simple wrapper around the
+:c:func:`PyFloat_AsDouble` C-API function. The intent is to provide at
+Python level a conversion whose semantics exactly match Python's own
+implicit float conversions, for example those used in the :mod:`math`
+module.

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -762,6 +762,50 @@ _tscmp(const unsigned char *a, const unsigned char *b,
 }
 
 /*[clinic input]
+_operator.as_float ->
+
+    obj: object
+    /
+
+Return *obj* interpreted as a float.
+
+If *obj* is already of exact type float, return it unchanged.
+
+If *obj* is already an instance of float (including possibly an instance of a
+float subclass), return a float with the same value as *obj*.
+
+If *obj* is not an instance of float but its type has a __float__ method, use
+that method to convert *obj* to a float.
+
+If *obj* is not an instance of float and its type does not have a __float__
+method but does have an __index__ method, use that method to
+convert *obj* to an integer, and then convert that integer to a float.
+
+If *obj* cannot be converted to a float, raise TypeError.
+
+Calling as_float is equivalent to calling *float* directly, except that string
+objects are not accepted.
+
+[clinic start generated code]*/
+
+static PyObject *
+_operator_as_float(PyObject *module, PyObject *obj)
+/*[clinic end generated code: output=25b27903bbd14913 input=39db64b91327f393]*/
+{
+    if (PyFloat_CheckExact(obj)) {
+        Py_INCREF(obj);
+        return obj;
+    }
+
+    double x = PyFloat_AsDouble(obj);
+    if (x == -1.0 && PyErr_Occurred()) {
+        return NULL;
+    }
+    return PyFloat_FromDouble(x);
+}
+
+
+/*[clinic input]
 _operator.length_hint -> Py_ssize_t
 
     obj: object
@@ -929,6 +973,7 @@ static struct PyMethodDef operator_methods[] = {
     _OPERATOR_GE_METHODDEF
     _OPERATOR__COMPARE_DIGEST_METHODDEF
     _OPERATOR_LENGTH_HINT_METHODDEF
+    _OPERATOR_AS_FLOAT_METHODDEF
     {NULL,              NULL}           /* sentinel */
 
 };

--- a/Modules/clinic/_operator.c.h
+++ b/Modules/clinic/_operator.c.h
@@ -1390,6 +1390,32 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_operator_as_float__doc__,
+"as_float($module, obj, /)\n"
+"--\n"
+"\n"
+"Return *obj* interpreted as a float.\n"
+"\n"
+"If *obj* is already of exact type float, return it unchanged.\n"
+"\n"
+"If *obj* is already an instance of float (including possibly an instance of a\n"
+"float subclass), return a float with the same value as *obj*.\n"
+"\n"
+"If *obj* is not an instance of float but its type has a __float__ method, use\n"
+"that method to convert *obj* to a float.\n"
+"\n"
+"If *obj* is not an instance of float and its type does not have a __float__\n"
+"method but does have an __index__ method, use that method to\n"
+"convert *obj* to an integer, and then convert that integer to a float.\n"
+"\n"
+"If *obj* cannot be converted to a float, raise TypeError.\n"
+"\n"
+"Calling as_float is equivalent to calling *float* directly, except that string\n"
+"objects are not accepted.");
+
+#define _OPERATOR_AS_FLOAT_METHODDEF    \
+    {"as_float", (PyCFunction)_operator_as_float, METH_O, _operator_as_float__doc__},
+
 PyDoc_STRVAR(_operator_length_hint__doc__,
 "length_hint($module, obj, default=0, /)\n"
 "--\n"
@@ -1486,4 +1512,4 @@ _operator__compare_digest(PyObject *module, PyObject *const *args, Py_ssize_t na
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=eae5d08f971a65fd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5a828b48c9f80dbf input=a9049054013a1b77]*/


### PR DESCRIPTION
This PR exposes `PyFloat_AsDouble` to Python level in the form `operator.as_float`. This provides a way for Python code to emulate the implicit float conversions that Python itself does at C level.

<!-- issue-number: [bpo-40801](https://bugs.python.org/issue40801) -->
https://bugs.python.org/issue40801
<!-- /issue-number -->
