### PR TITLE
bpo-40883: Fix memory leak in fstring_compile_expr in parse_string.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-05-23-25-00.bpo-40883.M6sQ-Q.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-05-23-25-00.bpo-40883.M6sQ-Q.rst
@@ -1,0 +1,1 @@
+Fix memory leak in when parsing f-strings in the new parser. Patch by Pablo Galindo

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -604,6 +604,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
 
     struct tok_state* tok = PyTokenizer_FromString(str, 1);
     if (tok == NULL) {
+        PyMem_RawFree(str);
         return NULL;
     }
     Py_INCREF(p->tok->filename);
@@ -629,6 +630,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
     result = expr;
 
 exit:
+    PyMem_RawFree(str);
     _PyPegen_Parser_Free(p2);
     PyTokenizer_Free(tok);
     return result;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40883](https://bugs.python.org/issue40883) -->
https://bugs.python.org/issue40883
<!-- /issue-number -->
