### PR TITLE
bpo-40989: Move _Py_NewReference() to the internal C API

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -181,3 +181,7 @@ Porting to Python 3.10
 
 Removed
 -------
+
+* Remove the :c:func:`_Py_NewReference` and :c:func:`_Py_ForgetReference`
+  functions from the public C API: move them to the internal C API.
+  (Contributed by Victor Stinner in :issue:`40989`.)

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -2,13 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-PyAPI_FUNC(void) _Py_NewReference(PyObject *op);
-
-#ifdef Py_TRACE_REFS
-/* Py_TRACE_REFS is such major surgery that we call external routines. */
-PyAPI_FUNC(void) _Py_ForgetReference(PyObject *);
-#endif
-
 #ifdef Py_REF_DEBUG
 PyAPI_FUNC(Py_ssize_t) _Py_GetRefTotal(void);
 #endif

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -15,11 +15,16 @@ extern "C" {
 PyAPI_FUNC(int) _PyType_CheckConsistency(PyTypeObject *type);
 PyAPI_FUNC(int) _PyDict_CheckConsistency(PyObject *mp, int check_content);
 
-/* Update the Python traceback of an object. This function must be called
-   when a memory block is reused from a free list.
+PyAPI_FUNC(void) _Py_NewReference(PyObject *op);
 
-   Internal function called by _Py_NewReference(). */
+/* Update the Python traceback of an object. This function must be called
+   when a memory block is reused from a free list. */
 extern int _PyTraceMalloc_NewReference(PyObject *op);
+
+#ifdef Py_TRACE_REFS
+/* Py_TRACE_REFS is such major surgery that we call external routines. */
+PyAPI_FUNC(void) _Py_ForgetReference(PyObject *);
+#endif
 
 // Fast inlined version of PyType_HasFeature()
 static inline int

--- a/Lib/test/test_finalization.py
+++ b/Lib/test/test_finalization.py
@@ -8,12 +8,12 @@ import unittest
 import weakref
 
 try:
-    from _testcapi import with_tp_del
+    from _testinternalcapi import with_tp_del
 except ImportError:
     def with_tp_del(cls):
         class C(object):
             def __new__(cls, *args, **kwargs):
-                raise TypeError('requires _testcapi.with_tp_del')
+                raise TypeError('requires _testinternalcapi.with_tp_del')
         return C
 
 from test import support

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -15,12 +15,12 @@ import time
 import weakref
 
 try:
-    from _testcapi import with_tp_del
+    from _testinternalcapi import with_tp_del
 except ImportError:
     def with_tp_del(cls):
         class C(object):
             def __new__(cls, *args, **kwargs):
-                raise TypeError('requires _testcapi.with_tp_del')
+                raise TypeError('requires _testinternalcapi.with_tp_del')
         return C
 
 try:
@@ -664,8 +664,8 @@ class GCTests(unittest.TestCase):
         import subprocess
         code = """if 1:
             import gc
-            import _testcapi
-            @_testcapi.with_tp_del
+            import _testinternalcapi
+            @_testinternalcapi.with_tp_del
             class X:
                 def __init__(self, name):
                     self.name = name

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1177,11 +1177,11 @@ class ArgsTestCase(BaseTestCase):
     @support.cpython_only
     def test_findleaks(self):
         code = textwrap.dedent(r"""
-            import _testcapi
+            import _testinternalcapi
             import gc
             import unittest
 
-            @_testcapi.with_tp_del
+            @_testinternalcapi.with_tp_del
             class Garbage:
                 def __tp_del__(self):
                     pass

--- a/Misc/NEWS.d/next/C API/2020-06-16-01-53-01.bpo-40989.5d3Eff.rst
+++ b/Misc/NEWS.d/next/C API/2020-06-16-01-53-01.bpo-40989.5d3Eff.rst
@@ -1,0 +1,2 @@
+Remove the :c:func:`_Py_NewReference` and :c:func:`_Py_ForgetReference`
+functions from the public C API:(move them to the internal C API.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_object.h"        // _Py_NewReference()
 #include "pycore_pyerrors.h"      // _PyErr_ClearExcState()
 #include <stddef.h>               // offsetof()
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -15,6 +15,7 @@
 #include "pycore_bitutils.h"     // _Py_bswap32()
 #include "pycore_initconfig.h"   // _Py_GetConfigsAsDict()
 #include "pycore_hashtable.h"    // _Py_hashtable_new()
+#include "pycore_object.h"       // _Py_NewReference()
 #include "pycore_gc.h"           // PyGC_Head
 
 
@@ -231,6 +232,81 @@ test_hashtable(PyObject *self, PyObject *Py_UNUSED(args))
 }
 
 
+static void
+slot_tp_del(PyObject *self)
+{
+    _Py_IDENTIFIER(__tp_del__);
+    PyObject *del, *res;
+    PyObject *error_type, *error_value, *error_traceback;
+
+    /* Temporarily resurrect the object. */
+    assert(Py_REFCNT(self) == 0);
+    Py_SET_REFCNT(self, 1);
+
+    /* Save the current exception, if any. */
+    PyErr_Fetch(&error_type, &error_value, &error_traceback);
+
+    /* Execute __del__ method, if any. */
+    del = _PyObject_LookupSpecial(self, &PyId___tp_del__);
+    if (del != NULL) {
+        res = _PyObject_CallNoArg(del);
+        if (res == NULL)
+            PyErr_WriteUnraisable(del);
+        else
+            Py_DECREF(res);
+        Py_DECREF(del);
+    }
+
+    /* Restore the saved exception. */
+    PyErr_Restore(error_type, error_value, error_traceback);
+
+    /* Undo the temporary resurrection; can't use DECREF here, it would
+     * cause a recursive call.
+     */
+    assert(Py_REFCNT(self) > 0);
+    Py_SET_REFCNT(self, Py_REFCNT(self) - 1);
+    if (Py_REFCNT(self) == 0) {
+        /* this is the normal path out */
+        return;
+    }
+
+    /* __del__ resurrected it!  Make it look like the original Py_DECREF
+     * never happened.
+     */
+    {
+        Py_ssize_t refcnt = Py_REFCNT(self);
+        _Py_NewReference(self);
+        Py_SET_REFCNT(self, refcnt);
+    }
+    assert(!PyType_IS_GC(Py_TYPE(self)) || PyObject_GC_IsTracked(self));
+    /* If Py_REF_DEBUG macro is defined, _Py_NewReference() increased
+       _Py_RefTotal, so we need to undo that. */
+#ifdef Py_REF_DEBUG
+    _Py_RefTotal--;
+#endif
+}
+
+
+static PyObject *
+with_tp_del(PyObject *self, PyObject *args)
+{
+    PyObject *obj;
+    PyTypeObject *tp;
+
+    if (!PyArg_ParseTuple(args, "O:with_tp_del", &obj))
+        return NULL;
+    tp = (PyTypeObject *) obj;
+    if (!PyType_Check(obj) || !PyType_HasFeature(tp, Py_TPFLAGS_HEAPTYPE)) {
+        PyErr_Format(PyExc_TypeError,
+                     "heap type expected, got %R", obj);
+        return NULL;
+    }
+    tp->tp_del = slot_tp_del;
+    Py_INCREF(obj);
+    return obj;
+}
+
+
 static PyMethodDef TestMethods[] = {
     {"get_configs", get_configs, METH_NOARGS},
     {"get_recursion_depth", get_recursion_depth, METH_NOARGS},
@@ -238,6 +314,7 @@ static PyMethodDef TestMethods[] = {
     {"test_popcount", test_popcount, METH_NOARGS},
     {"test_bit_length", test_bit_length, METH_NOARGS},
     {"test_hashtable", test_hashtable, METH_NOARGS},
+    {"with_tp_del", with_tp_del, METH_VARARGS},
     {NULL, NULL} /* sentinel */
 };
 


### PR DESCRIPTION
Remove the _Py_NewReference() function from the public C API (move it
to the internal C API).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40989](https://bugs.python.org/issue40989) -->
https://bugs.python.org/issue40989
<!-- /issue-number -->
