### PR TITLE
bpo-40846: Removed ambiguity in definition of parameters

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -419,7 +419,7 @@ What is the difference between arguments and parameters?
 
 :term:`Parameters <parameter>` are defined by the names that appear in a
 function definition, whereas :term:`arguments <argument>` are the values
-actually passed to a function when calling it.  Parameters define what types of
+actually passed to a function when calling it.  Parameters define what kind of
 arguments a function can accept.  For example, given the function definition::
 
    def func(foo, bar=None, **kwargs):


### PR DESCRIPTION
Clarified the definition of parameters with respect to issue : https://bugs.python.org/issue40846

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40846](https://bugs.python.org/issue40846) -->
https://bugs.python.org/issue40846
<!-- /issue-number -->
