### PR TITLE
[3.7] Revert bpo-39576: Clarify the word size for the 32-bit build. (GH-20744)

### DIFF
--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -2164,8 +2164,8 @@ RAM and expect 10 simultaneous operands using a maximum of 500MB each::
 
    >>> import sys
    >>>
-   >>> # Maximum number of digits for a single operand using 500MB in 8-byte words
-   >>> # with 19 digits per word (4-byte and 9 digits for the 32-bit build):
+   >>> # Maximum number of digits for a single operand using 500MB in 8 byte words
+   >>> # with 19 (9 for the 32-bit version) digits per word:
    >>> maxdigits = 19 * ((500 * 1024**2) // 8)
    >>>
    >>> # Check that this works:


### PR DESCRIPTION
Too much work to keep the system libmpdec in sync with the Linux distributions for 3.8.

<!-- issue-number: [bpo-39576](https://bugs.python.org/issue39576) -->
https://bugs.python.org/issue39576
<!-- /issue-number -->
