### PR TITLE
Add link to .pypirc specification

### DIFF
--- a/Doc/distributing/index.rst
+++ b/Doc/distributing/index.rst
@@ -128,6 +128,7 @@ involved in creating and publishing a project:
 * `Project structure`_
 * `Building and packaging the project`_
 * `Uploading the project to the Python Packaging Index`_
+* `The .pypirc file`_
 
 .. _Project structure: \
     https://packaging.python.org/tutorials/distributing-packages/
@@ -135,6 +136,8 @@ involved in creating and publishing a project:
    https://packaging.python.org/tutorials/distributing-packages/#packaging-your-project
 .. _Uploading the project to the Python Packaging Index: \
    https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi
+.. _The .pypirc file: \
+   https://packaging.python.org/specifications/pypirc/
 
 
 How do I...?


### PR DESCRIPTION
Related to https://github.com/pypa/twine/issues/638 and https://github.com/pypa/packaging.python.org/issues/730, I wrote a spec based on the one that was removed in https://github.com/python/cpython/pull/13087. However, a Google search for "pypirc" turned up at least one [blog post](https://truveris.github.io/articles/configuring-pypirc/) that links to https://docs.python.org/3/distutils/packageindex.html#the-pypirc-file, which now just links to this document. So, I thought a link to the spec would be handy.


Automerge-Triggered-By: @jaraco