### PR TITLE
bpo-40834: Fix truncate when sending str object with channel

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -378,6 +378,9 @@ class ShareableTypeTests(unittest.TestCase):
         self._assert_values(i.to_bytes(2, 'little', signed=True)
                             for i in range(-1, 258))
 
+    def test_strs(self):
+        self._assert_values(['hello world', '你好世界', ''])
+
     def test_int(self):
         self._assert_values(itertools.chain(range(-1, 258),
                                             [sys.maxsize, -sys.maxsize - 1]))

--- a/Misc/NEWS.d/next/Library/2020-05-31-15-52-18.bpo-40834.MO9_hb.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-31-15-52-18.bpo-40834.MO9_hb.rst
@@ -1,0 +1,1 @@
+Fix truncate when sending str object with_xxsubinterpreters.channel_send.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1735,7 +1735,7 @@ _str_shared(PyObject *obj, _PyCrossInterpreterData *data)
     struct _shared_str_data *shared = PyMem_NEW(struct _shared_str_data, 1);
     shared->kind = PyUnicode_KIND(obj);
     shared->buffer = PyUnicode_DATA(obj);
-    shared->len = PyUnicode_GET_LENGTH(obj) - 1;
+    shared->len = PyUnicode_GET_LENGTH(obj);
     data->data = (void *)shared;
     Py_INCREF(obj);
     data->obj = obj;  // Will be "released" (decref'ed) when data released.


### PR DESCRIPTION


<!-- issue-number: [bpo-40834](https://bugs.python.org/issue40834) -->
https://bugs.python.org/issue40834
<!-- /issue-number -->


Automerge-Triggered-By: @csabella