### PR TITLE
[3.9] bpo-40947: getpath.c uses PyConfig.platlibdir (GH-20807)

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -486,6 +486,7 @@ class SysModuleTest(unittest.TestCase):
         self.assertIsInstance(sys.platform, str)
         self.assertIsInstance(sys.prefix, str)
         self.assertIsInstance(sys.base_prefix, str)
+        self.assertIsInstance(sys.platlibdir, str)
         self.assertIsInstance(sys.version, str)
         vi = sys.version_info
         self.assertIsInstance(vi[:], tuple)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -775,7 +775,6 @@ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile
 		-DEXEC_PREFIX='"$(exec_prefix)"' \
 		-DVERSION='"$(VERSION)"' \
 		-DVPATH='"$(VPATH)"' \
-		-DPLATLIBDIR='"$(PLATLIBDIR)"' \
 		-o $@ $(srcdir)/Modules/getpath.c
 
 Programs/python.o: $(srcdir)/Programs/python.c
@@ -807,7 +806,6 @@ Python/dynload_hpux.o: $(srcdir)/Python/dynload_hpux.c Makefile
 Python/sysmodule.o: $(srcdir)/Python/sysmodule.c Makefile $(srcdir)/Include/pydtrace.h
 	$(CC) -c $(PY_CORE_CFLAGS) \
 		-DABIFLAGS='"$(ABIFLAGS)"' \
-		-DPLATLIBDIR='"$(PLATLIBDIR)"' \
 		$(MULTIARCH_CPPFLAGS) \
 		-o $@ $(srcdir)/Python/sysmodule.c
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-11-16-06-49.bpo-40947.72cZcR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-11-16-06-49.bpo-40947.72cZcR.rst
@@ -1,0 +1,2 @@
+The Python :ref:`Path Configuration <init-path-config>` now takes
+:c:member:`PyConfig.platlibdir` in account.

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -130,7 +130,7 @@ typedef struct {
     wchar_t *exec_prefix_macro;        /* EXEC_PREFIX macro */
     wchar_t *vpath_macro;              /* VPATH macro */
 
-    wchar_t *lib_python;               /* "lib/pythonX.Y" */
+    wchar_t *lib_python;               /* <platlibdir> / "pythonX.Y" */
 
     int prefix_found;         /* found platform independent libraries? */
     int exec_prefix_found;    /* found the platform dependent libraries? */
@@ -810,7 +810,7 @@ calculate_exec_prefix(PyCalculatePath *calculate, _PyPathConfig *pathconfig)
                 "Could not find platform dependent libraries <exec_prefix>\n");
         }
 
-        /* <PLATLIBDIR> / "lib-dynload" */
+        /* <platlibdir> / "lib-dynload" */
         wchar_t *lib_dynload = joinpath2(calculate->platlibdir,
                                          L"lib-dynload");
         if (lib_dynload == NULL) {
@@ -1296,8 +1296,10 @@ calculate_zip_path(PyCalculatePath *calculate)
 {
     PyStatus res;
 
-    /* Path: <PLATLIBDIR> / "pythonXY.zip" */
-    wchar_t *path = joinpath2(calculate->platlibdir, L"python" Py_STRINGIFY(PY_MAJOR_VERSION) Py_STRINGIFY(PY_MINOR_VERSION) L".zip");
+    /* Path: <platlibdir> / "pythonXY.zip" */
+    wchar_t *path = joinpath2(calculate->platlibdir,
+                              L"python" Py_STRINGIFY(PY_MAJOR_VERSION) Py_STRINGIFY(PY_MINOR_VERSION)
+                              L".zip");
     if (path == NULL) {
         return _PyStatus_NO_MEMORY();
     }
@@ -1305,7 +1307,7 @@ calculate_zip_path(PyCalculatePath *calculate)
     if (calculate->prefix_found > 0) {
         /* Use the reduced prefix returned by Py_GetPrefix()
 
-           Path: <basename(basename(prefix))> / <PLATLIBDIR> / "python00.zip" */
+           Path: <basename(basename(prefix))> / <platlibdir> / "pythonXY.zip" */
         wchar_t *parent = _PyMem_RawWcsdup(calculate->prefix);
         if (parent == NULL) {
             res = _PyStatus_NO_MEMORY();
@@ -1431,6 +1433,11 @@ static PyStatus
 calculate_init(PyCalculatePath *calculate, const PyConfig *config)
 {
     size_t len;
+
+    calculate->warnings = config->pathconfig_warnings;
+    calculate->pythonpath_env = config->pythonpath_env;
+    calculate->platlibdir = config->platlibdir;
+
     const char *path = getenv("PATH");
     if (path) {
         calculate->path_env = Py_DecodeLocale(path, &len);
@@ -1457,14 +1464,16 @@ calculate_init(PyCalculatePath *calculate, const PyConfig *config)
         return DECODE_LOCALE_ERR("VPATH macro", len);
     }
 
-    calculate->lib_python = Py_DecodeLocale(PLATLIBDIR "/python" VERSION, &len);
-    if (!calculate->lib_python) {
+    // <platlibdir> / "pythonX.Y"
+    wchar_t *pyversion = Py_DecodeLocale("python" VERSION, &len);
+    if (!pyversion) {
         return DECODE_LOCALE_ERR("VERSION macro", len);
     }
-
-    calculate->warnings = config->pathconfig_warnings;
-    calculate->pythonpath_env = config->pythonpath_env;
-    calculate->platlibdir = config->platlibdir;
+    calculate->lib_python = joinpath2(config->platlibdir, pyversion);
+    PyMem_RawFree(pyversion);
+    if (calculate->lib_python == NULL) {
+        return _PyStatus_NO_MEMORY();
+    }
 
     return _PyStatus_OK();
 }


### PR DESCRIPTION
Followup of [bpo-40854](https://bugs.python.org/issue40854), there is one remaining usage of PLATLIBDIR
which should be replaced by config->platlibdir.

test_sys checks that sys.platlibdir attribute exists and is a string.

Update Makefile: getpath.c and sysmodule.c no longer need PLATLIBDIR
macro, PyConfig.platlibdir member is used instead.

Co-authored-by: Sandro Mani <manisandro@gmail.com>
(cherry picked from commit d72b9644a3e6eec83be48b1ebc2ec6ca776134d3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40947](https://bugs.python.org/issue40947) -->
https://bugs.python.org/issue40947
<!-- /issue-number -->
