### PR TITLE
bpo-41024: doc: Explicitly mention use of 'enum.Enum' as a valid container for '…

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1133,6 +1133,20 @@ container should match the type_ specified::
 
 Any container can be passed as the *choices* value, so :class:`list` objects,
 :class:`set` objects, and custom containers are all supported.
+This includes :class:`enum.Enum`, which could be used to restrain
+argument's choices; if we reuse previous rock/paper/scissors game example,
+this could be as follows::
+
+   >>> from enum import Enum
+   >>> class GameMove(Enum):
+   ...     ROCK = 'rock'
+   ...     PAPER = 'paper'
+   ...     SCISSORS = 'scissors'
+   ...
+   >>> parser = argparse.ArgumentParser(prog='game.py')
+   >>> parser.add_argument('move', type=GameMove, choices=GameMove)
+   >>> parser.parse_args(['rock'])
+   Namespace(move=<GameMove.ROCK: 'rock'>)
 
 
 required


### PR DESCRIPTION
…choices' argument of 'argparse.ArgumentParser.add_argument'.

Here's a short first proposal of doc. enhancement addressing [bpo-41024](https://bugs.python.org/issue41024).


<!-- issue-number: [bpo-41024](https://bugs.python.org/issue41024) -->
https://bugs.python.org/issue41024
<!-- /issue-number -->


Automerge-Triggered-By: @csabella