### PR TITLE
bpo-40521: Make async gen free lists per-interpreter

### DIFF
--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -170,7 +170,7 @@ extern void _PyTuple_ClearFreeList(PyThreadState *tstate);
 extern void _PyFloat_ClearFreeList(PyThreadState *tstate);
 extern void _PyList_ClearFreeList(PyThreadState *tstate);
 extern void _PyDict_ClearFreeList(void);
-extern void _PyAsyncGen_ClearFreeLists(void);
+extern void _PyAsyncGen_ClearFreeLists(PyThreadState *tstate);
 extern void _PyContext_ClearFreeList(void);
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -108,6 +108,23 @@ struct _Py_frame_state {
     int numfree;
 };
 
+#ifndef _PyAsyncGen_MAXFREELIST
+#  define _PyAsyncGen_MAXFREELIST 80
+#endif
+
+struct _Py_async_gen_state {
+    /* Freelists boost performance 6-10%; they also reduce memory
+       fragmentation, as _PyAsyncGenWrappedValue and PyAsyncGenASend
+       are short-living objects that are instantiated for every
+       __anext__() call. */
+    struct _PyAsyncGenWrappedValue* value_freelist[_PyAsyncGen_MAXFREELIST];
+    int value_numfree;
+
+    struct PyAsyncGenASend* asend_freelist[_PyAsyncGen_MAXFREELIST];
+    int asend_numfree;
+};
+
+
 
 /* interpreter state */
 
@@ -205,6 +222,7 @@ struct _is {
     struct _Py_list_state list;
     struct _Py_float_state float_state;
     struct _Py_frame_state frame;
+    struct _Py_async_gen_state async_gen;
 
     /* Using a cache is very effective since typically only a single slice is
        created and then deleted again. */

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -66,7 +66,7 @@ extern void _PySet_Fini(void);
 extern void _PyBytes_Fini(void);
 extern void _PyFloat_Fini(PyThreadState *tstate);
 extern void _PySlice_Fini(PyThreadState *tstate);
-extern void _PyAsyncGen_Fini(void);
+extern void _PyAsyncGen_Fini(PyThreadState *tstate);
 
 extern void PyOS_FiniInterrupts(void);
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
@@ -1,3 +1,4 @@
 The tuple free lists, the empty tuple singleton, the list free list, the float
-free list, the slice cache, and the frame free list are no longer shared by all
-interpreters: each interpreter now its has own free lists and caches.
+free list, the slice cache, the frame free list, the asynchronous generator
+free lists are no longer shared by all interpreters: each interpreter now its
+has own free lists and caches.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1031,7 +1031,7 @@ clear_freelists(void)
     _PyFloat_ClearFreeList(tstate);
     _PyList_ClearFreeList(tstate);
     _PyDict_ClearFreeList();
-    _PyAsyncGen_ClearFreeLists();
+    _PyAsyncGen_ClearFreeLists(tstate);
     _PyContext_ClearFreeList();
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1270,7 +1270,11 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     if (is_main_interp) {
         _Py_HashRandomization_Fini();
         _PyArg_Fini();
-        _PyAsyncGen_Fini();
+    }
+
+    _PyAsyncGen_Fini(tstate);
+
+    if (is_main_interp) {
         _PyContext_Fini();
     }
 


### PR DESCRIPTION
Each interpreter now has its own asynchronous generator free list:

* Move async gen free lists into PyInterpreterState.
* Free list arrays are now arrays of PyObject*, since
  _PyAsyncGenWrappedValue and PyAsyncGenASend structures are only
  defined in genobject.c.
* Move _PyAsyncGen_MAXFREELIST define to pycore_interp.h
* Add _Py_async_gen_state structure.
* Add tstate parameter to _PyAsyncGen_ClearFreeLists
  and _PyAsyncGen_Fini().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
