### PR TITLE
bpo-41055: Remove outdated tests for the tp_print slot.

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -66,20 +66,6 @@ class CommonTest(seq_tests.CommonTest):
             a = self.type2test([a])
         self.assertRaises(RecursionError, repr, a)
 
-    def test_print(self):
-        d = self.type2test(range(200))
-        d.append(d)
-        d.extend(range(200,400))
-        d.append(d)
-        d.append(400)
-        try:
-            with open(support.TESTFN, "w") as fo:
-                fo.write(str(d))
-            with open(support.TESTFN, "r") as fo:
-                self.assertEqual(fo.read(), repr(d))
-        finally:
-            os.remove(support.TESTFN)
-
     def test_set_subscript(self):
         a = self.type2test(range(20))
         self.assertRaises(ValueError, a.__setitem__, slice(0, 10, 0), [1,2,3])

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -18,20 +18,11 @@ class BoolTest(unittest.TestCase):
 
         self.assertRaises(TypeError, int.__new__, bool, 0)
 
-    def test_print(self):
-        try:
-            with open(support.TESTFN, "w") as fo:
-                print(False, True, file=fo)
-            with open(support.TESTFN, "r") as fi:
-                self.assertEqual(fi.read(), 'False True\n')
-        finally:
-            os.remove(support.TESTFN)
-
     def test_repr(self):
         self.assertEqual(repr(False), 'False')
         self.assertEqual(repr(True), 'True')
-        self.assertEqual(eval(repr(False)), False)
-        self.assertEqual(eval(repr(True)), True)
+        self.assertIs(eval(repr(False)), False)
+        self.assertIs(eval(repr(True)), True)
 
     def test_str(self):
         self.assertEqual(str(False), 'False')

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -500,22 +500,6 @@ class ComplexTest(unittest.TestCase):
     def test_neg(self):
         self.assertEqual(-(1+6j), -1-6j)
 
-    def test_file(self):
-        a = 3.33+4.43j
-        b = 5.1+2.3j
-
-        fo = None
-        try:
-            fo = open(support.TESTFN, "w")
-            print(a, b, file=fo)
-            fo.close()
-            fo = open(support.TESTFN, "r")
-            self.assertEqual(fo.read(), ("%s %s\n" % (a, b)))
-        finally:
-            if (fo is not None) and (not fo.closed):
-                fo.close()
-            support.unlink(support.TESTFN)
-
     def test_getnewargs(self):
         self.assertEqual((1+2j).__getnewargs__(), (1.0, 2.0))
         self.assertEqual((1-2j).__getnewargs__(), (1.0, -2.0))

--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -72,27 +72,6 @@ class TestDefaultDict(unittest.TestCase):
         d3[13]
         self.assertEqual(repr(d3), "defaultdict(%s, {13: 43})" % repr(foo))
 
-    def test_print(self):
-        d1 = defaultdict()
-        def foo(): return 42
-        d2 = defaultdict(foo, {1: 2})
-        # NOTE: We can't use tempfile.[Named]TemporaryFile since this
-        # code must exercise the tp_print C code, which only gets
-        # invoked for *real* files.
-        tfn = tempfile.mktemp()
-        try:
-            f = open(tfn, "w+")
-            try:
-                print(d1, file=f)
-                print(d2, file=f)
-                f.seek(0)
-                self.assertEqual(f.readline(), repr(d1) + "\n")
-                self.assertEqual(f.readline(), repr(d2) + "\n")
-            finally:
-                f.close()
-        finally:
-            os.remove(tfn)
-
     def test_copy(self):
         d1 = defaultdict()
         d2 = d1.copy()
@@ -159,18 +138,6 @@ class TestDefaultDict(unittest.TestCase):
         self.assertRegex(repr(d),
             r"sub\(<bound method .*sub\._factory "
             r"of sub\(\.\.\., \{\}\)>, \{\}\)")
-
-        # NOTE: printing a subclass of a builtin type does not call its
-        # tp_print slot. So this part is essentially the same test as above.
-        tfn = tempfile.mktemp()
-        try:
-            f = open(tfn, "w+")
-            try:
-                print(d, file=f)
-            finally:
-                f.close()
-        finally:
-            os.remove(tfn)
 
     def test_callable_arg(self):
         self.assertRaises(TypeError, defaultdict, {})

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -66,28 +66,9 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(list(d), [7, 8, 9])
         d = deque(range(200), maxlen=10)
         d.append(d)
-        support.unlink(support.TESTFN)
-        fo = open(support.TESTFN, "w")
-        try:
-            fo.write(str(d))
-            fo.close()
-            fo = open(support.TESTFN, "r")
-            self.assertEqual(fo.read(), repr(d))
-        finally:
-            fo.close()
-            support.unlink(support.TESTFN)
-
+        self.assertEqual(repr(d)[-30:], ', 198, 199, [...]], maxlen=10)')
         d = deque(range(10), maxlen=None)
         self.assertEqual(repr(d), 'deque([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
-        fo = open(support.TESTFN, "w")
-        try:
-            fo.write(str(d))
-            fo.close()
-            fo = open(support.TESTFN, "r")
-            self.assertEqual(fo.read(), repr(d))
-        finally:
-            fo.close()
-            support.unlink(support.TESTFN)
 
     def test_maxlen_zero(self):
         it = iter(range(100))
@@ -545,21 +526,7 @@ class TestBasic(unittest.TestCase):
         e = eval(repr(d))
         self.assertEqual(list(d), list(e))
         d.append(d)
-        self.assertIn('...', repr(d))
-
-    def test_print(self):
-        d = deque(range(200))
-        d.append(d)
-        try:
-            support.unlink(support.TESTFN)
-            fo = open(support.TESTFN, "w")
-            print(d, file=fo, end='')
-            fo.close()
-            fo = open(support.TESTFN, "r")
-            self.assertEqual(fo.read(), repr(d))
-        finally:
-            fo.close()
-            support.unlink(support.TESTFN)
+        self.assertEqual(repr(d)[-20:], '7, 198, 199, [...]])')
 
     def test_init(self):
         self.assertRaises(TypeError, deque, 'abc', 2, 3);

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -3552,13 +3552,6 @@ order (MRO) for bases """
         self.assertEqual(o.__str__(), '41')
         self.assertEqual(o.__repr__(), 'A repr')
 
-        capture = io.StringIO()
-        # Calling str() or not exercises different internal paths.
-        print(o, file=capture)
-        print(str(o), file=capture)
-        self.assertEqual(capture.getvalue(), '41\n41\n')
-        capture.close()
-
     def test_keyword_arguments(self):
         # Testing keyword arguments to __init__, __call__...
         def f(a): return a

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -317,20 +317,6 @@ class TestJointOps:
             name = repr(s).partition('(')[0]    # strip class name
             self.assertEqual(repr(s), '%s({%s(...)})' % (name, name))
 
-    def test_cyclical_print(self):
-        w = ReprWrapper()
-        s = self.thetype([w])
-        w.value = s
-        fo = open(support.TESTFN, "w")
-        try:
-            fo.write(str(s))
-            fo.close()
-            fo = open(support.TESTFN, "r")
-            self.assertEqual(fo.read(), repr(s))
-        finally:
-            fo.close()
-            support.unlink(support.TESTFN)
-
     def test_do_not_rehash_dict_keys(self):
         n = 10
         d = dict.fromkeys(map(HashCountingInt, range(n)))
@@ -802,17 +788,6 @@ class TestBasicOps:
         sorted_repr_values = [repr(value) for value in self.values]
         sorted_repr_values.sort()
         self.assertEqual(result, sorted_repr_values)
-
-    def test_print(self):
-        try:
-            fo = open(support.TESTFN, "w")
-            fo.write(str(self.set))
-            fo.close()
-            fo = open(support.TESTFN, "r")
-            self.assertEqual(fo.read(), repr(self.set))
-        finally:
-            fo.close()
-            support.unlink(support.TESTFN)
 
     def test_length(self):
         self.assertEqual(len(self.set), self.length)

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2215,22 +2215,6 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertEqual(("abc" "def" "ghi"), "abcdefghi")
         self.assertEqual(("abc" "def" "ghi"), "abcdefghi")
 
-    def test_printing(self):
-        class BitBucket:
-            def write(self, text):
-                pass
-
-        out = BitBucket()
-        print('abc', file=out)
-        print('abc', 'def', file=out)
-        print('abc', 'def', file=out)
-        print('abc', 'def', file=out)
-        print('abc\n', file=out)
-        print('abc\n', end=' ', file=out)
-        print('abc\n', end=' ', file=out)
-        print('def\n', file=out)
-        print('def\n', file=out)
-
     def test_ucs4(self):
         x = '\U00100000'
         y = x.encode("raw-unicode-escape").decode("raw-unicode-escape")


### PR DESCRIPTION


<!-- issue-number: [bpo-41055](https://bugs.python.org/issue41055) -->
https://bugs.python.org/issue41055
<!-- /issue-number -->
