### PR TITLE
 bpo-40820: Add change version for Mock Call `args` and `kwargs` properties

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -649,7 +649,7 @@ the *new_callable* argument to :func:`patch`.
 
        .. versionchanged:: 3.8
           Added the ``args`` and ``kwargs`` properties to more easily access the
-          positional args and keyword args within a ``Call`` object tuple.
+          positional args and keyword args within a ``Call`` object.
 
 
     .. attribute:: call_args_list

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -647,6 +647,10 @@ the *new_callable* argument to :func:`patch`.
         arguments and make more complex assertions. See
         :ref:`calls as tuples <calls-as-tuples>`.
 
+       .. versionchanged:: 3.8
+          Added the ``args`` and ``kwargs`` properties to more easily access the
+          positional args and keyword args within a ``Call`` object tuple.
+
 
     .. attribute:: call_args_list
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -599,6 +599,7 @@ Neil Girdhar
 Matt Giuca
 Franz Glasner
 Wim Glenn
+Andrew Gobis
 Michael Goderbauer
 Karan Goel
 Jeroen Van Goey

--- a/Misc/NEWS.d/next/Documentation/2020-05-29-18-35-18.bpo-40820.SY-wL0.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-05-29-18-35-18.bpo-40820.SY-wL0.rst
@@ -1,0 +1,1 @@
+Add missing change version for ``args`` and ``kwargs`` mock call objects. Contributed by Andrew Gobis.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40820](https://bugs.python.org/issue40820) -->
https://bugs.python.org/issue40820
<!-- /issue-number -->
