### PR TITLE
bpo-41056: Fix a possible MemoryError leak within zoneinfo.

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-06-20-18-33-03.bpo-41056.gTH4Bq.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-20-18-33-03.bpo-41056.gTH4Bq.rst
@@ -1,0 +1,1 @@
+Fixed an instance where a MemoryError within the zoneinfo module might not be reported or not reported at its source. (found by Coverity)

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1622,7 +1622,7 @@ parse_abbr(const char *const p, PyObject **abbr)
     }
 
     *abbr = PyUnicode_FromStringAndSize(str_start, str_end - str_start);
-    if (abbr == NULL) {
+    if (*abbr == NULL) {
         return -1;
     }
 

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -278,13 +278,11 @@ zoneinfo_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 
         instance =
             PyObject_CallMethod(weak_cache, "setdefault", "OO", key, tmp);
-        ((PyZoneInfo_ZoneInfo *)instance)->source = SOURCE_CACHE;
-
         Py_DECREF(tmp);
-
         if (instance == NULL) {
             return NULL;
         }
+        ((PyZoneInfo_ZoneInfo *)instance)->source = SOURCE_CACHE;
     }
 
     update_strong_cache(type, key, instance);


### PR DESCRIPTION
This was detected by our Coverity scan as a REVERSE_INULL issue.

<!-- issue-number: [bpo-41056](https://bugs.python.org/issue41056) -->
https://bugs.python.org/issue41056
<!-- /issue-number -->


Automerge-Triggered-By: @gpshead