### PR TITLE
bpo-39791: Refresh importlib.metadata from importlib_metadata 1.6.1.

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -77,7 +77,9 @@ Entry points
 The ``entry_points()`` function returns a dictionary of all entry points,
 keyed by group.  Entry points are represented by ``EntryPoint`` instances;
 each ``EntryPoint`` has a ``.name``, ``.group``, and ``.value`` attributes and
-a ``.load()`` method to resolve the value.
+a ``.load()`` method to resolve the value.  There are also ``.module``,
+``.attr``, and ``.extras`` attributes for getting the components of the
+``.value`` attribute::
 
     >>> eps = entry_points()  # doctest: +SKIP
     >>> list(eps)  # doctest: +SKIP
@@ -86,6 +88,12 @@ a ``.load()`` method to resolve the value.
     >>> wheel = [ep for ep in scripts if ep.name == 'wheel'][0]  # doctest: +SKIP
     >>> wheel  # doctest: +SKIP
     EntryPoint(name='wheel', value='wheel.cli:main', group='console_scripts')
+    >>> wheel.module  # doctest: +SKIP
+    'wheel.cli'
+    >>> wheel.attr  # doctest: +SKIP
+    'main'
+    >>> wheel.extras  # doctest: +SKIP
+    []
     >>> main = wheel.load()  # doctest: +SKIP
     >>> main  # doctest: +SKIP
     <function main at 0x103528488>
@@ -94,7 +102,7 @@ The ``group`` and ``name`` are arbitrary values defined by the package author
 and usually a client will wish to resolve all entry points for a particular
 group.  Read `the setuptools docs
 <https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
-for more information on entrypoints, their definition, and usage.
+for more information on entry points, their definition, and usage.
 
 
 .. _metadata:
@@ -235,7 +243,7 @@ method::
         """
 
 The ``DistributionFinder.Context`` object provides ``.path`` and ``.name``
-properties indicating the path to search and names to match and may
+properties indicating the path to search and name to match and may
 supply other relevant context.
 
 What this means in practice is that to support finding distribution package

--- a/Lib/test/test_importlib/fixtures.py
+++ b/Lib/test/test_importlib/fixtures.py
@@ -161,6 +161,21 @@ class EggInfoFile(OnSysPath, SiteDir):
         build_files(EggInfoFile.files, prefix=self.site_dir)
 
 
+class LocalPackage:
+    files = {
+        "setup.py": """
+            import setuptools
+            setuptools.setup(name="local-pkg", version="2.0.1")
+            """,
+        }
+
+    def setUp(self):
+        self.fixtures = contextlib.ExitStack()
+        self.addCleanup(self.fixtures.close)
+        self.fixtures.enter_context(tempdir_as_cwd())
+        build_files(self.files)
+
+
 def build_files(file_defs, prefix=pathlib.Path()):
     """Build a set of files/directories, as described by the
 

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -246,3 +246,19 @@ class TestEntryPoints(unittest.TestCase):
         """
         with self.assertRaises(Exception):
             json.dumps(self.ep)
+
+    def test_module(self):
+        assert self.ep.module == 'value'
+
+    def test_attr(self):
+        assert self.ep.attr is None
+
+
+class FileSystem(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
+    def test_unicode_dir_on_sys_path(self):
+        """
+        Ensure a Unicode subdirectory of a directory on sys.path
+        does not crash.
+        """
+        fixtures.build_files({'☃': {}}, prefix=self.site_dir)
+        list(distributions())

--- a/Lib/test/test_importlib/test_zip.py
+++ b/Lib/test/test_importlib/test_zip.py
@@ -3,9 +3,10 @@ import unittest
 
 from contextlib import ExitStack
 from importlib.metadata import (
-    distribution, entry_points, files, PackageNotFoundError, version,
+    distribution, entry_points, files, PackageNotFoundError,
+    version, distributions,
 )
-from importlib.resources import path
+from importlib import resources
 
 from test.support import requires_zlib
 
@@ -14,15 +15,19 @@ from test.support import requires_zlib
 class TestZip(unittest.TestCase):
     root = 'test.test_importlib.data'
 
+    def _fixture_on_path(self, filename):
+        pkg_file = resources.files(self.root).joinpath(filename)
+        file = self.resources.enter_context(resources.as_file(pkg_file))
+        assert file.name.startswith('example-'), file.name
+        sys.path.insert(0, str(file))
+        self.resources.callback(sys.path.pop, 0)
+
     def setUp(self):
         # Find the path to the example-*.whl so we can add it to the front of
         # sys.path, where we'll then try to find the metadata thereof.
         self.resources = ExitStack()
         self.addCleanup(self.resources.close)
-        wheel = self.resources.enter_context(
-            path(self.root, 'example-21.12-py3-none-any.whl'))
-        sys.path.insert(0, str(wheel))
-        self.resources.callback(sys.path.pop, 0)
+        self._fixture_on_path('example-21.12-py3-none-any.whl')
 
     def test_zip_version(self):
         self.assertEqual(version('example'), '21.12')
@@ -49,6 +54,10 @@ class TestZip(unittest.TestCase):
             path = str(file.dist.locate_file(file))
             assert '.whl/' in path, path
 
+    def test_one_distribution(self):
+        dists = list(distributions(path=sys.path[:1]))
+        assert len(dists) == 1
+
 
 @requires_zlib()
 class TestEgg(TestZip):
@@ -57,10 +66,7 @@ class TestEgg(TestZip):
         # sys.path, where we'll then try to find the metadata thereof.
         self.resources = ExitStack()
         self.addCleanup(self.resources.close)
-        egg = self.resources.enter_context(
-            path(self.root, 'example-21.12-py3.6.egg'))
-        sys.path.insert(0, str(egg))
-        self.resources.callback(sys.path.pop, 0)
+        self._fixture_on_path('example-21.12-py3.6.egg')
 
     def test_files(self):
         for file in files('example'):

--- a/Misc/NEWS.d/next/Library/2020-06-05-19-29-10.bpo-39791._CcO3d.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-05-19-29-10.bpo-39791._CcO3d.rst
@@ -1,0 +1,1 @@
+Refresh importlib.metadata from importlib_metadata 1.6.1.


### PR DESCRIPTION
Refreshing importlib.metadata with 1.6.1 which uses `importlib.resources.files` in its tests should unblock the issues affecting GH-20576.

<!-- issue-number: [bpo-39791](https://bugs.python.org/issue39791) -->
https://bugs.python.org/issue39791
<!-- /issue-number -->
