### PR TITLE
bpo-39791: Support file systems that cannot support non-ascii filenames.

### DIFF
--- a/Lib/test/test_importlib/fixtures.py
+++ b/Lib/test/test_importlib/fixtures.py
@@ -210,6 +210,17 @@ def build_files(file_defs, prefix=pathlib.Path()):
                     f.write(DALS(contents))
 
 
+class FileBuilder:
+    def unicode_filename(self):
+        try:
+            import test.support
+        except ImportError:
+            # outside CPython, hard-code a unicode snowman
+            return '☃'
+        return test.support.FS_NONASCII or \
+            self.skip("File system does not support non-ascii.")
+
+
 def DALS(str):
     "Dedent and left-strip"
     return textwrap.dedent(str).lstrip()

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -254,11 +254,16 @@ class TestEntryPoints(unittest.TestCase):
         assert self.ep.attr is None
 
 
-class FileSystem(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
+class FileSystem(
+        fixtures.OnSysPath, fixtures.SiteDir, fixtures.FileBuilder,
+        unittest.TestCase):
     def test_unicode_dir_on_sys_path(self):
         """
         Ensure a Unicode subdirectory of a directory on sys.path
         does not crash.
         """
-        fixtures.build_files({'☃': {}}, prefix=self.site_dir)
+        fixtures.build_files(
+            {self.unicode_filename(): {}},
+            prefix=self.site_dir,
+            )
         list(distributions())


### PR DESCRIPTION
In that case, the test is skipped. Addressed issue [reported here](https://bugs.python.org/issue39791?@ok_message=msg%20370834%20created%0Aissue%2039791%20message_count%2C%20messages%20edited%20ok&@template=item#msg370825).

<!-- issue-number: [bpo-39791](https://bugs.python.org/issue39791) -->
https://bugs.python.org/issue39791
<!-- /issue-number -->


Automerge-Triggered-By: @jaraco