### PR TITLE
bpo-29882: Add _Py_popcount32() function

### DIFF
--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -1,4 +1,6 @@
-/* Bytes swap functions, reverse order of bytes:
+/* Bit and bytes utilities.
+
+   Bytes swap functions, reverse order of bytes:
 
    - _Py_bswap16(uint16_t)
    - _Py_bswap32(uint32_t)
@@ -78,6 +80,31 @@ _Py_bswap64(uint64_t word)
            | ((word & UINT64_C(0x0000FF0000000000)) >> 24)
            | ((word & UINT64_C(0x00FF000000000000)) >> 40)
            | ((word & UINT64_C(0xFF00000000000000)) >> 56));
+#endif
+}
+
+
+// Population count: count the number of 1's in 'u'
+// (number of bits set to 1)
+static inline int
+_Py_popcount32(uint32_t u)
+{
+#if defined(__clang__) || defined(__GNUC__)
+
+#if SIZEOF_INT == 4
+    return __builtin_popcount(u);
+#elif SIZEOF_LONG == 4
+    return __builtin_popcountl(u);
+#else
+#  error "unsupported configuration"
+#endif
+
+#else
+    /* 32-bit SWAR (SIMD Within A Register) popcount */
+    u -= (u >> 1) & UINT32_C(0x55555555);
+    u = (u & UINT32_C(0x33333333)) + ((u >> 2) & UINT32_C(0x33333333));
+    u = (u + (u >> 4)) & UINT32_C(0x0f0f0f0f);
+    return (uint32_t)(u * UINT32_C(0x01010101)) >> 24;
 #endif
 }
 

--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -86,6 +86,12 @@ _Py_bswap64(uint64_t word)
 
 // Population count: count the number of 1's in 'u'
 // (number of bits set to 1), also known as the hamming weight.
+//
+// Implementation note. CPUID is not used, to test if x86 POPCNT instruction
+// can be used, to keep the implementation simple. For example, Visual Studio
+// __popcnt() is not used this reason. The clang and GCC builtin function can
+// use the x86 POPCNT instruction if the target architecture has SSE4a or
+// newer.
 static inline int
 _Py_popcount32(uint32_t x)
 {

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1121,7 +1121,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_abstract.h \
 		$(srcdir)/Include/internal/pycore_accu.h \
 		$(srcdir)/Include/internal/pycore_atomic.h \
-		$(srcdir)/Include/internal/pycore_byteswap.h \
+		$(srcdir)/Include/internal/pycore_bitutils.h \
 		$(srcdir)/Include/internal/pycore_bytes_methods.h \
 		$(srcdir)/Include/internal/pycore_call.h \
 		$(srcdir)/Include/internal/pycore_ceval.h \

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -1,5 +1,5 @@
 #include "Python.h"
-#include "pycore_byteswap.h"      // _Py_bswap32()
+#include "pycore_bitutils.h"      // _Py_bswap32()
 
 #include <ffi.h>
 #ifdef MS_WIN32

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -94,7 +94,7 @@ test_popcount(PyObject *self, PyObject *Py_UNUSED(args))
     if (check_popcount(UINT32_C(0xffff), 16) < 0) {
         return NULL;
     }
-    if (check_popcount(UINT32_C(0x10101010), 4) < 0) {
+    if (check_popcount(UINT32_C(0x10204080), 4) < 0) {
         return NULL;
     }
     if (check_popcount(UINT32_C(0xDEADCAFE), 22) < 0) {

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -82,26 +82,23 @@ check_popcount(uint32_t x, int expected)
 static PyObject*
 test_popcount(PyObject *self, PyObject *Py_UNUSED(args))
 {
-    if (check_popcount(0, 0) < 0) {
-        return NULL;
-    }
-    if (check_popcount(1, 1) < 0) {
-        return NULL;
-    }
-    if (check_popcount(UINT32_C(0x100), 1) < 0) {
-        return NULL;
-    }
-    if (check_popcount(UINT32_C(0xffff), 16) < 0) {
-        return NULL;
-    }
-    if (check_popcount(UINT32_C(0x10204080), 4) < 0) {
-        return NULL;
-    }
-    if (check_popcount(UINT32_C(0xDEADCAFE), 22) < 0) {
-        return NULL;
-    }
+#define CHECK(X, RESULT) \
+    do { \
+        if (check_popcount(UINT32_C(X), RESULT) < 0) { \
+            return NULL; \
+        } \
+    } while (0)
 
+    CHECK(0, 0);
+    CHECK(1, 1);
+    CHECK(0x08080808, 4);
+    CHECK(0x10101010, 4);
+    CHECK(0x10204080, 4);
+    CHECK(0xDEADCAFE, 22);
+    CHECK(0xFFFFFFFF, 32);
     Py_RETURN_NONE;
+
+#undef CHECK
 }
 
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -84,7 +84,7 @@ test_popcount(PyObject *self, PyObject *Py_UNUSED(args))
 {
 #define CHECK(X, RESULT) \
     do { \
-        if (check_popcount(UINT32_C(X), RESULT) < 0) { \
+        if (check_popcount(X, RESULT) < 0) { \
             return NULL; \
         } \
     } while (0)

--- a/Modules/sha256module.c
+++ b/Modules/sha256module.c
@@ -17,7 +17,7 @@
 /* SHA objects */
 
 #include "Python.h"
-#include "pycore_byteswap.h"      // _Py_bswap32()
+#include "pycore_bitutils.h"      // _Py_bswap32()
 #include "structmember.h"         // PyMemberDef
 #include "hashlib.h"
 #include "pystrhex.h"

--- a/Modules/sha512module.c
+++ b/Modules/sha512module.c
@@ -17,7 +17,7 @@
 /* SHA objects */
 
 #include "Python.h"
-#include "pycore_byteswap.h"      // _Py_bswap32()
+#include "pycore_bitutils.h"      // _Py_bswap32()
 #include "structmember.h"         // PyMemberDef
 #include "hashlib.h"
 #include "pystrhex.h"

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3,8 +3,9 @@
 /* XXX The functional organization of this file is terrible */
 
 #include "Python.h"
-#include "pycore_interp.h"    // _PY_NSMALLPOSINTS
-#include "pycore_pystate.h"   // _Py_IsMainInterpreter()
+#include "pycore_bitutils.h"      // _Py_popcount32()
+#include "pycore_interp.h"        // _PY_NSMALLPOSINTS
+#include "pycore_pystate.h"       // _Py_IsMainInterpreter()
 #include "longintrepr.h"
 
 #include <float.h>
@@ -5307,12 +5308,8 @@ int_bit_length_impl(PyObject *self)
 static int
 popcount_digit(digit d)
 {
-    /* 32bit SWAR popcount. */
-    uint32_t u = d;
-    u -= (u >> 1) & 0x55555555U;
-    u = (u & 0x33333333U) + ((u >> 2) & 0x33333333U);
-    u = (u + (u >> 4)) & 0x0f0f0f0fU;
-    return (uint32_t)(u * 0x01010101U) >> 24;
+    Py_BUILD_ASSERT(sizeof(digit) <= sizeof(uint32_t));
+    return _Py_popcount32((uint32_t)d);
 }
 
 /*[clinic input]

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5308,7 +5308,9 @@ int_bit_length_impl(PyObject *self)
 static int
 popcount_digit(digit d)
 {
-    Py_BUILD_ASSERT(sizeof(digit) <= sizeof(uint32_t));
+    // digit can be larger than uint32_t, but only PyLong_SHIFT bits
+    // of it will be ever used.
+    Py_BUILD_ASSERT(PyLong_SHIFT <= 32);
     return _Py_popcount32((uint32_t)d);
 }
 

--- a/Objects/stringlib/codecs.h
+++ b/Objects/stringlib/codecs.h
@@ -4,7 +4,7 @@
 # error "codecs.h is specific to Unicode"
 #endif
 
-#include "pycore_byteswap.h"      // _Py_bswap32()
+#include "pycore_bitutils.h"      // _Py_bswap32()
 
 /* Mask to quickly check whether a C 'long' contains a
    non-ASCII, UTF8-encoded char. */

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -170,7 +170,7 @@
     <ClInclude Include="..\Include\internal\pycore_accu.h" />
     <ClInclude Include="..\Include\internal\pycore_atomic.h" />
     <ClInclude Include="..\Include\internal\pycore_bytes_methods.h" />
-    <ClInclude Include="..\Include\internal\pycore_byteswap.h" />
+    <ClInclude Include="..\Include\internal\pycore_bitutils.h" />
     <ClInclude Include="..\Include\internal\pycore_call.h" />
     <ClInclude Include="..\Include\internal\pycore_ceval.h" />
     <ClInclude Include="..\Include\internal\pycore_code.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -201,7 +201,7 @@
     <ClInclude Include="..\Include\internal\pycore_atomic.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\Include\internal\pycore_byteswap.h">
+    <ClInclude Include="..\Include\internal\pycore_bitutils.h">
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_bytes_methods.h">

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 
+#include "pycore_bitutils.h"      // _Py_popcount32
 #include "pycore_hamt.h"
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include <stddef.h>               // offsetof()
@@ -434,29 +435,9 @@ hamt_bitpos(int32_t hash, uint32_t shift)
 }
 
 static inline uint32_t
-hamt_bitcount(uint32_t i)
-{
-    /* We could use native popcount instruction but that would
-       require to either add configure flags to enable SSE4.2
-       support or to detect it dynamically.  Otherwise, we have
-       a risk of CPython not working properly on older hardware.
-
-       In practice, there's no observable difference in
-       performance between using a popcount instruction or the
-       following fallback code.
-
-       The algorithm is copied from:
-       https://graphics.stanford.edu/~seander/bithacks.html
-    */
-    i = i - ((i >> 1) & 0x55555555);
-    i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
-    return (((i + (i >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
-}
-
-static inline uint32_t
 hamt_bitindex(uint32_t bitmap, uint32_t bit)
 {
-    return hamt_bitcount(bitmap & (bit - 1));
+    return _Py_popcount32(bitmap & (bit - 1));
 }
 
 
@@ -820,7 +801,7 @@ hamt_node_bitmap_assoc(PyHamtNode_Bitmap *self,
     else {
         /* There was no key before with the same (shift,hash). */
 
-        uint32_t n = hamt_bitcount(self->b_bitmap);
+        uint32_t n = _Py_popcount32(self->b_bitmap);
 
         if (n >= 16) {
             /* When we have a situation where we want to store more

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -437,7 +437,7 @@ hamt_bitpos(int32_t hash, uint32_t shift)
 static inline uint32_t
 hamt_bitindex(uint32_t bitmap, uint32_t bit)
 {
-    return _Py_popcount32(bitmap & (bit - 1));
+    return (uint32_t)_Py_popcount32(bitmap & (bit - 1));
 }
 
 
@@ -801,7 +801,7 @@ hamt_node_bitmap_assoc(PyHamtNode_Bitmap *self,
     else {
         /* There was no key before with the same (shift,hash). */
 
-        uint32_t n = _Py_popcount32(self->b_bitmap);
+        uint32_t n = (uint32_t)_Py_popcount32(self->b_bitmap);
 
         if (n >= 16) {
             /* When we have a situation where we want to store more


### PR DESCRIPTION
* Rename pycore_byteswap.h to pycore_bitutils.h.
* Move popcount_digit() to pycore_bitutils.h as _Py_popcount32().
* _Py_popcount32() uses GCC and clang builtin function if available.
* Add unit tests to _Py_popcount32().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-29882](https://bugs.python.org/issue29882) -->
https://bugs.python.org/issue29882
<!-- /issue-number -->
