### PR TITLE
gh-69968: Prevent cycles in the __context__ chain.

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -601,6 +601,10 @@ Exception Objects
    it.  There is no type check to make sure that *ctx* is an exception instance.
    This steals a reference to *ctx*.
 
+   .. versionchanged:: 3.5.2
+      If *ctx* is *ex*, the function has no any effect.  If *ex* is in the
+      context chain started from *ctx*, it is moved to the start of the chain.
+
 
 .. c:function:: PyObject* PyException_GetCause(PyObject *ex)
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -66,6 +66,12 @@ In either case, the exception itself is always shown after any chained
 exceptions so that the final line of the traceback always shows the last
 exception that was raised.
 
+.. versionchanged:: 3.5.2
+
+   Setting :attr:`__context__` to self has no any effect.  If set
+   ``__context__`` to the chain contained original exception, it is moved to
+   the start of the context chain.
+
 
 Base classes
 ------------

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -716,6 +716,26 @@ class ExceptionTests(unittest.TestCase):
         obj = wr()
         self.assertIsNone(obj)
 
+    def test_context_loop(self):
+        exc1 = Exception(1)
+        exc1.__context__ = exc1
+        self.assertIsNone(exc1.__context__)
+
+        exc2 = Exception(2)
+        exc2.__context__ = exc1
+        self.assertIs(exc2.__context__, exc1)
+        exc1.__context__ = exc2
+        self.assertIs(exc1.__context__, exc2)
+        self.assertIsNone(exc2.__context__)
+
+        exc3 = Exception(3)
+        exc3.__context__ = exc1
+        self.assertIs(exc3.__context__, exc1)
+        exc1.__context__ = exc3
+        self.assertIs(exc1.__context__, exc3)
+        self.assertIs(exc3.__context__, exc2)
+        self.assertIsNone(exc2.__context__)
+
     def test_exception_target_in_nested_scope(self):
         # issue 4617: This used to raise a SyntaxError
         # "can not delete variable 'e' referenced in nested scope"

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -356,8 +356,32 @@ PyException_GetContext(PyObject *self)
 void
 PyException_SetContext(PyObject *self, PyObject *context)
 {
-    Py_XSETREF(_PyBaseExceptionObject_cast(self)->context, context);
+    assert(PyExceptionInstance_Check(self));
+    assert(context == NULL || PyExceptionInstance_Check(context));
+
+    PyObject *exc = context;
+    PyObject *prev_exc = NULL;
+
+    while (exc != NULL) {
+        if (exc == self) {
+            if (prev_exc != NULL) {
+                /* Move self to the start of the chain. */
+                ((PyBaseExceptionObject *)prev_exc)->context =
+                        ((PyBaseExceptionObject *)self)->context;
+                ((PyBaseExceptionObject *)self)->context = context;
+            }
+            assert(Py_REFCNT(self) > 1);
+            Py_DECREF(self);
+            return;
+        }
+        assert(PyExceptionInstance_Check(exc));
+        prev_exc = exc;
+        exc = ((PyBaseExceptionObject *)exc)->context;
+    }
+
+    Py_XSETREF(((PyBaseExceptionObject *)self)->context, context);
 }
+
 
 #undef PyExceptionClass_Name
 


### PR DESCRIPTION
Setting `__context__` to self has no any effect.  If set `__context__` to the chain contained original exception, it is moved to the start of the context chain.


<!-- issue-number: [bpo-25782](https://bugs.python.org/issue25782) -->
https://bugs.python.org/issue25782
<!-- /issue-number -->

<!-- gh-issue-number: gh-69968 -->
* Issue: gh-69968
<!-- /gh-issue-number -->
