### PR TITLE
bpo-41049: Document pointer comparison in Py_RichCompareBool()

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -145,7 +145,7 @@ Object Protocol
    the Python expression ``o1 op o2``, where ``op`` is the operator corresponding
    to *opid*. Returns the value of the comparison on success, or ``NULL`` on failure.
 
-   If the two pointers are the same, the const:`Py_EQ` operation always returns
+   If the two pointers are the same, the :const:`Py_EQ` operation always returns
    ``True`` and the :const:`Py_NE` operation always returns ``False``.
 
 .. c:function:: int PyObject_RichCompareBool(PyObject *o1, PyObject *o2, int opid)

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -145,6 +145,8 @@ Object Protocol
    the Python expression ``o1 op o2``, where ``op`` is the operator corresponding
    to *opid*. Returns the value of the comparison on success, or ``NULL`` on failure.
 
+   If the two pointers are the same, the const:`Py_EQ` operation always returns
+   ``True`` and the :const:`Py_NE` operation always returns ``False``.
 
 .. c:function:: int PyObject_RichCompareBool(PyObject *o1, PyObject *o2, int opid)
 

--- a/Misc/NEWS.d/next/Documentation/2020-06-20-02-55-31.bpo-41049.9KFg7g.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-06-20-02-55-31.bpo-41049.9KFg7g.rst
@@ -1,0 +1,2 @@
+Document pointer comparison (identity-implies-equality) for
+Py_RichCompareBool().


### PR DESCRIPTION


<!-- issue-number: [bpo-41049](https://bugs.python.org/issue41049) -->
https://bugs.python.org/issue41049
<!-- /issue-number -->
