### PR TITLE
bpo-30064: Fix unstable asyncio "racing" socket tests

### DIFF
--- a/Lib/test/test_asyncio/test_sock_lowlevel.py
+++ b/Lib/test/test_asyncio/test_sock_lowlevel.py
@@ -2,6 +2,8 @@ import socket
 import time
 import asyncio
 import sys
+import unittest
+
 from asyncio import proactor_events
 from itertools import cycle, islice
 from test.test_asyncio import utils as test_utils
@@ -232,6 +234,8 @@ class BaseSockTestsMixin:
                 # avoid touching event loop to maintain race condition
                 time.sleep(0.01)
 
+    # FIXME: https://bugs.python.org/issue30064#msg370143
+    @unittest.skipIf(True, "unstable test")
     def test_sock_client_racing(self):
         with test_utils.run_test_server() as httpd:
             sock = socket.socket()


### PR DESCRIPTION
Skip new "racing" socket tests which fail randomly until someone fix
them, to ease analysis of buildbot failures (skip tests which are
known to be broken/unstable).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30064](https://bugs.python.org/issue30064) -->
https://bugs.python.org/issue30064
<!-- /issue-number -->
