### PR TITLE
bpo-39573: Porting to Python 3.10: Py_SET_SIZE() macro

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -139,7 +139,7 @@ Porting to Python 3.10
   compatibility, this macro can be used::
 
       #if PY_VERSION_HEX < 0x030900A4
-      #  define Py_SET_TYPE(obj, type) do { Py_TYPE(obj) = (type); } while (0)
+      #  define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void)0)
       #endif
 
   (Contributed by Dong-hee Na in :issue:`39573`.)
@@ -150,7 +150,7 @@ Porting to Python 3.10
   compatibility, this macro can be used::
 
       #if PY_VERSION_HEX < 0x030900A4
-      #  define Py_SET_REFCNT(obj, refcnt) do { Py_REFCNT(obj) = (refcnt); } while (0)
+      #  define Py_SET_REFCNT(obj, refcnt) ((Py_REFCNT(obj) = (refcnt)), (void)0)
       #endif
 
   (Contributed by Victor Stinner in :issue:`39573`.)
@@ -161,7 +161,7 @@ Porting to Python 3.10
   compatibility, this macro can be used::
 
       #if PY_VERSION_HEX < 0x030900A4
-      #  define Py_SET_SIZE(obj, size) do { Py_SIZE(obj) = (size); } while (0)
+      #  define Py_SET_SIZE(obj, size) ((Py_SIZE(obj) = (size)), (void)0)
       #endif
 
   (Contributed by Victor Stinner in :issue:`39573`.)

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -135,17 +135,35 @@ Porting to Python 3.10
 
 * Since :c:func:`Py_TYPE()` is changed to the inline static function,
   ``Py_TYPE(obj) = new_type`` must be replaced with ``Py_SET_TYPE(obj, new_type)``:
-  see :c:func:`Py_SET_TYPE()` (available since Python 3.9).
+  see :c:func:`Py_SET_TYPE()` (available since Python 3.9). For backward
+  compatibility, this macro can be used::
+
+      #if PY_VERSION_HEX < 0x030900A4
+      #  define Py_SET_TYPE(obj, type) do { Py_TYPE(obj) = (type); } while (0)
+      #endif
+
   (Contributed by Dong-hee Na in :issue:`39573`.)
 
 * Since :c:func:`Py_REFCNT()` is changed to the inline static function,
   ``Py_REFCNT(obj) = new_refcnt`` must be replaced with ``Py_SET_REFCNT(obj, new_refcnt)``:
-  see :c:func:`Py_SET_REFCNT()` (available since Python 3.9).
+  see :c:func:`Py_SET_REFCNT()` (available since Python 3.9). For backward
+  compatibility, this macro can be used::
+
+      #if PY_VERSION_HEX < 0x030900A4
+      #  define Py_SET_REFCNT(obj, refcnt) do { Py_REFCNT(obj) = (refcnt); } while (0)
+      #endif
+
   (Contributed by Victor Stinner in :issue:`39573`.)
 
 * Since :c:func:`Py_SIZE()` is changed to the inline static function,
   ``Py_SIZE(obj) = new_size`` must be replaced with ``Py_SET_SIZE(obj, new_size)``:
-  see :c:func:`Py_SET_SIZE()` (available since Python 3.9).
+  see :c:func:`Py_SET_SIZE()` (available since Python 3.9). For backward
+  compatibility, this macro can be used::
+
+      #if PY_VERSION_HEX < 0x030900A4
+      #  define Py_SET_SIZE(obj, size) do { Py_SIZE(obj) = (size); } while (0)
+      #endif
+
   (Contributed by Victor Stinner in :issue:`39573`.)
 
 * Calling :c:func:`PyDict_GetItem` without :term:`GIL` held had been allowed


### PR DESCRIPTION
In What's New in Python 3.10, propose Py_SET_SIZE(), Py_SET_REFCNT()
and Py_SET_TYPE() macros for backward compatibility with Python 3.9
and older.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39573](https://bugs.python.org/issue39573) -->
https://bugs.python.org/issue39573
<!-- /issue-number -->
