### PR TITLE
bpo-40865: Remove unused insint() macro from hash modules

### DIFF
--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -552,9 +552,6 @@ static struct PyMethodDef MD5_functions[] = {
 
 /* Initialize this module. */
 
-#define insint(n,v) { PyModule_AddIntConstant(m,n,v); }
-
-
 static struct PyModuleDef _md5module = {
         PyModuleDef_HEAD_INIT,
         "_md5",

--- a/Modules/sha1module.c
+++ b/Modules/sha1module.c
@@ -529,9 +529,6 @@ static struct PyMethodDef SHA1_functions[] = {
 
 /* Initialize this module. */
 
-#define insint(n,v) { PyModule_AddIntConstant(m,n,v); }
-
-
 static struct PyModuleDef _sha1module = {
         PyModuleDef_HEAD_INIT,
         "_sha1",

--- a/Modules/sha256module.c
+++ b/Modules/sha256module.c
@@ -684,9 +684,6 @@ static struct PyMethodDef SHA_functions[] = {
 
 /* Initialize this module. */
 
-#define insint(n,v) { PyModule_AddIntConstant(m,n,v); }
-
-
 static struct PyModuleDef _sha256module = {
         PyModuleDef_HEAD_INIT,
         "_sha256",

--- a/Modules/sha512module.c
+++ b/Modules/sha512module.c
@@ -741,9 +741,6 @@ static struct PyMethodDef SHA_functions[] = {
 
 /* Initialize this module. */
 
-#define insint(n,v) { PyModule_AddIntConstant(m,n,v); }
-
-
 static struct PyModuleDef _sha512module = {
         PyModuleDef_HEAD_INIT,
         "_sha512",


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40865](https://bugs.python.org/issue40865) -->
https://bugs.python.org/issue40865
<!-- /issue-number -->


Automerge-Triggered-By: @tiran