### PR TITLE
bpo-40521: Make float free list per-interpreter

### DIFF
--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -167,7 +167,7 @@ PyAPI_FUNC(void) _PyGC_InitState(struct _gc_runtime_state *);
 // Functions to clear types free lists
 extern void _PyFrame_ClearFreeList(void);
 extern void _PyTuple_ClearFreeList(PyThreadState *tstate);
-extern void _PyFloat_ClearFreeList(void);
+extern void _PyFloat_ClearFreeList(PyThreadState *tstate);
 extern void _PyList_ClearFreeList(void);
 extern void _PyDict_ClearFreeList(void);
 extern void _PyAsyncGen_ClearFreeLists(void);

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -84,6 +84,14 @@ struct _Py_tuple_state {
 #endif
 };
 
+struct _Py_float_state {
+    /* Special free list
+       free_list is a singly-linked list of available PyFloatObjects,
+       linked via abuse of their ob_type members. */
+    int numfree;
+    PyFloatObject *free_list;
+};
+
 
 /* interpreter state */
 
@@ -178,6 +186,7 @@ struct _is {
     PyLongObject* small_ints[_PY_NSMALLNEGINTS + _PY_NSMALLPOSINTS];
 #endif
     struct _Py_tuple_state tuple;
+    struct _Py_float_state float_state;
 };
 
 /* Used by _PyImport_Cleanup() */

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -64,7 +64,7 @@ extern void _PyTuple_Fini(PyThreadState *tstate);
 extern void _PyList_Fini(void);
 extern void _PySet_Fini(void);
 extern void _PyBytes_Fini(void);
-extern void _PyFloat_Fini(void);
+extern void _PyFloat_Fini(PyThreadState *tstate);
 extern void _PySlice_Fini(void);
 extern void _PyAsyncGen_Fini(void);
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
@@ -1,1 +1,2 @@
-Each interpreter now has its own tuple free lists and empty tuple singleton.
+Tuple free lists, empty tuple singleton, and float free list are no longer
+shared by all interpreters: each interpreter now its own free lists.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1028,7 +1028,7 @@ clear_freelists(void)
     PyThreadState *tstate = _PyThreadState_GET();
     _PyFrame_ClearFreeList();
     _PyTuple_ClearFreeList(tstate);
-    _PyFloat_ClearFreeList();
+    _PyFloat_ClearFreeList(tstate);
     _PyList_ClearFreeList();
     _PyDict_ClearFreeList();
     _PyAsyncGen_ClearFreeLists();

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1261,9 +1261,9 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     }
 
     _PyLong_Fini(tstate);
+    _PyFloat_Fini(tstate);
 
     if (is_main_interp) {
-        _PyFloat_Fini();
         _PyDict_Fini();
         _PySlice_Fini();
     }


### PR DESCRIPTION
Each interpreter now has its own float free list:

* Move tuple numfree and free_list into PyInterpreterState.
* Add _Py_float_state structure.
* Add tstate parameter to _PyFloat_ClearFreeList()
  and _PyFloat_Fini().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
