### PR TITLE
bpo-40839: PyDict_GetItem() requires the GIL

### DIFF
--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -100,6 +100,10 @@ Dictionary Objects
    :meth:`__eq__` methods will get suppressed.
    To get error reporting use :c:func:`PyDict_GetItemWithError()` instead.
 
+   .. versionchanged:: 3.10
+      Calling this API without :term:`GIL` held had been allowed for historical
+      reason. It is no longer allowed.
+
 
 .. c:function:: PyObject* PyDict_GetItemWithError(PyObject *p, PyObject *key)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -148,5 +148,9 @@ Porting to Python 3.10
   see :c:func:`Py_SET_SIZE()` (available since Python 3.9).
   (Contributed by Victor Stinner in :issue:`39573`.)
 
+* Calling :c:func:`PyDict_GetItem` without :term:`GIL` held had been allowed
+  for historical reason. It is no longer allowed.
+  (Contributed by Victor Stinner in :issue:`40839`.)
+
 Removed
 -------

--- a/Misc/NEWS.d/next/C API/2020-06-01-20-47-49.bpo-40839.bAi52Z.rst
+++ b/Misc/NEWS.d/next/C API/2020-06-01-20-47-49.bpo-40839.bAi52Z.rst
@@ -1,0 +1,2 @@
+Calling :c:func:`PyDict_GetItem` without :term:`GIL` held had been allowed for
+historical reason. It is no longer allowed.


### PR DESCRIPTION
The PyDict_GetItem() must now be called with the GIL held.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40839](https://bugs.python.org/issue40839) -->
https://bugs.python.org/issue40839
<!-- /issue-number -->
