### PR TITLE
gh-85071: asyncio.gather() cancelled() always False

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -709,6 +709,9 @@ class _GatheringFuture(futures.Future):
         self._children = children
         self._cancel_requested = False
 
+    def cancelled(self):
+        return self.done() and self._cancel_requested
+
     def cancel(self, msg=None):
         if self.done():
             return False

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -710,7 +710,10 @@ class _GatheringFuture(futures.Future):
         self._cancel_requested = False
 
     def cancelled(self):
-        return self.done() and self._cancel_requested
+        # we assume to never raise for exception() because
+        # done() ensures !_PENDING and _CANCELLED cannot be set
+        # on _GatheringFuture.
+        return self.done() and isinstance(self.exception(), exceptions.CancelledError)
 
     def cancel(self, msg=None):
         if self.done():

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2963,7 +2963,7 @@ class FutureGatherTests(GatherTestsBase, test_utils.TestCase):
         self._run_loop(self.one_loop)
         self.assertTrue(fut.done())
         cb.assert_called_once_with(fut)
-        self.assertFalse(fut.cancelled())
+        self.assertTrue(fut.cancelled())
         self.assertIsInstance(fut.exception(), asyncio.CancelledError)
         # Does nothing
         c.set_result(3)
@@ -2994,7 +2994,7 @@ class FutureGatherTests(GatherTestsBase, test_utils.TestCase):
         self.assertEqual(res, [1, zde, None, 3, None, rte])
         cb.assert_called_once_with(fut)
 
-    def test_gather_is_cancelled_is_true_when_gather_cancel_is_true(self):
+    def test_gather_is_cancelled_when_gather_cancelled_directly(self):
         for re in [True, False]:
             with self.subTest(return_exceptions=re):
 
@@ -3013,7 +3013,42 @@ class FutureGatherTests(GatherTestsBase, test_utils.TestCase):
                     self.one_loop.run_until_complete(gather_)
                 self.assertTrue(gather_.cancelled())
 
-    def test_gather_is_cancelled_is_false_when_gather_cancel_is_false(self):
+    def test_gather_is_cancelled_when_child_cancelled_externally_and_return_exceptions_false(self):
+
+        # thread state and cleanup
+        asyncio.set_event_loop(self.one_loop)
+        self.addCleanup(asyncio.set_event_loop, None)
+
+        # setup gather
+        child = asyncio.ensure_future(asyncio.sleep(1, result=1))
+        gather_ = asyncio.gather(child, return_exceptions=False)
+        self.assertTrue(child.cancel())
+
+        # run and assert
+        self.assertFalse(gather_.cancelled())
+        with self.assertRaises(asyncio.CancelledError):
+            self.one_loop.run_until_complete(gather_)
+        self.assertTrue(gather_.cancelled())
+
+    def test_gather_is_not_cancelled_when_child_cancelled_externally_and_return_exceptions_true(self):
+
+        # thread state and cleanup
+        asyncio.set_event_loop(self.one_loop)
+        self.addCleanup(asyncio.set_event_loop, None)
+
+        # setup gather
+        child = asyncio.ensure_future(asyncio.sleep(1, result=1))
+        gather_ = asyncio.gather(child, return_exceptions=True)
+        self.assertTrue(child.cancel())
+
+        # run and assert
+        self.assertFalse(gather_.cancelled())
+        result = self.one_loop.run_until_complete(gather_)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(isinstance(result[0], asyncio.CancelledError))
+        self.assertFalse(gather_.cancelled())
+
+    def test_gather_is_cancelled_is_false_when_gather_child_succeeds(self):
         for re in [True, False]:
             with self.subTest(return_exceptions=re):
 

--- a/Misc/NEWS.d/next/Library/2022-05-14-19-03-30.gh-issue-40894.A4Rt59.rst
+++ b/Misc/NEWS.d/next/Library/2022-05-14-19-03-30.gh-issue-40894.A4Rt59.rst
@@ -1,0 +1,4 @@
+Fixed future subclass returned by :func:`asyncio.gather` to behave like
+other futures by returning True on a call to :meth:`cancelled` after
+a successful cancellation occurred. Previously it always returned False.
+Patch by Timm Wagener.


### PR DESCRIPTION
## [bpo-40894](https://bugs.python.org/issue40894): asyncio.gather() cancelled() always False

It seems like the future subclass returned by asyncio.gather() _(`_GatheringFuture`)_ can never return True for future.cancelled() even after it's cancel() has been invoked successfully (returning True) and an await on it actually raised a CancelledError. This is in contrast to the behavior of normal Futures and it seems generally to be classified as a minor bug by developers.

* [Stackoverflow Post](https://stackoverflow.com/questions/61942306/asyncio-gather-task-cancelled-is-false-after-task-cancel)
* [Github snippet](https://gist.github.com/timmwagener/dfed038dc2081c8b5a770e175ba3756b)

This PR consists of a small and simple fix. So maybe this is a minor bug, whose fix has no backward-compatibility consequences. However, my understanding is that asyncio.gather() is scheduled for deprecation, so maybe changes in this area are on halt anyways!?

## Summary

This PR enables `asyncio.gather().cancelled()` to return `True` by overriding `_GatheringFuture.cancelled()` to return `True` when:
* `_GatheringFuture.done()` is True.
* `_GatheringFuture` has `CancelledError` set as exception.
* Tests are provided.

<!-- issue-number: [bpo-40894](https://bugs.python.org/issue40894) -->
https://bugs.python.org/issue40894
<!-- /issue-number -->

<!-- gh-issue-number: gh-85071 -->
* Issue: gh-85071
<!-- /gh-issue-number -->
