### PR TITLE
bpo-41038: Fix non-ASCII string corruption in Win32 resource files

### DIFF
--- a/PC/python_ver_rc.h
+++ b/PC/python_ver_rc.h
@@ -1,6 +1,7 @@
 // Resource script for Python core DLL.
 // Currently only holds version information.
 //
+#pragma code_page(1252)
 #include "winver.h"
 
 #define PYTHON_COMPANY   "Python Software Foundation"


### PR DESCRIPTION
In absence of explicit declaration, resource compiler uses system
codepage. When this codepage is DBCS or UTF-8, Python's copyright
string is corrupted, because it contains copyright sign encoded
as \xA9.

The fix is to explicitly declare codepage 1252.

<!-- issue-number: [bpo-41038](https://bugs.python.org/issue41038) -->
https://bugs.python.org/issue41038
<!-- /issue-number -->
