### PR TITLE
[doc] Mention __slots__ behavior in weakref.rst

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -88,6 +88,9 @@ support weak references but can add support through subclassing::
 Extension types can easily be made to support weak references; see
 :ref:`weakref-support`.
 
+``__slots__`` existence in a type (and the contents) affects whether that type
+supports weak references. See :ref:`__slots__ documentation <slots>` for details.
+
 
 .. class:: ref(object[, callback])
 

--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -88,9 +88,10 @@ support weak references but can add support through subclassing::
 Extension types can easily be made to support weak references; see
 :ref:`weakref-support`.
 
-``__slots__`` existence in a type (and the contents) affects whether that type
-supports weak references. See :ref:`__slots__ documentation <slots>` for details.
-
+When ``__slots__`` are defined for a given type, weak reference support is
+disabled unless a ``'__weakref__'`` string is also present in the sequence of
+strings in the ``__slots__`` declaration.
+See :ref:`__slots__ documentation <slots>` for details.
 
 .. class:: ref(object[, callback])
 


### PR DESCRIPTION
It took me longer than I expected to figure out why a random class
I dealt with didn't support weak references. I believe this addition
will make the __slots__/weakref interaction more discoverable to people
having troubles with this. (Before this patch __slots__ was not
mentioned in weakref documentation even once).