### PR TITLE
bpo-11105: Do not crash when compiling recursive ASTs

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1097,6 +1097,20 @@ Module(
         exec(code, ns)
         self.assertIn('sleep', ns)
 
+    def test_recursion_direct(self):
+        e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
+        e.operand = e
+        with self.assertRaises(RecursionError):
+            compile(ast.Expression(e), "<test>", "eval")
+
+    def test_recursion_indirect(self):
+        e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
+        f = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
+        e.operand = f
+        f.operand = e
+        with self.assertRaises(RecursionError):
+            compile(ast.Expression(e), "<test>", "eval")
+
 
 class ASTValidatorTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-02-13-21-14.bpo-11105.wceryW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-02-13-21-14.bpo-11105.wceryW.rst
@@ -1,1 +1,3 @@
-Don't crash / raise segfault when compiling an AST with recursive fields.
+When compiling :class:`ast.AST` objects with recursive references
+through :func:`compile`, the interpreter doesn't crash anymore instead
+it raises a :exc:`RecursionError`.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-02-13-21-14.bpo-11105.wceryW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-02-13-21-14.bpo-11105.wceryW.rst
@@ -1,0 +1,1 @@
+Don't crash / raise segfault when compiling an AST with recursive fields.

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -5373,7 +5373,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Module' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5406,7 +5410,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 type_ignore_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Module' node")) {
+                    goto failed;
+                }
                 res = obj2ast_type_ignore(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5451,7 +5459,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Interactive' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5483,7 +5495,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Expression' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &body, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5522,7 +5538,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'FunctionType' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5542,7 +5562,11 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FunctionType' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &returns, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5583,7 +5607,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5596,7 +5624,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5609,7 +5641,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5622,7 +5658,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'stmt' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -5648,7 +5688,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &name, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5661,7 +5705,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_arguments(state, tmp, &args, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5687,7 +5735,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5720,7 +5772,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5740,7 +5796,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &returns, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5753,7 +5813,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &type_comment, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5785,7 +5849,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &name, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5798,7 +5866,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_arguments(state, tmp, &args, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5824,7 +5896,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5857,7 +5933,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5877,7 +5957,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &returns, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5890,7 +5974,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncFunctionDef' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &type_comment, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5922,7 +6010,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &name, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5948,7 +6040,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5981,7 +6077,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 keyword_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_keyword(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6014,7 +6114,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6047,7 +6151,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'ClassDef' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6081,7 +6189,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Return' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6120,7 +6232,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Delete' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6168,7 +6284,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6188,7 +6308,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6201,7 +6325,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Assign' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &type_comment, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6229,7 +6357,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &target, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6242,7 +6374,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
+                goto failed;
+            }
             res = obj2ast_operator(state, tmp, &op, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6255,7 +6391,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AugAssign' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6284,7 +6424,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &target, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6297,7 +6441,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &annotation, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6310,7 +6458,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6323,7 +6475,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AnnAssign' node")) {
+                goto failed;
+            }
             res = obj2ast_int(state, tmp, &simple, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6353,7 +6509,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &target, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6366,7 +6526,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &iter, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6392,7 +6556,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6425,7 +6593,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6445,7 +6617,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'For' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &type_comment, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6475,7 +6651,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &target, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6488,7 +6668,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &iter, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6514,7 +6698,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6547,7 +6735,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6567,7 +6759,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncFor' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &type_comment, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6596,7 +6792,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'While' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &test, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6622,7 +6822,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'While' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6655,7 +6859,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'While' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6690,7 +6898,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'If' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &test, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6716,7 +6928,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'If' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6749,7 +6965,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'If' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6797,7 +7017,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 withitem_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'With' node")) {
+                    goto failed;
+                }
                 res = obj2ast_withitem(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6830,7 +7054,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'With' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6850,7 +7078,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'With' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &type_comment, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6891,7 +7123,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 withitem_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
+                    goto failed;
+                }
                 res = obj2ast_withitem(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6924,7 +7160,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6944,7 +7184,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'AsyncWith' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &type_comment, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6971,7 +7215,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Match' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &subject, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6997,7 +7245,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 match_case_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Match' node")) {
+                    goto failed;
+                }
                 res = obj2ast_match_case(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7031,7 +7283,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Raise' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &exc, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7044,7 +7300,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Raise' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &cause, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7086,7 +7346,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7119,7 +7383,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 excepthandler_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                    goto failed;
+                }
                 res = obj2ast_excepthandler(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7152,7 +7420,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7185,7 +7457,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Try' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7219,7 +7495,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Assert' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &test, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7232,7 +7512,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Assert' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &msg, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7271,7 +7555,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 alias_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Import' node")) {
+                    goto failed;
+                }
                 res = obj2ast_alias(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7306,7 +7594,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &module, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7332,7 +7624,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 alias_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
+                    goto failed;
+                }
                 res = obj2ast_alias(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7352,7 +7648,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'ImportFrom' node")) {
+                goto failed;
+            }
             res = obj2ast_int(state, tmp, &level, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7391,7 +7691,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Global' node")) {
+                    goto failed;
+                }
                 res = obj2ast_identifier(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7437,7 +7741,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Nonlocal' node")) {
+                    goto failed;
+                }
                 res = obj2ast_identifier(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7470,7 +7778,11 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Expr' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7548,7 +7860,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -7561,7 +7877,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -7574,7 +7894,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -7587,7 +7911,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'expr' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -7609,7 +7937,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'BoolOp' node")) {
+                goto failed;
+            }
             res = obj2ast_boolop(state, tmp, &op, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7635,7 +7967,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'BoolOp' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7669,7 +8005,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'NamedExpr' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &target, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7682,7 +8022,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'NamedExpr' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7710,7 +8054,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &left, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7723,7 +8071,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
+                goto failed;
+            }
             res = obj2ast_operator(state, tmp, &op, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7736,7 +8088,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'BinOp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &right, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7763,7 +8119,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'UnaryOp' node")) {
+                goto failed;
+            }
             res = obj2ast_unaryop(state, tmp, &op, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7776,7 +8136,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'UnaryOp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &operand, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7803,7 +8167,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Lambda' node")) {
+                goto failed;
+            }
             res = obj2ast_arguments(state, tmp, &args, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7816,7 +8184,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Lambda' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &body, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7844,7 +8216,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &test, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7857,7 +8233,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &body, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7870,7 +8250,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'IfExp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &orelse, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7910,7 +8294,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Dict' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7943,7 +8331,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Dict' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7989,7 +8381,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Set' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8023,7 +8419,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'ListComp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &elt, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8049,7 +8449,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'ListComp' node")) {
+                    goto failed;
+                }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8083,7 +8487,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'SetComp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &elt, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8109,7 +8517,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'SetComp' node")) {
+                    goto failed;
+                }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8144,7 +8556,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &key, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8157,7 +8573,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8183,7 +8603,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'DictComp' node")) {
+                    goto failed;
+                }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8217,7 +8641,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'GeneratorExp' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &elt, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8243,7 +8671,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'GeneratorExp' node")) {
+                    goto failed;
+                }
                 res = obj2ast_comprehension(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8276,7 +8708,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Await' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8302,7 +8738,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Yield' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8328,7 +8768,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'YieldFrom' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8356,7 +8800,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &left, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8382,7 +8830,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 cmpop_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
+                    goto failed;
+                }
                 res = obj2ast_cmpop(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8415,7 +8867,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Compare' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8450,7 +8906,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Call' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &func, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8476,7 +8936,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Call' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8509,7 +8973,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 keyword_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Call' node")) {
+                    goto failed;
+                }
                 res = obj2ast_keyword(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8544,7 +9012,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8557,7 +9029,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
+                goto failed;
+            }
             res = obj2ast_int(state, tmp, &conversion, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8570,7 +9046,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'FormattedValue' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &format_spec, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8610,7 +9090,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'JoinedStr' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8644,7 +9128,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Constant' node")) {
+                goto failed;
+            }
             res = obj2ast_constant(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8657,7 +9145,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Constant' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &kind, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8685,7 +9177,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8698,7 +9194,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &attr, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8711,7 +9211,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Attribute' node")) {
+                goto failed;
+            }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8739,7 +9243,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8752,7 +9260,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &slice, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8765,7 +9277,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Subscript' node")) {
+                goto failed;
+            }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8792,7 +9308,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Starred' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8805,7 +9325,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Starred' node")) {
+                goto failed;
+            }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8832,7 +9356,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Name' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &id, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8845,7 +9373,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Name' node")) {
+                goto failed;
+            }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8885,7 +9417,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'List' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8905,7 +9441,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'List' node")) {
+                goto failed;
+            }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8945,7 +9485,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'Tuple' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8965,7 +9509,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Tuple' node")) {
+                goto failed;
+            }
             res = obj2ast_expr_context(state, tmp, &ctx, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8993,7 +9541,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &lower, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9006,7 +9558,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &upper, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9019,7 +9575,11 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'Slice' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &step, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9365,7 +9925,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+            goto failed;
+        }
         res = obj2ast_expr(state, tmp, &target, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9378,7 +9942,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+            goto failed;
+        }
         res = obj2ast_expr(state, tmp, &iter, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9404,7 +9972,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
+            if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp2, &val, arena);
+            Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9424,7 +9996,11 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'comprehension' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &is_async, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9461,7 +10037,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9474,7 +10054,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9487,7 +10071,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9500,7 +10088,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'excepthandler' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9523,7 +10115,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &type, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9536,7 +10132,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &name, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9562,7 +10162,11 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'ExceptHandler' node")) {
+                    goto failed;
+                }
                 res = obj2ast_stmt(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9620,7 +10224,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
+            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+                goto failed;
+            }
             res = obj2ast_arg(state, tmp2, &val, arena);
+            Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9653,7 +10261,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
+            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+                goto failed;
+            }
             res = obj2ast_arg(state, tmp2, &val, arena);
+            Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9673,7 +10285,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+            goto failed;
+        }
         res = obj2ast_arg(state, tmp, &vararg, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9699,7 +10315,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
+            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+                goto failed;
+            }
             res = obj2ast_arg(state, tmp2, &val, arena);
+            Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9732,7 +10352,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
+            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp2, &val, arena);
+            Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9752,7 +10376,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+            goto failed;
+        }
         res = obj2ast_arg(state, tmp, &kwarg, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9778,7 +10406,11 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
+            if (Py_EnterRecursiveCall(" while traversing 'arguments' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp2, &val, arena);
+            Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9818,7 +10450,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+            goto failed;
+        }
         res = obj2ast_identifier(state, tmp, &arg, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9831,7 +10467,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+            goto failed;
+        }
         res = obj2ast_expr(state, tmp, &annotation, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9844,7 +10484,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+            goto failed;
+        }
         res = obj2ast_string(state, tmp, &type_comment, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9857,7 +10501,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9870,7 +10518,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9883,7 +10535,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9896,7 +10552,11 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'arg' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9929,7 +10589,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+            goto failed;
+        }
         res = obj2ast_identifier(state, tmp, &arg, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9942,7 +10606,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+            goto failed;
+        }
         res = obj2ast_expr(state, tmp, &value, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9955,7 +10623,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9968,7 +10640,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9981,7 +10657,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9994,7 +10674,11 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'keyword' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10027,7 +10711,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+            goto failed;
+        }
         res = obj2ast_identifier(state, tmp, &name, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10040,7 +10728,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+            goto failed;
+        }
         res = obj2ast_identifier(state, tmp, &asname, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10053,7 +10745,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10066,7 +10762,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10079,7 +10779,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10092,7 +10796,11 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'alias' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10121,7 +10829,11 @@ obj2ast_withitem(struct ast_state *state, PyObject* obj, withitem_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'withitem' node")) {
+            goto failed;
+        }
         res = obj2ast_expr(state, tmp, &context_expr, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10134,7 +10846,11 @@ obj2ast_withitem(struct ast_state *state, PyObject* obj, withitem_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'withitem' node")) {
+            goto failed;
+        }
         res = obj2ast_expr(state, tmp, &optional_vars, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10163,7 +10879,11 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
+            goto failed;
+        }
         res = obj2ast_pattern(state, tmp, &pattern, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10176,7 +10896,11 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
+            goto failed;
+        }
         res = obj2ast_expr(state, tmp, &guard, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10202,7 +10926,11 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
             stmt_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
+            if (Py_EnterRecursiveCall(" while traversing 'match_case' node")) {
+                goto failed;
+            }
             res = obj2ast_stmt(state, tmp2, &val, arena);
+            Py_LeaveRecursiveCall();
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -10246,7 +10974,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10259,7 +10991,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10272,7 +11008,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_lineno, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10285,7 +11025,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
     }
     else {
         int res;
+        if (Py_EnterRecursiveCall(" while traversing 'pattern' node")) {
+            goto failed;
+        }
         res = obj2ast_int(state, tmp, &end_col_offset, arena);
+        Py_LeaveRecursiveCall();
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -10306,7 +11050,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'MatchValue' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10332,7 +11080,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'MatchSingleton' node")) {
+                goto failed;
+            }
             res = obj2ast_constant(state, tmp, &value, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10371,7 +11123,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'MatchSequence' node")) {
+                    goto failed;
+                }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10419,7 +11175,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
+                    goto failed;
+                }
                 res = obj2ast_expr(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10452,7 +11212,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
+                    goto failed;
+                }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10472,7 +11236,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'MatchMapping' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &rest, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10501,7 +11269,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+                goto failed;
+            }
             res = obj2ast_expr(state, tmp, &cls, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10527,7 +11299,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+                    goto failed;
+                }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10560,7 +11336,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+                    goto failed;
+                }
                 res = obj2ast_identifier(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10593,7 +11373,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'MatchClass' node")) {
+                    goto failed;
+                }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10627,7 +11411,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'MatchStar' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &name, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10654,7 +11442,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'MatchAs' node")) {
+                goto failed;
+            }
             res = obj2ast_pattern(state, tmp, &pattern, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10667,7 +11459,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'MatchAs' node")) {
+                goto failed;
+            }
             res = obj2ast_identifier(state, tmp, &name, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10706,7 +11502,11 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
                 pattern_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
+                if (Py_EnterRecursiveCall(" while traversing 'MatchOr' node")) {
+                    goto failed;
+                }
                 res = obj2ast_pattern(state, tmp2, &val, arena);
+                Py_LeaveRecursiveCall();
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -10760,7 +11560,11 @@ obj2ast_type_ignore(struct ast_state *state, PyObject* obj, type_ignore_ty*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'TypeIgnore' node")) {
+                goto failed;
+            }
             res = obj2ast_int(state, tmp, &lineno, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -10773,7 +11577,11 @@ obj2ast_type_ignore(struct ast_state *state, PyObject* obj, type_ignore_ty*
         }
         else {
             int res;
+            if (Py_EnterRecursiveCall(" while traversing 'TypeIgnore' node")) {
+                goto failed;
+            }
             res = obj2ast_string(state, tmp, &tag, arena);
+            Py_LeaveRecursiveCall();
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }


### PR DESCRIPTION
When compiling AST objects with direct or indirect reference cycles, the converter (python -> native) used to crash. Now it properly manages all the potential calls that might fall into a recursive state with `Py_EnterRecursiveCall`/`Py_LeaveRecursiveCall`. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-11105](https://bugs.python.org/issue11105) -->
https://bugs.python.org/issue11105
<!-- /issue-number -->
