### PR TITLE
bpo-41044: generate a valid python parser for opt+seq rules

### DIFF
--- a/Lib/test/test_peg_generator/test_pegen.py
+++ b/Lib/test/test_peg_generator/test_pegen.py
@@ -493,6 +493,14 @@ class TestPegen(unittest.TestCase):
         # Would assert False without a special case in compute_left_recursives().
         make_parser(grammar)
 
+    def test_opt_sequence(self) -> None:
+        grammar = """
+        start: [NAME*]
+        """
+        # This case was failing because of double trailing comma at the end
+        # of the generated parser. See bpo-41044
+        make_parser(grammar)
+
     def test_left_recursion_too_complex(self) -> None:
         grammar = """
         start: foo

--- a/Lib/test/test_peg_generator/test_pegen.py
+++ b/Lib/test/test_peg_generator/test_pegen.py
@@ -497,8 +497,8 @@ class TestPegen(unittest.TestCase):
         grammar = """
         start: [NAME*]
         """
-        # This case was failing because of double trailing comma at the end
-        # of the generated parser. See bpo-41044
+        # This case was failing because of a double trailing comma at the end
+        # of a line in the generated source. See bpo-41044
         make_parser(grammar)
 
     def test_left_recursion_too_complex(self) -> None:

--- a/Tools/peg_generator/pegen/python_generator.py
+++ b/Tools/peg_generator/pegen/python_generator.py
@@ -93,9 +93,9 @@ class PythonCallMakerVisitor(GrammarVisitor):
 
     def visit_Opt(self, node: Opt) -> Tuple[str, str]:
         name, call = self.visit(node.node)
-        # Note trailing comma (if there isn't already one,
-        # which can occur when rules have both repeat0 and optional
-        # marker, e.g: [rule*])
+        # Note trailing comma (the call may already have one comma
+        # at the end, for example when rules have both repeat0 and optional
+        # markers, e.g: [rule*])
         if call.endswith(","):
             return "opt", call
         else:

--- a/Tools/peg_generator/pegen/python_generator.py
+++ b/Tools/peg_generator/pegen/python_generator.py
@@ -93,7 +93,13 @@ class PythonCallMakerVisitor(GrammarVisitor):
 
     def visit_Opt(self, node: Opt) -> Tuple[str, str]:
         name, call = self.visit(node.node)
-        return "opt", f"{call},"  # Note trailing comma!
+        # Note trailing comma (if there isn't already one,
+        # which can occur when rules have both repeat0 and optional
+        # marker, e.g: [rule*])
+        if call.endswith(","):
+            return "opt", call
+        else:
+            return "opt", f"{call},"
 
     def visit_Repeat0(self, node: Repeat0) -> Tuple[str, str]:
         if node in self.cache:


### PR DESCRIPTION


<!-- issue-number: [bpo-41044](https://bugs.python.org/issue41044) -->
https://bugs.python.org/issue41044
<!-- /issue-number -->
