### PR TITLE
bpo-41061: Fix incorrect expressions in hashtable

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-21-10-54-02.bpo-41061.AHf9MU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-21-10-54-02.bpo-41061.AHf9MU.rst
@@ -1,0 +1,1 @@
+Fix incorrect expressions and asserts in hashtable code and tests.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -197,8 +197,8 @@ test_hashtable(PyObject *self, PyObject *Py_UNUSED(args))
     for (key='a'; key <= 'z'; key++) {
         _Py_hashtable_entry_t *entry = _Py_hashtable_get_entry(table, TO_PTR(key));
         assert(entry != NULL);
-        assert(entry->key = TO_PTR(key));
-        assert(entry->value = TO_PTR(VALUE(key)));
+        assert(entry->key == TO_PTR(key));
+        assert(entry->value == TO_PTR(VALUE(key)));
     }
 
     // Test _Py_hashtable_get()

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -133,7 +133,7 @@ _Py_hashtable_get_entry_generic(_Py_hashtable_t *ht, const void *key)
 {
     Py_uhash_t key_hash = ht->hash_func(key);
     size_t index = key_hash & (ht->nbuckets - 1);
-    _Py_hashtable_entry_t *entry = entry = TABLE_HEAD(ht, index);
+    _Py_hashtable_entry_t *entry = TABLE_HEAD(ht, index);
     while (1) {
         if (entry == NULL) {
             return NULL;
@@ -155,7 +155,7 @@ _Py_hashtable_get_entry_ptr(_Py_hashtable_t *ht, const void *key)
 {
     Py_uhash_t key_hash = _Py_hashtable_hash_ptr(key);
     size_t index = key_hash & (ht->nbuckets - 1);
-    _Py_hashtable_entry_t *entry = entry = TABLE_HEAD(ht, index);
+    _Py_hashtable_entry_t *entry = TABLE_HEAD(ht, index);
     while (1) {
         if (entry == NULL) {
             return NULL;


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41061](https://bugs.python.org/issue41061) -->
https://bugs.python.org/issue41061
<!-- /issue-number -->


Automerge-Triggered-By: @tiran