### PR TITLE
bpo-41046: Make unittest.TestCase.skipTest a classmethod

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -661,7 +661,8 @@ class TestCase(object):
             function, args, kwargs = self._cleanups.pop(-1)
             function(*args, **kwargs)
 
-    def skipTest(self, reason):
+    @classmethod
+    def skipTest(cls, reason):
         """Skip this test."""
         raise SkipTest(reason)
 


### PR DESCRIPTION
Make `unittest.TestCase.skipTest` a `classmethod` so it can be called from `setUpClass` and `tearDownClass`.


<!-- issue-number: [bpo-41046](https://bugs.python.org/issue41046) -->
https://bugs.python.org/issue41046
<!-- /issue-number -->
