### PR TITLE
bpo-39710: update documentation for calender module

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -279,16 +279,12 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 
    This subclass of :class:`TextCalendar` can be passed a locale name in the
    constructor and will return month and weekday names in the specified locale.
-   If this locale includes an encoding all strings containing month and weekday
-   names will be returned as unicode.
 
 
 .. class:: LocaleHTMLCalendar(firstweekday=0, locale=None)
 
    This subclass of :class:`HTMLCalendar` can be passed a locale name in the
-   constructor and will return month and weekday names in the specified
-   locale. If this locale includes an encoding all strings containing month and
-   weekday names will be returned as unicode.
+   constructor and will return month and weekday names in the specified locale.
 
 .. note::
 

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -558,9 +558,7 @@ class different_locale:
 class LocaleTextCalendar(TextCalendar):
     """
     This class can be passed a locale name in the constructor and will return
-    month and weekday names in the specified locale. If this locale includes
-    an encoding all strings containing month and weekday names will be returned
-    as unicode.
+    month and weekday names in the specified locale.
     """
 
     def __init__(self, firstweekday=0, locale=None):
@@ -589,9 +587,7 @@ class LocaleTextCalendar(TextCalendar):
 class LocaleHTMLCalendar(HTMLCalendar):
     """
     This class can be passed a locale name in the constructor and will return
-    month and weekday names in the specified locale. If this locale includes
-    an encoding all strings containing month and weekday names will be returned
-    as unicode.
+    month and weekday names in the specified locale.
     """
     def __init__(self, firstweekday=0, locale=None):
         HTMLCalendar.__init__(self, firstweekday)

--- a/Misc/NEWS.d/next/Documentation/2020-05-31-18-09-33.bpo-39710.kIpmGR.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-05-31-18-09-33.bpo-39710.kIpmGR.rst
@@ -1,0 +1,1 @@
+"will be returned as unicode" reminiscent from Python 2


### PR DESCRIPTION
As per the issue

Made changes to docstrings and documentation for calendar module methods (LocaleTextCalendar and LocaleHTMLCalendar)  that are not valid explanations for python 3.

<!-- issue-number: [bpo-39710](https://bugs.python.org/issue39710) -->
https://bugs.python.org/issue39710
<!-- /issue-number -->
