### PR TITLE
bpo-41004: IPv4Interface, and IPv6Interface hash collisions 

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1420,7 +1420,7 @@ class IPv4Interface(IPv4Address):
             return False
 
     def __hash__(self):
-        return self._ip ^ self._prefixlen ^ int(self.network.network_address)
+        return hash((self._ip, self._prefixlen, int(self.network.network_address)))
 
     __reduce__ = _IPAddressBase.__reduce__
 
@@ -2120,7 +2120,7 @@ class IPv6Interface(IPv6Address):
             return False
 
     def __hash__(self):
-        return self._ip ^ self._prefixlen ^ int(self.network.network_address)
+        return hash((self._ip, self._prefixlen, int(self.network.network_address)))
 
     __reduce__ = _IPAddressBase.__reduce__
 


### PR DESCRIPTION


Automerge-Triggered-By: @ericvsmith

<!-- issue-number: [bpo-41004](https://bugs.python.org/issue41004) -->
https://bugs.python.org/issue41004
<!-- /issue-number -->
