### PR TITLE
bpo-12800: 'tarfile.StreamError: seeking backwards is not allowed' when extract symlink

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2232,6 +2232,9 @@ class TarFile(object):
         try:
             # For systems that support symbolic and hard links.
             if tarinfo.issym():
+                if os.path.islink(targetpath) or os.path.isfile(targetpath):
+                    os.unlink(targetpath)
+
                 os.symlink(tarinfo.linkname, targetpath)
             else:
                 # See extract().

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2580,6 +2580,70 @@ class Bz2PartialReadTest(Bz2Test, unittest.TestCase):
         self._test_partial_input("r:bz2")
 
 
+class SymlinkOverwriteTest(unittest.TestCase):
+    # The testcase checks for correct overwriting of an
+    # existing symlink (issue #12800)
+
+    @support.skip_unless_symlink
+    def test_overwrite_symlink(self):
+        tmpdir = support.temp_cwd('overwrite_symlink')
+        source = 'source'
+        link = 'link'
+        try:
+            with open(source, 'wb'):
+                pass
+            os.symlink(source, link)
+            with tarfile.open(tmpname, 'w') as tar:
+                tar.add(source, arcname=os.path.basename(source))
+                tar.add(link, arcname=os.path.basename(link))
+
+            with open(tmpname, 'rb') as fileobj:
+                with tarfile.open(fileobj=fileobj, mode='r|') as tar:
+                    tar.extractall(path=support.SAVEDCWD)
+        finally:
+            try:
+                os.unlink(link)
+            except:
+                pass
+
+            try:
+                os.unlink(source)
+            except:
+                pass
+
+    @support.skip_unless_symlink
+    def test_overwrite_file_with_symlink(self):
+        tmpdir = support.temp_cwd('overwrite_file_with_symlink')
+        source = 'source'
+        link = 'link'
+        try:
+            with open(source, 'wb'):
+                pass
+            os.symlink(source, link)
+            with tarfile.open(tmpname, 'w') as tar:
+                tar.add(source, arcname=os.path.basename(source))
+                tar.add(link, arcname=os.path.basename(link))
+
+            os.unlink(link)
+
+            with open(link, 'wb'):
+                pass
+
+            with open(tmpname, 'rb') as fileobj:
+                with tarfile.open(fileobj=fileobj, mode='r|') as tar:
+                    tar.extractall(path=support.SAVEDCWD)
+        finally:
+            try:
+                os.unlink(link)
+            except:
+                pass
+
+            try:
+                os.unlink(source)
+            except:
+                pass
+
+
 def root_is_uid_gid_0():
     try:
         import pwd, grp

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2586,10 +2586,9 @@ class SymlinkOverwriteTest(unittest.TestCase):
 
     @support.skip_unless_symlink
     def test_overwrite_symlink(self):
-        tmpdir = support.temp_cwd('overwrite_symlink')
-        source = 'source'
-        link = 'link'
-        try:
+        with support.temp_cwd('overwrite_symlink'):
+            source = 'source'
+            link = 'link'
             with open(source, 'wb'):
                 pass
             os.symlink(source, link)
@@ -2600,23 +2599,12 @@ class SymlinkOverwriteTest(unittest.TestCase):
             with open(tmpname, 'rb') as fileobj:
                 with tarfile.open(fileobj=fileobj, mode='r|') as tar:
                     tar.extractall(path=support.SAVEDCWD)
-        finally:
-            try:
-                os.unlink(link)
-            except:
-                pass
-
-            try:
-                os.unlink(source)
-            except:
-                pass
 
     @support.skip_unless_symlink
     def test_overwrite_file_with_symlink(self):
-        tmpdir = support.temp_cwd('overwrite_file_with_symlink')
-        source = 'source'
-        link = 'link'
-        try:
+        with support.temp_cwd('overwrite_file_with_symlink'):
+            source = 'source'
+            link = 'link'
             with open(source, 'wb'):
                 pass
             os.symlink(source, link)
@@ -2632,17 +2620,6 @@ class SymlinkOverwriteTest(unittest.TestCase):
             with open(tmpname, 'rb') as fileobj:
                 with tarfile.open(fileobj=fileobj, mode='r|') as tar:
                     tar.extractall(path=support.SAVEDCWD)
-        finally:
-            try:
-                os.unlink(link)
-            except:
-                pass
-
-            try:
-                os.unlink(source)
-            except:
-                pass
-
 
 def root_is_uid_gid_0():
     try:

--- a/Misc/NEWS.d/next/Library/2019-05-09-18-37-37.bpo-12800.TyjRQq.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-09-18-37-37.bpo-12800.TyjRQq.rst
@@ -1,0 +1,1 @@
+Extracting a symlink from a tarball using the tarfile module in stream mode ('r|') fails with an exception when a file or symlink of the same name already exists. The fix is to remove the existing file or symlink before extraction.


### PR DESCRIPTION
This is addressing the review comments in https://github.com/python/cpython/pull/13217

<!-- issue-number: [bpo-12800](https://bugs.python.org/issue12800) -->
https://bugs.python.org/issue12800
<!-- /issue-number -->
