### PR TITLE
bpo-40904: Fix segfault in the new parser with f-string containing yield statements with no value

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -725,9 +725,11 @@ non-important content
         #  a function into a generator
         def fn(y):
             f'y:{yield y*2}'
+            f'{yield}'
 
         g = fn(4)
         self.assertEqual(next(g), 8)
+        self.assertEqual(next(g), None)
 
     def test_yield_send(self):
         def fn(x):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-08-01-08-57.bpo-40904.76qQzo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-08-01-08-57.bpo-40904.76qQzo.rst
@@ -1,0 +1,2 @@
+Fix possible segfault in the new PEG parser when parsing f-string containing
+yield statements with no value (:code:`f"{yield}"`). Patch by Pablo Galindo

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -278,6 +278,9 @@ static void fstring_shift_argument(expr_ty parent, arg_ty args, int lineno, int 
 
 
 static inline void shift_expr(expr_ty parent, expr_ty n, int line, int col) {
+    if (n == NULL) {
+        return;
+    }
     if (parent->lineno < n->lineno) {
         col = 0;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-40904](https://bugs.python.org/issue40904) -->
https://bugs.python.org/issue40904
<!-- /issue-number -->
