### PR TITLE
bpo-39314: Closes parenthesis when autocompleting for functions that take no arguments

### DIFF
--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -31,6 +31,7 @@ Notes:
 
 import atexit
 import builtins
+import inspect
 import __main__
 
 __all__ = ["Completer"]
@@ -96,7 +97,13 @@ class Completer:
 
     def _callable_postfix(self, val, word):
         if callable(val):
-            word = word + "("
+            word += "("
+            try:
+                if not inspect.signature(val).parameters:
+                    word += ")"
+            except ValueError:
+                pass
+
         return word
 
     def global_matches(self, text):

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -40,12 +40,12 @@ class TestRlcompleter(unittest.TestCase):
 
         # test with a customized namespace
         self.assertEqual(self.completer.global_matches('CompleteM'),
-                         ['CompleteMe('])
+                         ['CompleteMe()'])
         self.assertEqual(self.completer.global_matches('eg'),
                          ['egg('])
         # XXX: see issue5256
         self.assertEqual(self.completer.global_matches('CompleteM'),
-                         ['CompleteMe('])
+                         ['CompleteMe()'])
 
     def test_attr_matches(self):
         # test with builtins namespace
@@ -64,7 +64,7 @@ class TestRlcompleter(unittest.TestCase):
                          ['CompleteMe.spam'])
         self.assertEqual(self.completer.attr_matches('Completeme.egg'), [])
         self.assertEqual(self.completer.attr_matches('CompleteMe.'),
-                         ['CompleteMe.mro(', 'CompleteMe.spam'])
+                         ['CompleteMe.mro()', 'CompleteMe.spam'])
         self.assertEqual(self.completer.attr_matches('CompleteMe._'),
                          ['CompleteMe._ham'])
         matches = self.completer.attr_matches('CompleteMe.__')
@@ -134,7 +134,7 @@ class TestRlcompleter(unittest.TestCase):
         # No opening bracket "(" because we overrode the built-in class
         self.assertEqual(completer.complete('memoryview', 0), 'memoryview')
         self.assertIsNone(completer.complete('memoryview', 1))
-        self.assertEqual(completer.complete('Ellipsis', 0), 'Ellipsis(')
+        self.assertEqual(completer.complete('Ellipsis', 0), 'Ellipsis()')
         self.assertIsNone(completer.complete('Ellipsis', 1))
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2020-06-01-02-16-29.bpo-39314.0T9hlA.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-01-02-16-29.bpo-39314.0T9hlA.rst
@@ -1,3 +1,3 @@
 :class:`rlcompleter.Completer` and the standard Python shell now close the
-parenthesis for functions that take no arguments. Path contributed by Rémi
+parenthesis for functions that take no arguments. Patch contributed by Rémi
 Lapeyre.

--- a/Misc/NEWS.d/next/Library/2020-06-01-02-16-29.bpo-39314.0T9hlA.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-01-02-16-29.bpo-39314.0T9hlA.rst
@@ -1,0 +1,3 @@
+:class:`rlcompleter.Completer` and the standard Python shell now close the
+parenthesis for functions that take no arguments. Path contributed by Rémi
+Lapeyre.


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39314](https://bugs.python.org/issue39314) -->
https://bugs.python.org/issue39314
<!-- /issue-number -->
