### PR TITLE
fix typo in warning

### DIFF
--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -42,8 +42,8 @@ def _parse_python_tzpath(env_var):
         msg = _get_invalid_paths_message(raw_tzpath)
 
         warnings.warn(
-            "Invalid paths specified in PYTHONTZPATH environment variable."
-            + msg,
+            f"Invalid paths specified in PYTHONTZPATH "
+            + f"environment variable. {msg}",
             InvalidTZPathWarning,
         )
 

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -42,8 +42,8 @@ def _parse_python_tzpath(env_var):
         msg = _get_invalid_paths_message(raw_tzpath)
 
         warnings.warn(
-            f"Invalid paths specified in PYTHONTZPATH "
-            + f"environment variable. {msg}",
+            "Invalid paths specified in PYTHONTZPATH environment variable. "
+            + msg,
             InvalidTZPathWarning,
         )
 


### PR DESCRIPTION
Add space after period.

Current warning:
InvalidTZPathWarning: Invalid paths specified in PYTHONTZPATH environment variable.Paths should be absolute but found the following relative paths: ...

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
