### PR TITLE
[3.9] bpo-40637: Do not emit warnings for disabled builtin hashes (GH…

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -102,7 +102,7 @@ class HashLibTestCase(unittest.TestCase):
         try:
             return importlib.import_module(module_name)
         except ModuleNotFoundError as error:
-            if self._warn_on_extension_import:
+            if self._warn_on_extension_import and module_name in builtin_hashes:
                 warnings.warn('Did a C extension fail to compile? %s' % error)
         return None
 


### PR DESCRIPTION
…-20937)

test_hashlib emits some warnings when it cannot find some hashes
as it assumes they failed to compile. Since we can disable hashes
through configure, we emit the warnings only in the case that we
did not intentionaly disable them.

Automerge-Triggered-By: @tiran
(cherry picked from commit 236a0f5)

Co-authored-by: stratakis <cstratak@redhat.com>


<!-- issue-number: [bpo-40637](https://bugs.python.org/issue40637) -->
https://bugs.python.org/issue40637
<!-- /issue-number -->


Automerge-Triggered-By: @tiran