### PR TITLE
bpo-30533:Add function inspect.getmembers_static that does not call properties or dynamic properties.

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -441,7 +441,7 @@ def isabstract(object):
                 return True
     return False
 
-def _getmembers(object, predicate=None, getter=None):
+def _getmembers(object, predicate, getter):
     """Return all members of an object as (name, value) pairs sorted by name.
     Optionally, only return members that satisfy a given predicate."""
     if isclass(object):

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -441,7 +441,7 @@ def isabstract(object):
                 return True
     return False
 
-def getmembers(object, predicate=None):
+def _getmembers(object, predicate=None, getter=None):
     """Return all members of an object as (name, value) pairs sorted by name.
     Optionally, only return members that satisfy a given predicate."""
     if isclass(object):
@@ -466,7 +466,7 @@ def getmembers(object, predicate=None):
         # like calling their __get__ (see bug #1785), so fall back to
         # looking in the __dict__.
         try:
-            value = getattr(object, key)
+            value = getter(object, key)
             # handle the duplicate key
             if key in processed:
                 raise AttributeError
@@ -484,6 +484,17 @@ def getmembers(object, predicate=None):
         processed.add(key)
     results.sort(key=lambda pair: pair[0])
     return results
+
+def getmembers(object, predicate=None):
+    """Return all members of an object as (name, value) pairs sorted by name.
+    Optionally, only return members that satisfy a given predicate."""
+    return _getmembers(object, predicate, getattr)
+
+def getmembers_static(object, predicate=None):
+    """Return all members of an object as (name, value) pairs sorted by name
+    without calling properties and other dynamic. Optionally, only return
+    members that satisfy a given predicate."""
+    return _getmembers(object, predicate, getattr_static)
 
 Attribute = namedtuple('Attribute', 'name kind defining_class object')
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -442,8 +442,6 @@ def isabstract(object):
     return False
 
 def _getmembers(object, predicate, getter):
-    """Return all members of an object as (name, value) pairs sorted by name.
-    Optionally, only return members that satisfy a given predicate."""
     if isclass(object):
         mro = (object,) + getmro(object)
     else:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -492,8 +492,16 @@ def getmembers(object, predicate=None):
 
 def getmembers_static(object, predicate=None):
     """Return all members of an object as (name, value) pairs sorted by name
-    without calling properties and other dynamic. Optionally, only return
-    members that satisfy a given predicate."""
+    without triggering dynamic lookup via the descriptor protocol,
+    __getattr__ or __getattribute__. Optionally, only return members that
+    satisfy a given predicate.
+    
+    Note: this function may not be able to retrieve all members
+       that getmembers can fetch (like dynamically created attributes)
+       and may find members that getmembers can't (like descriptors
+       that raise AttributeError). It can also return descriptor objects
+       instead of instance members in some cases.
+    """
     return _getmembers(object, predicate, getattr_static)
 
 Attribute = namedtuple('Attribute', 'name kind defining_class object')

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1275,6 +1275,23 @@ class TestClassesAndFunctions(unittest.TestCase):
         self.assertIn(('eggs', 'scrambled'), inspect.getmembers(A))
         self.assertIn(('eggs', 'spam'), inspect.getmembers(A()))
 
+    def test_getmembers_static(self):
+        class A:
+            @property
+            def name(self):
+                raise NotImplementedError
+            @types.DynamicClassAttribute
+            def eggs(self):
+                raise NotImplementedError
+
+        a = A()
+        instance_members = inspect.getmembers_static(a)
+        class_members = inspect.getmembers_static(A)
+        self.assertIn(('name', inspect.getattr_static(a, 'name')), instance_members)
+        self.assertIn(('eggs', inspect.getattr_static(a, 'eggs')), instance_members)
+        self.assertIn(('name', inspect.getattr_static(A, 'name')), class_members)
+        self.assertIn(('eggs', inspect.getattr_static(A, 'eggs')), class_members)
+
     def test_getmembers_with_buggy_dir(self):
         class M(type):
             def __dir__(cls):

--- a/Misc/NEWS.d/next/Library/2020-06-16-18-00-56.bpo-30533.StL57t.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-16-18-00-56.bpo-30533.StL57t.rst
@@ -1,0 +1,2 @@
+Add :func:`inspect.getmembers_static` , it return all members without
+calling properties and other dynamic. Patch by Weipeng Hong.

--- a/Misc/NEWS.d/next/Library/2020-06-16-18-00-56.bpo-30533.StL57t.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-16-18-00-56.bpo-30533.StL57t.rst
@@ -1,2 +1,2 @@
 Add :func:`inspect.getmembers_static` , it return all members without
-calling properties and other dynamic. Patch by Weipeng Hong.
+triggering dynamic lookup via the descriptor protocol. Patch by Weipeng Hong.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30533](https://bugs.python.org/issue30533) -->
https://bugs.python.org/issue30533
<!-- /issue-number -->
