### PR TITLE
bpo-40947: getpath.c uses PyConfig.platlibdir

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -487,6 +487,7 @@ class SysModuleTest(unittest.TestCase):
         self.assertIsInstance(sys.platform, str)
         self.assertIsInstance(sys.prefix, str)
         self.assertIsInstance(sys.base_prefix, str)
+        self.assertIsInstance(sys.platlibdir, str)
         self.assertIsInstance(sys.version, str)
         vi = sys.version_info
         self.assertIsInstance(vi[:], tuple)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -775,7 +775,6 @@ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile
 		-DEXEC_PREFIX='"$(exec_prefix)"' \
 		-DVERSION='"$(VERSION)"' \
 		-DVPATH='"$(VPATH)"' \
-		-DPLATLIBDIR='"$(PLATLIBDIR)"' \
 		-o $@ $(srcdir)/Modules/getpath.c
 
 Programs/python.o: $(srcdir)/Programs/python.c
@@ -807,7 +806,6 @@ Python/dynload_hpux.o: $(srcdir)/Python/dynload_hpux.c Makefile
 Python/sysmodule.o: $(srcdir)/Python/sysmodule.c Makefile $(srcdir)/Include/pydtrace.h
 	$(CC) -c $(PY_CORE_CFLAGS) \
 		-DABIFLAGS='"$(ABIFLAGS)"' \
-		-DPLATLIBDIR='"$(PLATLIBDIR)"' \
 		$(MULTIARCH_CPPFLAGS) \
 		-o $@ $(srcdir)/Python/sysmodule.c
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-11-16-06-49.bpo-40947.72cZcR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-11-16-06-49.bpo-40947.72cZcR.rst
@@ -1,0 +1,2 @@
+The Python :ref:`Path Configuration <init-path-config>` now takes
+:c:member:`PyConfig.platlibdir` in account.


### PR DESCRIPTION
Followup of [bpo-40854](https://bugs.python.org/issue40854), there is one remaining usage of PLATLIBDIR
which should be replaced by config->platlibdir.

Co-Authored-by: Sandro Mani <manisandro@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40947](https://bugs.python.org/issue40947) -->
https://bugs.python.org/issue40947
<!-- /issue-number -->
