### PR TITLE
bpo-41004: Resolve hash collisions for IPv4Interface and IPv6Interface

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1420,7 +1420,7 @@ class IPv4Interface(IPv4Address):
             return False
 
     def __hash__(self):
-        return self._ip ^ self._prefixlen ^ int(self.network.network_address)
+        return hash((self._ip, self._prefixlen, int(self.network.network_address)))
 
     __reduce__ = _IPAddressBase.__reduce__
 
@@ -2120,7 +2120,7 @@ class IPv6Interface(IPv6Address):
             return False
 
     def __hash__(self):
-        return self._ip ^ self._prefixlen ^ int(self.network.network_address)
+        return hash((self._ip, self._prefixlen, int(self.network.network_address)))
 
     __reduce__ = _IPAddressBase.__reduce__
 

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2548,6 +2548,24 @@ class IpaddrUnitTest(unittest.TestCase):
                          sixtofouraddr.sixtofour)
         self.assertFalse(bad_addr.sixtofour)
 
+    # issue41004 Hash collisions in IPv4Interface and IPv6Interface
+
+    def testV4HashIsNotConstant(self):
+        ipv4_address1 = ipaddress.IPv4Interface("1.2.3.4")
+        ipv4_address2 = ipaddress.IPv4Interface("2.3.4.5")
+        self.assertNotEqual(32, ipv4_address1.__hash__())
+        self.assertNotEqual(32, ipv4_address2.__hash__())
+        self.assertNotEqual(ipv4_address1.__hash__(), ipv4_address2.__hash__())
+
+    # issue41004 Hash collisions in IPv4Interface and IPv6Interface
+
+    def testV6HashIsNotConstant(self):
+        ipv6_address1 = ipaddress.IPv6Interface("2001:658:22a:cafe:200:0:0:1")
+        ipv6_address2 = ipaddress.IPv6Interface("2001:658:22a:cafe:200:0:0:2")
+        self.assertNotEqual(128, ipv6_address1.__hash__())
+        self.assertNotEqual(128, ipv6_address2.__hash__())
+        self.assertNotEqual(ipv6_address1.__hash__(), ipv6_address2.__hash__())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2549,21 +2549,15 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertFalse(bad_addr.sixtofour)
 
     # issue41004 Hash collisions in IPv4Interface and IPv6Interface
-
     def testV4HashIsNotConstant(self):
         ipv4_address1 = ipaddress.IPv4Interface("1.2.3.4")
         ipv4_address2 = ipaddress.IPv4Interface("2.3.4.5")
-        self.assertNotEqual(32, ipv4_address1.__hash__())
-        self.assertNotEqual(32, ipv4_address2.__hash__())
         self.assertNotEqual(ipv4_address1.__hash__(), ipv4_address2.__hash__())
 
     # issue41004 Hash collisions in IPv4Interface and IPv6Interface
-
     def testV6HashIsNotConstant(self):
         ipv6_address1 = ipaddress.IPv6Interface("2001:658:22a:cafe:200:0:0:1")
         ipv6_address2 = ipaddress.IPv6Interface("2001:658:22a:cafe:200:0:0:2")
-        self.assertNotEqual(128, ipv6_address1.__hash__())
-        self.assertNotEqual(128, ipv6_address2.__hash__())
         self.assertNotEqual(ipv6_address1.__hash__(), ipv6_address2.__hash__())
 
 

--- a/Misc/NEWS.d/next/Security/2020-06-21-19-01-01.bpo-41004.P6i7Nj.rst
+++ b/Misc/NEWS.d/next/Security/2020-06-21-19-01-01.bpo-41004.P6i7Nj.rst
@@ -1,2 +1,0 @@
-The hash() methods of classes IPv4Interface and IPv6Interface (of the ipaddress library) had issue of generating constant hash values of 32 and 128 respectively causing hash collisions.
-The fix uses the hash() function to generate hash values for the objects instead of XOR operation

--- a/Misc/NEWS.d/next/Security/2020-06-21-19-01-01.bpo-41004.P6i7Nj.rst
+++ b/Misc/NEWS.d/next/Security/2020-06-21-19-01-01.bpo-41004.P6i7Nj.rst
@@ -1,0 +1,2 @@
+The hash() methods of classes IPv4Interface and IPv6Interface (of the ipaddress library) had issue of generating constant hash values of 32 and 128 respectively causing hash collisions.
+The fix uses the hash() function to generate hash values for the objects instead of XOR operation

--- a/Misc/NEWS.d/next/Security/2020-06-29-16-02-29.bpo-41004.ovF0KZ.rst
+++ b/Misc/NEWS.d/next/Security/2020-06-29-16-02-29.bpo-41004.ovF0KZ.rst
@@ -1,0 +1,1 @@
+The __hash__() methods of  ipaddress.IPv4Interface and ipaddress.IPv6Interface incorrectly generated constant hash values of 32 and 128 respectively. This resulted in always causing hash collisions.

--- a/Misc/NEWS.d/next/Security/2020-06-29-16-02-29.bpo-41004.ovF0KZ.rst
+++ b/Misc/NEWS.d/next/Security/2020-06-29-16-02-29.bpo-41004.ovF0KZ.rst
@@ -1,1 +1,1 @@
-The __hash__() methods of  ipaddress.IPv4Interface and ipaddress.IPv6Interface incorrectly generated constant hash values of 32 and 128 respectively. This resulted in always causing hash collisions.
+The __hash__() methods of  ipaddress.IPv4Interface and ipaddress.IPv6Interface incorrectly generated constant hash values of 32 and 128 respectively. This resulted in always causing hash collisions. The fix uses hash() to generate hash values for the tuple of (address, mask length, network address).


### PR DESCRIPTION
The __hash__() methods of classes IPv4Interface and IPv6Interface had issue
of generating constant hash values of 32 and 128 respectively causing hash collisions.
The fix uses the hash() function to generate hash values for the objects
instead of XOR operation

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41004](https://bugs.python.org/issue41004) -->
https://bugs.python.org/issue41004
<!-- /issue-number -->
