### PR TITLE
[3.9] bpo-40924: Remove protocol for supplying Traversable objects from loaders

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -813,9 +813,6 @@ ABC hierarchy::
     methods. Therefore, any loader supplying TraversableReader
     also supplies ResourceReader.
 
-    Loaders that wish to support resource reading are expected to
-    implement this interface.
-
     .. versionadded:: 3.9
 
 

--- a/Lib/importlib/_common.py
+++ b/Lib/importlib/_common.py
@@ -11,17 +11,7 @@ def from_package(package):
     Return a Traversable object for the given package.
 
     """
-    spec = package.__spec__
-    return from_traversable_resources(spec) or fallback_resources(spec)
-
-
-def from_traversable_resources(spec):
-    """
-    If the spec.loader implements TraversableResources,
-    directly or implicitly, it will have a ``files()`` method.
-    """
-    with contextlib.suppress(AttributeError):
-        return spec.loader.files()
+    return fallback_resources(package.__spec__)
 
 
 def fallback_resources(spec):

--- a/Misc/NEWS.d/next/Library/2020-06-11-23-41-50.bpo-40924.m17Fkm.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-11-23-41-50.bpo-40924.m17Fkm.rst
@@ -1,0 +1,1 @@
+Removed support for loaders implementing .files and supplying TraversableResources.


### PR DESCRIPTION
As discovered in [this comment](https://github.com/python/cpython/pull/20576#issuecomment-639954228), the protocol for soliciting a `files()` method on loaders is inadequate as some loaders do not have the context about the package with which they're associated, and although GH-20576 (and importlib_resources 2.x) attempted to address this concern while continuing to supply native support on ResourceReaders, it also brought unintended consequences, reported in [bpo-40924](https://bugs.python.org/issue40924).

This change selectively removes that behavior to avoid tempting custom loader implementers from implementing this protocol.

A different fix should be applied in master.

<!-- issue-number: [bpo-40924](https://bugs.python.org/issue40924) -->
https://bugs.python.org/issue40924
<!-- /issue-number -->
