### PR TITLE
bpo-40810: Fix CheckTraceCallbackContent for SQLite pre 3.7.15

### DIFF
--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -265,6 +265,10 @@ class TraceCallbackTests(unittest.TestCase):
         cur.execute(queries[0])
         con2.execute("create table bar(x)")
         cur.execute(queries[1])
+
+        # See bpo-40810
+        if sqlite.sqlite_version_info < (3, 7, 15):
+            queries.append(queries[-1])
         self.assertEqual(traced_statements, queries)
 
 

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -266,6 +266,10 @@ class TraceCallbackTests(unittest.TestCase):
         con2.execute("create table bar(x)")
         cur.execute(queries[1])
 
+        # Extract from SQLite 3.7.15 changelog:
+        # Avoid invoking the sqlite3_trace() callback multiple times when a
+        # statement is automatically reprepared due to SQLITE_SCHEMA errors.
+        #
         # See bpo-40810
         if sqlite.sqlite_version_info < (3, 7, 15):
             queries.append(queries[-1])

--- a/Misc/NEWS.d/next/Tests/2020-05-30-10-56-38.bpo-40810.LPqDLQ.rst
+++ b/Misc/NEWS.d/next/Tests/2020-05-30-10-56-38.bpo-40810.LPqDLQ.rst
@@ -1,0 +1,1 @@
+In :mod:`sqlite3`, fix `CheckTraceCallbackContent` for SQLite pre 3.7.15.


### PR DESCRIPTION
Ref. [SQLite 3.7.15 changelog](https://sqlite.org/changes.html#version_3_7_15):
_"Avoid invoking the sqlite3_trace() callback multiple times when a statement is automatically reprepared due to SQLITE_SCHEMA errors."_

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40810](https://bugs.python.org/issue40810) -->
https://bugs.python.org/issue40810
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum