### PR TITLE
bpo-40867: Remove unused include from Module/_randommodule.c

### DIFF
--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -67,7 +67,6 @@
 /* ---------------------------------------------------------------*/
 
 #include "Python.h"
-#include "pycore_byteswap.h"      // _Py_bswap32()
 #ifdef HAVE_PROCESS_H
 #  include <process.h>            // getpid()
 #endif


### PR DESCRIPTION
Including `pycore_byteswap.h` is not needed after `_Py_bswap32()` was removed in commit 2d8757758d0d75882fef0fe0e3c74c4756b3e81e.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40867](https://bugs.python.org/issue40867) -->
https://bugs.python.org/issue40867
<!-- /issue-number -->
