### PR TITLE
Further de-linting of zoneinfo module

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -19,12 +19,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from functools import cached_property
 
 from . import _support as test_support
-from ._support import (
-    OS_ENV_LOCK,
-    TZPATH_LOCK,
-    TZPATH_TEST_LOCK,
-    ZoneInfoTestBase,
-)
+from ._support import OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
 
 py_zoneinfo, c_zoneinfo = test_support.get_modules()
 

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -360,7 +360,6 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
                     self.assertEqual(dt.dst(), offset.dst, dt)
 
     def test_folds_from_utc(self):
-        tests = []
         for key in self.zones():
             zi = self.zone_from_key(key)
             with self.subTest(key=key):
@@ -922,7 +921,7 @@ class TZStrTest(ZoneInfoTestBase):
         # the Version 2+ file. In this case, we have no transitions, just
         # the tzstr in the footer, so up to the footer, the files are
         # identical and we can just write the same file twice in a row.
-        for i in range(2):
+        for _ in range(2):
             out += b"TZif"  # Magic value
             out += b"3"  # Version
             out += b" " * 15  # Reserved
@@ -947,7 +946,6 @@ class TZStrTest(ZoneInfoTestBase):
         return self.klass.from_file(zonefile, key=tzstr)
 
     def test_tzstr_localized(self):
-        i = 0
         for tzstr, cases in self.test_cases.items():
             with self.subTest(tzstr=tzstr):
                 zi = self.zone_from_tzstr(tzstr)

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -80,7 +80,6 @@ def load_data(fobj):
     # not by position in the array but by position in the unsplit
     # abbreviation string. I suppose this makes more sense in C, which uses
     # null to terminate the strings, but it's inconvenient here...
-    char_total = 0
     abbr_vals = {}
     abbr_chars = fobj.read(charcnt)
 

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -12,7 +12,8 @@ def reset_tzpath(to=None):
                 f"tzpaths must be a list or tuple, "
                 + f"not {type(tzpaths)}: {tzpaths!r}"
             )
-        elif not all(map(os.path.isabs, tzpaths)):
+
+        if not all(map(os.path.isabs, tzpaths)):
             raise ValueError(_get_invalid_paths_message(tzpaths))
         base_tzpath = tzpaths
     else:

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -4,7 +4,7 @@ import collections
 import functools
 import re
 import weakref
-from datetime import datetime, timedelta, timezone, tzinfo
+from datetime import datetime, timedelta, tzinfo
 
 from . import _common, _tzpath
 


### PR DESCRIPTION
After GH-20354, I [enabled a small whitelist of linting rules on the backport](https://github.com/pganssle/zoneinfo/pull/71), which found several unused imports, unused variables and unnecessary "else" clauses (I am on the fence about this as a general rule, but in this case I think it helps readability to drop them).