### PR TITLE
bpo-40777: Initialize PyDateTime_IsoCalendarDateType.tp_base at run-time

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-05-28-17-32-29.bpo-40777.1kJU6N.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-28-17-32-29.bpo-40777.1kJU6N.rst
@@ -1,0 +1,2 @@
+Initialize PyDateTime_IsoCalendarDateType.tp_base at run-time to avoid
+errors on some compilers.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3325,7 +3325,7 @@ static PyTypeObject PyDateTime_IsoCalendarDateType = {
     .tp_doc = iso_calendar_date__doc__,
     .tp_methods = iso_calendar_date_methods,
     .tp_getset = iso_calendar_date_getset,
-    .tp_base = &PyTuple_Type,
+    // .tp_base = &PyTuple_Type,  // filled in PyInit__datetime
     .tp_new = iso_calendar_date_new,
 };
 
@@ -4079,7 +4079,7 @@ static PyTypeObject PyDateTime_TimeZoneType = {
     timezone_methods,                 /* tp_methods */
     0,                                /* tp_members */
     0,                                /* tp_getset */
-    &PyDateTime_TZInfoType,           /* tp_base */
+    0,                                /* tp_base; filled in PyInit__datetime */
     0,                                /* tp_dict */
     0,                                /* tp_descr_get */
     0,                                /* tp_descr_set */
@@ -6458,7 +6458,8 @@ static PyTypeObject PyDateTime_DateTimeType = {
     datetime_methods,                           /* tp_methods */
     0,                                          /* tp_members */
     datetime_getset,                            /* tp_getset */
-    &PyDateTime_DateType,                       /* tp_base */
+    0,                                          /* tp_base; filled in
+                                                   PyInit__datetime */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */
     0,                                          /* tp_descr_set */
@@ -6524,6 +6525,12 @@ PyInit__datetime(void)
     if (m == NULL)
         return NULL;
 
+    // `&...` is not a constant expression according to a strict reading
+    // of C standards. Fill tp_base at run-time rather than statically.
+    // See https://bugs.python.org/issue40777
+    PyDateTime_IsoCalendarDateType.tp_base = &PyTuple_Type;
+    PyDateTime_TimeZoneType.tp_base = &PyDateTime_TZInfoType;
+    PyDateTime_DateTimeType.tp_base = &PyDateTime_DateType;
 
     PyTypeObject *types[] = {
         &PyDateTime_DateType,


### PR DESCRIPTION
Recent changes to _datetimemodule broke compilation on mingw; see the comments in this change for details.

FWIW, @corona10: this issue is why `PyType_FromModuleAndSpec` & friends take the `bases` argument at run time.

<!-- issue-number: [bpo-40777](https://bugs.python.org/issue40777) -->
https://bugs.python.org/issue40777
<!-- /issue-number -->


Automerge-Triggered-By: @encukou