### PR TITLE
bpo-40798: Generate a different message for already removed elements

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -35,7 +35,6 @@ from sphinx.domains.python import PyModulelevel, PyClassmember
 
 # Support for checking for suspicious markup
 
-import patchlevel
 import suspicious
 
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -312,9 +312,6 @@ class DeprecatedRemoved(Directive):
     final_argument_whitespace = True
     option_spec = {}
 
-    python_version = patchlevel.get_version_info()[0]
-    python_major, python_minor = map(int, python_version.split("."))
-
     _deprecated_label = 'Deprecated since version {deprecated}, will be removed in version {removed}'
     _removed_label = 'Deprecated since version {deprecated}, removed in version {removed}'
 
@@ -324,14 +321,15 @@ class DeprecatedRemoved(Directive):
         node['type'] = 'deprecated-removed'
         version = (self.arguments[0], self.arguments[1])
         node['version'] = version
-        removed_major, removed_minor = map(int, self.arguments[1].split("."))
-        if (
-            removed_major < self.python_major or
-            (removed_major == self.python_major and removed_minor <= self.python_minor)
-        ):
-            label = translators['sphinx'].gettext(self._removed_label)
+        env = self.state.document.settings.env
+        current_version = tuple(int(e) for e in env.config.version.split('.'))
+        removed_version = tuple(int(e) for e in self.arguments[1].split('.'))
+        if current_version < removed_version:
+            label = self._deprecated_label
         else:
-            label = translators['sphinx'].gettext(self._deprecated_label)
+            label = self._removed_label
+
+        label = translators['sphinx'].gettext(label)
         text = label.format(deprecated=self.arguments[0], removed=self.arguments[1])
         if len(self.arguments) == 3:
             inodes, messages = self.state.inline_text(self.arguments[2],

--- a/Doc/tools/templates/dummy.html
+++ b/Doc/tools/templates/dummy.html
@@ -5,3 +5,4 @@ In extensions/pyspecific.py:
 
 {% trans %}CPython implementation detail:{% endtrans %}
 {% trans %}Deprecated since version {deprecated}, will be removed in version {removed}{% endtrans %}
+{% trans %}Deprecated since version {deprecated}, removed in version {removed}{% endtrans %}


### PR DESCRIPTION
@remilapeyre I did not include a news entry as it only affects the documentation.

<!-- issue-number: [bpo-40798](https://bugs.python.org/issue40798) -->
https://bugs.python.org/issue40798
<!-- /issue-number -->
