### PR TITLE
[3.9] bpo-40939: Do not emit deprecation warnings inside CPython for old parser APIs

### DIFF
--- a/Include/pythonrun.h
+++ b/Include/pythonrun.h
@@ -72,15 +72,23 @@ PyAPI_FUNC(struct _mod *) PyParser_ASTFromFileObject(
 #define PyParser_SimpleParseFile(FP, S, B) \
     PyParser_SimpleParseFileFlags(FP, S, B, 0)
 #endif
-Py_DEPRECATED(3.9) PyAPI_FUNC(struct _node *) PyParser_SimpleParseStringFlags(const char *,
-                                                                              int, int);
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
-Py_DEPRECATED(3.9) PyAPI_FUNC(struct _node *) PyParser_SimpleParseStringFlagsFilename(const char *,
-                                                                                      const char *,
-                                                                                      int, int);
+
+#ifndef Py_BUILD_CORE
+Py_DEPRECATED(3.9)
 #endif
-Py_DEPRECATED(3.9) PyAPI_FUNC(struct _node *) PyParser_SimpleParseFileFlags(FILE *, const char *,
-                                                                            int, int);
+PyAPI_FUNC(struct _node *) PyParser_SimpleParseStringFlags(const char *, int, int);
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
+#ifndef Py_BUILD_CORE
+Py_DEPRECATED(3.9)
+#endif
+PyAPI_FUNC(struct _node *) PyParser_SimpleParseStringFlagsFilename(const char *,
+                                                                   const char *,
+                                                                   int, int);
+#endif
+#ifndef Py_BUILD_CORE
+Py_DEPRECATED(3.9)
+#endif
+PyAPI_FUNC(struct _node *) PyParser_SimpleParseFileFlags(FILE *, const char *, int, int);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) PyRun_StringFlags(const char *, int, PyObject *,
                                          PyObject *, PyCompilerFlags *);


### PR DESCRIPTION


<!-- issue-number: [bpo-40939](https://bugs.python.org/issue40939) -->
https://bugs.python.org/issue40939
<!-- /issue-number -->
