### PR TITLE
bpo-40686: Fix compiler warnings in _zoneinfo.c

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -172,7 +172,7 @@ static void
 update_strong_cache(const PyTypeObject *const type, PyObject *key,
                     PyObject *zone);
 static PyObject *
-zone_from_strong_cache(const PyTypeObject *const type, PyObject *key);
+zone_from_strong_cache(const PyTypeObject *const type, PyObject *const key);
 
 static PyObject *
 zoneinfo_new_instance(PyTypeObject *type, PyObject *key)
@@ -1220,19 +1220,19 @@ calendarrule_new(uint8_t month, uint8_t week, uint8_t day, int8_t hour,
     // optimize out the first comparison if day is an unsigned integer anyway,
     // we will leave this comparison in place and disable the compiler warning.
 #ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wtautological-compare"
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wtautological-compare"
 #endif
 #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtype-limits"
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
     if (day < 0 || day > 6) {
 #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
-#pragma GCC diagnostic pop
+# pragma GCC diagnostic pop
 #endif
 #ifdef __clang__
-#pragma clang diagnostic pop
+# pragma clang diagnostic pop
 #endif
         PyErr_Format(PyExc_ValueError, "Day must be in [0, 6]");
         return -1;

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1219,10 +1219,21 @@ calendarrule_new(uint8_t month, uint8_t week, uint8_t day, int8_t hour,
     // it may create a bug. Considering that the compiler should be able to
     // optimize out the first comparison if day is an unsigned integer anyway,
     // we will leave this comparison in place and disable the compiler warning.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
     if (day < 0 || day > 6) {
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
         PyErr_Format(PyExc_ValueError, "Day must be in [0, 6]");
         return -1;
     }


### PR DESCRIPTION
````
D:\a\cpython\cpython\Modules\_zoneinfo.c(1224,9): warning C4068: unknown pragma [D:\a\cpython\cpython\PCbuild\_zoneinfo.vcxproj]
D:\a\cpython\cpython\Modules\_zoneinfo.c(1225,9): warning C4068: unknown pragma [D:\a\cpython\cpython\PCbuild\_zoneinfo.vcxproj]
D:\a\cpython\cpython\Modules\_zoneinfo.c(1227,9): warning C4068: unknown pragma [D:\a\cpython\cpython\PCbuild\_zoneinfo.vcxproj]
````
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40686](https://bugs.python.org/issue40686) -->
https://bugs.python.org/issue40686
<!-- /issue-number -->
