### PR TITLE
bpo-40958: Avoid buffer overflow in the parser when indexing the current line

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-15-01-20-44.bpo-40958.7O2Wh1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-15-01-20-44.bpo-40958.7O2Wh1.rst
@@ -1,0 +1,2 @@
+Fix a possible buffer overflow in the PEG parser when gathering information
+for emitting syntax errors. Patch by Pablo Galindo.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -145,7 +145,7 @@ byte_offset_to_character_offset(PyObject *line, Py_ssize_t col_offset)
     if (!str) {
         return 0;
     }
-    assert(col_offset > 0 && (unsigned long)col_offset <= strlen(str));
+    assert(col_offset >= 0 && (unsigned long)col_offset <= strlen(str));
     PyObject *text = PyUnicode_DecodeUTF8(str, col_offset, "replace");
     if (!text) {
         return 0;

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -139,13 +139,13 @@ _create_dummy_identifier(Parser *p)
 }
 
 static inline Py_ssize_t
-byte_offset_to_character_offset(PyObject *line, int col_offset)
+byte_offset_to_character_offset(PyObject *line, Py_ssize_t col_offset)
 {
     const char *str = PyUnicode_AsUTF8(line);
     if (!str) {
         return 0;
     }
-    assert(col_offset <= strlen(str));
+    assert(col_offset > 0 && (unsigned long)col_offset <= strlen(str));
     PyObject *text = PyUnicode_DecodeUTF8(str, col_offset, "replace");
     if (!text) {
         return 0;
@@ -357,7 +357,7 @@ void *
 _PyPegen_raise_error(Parser *p, PyObject *errtype, const char *errmsg, ...)
 {
     Token *t = p->known_err_token != NULL ? p->known_err_token : p->tokens[p->fill - 1];
-    int col_offset;
+    Py_ssize_t col_offset;
     if (t->col_offset == -1) {
         col_offset = Py_SAFE_DOWNCAST(p->tok->cur - p->tok->buf,
                                       intptr_t, int);
@@ -377,7 +377,7 @@ _PyPegen_raise_error(Parser *p, PyObject *errtype, const char *errmsg, ...)
 
 void *
 _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
-                                    int lineno, int col_offset,
+                                    Py_ssize_t lineno, Py_ssize_t col_offset,
                                     const char *errmsg, va_list va)
 {
     PyObject *value = NULL;

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -34,7 +34,7 @@ typedef struct _memo {
 typedef struct {
     int type;
     PyObject *bytes;
-    int lineno, col_offset, end_lineno, end_col_offset;
+    Py_ssize_t lineno, col_offset, end_lineno, end_col_offset;
     Memo *memo;
 } Token;
 

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -132,7 +132,7 @@ void *_PyPegen_string_token(Parser *p);
 const char *_PyPegen_get_expr_name(expr_ty);
 void *_PyPegen_raise_error(Parser *p, PyObject *errtype, const char *errmsg, ...);
 void *_PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
-                                          int lineno, int col_offset,
+                                          Py_ssize_t lineno, Py_ssize_t col_offset,
                                           const char *errmsg, va_list va);
 void *_PyPegen_dummy_name(Parser *p, ...);
 


### PR DESCRIPTION
After thinking a bit more about the whole problem I found that we were processing the offsets incorrectly if the input is raw (no need to transform the offset to a character offset). Once we process the column offsets correctly, is quite straightforward to fix the incorrect access.

As an example of why we were processing the offset incorrectly previously, consider this code (current master without this PR):

```
❯ ./python
Python 3.9.0b1+ (heads/3.9:299d3d1c52, Jun  8 2020, 22:11:46)
[GCC 10.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> Python = "Ṕýţĥòñ" + 34 $ lelummsmdsads +
  File "<stdin>", line 1
    Python = "Ṕýţĥòñ" + 34 $ lelummsmdsads +
                                  ^
SyntaxError: invalid syntax
```

while the old parser points correctly to the `$` token:

```
❯ ./python -Xoldparser
Python 3.9.0b1+ (heads/3.9:299d3d1c52, Jun  8 2020, 22:11:46)
[GCC 10.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> Python = "Ṕýţĥòñ" + 34 $ lelummsmdsads +
  File "<stdin>", line 1
    Python = "Ṕýţĥòñ" + 34 $ lelummsmdsads +
                           ^
SyntaxError: invalid syntax
```



<!-- issue-number: [bpo-40958](https://bugs.python.org/issue40958) -->
https://bugs.python.org/issue40958
<!-- /issue-number -->
