### PR TITLE
Remove dead code from tracemalloc (GH-21029)

### DIFF
--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -319,10 +319,6 @@ tracemalloc_get_frame(PyFrameObject *pyframe, frame_t *frame)
         return;
     }
 
-    assert(filename != NULL);
-    if (filename == NULL)
-        return;
-
     if (!PyUnicode_Check(filename)) {
 #ifdef TRACE_DEBUG
         tracemalloc_error("filename is not a unicode string");


### PR DESCRIPTION
tracemalloc_get_frame() checked filename == NULL two times in a row.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


Automerge-Triggered-By: @tiran

Automerge-Triggered-By: @tiran