### PR TITLE
bpo-34401: Fix test_gdb for HP GDB version string

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -39,7 +39,8 @@ def get_gdb_version():
     # 'GNU gdb (GDB) Fedora 7.9.1-17.fc22\n' -> 7.9
     # 'GNU gdb 6.1.1 [FreeBSD]\n' -> 6.1
     # 'GNU gdb (GDB) Fedora (7.5.1-37.fc18)\n' -> 7.5
-    match = re.search(r"^GNU gdb.*?\b(\d+)\.(\d+)", version)
+    # 'HP gdb 6.7 for HP Itanium (32 or 64 bit) and target HP-UX 11iv2 and 11iv3.\n' -> 6.7
+    match = re.search(r"^(?:GNU|HP) gdb.*?\b(\d+)\.(\d+)", version)
     if match is None:
         raise Exception("unable to parse GDB version: %r" % version)
     return (version, int(match.group(1)), int(match.group(2)))

--- a/Misc/NEWS.d/next/Tests/2018-08-20-09-38-52.bpo-34401.eGxMPm.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-20-09-38-52.bpo-34401.eGxMPm.rst
@@ -1,0 +1,1 @@
+Make test_gdb properly run on HP-UX. Patch by Michael Osipov.


### PR DESCRIPTION
The GDB provided by HPE on HP-UX contains a modified version string. Therefore
the tests fail. Adapt the regex to match that string.

Patch by Michael Osipov.

Co-Authored-by: Michael Osipov <michael.osipov@siemens.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34401](https://bugs.python.org/issue34401) -->
https://bugs.python.org/issue34401
<!-- /issue-number -->
