### PR TITLE
bpo-40275: test.supports imports lazily fnmatch, glob, struct

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -5,13 +5,10 @@ if __name__ != 'test.support':
 
 import contextlib
 import errno
-import fnmatch
 import functools
-import glob
 import os
 import re
 import stat
-import struct
 import sys
 import sysconfig
 import time
@@ -846,9 +843,11 @@ if hasattr(sys, "getobjects"):
 _vheader = _header + 'n'
 
 def calcobjsize(fmt):
+    import struct
     return struct.calcsize(_header + fmt + _align)
 
 def calcvobjsize(fmt):
+    import struct
     return struct.calcsize(_vheader + fmt + _align)
 
 
@@ -1255,6 +1254,7 @@ def _compile_match_function(patterns):
         # The test.bisect_cmd utility only uses such full test identifiers.
         func = set(patterns).__contains__
     else:
+        import fnmatch
         regex = '|'.join(map(fnmatch.translate, patterns))
         # The search *is* case sensitive on purpose:
         # don't use flags=re.IGNORECASE
@@ -1534,6 +1534,7 @@ class PythonSymlink:
 
     if sys.platform == "win32":
         def _platform_specific(self):
+            import glob
             import _winapi
 
             if os.path.lexists(self.real) and not os.path.exists(self.real):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
