### PR TITLE
bpo-40275: Adding filesystem_helper submodule in test.support

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -1631,7 +1631,7 @@ The :mod:`test.support.threading_helper` module provides support for threading t
 
 
 :mod:`test.support.filesystem_helper` --- Utilities for filesystem tests
-======================================================================
+========================================================================
 
 .. module:: test.support.filesystem_helper
    :synopsis: Support for filesystem tests.

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -252,12 +252,6 @@ The :mod:`test.support` module defines the following constants:
    A non-ASCII character encodable by :func:`os.fsencode`.
 
 
-.. data:: TESTFN
-
-   Set to a name that is safe to use as the name of a temporary file.  Any
-   temporary file that is created should be closed and unlinked (removed).
-
-
 .. data:: TESTFN_UNICODE
 
     Set to a non-ASCII name for a temporary file.
@@ -1634,3 +1628,20 @@ The :mod:`test.support.threading_helper` module provides support for threading t
        # (to avoid reference cycles)
 
    .. versionadded:: 3.8
+
+
+:mod:`test.support.filesystem_helper` --- Utilities for filesystem tests
+======================================================================
+
+.. module:: test.support.filesystem_helper
+   :synopsis: Support for filesystem tests.
+
+The :mod:`test.support.filesystem_helper` module provides support for filesystem tests.
+
+.. versionadded:: 3.10
+
+
+.. data:: TESTFN
+
+   Set to a name that is safe to use as the name of a temporary file.  Any
+   temporary file that is created should be closed and unlinked (removed).

--- a/Lib/ctypes/test/test_find.py
+++ b/Lib/ctypes/test/test_find.py
@@ -2,8 +2,10 @@ import unittest
 import os.path
 import sys
 import test.support
+from test.support import filesystem_helper
 from ctypes import *
 from ctypes.util import find_library
+
 
 # On some systems, loading the OpenGL libraries needs the RTLD_GLOBAL mode.
 class Test_OpenGL_libs(unittest.TestCase):
@@ -65,8 +67,9 @@ class Test_OpenGL_libs(unittest.TestCase):
         self.gle.gleGetJoinStyle
 
     def test_shell_injection(self):
-        result = find_library('; echo Hello shell > ' + test.support.TESTFN)
-        self.assertFalse(os.path.lexists(test.support.TESTFN))
+        result = find_library('; echo Hello shell > ' +
+                              filesystem_helper.TESTFN)
+        self.assertFalse(os.path.lexists(filesystem_helper.TESTFN))
         self.assertIsNone(result)
 
 

--- a/Lib/distutils/tests/test_core.py
+++ b/Lib/distutils/tests/test_core.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import test.support
 from test.support import captured_stdout, run_unittest
+from test.support import filesystem_helper
 import unittest
 from distutils.tests import support
 from distutils import log
@@ -62,13 +63,13 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         super(CoreTestCase, self).tearDown()
 
     def cleanup_testfn(self):
-        path = test.support.TESTFN
+        path = filesystem_helper.TESTFN
         if os.path.isfile(path):
             os.remove(path)
         elif os.path.isdir(path):
             shutil.rmtree(path)
 
-    def write_setup(self, text, path=test.support.TESTFN):
+    def write_setup(self, text, path=filesystem_helper.TESTFN):
         f = open(path, "w")
         try:
             f.write(text)
@@ -105,8 +106,8 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         cwd = os.getcwd()
 
         # Create a directory and write the setup.py file there:
-        os.mkdir(test.support.TESTFN)
-        setup_py = os.path.join(test.support.TESTFN, "setup.py")
+        os.mkdir(filesystem_helper.TESTFN)
+        setup_py = os.path.join(filesystem_helper.TESTFN, "setup.py")
         distutils.core.run_setup(
             self.write_setup(setup_prints_cwd, path=setup_py))
 

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -12,8 +12,9 @@ from distutils.dist import Distribution, fix_help_options
 from distutils.cmd import Command
 
 from test.support import (
-     TESTFN, captured_stdout, captured_stderr, run_unittest
+    captured_stdout, captured_stderr, run_unittest
 )
+from test.support.filesystem_helper import TESTFN
 from distutils.tests import support
 from distutils import log
 

--- a/Lib/distutils/tests/test_spawn.py
+++ b/Lib/distutils/tests/test_spawn.py
@@ -5,6 +5,7 @@ import sys
 import unittest.mock
 from test.support import run_unittest, unix_shell
 from test import support as test_support
+from test.support import filesystem_helper
 
 from distutils.spawn import find_executable
 from distutils.spawn import spawn
@@ -46,7 +47,7 @@ class SpawnTestCase(support.TempdirManager,
     def test_find_executable(self):
         with test_support.temp_dir() as tmp_dir:
             # use TESTFN to get a pseudo-unique filename
-            program_noeext = test_support.TESTFN
+            program_noeext = filesystem_helper.TESTFN
             # Give the temporary program an ".exe" suffix for all.
             # It's needed on Windows and not harmful on other platforms.
             program = program_noeext + ".exe"

--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -10,7 +10,9 @@ import unittest
 from distutils import sysconfig
 from distutils.ccompiler import get_default_compiler
 from distutils.tests import support
-from test.support import TESTFN, run_unittest, check_warnings, swap_item
+from test.support import run_unittest, check_warnings, swap_item
+from test.support.filesystem_helper import TESTFN
+
 
 class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
     def setUp(self):

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -25,7 +25,8 @@ import threading
 import unittest
 import sqlite3 as sqlite
 
-from test.support import TESTFN, unlink
+from test.support import unlink
+from test.support.filesystem_helper import TESTFN
 
 
 class ModuleTests(unittest.TestCase):

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -24,7 +24,9 @@
 import unittest
 import sqlite3 as sqlite
 
-from test.support import TESTFN, unlink
+from test.support import unlink
+from test.support.filesystem_helper import TESTFN
+
 
 class CollationTests(unittest.TestCase):
     def CheckCreateCollationNotString(self):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -26,6 +26,7 @@ import warnings
 import test.support
 import test.support.script_helper
 from test import support
+from test.support import filesystem_helper
 from test.support import hashlib_helper
 from test.support import socket_helper
 from test.support import threading_helper
@@ -818,7 +819,7 @@ class _TestSubclassingProcess(BaseTestCase):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
 
-        testfn = test.support.TESTFN
+        testfn = filesystem_helper.TESTFN
         self.addCleanup(test.support.unlink, testfn)
         proc = self.Process(target=self._test_stderr_flush, args=(testfn,))
         proc.start()
@@ -848,7 +849,7 @@ class _TestSubclassingProcess(BaseTestCase):
         if self.TYPE == 'threads':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
 
-        testfn = test.support.TESTFN
+        testfn = filesystem_helper.TESTFN
         self.addCleanup(test.support.unlink, testfn)
 
         for reason in (
@@ -3198,14 +3199,14 @@ class _TestConnection(BaseTestCase):
         p = self.Process(target=self._writefd, args=(child_conn, b"foo"))
         p.daemon = True
         p.start()
-        self.addCleanup(test.support.unlink, test.support.TESTFN)
-        with open(test.support.TESTFN, "wb") as f:
+        self.addCleanup(test.support.unlink, filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, "wb") as f:
             fd = f.fileno()
             if msvcrt:
                 fd = msvcrt.get_osfhandle(fd)
             reduction.send_handle(conn, fd, p.pid)
         p.join()
-        with open(test.support.TESTFN, "rb") as f:
+        with open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"foo")
 
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
@@ -3224,8 +3225,8 @@ class _TestConnection(BaseTestCase):
         p = self.Process(target=self._writefd, args=(child_conn, b"bar", True))
         p.daemon = True
         p.start()
-        self.addCleanup(test.support.unlink, test.support.TESTFN)
-        with open(test.support.TESTFN, "wb") as f:
+        self.addCleanup(test.support.unlink, filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, "wb") as f:
             fd = f.fileno()
             for newfd in range(256, MAXFD):
                 if not self._is_fd_assigned(newfd):
@@ -3238,7 +3239,7 @@ class _TestConnection(BaseTestCase):
             finally:
                 os.close(newfd)
         p.join()
-        with open(test.support.TESTFN, "rb") as f:
+        with open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"bar")
 
     @classmethod

--- a/Lib/test/audiotests.py
+++ b/Lib/test/audiotests.py
@@ -1,4 +1,5 @@
 from test.support import findfile, TESTFN, unlink
+from test.support.filesystem_helper import TESTFN 
 import array
 import io
 import pickle

--- a/Lib/test/audiotests.py
+++ b/Lib/test/audiotests.py
@@ -1,5 +1,5 @@
 from test.support import findfile, TESTFN, unlink
-from test.support.filesystem_helper import TESTFN 
+from test.support.filesystem_helper import TESTFN
 import array
 import io
 import pickle

--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -22,6 +22,7 @@ import time
 import unittest
 
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 
 @contextlib.contextmanager
@@ -314,7 +315,7 @@ class SocketEINTRTest(EINTRBaseTest):
     @support.requires_freebsd_version(10, 3)
     @unittest.skipUnless(hasattr(os, 'mkfifo'), 'needs mkfifo()')
     def _test_open(self, do_open_close_reader, do_open_close_writer):
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
 
         # Use a fifo: until the child opens it for reading, the parent will
         # block when trying to open it for writing.
@@ -486,16 +487,16 @@ class SelectEINTRTest(EINTRBaseTest):
 
 class FNTLEINTRTest(EINTRBaseTest):
     def _lock(self, lock_func, lock_name):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
         code = '\n'.join((
             "import fcntl, time",
-            "with open('%s', 'wb') as f:" % support.TESTFN,
+            "with open('%s', 'wb') as f:" % filesystem_helper.TESTFN,
             "   fcntl.%s(f, fcntl.LOCK_EX)" % lock_name,
             "   time.sleep(%s)" % self.sleep_time))
         start_time = time.monotonic()
         proc = self.subprocess(code)
         with kill_on_error(proc):
-            with open(support.TESTFN, 'wb') as f:
+            with open(filesystem_helper.TESTFN, 'wb') as f:
                 while True:  # synchronize the subprocess
                     dt = time.monotonic() - start_time
                     if dt > 60.0:

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -11,6 +11,7 @@ import traceback
 import unittest
 
 from test import support
+from test.support import filesystem_helper
 from test.libregrtest.refleak import dash_R, clear_caches
 from test.libregrtest.save_env import saved_test_environment
 from test.libregrtest.utils import format_duration, print_warning
@@ -313,7 +314,7 @@ def cleanup_test_droppings(test_name, verbose):
     # since if a test leaves a file open, it cannot be deleted by name (while
     # there's nothing we can do about that here either, we can display the
     # name of the offending test, which is a real help).
-    for name in (support.TESTFN,):
+    for name in (filesystem_helper.TESTFN,):
         if not os.path.exists(name):
             continue
 

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -10,6 +10,7 @@ import threading
 import urllib.request
 import warnings
 from test import support
+from test.support import filesystem_helper
 from test.libregrtest.utils import print_warning
 try:
     import _multiprocessing, multiprocessing.process
@@ -241,7 +242,7 @@ class saved_test_environment:
         return sorted(fn + ('/' if os.path.isdir(fn) else '')
                       for fn in os.listdir())
     def restore_files(self, saved_value):
-        fn = support.TESTFN
+        fn = filesystem_helper.TESTFN
         if fn not in saved_value and (fn + '/') not in saved_value:
             if os.path.isfile(fn):
                 support.unlink(fn)

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -7,6 +7,7 @@ import os
 from functools import cmp_to_key
 
 from test import support, seq_tests
+from test.support import filesystem_helper
 from test.support import ALWAYS_EQ, NEVER_EQ
 
 
@@ -73,12 +74,12 @@ class CommonTest(seq_tests.CommonTest):
         d.append(d)
         d.append(400)
         try:
-            with open(support.TESTFN, "w") as fo:
+            with open(filesystem_helper.TESTFN, "w") as fo:
                 fo.write(str(d))
-            with open(support.TESTFN, "r") as fo:
+            with open(filesystem_helper.TESTFN, "r") as fo:
                 self.assertEqual(fo.read(), repr(d))
         finally:
-            os.remove(support.TESTFN)
+            os.remove(filesystem_helper.TESTFN)
 
     def test_set_subscript(self):
         a = self.type2test(range(20))

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -31,6 +31,7 @@ from test.support import (
     TestFailed, TESTFN, run_with_locale, no_tracing,
     _2G, _4G, bigmemtest, forget,
     )
+from test.support.filesystem_helper import TESTFN
 from test.support import threading_helper
 
 from pickle import bytes_types

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -22,6 +22,7 @@ import types
 import unittest
 import warnings
 
+from test.support.filesystem_helper import TESTFN
 from .testresult import get_test_runner
 
 __all__ = [
@@ -37,7 +38,7 @@ __all__ = [
     "record_original_stdout", "get_original_stdout", "captured_stdout",
     "captured_stdin", "captured_stderr",
     # filesystem
-    "TESTFN", "SAVEDCWD", "unlink", "rmtree", "temp_cwd", "findfile",
+    "SAVEDCWD", "unlink", "rmtree", "temp_cwd", "findfile",
     "create_empty_file", "can_symlink", "fs_is_case_insensitive",
     # unittest
     "is_resource_enabled", "requires", "requires_freebsd_version",
@@ -713,17 +714,6 @@ if sys.platform != 'win32':
     unix_shell = '/system/bin/sh' if is_android else '/bin/sh'
 else:
     unix_shell = None
-
-# Filename used for testing
-if os.name == 'java':
-    # Jython disallows @ in module names
-    TESTFN = '$test'
-else:
-    TESTFN = '@test'
-
-# Disambiguate TESTFN for parallel testing, while letting it remain a valid
-# module name.
-TESTFN = "{}_{}_tmp".format(TESTFN, os.getpid())
 
 # Define the URL of a dedicated HTTP server for the network tests.
 # The URL must use clear-text HTTP: no redirection to encrypted HTTPS.

--- a/Lib/test/support/filesystem_helper.py
+++ b/Lib/test/support/filesystem_helper.py
@@ -1,0 +1,13 @@
+import os
+
+
+# Filename used for testing
+if os.name == 'java':
+    # Jython disallows @ in module names
+    TESTFN = '$test'
+else:
+    TESTFN = '@test'
+
+# Disambiguate TESTFN for parallel testing, while letting it remain a valid
+# module name.
+TESTFN = "{}_{}_tmp".format(TESTFN, os.getpid())

--- a/Lib/test/support/socket_helper.py
+++ b/Lib/test/support/socket_helper.py
@@ -146,7 +146,8 @@ def skip_unless_bind_unix_socket(test):
         return unittest.skip('No UNIX Sockets')(test)
     global _bind_nix_socket_error
     if _bind_nix_socket_error is None:
-        from test.support import TESTFN, unlink
+        from test.support import unlink
+        from test.support.filesystem_helper import TESTFN
         path = TESTFN + "can_bind_unix_socket"
         with socket.socket(socket.AF_UNIX) as sock:
             try:

--- a/Lib/test/test_aifc.py
+++ b/Lib/test/test_aifc.py
@@ -1,4 +1,5 @@
-from test.support import check_no_resource_warning, findfile, TESTFN, unlink
+from test.support import check_no_resource_warning, findfile, unlink
+from test.support.filesystem_helper import TESTFN
 import unittest
 from unittest import mock
 from test import audiotests

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -4,6 +4,7 @@
 
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.support import _2G
 import weakref
 import pickle
@@ -366,13 +367,13 @@ class BaseTest:
     def test_tofromfile(self):
         a = array.array(self.typecode, 2*self.example)
         self.assertRaises(TypeError, a.tofile)
-        support.unlink(support.TESTFN)
-        f = open(support.TESTFN, 'wb')
+        support.unlink(filesystem_helper.TESTFN)
+        f = open(filesystem_helper.TESTFN, 'wb')
         try:
             a.tofile(f)
             f.close()
             b = array.array(self.typecode)
-            f = open(support.TESTFN, 'rb')
+            f = open(filesystem_helper.TESTFN, 'rb')
             self.assertRaises(TypeError, b.fromfile)
             b.fromfile(f, len(self.example))
             self.assertEqual(b, array.array(self.typecode, self.example))
@@ -383,27 +384,27 @@ class BaseTest:
         finally:
             if not f.closed:
                 f.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_fromfile_ioerror(self):
         # Issue #5395: Check if fromfile raises a proper OSError
         # instead of EOFError.
         a = array.array(self.typecode)
-        f = open(support.TESTFN, 'wb')
+        f = open(filesystem_helper.TESTFN, 'wb')
         try:
             self.assertRaises(OSError, a.fromfile, f, len(self.example))
         finally:
             f.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_filewrite(self):
         a = array.array(self.typecode, 2*self.example)
-        f = open(support.TESTFN, 'wb')
+        f = open(filesystem_helper.TESTFN, 'wb')
         try:
             f.write(a)
             f.close()
             b = array.array(self.typecode)
-            f = open(support.TESTFN, 'rb')
+            f = open(filesystem_helper.TESTFN, 'rb')
             b.fromfile(f, len(self.example))
             self.assertEqual(b, array.array(self.typecode, self.example))
             self.assertNotEqual(a, b)
@@ -413,7 +414,7 @@ class BaseTest:
         finally:
             if not f.closed:
                 f.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_tofromlist(self):
         a = array.array(self.typecode, 2*self.example)

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -15,6 +15,7 @@ from asyncio import base_events
 from asyncio import constants
 from test.test_asyncio import utils as test_utils
 from test import support
+from test.support import filesystem_helper
 from test.support.script_helper import assert_python_ok
 from test.support import socket_helper
 
@@ -1983,14 +1984,14 @@ class BaseLoopSockSendfileTests(test_utils.TestCase):
     def setUpClass(cls):
         cls.__old_bufsize = constants.SENDFILE_FALLBACK_READBUFFER_SIZE
         constants.SENDFILE_FALLBACK_READBUFFER_SIZE = 1024 * 16
-        with open(support.TESTFN, 'wb') as fp:
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             fp.write(cls.DATA)
         super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
         constants.SENDFILE_FALLBACK_READBUFFER_SIZE = cls.__old_bufsize
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         super().tearDownClass()
 
     def setUp(self):
@@ -1998,7 +1999,7 @@ class BaseLoopSockSendfileTests(test_utils.TestCase):
         # BaseSelectorEventLoop() has no native implementation
         self.loop = BaseSelectorEventLoop()
         self.set_event_loop(self.loop)
-        self.file = open(support.TESTFN, 'rb')
+        self.file = open(filesystem_helper.TESTFN, 'rb')
         self.addCleanup(self.file.close)
         super().setUp()
 
@@ -2095,7 +2096,7 @@ class BaseLoopSockSendfileTests(test_utils.TestCase):
 
     def test_nonbinary_file(self):
         sock = self.make_socket()
-        with open(support.TESTFN, 'r') as f:
+        with open(filesystem_helper.TESTFN, 'r') as f:
             with self.assertRaisesRegex(ValueError, "binary mode"):
                 self.run_loop(self.loop.sock_sendfile(sock, f))
 

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -13,6 +13,7 @@ from asyncio.proactor_events import _ProactorWritePipeTransport
 from asyncio.proactor_events import _ProactorDuplexPipeTransport
 from asyncio.proactor_events import _ProactorDatagramTransport
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 from test.test_asyncio import utils as test_utils
 
@@ -919,20 +920,20 @@ class ProactorEventLoopUnixSockSendfileTests(test_utils.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with open(support.TESTFN, 'wb') as fp:
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             fp.write(cls.DATA)
         super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         super().tearDownClass()
 
     def setUp(self):
         self.loop = asyncio.ProactorEventLoop()
         self.set_event_loop(self.loop)
         self.addCleanup(self.loop.close)
-        self.file = open(support.TESTFN, 'rb')
+        self.file = open(filesystem_helper.TESTFN, 'rb')
         self.addCleanup(self.file.close)
         super().setUp()
 

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -10,6 +10,7 @@ from asyncio import base_events
 from asyncio import constants
 from unittest import mock
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 from test.test_asyncio import utils as test_utils
 
@@ -98,17 +99,17 @@ class SendfileBase:
 
     @classmethod
     def setUpClass(cls):
-        with open(support.TESTFN, 'wb') as fp:
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             fp.write(cls.DATA)
         super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         super().tearDownClass()
 
     def setUp(self):
-        self.file = open(support.TESTFN, 'rb')
+        self.file = open(filesystem_helper.TESTFN, 'rb')
         self.addCleanup(self.file.close)
         self.loop = self.create_event_loop()
         self.set_event_loop(self.loop)

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -15,6 +15,7 @@ import threading
 import unittest
 from unittest import mock
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 
 if sys.platform == 'win32':
@@ -467,19 +468,19 @@ class SelectorEventLoopUnixSockSendfileTests(test_utils.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with open(support.TESTFN, 'wb') as fp:
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             fp.write(cls.DATA)
         super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         super().tearDownClass()
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
         self.set_event_loop(self.loop)
-        self.file = open(support.TESTFN, 'rb')
+        self.file = open(filesystem_helper.TESTFN, 'rb')
         self.addCleanup(self.file.close)
         super().setUp()
 

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -10,6 +10,7 @@ import struct
 import threading
 
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 from test.support import threading_helper
 from io import BytesIO
@@ -369,14 +370,14 @@ class DispatcherWithSendTests(unittest.TestCase):
 class FileWrapperTest(unittest.TestCase):
     def setUp(self):
         self.d = b"It's not dead, it's sleeping!"
-        with open(support.TESTFN, 'wb') as file:
+        with open(filesystem_helper.TESTFN, 'wb') as file:
             file.write(self.d)
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def test_recv(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         w = asyncore.file_wrapper(fd)
         os.close(fd)
 
@@ -390,20 +391,20 @@ class FileWrapperTest(unittest.TestCase):
     def test_send(self):
         d1 = b"Come again?"
         d2 = b"I want to buy some cheese."
-        fd = os.open(support.TESTFN, os.O_WRONLY | os.O_APPEND)
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY | os.O_APPEND)
         w = asyncore.file_wrapper(fd)
         os.close(fd)
 
         w.write(d1)
         w.send(d2)
         w.close()
-        with open(support.TESTFN, 'rb') as file:
+        with open(filesystem_helper.TESTFN, 'rb') as file:
             self.assertEqual(file.read(), self.d + d1 + d2)
 
     @unittest.skipUnless(hasattr(asyncore, 'file_dispatcher'),
                          'asyncore.file_dispatcher required')
     def test_dispatcher(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         data = []
         class FileDispatcher(asyncore.file_dispatcher):
             def handle_read(self):
@@ -415,7 +416,7 @@ class FileWrapperTest(unittest.TestCase):
 
     def test_resource_warning(self):
         # Issue #11453
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         f = asyncore.file_wrapper(fd)
 
         os.close(fd)
@@ -424,7 +425,7 @@ class FileWrapperTest(unittest.TestCase):
             support.gc_collect()
 
     def test_close_twice(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         f = asyncore.file_wrapper(fd)
         os.close(fd)
 
@@ -804,7 +805,7 @@ class TestAPI_UseIPv6Sockets(BaseTestAPI):
 class TestAPI_UseUnixSockets(BaseTestAPI):
     if HAS_UNIX_SOCKETS:
         family = socket.AF_UNIX
-    addr = support.TESTFN
+    addr = filesystem_helper.TESTFN
 
     def tearDown(self):
         support.unlink(self.addr)

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import unittest
 from test import support
+from test.support import filesystem_helper
 
 if not hasattr(sys, "addaudithook") or not hasattr(sys, "audit"):
     raise unittest.SkipTest("test only relevant when sys.audit is available")
@@ -76,7 +77,7 @@ class AuditTest(unittest.TestCase):
         self.do_test("test_monkeypatch")
 
     def test_open(self):
-        self.do_test("test_open", support.TESTFN)
+        self.do_test("test_open", filesystem_helper.TESTFN)
 
     def test_cantrace(self):
         self.do_test("test_cantrace")

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -4,6 +4,7 @@ import base64
 import binascii
 import os
 from array import array
+from test.support import filesystem_helper
 from test.support import script_helper
 
 
@@ -647,8 +648,8 @@ class BaseXYTestCase(unittest.TestCase):
 
 class TestMain(unittest.TestCase):
     def tearDown(self):
-        if os.path.exists(support.TESTFN):
-            os.unlink(support.TESTFN)
+        if os.path.exists(filesystem_helper.TESTFN):
+            os.unlink(filesystem_helper.TESTFN)
 
     def get_output(self, *args):
         return script_helper.assert_python_ok('-m', 'base64', *args).out
@@ -662,9 +663,9 @@ class TestMain(unittest.TestCase):
         ))
 
     def test_encode_file(self):
-        with open(support.TESTFN, 'wb') as fp:
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             fp.write(b'a\xffb\n')
-        output = self.get_output('-e', support.TESTFN)
+        output = self.get_output('-e', filesystem_helper.TESTFN)
         self.assertEqual(output.rstrip(), b'Yf9iCg==')
 
     def test_encode_from_stdin(self):
@@ -674,9 +675,9 @@ class TestMain(unittest.TestCase):
         self.assertIsNone(err)
 
     def test_decode(self):
-        with open(support.TESTFN, 'wb') as fp:
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             fp.write(b'Yf9iCg==')
-        output = self.get_output('-d', support.TESTFN)
+        output = self.get_output('-d', filesystem_helper.TESTFN)
         self.assertEqual(output.rstrip(), b'a\xffb')
 
 if __name__ == '__main__':

--- a/Lib/test/test_binhex.py
+++ b/Lib/test/test_binhex.py
@@ -5,6 +5,7 @@
 """
 import unittest
 from test import support
+from test.support import filesystem_helper
 
 with support.check_warnings(('', DeprecationWarning)):
     import binhex
@@ -13,9 +14,9 @@ with support.check_warnings(('', DeprecationWarning)):
 class BinHexTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.fname1 = support.TESTFN + "1"
-        self.fname2 = support.TESTFN + "2"
-        self.fname3 = support.TESTFN + "very_long_filename__very_long_filename__very_long_filename__very_long_filename__"
+        self.fname1 = filesystem_helper.TESTFN + "1"
+        self.fname2 = filesystem_helper.TESTFN + "2"
+        self.fname3 = filesystem_helper.TESTFN + "very_long_filename__very_long_filename__very_long_filename__very_long_filename__"
 
     def tearDown(self):
         support.unlink(self.fname1)

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -2,6 +2,7 @@
 
 import unittest
 from test import support
+from test.support import filesystem_helper 
 
 import os
 
@@ -20,12 +21,12 @@ class BoolTest(unittest.TestCase):
 
     def test_print(self):
         try:
-            with open(support.TESTFN, "w") as fo:
+            with open(filesystem_helper.TESTFN, "w") as fo:
                 print(False, True, file=fo)
-            with open(support.TESTFN, "r") as fi:
+            with open(filesystem_helper.TESTFN, "r") as fi:
                 self.assertEqual(fi.read(), 'False True\n')
         finally:
-            os.remove(support.TESTFN)
+            os.remove(filesystem_helper.TESTFN)
 
     def test_repr(self):
         self.assertEqual(repr(False), 'False')
@@ -243,11 +244,11 @@ class BoolTest(unittest.TestCase):
 
     def test_fileclosed(self):
         try:
-            with open(support.TESTFN, "w") as f:
+            with open(filesystem_helper.TESTFN, "w") as f:
                 self.assertIs(f.closed, False)
             self.assertIs(f.closed, True)
         finally:
-            os.remove(support.TESTFN)
+            os.remove(filesystem_helper.TESTFN)
 
     def test_types(self):
         # types are always true.

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -2,7 +2,7 @@
 
 import unittest
 from test import support
-from test.support import filesystem_helper 
+from test.support import filesystem_helper
 
 import os
 

--- a/Lib/test/test_bufio.py
+++ b/Lib/test/test_bufio.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import filesystem_helper
 
 import io # C implementation.
 import _pyio as pyio # Python implementation.
@@ -17,18 +18,18 @@ class BufferSizeTest:
         # .readline()s deliver what we wrote.
 
         # Ensure we can open TESTFN for writing.
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
         # Since C doesn't guarantee we can write/read arbitrary bytes in text
         # files, use binary mode.
-        f = self.open(support.TESTFN, "wb")
+        f = self.open(filesystem_helper.TESTFN, "wb")
         try:
             # write once with \n and once without
             f.write(s)
             f.write(b"\n")
             f.write(s)
             f.close()
-            f = open(support.TESTFN, "rb")
+            f = open(filesystem_helper.TESTFN, "rb")
             line = f.readline()
             self.assertEqual(line, s + b"\n")
             line = f.readline()
@@ -37,7 +38,7 @@ class BufferSizeTest:
             self.assertFalse(line) # Must be at EOF
             f.close()
         finally:
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def drive_one(self, pattern):
         for length in lengths:

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -27,8 +27,9 @@ from types import AsyncGeneratorType, FunctionType
 from operator import neg
 from test import support
 from test.support import (
-    EnvironmentVarGuard, TESTFN, check_warnings, swap_attr, unlink,
+    EnvironmentVarGuard, check_warnings, swap_attr, unlink,
     maybe_get_event_loop_policy)
+from test.support.filesystem_helper import TESTFN
 from test.support.script_helper import assert_python_ok
 from unittest.mock import MagicMock, patch
 try:

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -9,6 +9,7 @@ import tempfile
 import textwrap
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.support.script_helper import (
     spawn_python, kill_python, assert_python_ok, assert_python_failure,
     interpreter_requires_environment
@@ -463,7 +464,7 @@ class CmdLineTest(unittest.TestCase):
         # Issue #15001: PyRun_SimpleFileExFlags() did crash because it kept a
         # borrowed reference to the dict of __main__ module and later modify
         # the dict whereas the module was destroyed
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
         with open(filename, "w") as script:
             print("import sys", file=script)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -8,6 +8,7 @@ import encodings
 from unittest import mock
 
 from test import support
+from test.support import filesystem_helper
 
 try:
     import _testcapi
@@ -709,11 +710,12 @@ class UTF16Test(ReadTest, unittest.TestCase):
         s1 = 'Hello\r\nworld\r\n'
 
         s = s1.encode(self.encoding)
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, 'wb') as fp:
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             fp.write(s)
         with support.check_warnings(('', DeprecationWarning)):
-            reader = codecs.open(support.TESTFN, 'U', encoding=self.encoding)
+            reader = codecs.open(filesystem_helper.TESTFN,
+                                 'U', encoding=self.encoding)
         with reader:
             self.assertEqual(reader.read(), s1)
 
@@ -1697,10 +1699,11 @@ class CodecsModuleTest(unittest.TestCase):
             getattr(codecs, api)
 
     def test_open(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
         for mode in ('w', 'r', 'r+', 'w+', 'a', 'a+'):
             with self.subTest(mode), \
-                    codecs.open(support.TESTFN, mode, 'ascii') as file:
+                    codecs.open(filesystem_helper.TESTFN,
+                                mode, 'ascii') as file:
                 self.assertIsInstance(file, codecs.StreamReaderWriter)
 
     def test_undefined(self):
@@ -1718,7 +1721,7 @@ class CodecsModuleTest(unittest.TestCase):
         mock_open = mock.mock_open()
         with mock.patch('builtins.open', mock_open) as file:
             with self.assertRaises(LookupError):
-                codecs.open(support.TESTFN, 'wt', 'invalid-encoding')
+                codecs.open(filesystem_helper.TESTFN, 'wt', 'invalid-encoding')
 
             file().close.assert_called()
 
@@ -2516,10 +2519,11 @@ class BomTest(unittest.TestCase):
                  "utf-32",
                  "utf-32-le",
                  "utf-32-be")
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
         for encoding in tests:
             # Check if the BOM is written only once
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(filesystem_helper.TESTFN,
+                             'w+', encoding=encoding) as f:
                 f.write(data)
                 f.write(data)
                 f.seek(0)
@@ -2528,7 +2532,8 @@ class BomTest(unittest.TestCase):
                 self.assertEqual(f.read(), data * 2)
 
             # Check that the BOM is written after a seek(0)
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(filesystem_helper.TESTFN,
+                             'w+', encoding=encoding) as f:
                 f.write(data[0])
                 self.assertNotEqual(f.tell(), 0)
                 f.seek(0)
@@ -2537,7 +2542,8 @@ class BomTest(unittest.TestCase):
                 self.assertEqual(f.read(), data)
 
             # (StreamWriter) Check that the BOM is written after a seek(0)
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(filesystem_helper.TESTFN,
+                             'w+', encoding=encoding) as f:
                 f.writer.write(data[0])
                 self.assertNotEqual(f.writer.tell(), 0)
                 f.writer.seek(0)
@@ -2547,7 +2553,8 @@ class BomTest(unittest.TestCase):
 
             # Check that the BOM is not written after a seek() at a position
             # different than the start
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(filesystem_helper.TESTFN,
+                             'w+', encoding=encoding) as f:
                 f.write(data)
                 f.seek(f.tell())
                 f.write(data)
@@ -2556,7 +2563,8 @@ class BomTest(unittest.TestCase):
 
             # (StreamWriter) Check that the BOM is not written after a seek()
             # at a position different than the start
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(filesystem_helper.TESTFN,
+                             'w+', encoding=encoding) as f:
                 f.writer.write(data)
                 f.writer.seek(f.writer.tell())
                 f.writer.write(data)

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
                                INVALID_UNDERSCORE_LITERALS)
 
@@ -506,15 +507,15 @@ class ComplexTest(unittest.TestCase):
 
         fo = None
         try:
-            fo = open(support.TESTFN, "w")
+            fo = open(filesystem_helper.TESTFN, "w")
             print(a, b, file=fo)
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(filesystem_helper.TESTFN, "r")
             self.assertEqual(fo.read(), ("%s %s\n" % (a, b)))
         finally:
             if (fo is not None) and (not fo.closed):
                 fo.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_getnewargs(self):
         self.assertEqual((1+2j).__getnewargs__(), (1.0, 2.0))

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -8,6 +8,7 @@ import unittest
 import warnings
 
 from test import support
+from test.support import filesystem_helper
 
 
 class SortedDict(collections.UserDict):
@@ -1063,17 +1064,17 @@ class MultilineValuesTestCase(BasicTestCase, unittest.TestCase):
             cf.add_section(s)
             for j in range(10):
                 cf.set(s, 'lovely_spam{}'.format(j), self.wonderful_spam)
-        with open(support.TESTFN, 'w') as f:
+        with open(filesystem_helper.TESTFN, 'w') as f:
             cf.write(f)
 
     def tearDown(self):
-        os.unlink(support.TESTFN)
+        os.unlink(filesystem_helper.TESTFN)
 
     def test_dominating_multiline_values(self):
         # We're reading from file because this is where the code changed
         # during performance updates in Python 3.2
         cf_from_file = self.newconfig()
-        with open(support.TESTFN) as f:
+        with open(filesystem_helper.TESTFN) as f:
             cf_from_file.read_file(f)
         self.assertEqual(cf_from_file.get('section8', 'lovely_spam4'),
                          self.wonderful_spam.replace('\t\n', '\n'))

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -3,6 +3,7 @@
 import unittest
 import glob
 import test.support
+from test.support import filesystem_helper
 
 # Skip tests if dbm module doesn't exist.
 dbm = test.support.import_module('dbm')
@@ -12,7 +13,7 @@ try:
 except ImportError:
     ndbm = None
 
-_fname = test.support.TESTFN
+_fname = filesystem_helper.TESTFN
 
 #
 # Iterates over every database module supported by dbm currently available,
@@ -177,7 +178,7 @@ class WhichDBTestCase(unittest.TestCase):
 
     def setUp(self):
         delete_files()
-        self.filename = test.support.TESTFN
+        self.filename = filesystem_helper.TESTFN
         self.d = dbm.open(self.filename, 'c')
         self.d.close()
         self.dbm = test.support.import_fresh_module('dbm')

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -10,9 +10,10 @@ import stat
 import unittest
 import dbm.dumb as dumbdbm
 from test import support
+from test.support import filesystem_helper
 from functools import partial
 
-_fname = support.TESTFN
+_fname = filesystem_helper.TESTFN
 
 def _delete_files():
     for ext in [".dir", ".dat", ".bak"]:

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -2,7 +2,8 @@ from test import support
 gdbm = support.import_module("dbm.gnu") #skip if not supported
 import unittest
 import os
-from test.support import TESTFN, TESTFN_NONASCII, unlink
+from test.support import TESTFN_NONASCII, unlink
+from test.support.filesystem_helper import TESTFN
 
 
 filename = TESTFN

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -102,10 +102,10 @@ class DbmTestCase(unittest.TestCase):
             with self.assertRaises(error):
                 db[b'not exist key'] = b'not exist value'
 
-    @unittest.skipUnless(filesystem_helper.TESTFN_NONASCII,
+    @unittest.skipUnless(support.TESTFN_NONASCII,
                          'requires OS support of non-ASCII encodings')
     def test_nonascii_filename(self):
-        filename = filesystem_helper.TESTFN_NONASCII
+        filename = support.TESTFN_NONASCII
         for suffix in ['', '.pag', '.dir', '.db']:
             self.addCleanup(support.unlink, filename + suffix)
         with dbm.ndbm.open(filename, 'c') as db:

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -1,4 +1,5 @@
 from test import support
+from test.support import filesystem_helper
 support.import_module("dbm.ndbm") #skip if not supported
 import os
 import unittest
@@ -8,7 +9,7 @@ from dbm.ndbm import error
 class DbmTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.filename = support.TESTFN
+        self.filename = filesystem_helper.TESTFN
         self.d = dbm.ndbm.open(self.filename, 'c')
         self.d.close()
 
@@ -101,10 +102,10 @@ class DbmTestCase(unittest.TestCase):
             with self.assertRaises(error):
                 db[b'not exist key'] = b'not exist value'
 
-    @unittest.skipUnless(support.TESTFN_NONASCII,
+    @unittest.skipUnless(filesystem_helper.TESTFN_NONASCII,
                          'requires OS support of non-ASCII encodings')
     def test_nonascii_filename(self):
-        filename = support.TESTFN_NONASCII
+        filename = filesystem_helper.TESTFN_NONASCII
         for suffix in ['', '.pag', '.dir', '.db']:
             self.addCleanup(support.unlink, filename + suffix)
         with dbm.ndbm.open(filename, 'c') as db:

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -1,6 +1,7 @@
 from collections import deque
 import unittest
 from test import support, seq_tests
+from test.support import filesystem_helper
 import gc
 import weakref
 import copy
@@ -66,28 +67,28 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(list(d), [7, 8, 9])
         d = deque(range(200), maxlen=10)
         d.append(d)
-        support.unlink(support.TESTFN)
-        fo = open(support.TESTFN, "w")
+        support.unlink(filesystem_helper.TESTFN)
+        fo = open(filesystem_helper.TESTFN, "w")
         try:
             fo.write(str(d))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(filesystem_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(d))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
         d = deque(range(10), maxlen=None)
         self.assertEqual(repr(d), 'deque([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
-        fo = open(support.TESTFN, "w")
+        fo = open(filesystem_helper.TESTFN, "w")
         try:
             fo.write(str(d))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(filesystem_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(d))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_maxlen_zero(self):
         it = iter(range(100))
@@ -551,15 +552,15 @@ class TestBasic(unittest.TestCase):
         d = deque(range(200))
         d.append(d)
         try:
-            support.unlink(support.TESTFN)
-            fo = open(support.TESTFN, "w")
+            support.unlink(filesystem_helper.TESTFN)
+            fo = open(filesystem_helper.TESTFN, "w")
             print(d, file=fo, end='')
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(filesystem_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(d))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_init(self):
         self.assertRaises(TypeError, deque, 'abc', 2, 3);

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -12,6 +12,7 @@ import weakref
 
 from copy import deepcopy
 from test import support
+from test.support import filesystem_helper
 
 try:
     import _testcapi
@@ -2975,12 +2976,12 @@ order (MRO) for bases """
         ##             self.ateof = 1
         ##        return s
         ##
-        ## f = file(name=support.TESTFN, mode='w')
+        ## f = file(name=filesystem_helper.TESTFN, mode='w')
         ## lines = ['a\n', 'b\n', 'c\n']
         ## try:
         ##     f.writelines(lines)
         ##     f.close()
-        ##     f = CountedInput(support.TESTFN)
+        ##     f = CountedInput(filesystem_helper.TESTFN)
         ##     for (i, expected) in zip(range(1, 5) + [4], lines + 2 * [""]):
         ##         got = f.readline()
         ##         self.assertEqual(expected, got)
@@ -2992,7 +2993,7 @@ order (MRO) for bases """
         ##         f.close()
         ##     except:
         ##         pass
-        ##     support.unlink(support.TESTFN)
+        ##     support.unlink(filesystem_helper.TESTFN)
 
     def test_keywords(self):
         # Testing keyword args to basic type constructors ...

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1,5 +1,6 @@
 # Run the tests in Programs/_testembed.c (tests for the CPython embedding APIs)
 from test import support
+from test.support import filesystem_helper
 import unittest
 
 from collections import namedtuple
@@ -1317,7 +1318,7 @@ class AuditingTests(EmbeddingTestsMixin, unittest.TestCase):
                                       returncode=1)
 
     def test_audit_run_interactivehook(self):
-        startup = os.path.join(self.oldcwd, support.TESTFN) + ".py"
+        startup = os.path.join(self.oldcwd, filesystem_helper.TESTFN) + ".py"
         with open(startup, "w", encoding="utf-8") as f:
             print("import sys", file=f)
             print("sys.__interactivehook__ = lambda: None", file=f)
@@ -1330,7 +1331,7 @@ class AuditingTests(EmbeddingTestsMixin, unittest.TestCase):
             os.unlink(startup)
 
     def test_audit_run_startup(self):
-        startup = os.path.join(self.oldcwd, support.TESTFN) + ".py"
+        startup = os.path.join(self.oldcwd, filesystem_helper.TESTFN) + ".py"
         with open(startup, "w", encoding="utf-8") as f:
             print("pass", file=f)
         try:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -8,10 +8,11 @@ import pickle
 import weakref
 import errno
 
-from test.support import (TESTFN, captured_stderr, check_impl_detail,
+from test.support import (captured_stderr, check_impl_detail,
                           check_warnings, cpython_only, gc_collect,
                           no_tracing, unlink, import_module, script_helper,
                           SuppressCrashReport)
+from test.support.filesystem_helper import TESTFN
 from test import support
 
 

--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -6,8 +6,9 @@ import struct
 import sys
 import unittest
 from multiprocessing import Process
-from test.support import (verbose, TESTFN, unlink, run_unittest, import_module,
+from test.support import (verbose, unlink, run_unittest, import_module,
                           cpython_only)
+from test.support.filesystem_helper import TESTFN
 
 # Skip test if no fcntl module.
 fcntl = import_module('fcntl')

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -7,9 +7,10 @@ from weakref import proxy
 import io
 import _pyio as pyio
 
-from test.support import TESTFN
+from test.support.filesystem_helper import TESTFN
 from test import support
 from collections import UserList
+
 
 class AutoFileTests:
     # file tests for which a test file is automatically set up

--- a/Lib/test/test_filecmp.py
+++ b/Lib/test/test_filecmp.py
@@ -5,13 +5,14 @@ import tempfile
 import unittest
 
 from test import support
+from test.support import filesystem_helper
 
 
 class FileCompareTestCase(unittest.TestCase):
     def setUp(self):
-        self.name = support.TESTFN
-        self.name_same = support.TESTFN + '-same'
-        self.name_diff = support.TESTFN + '-diff'
+        self.name = filesystem_helper.TESTFN
+        self.name_same = filesystem_helper.TESTFN + '-same'
+        self.name_diff = filesystem_helper.TESTFN + '-diff'
         data = 'Contents of file go here.\n'
         for name in [self.name, self.name_same, self.name_diff]:
             with open(name, 'w') as output:

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -24,8 +24,9 @@ from io import BytesIO, StringIO
 from fileinput import FileInput, hook_encoded
 from pathlib import Path
 
-from test.support import verbose, TESTFN, check_warnings
+from test.support import verbose, check_warnings
 from test.support import unlink as safe_unlink
+from test.support.filesystem_helper import TESTFN
 from test import support
 from unittest import mock
 

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -9,8 +9,9 @@ from array import array
 from weakref import proxy
 from functools import wraps
 
-from test.support import (TESTFN, TESTFN_UNICODE, check_warnings, run_unittest,
+from test.support import (TESTFN_UNICODE, check_warnings, run_unittest,
                           make_bad_fd, cpython_only, swap_attr)
+from test.support.filesystem_helper import TESTFN
 from collections import UserList
 
 import _io  # C implementation of io

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1,8 +1,9 @@
 import unittest
 import unittest.mock
 from test.support import (verbose, refcount_test, run_unittest,
-                          cpython_only, temp_dir, TESTFN, unlink,
+                          cpython_only, temp_dir, unlink,
                           import_module)
+from test.support.filesystem_helper import TESTFN
 from test.support.script_helper import assert_python_ok, make_script
 from test.support import threading_helper
 

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -475,13 +475,13 @@ class CommonTest(GenericTest):
                     self.assertIsInstance(abspath(path), str)
 
     def test_nonascii_abspath(self):
-        if (filesystem_helper.TESTFN_UNDECODABLE
+        if (support.TESTFN_UNDECODABLE
         # Mac OS X denies the creation of a directory with an invalid
         # UTF-8 name. Windows allows creating a directory with an
         # arbitrary bytes name, but fails to enter this directory
         # (when the bytes name is used).
         and sys.platform not in ('win32', 'darwin')):
-            name = filesystem_helper.TESTFN_UNDECODABLE
+            name = support.TESTFN_UNDECODABLE
         elif filesystem_helper.TESTFN_NONASCII:
             name = filesystem_helper.TESTFN_NONASCII
         else:

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -482,10 +482,10 @@ class CommonTest(GenericTest):
         # (when the bytes name is used).
         and sys.platform not in ('win32', 'darwin')):
             name = support.TESTFN_UNDECODABLE
-        elif filesystem_helper.TESTFN_NONASCII:
-            name = filesystem_helper.TESTFN_NONASCII
+        elif support.TESTFN_NONASCII:
+            name = support.TESTFN_NONASCII
         else:
-            self.skipTest("need filesystem_helper.TESTFN_NONASCII")
+            self.skipTest("need support.TESTFN_NONASCII")
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -8,6 +8,7 @@ import sys
 import unittest
 import warnings
 from test import support
+from test.support import filesystem_helper
 from test.support.script_helper import assert_python_ok
 from test.support import FakePath
 
@@ -97,7 +98,7 @@ class GenericTest:
                     self.assertNotEqual(s1[n:n+1], s2[n:n+1])
 
     def test_getsize(self):
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
 
         create_file(filename, b'Hello')
@@ -108,7 +109,7 @@ class GenericTest:
         self.assertEqual(self.pathmodule.getsize(filename), 12)
 
     def test_filetime(self):
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
 
         create_file(filename, b'foo')
@@ -126,7 +127,7 @@ class GenericTest:
         )
 
     def test_exists(self):
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         bfilename = os.fsencode(filename)
         self.addCleanup(support.unlink, filename)
 
@@ -163,7 +164,7 @@ class GenericTest:
         self.assertFalse(self.pathmodule.exists(r))
 
     def test_isdir(self):
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         bfilename = os.fsencode(filename)
         self.assertIs(self.pathmodule.isdir(filename), False)
         self.assertIs(self.pathmodule.isdir(bfilename), False)
@@ -188,7 +189,7 @@ class GenericTest:
             support.rmdir(filename)
 
     def test_isfile(self):
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         bfilename = os.fsencode(filename)
         self.assertIs(self.pathmodule.isfile(filename), False)
         self.assertIs(self.pathmodule.isfile(bfilename), False)
@@ -213,8 +214,8 @@ class GenericTest:
             support.rmdir(filename)
 
     def test_samefile(self):
-        file1 = support.TESTFN
-        file2 = support.TESTFN + "2"
+        file1 = filesystem_helper.TESTFN
+        file2 = filesystem_helper.TESTFN + "2"
         self.addCleanup(support.unlink, file1)
         self.addCleanup(support.unlink, file2)
 
@@ -227,8 +228,8 @@ class GenericTest:
         self.assertRaises(TypeError, self.pathmodule.samefile)
 
     def _test_samefile_on_link_func(self, func):
-        test_fn1 = support.TESTFN
-        test_fn2 = support.TESTFN + "2"
+        test_fn1 = filesystem_helper.TESTFN
+        test_fn2 = filesystem_helper.TESTFN + "2"
         self.addCleanup(support.unlink, test_fn1)
         self.addCleanup(support.unlink, test_fn2)
 
@@ -252,8 +253,8 @@ class GenericTest:
             self.skipTest('os.link(): %s' % e)
 
     def test_samestat(self):
-        test_fn1 = support.TESTFN
-        test_fn2 = support.TESTFN + "2"
+        test_fn1 = filesystem_helper.TESTFN
+        test_fn2 = filesystem_helper.TESTFN + "2"
         self.addCleanup(support.unlink, test_fn1)
         self.addCleanup(support.unlink, test_fn2)
 
@@ -268,8 +269,8 @@ class GenericTest:
         self.assertRaises(TypeError, self.pathmodule.samestat)
 
     def _test_samestat_on_link_func(self, func):
-        test_fn1 = support.TESTFN + "1"
-        test_fn2 = support.TESTFN + "2"
+        test_fn1 = filesystem_helper.TESTFN + "1"
+        test_fn2 = filesystem_helper.TESTFN + "2"
         self.addCleanup(support.unlink, test_fn1)
         self.addCleanup(support.unlink, test_fn2)
 
@@ -294,7 +295,7 @@ class GenericTest:
             self.skipTest('os.link(): %s' % e)
 
     def test_sameopenfile(self):
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
         create_file(filename)
 
@@ -474,17 +475,17 @@ class CommonTest(GenericTest):
                     self.assertIsInstance(abspath(path), str)
 
     def test_nonascii_abspath(self):
-        if (support.TESTFN_UNDECODABLE
+        if (filesystem_helper.TESTFN_UNDECODABLE
         # Mac OS X denies the creation of a directory with an invalid
         # UTF-8 name. Windows allows creating a directory with an
         # arbitrary bytes name, but fails to enter this directory
         # (when the bytes name is used).
         and sys.platform not in ('win32', 'darwin')):
-            name = support.TESTFN_UNDECODABLE
-        elif support.TESTFN_NONASCII:
-            name = support.TESTFN_NONASCII
+            name = filesystem_helper.TESTFN_UNDECODABLE
+        elif filesystem_helper.TESTFN_NONASCII:
+            name = filesystem_helper.TESTFN_NONASCII
         else:
-            self.skipTest("need support.TESTFN_NONASCII")
+            self.skipTest("need filesystem_helper.TESTFN_NONASCII")
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
@@ -534,8 +535,8 @@ class CommonTest(GenericTest):
 class PathLikeTests(unittest.TestCase):
 
     def setUp(self):
-        self.file_name = support.TESTFN.lower()
-        self.file_path = FakePath(support.TESTFN)
+        self.file_name = filesystem_helper.TESTFN.lower()
+        self.file_path = FakePath(filesystem_helper.TESTFN)
         self.addCleanup(support.unlink, self.file_name)
         create_file(self.file_name, b"test_genericpath.PathLikeTests")
 

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -6,6 +6,7 @@ import unittest
 
 from test.support import (TESTFN, skip_unless_symlink,
                           can_symlink, create_empty_file, change_cwd)
+from test.support.filesystem_helper import TESTFN
 
 
 class GlobTests(unittest.TestCase):

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -12,6 +12,7 @@ import unittest
 from subprocess import PIPE, Popen
 from test import support
 from test.support import _4G, bigmemtest
+from test.support import filesystem_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
 gzip = support.import_module('gzip')
@@ -29,7 +30,7 @@ data2 = b"""/* zlibmodule.c -- gzip-compatible data compression */
 """
 
 
-TEMPDIR = os.path.abspath(support.TESTFN) + '-gzdir'
+TEMPDIR = os.path.abspath(filesystem_helper.TESTFN) + '-gzdir'
 
 
 class UnseekableIO(io.BytesIO):
@@ -44,7 +45,7 @@ class UnseekableIO(io.BytesIO):
 
 
 class BaseTest(unittest.TestCase):
-    filename = support.TESTFN
+    filename = filesystem_helper.TESTFN
 
     def setUp(self):
         support.unlink(self.filename)

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -3,6 +3,7 @@
 import os
 import re
 import test.support
+from test.support import filesystem_helper
 import time
 import unittest
 import urllib.request
@@ -328,12 +329,12 @@ def _interact(cookiejar, url, set_cookie_hdrs, hdr_name):
 
 class FileCookieJarTests(unittest.TestCase):
     def test_constructor_with_str(self):
-        filename = test.support.TESTFN
+        filename = filesystem_helper.TESTFN
         c = LWPCookieJar(filename)
         self.assertEqual(c.filename, filename)
 
     def test_constructor_with_path_like(self):
-        filename = pathlib.Path(test.support.TESTFN)
+        filename = pathlib.Path(filesystem_helper.TESTFN)
         c = LWPCookieJar(filename)
         self.assertEqual(c.filename, os.fspath(filename))
 
@@ -353,7 +354,7 @@ class FileCookieJarTests(unittest.TestCase):
 
     def test_lwp_valueless_cookie(self):
         # cookies with no value should be saved and loaded consistently
-        filename = test.support.TESTFN
+        filename = filesystem_helper.TESTFN
         c = LWPCookieJar()
         interact_netscape(c, "http://www.acme.com/", 'boo')
         self.assertEqual(c._cookies["www.acme.com"]["/"]["boo"].value, None)
@@ -368,7 +369,7 @@ class FileCookieJarTests(unittest.TestCase):
 
     def test_bad_magic(self):
         # OSErrors (eg. file doesn't exist) are allowed to propagate
-        filename = test.support.TESTFN
+        filename = filesystem_helper.TESTFN
         for cookiejar_class in LWPCookieJar, MozillaCookieJar:
             c = cookiejar_class()
             try:
@@ -475,7 +476,7 @@ class CookieTests(unittest.TestCase):
     def test_missing_value(self):
         # missing = sign in Cookie: header is regarded by Mozilla as a missing
         # name, and by http.cookiejar as a missing value
-        filename = test.support.TESTFN
+        filename = filesystem_helper.TESTFN
         c = MozillaCookieJar(filename)
         interact_netscape(c, "http://www.acme.com/", 'eggs')
         interact_netscape(c, "http://www.acme.com/", '"spam"; path=/foo/')
@@ -1713,7 +1714,7 @@ class LWPCookieTests(unittest.TestCase):
         self.assertEqual(len(c), 6)
 
         # save and restore
-        filename = test.support.TESTFN
+        filename = filesystem_helper.TESTFN
 
         try:
             c.save(filename, ignore_discard=True)
@@ -1753,7 +1754,7 @@ class LWPCookieTests(unittest.TestCase):
         # Save / load Mozilla/Netscape cookie file format.
         year_plus_one = time.localtime()[0] + 1
 
-        filename = test.support.TESTFN
+        filename = filesystem_helper.TESTFN
 
         c = MozillaCookieJar(filename,
                              policy=DefaultCookiePolicy(rfc2965=True))

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -13,6 +13,7 @@ import unittest
 TestCase = unittest.TestCase
 
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 
 here = os.path.dirname(__file__)
@@ -1881,10 +1882,10 @@ class RequestBodyTest(TestCase):
         self.assertEqual(b'body\xc1', f.read())
 
     def test_text_file_body(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as f:
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, "w") as f:
             f.write("body")
-        with open(support.TESTFN) as f:
+        with open(filesystem_helper.TESTFN) as f:
             self.conn.request("PUT", "/url", f)
             message, f = self.get_headers_and_fp()
             self.assertEqual("text/plain", message.get_content_type())
@@ -1896,10 +1897,10 @@ class RequestBodyTest(TestCase):
             self.assertEqual(b'4\r\nbody\r\n0\r\n\r\n', f.read())
 
     def test_binary_file_body(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "wb") as f:
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, "wb") as f:
             f.write(b"body\xc1")
-        with open(support.TESTFN, "rb") as f:
+        with open(filesystem_helper.TESTFN, "rb") as f:
             self.conn.request("PUT", "/url", f)
             message, f = self.get_headers_and_fp()
             self.assertEqual("text/plain", message.get_content_type())

--- a/Lib/test/test_imghdr.py
+++ b/Lib/test/test_imghdr.py
@@ -4,7 +4,8 @@ import os
 import pathlib
 import unittest
 import warnings
-from test.support import findfile, TESTFN, unlink
+from test.support import findfile, unlink
+from test.support.filesystem_helper import TESTFN
 
 TEST_FILES = (
     ('python.png', 'png'),

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -5,6 +5,7 @@ import os.path
 import py_compile
 import sys
 from test import support
+from test.support import filesystem_helper
 from test.support import script_helper
 import unittest
 import warnings
@@ -300,10 +301,10 @@ class ImportTests(unittest.TestCase):
         "test meaningful only when writing bytecode")
     def test_bug7732(self):
         with support.temp_cwd():
-            source = support.TESTFN + '.py'
+            source = filesystem_helper.TESTFN + '.py'
             os.mkdir(source)
             self.assertRaisesRegex(ImportError, '^No module',
-                imp.find_module, support.TESTFN, ["."])
+                imp.find_module, filesystem_helper.TESTFN, ["."])
 
     def test_multiple_calls_to_get_data(self):
         # Issue #18755: make sure multiple calls to get_data() can succeed.

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -20,12 +20,13 @@ from unittest import mock
 
 import test.support
 from test.support import (
-    TESTFN, forget, is_jython,
+    forget, is_jython,
     make_legacy_pyc, rmtree, swap_attr, swap_item, temp_umask,
     unlink, unload, cpython_only, TESTFN_UNENCODABLE,
     temp_dir, DirsOnSysPath)
 from test.support import script_helper
 from test.support import threading_helper
+from test.support.filesystem_helper import TESTFN
 from test.test_importlib.util import uncache
 from types import ModuleType
 

--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -15,8 +15,9 @@ import threading
 import unittest
 from unittest import mock
 from test.support import (
-    verbose, run_unittest, TESTFN,
+    verbose, run_unittest,
     forget, unlink, rmtree)
+from test.support.filesystem_helper import TESTFN
 from test.support import threading_helper
 
 def task(N, done, done_tasks, errors):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -24,8 +24,9 @@ try:
 except ImportError:
     ThreadPoolExecutor = None
 
-from test.support import run_unittest, TESTFN, DirsOnSysPath, cpython_only
+from test.support import run_unittest, DirsOnSysPath, cpython_only
 from test.support import MISSING_C_DOCSTRINGS, ALWAYS_EQ
+from test.support.filesystem_helper import TESTFN
 from test.support.script_helper import assert_python_ok, assert_python_failure
 from test import inspect_fodder as mod
 from test import inspect_fodder2 as mod2

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -747,7 +747,7 @@ class IOTest(unittest.TestCase):
 
     def test_no_closefd_with_filename(self):
         # can't use closefd in combination with a file name
-        self.assertRaises(ValueError, self.open, 
+        self.assertRaises(ValueError, self.open,
                           filesystem_helper.TESTFN, "r", closefd=False)
 
     def test_closefd_attr(self):
@@ -1780,7 +1780,7 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
     def test_truncate(self):
         # Truncate implicitly flushes the buffer.
         self.addCleanup(support.unlink, filesystem_helper.TESTFN)
-        with self.open(filesystem_helper.TESTFN, 
+        with self.open(filesystem_helper.TESTFN,
                        self.write_mode, buffering=0) as raw:
             bufio = self.tp(raw, 8)
             bufio.write(b"abcdef")
@@ -1828,7 +1828,7 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
             # writing the buffer to the raw streams. This is in addition
             # to concurrency issues due to switching threads in the middle
             # of Python code.
-            with self.open(filesystem_helper.TESTFN, 
+            with self.open(filesystem_helper.TESTFN,
                            self.write_mode, buffering=0) as raw:
                 bufio = self.tp(raw, 8)
                 errors = []
@@ -4045,7 +4045,7 @@ class MiscIOTest(unittest.TestCase):
         self.assertIn(r, str(cm.warning.args[0]))
 
     def test_warn_on_dealloc(self):
-        self._check_warn_on_dealloc(filesystem_helper.TESTFN, 
+        self._check_warn_on_dealloc(filesystem_helper.TESTFN,
                                     "wb", buffering=0)
         self._check_warn_on_dealloc(filesystem_helper.TESTFN, "wb")
         self._check_warn_on_dealloc(filesystem_helper.TESTFN, "w")

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -40,6 +40,7 @@ from itertools import cycle, count
 from test import support
 from test.support.script_helper import (
     assert_python_ok, assert_python_failure, run_python_until_end)
+from test.support import filesystem_helper
 from test.support import threading_helper
 from test.support import FakePath
 
@@ -317,10 +318,10 @@ class PyMockNonBlockWriterIO(MockNonBlockWriterIO, pyio.RawIOBase):
 class IOTest(unittest.TestCase):
 
     def setUp(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def write_ops(self, f):
         self.assertEqual(f.write(b"blah."), 5)
@@ -405,19 +406,19 @@ class IOTest(unittest.TestCase):
         # Try writing on a file opened in read mode and vice-versa.
         exc = self.UnsupportedOperation
         for mode in ("w", "wb"):
-            with self.open(support.TESTFN, mode) as fp:
+            with self.open(filesystem_helper.TESTFN, mode) as fp:
                 self.assertRaises(exc, fp.read)
                 self.assertRaises(exc, fp.readline)
-        with self.open(support.TESTFN, "wb", buffering=0) as fp:
+        with self.open(filesystem_helper.TESTFN, "wb", buffering=0) as fp:
             self.assertRaises(exc, fp.read)
             self.assertRaises(exc, fp.readline)
-        with self.open(support.TESTFN, "rb", buffering=0) as fp:
+        with self.open(filesystem_helper.TESTFN, "rb", buffering=0) as fp:
             self.assertRaises(exc, fp.write, b"blah")
             self.assertRaises(exc, fp.writelines, [b"blah\n"])
-        with self.open(support.TESTFN, "rb") as fp:
+        with self.open(filesystem_helper.TESTFN, "rb") as fp:
             self.assertRaises(exc, fp.write, b"blah")
             self.assertRaises(exc, fp.writelines, [b"blah\n"])
-        with self.open(support.TESTFN, "r") as fp:
+        with self.open(filesystem_helper.TESTFN, "r") as fp:
             self.assertRaises(exc, fp.write, "blah")
             self.assertRaises(exc, fp.writelines, ["blah\n"])
             # Non-zero seeking from current or end pos
@@ -538,33 +539,33 @@ class IOTest(unittest.TestCase):
             self.assertRaises(ValueError, self.open, bytes_fn, 'w')
 
     def test_raw_file_io(self):
-        with self.open(support.TESTFN, "wb", buffering=0) as f:
+        with self.open(filesystem_helper.TESTFN, "wb", buffering=0) as f:
             self.assertEqual(f.readable(), False)
             self.assertEqual(f.writable(), True)
             self.assertEqual(f.seekable(), True)
             self.write_ops(f)
-        with self.open(support.TESTFN, "rb", buffering=0) as f:
+        with self.open(filesystem_helper.TESTFN, "rb", buffering=0) as f:
             self.assertEqual(f.readable(), True)
             self.assertEqual(f.writable(), False)
             self.assertEqual(f.seekable(), True)
             self.read_ops(f)
 
     def test_buffered_file_io(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             self.assertEqual(f.readable(), False)
             self.assertEqual(f.writable(), True)
             self.assertEqual(f.seekable(), True)
             self.write_ops(f)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.readable(), True)
             self.assertEqual(f.writable(), False)
             self.assertEqual(f.seekable(), True)
             self.read_ops(f, True)
 
     def test_readline(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             f.write(b"abc\ndef\nxyzzy\nfoo\x00bar\nanother line")
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.readline(), b"abc\n")
             self.assertEqual(f.readline(10), b"def\n")
             self.assertEqual(f.readline(2), b"xy")
@@ -572,7 +573,7 @@ class IOTest(unittest.TestCase):
             self.assertEqual(f.readline(), b"foo\x00bar\n")
             self.assertEqual(f.readline(None), b"another line")
             self.assertRaises(TypeError, f.readline, 5.3)
-        with self.open(support.TESTFN, "r") as f:
+        with self.open(filesystem_helper.TESTFN, "r") as f:
             self.assertRaises(TypeError, f.readline, 5.3)
 
     def test_readline_nonsizeable(self):
@@ -607,20 +608,20 @@ class IOTest(unittest.TestCase):
             support.requires(
                 'largefile',
                 'test requires %s bytes and a long time to run' % self.LARGE)
-        with self.open(support.TESTFN, "w+b", 0) as f:
+        with self.open(filesystem_helper.TESTFN, "w+b", 0) as f:
             self.large_file_ops(f)
-        with self.open(support.TESTFN, "w+b") as f:
+        with self.open(filesystem_helper.TESTFN, "w+b") as f:
             self.large_file_ops(f)
 
     def test_with_open(self):
         for bufsize in (0, 100):
             f = None
-            with self.open(support.TESTFN, "wb", bufsize) as f:
+            with self.open(filesystem_helper.TESTFN, "wb", bufsize) as f:
                 f.write(b"xxx")
             self.assertEqual(f.closed, True)
             f = None
             try:
-                with self.open(support.TESTFN, "wb", bufsize) as f:
+                with self.open(filesystem_helper.TESTFN, "wb", bufsize) as f:
                     1/0
             except ZeroDivisionError:
                 self.assertEqual(f.closed, True)
@@ -629,13 +630,13 @@ class IOTest(unittest.TestCase):
 
     # issue 5008
     def test_append_mode_tell(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             f.write(b"xxx")
-        with self.open(support.TESTFN, "ab", buffering=0) as f:
+        with self.open(filesystem_helper.TESTFN, "ab", buffering=0) as f:
             self.assertEqual(f.tell(), 3)
-        with self.open(support.TESTFN, "ab") as f:
+        with self.open(filesystem_helper.TESTFN, "ab") as f:
             self.assertEqual(f.tell(), 3)
-        with self.open(support.TESTFN, "a") as f:
+        with self.open(filesystem_helper.TESTFN, "a") as f:
             self.assertGreater(f.tell(), 0)
 
     def test_destructor(self):
@@ -656,12 +657,12 @@ class IOTest(unittest.TestCase):
                 record.append(3)
                 super().flush()
         with support.check_warnings(('', ResourceWarning)):
-            f = MyFileIO(support.TESTFN, "wb")
+            f = MyFileIO(filesystem_helper.TESTFN, "wb")
             f.write(b"xxx")
             del f
             support.gc_collect()
             self.assertEqual(record, [1, 2, 3])
-            with self.open(support.TESTFN, "rb") as f:
+            with self.open(filesystem_helper.TESTFN, "rb") as f:
                 self.assertEqual(f.read(), b"xxx")
 
     def _check_base_destructor(self, base):
@@ -707,9 +708,9 @@ class IOTest(unittest.TestCase):
         self._check_base_destructor(self.TextIOBase)
 
     def test_close_flushes(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             f.write(b"xxx")
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"xxx")
 
     def test_array_writes(self):
@@ -720,25 +721,25 @@ class IOTest(unittest.TestCase):
                 self.assertEqual(f.write(a), n)
                 f.writelines((a,))
         check(self.BytesIO())
-        check(self.FileIO(support.TESTFN, "w"))
+        check(self.FileIO(filesystem_helper.TESTFN, "w"))
         check(self.BufferedWriter(self.MockRawIO()))
         check(self.BufferedRandom(self.MockRawIO()))
         check(self.BufferedRWPair(self.MockRawIO(), self.MockRawIO()))
 
     def test_closefd(self):
-        self.assertRaises(ValueError, self.open, support.TESTFN, 'w',
+        self.assertRaises(ValueError, self.open, filesystem_helper.TESTFN, 'w',
                           closefd=False)
 
     def test_read_closed(self):
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(filesystem_helper.TESTFN, "w") as f:
             f.write("egg\n")
-        with self.open(support.TESTFN, "r") as f:
+        with self.open(filesystem_helper.TESTFN, "r") as f:
             file = self.open(f.fileno(), "r", closefd=False)
             self.assertEqual(file.read(), "egg\n")
             file.seek(0)
             file.close()
             self.assertRaises(ValueError, file.read)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(filesystem_helper.TESTFN, "rb") as f:
             file = self.open(f.fileno(), "rb", closefd=False)
             self.assertEqual(file.read()[:3], b"egg")
             file.close()
@@ -746,12 +747,13 @@ class IOTest(unittest.TestCase):
 
     def test_no_closefd_with_filename(self):
         # can't use closefd in combination with a file name
-        self.assertRaises(ValueError, self.open, support.TESTFN, "r", closefd=False)
+        self.assertRaises(ValueError, self.open, 
+                          filesystem_helper.TESTFN, "r", closefd=False)
 
     def test_closefd_attr(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             f.write(b"egg\n")
-        with self.open(support.TESTFN, "r") as f:
+        with self.open(filesystem_helper.TESTFN, "r") as f:
             self.assertEqual(f.buffer.raw.closefd, True)
             file = self.open(f.fileno(), "r", closefd=False)
             self.assertEqual(file.buffer.raw.closefd, False)
@@ -760,14 +762,14 @@ class IOTest(unittest.TestCase):
         # FileIO objects are collected, and collecting them flushes
         # all data to disk.
         with support.check_warnings(('', ResourceWarning)):
-            f = self.FileIO(support.TESTFN, "wb")
+            f = self.FileIO(filesystem_helper.TESTFN, "wb")
             f.write(b"abcxxx")
             f.f = f
             wr = weakref.ref(f)
             del f
             support.gc_collect()
         self.assertIsNone(wr(), wr)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"abcxxx")
 
     def test_unbounded_file(self):
@@ -804,29 +806,30 @@ class IOTest(unittest.TestCase):
     def test_flush_error_on_close(self):
         # raw file
         # Issue #5700: io.FileIO calls flush() after file closed
-        self.check_flush_error_on_close(support.TESTFN, 'wb', buffering=0)
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        self.check_flush_error_on_close(filesystem_helper.TESTFN,
+                                        'wb', buffering=0)
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb', buffering=0)
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb', buffering=0, closefd=False)
         os.close(fd)
         # buffered io
-        self.check_flush_error_on_close(support.TESTFN, 'wb')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        self.check_flush_error_on_close(filesystem_helper.TESTFN, 'wb')
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb', closefd=False)
         os.close(fd)
         # text io
-        self.check_flush_error_on_close(support.TESTFN, 'w')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        self.check_flush_error_on_close(filesystem_helper.TESTFN, 'w')
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'w')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'w', closefd=False)
         os.close(fd)
 
     def test_multi_close(self):
-        f = self.open(support.TESTFN, "wb", buffering=0)
+        f = self.open(filesystem_helper.TESTFN, "wb", buffering=0)
         f.close()
         f.close()
         f.close()
@@ -857,9 +860,9 @@ class IOTest(unittest.TestCase):
             self.assertTrue(hasattr(obj, "__dict__"))
 
     def test_opener(self):
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(filesystem_helper.TESTFN, "w") as f:
             f.write("egg\n")
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         def opener(path, flags):
             return fd
         with self.open("non-existent", "r", opener=opener) as f:
@@ -896,12 +899,12 @@ class IOTest(unittest.TestCase):
     def test_nonbuffered_textio(self):
         with support.check_no_resource_warning(self):
             with self.assertRaises(ValueError):
-                self.open(support.TESTFN, 'w', buffering=0)
+                self.open(filesystem_helper.TESTFN, 'w', buffering=0)
 
     def test_invalid_newline(self):
         with support.check_no_resource_warning(self):
             with self.assertRaises(ValueError):
-                self.open(support.TESTFN, 'w', newline='invalid')
+                self.open(filesystem_helper.TESTFN, 'w', newline='invalid')
 
     def test_buffered_readinto_mixin(self):
         # Test the implementation provided by BufferedIOBase
@@ -924,10 +927,10 @@ class IOTest(unittest.TestCase):
             with self.open(path, "r") as f:
                 self.assertEqual(f.read(), "egg\n")
 
-        check_path_succeeds(FakePath(support.TESTFN))
-        check_path_succeeds(FakePath(support.TESTFN.encode('utf-8')))
+        check_path_succeeds(FakePath(filesystem_helper.TESTFN))
+        check_path_succeeds(FakePath(filesystem_helper.TESTFN.encode('utf-8')))
 
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(filesystem_helper.TESTFN, "w") as f:
             bad_path = FakePath(f.fileno())
             with self.assertRaises(TypeError):
                 self.open(bad_path, 'w')
@@ -942,7 +945,7 @@ class IOTest(unittest.TestCase):
 
         # ensure that refcounting is correct with some error conditions
         with self.assertRaisesRegex(ValueError, 'read/write/append mode'):
-            self.open(FakePath(support.TESTFN), 'rwxa')
+            self.open(FakePath(filesystem_helper.TESTFN), 'rwxa')
 
     def test_RawIOBase_readall(self):
         # Exercise the default unlimited RawIOBase.read() and readall()
@@ -1454,9 +1457,10 @@ class BufferedReaderTest(unittest.TestCase, CommonBufferedTests):
             l = list(range(256)) * N
             random.shuffle(l)
             s = bytes(bytearray(l))
-            with self.open(support.TESTFN, "wb") as f:
+            with self.open(filesystem_helper.TESTFN, "wb") as f:
                 f.write(s)
-            with self.open(support.TESTFN, self.read_mode, buffering=0) as raw:
+            with self.open(filesystem_helper.TESTFN,
+                           self.read_mode, buffering=0) as raw:
                 bufio = self.tp(raw, 8)
                 errors = []
                 results = []
@@ -1482,7 +1486,7 @@ class BufferedReaderTest(unittest.TestCase, CommonBufferedTests):
                     c = bytes(bytearray([i]))
                     self.assertEqual(s.count(c), N)
         finally:
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_unseekable(self):
         bufio = self.tp(self.MockUnseekableIO(b"A" * 10))
@@ -1572,9 +1576,9 @@ class CBufferedReaderTest(BufferedReaderTest, SizeofTest):
     def test_garbage_collection(self):
         # C BufferedReader objects are collected.
         # The Python version has __del__, so it ends into gc.garbage instead
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
         with support.check_warnings(('', ResourceWarning)):
-            rawio = self.FileIO(support.TESTFN, "w+b")
+            rawio = self.FileIO(filesystem_helper.TESTFN, "w+b")
             f = self.tp(rawio)
             f.f = f
             wr = weakref.ref(f)
@@ -1775,26 +1779,28 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
 
     def test_truncate(self):
         # Truncate implicitly flushes the buffer.
-        self.addCleanup(support.unlink, support.TESTFN)
-        with self.open(support.TESTFN, self.write_mode, buffering=0) as raw:
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        with self.open(filesystem_helper.TESTFN, 
+                       self.write_mode, buffering=0) as raw:
             bufio = self.tp(raw, 8)
             bufio.write(b"abcdef")
             self.assertEqual(bufio.truncate(3), 3)
             self.assertEqual(bufio.tell(), 6)
-        with self.open(support.TESTFN, "rb", buffering=0) as f:
+        with self.open(filesystem_helper.TESTFN, "rb", buffering=0) as f:
             self.assertEqual(f.read(), b"abc")
 
     def test_truncate_after_write(self):
         # Ensure that truncate preserves the file position after
         # writes longer than the buffer size.
         # Issue: https://bugs.python.org/issue32228
-        self.addCleanup(support.unlink, support.TESTFN)
-        with self.open(support.TESTFN, "wb") as f:
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             # Fill with some buffer
             f.write(b'\x00' * 10000)
         buffer_sizes = [8192, 4096, 200]
         for buffer_size in buffer_sizes:
-            with self.open(support.TESTFN, "r+b", buffering=buffer_size) as f:
+            with self.open(filesystem_helper.TESTFN, "r+b",
+                           buffering=buffer_size) as f:
                 f.write(b'\x00' * (buffer_size + 1))
                 # After write write_pos and write_end are set to 0
                 f.read(1)
@@ -1822,7 +1828,8 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
             # writing the buffer to the raw streams. This is in addition
             # to concurrency issues due to switching threads in the middle
             # of Python code.
-            with self.open(support.TESTFN, self.write_mode, buffering=0) as raw:
+            with self.open(filesystem_helper.TESTFN, 
+                           self.write_mode, buffering=0) as raw:
                 bufio = self.tp(raw, 8)
                 errors = []
                 def f():
@@ -1842,12 +1849,12 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
                 self.assertFalse(errors,
                     "the following exceptions were caught: %r" % errors)
                 bufio.close()
-            with self.open(support.TESTFN, "rb") as f:
+            with self.open(filesystem_helper.TESTFN, "rb") as f:
                 s = f.read()
             for i in range(256):
                 self.assertEqual(s.count(bytes([i])), N)
         finally:
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_misbehaved_io(self):
         rawio = self.MisbehavedRawIO()
@@ -1915,9 +1922,9 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
         # C BufferedWriter objects are collected, and collecting them flushes
         # all data to disk.
         # The Python version has __del__, so it ends into gc.garbage instead
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
         with support.check_warnings(('', ResourceWarning)):
-            rawio = self.FileIO(support.TESTFN, "w+b")
+            rawio = self.FileIO(filesystem_helper.TESTFN, "w+b")
             f = self.tp(rawio)
             f.write(b"123xxx")
             f.x = f
@@ -1925,7 +1932,7 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
             del f
             support.gc_collect()
         self.assertIsNone(wr(), wr)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"123xxx")
 
     def test_args_error(self):
@@ -2563,10 +2570,10 @@ class TextIOWrapperTest(unittest.TestCase):
     def setUp(self):
         self.testdata = b"AAA\r\nBBB\rCCC\r\nDDD\nEEE\r\n"
         self.normalized = b"AAA\nBBB\nCCC\nDDD\nEEE\n".decode("ascii")
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def test_constructor(self):
         r = self.BytesIO(b"\xc3\xa9\n\n")
@@ -2902,11 +2909,11 @@ class TextIOWrapperTest(unittest.TestCase):
     def test_basic_io(self):
         for chunksize in (1, 2, 3, 4, 5, 15, 16, 17, 31, 32, 33, 63, 64, 65):
             for enc in "ascii", "latin-1", "utf-8" :# , "utf-16-be", "utf-16-le":
-                f = self.open(support.TESTFN, "w+", encoding=enc)
+                f = self.open(filesystem_helper.TESTFN, "w+", encoding=enc)
                 f._CHUNK_SIZE = chunksize
                 self.assertEqual(f.write("abc"), 3)
                 f.close()
-                f = self.open(support.TESTFN, "r+", encoding=enc)
+                f = self.open(filesystem_helper.TESTFN, "r+", encoding=enc)
                 f._CHUNK_SIZE = chunksize
                 self.assertEqual(f.tell(), 0)
                 self.assertEqual(f.read(), "abc")
@@ -2951,7 +2958,7 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(rlines, wlines)
 
     def test_telling(self):
-        f = self.open(support.TESTFN, "w+", encoding="utf-8")
+        f = self.open(filesystem_helper.TESTFN, "w+", encoding="utf-8")
         p0 = f.tell()
         f.write("\xff\n")
         p1 = f.tell()
@@ -2979,9 +2986,9 @@ class TextIOWrapperTest(unittest.TestCase):
         u_suffix = "\u8888\n"
         suffix = bytes(u_suffix.encode("utf-8"))
         line = prefix + suffix
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             f.write(line*2)
-        with self.open(support.TESTFN, "r", encoding="utf-8") as f:
+        with self.open(filesystem_helper.TESTFN, "r", encoding="utf-8") as f:
             s = f.read(prefix_size)
             self.assertEqual(s, str(prefix, "ascii"))
             self.assertEqual(f.tell(), prefix_size)
@@ -2990,9 +2997,9 @@ class TextIOWrapperTest(unittest.TestCase):
     def test_seeking_too(self):
         # Regression test for a specific bug
         data = b'\xe0\xbf\xbf\n'
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             f.write(data)
-        with self.open(support.TESTFN, "r", encoding="utf-8") as f:
+        with self.open(filesystem_helper.TESTFN, "r", encoding="utf-8") as f:
             f._CHUNK_SIZE  # Just test that it exists
             f._CHUNK_SIZE = 2
             f.readline()
@@ -3006,17 +3013,18 @@ class TextIOWrapperTest(unittest.TestCase):
         def test_seek_and_tell_with_data(data, min_pos=0):
             """Tell/seek to various points within a data stream and ensure
             that the decoded data returned by read() is consistent."""
-            f = self.open(support.TESTFN, 'wb')
+            f = self.open(filesystem_helper.TESTFN, 'wb')
             f.write(data)
             f.close()
-            f = self.open(support.TESTFN, encoding='test_decoder')
+            f = self.open(filesystem_helper.TESTFN, encoding='test_decoder')
             f._CHUNK_SIZE = CHUNK_SIZE
             decoded = f.read()
             f.close()
 
             for i in range(min_pos, len(decoded) + 1): # seek positions
                 for j in [1, 5, len(decoded) - i]: # read lengths
-                    f = self.open(support.TESTFN, encoding='test_decoder')
+                    f = self.open(filesystem_helper.TESTFN,
+                                  encoding='test_decoder')
                     self.assertEqual(f.read(i), decoded[:i])
                     cookie = f.tell()
                     self.assertEqual(f.read(j), decoded[i:i + j])
@@ -3046,11 +3054,11 @@ class TextIOWrapperTest(unittest.TestCase):
             StatefulIncrementalDecoder.codecEnabled = 0
 
     def test_multibyte_seek_and_tell(self):
-        f = self.open(support.TESTFN, "w", encoding="euc_jp")
+        f = self.open(filesystem_helper.TESTFN, "w", encoding="euc_jp")
         f.write("AB\n\u3046\u3048\n")
         f.close()
 
-        f = self.open(support.TESTFN, "r", encoding="euc_jp")
+        f = self.open(filesystem_helper.TESTFN, "r", encoding="euc_jp")
         self.assertEqual(f.readline(), "AB\n")
         p0 = f.tell()
         self.assertEqual(f.readline(), "\u3046\u3048\n")
@@ -3061,7 +3069,7 @@ class TextIOWrapperTest(unittest.TestCase):
         f.close()
 
     def test_seek_with_encoder_state(self):
-        f = self.open(support.TESTFN, "w", encoding="euc_jis_2004")
+        f = self.open(filesystem_helper.TESTFN, "w", encoding="euc_jis_2004")
         f.write("\u00e6\u0300")
         p0 = f.tell()
         f.write("\u00e6")
@@ -3069,7 +3077,7 @@ class TextIOWrapperTest(unittest.TestCase):
         f.write("\u0300")
         f.close()
 
-        f = self.open(support.TESTFN, "r", encoding="euc_jis_2004")
+        f = self.open(filesystem_helper.TESTFN, "r", encoding="euc_jis_2004")
         self.assertEqual(f.readline(), "\u00e6\u0300\u0300")
         f.close()
 
@@ -3213,7 +3221,7 @@ class TextIOWrapperTest(unittest.TestCase):
 
     def test_append_bom(self):
         # The BOM is not written again when appending to a non-empty file
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         for charset in ('utf-8-sig', 'utf-16', 'utf-32'):
             with self.open(filename, 'w', encoding=charset) as f:
                 f.write('aaa')
@@ -3228,7 +3236,7 @@ class TextIOWrapperTest(unittest.TestCase):
 
     def test_seek_bom(self):
         # Same test, but when seeking manually
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         for charset in ('utf-8-sig', 'utf-16', 'utf-32'):
             with self.open(filename, 'w', encoding=charset) as f:
                 f.write('aaa')
@@ -3243,7 +3251,7 @@ class TextIOWrapperTest(unittest.TestCase):
 
     def test_seek_append_bom(self):
         # Same test, but first seek to the start and then to the end
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         for charset in ('utf-8-sig', 'utf-16', 'utf-32'):
             with self.open(filename, 'w', encoding=charset) as f:
                 f.write('aaa')
@@ -3255,16 +3263,16 @@ class TextIOWrapperTest(unittest.TestCase):
                 self.assertEqual(f.read(), 'aaaxxx'.encode(charset))
 
     def test_errors_property(self):
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(filesystem_helper.TESTFN, "w") as f:
             self.assertEqual(f.errors, "strict")
-        with self.open(support.TESTFN, "w", errors="replace") as f:
+        with self.open(filesystem_helper.TESTFN, "w", errors="replace") as f:
             self.assertEqual(f.errors, "replace")
 
     @support.no_tracing
     def test_threads_write(self):
         # Issue6750: concurrent writes could duplicate data
         event = threading.Event()
-        with self.open(support.TESTFN, "w", buffering=1) as f:
+        with self.open(filesystem_helper.TESTFN, "w", buffering=1) as f:
             def run(n):
                 text = "Thread%03d\n" % n
                 event.wait()
@@ -3273,7 +3281,7 @@ class TextIOWrapperTest(unittest.TestCase):
                        for x in range(20)]
             with threading_helper.start_threads(threads, event.set):
                 time.sleep(0.02)
-        with self.open(support.TESTFN) as f:
+        with self.open(filesystem_helper.TESTFN) as f:
             content = f.read()
             for n in range(20):
                 self.assertEqual(content.count("Thread%03d\n" % n), 1)
@@ -3717,7 +3725,7 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         # all data to disk.
         # The Python version has __del__, so it ends in gc.garbage instead.
         with support.check_warnings(('', ResourceWarning)):
-            rawio = io.FileIO(support.TESTFN, "wb")
+            rawio = io.FileIO(filesystem_helper.TESTFN, "wb")
             b = self.BufferedWriter(rawio)
             t = self.TextIOWrapper(b, encoding="ascii")
             t.write("456def")
@@ -3726,7 +3734,7 @@ class CTextIOWrapperTest(TextIOWrapperTest):
             del t
             support.gc_collect()
         self.assertIsNone(wr(), wr)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(filesystem_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"456def")
 
     def test_rwpair_cleared_before_textio(self):
@@ -3883,7 +3891,7 @@ class PyIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest):
 class MiscIOTest(unittest.TestCase):
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def test___all__(self):
         for name in self.io.__all__:
@@ -3897,21 +3905,21 @@ class MiscIOTest(unittest.TestCase):
                 self.assertTrue(issubclass(obj, self.IOBase))
 
     def test_attributes(self):
-        f = self.open(support.TESTFN, "wb", buffering=0)
+        f = self.open(filesystem_helper.TESTFN, "wb", buffering=0)
         self.assertEqual(f.mode, "wb")
         f.close()
 
         with support.check_warnings(('', DeprecationWarning)):
-            f = self.open(support.TESTFN, "U")
-        self.assertEqual(f.name,            support.TESTFN)
-        self.assertEqual(f.buffer.name,     support.TESTFN)
-        self.assertEqual(f.buffer.raw.name, support.TESTFN)
+            f = self.open(filesystem_helper.TESTFN, "U")
+        self.assertEqual(f.name,            filesystem_helper.TESTFN)
+        self.assertEqual(f.buffer.name,     filesystem_helper.TESTFN)
+        self.assertEqual(f.buffer.raw.name, filesystem_helper.TESTFN)
         self.assertEqual(f.mode,            "U")
         self.assertEqual(f.buffer.mode,     "rb")
         self.assertEqual(f.buffer.raw.mode, "rb")
         f.close()
 
-        f = self.open(support.TESTFN, "w+")
+        f = self.open(filesystem_helper.TESTFN, "w+")
         self.assertEqual(f.mode,            "w+")
         self.assertEqual(f.buffer.mode,     "rb+") # Does it really matter?
         self.assertEqual(f.buffer.raw.mode, "rb+")
@@ -3953,7 +3961,7 @@ class MiscIOTest(unittest.TestCase):
                 {"mode": "w+", "buffering": 2},
                 {"mode": "w+b", "buffering": 0},
             ]:
-            f = self.open(support.TESTFN, **kwargs)
+            f = self.open(filesystem_helper.TESTFN, **kwargs)
             f.close()
             self.assertRaises(ValueError, f.flush)
             self.assertRaises(ValueError, f.fileno)
@@ -4003,17 +4011,17 @@ class MiscIOTest(unittest.TestCase):
         self.assertIsInstance(self.TextIOBase, abc.ABCMeta)
 
     def _check_abc_inheritance(self, abcmodule):
-        with self.open(support.TESTFN, "wb", buffering=0) as f:
+        with self.open(filesystem_helper.TESTFN, "wb", buffering=0) as f:
             self.assertIsInstance(f, abcmodule.IOBase)
             self.assertIsInstance(f, abcmodule.RawIOBase)
             self.assertNotIsInstance(f, abcmodule.BufferedIOBase)
             self.assertNotIsInstance(f, abcmodule.TextIOBase)
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(filesystem_helper.TESTFN, "wb") as f:
             self.assertIsInstance(f, abcmodule.IOBase)
             self.assertNotIsInstance(f, abcmodule.RawIOBase)
             self.assertIsInstance(f, abcmodule.BufferedIOBase)
             self.assertNotIsInstance(f, abcmodule.TextIOBase)
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(filesystem_helper.TESTFN, "w") as f:
             self.assertIsInstance(f, abcmodule.IOBase)
             self.assertNotIsInstance(f, abcmodule.RawIOBase)
             self.assertNotIsInstance(f, abcmodule.BufferedIOBase)
@@ -4037,9 +4045,10 @@ class MiscIOTest(unittest.TestCase):
         self.assertIn(r, str(cm.warning.args[0]))
 
     def test_warn_on_dealloc(self):
-        self._check_warn_on_dealloc(support.TESTFN, "wb", buffering=0)
-        self._check_warn_on_dealloc(support.TESTFN, "wb")
-        self._check_warn_on_dealloc(support.TESTFN, "w")
+        self._check_warn_on_dealloc(filesystem_helper.TESTFN, 
+                                    "wb", buffering=0)
+        self._check_warn_on_dealloc(filesystem_helper.TESTFN, "wb")
+        self._check_warn_on_dealloc(filesystem_helper.TESTFN, "w")
 
     def _check_warn_on_dealloc_fd(self, *args, **kwargs):
         fds = []
@@ -4080,7 +4089,7 @@ class MiscIOTest(unittest.TestCase):
                 {"mode": "w+b", "buffering": 0},
             ]:
             for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
-                with self.open(support.TESTFN, **kwargs) as f:
+                with self.open(filesystem_helper.TESTFN, **kwargs) as f:
                     self.assertRaises(TypeError, pickle.dumps, f, protocol)
 
     def test_nonblock_pipe_write_bigbuf(self):
@@ -4143,20 +4152,22 @@ class MiscIOTest(unittest.TestCase):
 
     def test_create_fail(self):
         # 'x' mode fails if file is existing
-        with self.open(support.TESTFN, 'w'):
+        with self.open(filesystem_helper.TESTFN, 'w'):
             pass
-        self.assertRaises(FileExistsError, self.open, support.TESTFN, 'x')
+        self.assertRaises(FileExistsError, self.open,
+                          filesystem_helper.TESTFN, 'x')
 
     def test_create_writes(self):
         # 'x' mode opens for writing
-        with self.open(support.TESTFN, 'xb') as f:
+        with self.open(filesystem_helper.TESTFN, 'xb') as f:
             f.write(b"spam")
-        with self.open(support.TESTFN, 'rb') as f:
+        with self.open(filesystem_helper.TESTFN, 'rb') as f:
             self.assertEqual(b"spam", f.read())
 
     def test_open_allargs(self):
         # there used to be a buffer overflow in the parser for rawmode
-        self.assertRaises(ValueError, self.open, support.TESTFN, 'rwax+')
+        self.assertRaises(ValueError, self.open,
+                          filesystem_helper.TESTFN, 'rwax+')
 
     def test_check_encoding_errors(self):
         # bpo-37388: open() and TextIOWrapper must check encoding and errors

--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -2,10 +2,12 @@
 
 import sys
 import unittest
-from test.support import run_unittest, TESTFN, unlink, cpython_only
+from test.support import run_unittest, unlink, cpython_only
 from test.support import check_free_after_iterating, ALWAYS_EQ, NEVER_EQ
+from test.support.filesystem_helper import TESTFN
 import pickle
 import collections.abc
+
 
 # Test result of triple loop (too big to inline)
 TRIPLETS = [(0, 0, 0), (0, 0, 1), (0, 0, 2),

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -6,6 +6,7 @@ import unittest
 import subprocess
 
 from test import support
+from test.support import filesystem_helper
 from test.support.script_helper import assert_python_ok
 
 
@@ -91,7 +92,7 @@ class TestTool(unittest.TestCase):
         self.assertEqual(process.stderr, '')
 
     def _create_infile(self, data=None):
-        infile = support.TESTFN
+        infile = filesystem_helper.TESTFN
         with open(infile, "w", encoding="utf-8") as fp:
             self.addCleanup(os.remove, infile)
             fp.write(data or self.data)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -8,7 +8,8 @@ import unittest
 import socket
 import shutil
 import threading
-from test.support import TESTFN, requires, unlink, bigmemtest
+from test.support import requires, unlink, bigmemtest
+from test.support.filesystem_helper import TESTFN
 from test.support import SHORT_TIMEOUT
 from test.support import socket_helper
 import io  # C implementation of io

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -6,6 +6,7 @@ import os.path
 import tempfile
 import tokenize
 from test import support
+from test.support import filesystem_helper
 
 
 FILENAME = linecache.__file__
@@ -124,10 +125,10 @@ class LineCacheTests(unittest.TestCase):
         self.assertEqual(empty, [])
 
     def test_no_ending_newline(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as fp:
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, "w") as fp:
             fp.write(SOURCE_3)
-        lines = linecache.getlines(support.TESTFN)
+        lines = linecache.getlines(filesystem_helper.TESTFN)
         self.assertEqual(lines, ["\n", "def f():\n", "    return 3\n"])
 
     def test_clearcache(self):
@@ -150,7 +151,7 @@ class LineCacheTests(unittest.TestCase):
     def test_checkcache(self):
         getline = linecache.getline
         # Create a source file and cache its contents
-        source_name = support.TESTFN + '.py'
+        source_name = filesystem_helper.TESTFN + '.py'
         self.addCleanup(support.unlink, source_name)
         with open(source_name, 'w') as source:
             source.write(SOURCE_1)

--- a/Lib/test/test_lltrace.py
+++ b/Lib/test/test_lltrace.py
@@ -3,6 +3,7 @@ import textwrap
 import unittest
 
 from test import support
+from test.support import filesystem_helper
 from test.support.script_helper import assert_python_ok
 
 
@@ -13,8 +14,8 @@ class TestLLTrace(unittest.TestCase):
         # bpo-34113. The crash happened at the command line console of
         # debug Python builds with __ltrace__ enabled (only possible in console),
         # when the interal Python stack was negatively adjusted
-        with open(support.TESTFN, 'w') as fd:
-            self.addCleanup(os.unlink, support.TESTFN)
+        with open(filesystem_helper.TESTFN, 'w') as fd:
+            self.addCleanup(os.unlink, filesystem_helper.TESTFN)
             fd.write(textwrap.dedent("""\
             import code
 
@@ -25,7 +26,7 @@ class TestLLTrace(unittest.TestCase):
             print('unreachable if bug exists')
             """))
 
-            assert_python_ok(support.TESTFN)
+            assert_python_ok(filesystem_helper.TESTFN)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -9,8 +9,9 @@ from test import support
 import unittest
 
 from test.support import (
-    _4G, TESTFN, import_module, bigmemtest, run_unittest, unlink
+    _4G, import_module, bigmemtest, run_unittest, unlink
 )
+from test.support.filesystem_helper import TESTFN
 
 lzma = import_module("lzma")
 from lzma import LZMACompressor, LZMADecompressor, LZMAError, LZMAFile

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -9,6 +9,7 @@ import re
 import io
 import tempfile
 from test import support
+from test.support import filesystem_helper
 import unittest
 import textwrap
 import mailbox
@@ -51,7 +52,7 @@ class TestMailbox(TestBase):
     _template = 'From: foo\n\n%s\n'
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = filesystem_helper.TESTFN
         self._delete_recursively(self._path)
         self._box = self._factory(self._path)
 
@@ -1369,7 +1370,7 @@ class TestMessage(TestBase, unittest.TestCase):
     _factory = mailbox.Message      # Overridden by subclasses to reuse tests
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = filesystem_helper.TESTFN
 
     def tearDown(self):
         self._delete_recursively(self._path)
@@ -2019,7 +2020,7 @@ class TestProxyFileBase(TestBase):
 class TestProxyFile(TestProxyFileBase, unittest.TestCase):
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = filesystem_helper.TESTFN
         self._file = open(self._path, 'wb+')
 
     def tearDown(self):
@@ -2068,7 +2069,7 @@ class TestProxyFile(TestProxyFileBase, unittest.TestCase):
 class TestPartialFile(TestProxyFileBase, unittest.TestCase):
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = filesystem_helper.TESTFN
         self._file = open(self._path, 'wb+')
 
     def tearDown(self):
@@ -2131,7 +2132,7 @@ class MaildirTestCase(unittest.TestCase):
 
     def setUp(self):
         # create a new maildir mailbox to work with:
-        self._dir = support.TESTFN
+        self._dir = filesystem_helper.TESTFN
         if os.path.isdir(self._dir):
             support.rmtree(self._dir)
         elif os.path.isfile(self._dir):

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -1,4 +1,5 @@
 from test import support
+from test.support import filesystem_helper
 import array
 import io
 import marshal
@@ -17,13 +18,13 @@ class HelperMixin:
         new = marshal.loads(marshal.dumps(sample, *extra))
         self.assertEqual(sample, new)
         try:
-            with open(support.TESTFN, "wb") as f:
+            with open(filesystem_helper.TESTFN, "wb") as f:
                 marshal.dump(sample, f, *extra)
-            with open(support.TESTFN, "rb") as f:
+            with open(filesystem_helper.TESTFN, "rb") as f:
                 new = marshal.load(f)
             self.assertEqual(sample, new)
         finally:
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
 class IntTestCase(unittest.TestCase, HelperMixin):
     def test_ints(self):
@@ -288,20 +289,20 @@ class BugsTestCase(unittest.TestCase):
             ilen = len(interleaved)
             positions = []
             try:
-                with open(support.TESTFN, 'wb') as f:
+                with open(filesystem_helper.TESTFN, 'wb') as f:
                     for d in data:
                         marshal.dump(d, f)
                         if ilen:
                             f.write(interleaved)
                         positions.append(f.tell())
-                with open(support.TESTFN, 'rb') as f:
+                with open(filesystem_helper.TESTFN, 'rb') as f:
                     for i, d in enumerate(data):
                         self.assertEqual(d, marshal.load(f))
                         if ilen:
                             f.read(ilen)
                         self.assertEqual(positions[i], f.tell())
             finally:
-                support.unlink(support.TESTFN)
+                support.unlink(filesystem_helper.TESTFN)
 
     def test_loads_reject_unicode_strings(self):
         # Issue #14177: marshal.loads() should not accept unicode strings
@@ -523,81 +524,89 @@ class CAPI_TestCase(unittest.TestCase, HelperMixin):
 
     def test_write_long_to_file(self):
         for v in range(marshal.version + 1):
-            _testcapi.pymarshal_write_long_to_file(0x12345678, support.TESTFN, v)
-            with open(support.TESTFN, 'rb') as f:
+            _testcapi.pymarshal_write_long_to_file(0x12345678,
+                                                   filesystem_helper.TESTFN, v)
+            with open(filesystem_helper.TESTFN, 'rb') as f:
                 data = f.read()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
             self.assertEqual(data, b'\x78\x56\x34\x12')
 
     def test_write_object_to_file(self):
         obj = ('\u20ac', b'abc', 123, 45.6, 7+8j, 'long line '*1000)
         for v in range(marshal.version + 1):
-            _testcapi.pymarshal_write_object_to_file(obj, support.TESTFN, v)
-            with open(support.TESTFN, 'rb') as f:
+            _testcapi.pymarshal_write_object_to_file(obj,
+                    filesystem_helper.TESTFN, v)
+            with open(filesystem_helper.TESTFN, 'rb') as f:
                 data = f.read()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
             self.assertEqual(marshal.loads(data), obj)
 
     def test_read_short_from_file(self):
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             f.write(b'\x34\x12xxxx')
-        r, p = _testcapi.pymarshal_read_short_from_file(support.TESTFN)
-        support.unlink(support.TESTFN)
+        r, p = _testcapi.pymarshal_read_short_from_file(
+                filesystem_helper.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         self.assertEqual(r, 0x1234)
         self.assertEqual(p, 2)
 
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             f.write(b'\x12')
         with self.assertRaises(EOFError):
-            _testcapi.pymarshal_read_short_from_file(support.TESTFN)
-        support.unlink(support.TESTFN)
+            _testcapi.pymarshal_read_short_from_file(filesystem_helper.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def test_read_long_from_file(self):
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             f.write(b'\x78\x56\x34\x12xxxx')
-        r, p = _testcapi.pymarshal_read_long_from_file(support.TESTFN)
-        support.unlink(support.TESTFN)
+        r, p = _testcapi.pymarshal_read_long_from_file(
+                filesystem_helper.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         self.assertEqual(r, 0x12345678)
         self.assertEqual(p, 4)
 
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             f.write(b'\x56\x34\x12')
         with self.assertRaises(EOFError):
-            _testcapi.pymarshal_read_long_from_file(support.TESTFN)
-        support.unlink(support.TESTFN)
+            _testcapi.pymarshal_read_long_from_file(filesystem_helper.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def test_read_last_object_from_file(self):
         obj = ('\u20ac', b'abc', 123, 45.6, 7+8j)
         for v in range(marshal.version + 1):
             data = marshal.dumps(obj, v)
-            with open(support.TESTFN, 'wb') as f:
+            with open(filesystem_helper.TESTFN, 'wb') as f:
                 f.write(data + b'xxxx')
-            r, p = _testcapi.pymarshal_read_last_object_from_file(support.TESTFN)
-            support.unlink(support.TESTFN)
+            r, p = _testcapi.pymarshal_read_last_object_from_file(
+                    filesystem_helper.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
             self.assertEqual(r, obj)
 
-            with open(support.TESTFN, 'wb') as f:
+            with open(filesystem_helper.TESTFN, 'wb') as f:
                 f.write(data[:1])
             with self.assertRaises(EOFError):
-                _testcapi.pymarshal_read_last_object_from_file(support.TESTFN)
-            support.unlink(support.TESTFN)
+                _testcapi.pymarshal_read_last_object_from_file(
+                        filesystem_helper.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_read_object_from_file(self):
         obj = ('\u20ac', b'abc', 123, 45.6, 7+8j)
         for v in range(marshal.version + 1):
             data = marshal.dumps(obj, v)
-            with open(support.TESTFN, 'wb') as f:
+            with open(filesystem_helper.TESTFN, 'wb') as f:
                 f.write(data + b'xxxx')
-            r, p = _testcapi.pymarshal_read_object_from_file(support.TESTFN)
-            support.unlink(support.TESTFN)
+            r, p = _testcapi.pymarshal_read_object_from_file(
+                    filesystem_helper.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
             self.assertEqual(r, obj)
             self.assertEqual(p, len(data))
 
-            with open(support.TESTFN, 'wb') as f:
+            with open(filesystem_helper.TESTFN, 'wb') as f:
                 f.write(data[:1])
             with self.assertRaises(EOFError):
-                _testcapi.pymarshal_read_object_from_file(support.TESTFN)
-            support.unlink(support.TESTFN)
+                _testcapi.pymarshal_read_object_from_file(
+                        filesystem_helper.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,5 +1,6 @@
-from test.support import (TESTFN, import_module, unlink,
+from test.support import (import_module, unlink,
                           requires, _2G, _4G, gc_collect, cpython_only)
+from test.support import TESTFN
 import unittest
 import os
 import re

--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -1,7 +1,8 @@
 """ Test suite for the code in msilib """
 import os
 import unittest
-from test.support import TESTFN, import_module, unlink
+from test.support import import_module, unlink
+from test.support.filesystem_helper import TESTFN
 msilib = import_module('msilib')
 import msilib.schema
 

--- a/Lib/test/test_multibytecodec.py
+++ b/Lib/test/test_multibytecodec.py
@@ -4,7 +4,7 @@
 #
 
 from test import support
-from test.support import TESTFN
+from test.support.filesystem_helper import TESTFN
 import unittest, io, codecs, sys
 import _multibytecodec
 

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,5 +1,6 @@
 import netrc, os, unittest, sys, tempfile, textwrap
 from test import support
+from test.support import filesystem_helper
 
 
 class NetrcTestCase(unittest.TestCase):
@@ -108,7 +109,7 @@ class NetrcTestCase(unittest.TestCase):
     def test_security(self):
         # This test is incomplete since we are normally not run as root and
         # therefore can't test the file ownership being wrong.
-        d = support.TESTFN
+        d = filesystem_helper.TESTFN
         os.mkdir(d)
         self.addCleanup(support.rmtree, d)
         fn = os.path.join(d, '.netrc')
@@ -127,7 +128,7 @@ class NetrcTestCase(unittest.TestCase):
             self.assertRaises(netrc.NetrcParseError, netrc.netrc)
 
     def test_file_not_found_in_home(self):
-        d = support.TESTFN
+        d = filesystem_helper.TESTFN
         os.mkdir(d)
         self.addCleanup(support.rmtree, d)
         with support.EnvironmentVarGuard() as environ:
@@ -139,7 +140,7 @@ class NetrcTestCase(unittest.TestCase):
                           file='unlikely_netrc')
 
     def test_home_not_set(self):
-        fake_home = support.TESTFN
+        fake_home = filesystem_helper.TESTFN
         os.mkdir(fake_home)
         self.addCleanup(support.rmtree, fake_home)
         fake_netrc_path = os.path.join(fake_home, '.netrc')

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -5,6 +5,7 @@ import unittest
 import warnings
 from test.support import TestFailed, FakePath
 from test import support, test_genericpath
+from test.support import filesystem_helper
 from tempfile import TemporaryFile
 
 
@@ -257,7 +258,7 @@ class TestNtpath(NtpathTestCase):
     @support.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_basic(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(filesystem_helper.TESTFN)
         open(ABSTFN, "wb").close()
         self.addCleanup(support.unlink, ABSTFN)
         self.addCleanup(support.unlink, ABSTFN + "1")
@@ -270,7 +271,7 @@ class TestNtpath(NtpathTestCase):
     @support.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_relative(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(filesystem_helper.TESTFN)
         open(ABSTFN, "wb").close()
         self.addCleanup(support.unlink, ABSTFN)
         self.addCleanup(support.unlink, ABSTFN + "1")
@@ -281,7 +282,7 @@ class TestNtpath(NtpathTestCase):
     @support.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_broken_symlinks(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(filesystem_helper.TESTFN)
         os.mkdir(ABSTFN)
         self.addCleanup(support.rmtree, ABSTFN)
 
@@ -340,7 +341,7 @@ class TestNtpath(NtpathTestCase):
     def test_realpath_symlink_loops(self):
         # Symlink loops are non-deterministic as to which path is returned, but
         # it will always be the fully resolved path of one member of the cycle
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(filesystem_helper.TESTFN)
         self.addCleanup(support.unlink, ABSTFN)
         self.addCleanup(support.unlink, ABSTFN + "1")
         self.addCleanup(support.unlink, ABSTFN + "2")
@@ -384,7 +385,7 @@ class TestNtpath(NtpathTestCase):
     @support.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_symlink_prefix(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(filesystem_helper.TESTFN)
         self.addCleanup(support.unlink, ABSTFN + "3")
         self.addCleanup(support.unlink, "\\\\?\\" + ABSTFN + "3.")
         self.addCleanup(support.unlink, ABSTFN + "3link")
@@ -422,7 +423,7 @@ class TestNtpath(NtpathTestCase):
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     @unittest.skipUnless(HAVE_GETSHORTPATHNAME, 'need _getshortpathname')
     def test_realpath_cwd(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(filesystem_helper.TESTFN)
 
         support.unlink(ABSTFN)
         support.rmtree(ABSTFN)
@@ -533,7 +534,7 @@ class TestNtpath(NtpathTestCase):
     @unittest.skipUnless(nt, "abspath requires 'nt' module")
     def test_abspath(self):
         tester('ntpath.abspath("C:\\")', "C:\\")
-        with support.temp_cwd(support.TESTFN) as cwd_dir: # bpo-31047
+        with support.temp_cwd(filesystem_helper.TESTFN) as cwd_dir: # bpo-31047
             tester('ntpath.abspath("")', cwd_dir)
             tester('ntpath.abspath(" ")', cwd_dir + "\\ ")
             tester('ntpath.abspath("?")', cwd_dir + "\\?")
@@ -545,7 +546,7 @@ class TestNtpath(NtpathTestCase):
         tester('ntpath.relpath(ntpath.abspath("a"))', 'a')
         tester('ntpath.relpath("a/b")', 'a\\b')
         tester('ntpath.relpath("../a/b")', '..\\a\\b')
-        with support.temp_cwd(support.TESTFN) as cwd_dir:
+        with support.temp_cwd(filesystem_helper.TESTFN) as cwd_dir:
             currentdir = ntpath.basename(cwd_dir)
             tester('ntpath.relpath("a", "../b")', '..\\'+currentdir+'\\a')
             tester('ntpath.relpath("a/b", "../c")', '..\\'+currentdir+'\\a\\b')
@@ -725,8 +726,8 @@ class PathLikeTests(NtpathTestCase):
     path = ntpath
 
     def setUp(self):
-        self.file_name = support.TESTFN.lower()
-        self.file_path = FakePath(support.TESTFN)
+        self.file_name = filesystem_helper.TESTFN.lower()
+        self.file_path = FakePath(filesystem_helper.TESTFN)
         self.addCleanup(support.unlink, self.file_name)
         with open(self.file_name, 'xb', 0) as file:
             file.write(b"test_ntpath.PathLikeTests")

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -14,6 +14,7 @@ import unittest
 
 from io import StringIO
 from test import support
+from test.support import filesystem_helper
 
 
 import optparse
@@ -1021,10 +1022,10 @@ class TestExtendAddTypes(BaseTest):
         self.parser.add_option("-f", "--file", type="file", dest="file")
 
     def tearDown(self):
-        if os.path.isdir(support.TESTFN):
-            os.rmdir(support.TESTFN)
-        elif os.path.isfile(support.TESTFN):
-            os.unlink(support.TESTFN)
+        if os.path.isdir(filesystem_helper.TESTFN):
+            os.rmdir(filesystem_helper.TESTFN)
+        elif os.path.isfile(filesystem_helper.TESTFN):
+            os.unlink(filesystem_helper.TESTFN)
 
     class MyOption (Option):
         def check_file(option, opt, value):
@@ -1039,21 +1040,21 @@ class TestExtendAddTypes(BaseTest):
         TYPE_CHECKER["file"] = check_file
 
     def test_filetype_ok(self):
-        support.create_empty_file(support.TESTFN)
-        self.assertParseOK(["--file", support.TESTFN, "-afoo"],
-                           {'file': support.TESTFN, 'a': 'foo'},
+        support.create_empty_file(filesystem_helper.TESTFN)
+        self.assertParseOK(["--file", filesystem_helper.TESTFN, "-afoo"],
+                           {'file': filesystem_helper.TESTFN, 'a': 'foo'},
                            [])
 
     def test_filetype_noexist(self):
-        self.assertParseFail(["--file", support.TESTFN, "-afoo"],
+        self.assertParseFail(["--file", filesystem_helper.TESTFN, "-afoo"],
                              "%s: file does not exist" %
-                             support.TESTFN)
+                             filesystem_helper.TESTFN)
 
     def test_filetype_notfile(self):
-        os.mkdir(support.TESTFN)
-        self.assertParseFail(["--file", support.TESTFN, "-afoo"],
+        os.mkdir(filesystem_helper.TESTFN)
+        self.assertParseFail(["--file", filesystem_helper.TESTFN, "-afoo"],
                              "%s: not a regular file" %
-                             support.TESTFN)
+                             filesystem_helper.TESTFN)
 
 
 class TestExtendAddActions(BaseTest):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -30,6 +30,7 @@ import unittest
 import uuid
 import warnings
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 from test.support import threading_helper
 from platform import win32_is_iot
@@ -153,17 +154,17 @@ class MiscTests(unittest.TestCase):
 # Tests creating TESTFN
 class FileTests(unittest.TestCase):
     def setUp(self):
-        if os.path.lexists(support.TESTFN):
-            os.unlink(support.TESTFN)
+        if os.path.lexists(filesystem_helper.TESTFN):
+            os.unlink(filesystem_helper.TESTFN)
     tearDown = setUp
 
     def test_access(self):
-        f = os.open(support.TESTFN, os.O_CREAT|os.O_RDWR)
+        f = os.open(filesystem_helper.TESTFN, os.O_CREAT|os.O_RDWR)
         os.close(f)
-        self.assertTrue(os.access(support.TESTFN, os.W_OK))
+        self.assertTrue(os.access(filesystem_helper.TESTFN, os.W_OK))
 
     def test_closerange(self):
-        first = os.open(support.TESTFN, os.O_CREAT|os.O_RDWR)
+        first = os.open(filesystem_helper.TESTFN, os.O_CREAT|os.O_RDWR)
         # We must allocate two consecutive file descriptors, otherwise
         # it will mess up other file descriptors (perhaps even the three
         # standard ones).
@@ -185,14 +186,14 @@ class FileTests(unittest.TestCase):
 
     @support.cpython_only
     def test_rename(self):
-        path = support.TESTFN
+        path = filesystem_helper.TESTFN
         old = sys.getrefcount(path)
         self.assertRaises(TypeError, os.rename, path, 0)
         new = sys.getrefcount(path)
         self.assertEqual(old, new)
 
     def test_read(self):
-        with open(support.TESTFN, "w+b") as fobj:
+        with open(filesystem_helper.TESTFN, "w+b") as fobj:
             fobj.write(b"spam")
             fobj.flush()
             fd = fobj.fileno()
@@ -208,12 +209,12 @@ class FileTests(unittest.TestCase):
                          "needs INT_MAX < PY_SSIZE_T_MAX")
     @support.bigmemtest(size=INT_MAX + 10, memuse=1, dry_run=False)
     def test_large_read(self, size):
-        self.addCleanup(support.unlink, support.TESTFN)
-        create_file(support.TESTFN, b'test')
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        create_file(filesystem_helper.TESTFN, b'test')
 
         # Issue #21932: Make sure that os.read() does not raise an
         # OverflowError for size larger than INT_MAX
-        with open(support.TESTFN, "rb") as fp:
+        with open(filesystem_helper.TESTFN, "rb") as fp:
             data = os.read(fp.fileno(), size)
 
         # The test does not try to read more than 2 GiB at once because the
@@ -222,13 +223,13 @@ class FileTests(unittest.TestCase):
 
     def test_write(self):
         # os.write() accepts bytes- and buffer-like objects but not strings
-        fd = os.open(support.TESTFN, os.O_CREAT | os.O_WRONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_CREAT | os.O_WRONLY)
         self.assertRaises(TypeError, os.write, fd, "beans")
         os.write(fd, b"bacon\n")
         os.write(fd, bytearray(b"eggs\n"))
         os.write(fd, memoryview(b"spam\n"))
         os.close(fd)
-        with open(support.TESTFN, "rb") as fobj:
+        with open(filesystem_helper.TESTFN, "rb") as fobj:
             self.assertEqual(fobj.read().splitlines(),
                 [b"bacon", b"eggs", b"spam"])
 
@@ -252,12 +253,12 @@ class FileTests(unittest.TestCase):
         self.write_windows_console(sys.executable, "-u", "-c", code)
 
     def fdopen_helper(self, *args):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         f = os.fdopen(fd, *args)
         f.close()
 
     def test_fdopen(self):
-        fd = os.open(support.TESTFN, os.O_CREAT|os.O_RDWR)
+        fd = os.open(filesystem_helper.TESTFN, os.O_CREAT|os.O_RDWR)
         os.close(fd)
 
         self.fdopen_helper()
@@ -265,15 +266,15 @@ class FileTests(unittest.TestCase):
         self.fdopen_helper('r', 100)
 
     def test_replace(self):
-        TESTFN2 = support.TESTFN + ".2"
-        self.addCleanup(support.unlink, support.TESTFN)
+        TESTFN2 = filesystem_helper.TESTFN + ".2"
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
         self.addCleanup(support.unlink, TESTFN2)
 
-        create_file(support.TESTFN, b"1")
+        create_file(filesystem_helper.TESTFN, b"1")
         create_file(TESTFN2, b"2")
 
-        os.replace(support.TESTFN, TESTFN2)
-        self.assertRaises(FileNotFoundError, os.stat, support.TESTFN)
+        os.replace(filesystem_helper.TESTFN, TESTFN2)
+        self.assertRaises(FileNotFoundError, os.stat, filesystem_helper.TESTFN)
         with open(TESTFN2, 'r') as f:
             self.assertEqual(f.read(), "1")
 
@@ -285,7 +286,7 @@ class FileTests(unittest.TestCase):
     def test_symlink_keywords(self):
         symlink = support.get_attribute(os, "symlink")
         try:
-            symlink(src='target', dst=support.TESTFN,
+            symlink(src='target', dst=filesystem_helper.TESTFN,
                 target_is_directory=False, dir_fd=None)
         except (NotImplementedError, OSError):
             pass  # No OS support or unprivileged user
@@ -297,13 +298,13 @@ class FileTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'copy_file_range'), 'test needs os.copy_file_range()')
     def test_copy_file_range(self):
-        TESTFN2 = support.TESTFN + ".3"
+        TESTFN2 = filesystem_helper.TESTFN + ".3"
         data = b'0123456789'
 
-        create_file(support.TESTFN, data)
-        self.addCleanup(support.unlink, support.TESTFN)
+        create_file(filesystem_helper.TESTFN, data)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
-        in_file = open(support.TESTFN, 'rb')
+        in_file = open(filesystem_helper.TESTFN, 'rb')
         self.addCleanup(in_file.close)
         in_fd = in_file.fileno()
 
@@ -331,16 +332,16 @@ class FileTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'copy_file_range'), 'test needs os.copy_file_range()')
     def test_copy_file_range_offset(self):
-        TESTFN4 = support.TESTFN + ".4"
+        TESTFN4 = filesystem_helper.TESTFN + ".4"
         data = b'0123456789'
         bytes_to_copy = 6
         in_skip = 3
         out_seek = 5
 
-        create_file(support.TESTFN, data)
-        self.addCleanup(support.unlink, support.TESTFN)
+        create_file(filesystem_helper.TESTFN, data)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
-        in_file = open(support.TESTFN, 'rb')
+        in_file = open(filesystem_helper.TESTFN, 'rb')
         self.addCleanup(in_file.close)
         in_fd = in_file.fileno()
 
@@ -377,7 +378,7 @@ class FileTests(unittest.TestCase):
 # Test attributes on return values from os.*stat* family.
 class StatAttributeTests(unittest.TestCase):
     def setUp(self):
-        self.fname = support.TESTFN
+        self.fname = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, self.fname)
         create_file(self.fname, b"ABC")
 
@@ -563,7 +564,7 @@ class StatAttributeTests(unittest.TestCase):
             0)
 
         # test directory st_file_attributes (FILE_ATTRIBUTE_DIRECTORY set)
-        dirname = support.TESTFN + "dir"
+        dirname = filesystem_helper.TESTFN + "dir"
         os.mkdir(dirname)
         self.addCleanup(os.rmdir, dirname)
 
@@ -605,7 +606,7 @@ class StatAttributeTests(unittest.TestCase):
 
 class UtimeTests(unittest.TestCase):
     def setUp(self):
-        self.dirname = support.TESTFN
+        self.dirname = filesystem_helper.TESTFN
         self.fname = os.path.join(self.dirname, "f1")
 
         self.addCleanup(support.rmtree, self.dirname)
@@ -1132,7 +1133,7 @@ class WalkTests(unittest.TestCase):
 
     def setUp(self):
         join = os.path.join
-        self.addCleanup(support.rmtree, support.TESTFN)
+        self.addCleanup(support.rmtree, filesystem_helper.TESTFN)
 
         # Build:
         #     TESTFN/
@@ -1151,7 +1152,7 @@ class WalkTests(unittest.TestCase):
         #           broken_link3
         #       TEST2/
         #         tmp4              a lone file
-        self.walk_path = join(support.TESTFN, "TEST1")
+        self.walk_path = join(filesystem_helper.TESTFN, "TEST1")
         self.sub1_path = join(self.walk_path, "SUB1")
         self.sub11_path = join(self.sub1_path, "SUB11")
         sub2_path = join(self.walk_path, "SUB2")
@@ -1161,8 +1162,8 @@ class WalkTests(unittest.TestCase):
         tmp3_path = join(sub2_path, "tmp3")
         tmp5_path = join(sub21_path, "tmp3")
         self.link_path = join(sub2_path, "link")
-        t2_path = join(support.TESTFN, "TEST2")
-        tmp4_path = join(support.TESTFN, "TEST2", "tmp4")
+        t2_path = join(filesystem_helper.TESTFN, "TEST2")
+        tmp4_path = join(filesystem_helper.TESTFN, "TEST2", "tmp4")
         broken_link_path = join(sub2_path, "broken_link")
         broken_link2_path = join(sub2_path, "broken_link2")
         broken_link3_path = join(sub2_path, "broken_link3")
@@ -1296,7 +1297,7 @@ class WalkTests(unittest.TestCase):
 
     def test_walk_many_open_files(self):
         depth = 30
-        base = os.path.join(support.TESTFN, 'deep')
+        base = os.path.join(filesystem_helper.TESTFN, 'deep')
         p = os.path.join(base, *(['d']*depth))
         os.makedirs(p)
 
@@ -1346,13 +1347,13 @@ class FwalkTests(WalkTests):
                 self.assertEqual(expected[root], (set(dirs), set(files)))
 
     def test_compare_to_walk(self):
-        kwargs = {'top': support.TESTFN}
+        kwargs = {'top': filesystem_helper.TESTFN}
         self._compare_to_walk(kwargs, kwargs)
 
     def test_dir_fd(self):
         try:
             fd = os.open(".", os.O_RDONLY)
-            walk_kwargs = {'top': support.TESTFN}
+            walk_kwargs = {'top': filesystem_helper.TESTFN}
             fwalk_kwargs = walk_kwargs.copy()
             fwalk_kwargs['dir_fd'] = fd
             self._compare_to_walk(walk_kwargs, fwalk_kwargs)
@@ -1362,7 +1363,7 @@ class FwalkTests(WalkTests):
     def test_yields_correct_dir_fd(self):
         # check returned file descriptors
         for topdown, follow_symlinks in itertools.product((True, False), repeat=2):
-            args = support.TESTFN, topdown, None
+            args = filesystem_helper.TESTFN, topdown, None
             for root, dirs, files, rootfd in self.fwalk(*args, follow_symlinks=follow_symlinks):
                 # check that the FD is valid
                 os.fstat(rootfd)
@@ -1378,7 +1379,7 @@ class FwalkTests(WalkTests):
         minfd = os.dup(1)
         os.close(minfd)
         for i in range(256):
-            for x in self.fwalk(support.TESTFN):
+            for x in self.fwalk(filesystem_helper.TESTFN):
                 pass
         newfd = os.dup(1)
         self.addCleanup(os.close, newfd)
@@ -1416,10 +1417,10 @@ class BytesFwalkTests(FwalkTests):
 
 class MakedirTests(unittest.TestCase):
     def setUp(self):
-        os.mkdir(support.TESTFN)
+        os.mkdir(filesystem_helper.TESTFN)
 
     def test_makedir(self):
-        base = support.TESTFN
+        base = filesystem_helper.TESTFN
         path = os.path.join(base, 'dir1', 'dir2', 'dir3')
         os.makedirs(path)             # Should work
         path = os.path.join(base, 'dir1', 'dir2', 'dir3', 'dir4')
@@ -1435,7 +1436,7 @@ class MakedirTests(unittest.TestCase):
 
     def test_mode(self):
         with support.temp_umask(0o002):
-            base = support.TESTFN
+            base = filesystem_helper.TESTFN
             parent = os.path.join(base, 'dir1')
             path = os.path.join(parent, 'dir2')
             os.makedirs(path, 0o555)
@@ -1446,7 +1447,7 @@ class MakedirTests(unittest.TestCase):
                 self.assertEqual(os.stat(parent).st_mode & 0o777, 0o775)
 
     def test_exist_ok_existing_directory(self):
-        path = os.path.join(support.TESTFN, 'dir1')
+        path = os.path.join(filesystem_helper.TESTFN, 'dir1')
         mode = 0o777
         old_mask = os.umask(0o022)
         os.makedirs(path, mode)
@@ -1460,18 +1461,18 @@ class MakedirTests(unittest.TestCase):
         os.makedirs(os.path.abspath('/'), exist_ok=True)
 
     def test_exist_ok_s_isgid_directory(self):
-        path = os.path.join(support.TESTFN, 'dir1')
+        path = os.path.join(filesystem_helper.TESTFN, 'dir1')
         S_ISGID = stat.S_ISGID
         mode = 0o777
         old_mask = os.umask(0o022)
         try:
             existing_testfn_mode = stat.S_IMODE(
-                    os.lstat(support.TESTFN).st_mode)
+                    os.lstat(filesystem_helper.TESTFN).st_mode)
             try:
-                os.chmod(support.TESTFN, existing_testfn_mode | S_ISGID)
+                os.chmod(filesystem_helper.TESTFN, existing_testfn_mode | S_ISGID)
             except PermissionError:
                 raise unittest.SkipTest('Cannot set S_ISGID for dir.')
-            if (os.lstat(support.TESTFN).st_mode & S_ISGID != S_ISGID):
+            if (os.lstat(filesystem_helper.TESTFN).st_mode & S_ISGID != S_ISGID):
                 raise unittest.SkipTest('No support for S_ISGID dir mode.')
             # The os should apply S_ISGID from the parent dir for us, but
             # this test need not depend on that behavior.  Be explicit.
@@ -1487,8 +1488,8 @@ class MakedirTests(unittest.TestCase):
             os.umask(old_mask)
 
     def test_exist_ok_existing_regular_file(self):
-        base = support.TESTFN
-        path = os.path.join(support.TESTFN, 'dir1')
+        base = filesystem_helper.TESTFN
+        path = os.path.join(filesystem_helper.TESTFN, 'dir1')
         with open(path, 'w') as f:
             f.write('abc')
         self.assertRaises(OSError, os.makedirs, path)
@@ -1497,12 +1498,12 @@ class MakedirTests(unittest.TestCase):
         os.remove(path)
 
     def tearDown(self):
-        path = os.path.join(support.TESTFN, 'dir1', 'dir2', 'dir3',
+        path = os.path.join(filesystem_helper.TESTFN, 'dir1', 'dir2', 'dir3',
                             'dir4', 'dir5', 'dir6')
         # If the tests failed, the bottom-most directory ('../dir6')
         # may not have been created, so we look for the outermost directory
         # that exists.
-        while not os.path.exists(path) and path != support.TESTFN:
+        while not os.path.exists(path) and path != filesystem_helper.TESTFN:
             path = os.path.dirname(path)
 
         os.removedirs(path)
@@ -1513,17 +1514,19 @@ class ChownFileTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        os.mkdir(support.TESTFN)
+        os.mkdir(filesystem_helper.TESTFN)
 
     def test_chown_uid_gid_arguments_must_be_index(self):
-        stat = os.stat(support.TESTFN)
+        stat = os.stat(filesystem_helper.TESTFN)
         uid = stat.st_uid
         gid = stat.st_gid
         for value in (-1.0, -1j, decimal.Decimal(-1), fractions.Fraction(-2, 2)):
-            self.assertRaises(TypeError, os.chown, support.TESTFN, value, gid)
-            self.assertRaises(TypeError, os.chown, support.TESTFN, uid, value)
-        self.assertIsNone(os.chown(support.TESTFN, uid, gid))
-        self.assertIsNone(os.chown(support.TESTFN, -1, -1))
+            self.assertRaises(TypeError, os.chown,
+                              filesystem_helper.TESTFN, value, gid)
+            self.assertRaises(TypeError, os.chown,
+                              filesystem_helper.TESTFN, uid, value)
+        self.assertIsNone(os.chown(filesystem_helper.TESTFN, uid, gid))
+        self.assertIsNone(os.chown(filesystem_helper.TESTFN, -1, -1))
 
     @unittest.skipUnless(hasattr(os, 'getgroups'), 'need os.getgroups')
     def test_chown_gid(self):
@@ -1532,61 +1535,61 @@ class ChownFileTests(unittest.TestCase):
             self.skipTest("test needs at least 2 groups")
 
         gid_1, gid_2 = groups[:2]
-        uid = os.stat(support.TESTFN).st_uid
+        uid = os.stat(filesystem_helper.TESTFN).st_uid
 
-        os.chown(support.TESTFN, uid, gid_1)
-        gid = os.stat(support.TESTFN).st_gid
+        os.chown(filesystem_helper.TESTFN, uid, gid_1)
+        gid = os.stat(filesystem_helper.TESTFN).st_gid
         self.assertEqual(gid, gid_1)
 
-        os.chown(support.TESTFN, uid, gid_2)
-        gid = os.stat(support.TESTFN).st_gid
+        os.chown(filesystem_helper.TESTFN, uid, gid_2)
+        gid = os.stat(filesystem_helper.TESTFN).st_gid
         self.assertEqual(gid, gid_2)
 
     @unittest.skipUnless(root_in_posix and len(all_users) > 1,
                          "test needs root privilege and more than one user")
     def test_chown_with_root(self):
         uid_1, uid_2 = all_users[:2]
-        gid = os.stat(support.TESTFN).st_gid
-        os.chown(support.TESTFN, uid_1, gid)
-        uid = os.stat(support.TESTFN).st_uid
+        gid = os.stat(filesystem_helper.TESTFN).st_gid
+        os.chown(filesystem_helper.TESTFN, uid_1, gid)
+        uid = os.stat(filesystem_helper.TESTFN).st_uid
         self.assertEqual(uid, uid_1)
-        os.chown(support.TESTFN, uid_2, gid)
-        uid = os.stat(support.TESTFN).st_uid
+        os.chown(filesystem_helper.TESTFN, uid_2, gid)
+        uid = os.stat(filesystem_helper.TESTFN).st_uid
         self.assertEqual(uid, uid_2)
 
     @unittest.skipUnless(not root_in_posix and len(all_users) > 1,
                          "test needs non-root account and more than one user")
     def test_chown_without_permission(self):
         uid_1, uid_2 = all_users[:2]
-        gid = os.stat(support.TESTFN).st_gid
+        gid = os.stat(filesystem_helper.TESTFN).st_gid
         with self.assertRaises(PermissionError):
-            os.chown(support.TESTFN, uid_1, gid)
-            os.chown(support.TESTFN, uid_2, gid)
+            os.chown(filesystem_helper.TESTFN, uid_1, gid)
+            os.chown(filesystem_helper.TESTFN, uid_2, gid)
 
     @classmethod
     def tearDownClass(cls):
-        os.rmdir(support.TESTFN)
+        os.rmdir(filesystem_helper.TESTFN)
 
 
 class RemoveDirsTests(unittest.TestCase):
     def setUp(self):
-        os.makedirs(support.TESTFN)
+        os.makedirs(filesystem_helper.TESTFN)
 
     def tearDown(self):
-        support.rmtree(support.TESTFN)
+        support.rmtree(filesystem_helper.TESTFN)
 
     def test_remove_all(self):
-        dira = os.path.join(support.TESTFN, 'dira')
+        dira = os.path.join(filesystem_helper.TESTFN, 'dira')
         os.mkdir(dira)
         dirb = os.path.join(dira, 'dirb')
         os.mkdir(dirb)
         os.removedirs(dirb)
         self.assertFalse(os.path.exists(dirb))
         self.assertFalse(os.path.exists(dira))
-        self.assertFalse(os.path.exists(support.TESTFN))
+        self.assertFalse(os.path.exists(filesystem_helper.TESTFN))
 
     def test_remove_partial(self):
-        dira = os.path.join(support.TESTFN, 'dira')
+        dira = os.path.join(filesystem_helper.TESTFN, 'dira')
         os.mkdir(dira)
         dirb = os.path.join(dira, 'dirb')
         os.mkdir(dirb)
@@ -1594,10 +1597,10 @@ class RemoveDirsTests(unittest.TestCase):
         os.removedirs(dirb)
         self.assertFalse(os.path.exists(dirb))
         self.assertTrue(os.path.exists(dira))
-        self.assertTrue(os.path.exists(support.TESTFN))
+        self.assertTrue(os.path.exists(filesystem_helper.TESTFN))
 
     def test_remove_nothing(self):
-        dira = os.path.join(support.TESTFN, 'dira')
+        dira = os.path.join(filesystem_helper.TESTFN, 'dira')
         os.mkdir(dira)
         dirb = os.path.join(dira, 'dirb')
         os.mkdir(dirb)
@@ -1606,7 +1609,7 @@ class RemoveDirsTests(unittest.TestCase):
             os.removedirs(dirb)
         self.assertTrue(os.path.exists(dirb))
         self.assertTrue(os.path.exists(dira))
-        self.assertTrue(os.path.exists(support.TESTFN))
+        self.assertTrue(os.path.exists(filesystem_helper.TESTFN))
 
 
 class DevNullTests(unittest.TestCase):
@@ -1744,8 +1747,8 @@ class URandomFDTests(unittest.TestCase):
     def test_urandom_fd_reopened(self):
         # Issue #21207: urandom() should detect its fd to /dev/urandom
         # changed to something else, and reopen it.
-        self.addCleanup(support.unlink, support.TESTFN)
-        create_file(support.TESTFN, b"x" * 256)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        create_file(filesystem_helper.TESTFN, b"x" * 256)
 
         code = """if 1:
             import os
@@ -1771,7 +1774,7 @@ class URandomFDTests(unittest.TestCase):
                     os.dup2(new_fd, fd)
                 sys.stdout.buffer.write(os.urandom(4))
                 sys.stdout.buffer.write(os.urandom(4))
-            """.format(TESTFN=support.TESTFN)
+            """.format(TESTFN=filesystem_helper.TESTFN)
         rc, out, err = assert_python_ok('-Sc', code)
         self.assertEqual(len(out), 8)
         self.assertNotEqual(out[0:4], out[4:8])
@@ -1923,36 +1926,37 @@ class ExecTests(unittest.TestCase):
 class Win32ErrorTests(unittest.TestCase):
     def setUp(self):
         try:
-            os.stat(support.TESTFN)
+            os.stat(filesystem_helper.TESTFN)
         except FileNotFoundError:
             exists = False
         except OSError as exc:
             exists = True
             self.fail("file %s must not exist; os.stat failed with %s"
-                      % (support.TESTFN, exc))
+                      % (filesystem_helper.TESTFN, exc))
         else:
-            self.fail("file %s must not exist" % support.TESTFN)
+            self.fail("file %s must not exist" % filesystem_helper.TESTFN)
 
     def test_rename(self):
-        self.assertRaises(OSError, os.rename, support.TESTFN, support.TESTFN+".bak")
+        self.assertRaises(OSError, os.rename,
+                          filesystem_helper.TESTFN, filesystem_helper.TESTFN+".bak")
 
     def test_remove(self):
-        self.assertRaises(OSError, os.remove, support.TESTFN)
+        self.assertRaises(OSError, os.remove, filesystem_helper.TESTFN)
 
     def test_chdir(self):
-        self.assertRaises(OSError, os.chdir, support.TESTFN)
+        self.assertRaises(OSError, os.chdir, filesystem_helper.TESTFN)
 
     def test_mkdir(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
-        with open(support.TESTFN, "x") as f:
-            self.assertRaises(OSError, os.mkdir, support.TESTFN)
+        with open(filesystem_helper.TESTFN, "x") as f:
+            self.assertRaises(OSError, os.mkdir, filesystem_helper.TESTFN)
 
     def test_utime(self):
-        self.assertRaises(OSError, os.utime, support.TESTFN, None)
+        self.assertRaises(OSError, os.utime, filesystem_helper.TESTFN, None)
 
     def test_chmod(self):
-        self.assertRaises(OSError, os.chmod, support.TESTFN, 0)
+        self.assertRaises(OSError, os.chmod, filesystem_helper.TESTFN, 0)
 
 
 class TestInvalidFD(unittest.TestCase):
@@ -2057,8 +2061,8 @@ class TestInvalidFD(unittest.TestCase):
 
 class LinkTests(unittest.TestCase):
     def setUp(self):
-        self.file1 = support.TESTFN
-        self.file2 = os.path.join(support.TESTFN + "2")
+        self.file1 = filesystem_helper.TESTFN
+        self.file2 = os.path.join(filesystem_helper.TESTFN + "2")
 
     def tearDown(self):
         for file in (self.file1, self.file2):
@@ -2168,7 +2172,7 @@ class Pep383Tests(unittest.TestCase):
         elif support.TESTFN_NONASCII:
             self.dir = support.TESTFN_NONASCII
         else:
-            self.dir = support.TESTFN
+            self.dir = filesystem_helper.TESTFN
         self.bdir = os.fsencode(self.dir)
 
         bytesfn = []
@@ -2356,9 +2360,9 @@ class Win32ListdirTests(unittest.TestCase):
         self.created_paths = []
         for i in range(2):
             dir_name = 'SUB%d' % i
-            dir_path = os.path.join(support.TESTFN, dir_name)
+            dir_path = os.path.join(filesystem_helper.TESTFN, dir_name)
             file_name = 'FILE%d' % i
-            file_path = os.path.join(support.TESTFN, file_name)
+            file_path = os.path.join(filesystem_helper.TESTFN, file_name)
             os.makedirs(dir_path)
             with open(file_path, 'w') as f:
                 f.write("I'm %s and proud of it. Blame test_os.\n" % file_path)
@@ -2366,31 +2370,32 @@ class Win32ListdirTests(unittest.TestCase):
         self.created_paths.sort()
 
     def tearDown(self):
-        shutil.rmtree(support.TESTFN)
+        shutil.rmtree(filesystem_helper.TESTFN)
 
     def test_listdir_no_extended_path(self):
         """Test when the path is not an "extended" path."""
         # unicode
         self.assertEqual(
-                sorted(os.listdir(support.TESTFN)),
+                sorted(os.listdir(filesystem_helper.TESTFN)),
                 self.created_paths)
 
         # bytes
         self.assertEqual(
-                sorted(os.listdir(os.fsencode(support.TESTFN))),
+                sorted(os.listdir(os.fsencode(filesystem_helper.TESTFN))),
                 [os.fsencode(path) for path in self.created_paths])
 
     def test_listdir_extended_path(self):
         """Test when the path starts with '\\\\?\\'."""
         # See: http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
         # unicode
-        path = '\\\\?\\' + os.path.abspath(support.TESTFN)
+        path = '\\\\?\\' + os.path.abspath(filesystem_helper.TESTFN)
         self.assertEqual(
                 sorted(os.listdir(path)),
                 self.created_paths)
 
         # bytes
-        path = b'\\\\?\\' + os.fsencode(os.path.abspath(support.TESTFN))
+        path = b'\\\\?\\' + os.fsencode(os.path.abspath(
+                                        filesystem_helper.TESTFN))
         self.assertEqual(
                 sorted(os.listdir(path)),
                 [os.fsencode(path) for path in self.created_paths])
@@ -2529,7 +2534,7 @@ class Win32SymlinkTests(unittest.TestCase):
         self.assertNotEqual(os.lstat(bytes_link), os.stat(bytes_link))
 
     def test_12084(self):
-        level1 = os.path.abspath(support.TESTFN)
+        level1 = os.path.abspath(filesystem_helper.TESTFN)
         level2 = os.path.join(level1, "level2")
         level3 = os.path.join(level2, "level3")
         self.addCleanup(support.rmtree, level1)
@@ -2857,7 +2862,7 @@ class SpawnTests(unittest.TestCase):
     def create_args(self, *, with_env=False, use_bytes=False):
         self.exitcode = 17
 
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
 
         if not with_env:
@@ -3009,7 +3014,7 @@ class SpawnTests(unittest.TestCase):
             self.assertEqual(exitcode, 127)
 
         # equal character in the environment variable value
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
         with open(filename, "w") as fp:
             fp.write('import sys, os\n'
@@ -3165,12 +3170,12 @@ class TestSendfile(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.key = threading_helper.threading_setup()
-        create_file(support.TESTFN, cls.DATA)
+        create_file(filesystem_helper.TESTFN, cls.DATA)
 
     @classmethod
     def tearDownClass(cls):
         threading_helper.threading_cleanup(*cls.key)
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def setUp(self):
         self.server = SendfileTestServer((socket_helper.HOST, 0))
@@ -3181,7 +3186,7 @@ class TestSendfile(unittest.TestCase):
         # synchronize by waiting for "220 ready" response
         self.client.recv(1024)
         self.sockno = self.client.fileno()
-        self.file = open(support.TESTFN, 'rb')
+        self.file = open(filesystem_helper.TESTFN, 'rb')
         self.fileno = self.file.fileno()
 
     def tearDown(self):
@@ -3313,7 +3318,7 @@ class TestSendfile(unittest.TestCase):
 
     @requires_headers_trailers
     def test_trailers(self):
-        TESTFN2 = support.TESTFN + "2"
+        TESTFN2 = filesystem_helper.TESTFN + "2"
         file_data = b"abcdef"
 
         self.addCleanup(support.unlink, TESTFN2)
@@ -3362,13 +3367,13 @@ def supports_extended_attributes():
         return False
 
     try:
-        with open(support.TESTFN, "xb", 0) as fp:
+        with open(filesystem_helper.TESTFN, "xb", 0) as fp:
             try:
                 os.setxattr(fp.fileno(), b"user.test", b"")
             except OSError:
                 return False
     finally:
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     return True
 
@@ -3380,7 +3385,7 @@ def supports_extended_attributes():
 class ExtendedAttributeTests(unittest.TestCase):
 
     def _check_xattrs_str(self, s, getxattr, setxattr, removexattr, listxattr, **kwargs):
-        fn = support.TESTFN
+        fn = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, fn)
         create_file(fn)
 
@@ -3429,10 +3434,10 @@ class ExtendedAttributeTests(unittest.TestCase):
 
     def _check_xattrs(self, *args, **kwargs):
         self._check_xattrs_str(str, *args, **kwargs)
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
         self._check_xattrs_str(os.fsencode, *args, **kwargs)
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def test_simple(self):
         self._check_xattrs(os.getxattr, os.setxattr, os.removexattr,
@@ -3534,13 +3539,13 @@ class OSErrorTests(unittest.TestCase):
         if support.TESTFN_UNENCODABLE is not None:
             decoded = support.TESTFN_UNENCODABLE
         else:
-            decoded = support.TESTFN
+            decoded = filesystem_helper.TESTFN
         self.unicode_filenames.append(decoded)
         self.unicode_filenames.append(Str(decoded))
         if support.TESTFN_UNDECODABLE is not None:
             encoded = support.TESTFN_UNDECODABLE
         else:
-            encoded = os.fsencode(support.TESTFN)
+            encoded = os.fsencode(filesystem_helper.TESTFN)
         self.bytes_filenames.append(encoded)
         self.bytes_filenames.append(bytearray(encoded))
         self.bytes_filenames.append(memoryview(encoded))
@@ -3734,14 +3739,14 @@ class PathTConverterTests(unittest.TestCase):
     ]
 
     def test_path_t_converter(self):
-        str_filename = support.TESTFN
+        str_filename = filesystem_helper.TESTFN
         if os.name == 'nt':
             bytes_fspath = bytes_filename = None
         else:
-            bytes_filename = support.TESTFN.encode('ascii')
+            bytes_filename = filesystem_helper.TESTFN.encode('ascii')
             bytes_fspath = FakePath(bytes_filename)
         fd = os.open(FakePath(str_filename), os.O_WRONLY|os.O_CREAT)
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
         self.addCleanup(os.close, fd)
 
         int_fspath = FakePath(fd)
@@ -3811,7 +3816,7 @@ class ExportsTests(unittest.TestCase):
 
 class TestDirEntry(unittest.TestCase):
     def setUp(self):
-        self.path = os.path.realpath(support.TESTFN)
+        self.path = os.path.realpath(filesystem_helper.TESTFN)
         self.addCleanup(support.rmtree, self.path)
         os.mkdir(self.path)
 
@@ -3831,7 +3836,7 @@ class TestScandir(unittest.TestCase):
     check_no_resource_warning = support.check_no_resource_warning
 
     def setUp(self):
-        self.path = os.path.realpath(support.TESTFN)
+        self.path = os.path.realpath(filesystem_helper.TESTFN)
         self.bytes_path = os.fsencode(self.path)
         self.addCleanup(support.rmtree, self.path)
         os.mkdir(self.path)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -12,7 +12,8 @@ import unittest
 from unittest import mock
 
 from test import support
-from test.support import TESTFN, FakePath
+from test.support import FakePath
+from test.support.filesystem_helper import TESTFN
 
 try:
     import grp, pwd

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -12,6 +12,7 @@ import textwrap
 from contextlib import ExitStack
 from io import StringIO
 from test import support
+from test.support import filesystem_helper
 # This little helper class is essential for testing pdb under doctest.
 from test.test_doctest import _FakeInput
 from unittest.mock import patch
@@ -1187,7 +1188,7 @@ def test_pdb_issue_20766():
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def _run_pdb(self, pdb_args, commands):
         self.addCleanup(support.rmtree, '__pycache__')
@@ -1228,13 +1229,13 @@ class PdbTestCase(unittest.TestCase):
     def _assert_find_function(self, file_content, func_name, expected):
         file_content = textwrap.dedent(file_content)
 
-        with open(support.TESTFN, 'w') as f:
+        with open(filesystem_helper.TESTFN, 'w') as f:
             f.write(file_content)
 
         expected = None if not expected else (
-            expected[0], support.TESTFN, expected[1])
+            expected[0], filesystem_helper.TESTFN, expected[1])
         self.assertEqual(
-            expected, pdb.find_function(func_name, support.TESTFN))
+            expected, pdb.find_function(func_name, filesystem_helper.TESTFN))
 
     def test_find_function_empty_file(self):
         self._assert_find_function('', 'foo', None)
@@ -1257,9 +1258,9 @@ class PdbTestCase(unittest.TestCase):
 
     def test_issue7964(self):
         # open the file as binary so we can force \r\n newline
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             f.write(b'print("testing my pdb")\r\n')
-        cmd = [sys.executable, '-m', 'pdb', support.TESTFN]
+        cmd = [sys.executable, '-m', 'pdb', filesystem_helper.TESTFN]
         proc = subprocess.Popen(cmd,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
@@ -1310,7 +1311,7 @@ class PdbTestCase(unittest.TestCase):
         # Invoking "continue" on a non-main thread triggered an exception
         # inside signal.signal.
 
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             f.write(textwrap.dedent("""
                 import threading
                 import pdb
@@ -1322,7 +1323,7 @@ class PdbTestCase(unittest.TestCase):
 
                 t = threading.Thread(target=start_pdb)
                 t.start()""").encode('ascii'))
-        cmd = [sys.executable, '-u', support.TESTFN]
+        cmd = [sys.executable, '-u', filesystem_helper.TESTFN]
         proc = subprocess.Popen(cmd,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
@@ -1335,7 +1336,7 @@ class PdbTestCase(unittest.TestCase):
 
     def test_issue36250(self):
 
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             f.write(textwrap.dedent("""
                 import threading
                 import pdb
@@ -1351,7 +1352,7 @@ class PdbTestCase(unittest.TestCase):
                 pdb.Pdb(readrc=False).set_trace()
                 evt.set()
                 t.join()""").encode('ascii'))
-        cmd = [sys.executable, '-u', support.TESTFN]
+        cmd = [sys.executable, '-u', filesystem_helper.TESTFN]
         proc = subprocess.Popen(cmd,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,

--- a/Lib/test/test_pipes.py
+++ b/Lib/test/test_pipes.py
@@ -4,6 +4,7 @@ import string
 import unittest
 import shutil
 from test.support import TESTFN, run_unittest, unlink, reap_children
+from test.support.filesystem_helper import TESTFN
 
 if os.name != 'posix':
     raise unittest.SkipTest('pipes module only works on posix')

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 from test import support
+from test.support import filesystem_helper
 
 
 class PlatformTest(unittest.TestCase):
@@ -281,7 +282,7 @@ class PlatformTest(unittest.TestCase):
             executable = sys.executable
         platform.libc_ver(executable)
 
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
 
         with mock.patch('os.confstr', create=True, return_value='mock 1.0'):

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -10,6 +10,7 @@ import codecs
 import binascii
 import collections
 from test import support
+from test.support import filesystem_helper
 from io import BytesIO
 
 from plistlib import UID
@@ -110,7 +111,7 @@ class TestPlistlib(unittest.TestCase):
 
     def tearDown(self):
         try:
-            os.unlink(support.TESTFN)
+            os.unlink(filesystem_helper.TESTFN)
         except:
             pass
 
@@ -148,10 +149,10 @@ class TestPlistlib(unittest.TestCase):
 
     def test_io(self):
         pl = self._create()
-        with open(support.TESTFN, 'wb') as fp:
+        with open(filesystem_helper.TESTFN, 'wb') as fp:
             plistlib.dump(pl, fp)
 
-        with open(support.TESTFN, 'rb') as fp:
+        with open(filesystem_helper.TESTFN, 'rb') as fp:
             pl2 = plistlib.load(fp)
 
         self.assertEqual(dict(pl), dict(pl2))

--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -7,7 +7,8 @@ import select
 import threading
 import time
 import unittest
-from test.support import TESTFN, run_unittest, cpython_only
+from test.support import run_unittest, cpython_only
+from test.support.filesystem_helper import TESTFN
 from test.support import threading_helper
 
 try:

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1,6 +1,7 @@
 "Test posix functions"
 
 from test import support
+from test.support import filesystem_helper
 from test.support.script_helper import assert_python_ok
 
 # Skip these tests if there is no posix module.
@@ -20,7 +21,7 @@ import warnings
 import textwrap
 
 _DUMMY_SYMLINK = os.path.join(tempfile.gettempdir(),
-                              support.TESTFN + '-dummy-symlink')
+                              filesystem_helper.TESTFN + '-dummy-symlink')
 
 requires_32b = unittest.skipUnless(sys.maxsize < 2**32,
         'test is only meaningful on 32-bit builds')
@@ -42,9 +43,9 @@ class PosixTester(unittest.TestCase):
 
     def setUp(self):
         # create empty file
-        fp = open(support.TESTFN, 'w+')
+        fp = open(filesystem_helper.TESTFN, 'w+')
         fp.close()
-        self.teardown_files = [ support.TESTFN ]
+        self.teardown_files = [ filesystem_helper.TESTFN ]
         self._warnings_manager = support.check_warnings()
         self._warnings_manager.__enter__()
         warnings.filterwarnings('ignore', '.* potential security risk .*',
@@ -153,7 +154,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'fstatvfs'),
                          'test needs posix.fstatvfs()')
     def test_fstatvfs(self):
-        fp = open(support.TESTFN)
+        fp = open(filesystem_helper.TESTFN)
         try:
             self.assertTrue(posix.fstatvfs(fp.fileno()))
             self.assertTrue(posix.statvfs(fp.fileno()))
@@ -163,7 +164,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'ftruncate'),
                          'test needs posix.ftruncate()')
     def test_ftruncate(self):
-        fp = open(support.TESTFN, 'w+')
+        fp = open(filesystem_helper.TESTFN, 'w+')
         try:
             # we need to have some data to truncate
             fp.write('test')
@@ -174,10 +175,10 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'truncate'), "test needs posix.truncate()")
     def test_truncate(self):
-        with open(support.TESTFN, 'w') as fp:
+        with open(filesystem_helper.TESTFN, 'w') as fp:
             fp.write('test')
             fp.flush()
-        posix.truncate(support.TESTFN, 0)
+        posix.truncate(filesystem_helper.TESTFN, 0)
 
     @unittest.skipUnless(getattr(os, 'execve', None) in os.supports_fd, "test needs execve() to support the fd parameter")
     @unittest.skipUnless(hasattr(os, 'fork'), "test needs os.fork()")
@@ -268,7 +269,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'lockf'), "test needs posix.lockf()")
     def test_lockf(self):
-        fd = os.open(support.TESTFN, os.O_WRONLY | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY | os.O_CREAT)
         try:
             os.write(fd, b'test')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -280,7 +281,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'pread'), "test needs posix.pread()")
     def test_pread(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -292,7 +293,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'preadv'), "test needs posix.preadv()")
     def test_preadv(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test1tt2t3t5t6t6t8')
             buf = [bytearray(i) for i in [5, 3, 2]]
@@ -304,7 +305,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'preadv'), "test needs posix.preadv()")
     @unittest.skipUnless(hasattr(posix, 'RWF_HIPRI'), "test needs posix.RWF_HIPRI")
     def test_preadv_flags(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test1tt2t3t5t6t6t8')
             buf = [bytearray(i) for i in [5, 3, 2]]
@@ -326,7 +327,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'preadv'), "test needs posix.preadv()")
     @requires_32b
     def test_preadv_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             buf = [bytearray(2**16)] * 2**15
             with self.assertRaises(OSError) as cm:
@@ -338,7 +339,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'pwrite'), "test needs posix.pwrite()")
     def test_pwrite(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -349,7 +350,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'pwritev'), "test needs posix.pwritev()")
     def test_pwritev(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b"xx")
             os.lseek(fd, 0, os.SEEK_SET)
@@ -364,7 +365,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'pwritev'), "test needs posix.pwritev()")
     @unittest.skipUnless(hasattr(posix, 'os.RWF_SYNC'), "test needs os.RWF_SYNC")
     def test_pwritev_flags(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd,b"xx")
             os.lseek(fd, 0, os.SEEK_SET)
@@ -379,7 +380,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'pwritev'), "test needs posix.pwritev()")
     @requires_32b
     def test_pwritev_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             with self.assertRaises(OSError) as cm:
                 os.pwritev(fd, [b"x" * 2**16] * 2**15, 0)
@@ -390,7 +391,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'posix_fallocate'),
         "test needs posix.posix_fallocate()")
     def test_posix_fallocate(self):
-        fd = os.open(support.TESTFN, os.O_WRONLY | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_WRONLY | os.O_CREAT)
         try:
             posix.posix_fallocate(fd, 0, 10)
         except OSError as inst:
@@ -419,7 +420,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'posix_fadvise'),
         "test needs posix.posix_fadvise()")
     def test_posix_fadvise(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         try:
             posix.posix_fadvise(fd, 0, 0, posix.POSIX_FADV_WILLNEED)
         finally:
@@ -437,7 +438,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(os.utime in os.supports_fd, "test needs fd support in os.utime")
     def test_utime_with_fd(self):
         now = time.time()
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY)
         try:
             posix.utime(fd)
             posix.utime(fd, None)
@@ -458,17 +459,22 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(os.utime in os.supports_follow_symlinks, "test needs follow_symlinks support in os.utime")
     def test_utime_nofollow_symlinks(self):
         now = time.time()
-        posix.utime(support.TESTFN, None, follow_symlinks=False)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, None), follow_symlinks=False)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, None), follow_symlinks=False)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, now), follow_symlinks=False)
-        posix.utime(support.TESTFN, (int(now), int(now)), follow_symlinks=False)
-        posix.utime(support.TESTFN, (now, now), follow_symlinks=False)
-        posix.utime(support.TESTFN, follow_symlinks=False)
+        posix.utime(filesystem_helper.TESTFN, None, follow_symlinks=False)
+        self.assertRaises(TypeError, posix.utime, filesystem_helper.TESTFN,
+                          (None, None), follow_symlinks=False)
+        self.assertRaises(TypeError, posix.utime, filesystem_helper.TESTFN,
+                          (now, None), follow_symlinks=False)
+        self.assertRaises(TypeError, posix.utime, filesystem_helper.TESTFN,
+                          (None, now), follow_symlinks=False)
+        posix.utime(filesystem_helper.TESTFN, (int(now), int(now)),
+                    follow_symlinks=False)
+        posix.utime(filesystem_helper.TESTFN,
+                    (now, now), follow_symlinks=False)
+        posix.utime(filesystem_helper.TESTFN, follow_symlinks=False)
 
     @unittest.skipUnless(hasattr(posix, 'writev'), "test needs posix.writev()")
     def test_writev(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             n = os.writev(fd, (b'test1', b'tt2', b't3'))
             self.assertEqual(n, 10)
@@ -491,7 +497,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'writev'), "test needs posix.writev()")
     @requires_32b
     def test_writev_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             with self.assertRaises(OSError) as cm:
                 os.writev(fd, [b"x" * 2**16] * 2**15)
@@ -501,7 +507,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'readv'), "test needs posix.readv()")
     def test_readv(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test1tt2t3')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -524,7 +530,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'readv'), "test needs posix.readv()")
     @requires_32b
     def test_readv_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             buf = [bytearray(2**16)] * 2**15
             with self.assertRaises(OSError) as cm:
@@ -537,7 +543,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'dup'),
                          'test needs posix.dup()')
     def test_dup(self):
-        fp = open(support.TESTFN)
+        fp = open(filesystem_helper.TESTFN)
         try:
             fd = posix.dup(fp.fileno())
             self.assertIsInstance(fd, int)
@@ -554,8 +560,8 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'dup2'),
                          'test needs posix.dup2()')
     def test_dup2(self):
-        fp1 = open(support.TESTFN)
-        fp2 = open(support.TESTFN)
+        fp1 = open(filesystem_helper.TESTFN)
+        fp2 = open(filesystem_helper.TESTFN)
         try:
             posix.dup2(fp1.fileno(), fp2.fileno())
         finally:
@@ -565,47 +571,47 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'O_CLOEXEC'), "needs os.O_CLOEXEC")
     @support.requires_linux_version(2, 6, 23)
     def test_oscloexec(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY|os.O_CLOEXEC)
+        fd = os.open(filesystem_helper.TESTFN, os.O_RDONLY|os.O_CLOEXEC)
         self.addCleanup(os.close, fd)
         self.assertFalse(os.get_inheritable(fd))
 
     @unittest.skipUnless(hasattr(posix, 'O_EXLOCK'),
                          'test needs posix.O_EXLOCK')
     def test_osexlock(self):
-        fd = os.open(support.TESTFN,
+        fd = os.open(filesystem_helper.TESTFN,
                      os.O_WRONLY|os.O_EXLOCK|os.O_CREAT)
-        self.assertRaises(OSError, os.open, support.TESTFN,
+        self.assertRaises(OSError, os.open, filesystem_helper.TESTFN,
                           os.O_WRONLY|os.O_EXLOCK|os.O_NONBLOCK)
         os.close(fd)
 
         if hasattr(posix, "O_SHLOCK"):
-            fd = os.open(support.TESTFN,
+            fd = os.open(filesystem_helper.TESTFN,
                          os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
-            self.assertRaises(OSError, os.open, support.TESTFN,
+            self.assertRaises(OSError, os.open, filesystem_helper.TESTFN,
                               os.O_WRONLY|os.O_EXLOCK|os.O_NONBLOCK)
             os.close(fd)
 
     @unittest.skipUnless(hasattr(posix, 'O_SHLOCK'),
                          'test needs posix.O_SHLOCK')
     def test_osshlock(self):
-        fd1 = os.open(support.TESTFN,
+        fd1 = os.open(filesystem_helper.TESTFN,
                      os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
-        fd2 = os.open(support.TESTFN,
+        fd2 = os.open(filesystem_helper.TESTFN,
                       os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
         os.close(fd2)
         os.close(fd1)
 
         if hasattr(posix, "O_EXLOCK"):
-            fd = os.open(support.TESTFN,
+            fd = os.open(filesystem_helper.TESTFN,
                          os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
-            self.assertRaises(OSError, os.open, support.TESTFN,
+            self.assertRaises(OSError, os.open, filesystem_helper.TESTFN,
                               os.O_RDONLY|os.O_EXLOCK|os.O_NONBLOCK)
             os.close(fd)
 
     @unittest.skipUnless(hasattr(posix, 'fstat'),
                          'test needs posix.fstat()')
     def test_fstat(self):
-        fp = open(support.TESTFN)
+        fp = open(filesystem_helper.TESTFN)
         try:
             self.assertTrue(posix.fstat(fp.fileno()))
             self.assertTrue(posix.stat(fp.fileno()))
@@ -617,58 +623,60 @@ class PosixTester(unittest.TestCase):
             fp.close()
 
     def test_stat(self):
-        self.assertTrue(posix.stat(support.TESTFN))
-        self.assertTrue(posix.stat(os.fsencode(support.TESTFN)))
+        self.assertTrue(posix.stat(filesystem_helper.TESTFN))
+        self.assertTrue(posix.stat(os.fsencode(filesystem_helper.TESTFN)))
 
         self.assertWarnsRegex(DeprecationWarning,
                 'should be string, bytes, os.PathLike or integer, not',
-                posix.stat, bytearray(os.fsencode(support.TESTFN)))
+                posix.stat, bytearray(os.fsencode(filesystem_helper.TESTFN)))
         self.assertRaisesRegex(TypeError,
                 'should be string, bytes, os.PathLike or integer, not',
                 posix.stat, None)
         self.assertRaisesRegex(TypeError,
                 'should be string, bytes, os.PathLike or integer, not',
-                posix.stat, list(support.TESTFN))
+                posix.stat, list(filesystem_helper.TESTFN))
         self.assertRaisesRegex(TypeError,
                 'should be string, bytes, os.PathLike or integer, not',
-                posix.stat, list(os.fsencode(support.TESTFN)))
+                posix.stat, list(os.fsencode(filesystem_helper.TESTFN)))
 
     @unittest.skipUnless(hasattr(posix, 'mkfifo'), "don't have mkfifo()")
     def test_mkfifo(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         try:
-            posix.mkfifo(support.TESTFN, stat.S_IRUSR | stat.S_IWUSR)
+            posix.mkfifo(filesystem_helper.TESTFN, stat.S_IRUSR | stat.S_IWUSR)
         except PermissionError as e:
             self.skipTest('posix.mkfifo(): %s' % e)
-        self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+        self.assertTrue(stat.S_ISFIFO(
+            posix.stat(filesystem_helper.TESTFN).st_mode))
 
     @unittest.skipUnless(hasattr(posix, 'mknod') and hasattr(stat, 'S_IFIFO'),
                          "don't have mknod()/S_IFIFO")
     def test_mknod(self):
         # Test using mknod() to create a FIFO (the only use specified
         # by POSIX).
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         mode = stat.S_IFIFO | stat.S_IRUSR | stat.S_IWUSR
         try:
-            posix.mknod(support.TESTFN, mode, 0)
+            posix.mknod(filesystem_helper.TESTFN, mode, 0)
         except OSError as e:
             # Some old systems don't allow unprivileged users to use
             # mknod(), or only support creating device nodes.
             self.assertIn(e.errno, (errno.EPERM, errno.EINVAL, errno.EACCES))
         else:
-            self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+            self.assertTrue(stat.S_ISFIFO(
+                posix.stat(filesystem_helper.TESTFN).st_mode))
 
         # Keyword arguments are also supported
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         try:
-            posix.mknod(path=support.TESTFN, mode=mode, device=0,
+            posix.mknod(path=filesystem_helper.TESTFN, mode=mode, device=0,
                 dir_fd=None)
         except OSError as e:
             self.assertIn(e.errno, (errno.EPERM, errno.EINVAL, errno.EACCES))
 
     @unittest.skipUnless(hasattr(posix, 'makedev'), 'test needs posix.makedev()')
     def test_makedev(self):
-        st = posix.stat(support.TESTFN)
+        st = posix.stat(filesystem_helper.TESTFN)
         dev = st.st_dev
         self.assertIsInstance(dev, int)
         self.assertGreaterEqual(dev, 0)
@@ -757,19 +765,21 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'chown'), "test needs os.chown()")
     def test_chown(self):
         # raise an OSError if the file does not exist
-        os.unlink(support.TESTFN)
-        self.assertRaises(OSError, posix.chown, support.TESTFN, -1, -1)
+        os.unlink(filesystem_helper.TESTFN)
+        self.assertRaises(OSError, posix.chown,
+                          filesystem_helper.TESTFN, -1, -1)
 
         # re-create the file
-        support.create_empty_file(support.TESTFN)
-        self._test_all_chown_common(posix.chown, support.TESTFN, posix.stat)
+        support.create_empty_file(filesystem_helper.TESTFN)
+        self._test_all_chown_common(posix.chown,
+                                    filesystem_helper.TESTFN, posix.stat)
 
     @unittest.skipUnless(hasattr(posix, 'fchown'), "test needs os.fchown()")
     def test_fchown(self):
-        os.unlink(support.TESTFN)
+        os.unlink(filesystem_helper.TESTFN)
 
         # re-create the file
-        test_file = open(support.TESTFN, 'w')
+        test_file = open(filesystem_helper.TESTFN, 'w')
         try:
             fd = test_file.fileno()
             self._test_all_chown_common(posix.fchown, fd,
@@ -779,35 +789,36 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'lchown'), "test needs os.lchown()")
     def test_lchown(self):
-        os.unlink(support.TESTFN)
+        os.unlink(filesystem_helper.TESTFN)
         # create a symlink
-        os.symlink(_DUMMY_SYMLINK, support.TESTFN)
-        self._test_all_chown_common(posix.lchown, support.TESTFN,
+        os.symlink(_DUMMY_SYMLINK, filesystem_helper.TESTFN)
+        self._test_all_chown_common(posix.lchown, filesystem_helper.TESTFN,
                                     getattr(posix, 'lstat', None))
 
     @unittest.skipUnless(hasattr(posix, 'chdir'), 'test needs posix.chdir()')
     def test_chdir(self):
         posix.chdir(os.curdir)
-        self.assertRaises(OSError, posix.chdir, support.TESTFN)
+        self.assertRaises(OSError, posix.chdir, filesystem_helper.TESTFN)
 
     def test_listdir(self):
-        self.assertIn(support.TESTFN, posix.listdir(os.curdir))
+        self.assertIn(filesystem_helper.TESTFN, posix.listdir(os.curdir))
 
     def test_listdir_default(self):
         # When listdir is called without argument,
         # it's the same as listdir(os.curdir).
-        self.assertIn(support.TESTFN, posix.listdir())
+        self.assertIn(filesystem_helper.TESTFN, posix.listdir())
 
     def test_listdir_bytes(self):
         # When listdir is called with a bytes object,
         # the returned strings are of type bytes.
-        self.assertIn(os.fsencode(support.TESTFN), posix.listdir(b'.'))
+        self.assertIn(os.fsencode(filesystem_helper.TESTFN),
+                      posix.listdir(b'.'))
 
     def test_listdir_bytes_like(self):
         for cls in bytearray, memoryview:
             with self.assertWarns(DeprecationWarning):
                 names = posix.listdir(cls(b'.'))
-            self.assertIn(os.fsencode(support.TESTFN), names)
+            self.assertIn(os.fsencode(filesystem_helper.TESTFN), names)
             for name in names:
                 self.assertIs(type(name), bytes)
 
@@ -828,7 +839,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'access'), 'test needs posix.access()')
     def test_access(self):
-        self.assertTrue(posix.access(support.TESTFN, os.R_OK))
+        self.assertTrue(posix.access(filesystem_helper.TESTFN, os.R_OK))
 
     @unittest.skipUnless(hasattr(posix, 'umask'), 'test needs posix.umask()')
     def test_umask(self):
@@ -887,12 +898,15 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'utime'), 'test needs posix.utime()')
     def test_utime(self):
         now = time.time()
-        posix.utime(support.TESTFN, None)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, None))
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, None))
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, now))
-        posix.utime(support.TESTFN, (int(now), int(now)))
-        posix.utime(support.TESTFN, (now, now))
+        posix.utime(filesystem_helper.TESTFN, None)
+        self.assertRaises(TypeError, posix.utime,
+                          filesystem_helper.TESTFN, (None, None))
+        self.assertRaises(TypeError, posix.utime,
+                          filesystem_helper.TESTFN, (now, None))
+        self.assertRaises(TypeError, posix.utime,
+                          filesystem_helper.TESTFN, (None, now))
+        posix.utime(filesystem_helper.TESTFN, (int(now), int(now)))
+        posix.utime(filesystem_helper.TESTFN, (now, now))
 
     def _test_chflags_regular_file(self, chflags_func, target_file, **kwargs):
         st = os.stat(target_file)
@@ -920,20 +934,24 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'chflags'), 'test needs os.chflags()')
     def test_chflags(self):
-        self._test_chflags_regular_file(posix.chflags, support.TESTFN)
+        self._test_chflags_regular_file(posix.chflags,
+                                        filesystem_helper.TESTFN)
 
     @unittest.skipUnless(hasattr(posix, 'lchflags'), 'test needs os.lchflags()')
     def test_lchflags_regular_file(self):
-        self._test_chflags_regular_file(posix.lchflags, support.TESTFN)
-        self._test_chflags_regular_file(posix.chflags, support.TESTFN, follow_symlinks=False)
+        self._test_chflags_regular_file(posix.lchflags,
+                                        filesystem_helper.TESTFN)
+        self._test_chflags_regular_file(posix.chflags,
+                                        filesystem_helper.TESTFN,
+                                        follow_symlinks=False)
 
     @unittest.skipUnless(hasattr(posix, 'lchflags'), 'test needs os.lchflags()')
     def test_lchflags_symlink(self):
-        testfn_st = os.stat(support.TESTFN)
+        testfn_st = os.stat(filesystem_helper.TESTFN)
 
         self.assertTrue(hasattr(testfn_st, 'st_flags'))
 
-        os.symlink(support.TESTFN, _DUMMY_SYMLINK)
+        os.symlink(filesystem_helper.TESTFN, _DUMMY_SYMLINK)
         self.teardown_files.append(_DUMMY_SYMLINK)
         dummy_symlink_st = os.lstat(_DUMMY_SYMLINK)
 
@@ -951,7 +969,7 @@ class PosixTester(unittest.TestCase):
                 msg = 'chflag UF_IMMUTABLE not supported by underlying fs'
                 self.skipTest(msg)
             try:
-                new_testfn_st = os.stat(support.TESTFN)
+                new_testfn_st = os.stat(filesystem_helper.TESTFN)
                 new_dummy_symlink_st = os.lstat(_DUMMY_SYMLINK)
 
                 self.assertEqual(testfn_st.st_flags, new_testfn_st.st_flags)
@@ -987,7 +1005,7 @@ class PosixTester(unittest.TestCase):
     def test_getcwd_long_pathnames(self):
         dirname = 'getcwd-test-directory-0123456789abcdef-01234567890abcdef'
         curdir = os.getcwd()
-        base_path = os.path.abspath(support.TESTFN) + '.getcwd'
+        base_path = os.path.abspath(filesystem_helper.TESTFN) + '.getcwd'
 
         try:
             os.mkdir(base_path)
@@ -1061,53 +1079,56 @@ class PosixTester(unittest.TestCase):
     def test_access_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            self.assertTrue(posix.access(support.TESTFN, os.R_OK, dir_fd=f))
+            self.assertTrue(posix.access(filesystem_helper.TESTFN,
+                                         os.R_OK, dir_fd=f))
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.chmod in os.supports_dir_fd, "test needs dir_fd support in os.chmod()")
     def test_chmod_dir_fd(self):
-        os.chmod(support.TESTFN, stat.S_IRUSR)
+        os.chmod(filesystem_helper.TESTFN, stat.S_IRUSR)
 
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.chmod(support.TESTFN, stat.S_IRUSR | stat.S_IWUSR, dir_fd=f)
+            posix.chmod(filesystem_helper.TESTFN,
+                        stat.S_IRUSR | stat.S_IWUSR, dir_fd=f)
 
-            s = posix.stat(support.TESTFN)
+            s = posix.stat(filesystem_helper.TESTFN)
             self.assertEqual(s[0] & stat.S_IRWXU, stat.S_IRUSR | stat.S_IWUSR)
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.chown in os.supports_dir_fd, "test needs dir_fd support in os.chown()")
     def test_chown_dir_fd(self):
-        support.unlink(support.TESTFN)
-        support.create_empty_file(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
+        support.create_empty_file(filesystem_helper.TESTFN)
 
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.chown(support.TESTFN, os.getuid(), os.getgid(), dir_fd=f)
+            posix.chown(filesystem_helper.TESTFN,
+                        os.getuid(), os.getgid(), dir_fd=f)
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.stat in os.supports_dir_fd, "test needs dir_fd support in os.stat()")
     def test_stat_dir_fd(self):
-        support.unlink(support.TESTFN)
-        with open(support.TESTFN, 'w') as outfile:
+        support.unlink(filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, 'w') as outfile:
             outfile.write("testline\n")
 
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            s1 = posix.stat(support.TESTFN)
-            s2 = posix.stat(support.TESTFN, dir_fd=f)
+            s1 = posix.stat(filesystem_helper.TESTFN)
+            s2 = posix.stat(filesystem_helper.TESTFN, dir_fd=f)
             self.assertEqual(s1, s2)
-            s2 = posix.stat(support.TESTFN, dir_fd=None)
+            s2 = posix.stat(filesystem_helper.TESTFN, dir_fd=None)
             self.assertEqual(s1, s2)
             self.assertRaisesRegex(TypeError, 'should be integer or None, not',
-                    posix.stat, support.TESTFN, dir_fd=posix.getcwd())
+                    posix.stat, filesystem_helper.TESTFN, dir_fd=posix.getcwd())
             self.assertRaisesRegex(TypeError, 'should be integer or None, not',
-                    posix.stat, support.TESTFN, dir_fd=float(f))
+                    posix.stat, filesystem_helper.TESTFN, dir_fd=float(f))
             self.assertRaises(OverflowError,
-                    posix.stat, support.TESTFN, dir_fd=10**20)
+                    posix.stat, filesystem_helper.TESTFN, dir_fd=10**20)
         finally:
             posix.close(f)
 
@@ -1116,24 +1137,31 @@ class PosixTester(unittest.TestCase):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
             now = time.time()
-            posix.utime(support.TESTFN, None, dir_fd=f)
-            posix.utime(support.TESTFN, dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, now, dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, None), dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, None), dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, now), dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, "x"), dir_fd=f)
-            posix.utime(support.TESTFN, (int(now), int(now)), dir_fd=f)
-            posix.utime(support.TESTFN, (now, now), dir_fd=f)
-            posix.utime(support.TESTFN,
+            posix.utime(filesystem_helper.TESTFN, None, dir_fd=f)
+            posix.utime(filesystem_helper.TESTFN, dir_fd=f)
+            self.assertRaises(TypeError, posix.utime,
+                              filesystem_helper.TESTFN, now, dir_fd=f)
+            self.assertRaises(TypeError, posix.utime,
+                              filesystem_helper.TESTFN, (None, None), dir_fd=f)
+            self.assertRaises(TypeError, posix.utime,
+                              filesystem_helper.TESTFN, (now, None), dir_fd=f)
+            self.assertRaises(TypeError, posix.utime,
+                              filesystem_helper.TESTFN, (None, now), dir_fd=f)
+            self.assertRaises(TypeError, posix.utime,
+                              filesystem_helper.TESTFN, (now, "x"), dir_fd=f)
+            posix.utime(filesystem_helper.TESTFN,
+                        (int(now), int(now)), dir_fd=f)
+            posix.utime(filesystem_helper.TESTFN, (now, now), dir_fd=f)
+            posix.utime(filesystem_helper.TESTFN,
                     (int(now), int((now - int(now)) * 1e9)), dir_fd=f)
-            posix.utime(support.TESTFN, dir_fd=f,
+            posix.utime(filesystem_helper.TESTFN, dir_fd=f,
                             times=(int(now), int((now - int(now)) * 1e9)))
 
             # try dir_fd and follow_symlinks together
             if os.utime in os.supports_follow_symlinks:
                 try:
-                    posix.utime(support.TESTFN, follow_symlinks=False, dir_fd=f)
+                    posix.utime(filesystem_helper.TESTFN,
+                                follow_symlinks=False, dir_fd=f)
                 except ValueError:
                     # whoops!  using both together not supported on this platform.
                     pass
@@ -1145,53 +1173,56 @@ class PosixTester(unittest.TestCase):
     def test_link_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.link(support.TESTFN, support.TESTFN + 'link', src_dir_fd=f, dst_dir_fd=f)
+            posix.link(filesystem_helper.TESTFN,
+                       filesystem_helper.TESTFN + 'link',
+                       src_dir_fd=f, dst_dir_fd=f)
         except PermissionError as e:
             self.skipTest('posix.link(): %s' % e)
         else:
             # should have same inodes
-            self.assertEqual(posix.stat(support.TESTFN)[1],
-                posix.stat(support.TESTFN + 'link')[1])
+            self.assertEqual(posix.stat(filesystem_helper.TESTFN)[1],
+                posix.stat(filesystem_helper.TESTFN + 'link')[1])
         finally:
             posix.close(f)
-            support.unlink(support.TESTFN + 'link')
+            support.unlink(filesystem_helper.TESTFN + 'link')
 
     @unittest.skipUnless(os.mkdir in os.supports_dir_fd, "test needs dir_fd support in os.mkdir()")
     def test_mkdir_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.mkdir(support.TESTFN + 'dir', dir_fd=f)
-            posix.stat(support.TESTFN + 'dir') # should not raise exception
+            posix.mkdir(filesystem_helper.TESTFN + 'dir', dir_fd=f)
+            posix.stat(filesystem_helper.TESTFN + 'dir') # should not raise exception
         finally:
             posix.close(f)
-            support.rmtree(support.TESTFN + 'dir')
+            support.rmtree(filesystem_helper.TESTFN + 'dir')
 
     @unittest.skipUnless((os.mknod in os.supports_dir_fd) and hasattr(stat, 'S_IFIFO'),
                          "test requires both stat.S_IFIFO and dir_fd support for os.mknod()")
     def test_mknod_dir_fd(self):
         # Test using mknodat() to create a FIFO (the only use specified
         # by POSIX).
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         mode = stat.S_IFIFO | stat.S_IRUSR | stat.S_IWUSR
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.mknod(support.TESTFN, mode, 0, dir_fd=f)
+            posix.mknod(filesystem_helper.TESTFN, mode, 0, dir_fd=f)
         except OSError as e:
             # Some old systems don't allow unprivileged users to use
             # mknod(), or only support creating device nodes.
             self.assertIn(e.errno, (errno.EPERM, errno.EINVAL, errno.EACCES))
         else:
-            self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+            self.assertTrue(stat.S_ISFIFO(
+                posix.stat(filesystem_helper.TESTFN).st_mode))
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.open in os.supports_dir_fd, "test needs dir_fd support in os.open()")
     def test_open_dir_fd(self):
-        support.unlink(support.TESTFN)
-        with open(support.TESTFN, 'w') as outfile:
+        support.unlink(filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, 'w') as outfile:
             outfile.write("testline\n")
         a = posix.open(posix.getcwd(), posix.O_RDONLY)
-        b = posix.open(support.TESTFN, posix.O_RDONLY, dir_fd=a)
+        b = posix.open(filesystem_helper.TESTFN, posix.O_RDONLY, dir_fd=a)
         try:
             res = posix.read(b, 9).decode(encoding="utf-8")
             self.assertEqual("testline\n", res)
@@ -1201,27 +1232,29 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(os.readlink in os.supports_dir_fd, "test needs dir_fd support in os.readlink()")
     def test_readlink_dir_fd(self):
-        os.symlink(support.TESTFN, support.TESTFN + 'link')
+        os.symlink(filesystem_helper.TESTFN, filesystem_helper.TESTFN + 'link')
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            self.assertEqual(posix.readlink(support.TESTFN + 'link'),
-                posix.readlink(support.TESTFN + 'link', dir_fd=f))
+            self.assertEqual(posix.readlink(filesystem_helper.TESTFN + 'link'),
+                posix.readlink(filesystem_helper.TESTFN + 'link', dir_fd=f))
         finally:
-            support.unlink(support.TESTFN + 'link')
+            support.unlink(filesystem_helper.TESTFN + 'link')
             posix.close(f)
 
     @unittest.skipUnless(os.rename in os.supports_dir_fd, "test needs dir_fd support in os.rename()")
     def test_rename_dir_fd(self):
-        support.unlink(support.TESTFN)
-        support.create_empty_file(support.TESTFN + 'ren')
+        support.unlink(filesystem_helper.TESTFN)
+        support.create_empty_file(filesystem_helper.TESTFN + 'ren')
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.rename(support.TESTFN + 'ren', support.TESTFN, src_dir_fd=f, dst_dir_fd=f)
+            posix.rename(filesystem_helper.TESTFN + 'ren',
+                         filesystem_helper.TESTFN, src_dir_fd=f, dst_dir_fd=f)
         except:
-            posix.rename(support.TESTFN + 'ren', support.TESTFN)
+            posix.rename(filesystem_helper.TESTFN + 'ren',
+                         filesystem_helper.TESTFN)
             raise
         else:
-            posix.stat(support.TESTFN) # should not raise exception
+            posix.stat(filesystem_helper.TESTFN) # should not raise exception
         finally:
             posix.close(f)
 
@@ -1239,38 +1272,42 @@ class PosixTester(unittest.TestCase):
     def test_symlink_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.symlink(support.TESTFN, support.TESTFN + 'link', dir_fd=f)
-            self.assertEqual(posix.readlink(support.TESTFN + 'link'), support.TESTFN)
+            posix.symlink(filesystem_helper.TESTFN,
+                          filesystem_helper.TESTFN + 'link', dir_fd=f)
+            self.assertEqual(posix.readlink(
+                filesystem_helper.TESTFN + 'link'), filesystem_helper.TESTFN)
         finally:
             posix.close(f)
-            support.unlink(support.TESTFN + 'link')
+            support.unlink(filesystem_helper.TESTFN + 'link')
 
     @unittest.skipUnless(os.unlink in os.supports_dir_fd, "test needs dir_fd support in os.unlink()")
     def test_unlink_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
-        support.create_empty_file(support.TESTFN + 'del')
-        posix.stat(support.TESTFN + 'del') # should not raise exception
+        support.create_empty_file(filesystem_helper.TESTFN + 'del')
+        posix.stat(filesystem_helper.TESTFN + 'del') # should not raise exception
         try:
-            posix.unlink(support.TESTFN + 'del', dir_fd=f)
+            posix.unlink(filesystem_helper.TESTFN + 'del', dir_fd=f)
         except:
-            support.unlink(support.TESTFN + 'del')
+            support.unlink(filesystem_helper.TESTFN + 'del')
             raise
         else:
-            self.assertRaises(OSError, posix.stat, support.TESTFN + 'link')
+            self.assertRaises(OSError, posix.stat,
+                              filesystem_helper.TESTFN + 'link')
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.mkfifo in os.supports_dir_fd, "test needs dir_fd support in os.mkfifo()")
     def test_mkfifo_dir_fd(self):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
             try:
-                posix.mkfifo(support.TESTFN,
+                posix.mkfifo(filesystem_helper.TESTFN,
                              stat.S_IRUSR | stat.S_IWUSR, dir_fd=f)
             except PermissionError as e:
                 self.skipTest('posix.mkfifo(): %s' % e)
-            self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+            self.assertTrue(stat.S_ISFIFO(
+                posix.stat(filesystem_helper.TESTFN).st_mode))
         finally:
             posix.close(f)
 
@@ -1397,7 +1434,7 @@ class PosixTester(unittest.TestCase):
         # behaviour:
         # os.SEEK_DATA = current position
         # os.SEEK_HOLE = end of file position
-        with open(support.TESTFN, 'r+b') as fp:
+        with open(filesystem_helper.TESTFN, 'r+b') as fp:
             fp.write(b"hello")
             fp.flush()
             size = fp.tell()
@@ -1424,7 +1461,7 @@ class PosixTester(unittest.TestCase):
             if function is None:
                 continue
 
-            for dst in ("noodly2", support.TESTFN):
+            for dst in ("noodly2", filesystem_helper.TESTFN):
                 try:
                     function('doesnotexistfilename', dst)
                 except OSError as e:
@@ -1434,7 +1471,7 @@ class PosixTester(unittest.TestCase):
                 self.fail("No valid path_error2() test for os." + name)
 
     def test_path_with_null_character(self):
-        fn = support.TESTFN
+        fn = filesystem_helper.TESTFN
         fn_with_NUL = fn + '\0'
         self.addCleanup(support.unlink, fn)
         support.unlink(fn)
@@ -1452,7 +1489,7 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(ValueError, os.stat, fn_with_NUL)
 
     def test_path_with_null_byte(self):
-        fn = os.fsencode(support.TESTFN)
+        fn = os.fsencode(filesystem_helper.TESTFN)
         fn_with_NUL = fn + b'\0'
         self.addCleanup(support.unlink, fn)
         support.unlink(fn)
@@ -1530,7 +1567,7 @@ class _PosixSpawnMixin:
         return (sys.executable, '-I', '-S', *args)
 
     def test_returns_pid(self):
-        pidfile = support.TESTFN
+        pidfile = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, pidfile)
         script = f"""if 1:
             import os
@@ -1559,7 +1596,7 @@ class _PosixSpawnMixin:
             self.assertNotEqual(status, 0)
 
     def test_specify_environment(self):
-        envfile = support.TESTFN
+        envfile = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, envfile)
         script = f"""if 1:
             import os
@@ -1806,7 +1843,7 @@ class _PosixSpawnMixin:
                                            os.O_RDONLY, 0)])
 
     def test_open_file(self):
-        outfile = support.TESTFN
+        outfile = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, outfile)
         script = """if 1:
             import sys
@@ -1826,7 +1863,7 @@ class _PosixSpawnMixin:
             self.assertEqual(f.read(), 'hello')
 
     def test_close_file(self):
-        closefile = support.TESTFN
+        closefile = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, closefile)
         script = f"""if 1:
             import os
@@ -1845,7 +1882,7 @@ class _PosixSpawnMixin:
             self.assertEqual(f.read(), 'is closed %d' % errno.EBADF)
 
     def test_dup2(self):
-        dupfile = support.TESTFN
+        dupfile = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, dupfile)
         script = """if 1:
             import sys

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -4,6 +4,7 @@ import unittest
 from posixpath import realpath, abspath, dirname, basename
 from test import support, test_genericpath
 from test.support import FakePath
+from test.support import filesystem_helper
 from unittest import mock
 
 try:
@@ -15,7 +16,7 @@ except ImportError:
 # An absolute path to a temporary filename for testing. We can't rely on TESTFN
 # being an absolute path, so we need this.
 
-ABSTFN = abspath(support.TESTFN)
+ABSTFN = abspath(filesystem_helper.TESTFN)
 
 def skip_if_ABSTFN_contains_backslash(test):
     """
@@ -40,8 +41,8 @@ class PosixPathTest(unittest.TestCase):
 
     def tearDown(self):
         for suffix in ["", "1", "2"]:
-            support.unlink(support.TESTFN + suffix)
-            safe_rmdir(support.TESTFN + suffix)
+            support.unlink(filesystem_helper.TESTFN + suffix)
+            safe_rmdir(filesystem_helper.TESTFN + suffix)
 
     def test_join(self):
         self.assertEqual(posixpath.join("/foo", "bar", "/bar", "baz"),
@@ -152,25 +153,34 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(posixpath.dirname(b"//foo//bar"), b"//foo")
 
     def test_islink(self):
-        self.assertIs(posixpath.islink(support.TESTFN + "1"), False)
-        self.assertIs(posixpath.lexists(support.TESTFN + "2"), False)
+        self.assertIs(posixpath.islink(filesystem_helper.TESTFN + "1"), False)
+        self.assertIs(posixpath.lexists(filesystem_helper.TESTFN + "2"), False)
 
-        with open(support.TESTFN + "1", "wb") as f:
+        with open(filesystem_helper.TESTFN + "1", "wb") as f:
             f.write(b"foo")
-        self.assertIs(posixpath.islink(support.TESTFN + "1"), False)
+        self.assertIs(posixpath.islink(filesystem_helper.TESTFN + "1"), False)
 
         if support.can_symlink():
-            os.symlink(support.TESTFN + "1", support.TESTFN + "2")
-            self.assertIs(posixpath.islink(support.TESTFN + "2"), True)
-            os.remove(support.TESTFN + "1")
-            self.assertIs(posixpath.islink(support.TESTFN + "2"), True)
-            self.assertIs(posixpath.exists(support.TESTFN + "2"), False)
-            self.assertIs(posixpath.lexists(support.TESTFN + "2"), True)
+            os.symlink(filesystem_helper.TESTFN + "1",
+                       filesystem_helper.TESTFN + "2")
+            self.assertIs(posixpath.islink(filesystem_helper.TESTFN + "2"),
+                          True)
+            os.remove(filesystem_helper.TESTFN + "1")
+            self.assertIs(posixpath.islink(filesystem_helper.TESTFN + "2"),
+                          True)
+            self.assertIs(posixpath.exists(filesystem_helper.TESTFN + "2"),
+                          False)
+            self.assertIs(posixpath.lexists(filesystem_helper.TESTFN + "2"),
+                          True)
 
-        self.assertIs(posixpath.islink(support.TESTFN + "\udfff"), False)
-        self.assertIs(posixpath.islink(os.fsencode(support.TESTFN) + b"\xff"), False)
-        self.assertIs(posixpath.islink(support.TESTFN + "\x00"), False)
-        self.assertIs(posixpath.islink(os.fsencode(support.TESTFN) + b"\x00"), False)
+        self.assertIs(posixpath.islink(filesystem_helper.TESTFN + "\udfff"),
+                      False)
+        self.assertIs(posixpath.islink(
+            os.fsencode(filesystem_helper.TESTFN) + b"\xff"), False)
+        self.assertIs(posixpath.islink(filesystem_helper.TESTFN + "\x00"),
+                      False)
+        self.assertIs(posixpath.islink(
+            os.fsencode(filesystem_helper.TESTFN) + b"\x00"), False)
 
     def test_ismount(self):
         self.assertIs(posixpath.ismount("/"), True)
@@ -627,8 +637,8 @@ class PathLikeTests(unittest.TestCase):
     path = posixpath
 
     def setUp(self):
-        self.file_name = support.TESTFN.lower()
-        self.file_path = FakePath(support.TESTFN)
+        self.file_name = filesystem_helper.TESTFN.lower()
+        self.file_path = FakePath(filesystem_helper.TESTFN)
         self.addCleanup(support.unlink, self.file_name)
         with open(self.file_name, 'xb', 0) as file:
             file.write(b"test_posixpath.PathLikeTests")

--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -6,7 +6,8 @@ import unittest
 import os
 from difflib import unified_diff
 from io import StringIO
-from test.support import TESTFN, run_unittest, unlink
+from test.support import run_unittest, unlink
+from test.support.filesystem_helper import TESTFN
 from contextlib import contextmanager
 
 import profile

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -26,10 +26,10 @@ from collections import namedtuple
 from test.support.script_helper import assert_python_ok
 from test.support import threading_helper
 from test.support import (
-    TESTFN, rmtree,
-    reap_children, captured_output, captured_stdout,
+    rmtree, reap_children, captured_output, captured_stdout,
     captured_stderr, unlink, requires_docstrings
 )
+from test.support.filesystem_helper import TESTFN
 from test import pydoc_mod
 
 

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -10,7 +10,8 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from test.support import import_module, unlink, temp_dir, TESTFN, verbose
+from test.support import import_module, unlink, temp_dir, verbose
+from test.support.filesystem_helper import TESTFN
 from test.support.script_helper import assert_python_ok
 
 # Skip tests if there is no readline module

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -18,6 +18,7 @@ import textwrap
 import unittest
 from test import libregrtest
 from test import support
+from test.support import filesystem_helper
 from test.libregrtest import utils
 
 
@@ -770,7 +771,7 @@ class ArgsTestCase(BaseTestCase):
         # Write the list of files using a format similar to regrtest output:
         # [1/2] test_1
         # [2/2] test_2
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
 
         # test format '0:00:00 [2/7] test_opcodes -- test_grammar took 0 sec'
@@ -997,7 +998,7 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         # only run a subset
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
 
         subset = [
@@ -1038,7 +1039,7 @@ class ArgsTestCase(BaseTestCase):
         self.assertEqual(methods, all_methods)
 
         # only run a subset
-        filename = support.TESTFN
+        filename = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, filename)
 
         subset = [

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -2,6 +2,7 @@ import contextlib
 import sys
 import unittest
 from test import support
+from test.support import filesystem_helper
 import time
 
 resource = support.import_module('resource')
@@ -51,7 +52,7 @@ class ResourceTest(unittest.TestCase):
                     limit_set = True
                 except ValueError:
                     limit_set = False
-                f = open(support.TESTFN, "wb")
+                f = open(filesystem_helper.TESTFN, "wb")
                 try:
                     f.write(b"X" * 1024)
                     try:
@@ -77,7 +78,7 @@ class ResourceTest(unittest.TestCase):
             finally:
                 if limit_set:
                     resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
-                support.unlink(support.TESTFN)
+                support.unlink(filesystem_helper.TESTFN)
 
     def test_fsize_toobig(self):
         # Be sure that setrlimit is checking for really large values

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -23,7 +23,8 @@ import sys
 from urllib.error import URLError
 import urllib.request
 from test import support
-from test.support import findfile, run_unittest, FakePath, TESTFN
+from test.support import findfile, run_unittest, FakePath
+from test.support.filesystem_helper import TESTFN
 
 TEST_XMLFILE = findfile("test.xml", subdir="xmltestdata")
 TEST_XMLFILE_OUT = findfile("test.xml.out", subdir="xmltestdata")

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import filesystem_helper
 import gc
 import weakref
 import operator
@@ -321,15 +322,15 @@ class TestJointOps:
         w = ReprWrapper()
         s = self.thetype([w])
         w.value = s
-        fo = open(support.TESTFN, "w")
+        fo = open(filesystem_helper.TESTFN, "w")
         try:
             fo.write(str(s))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(filesystem_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(s))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_do_not_rehash_dict_keys(self):
         n = 10
@@ -805,14 +806,14 @@ class TestBasicOps:
 
     def test_print(self):
         try:
-            fo = open(support.TESTFN, "w")
+            fo = open(filesystem_helper.TESTFN, "w")
             fo.write(str(self.set))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(filesystem_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(self.set))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            support.unlink(filesystem_helper.TESTFN)
 
     def test_length(self):
         self.assertEqual(len(self.set), self.length)

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -30,7 +30,8 @@ except ImportError:
     posix = None
 
 from test import support
-from test.support import TESTFN, FakePath
+from test.support import FakePath
+from test.support.filesystem_helper import TESTFN
 
 TESTFN2 = TESTFN + "2"
 MACOS = sys.platform.startswith("darwin")

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -8,8 +8,9 @@ import unittest
 import test.support
 from test import support
 from test.support import socket_helper
-from test.support import (captured_stderr, TESTFN, EnvironmentVarGuard,
+from test.support import (captured_stderr, EnvironmentVarGuard,
                           change_cwd)
+from test.support.filesystem_helper import TESTFN
 import builtins
 import encodings
 import glob

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 from test.support import threading_helper
 
@@ -5458,14 +5459,14 @@ class TestUnixDomain(unittest.TestCase):
 
     def testStrAddr(self):
         # Test binding to and retrieving a normal string pathname.
-        path = os.path.abspath(support.TESTFN)
+        path = os.path.abspath(filesystem_helper.TESTFN)
         self.bind(self.sock, path)
         self.addCleanup(support.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
 
     def testBytesAddr(self):
         # Test binding to a bytes pathname.
-        path = os.path.abspath(support.TESTFN)
+        path = os.path.abspath(filesystem_helper.TESTFN)
         self.bind(self.sock, self.encoded(path))
         self.addCleanup(support.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
@@ -5960,16 +5961,16 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
         chunk = b"".join([random.choice(string.ascii_letters).encode()
                           for i in range(cls.BUFSIZE)])
-        with open(support.TESTFN, 'wb') as f:
+        with open(filesystem_helper.TESTFN, 'wb') as f:
             for csize in chunks(cls.FILESIZE, cls.BUFSIZE):
                 f.write(chunk)
-        with open(support.TESTFN, 'rb') as f:
+        with open(filesystem_helper.TESTFN, 'rb') as f:
             cls.FILEDATA = f.read()
             assert len(cls.FILEDATA) == cls.FILESIZE
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(support.TESTFN)
+        support.unlink(filesystem_helper.TESTFN)
 
     def accept_conn(self):
         self.serv.settimeout(support.LONG_TIMEOUT)
@@ -5996,7 +5997,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testRegularFile(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(filesystem_helper.TESTFN, 'rb')
         with socket.create_connection(address) as sock, file as file:
             meth = self.meth_from_sock(sock)
             sent = meth(file)
@@ -6031,7 +6032,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testEmptyFileSend(self):
         address = self.serv.getsockname()
-        filename = support.TESTFN + "2"
+        filename = filesystem_helper.TESTFN + "2"
         with open(filename, 'wb'):
             self.addCleanup(support.unlink, filename)
         file = open(filename, 'rb')
@@ -6050,7 +6051,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testOffset(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(filesystem_helper.TESTFN, 'rb')
         with socket.create_connection(address) as sock, file as file:
             meth = self.meth_from_sock(sock)
             sent = meth(file, offset=5000)
@@ -6067,7 +6068,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testCount(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(filesystem_helper.TESTFN, 'rb')
         sock = socket.create_connection(address,
                                         timeout=support.LOOPBACK_TIMEOUT)
         with sock, file:
@@ -6088,7 +6089,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testCountSmall(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(filesystem_helper.TESTFN, 'rb')
         sock = socket.create_connection(address,
                                         timeout=support.LOOPBACK_TIMEOUT)
         with sock, file:
@@ -6109,7 +6110,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testCountWithOffset(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(filesystem_helper.TESTFN, 'rb')
         with socket.create_connection(address, timeout=2) as sock, file as file:
             count = 100007
             meth = self.meth_from_sock(sock)
@@ -6128,7 +6129,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testNonBlocking(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(filesystem_helper.TESTFN, 'rb')
         with socket.create_connection(address) as sock, file as file:
             sock.setblocking(False)
             meth = self.meth_from_sock(sock)
@@ -6144,7 +6145,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testWithTimeout(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(filesystem_helper.TESTFN, 'rb')
         sock = socket.create_connection(address,
                                         timeout=support.LOOPBACK_TIMEOUT)
         with sock, file:
@@ -6162,7 +6163,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testWithTimeoutTriggeredSend(self):
         address = self.serv.getsockname()
-        with open(support.TESTFN, 'rb') as file:
+        with open(filesystem_helper.TESTFN, 'rb') as file:
             with socket.create_connection(address) as sock:
                 sock.settimeout(0.01)
                 meth = self.meth_from_sock(sock)
@@ -6178,17 +6179,17 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
         pass
 
     def test_errors(self):
-        with open(support.TESTFN, 'rb') as file:
+        with open(filesystem_helper.TESTFN, 'rb') as file:
             with socket.socket(type=socket.SOCK_DGRAM) as s:
                 meth = self.meth_from_sock(s)
                 self.assertRaisesRegex(
                     ValueError, "SOCK_STREAM", meth, file)
-        with open(support.TESTFN, 'rt') as file:
+        with open(filesystem_helper.TESTFN, 'rt') as file:
             with socket.socket() as s:
                 meth = self.meth_from_sock(s)
                 self.assertRaisesRegex(
                     ValueError, "binary mode", meth, file)
-        with open(support.TESTFN, 'rb') as file:
+        with open(filesystem_helper.TESTFN, 'rb') as file:
             with socket.socket() as s:
                 meth = self.meth_from_sock(s)
                 self.assertRaisesRegex(TypeError, "positive integer",

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -15,6 +15,7 @@ import socketserver
 
 import test.support
 from test.support import reap_children, verbose
+from test.support import filesystem_helper
 from test.support import socket_helper
 from test.support import threading_helper
 

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -299,7 +299,7 @@ class ErrorHandlerTest(unittest.TestCase):
     KeyboardInterrupt are not passed."""
 
     def tearDown(self):
-        test.support.unlink(test.support.TESTFN)
+        test.support.unlink(filesystem_helper.TESTFN)
 
     def test_sync_handled(self):
         BaseErrorTestServer(ValueError)
@@ -329,7 +329,7 @@ class ErrorHandlerTest(unittest.TestCase):
         self.check_result(handled=False)
 
     def check_result(self, handled):
-        with open(test.support.TESTFN) as log:
+        with open(filesystem_helper.TESTFN) as log:
             expected = 'Handler called\n' + 'Error handled\n' * handled
             self.assertEqual(log.read(), expected)
 
@@ -347,7 +347,7 @@ class BaseErrorTestServer(socketserver.TCPServer):
         self.wait_done()
 
     def handle_error(self, request, client_address):
-        with open(test.support.TESTFN, 'a') as log:
+        with open(filesystem_helper.TESTFN, 'a') as log:
             log.write('Error handled\n')
 
     def wait_done(self):
@@ -356,7 +356,7 @@ class BaseErrorTestServer(socketserver.TCPServer):
 
 class BadHandler(socketserver.BaseRequestHandler):
     def handle(self):
-        with open(test.support.TESTFN, 'a') as log:
+        with open(filesystem_helper.TESTFN, 'a') as log:
             log.write('Handler called\n')
         raise self.server.exception('Test error')
 

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -1,7 +1,8 @@
 # -*- coding: koi8-r -*-
 
 import unittest
-from test.support import TESTFN, unlink, unload, rmtree, script_helper, captured_stdout
+from test.support import unlink, unload, rmtree, script_helper, captured_stdout
+from test.support.filesystem_helper import TESTFN
 import importlib
 import os
 import sys

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -3,7 +3,8 @@ import os
 import socket
 import sys
 from test.support import socket_helper
-from test.support import TESTFN, import_fresh_module
+from test.support import import_fresh_module
+from test.support.filesystem_helper import TESTFN
 
 c_stat = import_fresh_module('stat', fresh=['_stat'])
 py_stat = import_fresh_module('stat', blocked=['_stat'])

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 from test import support
+from test.support import filesystem_helper
 import subprocess
 import sys
 import signal
@@ -1052,7 +1053,7 @@ class ProcessTestCase(BaseTestCase):
         try:
             for i in range(max_handles):
                 try:
-                    tmpfile = os.path.join(tmpdir, support.TESTFN)
+                    tmpfile = os.path.join(tmpdir, filesystem_helper.TESTFN)
                     handles.append(os.open(tmpfile, os.O_WRONLY|os.O_CREAT))
                 except OSError as e:
                     if e.errno != errno.EMFILE:

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -12,10 +12,11 @@ import textwrap
 import time
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.support import script_helper
 from test.support import socket_helper
 
-TESTFN = support.TESTFN
+TESTFN = filesystem_helper.TESTFN
 
 
 class TestSupport(unittest.TestCase):

--- a/Lib/test/test_symbol.py
+++ b/Lib/test/test_symbol.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import filesystem_helper
 import os
 import sys
 import sysconfig
@@ -42,7 +43,7 @@ class TestSymbolGeneration(unittest.TestCase):
     @unittest.skipUnless(sysconfig.is_python_build(),
                          'test only works from source build directory')
     def test_real_grammar_and_symbol_file(self):
-        output = support.TESTFN
+        output = filesystem_helper.TESTFN
         self.addCleanup(support.unlink, output)
 
         self._copy_file_without_generated_symbols(SYMBOL_FILE, output)

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -5,9 +5,10 @@ import subprocess
 import shutil
 from copy import copy
 
-from test.support import (import_module, TESTFN, unlink, check_warnings,
+from test.support import (import_module, unlink, check_warnings,
                           captured_stdout, skip_unless_symlink, change_cwd,
                           PythonSymlink)
+from test.support.filesystem_helper import TESTFN
 
 import sysconfig
 from sysconfig import (get_paths, get_platform, get_config_vars,

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -11,6 +11,7 @@ import unittest.mock
 import tarfile
 
 from test import support
+from test.support import filesystem_helper
 from test.support import script_helper
 
 # Check for our compression modules.
@@ -30,7 +31,7 @@ except ImportError:
 def sha256sum(data):
     return sha256(data).hexdigest()
 
-TEMPDIR = os.path.abspath(support.TESTFN) + "-tardir"
+TEMPDIR = os.path.abspath(filesystem_helper.TESTFN) + "-tardir"
 tarextdir = TEMPDIR + '-extract-test'
 tarname = support.findfile("testtar.tar")
 gzipname = os.path.join(TEMPDIR, "testtar.tar.gz")

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -5,6 +5,7 @@ import sys
 import os
 import warnings
 from test import support
+from test.support import filesystem_helper
 
 # Skip this test if the _tkinter module wasn't built.
 _tkinter = support.import_module('_tkinter')
@@ -191,26 +192,26 @@ class TclTest(unittest.TestCase):
 
     def testEvalFile(self):
         tcl = self.interp
-        with open(support.TESTFN, 'w') as f:
-            self.addCleanup(support.unlink, support.TESTFN)
+        with open(filesystem_helper.TESTFN, 'w') as f:
+            self.addCleanup(support.unlink, filesystem_helper.TESTFN)
             f.write("""set a 1
             set b 2
             set c [ expr $a + $b ]
             """)
-        tcl.evalfile(support.TESTFN)
+        tcl.evalfile(filesystem_helper.TESTFN)
         self.assertEqual(tcl.eval('set a'),'1')
         self.assertEqual(tcl.eval('set b'),'2')
         self.assertEqual(tcl.eval('set c'),'3')
 
     def test_evalfile_null_in_result(self):
         tcl = self.interp
-        with open(support.TESTFN, 'w') as f:
-            self.addCleanup(support.unlink, support.TESTFN)
+        with open(filesystem_helper.TESTFN, 'w') as f:
+            self.addCleanup(support.unlink, filesystem_helper.TESTFN)
             f.write("""
             set a "a\0b"
             set b "a\\0b"
             """)
-        tcl.evalfile(support.TESTFN)
+        tcl.evalfile(filesystem_helper.TESTFN)
         self.assertEqual(tcl.eval('set a'), 'a\x00b')
         self.assertEqual(tcl.eval('set b'), 'a\x00b')
 

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1,4 +1,5 @@
 from test import support
+from test.support import filesystem_helper
 from tokenize import (tokenize, _tokenize, untokenize, NUMBER, NAME, OP,
                      STRING, ENDMARKER, ENCODING, tok_name, detect_encoding,
                      open as tokenize_open, Untokenizer, generate_tokens,
@@ -1265,7 +1266,7 @@ class TestDetectEncoding(TestCase):
         self.assertEqual(consumed_lines, [b'print("#coding=fake")'])
 
     def test_open(self):
-        filename = support.TESTFN + '.py'
+        filename = filesystem_helper.TESTFN + '.py'
         self.addCleanup(support.unlink, filename)
 
         # test coding cookie

--- a/Lib/test/test_tools/test_fixcid.py
+++ b/Lib/test/test_tools/test_fixcid.py
@@ -5,6 +5,7 @@ import os, os.path
 import runpy
 import sys
 from test import support
+from test.support import filesystem_helper
 from test.test_tools import skip_if_missing, scriptsdir
 import unittest
 
@@ -57,15 +58,16 @@ class Test(unittest.TestCase):
         )
 
     def test_directory(self):
-        os.mkdir(support.TESTFN)
-        self.addCleanup(support.rmtree, support.TESTFN)
-        c_filename = os.path.join(support.TESTFN, "file.c")
+        os.mkdir(filesystem_helper.TESTFN)
+        self.addCleanup(support.rmtree, filesystem_helper.TESTFN)
+        c_filename = os.path.join(filesystem_helper.TESTFN, "file.c")
         with open(c_filename, "w") as file:
             file.write("int xx;\n")
-        with open(os.path.join(support.TESTFN, "file.py"), "w") as file:
+        with open(os.path.join(filesystem_helper.TESTFN,
+                  "file.py"), "w") as file:
             file.write("xx = 'unaltered'\n")
         script = os.path.join(scriptsdir, "fixcid.py")
-        output = self.run_script(args=(support.TESTFN,))
+        output = self.run_script(args=(filesystem_helper.TESTFN,))
         self.assertMultiLineEqual(output,
             "{}:\n"
             "1\n"
@@ -74,7 +76,7 @@ class Test(unittest.TestCase):
         )
 
     def run_script(self, input="", *, args=("-",), substfile="xx yy\n"):
-        substfilename = support.TESTFN + ".subst"
+        substfilename = filesystem_helper.TESTFN + ".subst"
         with open(substfilename, "w") as file:
             file.write(substfile)
         self.addCleanup(support.unlink, substfilename)

--- a/Lib/test/test_tools/test_md5sum.py
+++ b/Lib/test/test_tools/test_md5sum.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.support import hashlib_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
@@ -15,8 +16,8 @@ class MD5SumTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.script = os.path.join(scriptsdir, 'md5sum.py')
-        os.mkdir(support.TESTFN)
-        cls.fodder = os.path.join(support.TESTFN, 'md5sum.fodder')
+        os.mkdir(filesystem_helper.TESTFN)
+        cls.fodder = os.path.join(filesystem_helper.TESTFN, 'md5sum.fodder')
         with open(cls.fodder, 'wb') as f:
             f.write(b'md5sum\r\ntest file\r\n')
         cls.fodder_md5 = b'd38dae2eb1ab346a292ef6850f9e1a0d'
@@ -24,7 +25,7 @@ class MD5SumTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        support.rmtree(support.TESTFN)
+        support.rmtree(filesystem_helper.TESTFN)
 
     def test_noargs(self):
         rc, out, err = assert_python_ok(self.script)

--- a/Lib/test/test_tools/test_pathfix.py
+++ b/Lib/test/test_tools/test_pathfix.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.test_tools import scriptsdir, skip_if_missing
 
 
@@ -14,7 +15,7 @@ class TestPathfixFunctional(unittest.TestCase):
     script = os.path.join(scriptsdir, 'pathfix.py')
 
     def setUp(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
     def pathfix(self, shebang, pathfix_flags, exitcode=0, stdout='', stderr='',
                 directory=''):
@@ -24,7 +25,7 @@ class TestPathfixFunctional(unittest.TestCase):
             filename = os.path.join(directory, 'script-A_1.py')
             pathfix_arg = directory
         else:
-            filename = support.TESTFN
+            filename = filesystem_helper.TESTFN
             pathfix_arg = filename
 
         with open(filename, 'w', encoding='utf8') as f:
@@ -54,7 +55,7 @@ class TestPathfixFunctional(unittest.TestCase):
         return new_shebang
 
     def test_recursive(self):
-        tmpdir = support.TESTFN + '.d'
+        tmpdir = filesystem_helper.TESTFN + '.d'
         self.addCleanup(support.rmtree, tmpdir)
         os.mkdir(tmpdir)
         expected_stderr = f"recursedown('{os.path.basename(tmpdir)}')\n"

--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -1,6 +1,7 @@
 import os
 import sys
-from test.support import TESTFN, rmtree, unlink, captured_stdout
+from test.support import rmtree, unlink, captured_stdout
+from test.support.filesystem_helper import TESTFN
 from test.support.script_helper import assert_python_ok, assert_python_failure
 import textwrap
 import unittest

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -7,7 +7,8 @@ import sys
 import unittest
 import re
 from test import support
-from test.support import TESTFN, Error, captured_output, unlink, cpython_only, ALWAYS_EQ
+from test.support import Error, captured_output, unlink, cpython_only, ALWAYS_EQ
+from test.support.filesystem_helper import TESTFN
 from test.support.script_helper import assert_python_ok
 import textwrap
 

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from test.support.script_helper import (assert_python_ok, assert_python_failure,
                                         interpreter_requires_environment)
 from test import support
+from test.support import filesystem_helper
 
 try:
     import _testcapi
@@ -287,11 +288,11 @@ class TestTracemallocEnabled(unittest.TestCase):
         self.assertGreater(snapshot.traces[1].traceback.total_nframe, 10)
 
         # write on disk
-        snapshot.dump(support.TESTFN)
-        self.addCleanup(support.unlink, support.TESTFN)
+        snapshot.dump(filesystem_helper.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
         # load from disk
-        snapshot2 = tracemalloc.Snapshot.load(support.TESTFN)
+        snapshot2 = tracemalloc.Snapshot.load(filesystem_helper.TESTFN)
         self.assertEqual(snapshot2.traces, snapshot.traces)
 
         # tracemalloc must be tracing memory allocations to take a snapshot
@@ -306,11 +307,11 @@ class TestTracemallocEnabled(unittest.TestCase):
         # take a snapshot with a new attribute
         snapshot = tracemalloc.take_snapshot()
         snapshot.test_attr = "new"
-        snapshot.dump(support.TESTFN)
-        self.addCleanup(support.unlink, support.TESTFN)
+        snapshot.dump(filesystem_helper.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
         # load() should recreate the attribute
-        snapshot2 = tracemalloc.Snapshot.load(support.TESTFN)
+        snapshot2 = tracemalloc.Snapshot.load(filesystem_helper.TESTFN)
         self.assertEqual(snapshot2.test_attr, "new")
 
     def fork_child(self):

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -1,6 +1,7 @@
 import pickle
 import unittest
 from test import support
+from test.support import filesystem_helper
 
 turtle = support.import_module('turtle')
 Vec2D = turtle.Vec2D
@@ -50,10 +51,10 @@ visible = False
 class TurtleConfigTest(unittest.TestCase):
 
     def get_cfg_file(self, cfg_str):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, 'w') as f:
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
+        with open(filesystem_helper.TESTFN, 'w') as f:
             f.write(cfg_str)
-        return support.TESTFN
+        return filesystem_helper.TESTFN
 
     def test_config_dict(self):
 

--- a/Lib/test/test_unicode_file_functions.py
+++ b/Lib/test/test_unicode_file_functions.py
@@ -6,6 +6,7 @@ import unittest
 import warnings
 from unicodedata import normalize
 from test import support
+from test.support import filesystem_helper
 
 filenames = [
     '1_abc',
@@ -62,14 +63,14 @@ class UnicodeFileTests(unittest.TestCase):
 
     def setUp(self):
         try:
-            os.mkdir(support.TESTFN)
+            os.mkdir(filesystem_helper.TESTFN)
         except FileExistsError:
             pass
-        self.addCleanup(support.rmtree, support.TESTFN)
+        self.addCleanup(support.rmtree, filesystem_helper.TESTFN)
 
         files = set()
         for name in self.files:
-            name = os.path.join(support.TESTFN, self.norm(name))
+            name = os.path.join(filesystem_helper.TESTFN, self.norm(name))
             with open(name, 'wb') as f:
                 f.write((name+'\n').encode("utf-8"))
             os.stat(name)
@@ -144,9 +145,10 @@ class UnicodeFileTests(unittest.TestCase):
         sf0 = set(self.files)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            f1 = os.listdir(support.TESTFN.encode(sys.getfilesystemencoding()))
-        f2 = os.listdir(support.TESTFN)
-        sf2 = set(os.path.join(support.TESTFN, f) for f in f2)
+            f1 = os.listdir(filesystem_helper.TESTFN.encode(
+                sys.getfilesystemencoding()))
+        f2 = os.listdir(filesystem_helper.TESTFN)
+        sf2 = set(os.path.join(filesystem_helper.TESTFN, f) for f in f2)
         self.assertEqual(sf0, sf2, "%a != %a" % (sf0, sf2))
         self.assertEqual(len(f1), len(f2))
 
@@ -156,7 +158,8 @@ class UnicodeFileTests(unittest.TestCase):
             os.rename("tmp", name)
 
     def test_directory(self):
-        dirname = os.path.join(support.TESTFN, 'Gr\xfc\xdf-\u66e8\u66e9\u66eb')
+        dirname = os.path.join(filesystem_helper.TESTFN,
+                               'Gr\xfc\xdf-\u66e8\u66e9\u66eb')
         filename = '\xdf-\u66e8\u66e9\u66eb'
         with support.temp_cwd(dirname):
             with open(filename, 'wb') as f:

--- a/Lib/test/test_univnewlines.py
+++ b/Lib/test/test_univnewlines.py
@@ -5,6 +5,8 @@ import unittest
 import os
 import sys
 from test import support
+from test.support import filesystem_helper
+
 
 if not hasattr(sys.stdin, 'newlines'):
     raise unittest.SkipTest(
@@ -46,29 +48,29 @@ class TestGenericUnivNewlines:
         data = self.DATA
         if "b" in self.WRITEMODE:
             data = data.encode("ascii")
-        with self.open(support.TESTFN, self.WRITEMODE) as fp:
+        with self.open(filesystem_helper.TESTFN, self.WRITEMODE) as fp:
             fp.write(data)
 
     def tearDown(self):
         try:
-            os.unlink(support.TESTFN)
+            os.unlink(filesystem_helper.TESTFN)
         except:
             pass
 
     def test_read(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(filesystem_helper.TESTFN, self.READMODE) as fp:
             data = fp.read()
         self.assertEqual(data, DATA_LF)
         self.assertEqual(repr(fp.newlines), repr(self.NEWLINE))
 
     def test_readlines(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(filesystem_helper.TESTFN, self.READMODE) as fp:
             data = fp.readlines()
         self.assertEqual(data, DATA_SPLIT)
         self.assertEqual(repr(fp.newlines), repr(self.NEWLINE))
 
     def test_readline(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(filesystem_helper.TESTFN, self.READMODE) as fp:
             data = []
             d = fp.readline()
             while d:
@@ -78,7 +80,7 @@ class TestGenericUnivNewlines:
         self.assertEqual(repr(fp.newlines), repr(self.NEWLINE))
 
     def test_seek(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(filesystem_helper.TESTFN, self.READMODE) as fp:
             fp.readline()
             pos = fp.tell()
             data = fp.readlines()
@@ -105,7 +107,7 @@ class TestCRLFNewlines(TestGenericUnivNewlines):
     DATA = DATA_CRLF
 
     def test_tell(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(filesystem_helper.TESTFN, self.READMODE) as fp:
             self.assertEqual(repr(fp.newlines), repr(None))
             data = fp.readline()
             pos = fp.tell()

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -9,6 +9,7 @@ import io
 import unittest
 from unittest.mock import patch
 from test import support
+from test.support import filesystem_helper
 import os
 try:
     import ssl
@@ -145,18 +146,18 @@ class urlopen_FileTests(unittest.TestCase):
         # Create a temp file to use for testing
         self.text = bytes("test_urllib: %s\n" % self.__class__.__name__,
                           "ascii")
-        f = open(support.TESTFN, 'wb')
+        f = open(filesystem_helper.TESTFN, 'wb')
         try:
             f.write(self.text)
         finally:
             f.close()
-        self.pathname = support.TESTFN
+        self.pathname = filesystem_helper.TESTFN
         self.returned_obj = urlopen("file:%s" % self.pathname)
 
     def tearDown(self):
         """Shut down the open object"""
         self.returned_obj.close()
-        os.remove(support.TESTFN)
+        os.remove(filesystem_helper.TESTFN)
 
     def test_interface(self):
         # Make sure object returned by urlopen() has the specified methods
@@ -698,10 +699,10 @@ class urlretrieve_FileTests(unittest.TestCase):
         self.tempFiles = []
 
         # Create a temporary file.
-        self.registerFileForCleanUp(support.TESTFN)
+        self.registerFileForCleanUp(filesystem_helper.TESTFN)
         self.text = b'testing urllib.urlretrieve'
         try:
-            FILE = open(support.TESTFN, 'wb')
+            FILE = open(filesystem_helper.TESTFN, 'wb')
             FILE.write(self.text)
             FILE.close()
         finally:
@@ -744,18 +745,19 @@ class urlretrieve_FileTests(unittest.TestCase):
     def test_basic(self):
         # Make sure that a local file just gets its own location returned and
         # a headers value is returned.
-        result = urllib.request.urlretrieve("file:%s" % support.TESTFN)
-        self.assertEqual(result[0], support.TESTFN)
+        result = urllib.request.urlretrieve(
+                "file:%s" % filesystem_helper.TESTFN)
+        self.assertEqual(result[0], filesystem_helper.TESTFN)
         self.assertIsInstance(result[1], email.message.Message,
                               "did not get an email.message.Message instance "
                               "as second returned value")
 
     def test_copy(self):
         # Test that setting the filename argument works.
-        second_temp = "%s.2" % support.TESTFN
+        second_temp = "%s.2" % filesystem_helper.TESTFN
         self.registerFileForCleanUp(second_temp)
         result = urllib.request.urlretrieve(self.constructLocalFileUrl(
-            support.TESTFN), second_temp)
+            filesystem_helper.TESTFN), second_temp)
         self.assertEqual(second_temp, result[0])
         self.assertTrue(os.path.exists(second_temp), "copy of the file was not "
                                                   "made")
@@ -776,10 +778,10 @@ class urlretrieve_FileTests(unittest.TestCase):
             self.assertIsInstance(file_size, int)
             self.assertEqual(block_count, count_holder[0])
             count_holder[0] = count_holder[0] + 1
-        second_temp = "%s.2" % support.TESTFN
+        second_temp = "%s.2" % filesystem_helper.TESTFN
         self.registerFileForCleanUp(second_temp)
         urllib.request.urlretrieve(
-            self.constructLocalFileUrl(support.TESTFN),
+            self.constructLocalFileUrl(filesystem_helper.TESTFN),
             second_temp, hooktester)
 
     def test_reporthook_0_bytes(self):
@@ -789,7 +791,7 @@ class urlretrieve_FileTests(unittest.TestCase):
             _report.append((block_count, block_read_size, file_size))
         srcFileName = self.createNewTempFile()
         urllib.request.urlretrieve(self.constructLocalFileUrl(srcFileName),
-            support.TESTFN, hooktester)
+            filesystem_helper.TESTFN, hooktester)
         self.assertEqual(len(report), 1)
         self.assertEqual(report[0][2], 0)
 
@@ -802,7 +804,7 @@ class urlretrieve_FileTests(unittest.TestCase):
             _report.append((block_count, block_read_size, file_size))
         srcFileName = self.createNewTempFile(b"x" * 5)
         urllib.request.urlretrieve(self.constructLocalFileUrl(srcFileName),
-            support.TESTFN, hooktester)
+            filesystem_helper.TESTFN, hooktester)
         self.assertEqual(len(report), 2)
         self.assertEqual(report[0][2], 5)
         self.assertEqual(report[1][2], 5)
@@ -816,7 +818,7 @@ class urlretrieve_FileTests(unittest.TestCase):
             _report.append((block_count, block_read_size, file_size))
         srcFileName = self.createNewTempFile(b"x" * 8193)
         urllib.request.urlretrieve(self.constructLocalFileUrl(srcFileName),
-            support.TESTFN, hooktester)
+            filesystem_helper.TESTFN, hooktester)
         self.assertEqual(len(report), 3)
         self.assertEqual(report[0][2], 8193)
         self.assertEqual(report[0][1], 8192)

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 from test.test_urllib2 import sanepathname2url
 
@@ -114,7 +115,7 @@ class OtherNetworkTests(unittest.TestCase):
         self._test_urls(urls, self._extra_handlers())
 
     def test_file(self):
-        TESTFN = support.TESTFN
+        TESTFN = filesystem_helper.TESTFN
         f = open(TESTFN, 'w')
         try:
             f.write('hi there\n')

--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import filesystem_helper
 from test.support import socket_helper
 
 import contextlib
@@ -176,8 +177,8 @@ class urlretrieveNetworkTests(unittest.TestCase):
     def test_specified_path(self):
         # Make sure that specifying the location of the file to write to works.
         with self.urlretrieve(self.logo,
-                              support.TESTFN) as (file_location, info):
-            self.assertEqual(file_location, support.TESTFN)
+                filesystem_helper.TESTFN) as (file_location, info):
+            self.assertEqual(file_location, filesystem_helper.TESTFN)
             self.assertTrue(os.path.exists(file_location))
             with open(file_location, 'rb') as f:
                 self.assertTrue(f.read(), "reading from temporary file failed")

--- a/Lib/test/test_uu.py
+++ b/Lib/test/test_uu.py
@@ -5,6 +5,7 @@ Nick Mathewson
 
 import unittest
 from test import support
+from test.support import filesystem_helper
 
 import os
 import stat
@@ -174,8 +175,8 @@ class UUStdIOTest(unittest.TestCase):
 class UUFileTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpin  = support.TESTFN + "i"
-        self.tmpout = support.TESTFN + "o"
+        self.tmpin  = filesystem_helper.TESTFN + "i"
+        self.tmpout = filesystem_helper.TESTFN + "o"
         self.addCleanup(support.unlink, self.tmpin)
         self.addCleanup(support.unlink, self.tmpout)
 

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -7,6 +7,7 @@ import sys
 import textwrap
 import unittest
 from test import support
+from test.support import filesystem_helper 
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
 from test.test_warnings.data import stacklevel as warning_tests
@@ -927,9 +928,9 @@ class PyWarningsDisplayTests(WarningsDisplayTests, unittest.TestCase):
     module = py_warnings
 
     def test_tracemalloc(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
-        with open(support.TESTFN, 'w') as fp:
+        with open(filesystem_helper.TESTFN, 'w') as fp:
             fp.write(textwrap.dedent("""
                 def func():
                     f = open(__file__)
@@ -949,8 +950,8 @@ class PyWarningsDisplayTests(WarningsDisplayTests, unittest.TestCase):
             return stderr
 
         # tracemalloc disabled
-        filename = os.path.abspath(support.TESTFN)
-        stderr = run('-Wd', support.TESTFN)
+        filename = os.path.abspath(filesystem_helper.TESTFN)
+        stderr = run('-Wd', filesystem_helper.TESTFN)
         expected = textwrap.dedent(f'''
             {filename}:5: ResourceWarning: unclosed file <...>
               f = None
@@ -959,7 +960,7 @@ class PyWarningsDisplayTests(WarningsDisplayTests, unittest.TestCase):
         self.assertEqual(stderr, expected)
 
         # tracemalloc enabled
-        stderr = run('-Wd', '-X', 'tracemalloc=2', support.TESTFN)
+        stderr = run('-Wd', '-X', 'tracemalloc=2', filesystem_helper.TESTFN)
         expected = textwrap.dedent(f'''
             {filename}:5: ResourceWarning: unclosed file <...>
               f = None

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 import unittest
 from test import support
-from test.support import filesystem_helper 
+from test.support import filesystem_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
 from test.test_warnings.data import stacklevel as warning_tests

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -24,7 +24,8 @@ import weakref
 from functools import partial
 from itertools import product, islice
 from test import support
-from test.support import TESTFN, findfile, import_fresh_module, gc_collect, swap_attr
+from test.support import findfile, import_fresh_module, gc_collect, swap_attr
+from test.support.filesystem_helper import TESTFN
 
 # pyET is the pure-Python implementation.
 #

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -19,9 +19,10 @@ from tempfile import TemporaryFile
 from random import randint, random, randbytes
 
 from test.support import script_helper
-from test.support import (TESTFN, findfile, unlink, rmtree, temp_dir, temp_cwd,
+from test.support import (findfile, unlink, rmtree, temp_dir, temp_cwd,
                           requires_zlib, requires_bz2, requires_lzma,
                           captured_stdout)
+from test.support.filesystem_helper import TESTFN
 
 TESTFN2 = TESTFN + "2"
 TESTFNDIR = TESTFN + "d"

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -17,7 +17,8 @@ import sys
 
 from tempfile import TemporaryFile
 
-from test.support import TESTFN, requires_zlib
+from test.support import requires_zlib
+from test.support.filesystem_helper import TESTFN
 
 TESTFN2 = TESTFN + "2"
 

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -9,6 +9,7 @@ import unittest
 import unittest.mock
 
 from test import support
+from test.support import filesystem_helper
 
 from zipfile import ZipFile, ZipInfo, ZIP_STORED, ZIP_DEFLATED
 
@@ -656,7 +657,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         zipimport.zipimporter(filename).load_module(TESTMOD)
 
     def testBytesPath(self):
-        filename = support.TESTFN + ".zip"
+        filename = filesystem_helper.TESTFN + ".zip"
         self.addCleanup(support.unlink, filename)
         with ZipFile(filename, "w") as z:
             zinfo = ZipInfo(TESTMOD + ".py", time.localtime(NOW))

--- a/Lib/tkinter/test/test_tkinter/test_images.py
+++ b/Lib/tkinter/test/test_tkinter/test_images.py
@@ -1,6 +1,7 @@
 import unittest
 import tkinter
 from test import support
+from test.support import filesystem_helper
 from tkinter.test.support import AbstractTkTest, requires_tcl
 
 support.requires('gui')
@@ -296,12 +297,12 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
 
     def test_write(self):
         image = self.create()
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(support.unlink, filesystem_helper.TESTFN)
 
-        image.write(support.TESTFN)
+        image.write(filesystem_helper.TESTFN)
         image2 = tkinter.PhotoImage('::img::test2', master=self.root,
                                     format='ppm',
-                                    file=support.TESTFN)
+                                    file=filesystem_helper.TESTFN)
         self.assertEqual(str(image2), '::img::test2')
         self.assertEqual(image2.type(), 'photo')
         self.assertEqual(image2.width(), 16)
@@ -309,10 +310,10 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(image2.get(0, 0), image.get(0, 0))
         self.assertEqual(image2.get(15, 8), image.get(15, 8))
 
-        image.write(support.TESTFN, format='gif', from_coords=(4, 6, 6, 9))
+        image.write(filesystem_helper.TESTFN, format='gif', from_coords=(4, 6, 6, 9))
         image3 = tkinter.PhotoImage('::img::test3', master=self.root,
                                     format='gif',
-                                    file=support.TESTFN)
+                                    file=filesystem_helper.TESTFN)
         self.assertEqual(str(image3), '::img::test3')
         self.assertEqual(image3.type(), 'photo')
         self.assertEqual(image3.width(), 2)


### PR DESCRIPTION
Add a new test.support.filesystem_helper submodule and move TESTFN to filesystem_helper.

<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
