### PR TITLE
bpo-40887: Don't use finalized free lists

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -595,6 +595,10 @@ frame_dealloc(PyFrameObject *f)
     else {
         PyInterpreterState *interp = _PyInterpreterState_GET();
         struct _Py_frame_state *state = &interp->frame;
+#ifdef Py_DEBUG
+        // frame_dealloc() must not be called after _PyFrame_Fini()
+        assert(state->numfree != -1);
+#endif
         if (state->numfree < PyFrame_MAXFREELIST) {
             ++state->numfree;
             f->f_back = state->free_list;
@@ -790,6 +794,10 @@ frame_alloc(PyCodeObject *code)
         }
     }
     else {
+#ifdef Py_DEBUG
+        // frame_alloc() must not be called after _PyFrame_Fini()
+        assert(state->numfree != -1);
+#endif
         assert(state->numfree > 0);
         --state->numfree;
         f = state->free_list;
@@ -1188,6 +1196,10 @@ void
 _PyFrame_Fini(PyThreadState *tstate)
 {
     _PyFrame_ClearFreeList(tstate);
+#ifdef Py_DEBUG
+    struct _Py_frame_state *state = &tstate->interp->frame;
+    state->numfree = -1;
+#endif
 }
 
 /* Print summary info about the state of the optimized allocator */

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1430,6 +1430,11 @@ void
 _PyAsyncGen_Fini(PyThreadState *tstate)
 {
     _PyAsyncGen_ClearFreeLists(tstate);
+#ifdef Py_DEBUG
+    struct _Py_async_gen_state *state = &tstate->interp->async_gen;
+    state->value_numfree = -1;
+    state->asend_numfree = -1;
+#endif
 }
 
 
@@ -1474,6 +1479,10 @@ async_gen_asend_dealloc(PyAsyncGenASend *o)
     Py_CLEAR(o->ags_sendval);
     PyInterpreterState *interp = _PyInterpreterState_GET();
     struct _Py_async_gen_state *state = &interp->async_gen;
+#ifdef Py_DEBUG
+    // async_gen_asend_dealloc() must not be called after _PyAsyncGen_Fini()
+    assert(state->asend_numfree != -1);
+#endif
     if (state->asend_numfree < _PyAsyncGen_MAXFREELIST) {
         assert(PyAsyncGenASend_CheckExact(o));
         state->asend_freelist[state->asend_numfree++] = o;
@@ -1632,6 +1641,10 @@ async_gen_asend_new(PyAsyncGenObject *gen, PyObject *sendval)
     PyAsyncGenASend *o;
     PyInterpreterState *interp = _PyInterpreterState_GET();
     struct _Py_async_gen_state *state = &interp->async_gen;
+#ifdef Py_DEBUG
+    // async_gen_asend_new() must not be called after _PyAsyncGen_Fini()
+    assert(state->asend_numfree != -1);
+#endif
     if (state->asend_numfree) {
         state->asend_numfree--;
         o = state->asend_freelist[state->asend_numfree];
@@ -1667,6 +1680,10 @@ async_gen_wrapped_val_dealloc(_PyAsyncGenWrappedValue *o)
     Py_CLEAR(o->agw_val);
     PyInterpreterState *interp = _PyInterpreterState_GET();
     struct _Py_async_gen_state *state = &interp->async_gen;
+#ifdef Py_DEBUG
+    // async_gen_wrapped_val_dealloc() must not be called after _PyAsyncGen_Fini()
+    assert(state->value_numfree != -1);
+#endif
     if (state->value_numfree < _PyAsyncGen_MAXFREELIST) {
         assert(_PyAsyncGenWrappedValue_CheckExact(o));
         state->value_freelist[state->value_numfree++] = o;
@@ -1737,6 +1754,10 @@ _PyAsyncGenValueWrapperNew(PyObject *val)
 
     PyInterpreterState *interp = _PyInterpreterState_GET();
     struct _Py_async_gen_state *state = &interp->async_gen;
+#ifdef Py_DEBUG
+    // _PyAsyncGenValueWrapperNew() must not be called after _PyAsyncGen_Fini()
+    assert(state->value_numfree != -1);
+#endif
     if (state->value_numfree) {
         state->value_numfree--;
         o = state->value_freelist[state->value_numfree];


### PR DESCRIPTION
In debug mode, ensure that free lists are no longer used after being
finalized. Set numfree to -1 in finalization functions
(eg. _PyList_Fini()), and then check that numfree is not equal to -1
before using a free list (e.g list_dealloc()).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40887](https://bugs.python.org/issue40887) -->
https://bugs.python.org/issue40887
<!-- /issue-number -->
