### PR TITLE
bpo-41009: fix requires_OS_version() class decorator

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -315,7 +315,7 @@ def _requires_unix_version(sysname, min_version):
     return unittest.skipIf(
         skip,
         f"{sysname} version {min_version_txt} or higher required, not "
-        f"{version_txt}."
+        f"{version_txt}"
     )
 
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -299,26 +299,25 @@ def _requires_unix_version(sysname, min_version):
     For example, @_requires_unix_version('FreeBSD', (7, 2)) raises SkipTest if
     the FreeBSD version is less than 7.2.
     """
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kw):
-            import platform
-            if platform.system() == sysname:
-                version_txt = platform.release().split('-', 1)[0]
-                try:
-                    version = tuple(map(int, version_txt.split('.')))
-                except ValueError:
-                    pass
-                else:
-                    if version < min_version:
-                        min_version_txt = '.'.join(map(str, min_version))
-                        raise unittest.SkipTest(
-                            "%s version %s or higher required, not %s"
-                            % (sysname, min_version_txt, version_txt))
-            return func(*args, **kw)
-        wrapper.min_version = min_version
-        return wrapper
-    return decorator
+    import platform
+    min_version_txt = '.'.join(map(str, min_version))
+    version_txt = platform.release().split('-', 1)[0]
+    if platform.system() == sysname:
+        try:
+            version = tuple(map(int, version_txt.split('.')))
+        except ValueError:
+            skip = False
+        else:
+            skip = version < min_version
+    else:
+        skip = False
+
+    return unittest.skipIf(
+        skip,
+        f"{sysname} version {min_version_txt} or higher required, not "
+        f"{version_txt}."
+    )
+
 
 def requires_freebsd_version(*min_version):
     """Decorator raising SkipTest if the OS is FreeBSD and the FreeBSD version is

--- a/Misc/NEWS.d/next/Tests/2020-06-17-17-27-07.bpo-41009.Rvn6OQ.rst
+++ b/Misc/NEWS.d/next/Tests/2020-06-17-17-27-07.bpo-41009.Rvn6OQ.rst
@@ -1,2 +1,2 @@
-Fix use of ``support.require_{linux|mac|freebsd}_version()`` decorator as
+Fix use of ``support.require_{linux|mac|freebsd}_version()`` decorators as
 class decorator.

--- a/Misc/NEWS.d/next/Tests/2020-06-17-17-27-07.bpo-41009.Rvn6OQ.rst
+++ b/Misc/NEWS.d/next/Tests/2020-06-17-17-27-07.bpo-41009.Rvn6OQ.rst
@@ -1,0 +1,2 @@
+Fix use of ``support.require_{linux|mac|freebsd}_version()`` decorator as
+class decorator.


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41009](https://bugs.python.org/issue41009) -->
https://bugs.python.org/issue41009
<!-- /issue-number -->


Automerge-Triggered-By: @tiran