### PR TITLE
bpo-41065: Use zip-strict in zoneinfo

### DIFF
--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -136,8 +136,7 @@ class _TZifHeader:
     ]
 
     def __init__(self, *args):
-        assert len(self.__slots__) == len(args)
-        for attr, val in zip(self.__slots__, args):
+        for attr, val in zip(self.__slots__, args, strict=True):
             setattr(self, attr, val)
 
     @classmethod


### PR DESCRIPTION
Can someone please put the skip-news tag here?

Thanks @alexmojaki for writing the script with which I found this instance.

<!-- issue-number: [bpo-41065](https://bugs.python.org/issue41065) -->
https://bugs.python.org/issue41065
<!-- /issue-number -->
