### PR TITLE
Fix MSVC warning in frameobject.c

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -397,7 +397,9 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         return -1;
     }
 
-    int len = PyBytes_GET_SIZE(f->f_code->co_code)/sizeof(_Py_CODEUNIT);
+    int len = Py_SAFE_DOWNCAST(
+        PyBytes_GET_SIZE(f->f_code->co_code)/sizeof(_Py_CODEUNIT),
+        Py_ssize_t, int);
     int *lines = marklines(f->f_code, len);
     if (lines == NULL) {
         return -1;


### PR DESCRIPTION
This should be a safe downcast as exceeding a size of `2^30` opcodes in a single code object is extremely unlikely and there's already some hard dependencies relying on 32-bit ints like `struct _frame`'s `f_lasti`, `f_iblock`. See [PEP 611](https://www.python.org/dev/peps/pep-0611) for proposals to solidify this limit and other research on existing limits.

While it would be possible to swap this out for a `Py_ssize_t`, it would be a much more involved refactoring as line numbers are still reliant on being ints.