### PR TITLE
bpo-33689: Blank lines in .pth file cause a duplicate sys.path entry

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -164,6 +164,8 @@ def addpackage(sitedir, name, known_paths):
         for n, line in enumerate(f):
             if line.startswith("#"):
                 continue
+            if line.strip() == "":
+                continue
             try:
                 if line.startswith(("import ", "import\t")):
                     exec(line)

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -170,7 +170,7 @@ class HelperFunctionsTests(unittest.TestCase):
         pth_dir, pth_fn = self.make_pth("abc\x00def\n")
         with captured_stderr() as err_out:
             self.assertFalse(site.addpackage(pth_dir, pth_fn, set()))
-        self.asserLib/site.pytEqual(err_out.getvalue(), "")
+        self.assertEqual(err_out.getvalue(), "")
         for path in sys.path:
             if isinstance(path, str):
                 self.assertNotIn("abc\x00def", path)

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -163,14 +163,14 @@ class HelperFunctionsTests(unittest.TestCase):
         # Issue 33689
         pth_dir, pth_fn = self.make_pth("\n\n  \n\n")
         known_paths = site.addpackage(pth_dir, pth_fn, set())
-        self.assertEqual(len(known_paths), 0)
+        self.assertEqual(known_paths, set())
 
     def test_addpackage_import_bad_pth_file(self):
         # Issue 5258
         pth_dir, pth_fn = self.make_pth("abc\x00def\n")
         with captured_stderr() as err_out:
             self.assertFalse(site.addpackage(pth_dir, pth_fn, set()))
-        self.assertEqual(err_out.getvalue(), "")
+        self.asserLib/site.pytEqual(err_out.getvalue(), "")
         for path in sys.path:
             if isinstance(path, str):
                 self.assertNotIn("abc\x00def", path)
@@ -590,16 +590,6 @@ class StartupImportTests(unittest.TestCase):
         r = subprocess.Popen([sys.executable, '-I', '-c',
             'import site, sys; site.enablerlcompleter(); sys.exit(hasattr(sys, "__interactivehook__"))']).wait()
         self.assertTrue(r, "'__interactivehook__' not added by enablerlcompleter()")
-
-    @classmethod
-    def _calc_sys_path_for_underpth_nosite(self, sys_prefix, lines):
-        sys_path = []
-        for line in lines:
-            if not line or line[0] == '#':
-                continue
-            abs_path = os.path.abspath(os.path.join(sys_prefix, line))
-            sys_path.append(abs_path)
-        return sys_path
 
 @unittest.skipUnless(sys.platform == 'win32', "only supported on Windows")
 class _pthFileTests(unittest.TestCase):

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -591,6 +591,15 @@ class StartupImportTests(unittest.TestCase):
             'import site, sys; site.enablerlcompleter(); sys.exit(hasattr(sys, "__interactivehook__"))']).wait()
         self.assertTrue(r, "'__interactivehook__' not added by enablerlcompleter()")
 
+    @classmethod
+    def _calc_sys_path_for_underpth_nosite(self, sys_prefix, lines):
+        sys_path = []
+        for line in lines:
+            if not line or line[0] == '#':
+                continue
+            abs_path = os.path.abspath(os.path.join(sys_prefix, line))
+            sys_path.append(abs_path)
+        return sys_path
 
 @unittest.skipUnless(sys.platform == 'win32', "only supported on Windows")
 class _pthFileTests(unittest.TestCase):

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -159,6 +159,12 @@ class HelperFunctionsTests(unittest.TestCase):
         self.assertRegex(err_out.getvalue(), 'Traceback')
         self.assertRegex(err_out.getvalue(), 'ModuleNotFoundError')
 
+    def test_addpackage_empty_lines(self):
+        # Issue 33689
+        pth_dir, pth_fn = self.make_pth("\n\n  \n\n")
+        known_paths = site.addpackage(pth_dir, pth_fn, set())
+        self.assertEqual(len(known_paths), 0)
+
     def test_addpackage_import_bad_pth_file(self):
         # Issue 5258
         pth_dir, pth_fn = self.make_pth("abc\x00def\n")

--- a/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
@@ -1,2 +1,2 @@
-Added support for empty .pth lines in the :mod:`site.py`
+Ignore empty or whitespace-only lines according to the existing documentation.
 By Ido Michael, contributors Malcolm Smith and Tal Einat.

--- a/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
@@ -1,0 +1,2 @@
+Added support for empty .pth lines in the :mod:`site.py`
+By Ido Michael, contributors Malcolm Smith and Tal Einat.

--- a/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
@@ -1,2 +1,4 @@
-Ignore empty or whitespace-only lines according to the existing documentation.
+Ignore empty or whitespace-only lines in .pth files. This matches the
+documentated behavior. Before, empty lines caused the site-packages
+dir to appear multiple times in sys.path.
 By Ido Michael, contributors Malcolm Smith and Tal Einat.


### PR DESCRIPTION
<!-- issue-number: [bpo-33689](https://bugs.python.org/issue33689) -->
https://bugs.python.org/issue33689
<!-- /issue-number -->
