### PR TITLE
bpo-40275: Move TransientResource to test_urllib2net

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -922,15 +922,6 @@ The :mod:`test.support` module defines the following functions:
 
 The :mod:`test.support` module defines the following classes:
 
-.. class:: TransientResource(exc, **kwargs)
-
-   Instances are a context manager that raises :exc:`ResourceDenied` if the
-   specified exception type is raised.  Any keyword arguments are treated as
-   attribute/value pairs to be compared against any exception raised within the
-   :keyword:`with` statement.  Only if all pairs match properly against
-   attributes on the exception is :exc:`ResourceDenied` raised.
-
-
 .. class:: SuppressCrashReport()
 
    A context manager used to try to prevent crash dialog popups on tests that

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -4,7 +4,6 @@ if __name__ != 'test.support':
     raise ImportError('support must be imported from the test package')
 
 import contextlib
-import errno
 import functools
 import os
 import re
@@ -49,7 +48,6 @@ __all__ = [
     "is_resource_enabled", "requires", "requires_freebsd_version",
     "requires_linux_version", "requires_mac_ver",
     "check_syntax_error",
-    "TransientResource", "time_out", "socket_peer_reset", "ioerror_peer_reset",
     "BasicTestRunner", "run_unittest", "run_doctest",
     "requires_gzip", "requires_bz2", "requires_lzma",
     "bigmemtest", "bigaddrspacetest", "cpython_only", "get_attribute",
@@ -549,39 +547,6 @@ def open_urlresource(url, *args, **kw):
     if f is not None:
         return f
     raise TestFailed('invalid resource %r' % fn)
-
-
-class TransientResource(object):
-
-    """Raise ResourceDenied if an exception is raised while the context manager
-    is in effect that matches the specified exception and attributes."""
-
-    def __init__(self, exc, **kwargs):
-        self.exc = exc
-        self.attrs = kwargs
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type_=None, value=None, traceback=None):
-        """If type_ is a subclass of self.exc and value has attributes matching
-        self.attrs, raise ResourceDenied.  Otherwise let the exception
-        propagate (if any)."""
-        if type_ is not None and issubclass(self.exc, type_):
-            for attr, attr_value in self.attrs.items():
-                if not hasattr(value, attr):
-                    break
-                if getattr(value, attr) != attr_value:
-                    break
-            else:
-                raise ResourceDenied("an optional resource is not available")
-
-# Context managers that raise ResourceDenied when various issues
-# with the Internet connection manifest themselves as exceptions.
-# XXX deprecate these and use transient_internet() instead
-time_out = TransientResource(OSError, errno=errno.ETIMEDOUT)
-socket_peer_reset = TransientResource(OSError, errno=errno.ECONNRESET)
-ioerror_peer_reset = TransientResource(OSError, errno=errno.ECONNRESET)
 
 
 @contextlib.contextmanager

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -660,7 +660,6 @@ class TestSupport(unittest.TestCase):
     # findfile
     # check_warnings
     # EnvironmentVarGuard
-    # TransientResource
     # transient_internet
     # run_with_locale
     # set_memlimit

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -1,3 +1,4 @@
+import errno
 import unittest
 from test import support
 from test.support import socket_helper
@@ -37,6 +38,39 @@ skip_ftp_test_on_travis = unittest.skipIf('TRAVIS' in os.environ,
 # the connection several times.
 _urlopen_with_retry = _wrap_with_retry_thrice(urllib.request.urlopen,
                                               urllib.error.URLError)
+
+
+class TransientResource(object):
+
+    """Raise ResourceDenied if an exception is raised while the context manager
+    is in effect that matches the specified exception and attributes."""
+
+    def __init__(self, exc, **kwargs):
+        self.exc = exc
+        self.attrs = kwargs
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_=None, value=None, traceback=None):
+        """If type_ is a subclass of self.exc and value has attributes matching
+        self.attrs, raise ResourceDenied.  Otherwise let the exception
+        propagate (if any)."""
+        if type_ is not None and issubclass(self.exc, type_):
+            for attr, attr_value in self.attrs.items():
+                if not hasattr(value, attr):
+                    break
+                if getattr(value, attr) != attr_value:
+                    break
+            else:
+                raise ResourceDenied("an optional resource is not available")
+
+# Context managers that raise ResourceDenied when various issues
+# with the Internet connection manifest themselves as exceptions.
+# XXX deprecate these and use transient_internet() instead
+time_out = TransientResource(OSError, errno=errno.ETIMEDOUT)
+socket_peer_reset = TransientResource(OSError, errno=errno.ECONNRESET)
+ioerror_peer_reset = TransientResource(OSError, errno=errno.ECONNRESET)
 
 
 class AuthTests(unittest.TestCase):
@@ -237,9 +271,9 @@ class OtherNetworkTests(unittest.TestCase):
                             raise
                     else:
                         try:
-                            with support.time_out, \
-                                 support.socket_peer_reset, \
-                                 support.ioerror_peer_reset:
+                            with time_out, \
+                                 socket_peer_reset, \
+                                 ioerror_peer_reset:
                                 buf = f.read()
                                 debug("read %d bytes" % len(buf))
                         except socket.timeout:


### PR DESCRIPTION
Move TransientResource, time_out, socket_peer_reset and
ioerror_peer_reset from test.support to test_urllib2net.

Remove "import errno" from test.support.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
