### PR TITLE
bpo-40855: Fix ignored mu and xbar parameters

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -682,8 +682,10 @@ def _ss(data, c=None):
     calculated from ``c`` as given. Use the second case with care, as it can
     lead to garbage results.
     """
-    if c is None:
-        c = mean(data)
+    if c is not None:
+        T, total, count = _sum((x-c)**2 for x in data)
+        return (T, total)
+    c = mean(data)
     T, total, count = _sum((x-c)**2 for x in data)
     # The following sum should mathematically equal zero, but due to rounding
     # error may not.

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2089,6 +2089,10 @@ class TestVariance(VarianceStdevMixin, NumericTestCase, UnivariateTypeMixin):
         self.assertEqual(result, exact)
         self.assertIsInstance(result, Decimal)
 
+    def test_center_not_at_mean(self):
+        data = (1.0, 2.0)
+        self.assertEqual(self.func(data), 0.5)
+        self.assertEqual(self.func(data, xbar=2.0), 1.0)
 
 class TestPStdev(VarianceStdevMixin, NumericTestCase):
     # Tests for population standard deviation.
@@ -2101,6 +2105,11 @@ class TestPStdev(VarianceStdevMixin, NumericTestCase):
         expected = math.sqrt(statistics.pvariance(data))
         self.assertEqual(self.func(data), expected)
 
+    def test_center_not_at_mean(self):
+        # See issue: 40855
+        data = (3, 6, 7, 10)
+        self.assertEqual(self.func(data), 2.5)
+        self.assertEqual(self.func(data, mu=0.5), 6.5)
 
 class TestStdev(VarianceStdevMixin, NumericTestCase):
     # Tests for sample standard deviation.
@@ -2118,6 +2127,9 @@ class TestStdev(VarianceStdevMixin, NumericTestCase):
         expected = math.sqrt(statistics.variance(data))
         self.assertEqual(self.func(data), expected)
 
+    def test_center_not_at_mean(self):
+        data = (1.0, 2.0)
+        self.assertEqual(self.func(data, xbar=2.0), 1.0)
 
 class TestGeometricMean(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2020-06-12-10-44-15.bpo-40855.jSot83.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-12-10-44-15.bpo-40855.jSot83.rst
@@ -1,0 +1,2 @@
+The standard deviation and variance functions in the statistics module were
+ignoring their mu and xbar arguments.


### PR DESCRIPTION


<!-- issue-number: [bpo-40855](https://bugs.python.org/issue40855) -->
https://bugs.python.org/issue40855
<!-- /issue-number -->
