### PR TITLE
Indicate that abs() method accept argument that implement __abs__(), …

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -43,9 +43,8 @@ are always available.  They are listed here in alphabetical order.
 .. function:: abs(x)
 
    Return the absolute value of a number.  The argument may be an
-   integer or a floating point number.  If the argument is a complex number, its
-   magnitude is returned. If *x* defines :meth:`__abs__`,
-   ``abs(x)`` returns ``x.__abs__()``.
+   integer, a floating point number, or an object implementing :meth:`__abs__`.
+   If the argument is a complex number, its magnitude is returned.
 
 
 .. function:: all(iterable)


### PR DESCRIPTION
I made a mistake at https://github.com/python/cpython/pull/7783. So I recreate a new PR.