### PR TITLE
bpo-41056: Fix a NULL pointer dereference on MemoryError within the ssl module.

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-06-20-18-35-43.bpo-41056.Garcle.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-20-18-35-43.bpo-41056.Garcle.rst
@@ -1,0 +1,1 @@
+Fix a NULL pointer dereference within the ssl module during a MemoryError in the keylog callback. (discovered by Coverity)

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -125,6 +125,12 @@ _PySSL_keylog_callback(const SSL *ssl, const char *line)
 
     threadstate = PyGILState_Ensure();
 
+    ssl_obj = (PySSLSocket *)SSL_get_app_data(ssl);
+    assert(PySSLSocket_Check(ssl_obj));
+    if (ssl_obj->ctx->keylog_bio == NULL) {
+        return;
+    }
+
     /* Allocate a static lock to synchronize writes to keylog file.
      * The lock is neither released on exit nor on fork(). The lock is
      * also shared between all SSLContexts although contexts may write to
@@ -139,12 +145,6 @@ _PySSL_keylog_callback(const SSL *ssl, const char *line)
                         &ssl_obj->exc_tb);
             return;
         }
-    }
-
-    ssl_obj = (PySSLSocket *)SSL_get_app_data(ssl);
-    assert(PySSLSocket_Check(ssl_obj));
-    if (ssl_obj->ctx->keylog_bio == NULL) {
-        return;
     }
 
     PySSL_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
Detected by Coverity.

<!-- issue-number: [bpo-41056](https://bugs.python.org/issue41056) -->
https://bugs.python.org/issue41056
<!-- /issue-number -->


Automerge-Triggered-By: @tiran