### PR TITLE
bpo-41067: Haiku build fix

### DIFF
--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -611,7 +611,11 @@ static PyObject *
 signal_strsignal_impl(PyObject *module, int signalnum)
 /*[clinic end generated code: output=44e12e1e3b666261 input=b77914b03f856c74]*/
 {
+#ifdef __HAIKU__
+    const char * res;
+#else
     char *res;
+#endif
 
     if (signalnum < 1 || signalnum >= NSIG) {
         PyErr_SetString(PyExc_ValueError,
@@ -663,7 +667,7 @@ signal_strsignal_impl(PyObject *module, int signalnum)
     }
 #else
     errno = 0;
-    res = strsignal(signalnum);
+    res = (const char *)strsignal(signalnum);
 
     if (errno || res == NULL || strstr(res, "Unknown signal") != NULL)
         Py_RETURN_NONE;

--- a/configure.ac
+++ b/configure.ac
@@ -2736,7 +2736,7 @@ then
 			BLDSHARED="$LDSHARED"
 		fi
 		;;
-	Linux*|GNU*|QNX*|VxWorks*)
+	Linux*|GNU*|QNX*|VxWorks*|Haiku*)
 		LDSHARED='$(CC) -shared'
 		LDCXXSHARED='$(CXX) -shared';;
 	FreeBSD*)
@@ -2805,6 +2805,7 @@ then
 	Linux-android*) ;;
 	Linux*|GNU*) CCSHARED="-fPIC";;
 	FreeBSD*|NetBSD*|OpenBSD*|DragonFly*) CCSHARED="-fPIC";;
+	Haiku*) CCSHARED="-fPIC";;
 	OpenUNIX*|UnixWare*)
 		if test "$GCC" = "yes"
 		then CCSHARED="-fPIC"
@@ -3097,6 +3098,9 @@ AC_SUBST(TZPATH)
 # Most SVR4 platforms (e.g. Solaris) need -lsocket and -lnsl.
 AC_CHECK_LIB(nsl, t_open, [LIBS="-lnsl $LIBS"]) # SVR4
 AC_CHECK_LIB(socket, socket, [LIBS="-lsocket $LIBS"], [], $LIBS) # SVR4 sockets
+
+# Haiku system library
+AC_CHECK_LIB(network, socket, [LIBS="-lnetwork $LIBS"], [] $LIBS)
 
 AC_MSG_CHECKING(for --with-libs)
 AC_ARG_WITH(libs,


### PR DESCRIPTION
posixmodule sysconf equivalence.

<!-- issue-number: [bpo-41067](https://bugs.python.org/issue41067) -->
https://bugs.python.org/issue41067
<!-- /issue-number -->
