### PR TITLE
bpo-40275: Remove redundant import in libregrtest

### DIFF
--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -12,7 +12,7 @@ import warnings
 from test import support
 from test.libregrtest.utils import print_warning
 try:
-    import _multiprocessing, multiprocessing.process
+    import multiprocessing.process
 except ImportError:
     multiprocessing = None
 


### PR DESCRIPTION
Remove the redundant import in libregrtest,
this redundant import spotted by pyflake.

<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
