### PR TITLE
bpo-40880: Fix invalid read in newline_in_string in pegen.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-06-00-23-19.bpo-40880.fjdzSh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-06-00-23-19.bpo-40880.fjdzSh.rst
@@ -1,0 +1,2 @@
+Fix invalid memory read in the new parser when checking newlines in string
+literals. Patch by Pablo Galindo.

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -937,8 +937,8 @@ _PyPegen_number_token(Parser *p)
 static int // bool
 newline_in_string(Parser *p, const char *cur)
 {
-    for (char c = *cur; cur > p->tok->buf; c = *--cur) {
-        if (c == '\'' || c == '"') {
+    for (const char *c = cur; c >= p->tok->buf; c--) {
+        if (*c == '\'' || *c == '"') {
             return 1;
         }
     }

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -937,7 +937,7 @@ _PyPegen_number_token(Parser *p)
 static int // bool
 newline_in_string(Parser *p, const char *cur)
 {
-    for (char c = *cur; cur >= p->tok->buf; c = *--cur) {
+    for (char c = *cur; cur > p->tok->buf; c = *--cur) {
         if (c == '\'' || c == '"') {
             return 1;
         }


### PR DESCRIPTION


<!-- issue-number: [bpo-40880](https://bugs.python.org/issue40880) -->
https://bugs.python.org/issue40880
<!-- /issue-number -->
