### PR TITLE
bpo-40898: Remove redundant if statements in tp_traverse

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -484,8 +484,7 @@ static int
 keyobject_traverse(keyobject *ko, visitproc visit, void *arg)
 {
     Py_VISIT(ko->cmp);
-    if (ko->object)
-        Py_VISIT(ko->object);
+    Py_VISIT(ko->object);
     return 0;
 }
 

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -623,9 +623,7 @@ iomodule_traverse(PyObject *mod, visitproc visit, void *arg) {
     _PyIO_State *state = get_io_state(mod);
     if (!state->initialized)
         return 0;
-    if (state->locale_module != NULL) {
-        Py_VISIT(state->locale_module);
-    }
+    Py_VISIT(state->locale_module);
     Py_VISIT(state->unsupported_operation);
     return 0;
 }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -999,8 +999,7 @@ cycle_dealloc(cycleobject *lz)
 static int
 cycle_traverse(cycleobject *lz, visitproc visit, void *arg)
 {
-    if (lz->it)
-        Py_VISIT(lz->it);
+    Py_VISIT(lz->it);
     Py_VISIT(lz->saved);
     return 0;
 }

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -1504,12 +1504,8 @@ Overlapped_traverse(OverlappedObject *self, visitproc visit, void *arg)
         }
         break;
     case TYPE_READ_FROM:
-        if(self->read_from.result) {
-            Py_VISIT(self->read_from.result);
-        }
-        if(self->read_from.allocated_buffer) {
-            Py_VISIT(self->read_from.allocated_buffer);
-        }
+        Py_VISIT(self->read_from.result);
+        Py_VISIT(self->read_from.allocated_buffer);
     }
     return 0;
 }


### PR DESCRIPTION
Remove redundant if statements of tp_traverse in itertools, _functools, _io, _overlapped.

<!-- issue-number: [bpo-40898](https://bugs.python.org/issue40898) -->
https://bugs.python.org/issue40898
<!-- /issue-number -->
