### PR TITLE
bpo-40275: Adding filesystem_helper submodule in test.support

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -252,12 +252,6 @@ The :mod:`test.support` module defines the following constants:
    A non-ASCII character encodable by :func:`os.fsencode`.
 
 
-.. data:: TESTFN
-
-   Set to a name that is safe to use as the name of a temporary file.  Any
-   temporary file that is created should be closed and unlinked (removed).
-
-
 .. data:: TESTFN_UNICODE
 
     Set to a non-ASCII name for a temporary file.
@@ -1634,3 +1628,20 @@ The :mod:`test.support.threading_helper` module provides support for threading t
        # (to avoid reference cycles)
 
    .. versionadded:: 3.8
+
+
+:mod:`test.support.filesystem_helper` --- Utilities for filesystem tests
+========================================================================
+
+.. module:: test.support.filesystem_helper
+   :synopsis: Support for filesystem tests.
+
+The :mod:`test.support.filesystem_helper` module provides support for filesystem tests.
+
+.. versionadded:: 3.10
+
+
+.. data:: TESTFN
+
+   Set to a name that is safe to use as the name of a temporary file.  Any
+   temporary file that is created should be closed and unlinked (removed).

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -22,6 +22,7 @@ import types
 import unittest
 import warnings
 
+from .filesystem_helper import TESTFN
 from .testresult import get_test_runner
 
 __all__ = [
@@ -37,7 +38,7 @@ __all__ = [
     "record_original_stdout", "get_original_stdout", "captured_stdout",
     "captured_stdin", "captured_stderr",
     # filesystem
-    "TESTFN", "SAVEDCWD", "unlink", "rmtree", "temp_cwd", "findfile",
+    "SAVEDCWD", "unlink", "rmtree", "temp_cwd", "findfile",
     "create_empty_file", "can_symlink", "fs_is_case_insensitive",
     # unittest
     "is_resource_enabled", "requires", "requires_freebsd_version",
@@ -713,17 +714,6 @@ if sys.platform != 'win32':
     unix_shell = '/system/bin/sh' if is_android else '/bin/sh'
 else:
     unix_shell = None
-
-# Filename used for testing
-if os.name == 'java':
-    # Jython disallows @ in module names
-    TESTFN = '$test'
-else:
-    TESTFN = '@test'
-
-# Disambiguate TESTFN for parallel testing, while letting it remain a valid
-# module name.
-TESTFN = "{}_{}_tmp".format(TESTFN, os.getpid())
 
 # Define the URL of a dedicated HTTP server for the network tests.
 # The URL must use clear-text HTTP: no redirection to encrypted HTTPS.

--- a/Lib/test/support/filesystem_helper.py
+++ b/Lib/test/support/filesystem_helper.py
@@ -1,0 +1,13 @@
+import os
+
+
+# Filename used for testing
+if os.name == 'java':
+    # Jython disallows @ in module names
+    TESTFN = '$test'
+else:
+    TESTFN = '@test'
+
+# Disambiguate TESTFN for parallel testing, while letting it remain a valid
+# module name.
+TESTFN = "{}_{}_tmp".format(TESTFN, os.getpid())


### PR DESCRIPTION
Add a new test.support.filesystem_helper submodule and move TESTFN to filesystem_helper.

<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
