### PR TITLE
bpo-40955: Fix memory leak in subprocess module

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-06-12-11-55-30.bpo-40955.huixCg.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-12-11-55-30.bpo-40955.huixCg.rst
@@ -1,0 +1,1 @@
+Fix a minor memory leak in :mod:`subprocess` module

--- a/Misc/NEWS.d/next/Library/2020-06-12-11-55-30.bpo-40955.huixCg.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-12-11-55-30.bpo-40955.huixCg.rst
@@ -1,1 +1,1 @@
-Fix a minor memory leak in :mod:`subprocess` module
+Fix a minor memory leak in :mod:`subprocess` module when extra_groups was specified.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -893,6 +893,7 @@ subprocess_fork_exec(PyObject* self, PyObject *args)
     if (_enable_gc(need_to_reenable_gc, gc_module)) {
         pid = -1;
     }
+    PyMem_RawFree(groups);
     Py_XDECREF(preexec_fn_args_tuple);
     Py_XDECREF(gc_module);
 


### PR DESCRIPTION
```
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f008bf19667 in __interceptor_malloc (/lib64/libasan.so.6+0xb0667)
    #1 0x7f007a0bee4a in subprocess_fork_exec /home/heimes/dev/python/cpython/Modules/_posixsubprocess.c:774
    #2 0xe0305b in cfunction_call Objects/methodobject.c:546
```

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40955](https://bugs.python.org/issue40955) -->
https://bugs.python.org/issue40955
<!-- /issue-number -->


Automerge-Triggered-By: @tiran