### PR TITLE
gh-85014: Fix email.utils.encode_rfc2231(string, None, None)

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -381,9 +381,9 @@ def encode_rfc2231(s, charset=None, language=None):
     charset is given but not language, the string is encoded using the empty
     string for language.
     """
-    s = urllib.parse.quote(s, safe='', encoding=charset or 'ascii')
     if charset is None and language is None:
         return s
+    s = urllib.parse.quote(s, safe='', encoding=charset or 'ascii')
     if language is None:
         language = ''
     return "%s'%s'%s" % (charset, language, s)

--- a/Misc/NEWS.d/next/Library/2020-06-01-04-11-28.bpo-40837.foob.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-01-04-11-28.bpo-40837.foob.rst
@@ -1,0 +1,3 @@
+:func:`email.utils.encode_rfc2231` no longer percent-encodes the input string
+when both *charset* and *language* are ``None``.  This matches the behavior
+documented in the function's docstring. Patch by Florian Best.


### PR DESCRIPTION
`encode_rfc2231()` must not change the returned value if no transformation of the input was done.
This is also mentioned in the docstring of that function.

Actual behavior:
```python
encode_rfc2231('foo bar', None, None)
'foo%20bar'
```
Expected behavior:
```python
encode_rfc2231('foo bar', None, None)
'foo bar'
```

<!-- issue-number: [bpo-40837](https://bugs.python.org/issue40837) -->
https://bugs.python.org/issue40837
<!-- /issue-number -->


<!-- gh-issue-number: gh-85014 -->
* Issue: gh-85014
<!-- /gh-issue-number -->
