### PR TITLE
Improve asyncio.loop.call_soon() documentation

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -189,6 +189,10 @@ Glossary
       A list of bytecode instructions can be found in the documentation for
       :ref:`the dis module <bytecodes>`.
 
+   callback
+      A subroutine function which is passed as an argument to be executed at 
+      some point in the future.
+
    class
       A template for creating user-defined objects. Class definitions
       normally contain method definitions which operate on instances of the

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -190,7 +190,7 @@ Glossary
       :ref:`the dis module <bytecodes>`.
 
    callback
-      A subroutine function which is passed as an argument to be executed at 
+      A subroutine function which is passed as an argument to be executed at
       some point in the future.
 
    class

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -73,8 +73,8 @@ event loop, no other Tasks can run in the same thread.  When a Task
 executes an ``await`` expression, the running Task gets suspended, and
 the event loop executes the next Task.
 
-To schedule a :ref:`callback <callback>` from a different OS thread,
-the :meth:`loop.call_soon_threadsafe` method should be used. Example::
+To schedule a :term:`callback` from a different OS thread, the
+:meth:`loop.call_soon_threadsafe` method should be used. Example::
 
     loop.call_soon_threadsafe(callback, *args)
 

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -73,7 +73,7 @@ event loop, no other Tasks can run in the same thread.  When a Task
 executes an ``await`` expression, the running Task gets suspended, and
 the event loop executes the next Task.
 
-To schedule a non-async callback from a different OS thread, the
+To schedule a synchronous callback from a different OS thread, the
 :meth:`loop.call_soon_threadsafe` method should be used. Example::
 
     loop.call_soon_threadsafe(callback, *args)

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -73,8 +73,8 @@ event loop, no other Tasks can run in the same thread.  When a Task
 executes an ``await`` expression, the running Task gets suspended, and
 the event loop executes the next Task.
 
-To schedule a synchronous callback from a different OS thread, the
-:meth:`loop.call_soon_threadsafe` method should be used. Example::
+To schedule a :ref:`callback <callback>` from a different OS thread,
+the :meth:`loop.call_soon_threadsafe` method should be used. Example::
 
     loop.call_soon_threadsafe(callback, *args)
 

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -73,7 +73,7 @@ event loop, no other Tasks can run in the same thread.  When a Task
 executes an ``await`` expression, the running Task gets suspended, and
 the event loop executes the next Task.
 
-To schedule a :term:`callback` from a different OS thread, the
+To schedule a :term:`callback` from another OS thread, the
 :meth:`loop.call_soon_threadsafe` method should be used. Example::
 
     loop.call_soon_threadsafe(callback, *args)

--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -73,7 +73,7 @@ event loop, no other Tasks can run in the same thread.  When a Task
 executes an ``await`` expression, the running Task gets suspended, and
 the event loop executes the next Task.
 
-To schedule a callback from a different OS thread, the
+To schedule a non-async callback from a different OS thread, the
 :meth:`loop.call_soon_threadsafe` method should be used. Example::
 
     loop.call_soon_threadsafe(callback, *args)

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -196,6 +196,9 @@ Scheduling callbacks
 
    Callbacks are called in the order in which they are registered.
    Each callback will be called exactly once.
+   
+   A callback is a standard Python function. Passing a coroutine to
+   as callback will result in an error.
 
    An optional keyword-only *context* argument allows specifying a
    custom :class:`contextvars.Context` for the *callback* to run in.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -191,7 +191,7 @@ Scheduling callbacks
 
 .. method:: loop.call_soon(callback, *args, context=None)
 
-   Schedule a non-async *callback* to be called with *args* 
+   Schedule a synchronous *callback* to be called with *args* 
    arguments at the next iteration of the event loop.
 
    Callbacks are called in the order in which they are registered.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -191,7 +191,7 @@ Scheduling callbacks
 
 .. method:: loop.call_soon(callback, *args, context=None)
 
-   Schedule the *callback* :ref:`callback <callback>` to be called with
+   Schedule the *callback* :term:`callback` to be called with
    *args* arguments at the next iteration of the event loop.
 
    Callbacks are called in the order in which they are registered.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -198,7 +198,7 @@ Scheduling callbacks
    Each callback will be called exactly once.
    
    A callback is a standard Python function. Passing a coroutine
-   as the `callback` argument will result in an error.
+   as the *callback* argument will result in an error.
 
    An optional keyword-only *context* argument allows specifying a
    custom :class:`contextvars.Context` for the *callback* to run in.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -191,14 +191,11 @@ Scheduling callbacks
 
 .. method:: loop.call_soon(callback, *args, context=None)
 
-   Schedule a *callback* to be called with *args* arguments at
-   the next iteration of the event loop.
+   Schedule a non-async *callback* to be called with *args* 
+   arguments at the next iteration of the event loop.
 
    Callbacks are called in the order in which they are registered.
    Each callback will be called exactly once.
-
-   A callback is a standard Python function. Passing a coroutine
-   as the *callback* argument will result in an error.
 
    An optional keyword-only *context* argument allows specifying a
    custom :class:`contextvars.Context` for the *callback* to run in.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -191,8 +191,8 @@ Scheduling callbacks
 
 .. method:: loop.call_soon(callback, *args, context=None)
 
-   Schedule a synchronous *callback* to be called with *args* 
-   arguments at the next iteration of the event loop.
+   Schedule the *callback* :ref:`callback <callback>` to be called with
+   *args* arguments at the next iteration of the event loop.
 
    Callbacks are called in the order in which they are registered.
    Each callback will be called exactly once.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -197,8 +197,8 @@ Scheduling callbacks
    Callbacks are called in the order in which they are registered.
    Each callback will be called exactly once.
    
-   A callback is a standard Python function. Passing a coroutine to
-   as callback will result in an error.
+   A callback is a standard Python function. Passing a coroutine
+   as the `callback` argument will result in an error.
 
    An optional keyword-only *context* argument allows specifying a
    custom :class:`contextvars.Context` for the *callback* to run in.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -196,7 +196,7 @@ Scheduling callbacks
 
    Callbacks are called in the order in which they are registered.
    Each callback will be called exactly once.
-   
+
    A callback is a standard Python function. Passing a coroutine
    as the *callback* argument will result in an error.
 


### PR DESCRIPTION
I was initially confused about the difference between `loop.call_soon_threadsafe()` and `run_coroutine_threadsafe()`. I believe this change will make this distinction clearer to people who are looking at asyncio for the first time. 