### PR TITLE
bpo-41036: Implement object_traverse()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-19-16-10-44.bpo-41036.QO7L7f.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-19-16-10-44.bpo-41036.QO7L7f.rst
@@ -1,0 +1,3 @@
+Provide a default tp_traverse implementation for the base object type for
+heap types which have no tp_traverse function. The traverse function visits
+the type if the type is a heap type.


### PR DESCRIPTION
Provide a default tp_traverse implementation for the base object
type for heap types which have no tp_traverse function. The
traverse function visits the type if the type is a heap type.

Update subtype_traverse(): don't call object_traverse() to avoid
visiting the type twice.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41036](https://bugs.python.org/issue41036) -->
https://bugs.python.org/issue41036
<!-- /issue-number -->
