### PR TITLE
bpo-40876: Clarify error message in the csv module

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-06-05-20-00-18.bpo-40876.zDhiZj.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-05-20-00-18.bpo-40876.zDhiZj.rst
@@ -1,0 +1,1 @@
+Clarify error message in the :mod:`csv` module.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -810,7 +810,7 @@ Reader_iternext(ReaderObj *self)
             PyErr_Format(_csvstate_global->error_obj,
                          "iterator should return strings, "
                          "not %.200s "
-                         "(did you open the file in text mode?)",
+                         "(the file should be opened in text mode)",
                          Py_TYPE(lineobj)->tp_name
                 );
             Py_DECREF(lineobj);


### PR DESCRIPTION
I was working with the csv module, and I vaguely remembered that you should open files in binary mode. So I did.

Then I saw this error message:

```
_csv.Error: iterator should return strings, not bytes (did you open the file in text mode?)
```

I read the end and thought "I didn't open it in text mode, what does it want from me?!" It took a careful reading to figure out that I was *supposed to* open it in text mode.

This PR slightly changes the text to:

```
_csv.Error: iterator should return strings, not bytes (the file should be opened in text mode)
```



<!-- issue-number: [bpo-40876](https://bugs.python.org/issue40876) -->
https://bugs.python.org/issue40876
<!-- /issue-number -->
