### PR TITLE
bpo-41027: added flag in get_versions() for gcc-7 compatibility

### DIFF
--- a/Lib/distutils/cygwinccompiler.py
+++ b/Lib/distutils/cygwinccompiler.py
@@ -394,7 +394,7 @@ def get_versions():
 
     If not possible it returns None for it.
     """
-    commands = ['gcc -dumpversion', 'ld -v', 'dllwrap --version']
+    commands = ['gcc -dumpfullversion -dumpversion', 'ld -v', 'dllwrap --version']
     return tuple([_find_exe_version(cmd) for cmd in commands])
 
 def is_cygwingcc():

--- a/Misc/NEWS.d/next/Build/2020-06-18-19-11-18.bpo-41027.6dJ6-K.rst
+++ b/Misc/NEWS.d/next/Build/2020-06-18-19-11-18.bpo-41027.6dJ6-K.rst
@@ -1,0 +1,1 @@
+Fix obtaining version number for gcc-7 in distutils/cygwincompiler :func:`get_version`. Patch by Matteo Barbera


### PR DESCRIPTION
Keeping both -dumpfullversion and -dumpversion should ensure backward compatibility.

<!-- issue-number: [bpo-41027](https://bugs.python.org/issue41027) -->
https://bugs.python.org/issue41027
<!-- /issue-number -->
