### PR TITLE
bpo-40862: Raise TypeError when const is given to argparse.BooleanOptionalAction

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -857,7 +857,6 @@ class BooleanOptionalAction(Action):
     def __init__(self,
                  option_strings,
                  dest,
-                 const=None,
                  default=None,
                  type=None,
                  choices=None,

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -701,7 +701,7 @@ class TestBooleanOptionalAction(ParserTestCase):
     ]
 
     def test_const(self):
-        # See bpo-wip
+        # See bpo-40862
         parser = argparse.ArgumentParser()
         with self.assertRaises(TypeError) as cm:
             parser.add_argument('--foo', const=True, action=argparse.BooleanOptionalAction)

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -700,6 +700,14 @@ class TestBooleanOptionalAction(ParserTestCase):
         ('--no-foo --foo', NS(foo=True)),
     ]
 
+    def test_const(self):
+        # See bpo-wip
+        parser = argparse.ArgumentParser()
+        with self.assertRaises(TypeError) as cm:
+            parser.add_argument('--foo', const=True, action=argparse.BooleanOptionalAction)
+
+        self.assertIn("got an unexpected keyword argument 'const'", str(cm.exception))
+
 class TestBooleanOptionalActionRequired(ParserTestCase):
     """Tests BooleanOptionalAction required"""
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40862](https://bugs.python.org/issue40862) -->
https://bugs.python.org/issue40862
<!-- /issue-number -->
