### PR TITLE
bpo-40833: Clarify docstring of Path.rename

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1008,6 +1008,10 @@ call fails (for example because the path doesn't exist).
       >>> target.open().read()
       'some text'
 
+   The target path may be absolute or relative. Relative paths are interpreted
+   relative to the current working directory, *not* the directory of the Path
+   object.
+
    .. versionchanged:: 3.8
       Added return value, return the new Path instance.
 
@@ -1017,6 +1021,10 @@ call fails (for example because the path doesn't exist).
    Rename this file or directory to the given *target*, and return a new Path
    instance pointing to *target*.  If *target* points to an existing file or
    directory, it will be unconditionally replaced.
+
+   The target path may be absolute or relative. Relative paths are interpreted
+   relative to the current working directory, *not* the directory of the Path
+   object.
 
    .. versionchanged:: 3.8
       Added return value, return the new Path instance.

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1366,17 +1366,26 @@ class Path(PurePath):
 
     def rename(self, target):
         """
-        Rename this path to the given path,
-        and return a new Path instance pointing to the given path.
+        Rename this path to the target path.
+
+        The target path may be absolute or relative. Relative paths are
+        interpreted relative to the current working directory, *not* the
+        directory of the Path object.
+
+        Returns the new Path instance pointing to the target path.
         """
         self._accessor.rename(self, target)
         return self.__class__(target)
 
     def replace(self, target):
         """
-        Rename this path to the given path, clobbering the existing
-        destination if it exists, and return a new Path instance
-        pointing to the given path.
+        Rename this path to the target path, overwriting if that path exists.
+
+        The target path may be absolute or relative. Relative paths are
+        interpreted relative to the current working directory, *not* the
+        directory of the Path object.
+
+        Returns the new Path instance pointing to the target path.
         """
         self._accessor.replace(self, target)
         return self.__class__(target)


### PR DESCRIPTION
I made this after I was bitten when assuming `Path.rename` would take just the new name rather than the full path.

Question: How can I get an automatic backport to 3.8?

<!-- issue-number: [bpo-40833](https://bugs.python.org/issue40833) -->
https://bugs.python.org/issue40833
<!-- /issue-number -->
