### PR TITLE
[3.8] bpo-41003: Fix test_copyreg when numpy is installed (GH-20935) (GH-20945)

### DIFF
--- a/Lib/distutils/tests/__init__.py
+++ b/Lib/distutils/tests/__init__.py
@@ -15,26 +15,24 @@ by import rather than matching pre-defined names.
 import os
 import sys
 import unittest
-import warnings
-from test.support import run_unittest
+from test.support import run_unittest, save_restore_warnings_filters
 
 
 here = os.path.dirname(__file__) or os.curdir
 
 
 def test_suite():
-    old_filters = warnings.filters[:]
     suite = unittest.TestSuite()
     for fn in os.listdir(here):
         if fn.startswith("test") and fn.endswith(".py"):
             modname = "distutils.tests." + fn[:-3]
-            __import__(modname)
+            # bpo-40055: Save/restore warnings filters to leave them unchanged.
+            # Importing tests imports docutils which imports pkg_resources
+            # which adds a warnings filter.
+            with save_restore_warnings_filters():
+                __import__(modname)
             module = sys.modules[modname]
             suite.addTest(module.test_suite())
-    # bpo-40055: Save/restore warnings filters to leave them unchanged.
-    # Importing tests imports docutils which imports pkg_resources which adds a
-    # warnings filter.
-    warnings.filters[:] = old_filters
     return suite
 
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -21,18 +21,24 @@ try:
 except ImportError:
     _testbuffer = None
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
-
 from test import support
 from test.support import (
     TestFailed, TESTFN, run_with_locale, no_tracing,
     _2G, _4G, bigmemtest, reap_threads, forget,
+    save_restore_warnings_filters
     )
 
 from pickle import bytes_types
+
+
+# bpo-41003: Save/restore warnings filters to leave them unchanged.
+# Ignore filters installed by numpy.
+try:
+    with save_restore_warnings_filters():
+        import numpy as np
+except ImportError:
+    np = None
+
 
 requires_32b = unittest.skipUnless(sys.maxsize < 2**32,
                                    "test is only meaningful on 32-bit builds")

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3368,3 +3368,12 @@ class catch_threading_exception:
         del self.exc_value
         del self.exc_traceback
         del self.thread
+
+
+@contextlib.contextmanager
+def save_restore_warnings_filters():
+    old_filters = warnings.filters[:]
+    try:
+        yield
+    finally:
+        warnings.filters[:] = old_filters

--- a/Misc/NEWS.d/next/Tests/2020-06-17-15-07-14.bpo-41003.tiH_Fy.rst
+++ b/Misc/NEWS.d/next/Tests/2020-06-17-15-07-14.bpo-41003.tiH_Fy.rst
@@ -1,0 +1,3 @@
+Fix ``test_copyreg`` when ``numpy`` is installed: ``test.pickletester`` now
+saves/restores warnings filters when importing ``numpy``, to ignore filters
+installed by ``numpy``.


### PR DESCRIPTION
Fix test_copyreg when numpy is installed: test.pickletester now
saves/restores warnings.filters when importing numpy, to ignore
filters installed by numpy.

Add the save_restore_warnings_filters() function to the
test.support.warnings_helper module.

(cherry picked from commit 8362893e3fe083df2ec8bb94c28b1a78383eadbf)
(cherry picked from commit b39d41ba1b77f7bc51c4d6f6d0e336693192cb3a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41003](https://bugs.python.org/issue41003) -->
https://bugs.python.org/issue41003
<!-- /issue-number -->
