### PR TITLE
bpo-40927: Fix test_binhex when run twice

### DIFF
--- a/Lib/test/test_binhex.py
+++ b/Lib/test/test_binhex.py
@@ -7,7 +7,7 @@ import unittest
 from test import support
 
 with support.check_warnings(('', DeprecationWarning)):
-    import binhex
+    binhex = support.import_fresh_module('binhex')
 
 
 class BinHexTestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/Tests/2020-06-09-18-48-18.bpo-40927.67ylLg.rst
+++ b/Misc/NEWS.d/next/Tests/2020-06-09-18-48-18.bpo-40927.67ylLg.rst
@@ -1,0 +1,2 @@
+Fix test_binhex when run twice: it now uses import_fresh_module() to ensure
+that it raises DeprecationWarning each time.


### PR DESCRIPTION
test_binhex now uses import_fresh_module() to ensure that it raises
DeprecationWarning each time.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40927](https://bugs.python.org/issue40927) -->
https://bugs.python.org/issue40927
<!-- /issue-number -->
