### PR TITLE
bpo-40870: Invalidate usage of some constants with ast.Name

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -668,6 +668,13 @@ class AST_Tests(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ast.parse('f"{x=}"', feature_version=(3, 7))
 
+    def test_constant_as_name(self):
+        for constant in "True", "False", "None":
+            expr = ast.Expression(ast.Name(constant, ast.Load()))
+            ast.fix_missing_locations(expr)
+            with self.assertRaisesRegex(ValueError, f"Name node can't be used with '{constant}' constant"):
+                compile(expr, "<test>", "eval")
+
 
 class ASTHelpers_Test(unittest.TestCase):
     maxDiff = None

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-05-12-48-28.bpo-40870.9cd2sk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-05-12-48-28.bpo-40870.9cd2sk.rst
@@ -1,2 +1,2 @@
 Raise :exc:`ValueError` when validating custom AST's where the constants
-``True``, ``False`` and ``None`` used with a :class:`ast.Name` node.
+``True``, ``False`` and ``None`` are used within a :class:`ast.Name` node.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-05-12-48-28.bpo-40870.9cd2sk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-05-12-48-28.bpo-40870.9cd2sk.rst
@@ -1,0 +1,2 @@
+Raise :exc:`ValueError` when validating custom AST's where the constants
+``True``, ``False`` and ``None`` used with a :class:`ast.Name` node.


### PR DESCRIPTION

<!-- issue-number: [bpo-40870](https://bugs.python.org/issue40870) -->
https://bugs.python.org/issue40870
<!-- /issue-number -->
