### PR TITLE
bpo-40630: adjust tracemalloc.reset_peak docs for backport to 3.9

### DIFF
--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -345,7 +345,7 @@ Functions
 
    See also :func:`get_traced_memory`.
 
-   .. versionadded:: 3.10
+   .. versionadded:: 3.9
 
 
 .. function:: get_tracemalloc_memory()

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -95,13 +95,6 @@ New Modules
 Improved Modules
 ================
 
-tracemalloc
------------
-
-Added :func:`tracemalloc.reset_peak` to set the peak size of traced memory
-blocks to the current size, to measure the peak of specific pieces of code.
-(Contributed by Huon Wilson in :issue:`40630`.)
-
 Optimizations
 =============
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -561,6 +561,12 @@ Previously, :attr:`sys.stderr` was block-buffered when non-interactive. Now
 ``stderr`` defaults to always being line-buffered.
 (Contributed by Jendrik Seipp in :issue:`13601`.)
 
+tracemalloc
+-----------
+
+Added :func:`tracemalloc.reset_peak` to set the peak size of traced memory
+blocks to the current size, to measure the peak of specific pieces of code.
+(Contributed by Huon Wilson in :issue:`40630`.)
 
 typing
 ------

--- a/Misc/NEWS.d/next/Library/2020-05-15-13-40-15.bpo-40630.YXEX_M.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-15-13-40-15.bpo-40630.YXEX_M.rst
@@ -1,2 +1,0 @@
-Added :func:`tracemalloc.reset_peak` to set the peak size of traced memory
-blocks to the current size, to measure the peak of specific pieces of code.


### PR DESCRIPTION
#20545 backports #20102 to 3.9, per https://github.com/python/cpython/pull/20102#issuecomment-632728791. This PR therefore updates the documentation on `master` to reflect this different version-added.

<!-- issue-number: [bpo-40630](https://bugs.python.org/issue40630) -->
https://bugs.python.org/issue40630
<!-- /issue-number -->
