### PR TITLE
bpo-41006: Remove init_sys_streams() hack

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-18-00-07-09.bpo-41006.H-wN-d.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-18-00-07-09.bpo-41006.H-wN-d.rst
@@ -1,2 +1,2 @@
 The ``encodings.latin_1`` module is no longer imported at startup. Now it is
-only imported when it is the filesystem encoding.
+only imported when it is the filesystem encoding or the stdio encoding.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-18-00-07-09.bpo-41006.H-wN-d.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-18-00-07-09.bpo-41006.H-wN-d.rst
@@ -1,0 +1,2 @@
+The ``encodings.latin_1`` module is no longer imported at startup. Now it is
+only imported when it is the filesystem encoding.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1939,7 +1939,6 @@ static PyStatus
 init_sys_streams(PyThreadState *tstate)
 {
     PyObject *iomod = NULL;
-    PyObject *m;
     PyObject *std = NULL;
     int fd;
     PyObject * encoding_attr;
@@ -1958,18 +1957,6 @@ init_sys_streams(PyThreadState *tstate)
         return _PyStatus_ERR("<stdin> is a directory, cannot continue");
     }
 #endif
-
-    /* Hack to avoid a nasty recursion issue when Python is invoked
-       in verbose mode: pre-import the Latin-1 and UTF-8 codecs */
-    if ((m = PyImport_ImportModule("encodings.utf_8")) == NULL) {
-        goto error;
-    }
-    Py_DECREF(m);
-
-    if (!(m = PyImport_ImportModule("encodings.latin_1"))) {
-        goto error;
-    }
-    Py_DECREF(m);
 
     if (!(iomod = PyImport_ImportModule("io"))) {
         goto error;


### PR DESCRIPTION
The encodings.latin_1 module is no longer imported at startup. Now it
is only imported when it is the filesystem encoding.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41006](https://bugs.python.org/issue41006) -->
https://bugs.python.org/issue41006
<!-- /issue-number -->
