### PR TITLE
bpo-36470: Allow dataclasses.replace() to handle InitVars with default values

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1271,7 +1271,7 @@ def replace(obj, /, **changes):
             continue
 
         if f.name not in changes:
-            if f._field_type is _FIELD_INITVAR:
+            if f._field_type is _FIELD_INITVAR and f.default is MISSING:
                 raise ValueError(f"InitVar {f.name!r} "
                                  'must be specified with replace()')
             changes[f.name] = getattr(obj, f.name)

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3245,6 +3245,24 @@ class TestReplace(unittest.TestCase):
         c = replace(c, x=3, y=5)
         self.assertEqual(c.x, 15)
 
+    def test_initvar_with_default_value(self):
+        @dataclass
+        class C:
+            x: int
+            y: InitVar[int] = None
+            z: InitVar[int] = 42
+
+            def __post_init__(self, y, z):
+                if y is not None:
+                    self.x += y
+                if z is not None:
+                    self.x += z
+
+        c = C(x=1, y=10, z=1)
+        self.assertEqual(replace(c), C(x=12))
+        self.assertEqual(replace(c, y=4), C(x=12, y=4, z=42))
+        self.assertEqual(replace(c, y=4, z=1), C(x=12, y=4, z=1))
+
     def test_recursive_repr(self):
         @dataclass
         class C:

--- a/Misc/NEWS.d/next/Library/2020-06-13-23-33-32.bpo-36470.oi6Kdb.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-13-23-33-32.bpo-36470.oi6Kdb.rst
@@ -1,2 +1,2 @@
-Fix dataclasses with ``InitVar``s and :func:`~dataclasses.replace()`. Patch
+Fix dataclasses with ``InitVar``\s and :func:`~dataclasses.replace()`. Patch
 by Claudiu Popa.

--- a/Misc/NEWS.d/next/Library/2020-06-13-23-33-32.bpo-36470.oi6Kdb.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-13-23-33-32.bpo-36470.oi6Kdb.rst
@@ -1,0 +1,2 @@
+Fix dataclasses with ``InitVar``s and :func:`~dataclasses.replace()`. Patch
+by Claudiu Popa.


### PR DESCRIPTION

Co-Authored-By: Claudiu Popa <pcmanticore@gmail.com>



<!-- issue-number: [bpo-36470](https://bugs.python.org/issue36470) -->
https://bugs.python.org/issue36470
<!-- /issue-number -->

Automerge-Triggered-By: GH:ericvsmith