### PR TITLE
doc: Link to `string.capwords` from `str.title`

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2137,7 +2137,7 @@ expression support in the :mod:`re` module).
         "They'Re Bill'S Friends From The Uk"
 
    The :func:`string.capwords` function does not have this problem, as it
-   splits words on spaces first.
+   splits words on spaces only.
 
    Alternatively, a workaround for apostrophes can be constructed using regular
    expressions::

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2135,8 +2135,12 @@ expression support in the :mod:`re` module).
 
         >>> "they're bill's friends from the UK".title()
         "They'Re Bill'S Friends From The Uk"
+   
+   The :func:`string.capwords` function does not have this problem, as it
+   splits words on spaces first.
 
-   A workaround for apostrophes can be constructed using regular expressions::
+   Alternatively, a workaround for apostrophes can be constructed using regular
+   expressions::
 
         >>> import re
         >>> def titlecase(s):

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2135,7 +2135,6 @@ expression support in the :mod:`re` module).
 
         >>> "they're bill's friends from the UK".title()
         "They'Re Bill'S Friends From The Uk"
-   
    The :func:`string.capwords` function does not have this problem, as it
    splits words on spaces first.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2135,6 +2135,7 @@ expression support in the :mod:`re` module).
 
         >>> "they're bill's friends from the UK".title()
         "They'Re Bill'S Friends From The Uk"
+
    The :func:`string.capwords` function does not have this problem, as it
    splits words on spaces first.
 


### PR DESCRIPTION
Since `title()` mentions its own short-comings, it should also mention the library function which does not possess them.

No bpo issue since this is a trivial docs change.
