### PR TITLE
bpo-40636: Documentation for zip-strict

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1722,7 +1722,8 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: zip(*iterables, strict=False)
 
-   Invert a series of iterables, turning rows into columns, and columns into rows.
+   Iterate over several iterables in parallel, producing tuples with an item
+   from each one.
 
    Example::
 
@@ -1735,6 +1736,10 @@ are always available.  They are listed here in alphabetical order.
 
    More formally: :func:`zip` returns an iterator of tuples, where the *i*-th
    tuple contains the *i*-th element from each of the argument iterables.
+
+   Another way to think of :func:`zip` is that it turns rows into columns, and
+   columns into rows.  This is similar to `transposing a matrix
+   <https://en.wikipedia.org/wiki/Transpose>`_.
 
    :func:`zip` is lazy: The elements wouldn't be processed until the iterable
    is iterated on, e.g. by wrapping in a :class:`list`.
@@ -1756,7 +1761,7 @@ are always available.  They are listed here in alphabetical order.
      option. Its output is the same as regular :func:`zip`::
 
         >>> list(zip(('a', 'b', 'c'), (1, 2, 3), strict=True))
-        (('a', 1), ('b', 2), ('c', 3))
+        [('a', 1), ('b', 2), ('c', 3)]
 
      Unlike the default behavior, it checks that the lengths of iterables is
      identical, raising a :exc:`ValueError` if they aren't:

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1727,12 +1727,12 @@ are always available.  They are listed here in alphabetical order.
 
    Example::
 
-      >>> for item in zip(['a', 'b', 'c'], [1, 2, 3]):
+      >>> for item in zip([1, 2, 3], ['sugar', 'spice', 'everything nice']):
       ...     print(item)
       ...
-      ('a', 1)
-      ('b', 2)
-      ('c', 3)
+      (1, 'sugar')
+      (2, 'spice')
+      (3, 'everything nice')
 
    More formally: :func:`zip` returns an iterator of tuples, where the *i*-th
    tuple contains the *i*-th element from each of the argument iterables.
@@ -1741,8 +1741,9 @@ are always available.  They are listed here in alphabetical order.
    columns into rows.  This is similar to `transposing a matrix
    <https://en.wikipedia.org/wiki/Transpose>`_.
 
-   :func:`zip` is lazy: The elements wouldn't be processed until the iterable
-   is iterated on, e.g. by wrapping in a :class:`list`.
+   :func:`zip` is lazy: The elements won't be processed until the iterable is
+   iterated on, e.g. by a :keyword:`!for` loop or by wrapping in a
+   :class:`list`.
 
    One thing to consider is that the iterables passed to :func:`zip` could have
    different lengths; sometimes by design, and sometimes because of a bug in
@@ -1750,8 +1751,8 @@ are always available.  They are listed here in alphabetical order.
    approaches to dealing with this issue:
 
    * By default, :func:`zip` stops when the shortest iterable is exhausted.
-     :func:`zip` will ignore the remaining items in the longer iterables, cutting
-     off the result to the length of the shortest iterable::
+     It will ignore the remaining items in the longer iterables, cutting off
+     the result to the length of the shortest iterable::
 
         >>> list(zip(range(3), ['fee', 'fi', 'fo', 'fum']))
         [(0, 'fee'), (1, 'fi'), (2, 'fo')]
@@ -1776,7 +1777,7 @@ are always available.  They are listed here in alphabetical order.
    * Shorter iterables can be padded with a constant value to make all the
      iterables equal. This is done by :func:`itertools.zip_longest`.
 
-   Special cases: With a single iterable argument, :func:`zip` returns an
+   Edge cases: With a single iterable argument, :func:`zip` returns an
    iterator of 1-tuples.  With no arguments, it returns an empty iterator.
 
    Tips and tricks:

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1768,6 +1768,8 @@ are always available.  They are listed here in alphabetical order.
      identical, raising a :exc:`ValueError` if they aren't:
 
         >>> list(zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True))
+        Traceback (most recent call last):
+          ...
         ValueError: zip() argument 2 is longer than argument 1
 
      Without the ``strict=True`` argument, any bug that results in iterables of

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1726,7 +1726,7 @@ are always available.  They are listed here in alphabetical order.
 
    Example::
 
-      >>> for item in zip(('a', 'b', 'c'), (1, 2, 3)):
+      >>> for item in zip(['a', 'b', 'c'], [1, 2, 3]):
       ...     print(item)
       ...
       ('a', 1)
@@ -1734,36 +1734,34 @@ are always available.  They are listed here in alphabetical order.
       ('c', 3)
 
    More formally: :func:`zip` returns an iterator of tuples, where the *i*-th
-   tuple contains the *i*-th element from each of the argument sequences or
-   iterables.
+   tuple contains the *i*-th element from each of the argument iterables.
 
-   :func:`zip` returns a lazy iterable. The elements wouldn't be processed
-   until the iterable is iterated on, e.g. by wrapping in a :class:`tuple`.
+   :func:`zip` is lazy: The elements wouldn't be processed until the iterable
+   is iterated on, e.g. by wrapping in a :class:`list`.
 
-   One possible wrinkle is that the iterables passed to :func:`zip` could have
+   One thing to consider is that the iterables passed to :func:`zip` could have
    different lengths; sometimes by design, and sometimes because of a bug in
    the code that prepared these iterables.  Python offers three different
    approaches to dealing with this issue:
 
-   * By default, :func:`zip` has short-circuit behavior.  If any of the
-     iterables are shorter than the rest, :func:`zip` will ignore the remainders
-     of the longer iterables, cutting off the result to the length of the shortest
-     iterable::
+   * By default, :func:`zip` stops when the shortest iterable is exhausted.
+     :func:`zip` will ignore the remaining items in the longer iterables, cutting
+     off the result to the length of the shortest iterable::
 
-        >>> tuple(zip(range(3), ['fee', 'fi', 'fo', 'fum']))
-        ((0, 'fee'), (1, 'fi'), (2, 'fo'))
+        >>> list(zip(range(3), ['fee', 'fi', 'fo', 'fum']))
+        [(0, 'fee'), (1, 'fi'), (2, 'fo')]
 
    * :func:`zip` is often used in cases where the iterables are assumed to be
-     equal.  In such cases, it's recommended to use the ``strict=True`` option.
-     Its output is the same as regular :func:`zip`::
+     of equal length.  In such cases, it's recommended to use the ``strict=True``
+     option. Its output is the same as regular :func:`zip`::
 
-        >>> tuple(zip(('a', 'b', 'c'), (1, 2, 3), strict=True))
+        >>> list(zip(('a', 'b', 'c'), (1, 2, 3), strict=True))
         (('a', 1), ('b', 2), ('c', 3))
 
-     Unlike the default behavior, it asserts that the lengths of iterables is
+     Unlike the default behavior, it checks that the lengths of iterables is
      identical, raising a :exc:`ValueError` if they aren't:
 
-        >>> tuple(zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True))
+        >>> list(zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True))
         ValueError: zip() argument 2 is longer than argument 1
 
      Without the ``strict=True`` argument, any bug that results in iterables of
@@ -1780,24 +1778,23 @@ are always available.  They are listed here in alphabetical order.
 
    * The left-to-right evaluation order of the iterables is guaranteed. This
      makes possible an idiom for clustering a data series into n-length groups
-     using ``zip(*[iter(s)]*n)``.  This repeats the *same* iterator ``n`` times
-     so that each output tuple has the result of ``n`` calls to the iterator.
-     This has the effect of dividing the input into n-length chunks.
+     using ``zip(*[iter(s)]*n, strict=True)``.  This repeats the *same* iterator
+     ``n`` times so that each output tuple has the result of ``n`` calls to the
+     iterator. This has the effect of dividing the input into n-length chunks.
 
    * :func:`zip` in conjunction with the ``*`` operator can be used to unzip a
      list::
 
         >>> x = [1, 2, 3]
         >>> y = [4, 5, 6]
-        >>> zipped = zip(x, y)
-        >>> list(zipped)
+        >>> list(zip(x, y))
         [(1, 4), (2, 5), (3, 6)]
         >>> x2, y2 = zip(*zip(x, y))
         >>> x == list(x2) and y == list(y2)
         True
 
    .. versionchanged:: 3.10
-      The ``strict`` argument was added
+      Added the ``strict`` argument.
 
 
 .. function:: __import__(name, globals=None, locals=None, fromlist=(), level=0)

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1764,7 +1764,7 @@ are always available.  They are listed here in alphabetical order.
         >>> list(zip(('a', 'b', 'c'), (1, 2, 3), strict=True))
         [('a', 1), ('b', 2), ('c', 3)]
 
-     Unlike the default behavior, it checks that the lengths of iterables is
+     Unlike the default behavior, it checks that the lengths of iterables are
      identical, raising a :exc:`ValueError` if they aren't:
 
         >>> list(zip(range(3), ['fee', 'fi', 'fo', 'fum'], strict=True))
@@ -1777,7 +1777,8 @@ are always available.  They are listed here in alphabetical order.
      bug in another part of the program.
 
    * Shorter iterables can be padded with a constant value to make all the
-     iterables equal. This is done by :func:`itertools.zip_longest`.
+     iterables have the same length.  This is done by
+     :func:`itertools.zip_longest`.
 
    Edge cases: With a single iterable argument, :func:`zip` returns an
    iterator of 1-tuples.  With no arguments, it returns an empty iterator.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -79,6 +79,9 @@ New Features
   :class:`types.MappingProxyType` object wrapping the original
   dictionary. (Contributed by Dennis Sweeney in :issue:`40890`.)
 
+* PEP 618: The :func:`zip` function now has an optional ``strict`` flag, used
+  to enforce that the all the iterables have an equal length.
+
 
 Other Language Changes
 ======================

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -79,8 +79,8 @@ New Features
   :class:`types.MappingProxyType` object wrapping the original
   dictionary. (Contributed by Dennis Sweeney in :issue:`40890`.)
 
-* PEP 618: The :func:`zip` function now has an optional ``strict`` flag, used
-  to enforce that the all the iterables have an equal length.
+* :pep`618`: The :func:`zip` function now has an optional ``strict`` flag, used
+  to require that all the iterables have an equal length.
 
 
 Other Language Changes

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -79,7 +79,7 @@ New Features
   :class:`types.MappingProxyType` object wrapping the original
   dictionary. (Contributed by Dennis Sweeney in :issue:`40890`.)
 
-* :pep`618`: The :func:`zip` function now has an optional ``strict`` flag, used
+* :pep:`618`: The :func:`zip` function now has an optional ``strict`` flag, used
   to require that all the iterables have an equal length.
 
 


### PR DESCRIPTION
@brandtbucher @vstinner @gvanrossum 

This is the documentation for the zip-strict feature implemented in #20921 .

When reviewing this PR, I suggest that you look at it in the HTML view.

Also, can someone put the skip-news tag here? There's a news item in the other PR.

<!-- issue-number: [bpo-40636](https://bugs.python.org/issue40636) -->
https://bugs.python.org/issue40636
<!-- /issue-number -->
