### PR TITLE
bpo-41047: fix argparse misbehavior with choices and nargs='*'

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2435,7 +2435,6 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 value = action.default
             else:
                 value = arg_strings
-            self._check_value(action, value)
 
         # single argument or optional argument produces a single value
         elif len(arg_strings) == 1 and action.nargs in [None, OPTIONAL]:


### PR DESCRIPTION
The `argparse.ArgumentParser` sometimes rejects positional arguments with no arguments when `choices` is set and `nargs="*"`. This PR would fix that, so they would never be rejected. This would make the behavior of positional arguments align with the behavior of optional arguments in this specific case.


<!-- issue-number: [bpo-41047](https://bugs.python.org/issue41047) -->
https://bugs.python.org/issue41047
<!-- /issue-number -->
