### PR TITLE
bpo-38377: Fix skip_if_broken_multiprocessing_synchronize() on macOS

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1972,10 +1972,11 @@ def skip_if_broken_multiprocessing_synchronize():
     # multiprocessing.synchronize requires _multiprocessing.SemLock.
     synchronize = import_module('multiprocessing.synchronize')
 
-    try:
-        # bpo-38377: On Linux, creating a semaphore is the current user
-        # does not have the permission to create a file in /dev/shm.
-        # Create a semaphore to check permissions.
-        synchronize.Lock(ctx=None)
-    except OSError as exc:
-        raise unittest.SkipTest(f"broken multiprocessing SemLock: {exc!r}")
+    if sys.platform == "linux":
+        try:
+            # bpo-38377: On Linux, creating a semaphore is the current user
+            # does not have the permission to create a file in /dev/shm.
+            # Create a semaphore to check permissions.
+            synchronize.Lock(ctx=None)
+        except OSError as exc:
+            raise unittest.SkipTest(f"broken multiprocessing SemLock: {exc!r}")

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1962,7 +1962,7 @@ def skip_if_broken_multiprocessing_synchronize():
     """
     Skip tests if the multiprocessing.synchronize module is missing, if there
     is no available semaphore implementation, or if creating a lock raises an
-    OSError.
+    OSError (on Linux only).
     """
 
     # Skip tests if the _multiprocessing extension is missing.
@@ -1974,9 +1974,9 @@ def skip_if_broken_multiprocessing_synchronize():
 
     if sys.platform == "linux":
         try:
-            # bpo-38377: On Linux, creating a semaphore is the current user
-            # does not have the permission to create a file in /dev/shm.
-            # Create a semaphore to check permissions.
+            # bpo-38377: On Linux, creating a semaphore fails with OSError
+            # if the current user does not have the permission to create
+            # a file in /dev/shm/ directory.
             synchronize.Lock(ctx=None)
         except OSError as exc:
             raise unittest.SkipTest(f"broken multiprocessing SemLock: {exc!r}")


### PR DESCRIPTION
skip_if_broken_multiprocessing_synchronize() only attempts for create
a semaphore on Linux to fix multiprocessing
test_resource_tracker_reused() on macOS.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38377](https://bugs.python.org/issue38377) -->
https://bugs.python.org/issue38377
<!-- /issue-number -->
