### PR TITLE
Restrict co_code to be under INT_MAX in codeobject

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -166,6 +166,14 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
         return NULL;
     }
 
+    /* Make sure that code is indexable with an int, this is
+       a long running assumption in ceval.c and many parts of
+       the interpreter. */
+    if (PyBytes_GET_SIZE(code) > INT_MAX) {
+        PyErr_SetString(PyExc_OverflowError, "co_code larger than INT_MAX");
+        return NULL;
+    }
+
     /* Check for any inner or outer closure references */
     n_cellvars = PyTuple_GET_SIZE(cellvars);
     if (!n_cellvars && !PyTuple_GET_SIZE(freevars)) {

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -397,9 +397,9 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         return -1;
     }
 
-    int len = Py_SAFE_DOWNCAST(
-        PyBytes_GET_SIZE(f->f_code->co_code)/sizeof(_Py_CODEUNIT),
-        Py_ssize_t, int);
+    /* PyCode_NewWithPosOnlyArgs limits co_code to be under INT_MAX so this
+     * should never overflow. */
+    int len = (int)(PyBytes_GET_SIZE(f->f_code->co_code) / sizeof(_Py_CODEUNIT));
     int *lines = marklines(f->f_code, len);
     if (lines == NULL) {
         return -1;


### PR DESCRIPTION
Based on @vstinner's advice from https://github.com/python/cpython/pull/20590#issuecomment-638830133

This assumption already exists in the interpreter: https://github.com/python/cpython/blob/master/Python/ceval.c#L1328

I checked `PyBytes_GET_SIZE(x)` directly instead of `PyBytes_GET_SIZE(x)/sizeof(_Py_CODEUNIT)` just like ceval, since presumably the smallest size of 1 for `_Py_CODEUNIT` would still allow `co_code` to be fully indexable with an int.