### PR TITLE
bpo-21756: fix IDLE's "show surrounding parens" for multi-line statements

### DIFF
--- a/Lib/idlelib/parenmatch.py
+++ b/Lib/idlelib/parenmatch.py
@@ -75,8 +75,8 @@ class ParenMatch:
 
     def flash_paren_event(self, event):
         "Handle editor 'show surrounding parens' event (menu or shortcut)."
-        indices = (HyperParser(self.editwin, "insert")
-                   .get_surrounding_brackets())
+        hp = HyperParser(self.editwin, "insert", end_at_eol=False)
+        indices = hp.get_surrounding_brackets()
         self.finish_paren_event(indices)
         return "break"
 

--- a/Misc/NEWS.d/next/IDLE/2020-06-09-10-47-33.bpo-21756.auszVR.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-06-09-10-47-33.bpo-21756.auszVR.rst
@@ -1,0 +1,1 @@
+Fixed IDLE's "show surrounding parens" for multi-line statements.


### PR DESCRIPTION


<!-- issue-number: [bpo-21756](https://bugs.python.org/issue21756) -->
https://bugs.python.org/issue21756
<!-- /issue-number -->
