### PR TITLE
bpo-38938: Optimize heapq.merge()

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -329,67 +329,126 @@ def merge(*iterables, key=None, reverse=False):
 
     '''
 
-    h = []
-    h_append = h.append
+    # Invariants for the binary tree structure used here:
+    #   - All leaf nodes have leaf[LEFT] = None and leaf[RIGHT] = the
+    #     __next__ method of an iterator.
+    #   - For non-leaf nodes, node[LEFT][PARENT] is node and
+    #     node[RIGHT][PARENT] is node.
+    #   - The root's PARENT is None, and all other PARENTs are nodes.
+    #   - Each node's KEY and VALUE are identical to the KEY and VALUE
+    #     of one of its descendent leaves. A node's LEAF points to
+    #     which descendent leaf the key and value come from.
+    #   - A parent's key/value will be the same as the higher-priority
+    #     key/value among that of its two children
 
-    if reverse:
-        _heapify = _heapify_max
-        _heappop = _heappop_max
-        _heapreplace = _heapreplace_max
-        direction = -1
-    else:
-        _heapify = heapify
-        _heappop = heappop
-        _heapreplace = heapreplace
-        direction = 1
+    # A node will just be a list with these semantic aliases for
+    # indices into it.
+    PARENT, LEFT, RIGHT, LEAF, VALUE = range(5)
+    KEY = VALUE if key is None else 5
+    sentinel = object()
 
-    if key is None:
-        for order, it in enumerate(map(iter, iterables)):
-            try:
-                next = it.__next__
-                h_append([next(), order * direction, next])
-            except StopIteration:
-                pass
-        _heapify(h)
-        while len(h) > 1:
-            try:
-                while True:
-                    value, order, next = s = h[0]
-                    yield value
-                    s[0] = next()           # raises StopIteration when exhausted
-                    _heapreplace(h, s)      # restore heap condition
-            except StopIteration:
-                _heappop(h)                 # remove empty iterator
-        if h:
-            # fast case when only a single iterator remains
-            value, order, next = h[0]
-            yield value
-            yield from next.__self__
+    # Produce leaf nodes, storing a value/key its source.
+    # This eliminates empty iterators.
+    nodes = []
+    for it in map(iter, iterables):
+        value = next(it, sentinel)
+        if value is not sentinel:
+            leaf = [None, None, it.__next__, None, value]
+            if key is not None:
+                leaf.append(key(value))
+            leaf[LEAF] = leaf
+            nodes.append(leaf)
+    
+    # fast early-outs
+    if not nodes:
+        return
+    if len(nodes) == 1:
+        node = nodes[0]
+        yield node[VALUE]
+        yield from node[RIGHT].__self__
         return
 
-    for order, it in enumerate(map(iter, iterables)):
+    # Add a shared parent for adjacent nodes, then add a shared parent
+    # for adjacent parents, etc., until there is one common root.
+    while (n := len(nodes)) > 1:
+        # split odd numbers in favor of the right (leaving the
+        # unpaired nodes to the left). This is better because, e.g.:
+        #   - merge([1], merge([2], [1])) requires 2 comparisons, but
+        #   - merge(merge([1], [2]), [1]) requires 3 comparisons due
+        #     to stability considerations.
+        new_nodes = nodes[:n & 1]
+        for i in range(n & 1, n - 1, 2):
+            left, right = nodes[i:i + 2]
+            if reverse:
+                winner = right if left[KEY] < right[KEY] else left
+            else:
+                winner = right if right[KEY] < left[KEY] else left
+            node = [None, left, right]
+            # the winner's LEAF, VALUE, and KEY are copied into the
+            # parent node
+            node[LEAF:] = winner[LEAF:]
+            left[PARENT] = right[PARENT] = node
+            new_nodes.append(node)
+        nodes = new_nodes
+    (root,) = nodes
+    del nodes
+
+    # main loop
+    while True:
+        yield root[VALUE]
+
+        # jump to the leaf that produced the value we just yielded.
+        node = root[LEAF]
+
+        # replace the leaf's value using the iterator
         try:
-            next = it.__next__
-            value = next()
-            h_append([key(value), order * direction, value, next])
+            node[VALUE] = node[RIGHT]()
         except StopIteration:
-            pass
-    _heapify(h)
-    while len(h) > 1:
-        try:
-            while True:
-                key_value, order, value, next = s = h[0]
-                yield value
-                value = next()
-                s[0] = key(value)
-                s[2] = value
-                _heapreplace(h, s)
-        except StopIteration:
-            _heappop(h)
-    if h:
-        key_value, order, value, next = h[0]
-        yield value
-        yield from next.__self__
+            # Upon exhuastion, Promote the exhausted leaf's sibling.
+            # The sibling must exist because of the early-outs.
+            parent = node[PARENT]
+            left, right = parent[LEFT], parent[RIGHT]
+            sibling = left if right is node else right
+            # copy everything but the PARENT
+            parent[LEFT:] = sibling[LEFT:]
+            if sibling[LEFT] is not None:
+                # If sibling has children, give custody to parent.
+                sibling[LEFT][PARENT] = sibling[RIGHT][PARENT] = parent
+                parent[LEAF] = sibling[LEAF]
+            else:
+                # If sibling is a leaf, then parent is now a leaf. 
+                parent[LEAF] = parent
+                if parent is root:
+                    # a leaf has been promoted to root.
+                    # There's only one node, so do a fast out.
+                    yield parent[VALUE]
+                    yield from parent[RIGHT].__self__
+                    return
+            # break some GC cycles
+            del sibling[:], node[:], sibling, node
+            node = parent
+        else:
+            # If a new value was successfully supplied, compute its key.
+            if key is not None:
+                node[KEY] = key(node[VALUE])
+
+        # "replay the games" leading from the leaf to the root, i.e.,
+        # restore the invariant that each parent's value coicides with
+        # its higher-priority child's value.
+        if reverse:
+            while node is not root:
+                node = node[PARENT]
+                left, right = node[LEFT], node[RIGHT]
+                winner = right if left[KEY] < right[KEY] else left
+                # advance the winner's LEAF, VALUE, and KEY
+                node[LEAF:] = winner[LEAF:]
+        else:
+            while node is not root:
+                node = node[PARENT]
+                left, right = node[LEFT], node[RIGHT]
+                winner = right if right[KEY] < left[KEY] else left
+                # advance the winner's LEAF, VALUE, and KEY
+                node[LEAF:] = winner[LEAF:]
 
 
 # Algorithm notes for nlargest() and nsmallest()

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -512,7 +512,7 @@ class TestErrorHandling:
                         args = [get_object_that_stops_iterating(length)
                                 for _ in range(n)]
                         mo = merge(*args, key=key, reverse=reverse)
-                        self.assertRaises(TypeError, list, mo)
+                        self.assertRaises((TypeError, AttributeError), list, mo)
 
         for reverse in [False, True]:
             # test error during key computation

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -194,6 +194,12 @@ class TestHeap:
                 self.assertEqual(list(m), expected)
                 self.assertEqual(list(m), [])
 
+    def test_empty_merges(self):
+        # Merging two empty lists (with or without a key) should produce
+        # another empty list.
+        self.assertEqual(list(self.module.merge([], [])), [])
+        self.assertEqual(list(self.module.merge([], [], key=lambda: 6)), [])
+
     def test_merge_does_not_suppress_index_error(self):
         # Issue 19018: Heapq.merge suppresses IndexError from user generator
         def iterable():

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -26,7 +26,6 @@ class TestModules(TestCase):
         for fname in func_names:
             self.assertEqual(getattr(c_heapq, fname).__module__, '_heapq')
 
-
 def load_tests(loader, tests, ignore):
     # The 'merge' function has examples in its docstring which we should test
     # with 'doctest'.
@@ -463,6 +462,42 @@ class TestErrorHandling:
 
         self.assertRaises((IndexError, RuntimeError), self.module.heappush, list1, g(1))
         self.assertRaises((IndexError, RuntimeError), self.module.heappush, list2, h(1))
+
+    def test_merge_err(self):
+        nexterr_immediate = E
+        def nexterr_delayed():
+            yield from range(10)
+            raise ZeroDivisionError
+        merge = self.module.merge
+        for key in [None, lambda x:x]:
+            for reverse in [False, True]:
+                # test comparison failure during heapification
+                args = [[CmpErr()]] + [range(100)]*10
+                mo = merge(*args, key=key, reverse=reverse)
+                self.assertRaises(ZeroDivisionError, list, mo)
+
+                for n in range(2,10):
+                    # test comparison failure during intermediate steps
+                    args = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, CmpErr()]]*n
+                    mo = merge(*args, key=key, reverse=reverse)
+                    self.assertRaises(ZeroDivisionError, list, mo)
+                for n in range(1, 10):
+                    # test __next__ error during heapification
+                    args = [nexterr_immediate(range(10)) for _ in range(n)]
+                    mo = merge(*args, key=key, reverse=reverse)
+                    self.assertRaises(ZeroDivisionError, list, mo)
+                for n in range(1, 10):
+                    # test __next__ error during intermediate steps
+                    args = [nexterr_delayed() for _ in range(n)]
+                    mo = merge(*args, key=key, reverse=reverse)
+                    self.assertRaises(ZeroDivisionError, list, mo)
+
+        for reverse in [False, True]:
+            # test error during key computation
+            mo = merge(range(10), range(10), key=lambda x: x // 0, reverse=reverse)
+            self.assertRaises(ZeroDivisionError, list, mo)
+            mo = merge(range(10), key=object(), reverse=reverse)
+            self.assertRaises(TypeError, list, merge)
 
 class TestErrorHandlingPython(TestErrorHandling, TestCase):
     module = py_heapq

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -27,6 +27,7 @@ class TestModules(TestCase):
         for fname in func_names:
             self.assertEqual(getattr(c_heapq, fname).__module__, '_heapq')
 
+
 def load_tests(loader, tests, ignore):
     # The 'merge' function has examples in its docstring which we should test
     # with 'doctest'.

--- a/Misc/NEWS.d/next/Library/2020-05-31-05-10-56.bpo-38938.y5LXxt.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-31-05-10-56.bpo-38938.y5LXxt.rst
@@ -1,0 +1,1 @@
+Use a more optimized :func:`heapq.merge()` algorithm and add a C implementation. Patch by Dennis Sweeney.

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -640,7 +640,6 @@ static inline PyObject *
 leaf_iterator(merge_node *node)
 {
     assert(is_leaf(node));
-    assert(PyIter_Check(node->right));
     return node->right;
 }
 

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -872,13 +872,13 @@ build_tree(mergeobject *mo)
 
     mo->root = (merge_node *)PyList_GET_ITEM(nodes, 0);
     Py_INCREF(mo->root);
-    Py_CLEAR(nodes);
+    Py_DECREF(nodes);
     return 0;
 
 error:
     Py_CLEAR(mo->iterables);
-    Py_CLEAR(new_nodes);
-    Py_CLEAR(nodes);
+    Py_XDECREF(new_nodes);
+    Py_XDECREF(nodes);
     return -1;
 }
 
@@ -1040,7 +1040,7 @@ merge_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     int reverse = 0;
 
     if (kwds != NULL) {
-        char *kwlist[] = {"key", "reverse", 0};
+        char *kwlist[] = {"key", "reverse", NULL};
         PyObject *tmpargs = PyTuple_New(0);
         if (tmpargs == NULL) {
             return NULL;

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -846,6 +846,9 @@ build_tree(mergeobject *mo)
     while (n0 > 1) {
         Py_ssize_t n1 = (n0 + 1) / 2;
         new_nodes = PyList_New(n1);
+        if (new_nodes == NULL) {
+            goto error;
+        }
         Py_ssize_t j = 0;
         if (n0 & 1) {
             PyObject *first = PyList_GET_ITEM(nodes, 0);


### PR DESCRIPTION
This is a more optimized merging algorithm with C and Python implementations.

Instead of using heapreplace repeatedly, maintain a linked binary tree ("tournament tree") structure.

On average the algorithm uses fewer ``<`` comparisons. It also sidesteps the ``==`` comparisons of keys that are required when doing the tuple comparison ``(key1, ...) < (key2, ...)``.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38938](https://bugs.python.org/issue38938) -->
https://bugs.python.org/issue38938
<!-- /issue-number -->
