### PR TITLE
bpo-40989: Make _PyTraceMalloc_NewReference() internal

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -9,10 +9,6 @@ PyAPI_FUNC(void) _Py_NewReference(PyObject *op);
 PyAPI_FUNC(void) _Py_ForgetReference(PyObject *);
 #endif
 
-/* Update the Python traceback of an object. This function must be called
-   when a memory block is reused from a free list. */
-PyAPI_FUNC(int) _PyTraceMalloc_NewReference(PyObject *op);
-
 #ifdef Py_REF_DEBUG
 PyAPI_FUNC(Py_ssize_t) _Py_GetRefTotal(void);
 #endif

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -15,6 +15,12 @@ extern "C" {
 PyAPI_FUNC(int) _PyType_CheckConsistency(PyTypeObject *type);
 PyAPI_FUNC(int) _PyDict_CheckConsistency(PyObject *mp, int check_content);
 
+/* Update the Python traceback of an object. This function must be called
+   when a memory block is reused from a free list.
+
+   Internal function called by _Py_NewReference(). */
+extern int _PyTraceMalloc_NewReference(PyObject *op);
+
 // Fast inlined version of PyType_HasFeature()
 static inline int
 _PyType_HasFeature(PyTypeObject *type, unsigned long feature) {


### PR DESCRIPTION
Make the _PyTraceMalloc_NewReference() function fully internal:
remove it from the public C API and don't export it anymore.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40989](https://bugs.python.org/issue40989) -->
https://bugs.python.org/issue40989
<!-- /issue-number -->
