### PR TITLE
gh-71916: Give a better error msg when a file path is too long on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-06-12-15-29-18.bpo-27729.nNXQot.rst
+++ b/Misc/NEWS.d/next/Windows/2020-06-12-15-29-18.bpo-27729.nNXQot.rst
@@ -1,0 +1,1 @@
+Give a better error message when a file path is too long on Windows.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -370,6 +370,9 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
         }
 
         errno = 0;
+#ifdef MS_WINDOWS
+        _doserrno = 0;
+#endif
         if (opener == Py_None) {
             do {
                 Py_BEGIN_ALLOW_THREADS
@@ -418,7 +421,12 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
 
         fd_is_own = 1;
         if (self->fd < 0) {
+#ifdef MS_WINDOWS
+            PyErr_SetExcFromWindowsErrWithFilenameObject(
+                    PyExc_OSError, _doserrno, nameobj);
+#else
             PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, nameobj);
+#endif
             goto error;
         }
 

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -700,11 +700,7 @@ PyErr_SetFromErrnoWithFilenameObjects(PyObject *exc, PyObject *filenameObject, P
            table, we use it, otherwise we assume it really _is_
            a Win32 error code
         */
-        if (i == ENOENT && GetLastError() == ERROR_PATH_NOT_FOUND) {
-            message = PyUnicode_FromString("No such path or path exceeds "
-                                           "maximum allowed length");
-        }
-        else if (i > 0 && i < _sys_nerr) {
+        if (i > 0 && i < _sys_nerr) {
             message = PyUnicode_FromString(_sys_errlist[i]);
         }
         else {

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -700,7 +700,11 @@ PyErr_SetFromErrnoWithFilenameObjects(PyObject *exc, PyObject *filenameObject, P
            table, we use it, otherwise we assume it really _is_
            a Win32 error code
         */
-        if (i > 0 && i < _sys_nerr) {
+        if (i == ENOENT && GetLastError() == ERROR_PATH_NOT_FOUND) {
+            message = PyUnicode_FromString("No such path or path exceeds "
+                                           "maximum allowed length");
+        }
+        else if (i > 0 && i < _sys_nerr) {
             message = PyUnicode_FromString(_sys_errlist[i]);
         }
         else {


### PR DESCRIPTION


<!-- issue-number: [bpo-27729](https://bugs.python.org/issue27729) -->
https://bugs.python.org/issue27729
<!-- /issue-number -->


<!-- gh-issue-number: gh-71916 -->
* Issue: gh-71916
<!-- /gh-issue-number -->
