### PR TITLE
bpo-40890: Fix compiler warning in dictobject.c

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4123,8 +4123,7 @@ _PyDictView_New(PyObject *dict, PyTypeObject *type)
 }
 
 static PyObject *
-dictview_mapping(PyObject *view)
-{
+dictview_mapping(PyObject *view, void *Py_UNUSED(ignored)) {
     assert(view != NULL);
     assert(PyDictKeys_Check(view)
            || PyDictValues_Check(view)
@@ -4134,7 +4133,7 @@ dictview_mapping(PyObject *view)
 }
 
 static PyGetSetDef dictview_getset[] = {
-    {"mapping", (getter)dictview_mapping, (setter)NULL,
+    {"mapping", dictview_mapping, (setter)NULL,
      "dictionary that this view refers to", NULL},
     {0}
 };


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40890](https://bugs.python.org/issue40890) -->
https://bugs.python.org/issue40890
<!-- /issue-number -->
