### PR TITLE
bpo-41056: Use the fildes converter for fd to please Coverity.

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-06-20-18-37-29.bpo-41056.d9v_uL.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-20-18-37-29.bpo-41056.d9v_uL.rst
@@ -1,0 +1,1 @@
+Invalid file descriptor values are now prevented from being passed to os.fpathconf. (discovered by Coverity)

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -6803,8 +6803,7 @@ os_fpathconf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("fpathconf", nargs, 2, 2)) {
         goto exit;
     }
-    fd = _PyLong_AsInt(args[0]);
-    if (fd == -1 && PyErr_Occurred()) {
+    if (!fildes_converter(args[0], &fd)) {
         goto exit;
     }
     if (!conv_path_confname(args[1], &name)) {
@@ -8877,4 +8876,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=767780ea3beacf34 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d7c1212a94613496 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -10988,7 +10988,7 @@ conv_path_confname(PyObject *arg, int *valuep)
 /*[clinic input]
 os.fpathconf -> long
 
-    fd: int
+    fd: fildes
     name: path_confname
     /
 
@@ -10999,7 +10999,7 @@ If there is no limit, return -1.
 
 static long
 os_fpathconf_impl(PyObject *module, int fd, int name)
-/*[clinic end generated code: output=d5b7042425fc3e21 input=5942a024d3777810]*/
+/*[clinic end generated code: output=d5b7042425fc3e21 input=5b8d2471cfaae186]*/
 {
     long limit;
 


### PR DESCRIPTION
There are a bunch of other fd: int uses in this file, I expect many if not
all of them would be better off using the fildes converter.  This particular
one was flagged by Coverity as it presumably flags fpathconf as not accepting
negative fds.  I'd expect the other fd's to have been flagged as well
otherwise.

I'm marking this one as skip news as it really is a no-op.

<!-- issue-number: [bpo-41056](https://bugs.python.org/issue41056) -->
https://bugs.python.org/issue41056
<!-- /issue-number -->


Automerge-Triggered-By: @tiran