### PR TITLE
bpo-40847: Consider a line with only a LINECONT a blank line

### DIFF
--- a/Lib/test/test_peg_parser.py
+++ b/Lib/test/test_peg_parser.py
@@ -153,6 +153,13 @@ TEST_CASES = [
     ('dict_comp', '{x:1 for x in a}'),
     ('dict_comp_if', '{x:1+2 for x in a if b}'),
     ('dict_empty', '{}'),
+    ('empty_line_after_linecont',
+     r'''
+        pass
+        \
+
+        pass
+     '''),
     ('for',
      '''
         for i in a:

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -858,6 +858,20 @@ class SyntaxTestCase(unittest.TestCase):
                           "iterable argument unpacking follows "
                           "keyword argument unpacking")
 
+    def test_empty_line_after_linecont(self):
+        # See issue-40847
+        s = r"""\
+pass
+        \
+
+pass
+"""
+        try:
+            compile(s, '<string>', 'exec')
+        except SyntaxError:
+            self.fail("Empty line after a line continuation character is valid.")
+
+
 def test_main():
     support.run_unittest(SyntaxTestCase)
     from test import test_syntax

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
@@ -1,4 +1,4 @@
 Fix a bug where a line with only a line continuation character is not considered a blank line at tokenizer level.
-In such cases more than a single `NEWLINE` token were emitted. The old parser was working around the issue,
+In such cases, more than a single `NEWLINE` token was emitted. The old parser was working around the issue,
 but the new parser threw a :exc:`SyntaxError` for valid input due to this. For example, an empty line following
 a line continuation character was interpreted as a :exc:`SyntaxError`. 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
@@ -1,2 +1,3 @@
-A line with only a line continuation character should be considered a blank line at tokenizer level, so that only a single NEWLINE token gets
-emitted. The old parser was working around the issue, but the new parser threw a SyntaxError for valid input. For example, an empty line following a line continuation character was interpreted as a SyntaxError.
+A line with only a line continuation character should be considered a blank line at tokenizer level, so that only a
+single NEWLINE token gets emitted. The old parser was working around the issue, but the new parser threw a SyntaxError
+for valid input. For example, an empty line following a line continuation character was interpreted as a SyntaxError.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
@@ -1,0 +1,2 @@
+A line with only a line continuation character should be considered a blank line at tokenizer level, so that only a single NEWLINE token gets
+emitted. The old parser was working around the issue, but the new parser threw a SyntaxError for valid input. For example, an empty line following a line continuation character was interpreted as a SyntaxError.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-09-23-52-32.bpo-40847.4XAACw.rst
@@ -1,3 +1,4 @@
-A line with only a line continuation character should be considered a blank line at tokenizer level, so that only a
-single NEWLINE token gets emitted. The old parser was working around the issue, but the new parser threw a SyntaxError
-for valid input. For example, an empty line following a line continuation character was interpreted as a SyntaxError.
+Fix a bug where a line with only a line continuation character is not considered a blank line at tokenizer level.
+In such cases more than a single `NEWLINE` token were emitted. The old parser was working around the issue,
+but the new parser threw a :exc:`SyntaxError` for valid input due to this. For example, an empty line following
+a line continuation character was interpreted as a :exc:`SyntaxError`. 

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1203,8 +1203,9 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
             }
         }
         tok_backup(tok, c);
-        if (c == '#' || c == '\n') {
+        if (c == '#' || c == '\n' || c == '\\') {
             /* Lines with only whitespace and/or comments
+               and/or a line continuation character
                shouldn't affect the indentation and are
                not passed to the parser as NEWLINE tokens,
                except *totally* empty lines in interactive


### PR DESCRIPTION
A line with only a line continuation character should be considered
a blank line at tokenizer level, so that only a single NEWLINE token
gets emitted. The old parser was working around the issue, but the
new parser threw a `SyntaxError` for valid input. For example,
an empty line following a line continuation character was interpreted
as a `SyntaxError`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40847](https://bugs.python.org/issue40847) -->
https://bugs.python.org/issue40847
<!-- /issue-number -->
