### PR TITLE
bpo-39943: Fix MSVC warnings in sre extension

### DIFF
--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -454,7 +454,10 @@ state_init(SRE_STATE* state, PatternObject* pattern, PyObject* string,
 
     return string;
   err:
-    PyMem_Del(state->mark);
+    /* We add an explicit cast here because MSVC has a bug when
+       compiling C code where it believes that `const void**` cannot be
+       safely casted to `void*`, see bpo-39943 for details. */
+    PyMem_Del((void*) state->mark);
     state->mark = NULL;
     if (state->buffer.buf)
         PyBuffer_Release(&state->buffer);
@@ -468,7 +471,8 @@ state_fini(SRE_STATE* state)
         PyBuffer_Release(&state->buffer);
     Py_XDECREF(state->string);
     data_stack_dealloc(state);
-    PyMem_Del(state->mark);
+    /* See above PyMem_Del for why we explicitly cast here. */
+    PyMem_Del((void*) state->mark);
     state->mark = NULL;
 }
 

--- a/Modules/sre_lib.h
+++ b/Modules/sre_lib.h
@@ -448,12 +448,15 @@ do { \
     state->data_stack_base += size; \
 } while (0)
 
+/* We add an explicit cast to memcpy here because MSVC has a bug when
+   compiling C code where it believes that `const void**` cannot be
+   safely casted to `void*`, see bpo-39943 for details. */
 #define DATA_STACK_POP(state, data, size, discard) \
 do { \
     TRACE(("copy data to %p from %" PY_FORMAT_SIZE_T "d " \
            "(%" PY_FORMAT_SIZE_T "d)\n", \
            data, state->data_stack_base-size, size)); \
-    memcpy(data, state->data_stack+state->data_stack_base-size, size); \
+    memcpy((void*) data, state->data_stack+state->data_stack_base-size, size); \
     if (discard) \
         state->data_stack_base -= size; \
 } while (0)


### PR DESCRIPTION
While the `PyMem_Del` change seems harmless enough, I'm a little bit uneasy about the `memcpy` one. This file is pretty old and unlikely to change in the future but it seems like it opens up the possibility of someone making a mistake like `DATA_STACK_POP(state, 5, ...)` and have it not caught by the type checker because of the explicit cast.

For that particular one we could guard the explicitly casted version with `#ifdef _MSC_VER` or something so it's harder to make that mistake and not have it be caught by the CI.

<!-- issue-number: [bpo-39943](https://bugs.python.org/issue39943) -->
https://bugs.python.org/issue39943
<!-- /issue-number -->
