### PR TITLE
bpo-41054: Simplify resource compilation on Windows

### DIFF
--- a/PC/dl_nt.c
+++ b/PC/dl_nt.c
@@ -12,16 +12,10 @@ forgotten) from the programmer.
 #include "windows.h"
 
 #ifdef Py_ENABLE_SHARED
-#ifdef MS_DLL_ID
-// The string is available at build, so fill the buffer immediately
-char dllVersionBuffer[16] = MS_DLL_ID;
-#else
-char dllVersionBuffer[16] = ""; // a private buffer
-#endif
 
 // Python Globals
 HMODULE PyWin_DLLhModule = NULL;
-const char *PyWin_DLLVersionString = dllVersionBuffer;
+const char *PyWin_DLLVersionString = MS_DLL_ID;
 
 BOOL    WINAPI  DllMain (HANDLE hInst,
                                                 ULONG ul_reason_for_call,
@@ -31,11 +25,6 @@ BOOL    WINAPI  DllMain (HANDLE hInst,
     {
         case DLL_PROCESS_ATTACH:
             PyWin_DLLhModule = hInst;
-#ifndef MS_DLL_ID
-            // If we have MS_DLL_ID, we don't need to load the string.
-            // 1000 is a magic number I picked out of the air.  Could do with a #define, I spose...
-            LoadString(hInst, 1000, dllVersionBuffer, sizeof(dllVersionBuffer));
-#endif
             break;
 
         case DLL_PROCESS_DETACH:

--- a/PC/python_nt.rc
+++ b/PC/python_nt.rc
@@ -7,12 +7,6 @@
 #include <winuser.h>
 2 RT_MANIFEST "python.manifest"
 
-// String Tables
-STRINGTABLE DISCARDABLE
-BEGIN
-    1000,   MS_DLL_ID
-END
-
 /////////////////////////////////////////////////////////////////////////////
 //
 // Version

--- a/PC/python_nt.rc
+++ b/PC/python_nt.rc
@@ -34,7 +34,7 @@ BEGIN
             VALUE "FileVersion", PYTHON_VERSION
             VALUE "InternalName", "Python DLL\0"
             VALUE "LegalCopyright", PYTHON_COPYRIGHT "\0"
-            VALUE "OriginalFilename", PYTHON_DLL_NAME "\0"
+            VALUE "OriginalFilename", ORIGINAL_FILENAME "\0"
             VALUE "ProductName", "Python\0"
             VALUE "ProductVersion", PYTHON_VERSION
         END

--- a/PC/python_ver_rc.h
+++ b/PC/python_ver_rc.h
@@ -9,7 +9,6 @@
 #define MS_WINDOWS
 #include "modsupport.h"
 #include "patchlevel.h"
-#include <pythonnt_rc.h>
 #ifdef _DEBUG
 #   define PYTHON_DEBUG_EXT "_d"
 #else

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -80,7 +80,7 @@
     </Lib>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(PySourcePath)PC;$(PySourcePath)Include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>$(_DebugPreprocessorDefinition)%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PYTHON_DLL_NAME=\"$(TargetName)$(TargetExt)\";FIELD3=$(Field3Value);$(_DebugPreprocessorDefinition)%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Midl>
@@ -94,21 +94,6 @@
       <ProxyFileName>$(MSBuildProjectName)_p.c</ProxyFileName>
     </Midl>
   </ItemDefinitionGroup>
-
-  <Target Name="GeneratePythonNtRcH"
-          BeforeTargets="ClCompile"
-          Inputs="$(PySourcePath)Include\patchlevel.h"
-          Outputs="$(IntDir)pythonnt_rc.h">
-    <WriteLinesToFile File="$(IntDir)pythonnt_rc.h" Overwrite="true" Encoding="ascii"
-                      Lines='/* This file created by pyproject.props /t:GeneratePythonNtRcH */
-#define FIELD3 $(Field3Value)
-#define MS_DLL_ID "$(SysWinVer)"
-#define PYTHON_DLL_NAME "$(TargetName)$(TargetExt)"
-' />
-    <ItemGroup>
-        <FileWrites Include="$(IntDir)pythonnt_rc.h" />
-    </ItemGroup>
-  </Target>
 
   <UsingTask TaskName="KillPython" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -80,7 +80,7 @@
     </Lib>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(PySourcePath)PC;$(PySourcePath)Include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>PYTHON_DLL_NAME=\"$(TargetName)$(TargetExt)\";FIELD3=$(Field3Value);$(_DebugPreprocessorDefinition)%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ORIGINAL_FILENAME=\"$(TargetName)$(TargetExt)\";FIELD3=$(Field3Value);$(_DebugPreprocessorDefinition)%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Midl>


### PR DESCRIPTION
Remove auto-generated resource header. Pass definitions required by resource files (`PYTHON_DLL_NAME` and `FIELD3`) directly to resource compiler.

Remove unused `MS_DLL_ID` resource string and related dead code.

<!-- issue-number: [bpo-41054](https://bugs.python.org/issue41054) -->
https://bugs.python.org/issue41054
<!-- /issue-number -->
