### PR TITLE
bpo-40741: Update macOS installer to use SQLite 3.32.2.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -313,9 +313,9 @@ def library_recipes():
                   ),
           ),
           dict(
-              name="SQLite 3.31.1",
-              url="https://sqlite.org/2020/sqlite-autoconf-3310100.tar.gz",
-              checksum='2d0a553534c521504e3ac3ad3b90f125',
+              name="SQLite 3.32.2",
+              url="https://sqlite.org/2020/sqlite-autoconf-3320200.tar.gz",
+              checksum='eb498918a33159cdf8104997aad29e83',
               extra_cflags=('-Os '
                             '-DSQLITE_ENABLE_FTS5 '
                             '-DSQLITE_ENABLE_FTS4 '

--- a/Misc/NEWS.d/next/macOS/2020-06-07-20-10-56.bpo-40741.80A2BW.rst
+++ b/Misc/NEWS.d/next/macOS/2020-06-07-20-10-56.bpo-40741.80A2BW.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use SQLite 3.32.2.


### PR DESCRIPTION


<!-- issue-number: [bpo-40741](https://bugs.python.org/issue40741) -->
https://bugs.python.org/issue40741
<!-- /issue-number -->
