### PR TITLE
bpo-40275: Use test helpers to replace test.support [part 2]

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -20,6 +20,7 @@ from test.libregrtest.setup import setup_tests
 from test.libregrtest.pgo import setup_pgo_tests
 from test.libregrtest.utils import removepy, count, format_duration, printlist
 from test import support
+from test.support import os_helper
 
 
 # bpo-38203: Maximum delay in seconds to exit Python (call Py_Finalize()).
@@ -628,7 +629,7 @@ class Regrtest:
             # to a temporary and writable directory. If it's not possible to
             # create or change the CWD, the original CWD will be used.
             # The original CWD is available from support.SAVEDCWD.
-            with support.temp_cwd(test_cwd, quiet=True):
+            with os_helper.temp_cwd(test_cwd, quiet=True):
                 # When using multiprocessing, worker processes will use test_cwd
                 # as their parent temporary directory. So when the main process
                 # exit, it removes also subdirectories of worker processes.

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -11,6 +11,8 @@ import traceback
 import unittest
 
 from test import support
+from test.support import import_helper
+from test.support import os_helper
 from test.libregrtest.refleak import dash_R, clear_caches
 from test.libregrtest.save_env import saved_test_environment
 from test.libregrtest.utils import format_duration, print_warning
@@ -216,7 +218,7 @@ def _runtest_inner2(ns, test_name):
     abstest = get_abs_module(ns, test_name)
 
     # remove the module from sys.module to reload it if it was already imported
-    support.unload(abstest)
+    import_helper.unload(abstest)
 
     the_module = importlib.import_module(abstest)
 
@@ -313,7 +315,7 @@ def cleanup_test_droppings(test_name, verbose):
     # since if a test leaves a file open, it cannot be deleted by name (while
     # there's nothing we can do about that here either, we can display the
     # name of the offending test, which is a real help).
-    for name in (support.TESTFN,):
+    for name in (os_helper.TESTFN,):
         if not os.path.exists(name):
             continue
 

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -10,6 +10,7 @@ import threading
 import urllib.request
 import warnings
 from test import support
+from test.support import os_helper
 from test.libregrtest.utils import print_warning
 try:
     import _multiprocessing, multiprocessing.process
@@ -241,7 +242,7 @@ class saved_test_environment:
         return sorted(fn + ('/' if os.path.isdir(fn) else '')
                       for fn in os.listdir())
     def restore_files(self, saved_value):
-        fn = support.TESTFN
+        fn = os_helper.TESTFN
         if fn not in saved_value and (fn + '/') not in saved_value:
             if os.path.isfile(fn):
                 support.unlink(fn)

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -11,7 +11,7 @@ import py_compile
 import zipfile
 
 from importlib.util import source_from_cache
-from test.support import make_legacy_pyc
+from test.support.import_helper import make_legacy_pyc
 
 
 # Cached result of the expensive test performed in the function below.

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -10,10 +10,11 @@ import time
 import unittest
 
 from test import support
+from test.support import import_helper
 from test.support import script_helper
 
 
-interpreters = support.import_module('_xxsubinterpreters')
+interpreters = import_helper.import_module('_xxsubinterpreters')
 
 
 ##################################

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -4,6 +4,7 @@
 
 import unittest
 from test import support
+from test.support import os_helper
 from test.support import _2G
 import weakref
 import pickle
@@ -366,13 +367,13 @@ class BaseTest:
     def test_tofromfile(self):
         a = array.array(self.typecode, 2*self.example)
         self.assertRaises(TypeError, a.tofile)
-        support.unlink(support.TESTFN)
-        f = open(support.TESTFN, 'wb')
+        os_helper.unlink(os_helper.TESTFN)
+        f = open(os_helper.TESTFN, 'wb')
         try:
             a.tofile(f)
             f.close()
             b = array.array(self.typecode)
-            f = open(support.TESTFN, 'rb')
+            f = open(os_helper.TESTFN, 'rb')
             self.assertRaises(TypeError, b.fromfile)
             b.fromfile(f, len(self.example))
             self.assertEqual(b, array.array(self.typecode, self.example))
@@ -383,27 +384,27 @@ class BaseTest:
         finally:
             if not f.closed:
                 f.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_fromfile_ioerror(self):
         # Issue #5395: Check if fromfile raises a proper OSError
         # instead of EOFError.
         a = array.array(self.typecode)
-        f = open(support.TESTFN, 'wb')
+        f = open(os_helper.TESTFN, 'wb')
         try:
             self.assertRaises(OSError, a.fromfile, f, len(self.example))
         finally:
             f.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_filewrite(self):
         a = array.array(self.typecode, 2*self.example)
-        f = open(support.TESTFN, 'wb')
+        f = open(os_helper.TESTFN, 'wb')
         try:
             f.write(a)
             f.close()
             b = array.array(self.typecode)
-            f = open(support.TESTFN, 'rb')
+            f = open(os_helper.TESTFN, 'rb')
             b.fromfile(f, len(self.example))
             self.assertEqual(b, array.array(self.typecode, self.example))
             self.assertNotEqual(a, b)
@@ -413,7 +414,7 @@ class BaseTest:
         finally:
             if not f.closed:
                 f.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_tofromlist(self):
         a = array.array(self.typecode, 2*self.example)

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -9,6 +9,7 @@ import tempfile
 import textwrap
 import unittest
 from test import support
+from test.support import os_helper
 from test.support.script_helper import (
     spawn_python, kill_python, assert_python_ok, assert_python_failure,
     interpreter_requires_environment
@@ -141,11 +142,11 @@ class CmdLineTest(unittest.TestCase):
         # All good if execution is successful
         assert_python_ok('-c', 'pass')
 
-    @unittest.skipUnless(support.FS_NONASCII, 'need support.FS_NONASCII')
+    @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_non_ascii(self):
         # Test handling of non-ascii data
         command = ("assert(ord(%r) == %s)"
-                   % (support.FS_NONASCII, ord(support.FS_NONASCII)))
+                   % (os_helper.FS_NONASCII, ord(os_helper.FS_NONASCII)))
         assert_python_ok('-c', command)
 
     # On Windows, pass bytes to subprocess doesn't test how Python decodes the
@@ -463,8 +464,8 @@ class CmdLineTest(unittest.TestCase):
         # Issue #15001: PyRun_SimpleFileExFlags() did crash because it kept a
         # borrowed reference to the dict of __main__ module and later modify
         # the dict whereas the module was destroyed
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
         with open(filename, "w") as script:
             print("import sys", file=script)
             print("del sys.modules['__main__']", file=script)
@@ -499,7 +500,7 @@ class CmdLineTest(unittest.TestCase):
             # dummyvar to prevent extraneous -E
             dummyvar="")
         self.assertEqual(out.strip(), b'1 1 1')
-        with support.temp_cwd() as tmpdir:
+        with os_helper.temp_cwd() as tmpdir:
             fake = os.path.join(tmpdir, "uuid.py")
             main = os.path.join(tmpdir, "main.py")
             with open(fake, "w") as f:
@@ -561,7 +562,7 @@ class CmdLineTest(unittest.TestCase):
             elif opt is not None:
                 args[:0] = ['-X', f'pycache_prefix={opt}']
             with self.subTest(envval=envval, opt=opt):
-                with support.temp_cwd():
+                with os_helper.temp_cwd():
                     assert_python_ok(*args, **env)
 
     def run_xdev(self, *args, check_exitcode=True, xdev=True):
@@ -644,7 +645,8 @@ class CmdLineTest(unittest.TestCase):
 
     def check_warnings_filters(self, cmdline_option, envvar, use_pywarning=False):
         if use_pywarning:
-            code = ("import sys; from test.support import import_fresh_module; "
+            code = ("import sys; from test.support.import_helper import "
+                    "import_fresh_module; "
                     "warnings = import_fresh_module('warnings', blocked=['_warnings']); ")
         else:
             code = "import sys, warnings; "

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -10,9 +10,11 @@ import stat
 import unittest
 import dbm.dumb as dumbdbm
 from test import support
+from test.support import os_helper
 from functools import partial
 
-_fname = support.TESTFN
+_fname = os_helper.TESTFN
+
 
 def _delete_files():
     for ext in [".dir", ".dat", ".bak"]:
@@ -264,7 +266,7 @@ class DumbDBMTestCase(unittest.TestCase):
                 dumbdbm.open(_fname, flag)
 
     def test_readonly_files(self):
-        with support.temp_dir() as dir:
+        with os_helper.temp_dir() as dir:
             fname = os.path.join(dir, 'db')
             with dumbdbm.open(fname, 'n') as f:
                 self.assertEqual(list(f.keys()), [])
@@ -277,12 +279,12 @@ class DumbDBMTestCase(unittest.TestCase):
                 self.assertEqual(sorted(f.keys()), sorted(self._dict))
                 f.close()  # don't write
 
-    @unittest.skipUnless(support.TESTFN_NONASCII,
+    @unittest.skipUnless(os_helper.TESTFN_NONASCII,
                          'requires OS support of non-ASCII encodings')
     def test_nonascii_filename(self):
-        filename = support.TESTFN_NONASCII
+        filename = os_helper.TESTFN_NONASCII
         for suffix in ['.dir', '.dat', '.bak']:
-            self.addCleanup(support.unlink, filename + suffix)
+            self.addCleanup(os_helper.unlink, filename + suffix)
         with dumbdbm.open(filename, 'c') as db:
             db[b'key'] = b'value'
         self.assertTrue(os.path.exists(filename + '.dat'))

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -34,8 +34,9 @@ import numbers
 import locale
 from test.support import (run_unittest, run_doctest, is_resource_enabled,
                           requires_IEEE_754, requires_docstrings)
-from test.support import (import_fresh_module, TestFailed,
+from test.support import (TestFailed,
                           run_with_locale, cpython_only)
+from test.support.import_helper import import_fresh_module
 import random
 import inspect
 import threading

--- a/Lib/test/test_global.py
+++ b/Lib/test/test_global.py
@@ -1,6 +1,7 @@
 """Verify that warnings are issued for global statements following use."""
 
-from test.support import run_unittest, check_syntax_error, check_warnings
+from test.support import run_unittest, check_syntax_error
+from test.support.warnings_helper import check_warnings
 import unittest
 import warnings
 

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -5,6 +5,8 @@ import os.path
 import py_compile
 import sys
 from test import support
+from test.support import import_helper
+from test.support import os_helper
 from test.support import script_helper
 import unittest
 import warnings
@@ -107,8 +109,8 @@ class ImportTests(unittest.TestCase):
             self.assertEqual(file.encoding, 'cp1252')
         finally:
             del sys.path[0]
-            support.unlink(temp_mod_name + '.py')
-            support.unlink(temp_mod_name + '.pyc')
+            os_helper.unlink(temp_mod_name + '.py')
+            os_helper.unlink(temp_mod_name + '.pyc')
 
     def test_issue5604(self):
         # Test cannot cover imp.load_compiled function.
@@ -192,10 +194,10 @@ class ImportTests(unittest.TestCase):
         finally:
             del sys.path[0]
             for ext in ('.py', '.pyc'):
-                support.unlink(temp_mod_name + ext)
-                support.unlink(init_file_name + ext)
-            support.rmtree(test_package_name)
-            support.rmtree('__pycache__')
+                os_helper.unlink(temp_mod_name + ext)
+                os_helper.unlink(init_file_name + ext)
+            os_helper.rmtree(test_package_name)
+            os_helper.rmtree('__pycache__')
 
     def test_issue9319(self):
         path = os.path.dirname(__file__)
@@ -204,7 +206,7 @@ class ImportTests(unittest.TestCase):
 
     def test_load_from_source(self):
         # Verify that the imp module can correctly load and find .py files
-        # XXX (ncoghlan): It would be nice to use support.CleanImport
+        # XXX (ncoghlan): It would be nice to use import_helper.CleanImport
         # here, but that breaks because the os module registers some
         # handlers in copy_reg on import. Since CleanImport doesn't
         # revert that registration, the module is left in a broken
@@ -213,7 +215,7 @@ class ImportTests(unittest.TestCase):
         # workaround
         orig_path = os.path
         orig_getenv = os.getenv
-        with support.EnvironmentVarGuard():
+        with os_helper.EnvironmentVarGuard():
             x = imp.find_module("os")
             self.addCleanup(x[0].close)
             new_os = imp.load_module("os", *x)
@@ -299,11 +301,11 @@ class ImportTests(unittest.TestCase):
     @unittest.skipIf(sys.dont_write_bytecode,
         "test meaningful only when writing bytecode")
     def test_bug7732(self):
-        with support.temp_cwd():
-            source = support.TESTFN + '.py'
+        with os_helper.temp_cwd():
+            source = os_helper.TESTFN + '.py'
             os.mkdir(source)
             self.assertRaisesRegex(ImportError, '^No module',
-                imp.find_module, support.TESTFN, ["."])
+                imp.find_module, os_helper.TESTFN, ["."])
 
     def test_multiple_calls_to_get_data(self):
         # Issue #18755: make sure multiple calls to get_data() can succeed.
@@ -364,7 +366,7 @@ class ImportTests(unittest.TestCase):
 
     def test_find_and_load_checked_pyc(self):
         # issue 34056
-        with support.temp_cwd():
+        with os_helper.temp_cwd():
             with open('mymod.py', 'wb') as fp:
                 fp.write(b'x = 42\n')
             py_compile.compile(
@@ -383,24 +385,24 @@ class ReloadTests(unittest.TestCase):
     reload()."""
 
     def test_source(self):
-        # XXX (ncoghlan): It would be nice to use test.support.CleanImport
+        # XXX (ncoghlan): It would be nice to use test.import_helper.CleanImport
         # here, but that breaks because the os module registers some
         # handlers in copy_reg on import. Since CleanImport doesn't
         # revert that registration, the module is left in a broken
         # state after reversion. Reinitialising the module contents
         # and just reverting os.environ to its previous state is an OK
         # workaround
-        with support.EnvironmentVarGuard():
+        with os_helper.EnvironmentVarGuard():
             import os
             imp.reload(os)
 
     def test_extension(self):
-        with support.CleanImport('time'):
+        with import_helper.CleanImport('time'):
             import time
             imp.reload(time)
 
     def test_builtin(self):
-        with support.CleanImport('marshal'):
+        with import_helper.CleanImport('marshal'):
             import marshal
             imp.reload(marshal)
 
@@ -443,10 +445,10 @@ class PEP3147Tests(unittest.TestCase):
 
 
 class NullImporterTests(unittest.TestCase):
-    @unittest.skipIf(support.TESTFN_UNENCODABLE is None,
+    @unittest.skipIf(os_helper.TESTFN_UNENCODABLE is None,
                      "Need an undecodeable filename")
     def test_unencodeable(self):
-        name = support.TESTFN_UNENCODABLE
+        name = os_helper.TESTFN_UNENCODABLE
         os.mkdir(name)
         try:
             self.assertRaises(ImportError, imp.NullImporter, name)

--- a/Lib/test/test_ioctl.py
+++ b/Lib/test/test_ioctl.py
@@ -1,6 +1,7 @@
 import array
 import unittest
-from test.support import import_module, get_attribute
+from test.support import get_attribute
+from test.support.import_helper import import_module
 import os, struct
 fcntl = import_module('fcntl')
 termios = import_module('termios')

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 from test import support
+from test.support import os_helper
 
 
 class PlatformTest(unittest.TestCase):
@@ -17,7 +18,7 @@ class PlatformTest(unittest.TestCase):
     def test_architecture(self):
         res = platform.architecture()
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_architecture_via_symlink(self): # issue3762
         with support.PythonSymlink() as py:
             cmd = "-c", "import platform; print(platform.architecture())"
@@ -281,8 +282,8 @@ class PlatformTest(unittest.TestCase):
             executable = sys.executable
         platform.libc_ver(executable)
 
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         with mock.patch('os.confstr', create=True, return_value='mock 1.0'):
             # test os.confstr() code path

--- a/Lib/test/test_pwd.py
+++ b/Lib/test/test_pwd.py
@@ -1,8 +1,8 @@
 import sys
 import unittest
-from test import support
+from test.support import import_helper
 
-pwd = support.import_module('pwd')
+pwd = import_helper.import_module('pwd')
 
 @unittest.skipUnless(hasattr(pwd, 'getpwall'), 'Does not have getpwall()')
 class PwdTest(unittest.TestCase):

--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -1,9 +1,10 @@
 import unittest
 from test import support
+from test.support import import_helper
 import sys
 
 # Skip this test if the _tkinter module wasn't built.
-_tkinter = support.import_module('_tkinter')
+_tkinter = import_helper.import_module('_tkinter')
 
 # Skip test if tk cannot be initialized.
 support.requires('gui')

--- a/Lib/test/test_uu.py
+++ b/Lib/test/test_uu.py
@@ -4,7 +4,7 @@ Nick Mathewson
 """
 
 import unittest
-from test import support
+from test.support import os_helper
 
 import os
 import stat
@@ -174,10 +174,10 @@ class UUStdIOTest(unittest.TestCase):
 class UUFileTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpin  = support.TESTFN + "i"
-        self.tmpout = support.TESTFN + "o"
-        self.addCleanup(support.unlink, self.tmpin)
-        self.addCleanup(support.unlink, self.tmpout)
+        self.tmpin  = os_helper.TESTFN + "i"
+        self.tmpout = os_helper.TESTFN + "o"
+        self.addCleanup(os_helper.unlink, self.tmpin)
+        self.addCleanup(os_helper.unlink, self.tmpout)
 
     def test_encode(self):
         with open(self.tmpin, 'wb') as fin:

--- a/Lib/test/test_winreg.py
+++ b/Lib/test/test_winreg.py
@@ -4,11 +4,12 @@
 import os, sys, errno
 import unittest
 from test import support
+from test.support import import_helper
 import threading
 from platform import machine, win32_edition
 
 # Do this first so test will be skipped if module doesn't exist
-support.import_module('winreg', required_on=['win'])
+import_helper.import_module('winreg', required_on=['win'])
 # Now import everything
 from winreg import *
 


### PR DESCRIPTION
Use test helpers in the following test cases:
* test_xxsubinterpreters
* test_array
* test_cmd_line
* test_dbm_dumb
* test_decimal
* test_global
* test_imp
* test_ioctl
* test_platform
* test_pwd
* test_tix
* test_uu
* test_winreg

<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
