### PR TITLE
Fix asyncio.to_thread() documented return type

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -614,8 +614,7 @@ Running in Threads
    allowing context variables from the event loop thread to be accessed in the
    separate thread.
 
-   Return an :class:`asyncio.Future` which represents the eventual result of
-   *func*.
+   Return a coroutine that can be awaited to get the eventual result of *func*.
 
    This coroutine function is primarily intended to be used for executing
    IO-bound functions/methods that would otherwise block the event loop if

--- a/Lib/asyncio/threads.py
+++ b/Lib/asyncio/threads.py
@@ -17,7 +17,7 @@ async def to_thread(func, /, *args, **kwargs):
     allowing context variables from the main thread to be accessed in the
     separate thread.
 
-    Return an asyncio.Future which represents the eventual result of *func*.
+    Return a coroutine that can be awaited to get the eventual result of *func*.
     """
     loop = events.get_running_loop()
     ctx = contextvars.copy_context()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

When I wrote the documentation for `asyncio.to_thread()`, I mistakenly assumed that `return await loop.run_in_executor(...)` within an async def function would return a Future. In reality, it returns a coroutine.

This likely won't affect typical usage of `asyncio.to_thread()`, but it's important for the documentation to be correct here. In general, we also tend to avoid returning futures from high-level APIs in asyncio.

Automerge-Triggered-By: @aeros