### PR TITLE
Add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ Tools/unicode/data/
 /config.log
 /config.status
 /config.status.lineno
+/compile_commands.json
 /platform
 /pybuilddir.txt
 /pyconfig.h


### PR DESCRIPTION
This file is generated by https://pypi.org/project/compiledb/ and is
needed for https://www.jetbrains.com/clion IDE support.