### PR TITLE
bpo-40924: Ensure importlib.resources.path returns an extant path

### DIFF
--- a/Lib/importlib/readers.py
+++ b/Lib/importlib/readers.py
@@ -7,11 +7,19 @@ class FileReader(abc.TraversableResources):
     def __init__(self, loader):
         self.path = pathlib.Path(loader.path).parent
 
+    def resource_path(self, resource):
+        """
+        Return the file system path to prevent
+        `resources.path()` from creating a temporary
+        copy.
+        """
+        return str(self.path.joinpath(resource))
+
     def files(self):
         return self.path
 
 
-class ZipReader(FileReader):
+class ZipReader(abc.TraversableResources):
     def __init__(self, loader, module):
         _, _, name = module.rpartition('.')
         prefix = loader.prefix.replace('\\', '/') + name + '/'
@@ -28,3 +36,6 @@ class ZipReader(FileReader):
         # for non-existent paths.
         target = self.files().joinpath(path)
         return target.is_file() and target.exists()
+
+    def files(self):
+        return self.path

--- a/Lib/test/test_importlib/test_path.py
+++ b/Lib/test/test_importlib/test_path.py
@@ -27,6 +27,15 @@ class PathTests:
 class PathDiskTests(PathTests, unittest.TestCase):
     data = data01
 
+    def test_natural_path(self):
+        """
+        Guarantee the internal implementation detail that
+        file-system-backed resources do not get the tempdir
+        treatment.
+        """
+        with resources.path(self.data, 'utf-8.file') as path:
+            assert 'data' in str(path)
+
 
 class PathZipTests(PathTests, util.ZipSetup, unittest.TestCase):
     def test_remove_in_context_manager(self):

--- a/Misc/NEWS.d/next/Library/2020-06-13-12-04-50.bpo-40924.SM_luS.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-13-12-04-50.bpo-40924.SM_luS.rst
@@ -1,0 +1,3 @@
+Ensure ``importlib.resources.path`` returns an extant path for the
+SourceFileLoader's resource reader. Avoids the regression identified in
+master while a long-term solution is devised.


### PR DESCRIPTION
Ensure `importlib.resources.path` returns an extant path for the SourceFileLoader's resource reader. Avoids the regression identified in [bpo-40924](https://bugs.python.org/issue40924) in master while a long-term solution is devised.

<!-- issue-number: [bpo-40924](https://bugs.python.org/issue40924) -->
https://bugs.python.org/issue40924
<!-- /issue-number -->
