### PR TITLE
Streamline counter rich comparisons

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -760,10 +760,12 @@ class Counter(dict):
     #         set(cp - cq) == sp - sq
     #         set(cp | cq) == sp | sq
     #         set(cp & cq) == sp & sq
-    #         cp.isequal(cq) == (sp == sq)
-    #         cp.issubset(cq) == sp.issubset(sq)
-    #         cp.issuperset(cq) == sp.issuperset(sq)
-    #         cp.isdisjoint(cq) == sp.isdisjoint(sq)
+    #         (cp == cq) == (sp == sq)
+    #         (cp != cq) == (sp != sq)
+    #         (cp <= cq) == (sp <= sq)
+    #         (cp < cq) == (sp < sq)
+    #         (cp >= cq) == (sp >= sq)
+    #         (cp > cq) == (sp > sq)
 
     def __add__(self, other):
         '''Add counts from two counters.

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -695,7 +695,13 @@ class Counter(dict):
         'True if all counts agree. Missing counts are treated as zero.'
         if not isinstance(other, Counter):
             return NotImplemented
-        return all(self[e] == other[e] for c in (self, other) for e in c)
+        for elem, count in self.items() - other.items():
+            if count != other[elem]:
+                return False
+        for elem, count in other.items() - self.items():
+            if self[elem] != count:
+                return False
+        return True
 
     def __ne__(self, other):
         'True if any counts disagree. Missing counts are treated as zero.'

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -707,7 +707,7 @@ class Counter(dict):
         'True if all counts in self are a subset of those in other.'
         if not isinstance(other, Counter):
             return NotImplemented
-        return all(self[e] <= other[e] for c in (self, other) for e in c)
+        return all(self[e] <= other[e] for e, _ in self.items() ^ other.items())
 
     def __lt__(self, other):
         'True if all counts in self are a proper subset of those in other.'
@@ -719,7 +719,7 @@ class Counter(dict):
         'True if all counts in self are a superset of those in other.'
         if not isinstance(other, Counter):
             return NotImplemented
-        return all(self[e] >= other[e] for c in (self, other) for e in c)
+        return all(self[e] >= other[e] for e, _ in self.items() ^ other.items())
 
     def __gt__(self, other):
         'True if all counts in self are a proper superset of those in other.'

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -695,13 +695,7 @@ class Counter(dict):
         'True if all counts agree. Missing counts are treated as zero.'
         if not isinstance(other, Counter):
             return NotImplemented
-        for elem, count in self.items() - other.items():
-            if count != other[elem]:
-                return False
-        for elem, count in other.items() - self.items():
-            if self[elem] != count:
-                return False
-        return True
+        return all(self[e] == other[e] for e, _ in self.items() ^ other.items())
 
     def __ne__(self, other):
         'True if any counts disagree. Missing counts are treated as zero.'


### PR DESCRIPTION
Leverage dict view set operations to do most of the work.  Only perform the slow lookup and fallback to ``__missing__()`` for pairs known to differ between the two inputs.  If there are no differences (a common case), all pairs are compared at C speed.