### PR TITLE
gh-61215: Add Mock.call_event to allow waiting for calls

### DIFF
--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -70,6 +70,25 @@ the ``something`` method:
     >>> real.method()
     >>> real.something.assert_called_once_with(1, 2, 3)
 
+When testing mutltithreaded code it may be important to ensure that certain
+method is eventually called, e.g. as a result of scheduling asynchronous
+operation. :attr:`~Mock.call_event` exposes methods that allow to assert that:
+
+    >>> from threading import Timer
+    >>>
+    >>> class ProductionClass:
+    ...     def method(self):
+    ...         self.t1 = Timer(0.1, self.something, args=(1, 2, 3))
+    ...         self.t1.start()
+    ...         self.t2 = Timer(0.1, self.something, args=(4, 5, 6))
+    ...         self.t2.start()
+    ...     def something(self, a, b, c):
+    ...         pass
+    ...
+    >>> real = ProductionClass()
+    >>> real.something = MagicMock()
+    >>> real.method()
+    >>> real.something.call_event.wait_for_call(call(4, 5, 6), timeout=1.0)
 
 
 Mock for Method Calls on an Object

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -515,6 +515,20 @@ the *new_callable* argument to :func:`patch`.
             >>> mock.call_count
             2
 
+    .. attribute:: call_event
+
+        An object that can be used in multithreaded tests to assert that a call was made.
+
+        - :meth:`wait(/, skip=0, timeout=None)` asserts that mock is called
+          *skip* + 1 times during the *timeout*
+
+        - :meth:`wait_for(predicate, /, timeout=None)` asserts that
+          *predicate* was ``True`` at least once during the *timeout*;
+          *predicate* receives exactly one positional argument: the mock itself
+
+        - :meth:`wait_for_call(call, /, skip=0, timeout=None)` asserts that
+          *call* has happened at least *skip* + 1 times during the *timeout*
+
     .. attribute:: return_value
 
         Set this to configure the value returned by calling the mock:

--- a/Lib/unittest/test/testmock/support.py
+++ b/Lib/unittest/test/testmock/support.py
@@ -1,3 +1,7 @@
+import concurrent.futures
+import time
+
+
 target = {'foo': 'FOO'}
 
 
@@ -14,3 +18,15 @@ class SomeClass(object):
 
 class X(object):
     pass
+
+
+def call_after_delay(func, /, *args, **kwargs):
+    time.sleep(kwargs.pop('delay'))
+    func(*args, **kwargs)
+
+
+def run_async(func, /, *args, executor=None, delay=0, **kwargs):
+    if executor is None:
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=5)
+
+    executor.submit(call_after_delay, func, *args, **kwargs, delay=delay)

--- a/Misc/NEWS.d/next/Library/2019-11-12-13-11-44.bpo-17013.C06aC9.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-12-13-11-44.bpo-17013.C06aC9.rst
@@ -1,0 +1,2 @@
+Add :attr:`call_event` to :class:`Mock` that allows to wait for the calls in
+multithreaded tests. Patch by Ilya Kulakov.


### PR DESCRIPTION
This implementation of [bpo-17013](https://bugs.python.org/issue17013) is alternative to #16094

Changes are based on my work for [`asynctest`](https://github.com/Martiusweb/asynctest). Specifically on [`_AwaitEvent`](https://github.com/Martiusweb/asynctest/pull/67) that was left out when related code was [ported](https://github.com/python/cpython/pull/9296) to CPython.

Key features:

- Does not require end users to do anything: change is automatically available in every Mock
- Utilizes existing semantics of python conditionals (both asyncio and threading)

Accepting this change will allow me to port `_AwaitEvent` therefore giving identical semantics to both wait-for-calls and wait-for-awaits.

I will provide necessary typing annotations for typeshed.

Considerations:
1. ~~This approach changes type of the `Mock.called` property from `bool` to private bool-like `_CallEvent`. However, the only practical problem I could think of is if someone was checking type of `Mock.called` (e.g. `isinstance`, `is`). That does not sound like a plausible problem: after all the property itself is seldom used with exception of conditional expressions where `_CallEvent.__bool__` and `_CallEvent.__eq__` is sufficient.~~ Added new property instead.
2. ~~It probably makes sense to provide convenience methods like `wait_for_call`, but I would like to hear the opinion of the reviewers.~~ Implemented.

CC: @vstinner @tirkarthi @mariocj89


<!-- issue-number: [bpo-17013](https://bugs.python.org/issue17013) -->
https://bugs.python.org/issue17013
<!-- /issue-number -->


<!-- gh-issue-number: gh-61215 -->
* Issue: gh-61215
<!-- /gh-issue-number -->
