### PR TITLE
bpo-41058: Use source file encoding in pdb.find_function().

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -79,6 +79,7 @@ import glob
 import pprint
 import signal
 import inspect
+import tokenize
 import traceback
 import linecache
 
@@ -93,7 +94,7 @@ __all__ = ["run", "pm", "Pdb", "runeval", "runctx", "runcall", "set_trace",
 def find_function(funcname, filename):
     cre = re.compile(r'def\s+%s\s*[(]' % re.escape(funcname))
     try:
-        fp = open(filename)
+        fp = tokenize.open(filename)
     except OSError:
         return None
     # consumer of this info expects the first line to be 1

--- a/Misc/NEWS.d/next/Library/2020-06-20-21-03-55.bpo-41058.gztdZy.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-20-21-03-55.bpo-41058.gztdZy.rst
@@ -1,0 +1,1 @@
+:func:`pdb.find_function` now correctly determines the source file encoding.


### PR DESCRIPTION


<!-- issue-number: [bpo-41058](https://bugs.python.org/issue41058) -->
https://bugs.python.org/issue41058
<!-- /issue-number -->
