### PR TITLE
bpo-40686: Replace error suppression with static assertion

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -88,6 +88,7 @@
         (uintptr_t)((a) - 1)) & ~(uintptr_t)((a) - 1)))
 /* Check if pointer "p" is aligned to "a"-bytes boundary. */
 #define _Py_IS_ALIGNED(p, a) (!((uintptr_t)(p) & (uintptr_t)((a) - 1)))
+#define _Py_IS_TYPE_UNSIGNED(type) (((type)-1) > (type)0)
 
 /* Use this for unused arguments in a function definition to silence compiler
  * warnings. Example:

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -162,6 +162,27 @@ typedef int Py_ssize_clean_t;
 #   define PY_FORMAT_SIZE_T "z"
 #endif
 
+
+/* _Py_HAVE_TYPEOF and _Py_TYPEOF can opportunistically support an equivalent
+ * of GCC's typeof extension where possible. It is not possible to get
+ * equivalent behavior on all platforms, so all uses of _Py_TYPEOF should be
+ * guarded by _Py_HAVE_TYPEOF.
+ */
+#if defined(__GNUC__) || defined(__clang__) || defined(__cplusplus)
+#   define _Py_HAVE_TYPEOF 1
+#   if defined(__cplusplus)
+#       define _Py_TYPEOF(x) decltype(x)
+#   else
+#       define _Py_TYPEOF(x) __typeof__(x)
+#   endif
+#else
+#   define _Py_TYPEOF(x) Py_FatalError( \
+        "_Py_TYPEOF is not available in all supported compilation modes on " \
+        "all supported compilers.  Use the _Py_HAVE_TYPEOF macro to guard " \
+        "any statements using _Py_TYPEOF." \
+        )
+#endif
+
 /* Py_LOCAL can be used instead of static to get the fastest possible calling
  * convention for functions that are local to a given module.
  *

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -10,9 +10,10 @@
 // This takes advantage of GCC compiler extensions to determine the type of the
 // variable, so we'll make Py_ASSERT_VAR_UNSIGNED a noop on non-GCC platforms.
 // This is not perfect, but it's better than nothing.
-#ifdef _Py_HAVE_TYPEOF
+#ifdef __GNUC__
+#define IS_TYPE_UNSIGNED(type) (((type)-1) > (type)0)
 #define Py_ASSERT_VAR_UNSIGNED(var) \
-    Py_BUILD_ASSERT(_Py_IS_TYPE_UNSIGNED(_Py_TYPEOF(var)))
+    Py_BUILD_ASSERT(IS_TYPE_UNSIGNED(__typeof__(var)))
 #else
 #define Py_ASSERT_VAR_UNSIGNED(var)
 #endif

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -10,10 +10,9 @@
 // This takes advantage of GCC compiler extensions to determine the type of the
 // variable, so we'll make Py_ASSERT_VAR_UNSIGNED a noop on non-GCC platforms.
 // This is not perfect, but it's better than nothing.
-#ifdef __GNUC__
-#define IS_TYPE_UNSIGNED(type) (((type)-1) > (type)0)
+#ifdef _Py_HAVE_TYPEOF
 #define Py_ASSERT_VAR_UNSIGNED(var) \
-    Py_BUILD_ASSERT(IS_TYPE_UNSIGNED(__typeof__(var)))
+    Py_BUILD_ASSERT(_Py_IS_TYPE_UNSIGNED(_Py_TYPEOF(var)))
 #else
 #define Py_ASSERT_VAR_UNSIGNED(var)
 #endif


### PR DESCRIPTION
Rather than suppressing the unnecessary compiler warning, we will avoid the question by removing the lower bound and introducing a static assertion about the type of `day`.

In some ways this is still worse than the original version, since it only does the assertion when the `__typeof__` GCC extension is available, and if the type of `day` is changed to be signed it will actually require code changes to the boundary check, but for practical purposes (since, at least at the moment, there's very little chance that we will remove GCC-based compilations from our CI checks) this will at least prevent the introduction of this particular bug.

This supercedes #20619. There's a corresponding patch to the backport [here](https://github.com/pganssle/zoneinfo/pull/81).

CC @corona10 @vstinner @pablogsal 

<!-- issue-number: [bpo-40686](https://bugs.python.org/issue40686) -->
https://bugs.python.org/issue40686
<!-- /issue-number -->
