### PR TITLE
Improve asyncio-dev 'Concurrency and Multithreading' docs

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -107,6 +107,16 @@ The :meth:`loop.run_in_executor` method can be used with a
 blocking code in a different OS thread without blocking the OS thread
 that the event loop runs in.
 
+There is no way to schedule coroutines or callbacks directly from a 
+different process (such as one started with :mod:`multiprocessing`).
+The :ref:`Event Loop Methods <asyncio-event-loop>` section lists APIs
+that can read from pipes and watch file descriptors without blocking 
+the event loop. In addition, asyncio's 
+:ref:`Subprocess <asyncio-subprocess>` APIs provide a way to start a
+process and communicate with it from the event loop. Lastly, the
+aforementioned :meth:`loop.run_in_executor` method can also be used
+with a :class:`concurrent.futures.ProcessPoolExecutor` to execute 
+code in a different process.
 
 .. _asyncio-handle-blocking:
 

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -107,15 +107,15 @@ The :meth:`loop.run_in_executor` method can be used with a
 blocking code in a different OS thread without blocking the OS thread
 that the event loop runs in.
 
-There is no way to schedule coroutines or callbacks directly from a 
+There is no way to schedule coroutines or callbacks directly from a
 different process (such as one started with :mod:`multiprocessing`).
 The :ref:`Event Loop Methods <asyncio-event-loop>` section lists APIs
-that can read from pipes and watch file descriptors without blocking 
-the event loop. In addition, asyncio's 
+that can read from pipes and watch file descriptors without blocking
+the event loop. In addition, asyncio's
 :ref:`Subprocess <asyncio-subprocess>` APIs provide a way to start a
 process and communicate with it from the event loop. Lastly, the
 aforementioned :meth:`loop.run_in_executor` method can also be used
-with a :class:`concurrent.futures.ProcessPoolExecutor` to execute 
+with a :class:`concurrent.futures.ProcessPoolExecutor` to execute
 code in a different process.
 
 .. _asyncio-handle-blocking:

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -107,11 +107,11 @@ The :meth:`loop.run_in_executor` method can be used with a
 blocking code in a different OS thread without blocking the OS thread
 that the event loop runs in.
 
-There is no way to schedule coroutines or callbacks directly from a
-different process (such as one started with :mod:`multiprocessing`).
-The :ref:`Event Loop Methods <asyncio-event-loop>` section lists APIs
-that can read from pipes and watch file descriptors without blocking
-the event loop. In addition, asyncio's
+There is currently no way to schedule coroutines or callbacks directly
+from a different process (such as one started with
+:mod:`multiprocessing`). The :ref:`Event Loop Methods <asyncio-event-loop>`
+section lists APIs that can read from pipes and watch file descriptors
+without blocking the event loop. In addition, asyncio's
 :ref:`Subprocess <asyncio-subprocess>` APIs provide a way to start a
 process and communicate with it from the event loop. Lastly, the
 aforementioned :meth:`loop.run_in_executor` method can also be used


### PR DESCRIPTION
I added some information to the `Concurrency and Multithreading` section of the `Developing with asyncio` guide. 

This is all information that would have helped me when I started using asyncio. I incorrectly assumed that `loop.call_soon_threadsafe()` and `run_coroutine_threadsafe()` could be called from a thread in a process separate from the one that the event loop is running in. Explicitly stating that this will not work will probably help some people starting out with asyncio in the future.

I also added references to some other functions that can be used for inter-process communication without blocking the event loop. The section already mentions running blocking code in a ThreadPoolExecutor, but I think listing these other options in this section will also be helpful.



Automerge-Triggered-By: @aeros