### PR TITLE
bpo-39949: Add ... to truncated match in repr(match)

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1784,6 +1784,20 @@ class ReTests(unittest.TestCase):
         )
         self.assertRegex(repr(second), pattern)
 
+        # Issue 39949: Verify truncation of long match
+        self.assertEqual(
+            repr(re.match(r'\w*', ('abcde'*10)[:48])),
+            "<re.Match object; span=(0, 48), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabc'>")
+        self.assertEqual(
+            repr(re.match(r'\w*', ('abcde'*10)[:49])),
+            "<re.Match object; span=(0, 49), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdea...>")
+        self.assertEqual(
+            repr(re.match(rb'\w*', (b'aoeui'*10)[:47])),
+            "<re.Match object; span=(0, 47), match=b'aoeuiaoeuiaoeuiaoeuiaoeuiaoeuiaoeuiaoeuiaoeuiao'>")
+        self.assertEqual(
+            repr(re.match(rb'\w*', (b'aoeui'*10)[:48])),
+            "<re.Match object; span=(0, 48), match=b'aoeuiaoeuiaoeuiaoeuiaoeuiaoeuiaoeuiaoeuiaoeui...>")
+
     def test_zerowidth(self):
         # Issues 852532, 1647489, 3262, 25054.
         self.assertEqual(re.split(r"\b", "a::bc"), ['', 'a', '::', 'bc', ''])

--- a/Misc/NEWS.d/next/Library/2020-06-16-21-59-36.bpo-39949.dtDnzG.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-16-21-59-36.bpo-39949.dtDnzG.rst
@@ -1,0 +1,1 @@
+Add ... when truncating group0 match in :func:`repr` of re.match objects.

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -2308,10 +2308,19 @@ match_repr(MatchObject *self)
     PyObject *group0 = match_getslice_by_index(self, 0, Py_None);
     if (group0 == NULL)
         return NULL;
-    result = PyUnicode_FromFormat(
-            "<%s object; span=(%zd, %zd), match=%.50R>",
-            Py_TYPE(self)->tp_name,
-            self->mark[0], self->mark[1], group0);
+
+    /* Truncate group0 with ... if repr will be longer than 50 characters */
+    if (PySequence_Length(group0) <= 48 - PyBytes_Check(group0)) {
+        result = PyUnicode_FromFormat(
+                "<%s object; span=(%zd, %zd), match=%.50R>",
+                Py_TYPE(self)->tp_name,
+                self->mark[0], self->mark[1], group0);
+    } else {
+        result = PyUnicode_FromFormat(
+                "<%s object; span=(%zd, %zd), match=%.47R...>",
+                Py_TYPE(self)->tp_name,
+                self->mark[0], self->mark[1], group0);
+    }
     Py_DECREF(group0);
     return result;
 }


### PR DESCRIPTION
<!-- issue-number: [bpo-39949](https://bugs.python.org/issue39949) -->
https://bugs.python.org/issue39949
<!-- /issue-number -->

This is my first change to `cpython` so apologies if I've missed anything.

* I've tried to format my commit correctly,
* I've run `make; make test`,
* I've tested with both bytes and string (and left a note for help in the c code)
* I've added a NEWS message entry, but haven't tested it's formatted correctly. 

Big outstanding questions is
```
# No trailing quote
<Match object; span=(0, X), match='abc...>
# ellipses after quote
<Match object; span=(0, X), match='abc'...>
```

If this change should be documented somewhere other than NEWS let me know

Old Behavior
```
>>> re.match('\w*', ('abcde'*10)[:40])
<_sre.SRE_Match object; span=(0, 40), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde'>
>>> re.match('\w*', ('abcde'*10)[:47])
<_sre.SRE_Match object; span=(0, 47), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeab'>
>>> re.match('\w*', ('abcde'*10)[:48])
<_sre.SRE_Match object; span=(0, 48), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabc'>
>>> re.match('\w*', ('abcde'*10)[:49])
<_sre.SRE_Match object; span=(0, 49), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcd>
>>> re.match('\w*', ('abcde'*10)[:50])
<_sre.SRE_Match object; span=(0, 50), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcd>
>>> re.match('\w*', ('abcde'*20)[:100])
<_sre.SRE_Match object; span=(0, 100), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcd>
>>> re.match(b'\w*', (b'abcde'*20)[:100])
<_sre.SRE_Match object; span=(0, 100), match=b'abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabc>
```

New Behavior
```
>>> re.match('\w*', ('abcde'*10)[:40])
<re.Match object; span=(0, 40), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde'>
>>> re.match('\w*', ('abcde'*10)[:47])
<re.Match object; span=(0, 47), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeab'>
>>> re.match('\w*', ('abcde'*10)[:48])
<re.Match object; span=(0, 48), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabc'>
>>> re.match('\w*', ('abcde'*10)[:49])
<re.Match object; span=(0, 49), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdea...>
>>> re.match('\w*', ('abcde'*10)[:50])
<re.Match object; span=(0, 50), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdea...>
>>> re.match('\w*', ('abcde'*15)[:51])
<re.Match object; span=(0, 51), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdea...>
>>> re.match('\w*', ('abcde'*20)[:100])
<re.Match object; span=(0, 100), match='abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdea...>

>>> re.match(b'\w*', (b'abcde'*20)[:47])
<re.Match object; span=(0, 47), match=b'abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeab'>
>>> re.match(b'\w*', (b'abcde'*20)[:48])
<re.Match object; span=(0, 48), match=b'abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde...>
>>> re.match(b'\w*', (b'abcde'*20)[:50])
<re.Match object; span=(0, 50), match=b'abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde...>
>>> re.match(b'\w*', (b'abcde'*20)[:100])
<re.Match object; span=(0, 100), match=b'abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde...>
```