### PR TITLE
bpo-40811: Allowing to create event loops on threads

### DIFF
--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -635,7 +635,7 @@ class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
         """
         if (self._local._loop is None and
                 not self._local._set_called and
-                threading.current_thread() is threading.main_thread()):
+                isinstance(threading.current_thread(), threading.Thread)):
             self.set_event_loop(self.new_event_loop())
 
         if self._local._loop is None:

--- a/Misc/NEWS.d/next/Library/2020-05-28-17-32-29.bpo-40811.28zxr0.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-28-17-32-29.bpo-40811.28zxr0.rst
@@ -1,0 +1,2 @@
+Create new event loop in application sub threads if we are trying to get it and
+it is not created yet.


### PR DESCRIPTION
```
[bpo-40811](https://bugs.python.org/issue40811): Allowing Async IO module to create and set event loops on threads of a Python app.
```
<!-- issue-number: [bpo-40811](https://bugs.python.org/issue40811) -->
https://bugs.python.org/issue40811
<!-- /issue-number -->
