### PR TITLE
Fix spacing in docs for tarfile

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -787,7 +787,7 @@ How to read a gzip compressed tar archive and display some member information::
    import tarfile
    tar = tarfile.open("sample.tar.gz", "r:gz")
    for tarinfo in tar:
-       print(tarinfo.name, "is", tarinfo.size, "bytes in size and is", end="")
+       print(tarinfo.name, "is", tarinfo.size, "bytes in size and is ", end="")
        if tarinfo.isreg():
            print("a regular file.")
        elif tarinfo.isdir():


### PR DESCRIPTION
Before
```
content.txt is 42 bytes in size and isa regular file.
folder is 420 bytes in size and isa directory.
magic is 4200 bytes in size and issomething else.
```

After:
```
content.txt is 42 bytes in size and is a regular file.
folder is 420 bytes in size and is a directory.
magic is 4200 bytes in size and is something else.
```

Automerge-Triggered-By: @orsenthil