### PR TITLE
bpo-40830: Make sure that keyword arguments are merged into the arguments dictionary when dict unpacking and keyword arguments are interleaved.

### DIFF
--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -79,6 +79,24 @@ Here we add keyword arguments
     >>> f(1, 2, 3, *(4, 5), x=6, y=7, **UserDict(a=8, b=9))
     (1, 2, 3, 4, 5) {'a': 8, 'b': 9, 'x': 6, 'y': 7}
 
+Mix keyword arguments and dict unpacking
+
+    >>> d1 = {'a':1}
+
+    >>> d2 = {'c':3}
+
+    >>> f(b=2, **d1, **d2)
+    () {'a': 1, 'b': 2, 'c': 3}
+
+    >>> f(**d1, b=2, **d2)
+    () {'a': 1, 'b': 2, 'c': 3}
+
+    >>> f(**d1, **d2, b=2)
+    () {'a': 1, 'b': 2, 'c': 3}
+
+    >>> f(**d1, b=2, **d2, d=4)
+    () {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+
 Examples with invalid arguments (TypeErrors). We're also testing the function
 names in the exception messages.
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4321,6 +4321,9 @@ ex_call:
                     if (!compiler_subkwargs(c, keywords, i - nseen, i)) {
                         return 0;
                     }
+                    if (have_dict) {
+                        ADDOP_I(c, DICT_MERGE, 1);
+                    }
                     have_dict = 1;
                     nseen = 0;
                 }


### PR DESCRIPTION


<!-- issue-number: [bpo-40830](https://bugs.python.org/issue40830) -->
https://bugs.python.org/issue40830
<!-- /issue-number -->
