### PR TITLE
bpo-40958: Avoid buffer overflow in the parser when indexing the current line

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-12-22-17-51.bpo-40958.7O2Wh1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-12-22-17-51.bpo-40958.7O2Wh1.rst
@@ -1,0 +1,2 @@
+Fix a possible buffer overflow in the PEG parser when gathering information
+for emitting syntax errors. Patch by Pablo Galindo.


### PR DESCRIPTION


<!-- issue-number: [bpo-40958](https://bugs.python.org/issue40958) -->
https://bugs.python.org/issue40958
<!-- /issue-number -->
