### PR TITLE
bpo-41025: Fix subclassing for zoneinfo.ZoneInfo

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -463,7 +463,7 @@ class CZoneInfoDatetimeSubclassTest(DatetimeSubclassMixin, CZoneInfoTest):
     pass
 
 
-class ZoneInfoTestSubclass(ZoneInfoTest):
+class ZoneInfoSubclassTest(ZoneInfoTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -484,7 +484,7 @@ class ZoneInfoTestSubclass(ZoneInfoTest):
         self.assertIsInstance(sub_obj, self.klass)
 
 
-class CZoneInfoTestSubclass(ZoneInfoTest):
+class CZoneInfoSubclassTest(ZoneInfoSubclassTest):
     module = c_zoneinfo
 
 

--- a/Misc/NEWS.d/next/Library/2020-06-18-10-34-59.bpo-41025.elf_nz.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-18-10-34-59.bpo-41025.elf_nz.rst
@@ -1,0 +1,2 @@
+Fixed an issue preventing the C implementation of :class:`zoneinfo.ZoneInfo`
+from being subclassed.

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2557,7 +2557,7 @@ static PyMethodDef zoneinfo_methods[] = {
     {"_unpickle", (PyCFunction)zoneinfo__unpickle, METH_VARARGS | METH_CLASS,
      PyDoc_STR("Private method used in unpickling.")},
     {"__init_subclass__", (PyCFunction)(void (*)(void))zoneinfo_init_subclass,
-     METH_VARARGS | METH_KEYWORDS,
+     METH_VARARGS | METH_KEYWORDS | METH_CLASS,
      PyDoc_STR("Function to initialize subclasses.")},
     {NULL} /* Sentinel */
 };


### PR DESCRIPTION
Prior to this change, attempting to subclass the C implementation of `zoneinfo.ZoneInfo` gave the following error:

```
TypeError: unbound method ZoneInfo.__init_subclass__() needs an argument
```

CC: @sdispater

<!-- issue-number: [bpo-41025](https://bugs.python.org/issue41025) -->
https://bugs.python.org/issue41025
<!-- /issue-number -->


Automerge-Triggered-By: @pganssle