### PR TITLE
bpo-40941: Unify implicit and explicit state in the frame and generator objects into a single value.

### DIFF
--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -49,11 +49,11 @@ struct _frame {
     PyObject *f_localsplus[1];  /* locals+stack, dynamically sized */
 };
 
-static inline int _PyFrameIsRunnable(struct _frame *f) {
+static inline int _PyFrame_IsExecutingRunnable(struct _frame *f) {
     return f->f_state < FRAME_EXECUTING;
 }
 
-static inline int _PyFrameIsExecuting(struct _frame *f) {
+static inline int _PyFrame_IsExecuting(struct _frame *f) {
     return f->f_state == FRAME_EXECUTING;
 }
 

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -4,15 +4,19 @@
 #  error "this header file must not be included directly"
 #endif
 
-/* These values are chosen so that all tests involve comparing to zero. */
-typedef enum _framestate {
+/* These values are chosen so that the inline functions below all
+ * compare f_state to zero.
+ */
+enum _framestate {
     FRAME_CREATED = -2,
     FRAME_SUSPENDED = -1,
     FRAME_EXECUTING = 0,
     FRAME_RETURNED = 1,
     FRAME_RAISED = 2,
     FRAME_CLEARED = 3
-} PyFrameState;
+};
+
+typedef signed char PyFrameState;
 
 typedef struct {
     int b_type;                 /* what kind of block this is */

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -4,6 +4,16 @@
 #  error "this header file must not be included directly"
 #endif
 
+/* These values are chosen so that all tests involve comparing to zero. */
+typedef enum _framestate {
+    FRAME_CREATED = -2,
+    FRAME_SUSPENDED = -1,
+    FRAME_EXECUTING = 0,
+    FRAME_RETURNED = 1,
+    FRAME_RAISED = 2,
+    FRAME_CLEARED = 3
+} PyFrameState;
+
 typedef struct {
     int b_type;                 /* what kind of block this is */
     int b_handler;              /* where to jump to find handler */
@@ -37,11 +47,22 @@ struct _frame {
        bytecode index. */
     int f_lineno;               /* Current line number */
     int f_iblock;               /* index in f_blockstack */
-    char f_executing;           /* whether the frame is still executing */
+    PyFrameState f_state;       /* What state the frame is in */
     PyTryBlock f_blockstack[CO_MAXBLOCKS]; /* for try and loop blocks */
     PyObject *f_localsplus[1];  /* locals+stack, dynamically sized */
 };
 
+static inline int _PyFrameIsRunnable(struct _frame *f) {
+    return f->f_state < FRAME_EXECUTING;
+}
+
+static inline int _PyFrameIsExecuting(struct _frame *f) {
+    return f->f_state == FRAME_EXECUTING;
+}
+
+static inline int _PyFrameHasCompleted(struct _frame *f) {
+    return f->f_state > FRAME_EXECUTING;
+}
 
 /* Standard object interface */
 

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -12,8 +12,9 @@ enum _framestate {
     FRAME_SUSPENDED = -1,
     FRAME_EXECUTING = 0,
     FRAME_RETURNED = 1,
-    FRAME_RAISED = 2,
-    FRAME_CLEARED = 3
+    FRAME_UNWINDING = 2,
+    FRAME_RAISED = 3,
+    FRAME_CLEARED = 4
 };
 
 typedef signed char PyFrameState;

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -49,7 +49,7 @@ struct _frame {
     PyObject *f_localsplus[1];  /* locals+stack, dynamically sized */
 };
 
-static inline int _PyFrame_IsExecutingRunnable(struct _frame *f) {
+static inline int _PyFrame_IsRunnable(struct _frame *f) {
     return f->f_state < FRAME_EXECUTING;
 }
 

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -28,11 +28,8 @@ struct _frame {
     PyObject *f_globals;        /* global symbol table (PyDictObject) */
     PyObject *f_locals;         /* local symbol table (any mapping) */
     PyObject **f_valuestack;    /* points after the last local */
-    /* Next free slot in f_valuestack.  Frame creation sets to f_valuestack.
-       Frame evaluation usually NULLs it, but a frame that yields sets it
-       to the current stack top. */
-    PyObject **f_stacktop;
     PyObject *f_trace;          /* Trace function */
+    int f_stackdepth;           /* Depth of value stack */
     char f_trace_lines;         /* Emit per-line trace events? */
     char f_trace_opcodes;       /* Emit per-opcode trace events? */
 

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -16,8 +16,6 @@ extern "C" {
     PyObject_HEAD                                                           \
     /* Note: gi_frame can be NULL if the generator is "finished" */         \
     PyFrameObject *prefix##_frame;                                          \
-    /* True if generator is being executed. */                              \
-    char prefix##_running;                                                  \
     /* The code object backing the generator */                             \
     PyObject *prefix##_code;                                                \
     /* List of weak reference. */                                           \

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -881,7 +881,7 @@ And more, added later.
 >>> i.gi_running = 42
 Traceback (most recent call last):
   ...
-AttributeError: readonly attribute
+AttributeError: attribute 'gi_running' of 'generator' objects is not writable
 >>> def g():
 ...     yield me.gi_running
 >>> me = g()

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1236,7 +1236,7 @@ class SizeofTest(unittest.TestCase):
         nfrees = len(x.f_code.co_freevars)
         extras = x.f_code.co_stacksize + x.f_code.co_nlocals +\
                   ncells + nfrees - 1
-        check(x, vsize('5P2c4P3ic' + CO_MAXBLOCKS*'3i' + 'P' + extras*'P'))
+        check(x, vsize('4Pi2c4P3ic' + CO_MAXBLOCKS*'3i' + 'P' + extras*'P'))
         # function
         def func(): pass
         check(func, size('13P'))

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1253,7 +1253,7 @@ class SizeofTest(unittest.TestCase):
             check(bar, size('PP'))
         # generator
         def get_gen(): yield 1
-        check(get_gen(), size('Pb2PPP4P'))
+        check(get_gen(), size('P2PPP4P'))
         # iterator
         check(iter('abc'), size('lP'))
         # callable-iterator

--- a/Lib/test/test_yield_from.py
+++ b/Lib/test/test_yield_from.py
@@ -938,6 +938,9 @@ class TestPEP380Operation(unittest.TestCase):
                 res.append(g1.throw(MyErr))
         except StopIteration:
             pass
+        except:
+            self.assertEqual(res, [0, 1, 2, 3])
+            raise
         # Check with close
         class MyIt(object):
             def __iter__(self):

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1847,7 +1847,7 @@ _is_running(PyInterpreterState *interp)
         return 0;
     }
 
-    int executing = _PyFrameIsExecuting(frame);
+    int executing = _PyFrame_IsExecuting(frame);
     Py_DECREF(frame);
 
     return executing;

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1847,7 +1847,7 @@ _is_running(PyInterpreterState *interp)
         return 0;
     }
 
-    int executing = (int)(frame->f_executing);
+    int executing = _PyFrameIsExecuting(frame);
     Py_DECREF(frame);
 
     return executing;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -355,11 +355,14 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         return -1;
     }
 
-    /* Forbid jumps upon a 'return' trace event (except after executing a
-     * YIELD_VALUE or YIELD_FROM opcode)
-     * and upon an 'exception' trace event.
-     * Jumps from 'call' trace events have already been forbidden above for new
-     * frames, so this check does not change anything for 'call' events. */
+    /*
+     * This code preserves the historical restrictions on
+     * setting the line number of a frame.
+     * Jumps are forbidden on a 'return' trace event (except after a yield).
+     * Jumps from 'call' trace events are also forbidden.
+     * In addition, jumps are forbidden when not tracing,
+     * as this is a debugging feature.
+     */
     switch(f->f_state) {
         case FRAME_CREATED:
             PyErr_Format(PyExc_ValueError,

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -300,6 +300,7 @@ first_line_not_before(int *lines, int len, int line)
 static void
 frame_stack_pop(PyFrameObject *f)
 {
+    assert(f->f_stackdepth >= 0);
     f->f_stackdepth--;
     PyObject *v = f->f_valuestack[f->f_stackdepth];
     Py_DECREF(v);
@@ -308,6 +309,7 @@ frame_stack_pop(PyFrameObject *f)
 static void
 frame_block_unwind(PyFrameObject *f)
 {
+    assert(f->f_stackdepth >= 0);
     assert(f->f_iblock > 0);
     f->f_iblock--;
     PyTryBlock *b = &f->f_blockstack[f->f_iblock];

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -369,6 +369,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
                      "can't jump from the 'call' trace event of a new frame");
             return -1;
         case FRAME_RETURNED:
+        case FRAME_UNWINDING:
         case FRAME_RAISED:
         case FRAME_CLEARED:
             PyErr_SetString(PyExc_ValueError,

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -683,7 +683,7 @@ frame_tp_clear(PyFrameObject *f)
 static PyObject *
 frame_clear(PyFrameObject *f, PyObject *Py_UNUSED(ignored))
 {
-    if (_PyFrameIsExecuting(f)) {
+    if (_PyFrame_IsExecuting(f)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot clear an executing frame");
         return NULL;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -176,7 +176,7 @@ gen_send_ex(PyGenObject *gen, PyObject *arg, int exc, int closing)
         return NULL;
     }
 
-    assert(_PyFrameIsRunnable(f));
+    assert(_PyFrame_IsRunnable(f));
     if (f->f_lasti == -1) {
         if (arg && arg != Py_None) {
             const char *msg = "can't send non-None value to a "

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -433,8 +433,8 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
             gen->gi_frame->f_state = FRAME_EXECUTING;
             ret = _gen_throw((PyGenObject *)yf, close_on_genexit,
                              typ, val, tb);
-            tstate->frame = f;
             gen->gi_frame->f_state = state;
+            tstate->frame = f;
         } else {
             /* `yf` is an iterator or a coroutine-like object. */
             PyObject *meth;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -143,7 +143,7 @@ gen_send_ex(PyGenObject *gen, PyObject *arg, int exc, int closing)
     PyFrameObject *f = gen->gi_frame;
     PyObject *result;
 
-    if (f != NULL && _PyFrameIsExecuting(f)) {
+    if (f != NULL && _PyFrame_IsExecuting(f)) {
         const char *msg = "generator already executing";
         if (PyCoro_CheckExact(gen)) {
             msg = "coroutine already executing";
@@ -715,7 +715,7 @@ gen_getrunning(PyGenObject *gen, void *Py_UNUSED(ignored))
         Py_INCREF(Py_False);
         return Py_False;
     }
-    return PyBool_FromLong(_PyFrameIsExecuting(gen->gi_frame));
+    return PyBool_FromLong(_PyFrame_IsExecuting(gen->gi_frame));
 }
 
 static PyGetSetDef gen_getsetlist[] = {
@@ -944,7 +944,7 @@ cr_getrunning(PyCoroObject *coro, void *Py_UNUSED(ignored))
         Py_INCREF(Py_False);
         return Py_False;
     }
-    return PyBool_FromLong(_PyFrameIsExecuting(coro->cr_frame));
+    return PyBool_FromLong(_PyFrame_IsExecuting(coro->cr_frame));
 }
 
 static PyGetSetDef coro_getsetlist[] = {

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -456,6 +456,7 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
         if (!ret) {
             PyObject *val;
             /* Pop subiterator from stack */
+            assert(gen->gi_frame->f_stackdepth > 0);
             gen->gi_frame->f_stackdepth--;
             ret = gen->gi_frame->f_valuestack[gen->gi_frame->f_stackdepth];
             assert(ret == yf);
@@ -712,8 +713,7 @@ static PyObject *
 gen_getrunning(PyGenObject *gen, void *Py_UNUSED(ignored))
 {
     if (gen->gi_frame == NULL) {
-        Py_INCREF(Py_False);
-        return Py_False;
+        Py_RETURN_FALSE;
     }
     return PyBool_FromLong(_PyFrame_IsExecuting(gen->gi_frame));
 }
@@ -941,8 +941,7 @@ static PyObject *
 cr_getrunning(PyCoroObject *coro, void *Py_UNUSED(ignored))
 {
     if (coro->cr_frame == NULL) {
-        Py_INCREF(Py_False);
-        return Py_False;
+        Py_RETURN_FALSE;
     }
     return PyBool_FromLong(_PyFrame_IsExecuting(coro->cr_frame));
 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3769,14 +3769,14 @@ error:
         PyTraceBack_Here(f);
 
         if (tstate->c_tracefunc != NULL) {
-            /* Temporarily set frame state to RAISED for benefit of frame.setlineno */
+            /* Make sure state is set to FRAME_EXECUTING for tracing */
             assert(f->f_state == FRAME_EXECUTING);
-            f->f_state = FRAME_RAISED;
+            f->f_state = FRAME_UNWINDING;
             call_exc_trace(tstate->c_tracefunc, tstate->c_traceobj,
                            tstate, f);
-            f->f_state = FRAME_EXECUTING;
         }
 exception_unwind:
+        f->f_state = FRAME_UNWINDING;
         /* Unwind stacks if an exception occurred */
         while (f->f_iblock > 0) {
             /* Pop the current block. */
@@ -3835,6 +3835,7 @@ exception_unwind:
                     }
                 }
                 /* Resume normal execution */
+                f->f_state = FRAME_EXECUTING;
                 goto main_loop;
             }
         } /* unwind stack */


### PR DESCRIPTION
Merges the explicit state in `PyFrameObject.f_excuting` and `PyGenObject.gi_running`, and the implicit state in `PyFrameObject.f_stacktop == NULL` and `PyFrameObject.f_last == -1` into a single enum field in `PyFrameObject`

Since we no longer need to test `PyFrameObject.f_stacktop == NULL` , The `f_stacktop` pointer can be replaced with a `f_stackdepth` integer, which makes for simpler code when iterating over the stack and avoids the potential hazard of NULL pointers.

There are  three benefits to these changes:

1. The code is more robust and, IMO, easier to understand, as all state is now explicit.
2. It carries additional information about the state of the frame. Information about whether a frame exiting by `return` or by `raise` is available.
3. A modest reduction in size of frame and generator objects.

<!-- issue-number: [bpo-40941](https://bugs.python.org/issue40941) -->
https://bugs.python.org/issue40941
<!-- /issue-number -->
