### PR TITLE
bpo-40993: Don't run Travis CI coverage on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,12 @@ matrix:
           packages:
             - xvfb
       before_script:
+        - |
+            if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]
+            then
+              echo "Don't run Python coverage on pull requests."
+              exit
+            fi
         - ./configure
         - make -j4
         # Need a venv that can parse covered code.
@@ -109,6 +115,12 @@ matrix:
             - lcov
             - xvfb
       before_script:
+        - |
+            if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]
+            then
+              echo "Don't run C coverage on pull requests."
+              exit
+            fi
         - ./configure
       script:
         - xvfb-run make -j4 coverage-report


### PR DESCRIPTION
C and Python coverage jobs of Travis CI are no longer run on pull
requests, only on branches like master.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40993](https://bugs.python.org/issue40993) -->
https://bugs.python.org/issue40993
<!-- /issue-number -->
