### PR TITLE
bpo-41056: Fix reference to deallocated stack in pathconfig (Coverity)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-21-19-53-33.bpo-41056.IDu_EK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-21-19-53-33.bpo-41056.IDu_EK.rst
@@ -1,0 +1,1 @@
+Fixes a reference to deallocated stack space during startup when constructing sys.path involving a relative symlink when code was supplied via -c.  (discovered via Coverity)

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -686,6 +686,7 @@ _PyPathConfig_ComputeSysPath0(const PyWideStringList *argv, PyObject **path0_p)
 #ifdef HAVE_READLINK
     wchar_t link[MAXPATHLEN + 1];
     int nr = 0;
+    wchar_t path0copy[2 * MAXPATHLEN + 1];
 
     if (have_script_arg) {
         nr = _Py_wreadlink(path0, link, Py_ARRAY_LENGTH(link));
@@ -708,7 +709,6 @@ _PyPathConfig_ComputeSysPath0(const PyWideStringList *argv, PyObject **path0_p)
             }
             else {
                 /* Must make a copy, path0copy has room for 2 * MAXPATHLEN */
-                wchar_t path0copy[2 * MAXPATHLEN + 1];
                 wcsncpy(path0copy, path0, MAXPATHLEN);
                 q = wcsrchr(path0copy, SEP);
                 wcsncpy(q+1, link, MAXPATHLEN);


### PR DESCRIPTION
Reported by Coverity.  (CID 1457554 RETURN_LOCAL)

path0 is assigned as a pointer to this right before it goes out of scope.

<!-- issue-number: [bpo-41056](https://bugs.python.org/issue41056) -->
https://bugs.python.org/issue41056
<!-- /issue-number -->


Automerge-Triggered-By: @tiran