### PR TITLE
bpo-40724: Fix return type of heapctypewithbuffer_releasebuffer()

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -6318,7 +6318,7 @@ heapctypewithbuffer_getbuffer(HeapCTypeWithBufferObject *self, Py_buffer *view, 
         view, (PyObject*)self, (void *)self->buffer, 4, 1, flags);
 }
 
-static int
+static void
 heapctypewithbuffer_releasebuffer(HeapCTypeWithBufferObject *self, Py_buffer *view)
 {
     assert(view->obj == (void*) self);


### PR DESCRIPTION
CC @scoder 

This function has no return value:

```
/Users/remi/src/cpython/Modules/_testcapimodule.c:6325:1: warning: control may reach end of non-void function [-Wreturn-type]
}
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40724](https://bugs.python.org/issue40724) -->
https://bugs.python.org/issue40724
<!-- /issue-number -->
