### PR TITLE
bpo-40829: Add a what's new entry about deprecation of shuffle's random parameter

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -761,6 +761,9 @@ Deprecated
   `parso`_.
   (Contributed by Carl Meyer in :issue:`40360`.)
 
+* The *random* parameter of :func:`random.shuffle` has been deprecated.
+  (Contributed by Raymond Hettinger in :issue:`40465`)
+
 .. _LibCST: https://libcst.readthedocs.io/
 .. _parso: https://parso.readthedocs.io/
 


### PR DESCRIPTION


<!-- issue-number: [bpo-40829](https://bugs.python.org/issue40829) -->
https://bugs.python.org/issue40829
<!-- /issue-number -->
