### PR TITLE
bpo-32604: Fix reference leak in select module

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-06-02-23-49-07.bpo-32604.ZN4V4l.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-02-23-49-07.bpo-32604.ZN4V4l.rst
@@ -1,0 +1,2 @@
+Fix reference leak in the :mod:`select` module when the the module is
+imported in a subinterpreter.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -2482,7 +2482,6 @@ PyInit_select(void)
         if (poll_Type == NULL)
             return NULL;
         get_select_state(m)->poll_Type = (PyTypeObject *)poll_Type;
-        Py_INCREF(poll_Type);
 
         PyModule_AddIntMacro(m, POLLIN);
         PyModule_AddIntMacro(m, POLLPRI);
@@ -2518,7 +2517,6 @@ PyInit_select(void)
     if (devpoll_Type == NULL)
         return NULL;
     get_select_state(m)->devpoll_Type = (PyTypeObject *)devpoll_Type;
-    Py_INCREF(devpoll_Type);
 #endif
 
 #ifdef HAVE_EPOLL


### PR DESCRIPTION
Fix reference leak in PyInit_select() of the select module:
remove Py_INCREF(poll_Type).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32604](https://bugs.python.org/issue32604) -->
https://bugs.python.org/issue32604
<!-- /issue-number -->
