### PR TITLE
gh-85049: Add multiprocessing.Lock.locked()

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1301,6 +1301,12 @@ object -- see :ref:`multiprocessing-managers`.
       Behavior is the same as in :meth:`threading.Lock.release` except that
       when invoked on an unlocked lock, a :exc:`ValueError` is raised.
 
+   .. method:: locked()
+
+      Return true if the lock is acquired.
+
+      .. versionadded:: 3.10
+
 
 .. class:: RLock()
 

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -161,6 +161,9 @@ class Lock(SemLock):
     def __init__(self, *, ctx):
         SemLock.__init__(self, SEMAPHORE, 1, 1, ctx=ctx)
 
+    def locked(self):
+        return self._semlock._is_zero()
+
     def __repr__(self):
         try:
             if self._semlock._is_mine():

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1230,8 +1230,10 @@ class _TestLock(BaseTestCase):
     def test_lock(self):
         lock = self.Lock()
         self.assertEqual(lock.acquire(), True)
+        self.assertTrue(lock.locked())
         self.assertEqual(lock.acquire(False), False)
         self.assertEqual(lock.release(), None)
+        self.assertFalse(lock.locked())
         self.assertRaises((ValueError, threading.ThreadError), lock.release)
 
     def test_rlock(self):

--- a/Misc/NEWS.d/next/Library/2020-06-05-15-47-43.bpo-40872.hW9afp.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-05-15-47-43.bpo-40872.hW9afp.rst
@@ -1,0 +1,2 @@
+:class:`multiprocessing.Lock` now has a `locked()` method that returns
+whether the lock is currently held. Patch contributed by Rémi Lapeyre.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40872](https://bugs.python.org/issue40872) -->
https://bugs.python.org/issue40872
<!-- /issue-number -->

<!-- gh-issue-number: gh-85049 -->
* Issue: gh-85049
<!-- /gh-issue-number -->
