### PR TITLE
[WIP] bpo-41078: Convert PyTuple_GET_ITEM() macro to static inline function

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -202,5 +202,15 @@ Porting to Python 3.10
   for historical reason. It is no longer allowed.
   (Contributed by Victor Stinner in :issue:`40839`.)
 
+* Convert ``PyTuple`` and ``PyList`` macros to static inline functions:
+
+  * :c:func:`PyTuple_GET_SIZE`, :c:func:`PyList_GET_SIZE`
+  * :c:func:`PyTuple_GET_ITEM`, :c:func:`PyList_GET_ITEM`
+  * :c:func:`PyTuple_SET_ITEM`, :c:func:`PyList_SET_ITEM`
+
+  It is no longer possible to write ``&PyTuple_GET_ITEM()`` or
+  ``&PyList_GET_ITEM()``.
+  (Contributed by Victor Stinner in :issue:`41078`.)
+
 Removed
 -------

--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -29,6 +29,24 @@ PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 /* Cast argument to PyTupleObject* type. */
 #define _PyList_CAST(op) (assert(PyList_Check(op)), (PyListObject *)(op))
 
-#define PyList_GET_ITEM(op, i) (_PyList_CAST(op)->ob_item[i])
-#define PyList_SET_ITEM(op, i, v) (_PyList_CAST(op)->ob_item[i] = (v))
-#define PyList_GET_SIZE(op)    Py_SIZE(_PyList_CAST(op))
+
+static inline Py_ssize_t _PyList_GET_SIZE(PyListObject *op)
+{
+    return Py_SIZE(op);
+}
+#define PyList_GET_SIZE(op) _PyList_GET_SIZE(_PyList_CAST(op))
+
+
+static inline PyObject* _PyList_GET_ITEM(PyListObject *op, Py_ssize_t i)
+{
+    return op->ob_item[i];
+}
+#define PyList_GET_ITEM(op, i) _PyList_GET_ITEM(_PyList_CAST(op), i)
+
+
+static inline void _PyList_SET_ITEM(PyListObject *op, Py_ssize_t i, PyObject *item)
+{
+    op->ob_item[i] = item;
+}
+#define PyList_SET_ITEM(op, i, item) \
+    _PyList_SET_ITEM(_PyList_CAST(op), i, item)

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -18,11 +18,28 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 /* Cast argument to PyTupleObject* type. */
 #define _PyTuple_CAST(op) (assert(PyTuple_Check(op)), (PyTupleObject *)(op))
 
-#define PyTuple_GET_SIZE(op)    Py_SIZE(_PyTuple_CAST(op))
 
-#define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
+static inline Py_ssize_t _PyTuple_GET_SIZE(PyTupleObject *op)
+{
+    return Py_SIZE(op);
+}
+#define PyTuple_GET_SIZE(op) _PyTuple_GET_SIZE(_PyTuple_CAST(op))
 
-/* Macro, *only* to be used to fill in brand new tuples */
-#define PyTuple_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
+
+static inline PyObject* _PyTuple_GET_ITEM(PyTupleObject *op, Py_ssize_t i)
+{
+    return op->ob_item[i];
+}
+#define PyTuple_GET_ITEM(op, i) _PyTuple_GET_ITEM(_PyTuple_CAST(op), i)
+
+
+static inline void _PyTuple_SET_ITEM(PyTupleObject *op, Py_ssize_t i, PyObject *item)
+{
+    op->ob_item[i] = item;
+}
+/* Function, *only* to be used to fill in brand new tuples */
+#define PyTuple_SET_ITEM(op, i, item) \
+    _PyTuple_SET_ITEM(_PyTuple_CAST(op), i, item)
+
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);

--- a/Misc/NEWS.d/next/C API/2020-06-22-18-05-37.bpo-41078.-nx_Wm.rst
+++ b/Misc/NEWS.d/next/C API/2020-06-22-18-05-37.bpo-41078.-nx_Wm.rst
@@ -1,0 +1,8 @@
+Convert ``PyTuple`` and ``PyList`` macros to static inline functions:
+
+* :c:func:`PyTuple_GET_SIZE`, :c:func:`PyList_GET_SIZE`
+* :c:func:`PyTuple_GET_ITEM`, :c:func:`PyList_GET_ITEM`
+* :c:func:`PyTuple_SET_ITEM`, :c:func:`PyList_SET_ITEM`
+
+It is no longer possible to write ``&PyTuple_GET_ITEM()`` or
+``&PyList_GET_ITEM()``.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_object.h"
+#include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "structmember.h"         // PyMemberDef
 
 typedef struct {
@@ -308,7 +309,7 @@ ga_getitem(PyObject *self, PyObject *item)
     }
     int is_tuple = PyTuple_Check(item);
     Py_ssize_t nitems = is_tuple ? PyTuple_GET_SIZE(item) : 1;
-    PyObject **argitems = is_tuple ? &PyTuple_GET_ITEM(item, 0) : &item;
+    PyObject **argitems = is_tuple ? _PyTuple_ITEMS(item) : &item;
     if (nitems != nparams) {
         return PyErr_Format(PyExc_TypeError,
                             "Too %s arguments for %R",


### PR DESCRIPTION
Convert PyTuple and PyList macros to static inline functions:

* PyTuple_GET_SIZE(), PyList_GET_SIZE()
* PyTuple_GET_ITEM(), PyList_GET_ITEM()
* PyTuple_SET_ITEM(), PyList_SET_ITEM()

It is no longer possible to use "&PyTuple_GET_ITEM()" or "&PyList_GET_ITEM()".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41078](https://bugs.python.org/issue41078) -->
https://bugs.python.org/issue41078
<!-- /issue-number -->
