### PR TITLE
allow macOS installer builds to package pre-built html docs

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1066,14 +1066,40 @@ def buildPythonDocs():
     curDir = os.getcwd()
     os.chdir(buildDir)
     runCommand('make clean')
-    # Create virtual environment for docs builds with blurb and sphinx
-    runCommand('make venv')
-    runCommand('venv/bin/python3 -m pip install -U Sphinx==2.2.0')
-    runCommand('make html PYTHON=venv/bin/python')
+
+    # Search third-party source directory for a pre-built version of the docs.
+    #   Use the naming convention of the docs.python.org html downloads:
+    #       python-3.9.0b1-docs-html.tar.bz2
+    doctarfiles = [ f for f in os.listdir(DEPSRC)
+        if f.startswith('python-'+getFullVersion())
+        if f.endswith('-docs-html.tar.bz2') ]
+    if doctarfiles:
+        doctarfile = doctarfiles[0]
+        if not os.path.exists('build'):
+            os.mkdir('build')
+        # if build directory existed, it was emptied by make clean, above
+        os.chdir('build')
+        # Extract the first archive found for this version into build
+        runCommand('tar xjf %s'%shellQuote(doctarfile))
+        # see if tar extracted a directory ending in -docs-html
+        archivefiles = [ f for f in os.listdir('.')
+            if f.endswith('-docs-html')
+            if os.path.isdir(f) ]
+        if archivefiles:
+            archivefile = archivefiles[0]
+            # make it our 'Docs/build/html' directory
+            print(' -- using pre-built python documentation from %s'%archivefile)
+            os.rename(archivefile, 'html')
+        os.chdir(buildDir)
+
+    htmlDir = os.path.join('build', 'html')
+    if not os.path.exists(htmlDir):
+        # Create virtual environment for docs builds with blurb and sphinx
+        runCommand('make venv')
+        runCommand('venv/bin/python3 -m pip install -U Sphinx==2.2.0')
+        runCommand('make html PYTHON=venv/bin/python')
+    os.rename(htmlDir, docdir)
     os.chdir(curDir)
-    if not os.path.exists(docdir):
-        os.mkdir(docdir)
-    os.rename(os.path.join(buildDir, 'build', 'html'), docdir)
 
 
 def buildPython():

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1080,7 +1080,7 @@ def buildPythonDocs():
         # if build directory existed, it was emptied by make clean, above
         os.chdir('build')
         # Extract the first archive found for this version into build
-        runCommand('tar xjf %s'%shellQuote(doctarfile))
+        runCommand('tar xjf %s'%shellQuote(os.path.join(DEPSRC, doctarfile)))
         # see if tar extracted a directory ending in -docs-html
         archivefiles = [ f for f in os.listdir('.')
             if f.endswith('-docs-html')


### PR DESCRIPTION
The macOS `build-installer` script now looks in its directory of
source tarballs for a suitable html tarball of the same version.
If found, it will unpack and use it rather than rebuilding the html
format documentation set from the source repo.
This is intended as a speedup for test builds of the installer. 
Files names must be in the same format as produced by the
docs build for download, for example,
`python-3.9.0b1-docs-html.tar.bz2`.