### PR TITLE
[WIP] bpo-39465: Optimize _PyInterpreterState_GET()

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -33,6 +33,9 @@ struct _gilstate_runtime_state {
     /* Assuming the current thread holds the GIL, this is the
        PyThreadState for the current thread. */
     _Py_atomic_address tstate_current;
+    /* Assuming the current thread holds the GIL, this is the
+       PyInterpreterState of tstate_current. */
+    _Py_atomic_address interp_current;
     /* The single PyInterpreterState used by this process'
        GILState implementation
     */


### PR DESCRIPTION
* Add _PyRuntimeState.gilstate.interp_current.
* _PyThreadState_Swap() now sets interp_current.
  PyThreadState_Swap(NULL) sets interp_current to NULL.
* Replace _PyThreadState_GET() with _PyInterpreterState_GET() in:

  * get_small_int()
  * gcmodule.c: add also get_gc_state() function
  * _PyTrash_deposit_object()
  * _PyTrash_destroy_chain()
  * warnings_get_state()
  * Py_GetRecursionLimit()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39465](https://bugs.python.org/issue39465) -->
https://bugs.python.org/issue39465
<!-- /issue-number -->
