### PR TITLE
Update error message in _zoneinfo.py to use f-string

### DIFF
--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -742,7 +742,7 @@ def _parse_tz_delta(tz_delta):
 
     if not -86400 < total < 86400:
         raise ValueError(
-            f"Offset must be strictly between -24h and +24h:{tz_delta}"
+            f"Offset must be strictly between -24h and +24h: {tz_delta}"
         )
 
     # Yes, +5 maps to an offset of -5h

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -742,7 +742,7 @@ def _parse_tz_delta(tz_delta):
 
     if not -86400 < total < 86400:
         raise ValueError(
-            "Offset must be strictly between -24h and +24h:" + tz_delta
+            f"Offset must be strictly between -24h and +24h:{tz_delta}"
         )
 
     # Yes, +5 maps to an offset of -5h


### PR DESCRIPTION
Inline with the rest of the file, updated error message to use f-string.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


Automerge-Triggered-By: @pganssle