### PR TITLE
bpo-41068: Fix read after write in zipfile for non-ASCII files names.

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1600,6 +1600,11 @@ class OtherTests(unittest.TestCase):
             self.assertEqual(zf.filelist[0].filename, "foo.txt")
             self.assertEqual(zf.filelist[1].filename, "\xf6.txt")
 
+    def test_read_after_write_unicode_filenames(self):
+        with zipfile.ZipFile(TESTFN2, 'w') as zipfp:
+            zipfp.writestr('приклад', b'sample')
+            self.assertEqual(zipfp.read('приклад'), b'sample')
+
     def test_exclusive_create_zip_file(self):
         """Test exclusive creating a new zipfile."""
         unlink(TESTFN2)

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1534,7 +1534,7 @@ class ZipFile:
                 # strong encryption
                 raise NotImplementedError("strong encryption (flag bit 6)")
 
-            if zinfo.flag_bits & 0x800:
+            if fheader[_FH_GENERAL_PURPOSE_FLAG_BITS] & 0x800:
                 # UTF-8 filename
                 fname_str = fname.decode("utf-8")
             else:

--- a/Misc/NEWS.d/next/Library/2020-06-22-10-25-39.bpo-41068._bX2BW.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-22-10-25-39.bpo-41068._bX2BW.rst
@@ -1,0 +1,2 @@
+Fixed reading files with non-ASCII names from ZIP archive directly after
+writing them.


### PR DESCRIPTION


<!-- issue-number: [bpo-41068](https://bugs.python.org/issue41068) -->
https://bugs.python.org/issue41068
<!-- /issue-number -->
