### PR TITLE
bpo-41086: Add exception for uninstantiated interpolation (configparser)

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -613,7 +613,10 @@ class RawConfigParser(MutableMapping):
         if self._interpolation is None:
             self._interpolation = Interpolation()
         if not isinstance(self._interpolation, Interpolation):
-            raise TypeError("interpolation is not an instance of Interpolation")
+            raise TypeError(
+                f"interpolation= must be None or an instance of Interpolation;"
+                f" got an object of type {type(self._interpolation)}"
+            )
         if converters is not _UNSET:
             self._converters.update(converters)
         if defaults:

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -150,8 +150,8 @@ import sys
 __all__ = ["NoSectionError", "DuplicateOptionError", "DuplicateSectionError",
            "NoOptionError", "InterpolationError", "InterpolationDepthError",
            "InterpolationMissingOptionError", "InterpolationSyntaxError",
-           "InterpolationTypeError", "ParsingError",
-           "MissingSectionHeaderError", "ConfigParser", "RawConfigParser",
+           "ParsingError", "MissingSectionHeaderError",
+           "ConfigParser", "RawConfigParser",
            "Interpolation", "BasicInterpolation",  "ExtendedInterpolation",
            "LegacyInterpolation", "SectionProxy", "ConverterMapping",
            "DEFAULTSECT", "MAX_INTERPOLATION_DEPTH"]
@@ -279,13 +279,6 @@ class InterpolationSyntaxError(InterpolationError):
     which substitutions are made does not conform to the required syntax.
     """
 
-class InterpolationTypeError(Error):
-    """Raised when the _interpolation is not an instance of Interpolation
-
-    Giving users faster and more clear feedback on how to fix a common error
-    """
-    def __init__(self):
-        msg = ("interpolation is not an instance of Interpolation")
 
 class InterpolationDepthError(InterpolationError):
     """Raised when substitutions are nested too deeply."""
@@ -620,7 +613,7 @@ class RawConfigParser(MutableMapping):
         if self._interpolation is None:
             self._interpolation = Interpolation()
         if not isinstance(self._interpolation, Interpolation):
-            raise InterpolationTypeError()
+            raise TypeError("interpolation is not an instance of Interpolation")
         if converters is not _UNSET:
             self._converters.update(converters)
         if defaults:

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -150,8 +150,8 @@ import sys
 __all__ = ["NoSectionError", "DuplicateOptionError", "DuplicateSectionError",
            "NoOptionError", "InterpolationError", "InterpolationDepthError",
            "InterpolationMissingOptionError", "InterpolationSyntaxError",
-           "ParsingError", "MissingSectionHeaderError",
-           "ConfigParser", "RawConfigParser",
+           "InterpolationTypeError", "ParsingError",
+           "MissingSectionHeaderError", "ConfigParser", "RawConfigParser",
            "Interpolation", "BasicInterpolation",  "ExtendedInterpolation",
            "LegacyInterpolation", "SectionProxy", "ConverterMapping",
            "DEFAULTSECT", "MAX_INTERPOLATION_DEPTH"]
@@ -279,6 +279,13 @@ class InterpolationSyntaxError(InterpolationError):
     which substitutions are made does not conform to the required syntax.
     """
 
+class InterpolationTypeError(Error):
+    """Raised when the _interpolation is not an instance of Interpolation
+
+    Giving users faster and more clear feedback on how to fix a common error
+    """
+    def __init__(self):
+        msg = ("interpolation is not an instance of Interpolation")
 
 class InterpolationDepthError(InterpolationError):
     """Raised when substitutions are nested too deeply."""
@@ -612,6 +619,8 @@ class RawConfigParser(MutableMapping):
             self._interpolation = self._DEFAULT_INTERPOLATION
         if self._interpolation is None:
             self._interpolation = Interpolation()
+        if not isinstance(self._interpolation, Interpolation):
+            raise InterpolationTypeError()
         if converters is not _UNSET:
             self._converters.update(converters)
         if defaults:

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1048,10 +1048,12 @@ class ConfigParserTestCaseLegacyInterpolation(ConfigParserTestCase):
         self.assertEqual(cf.get("sect", "option2"), "foo%%bar")
 
 
-class ConfigParserTestCaseInterpolationIsInstantiated(unittest.TestCase):
-    def test_error_on_uninstantiated_interpolation(self):
-        with self.assertRaises(configparser.InterpolationTypeError) as context:
-            cf = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation)
+class ConfigParserTestCaseInvalidInterpolationType(unittest.TestCase):
+    def test_error_on_wrong_type_for_interpolation(self):
+        for value in [configparser.ExtendedInterpolation,  42,  "a string"]:
+            with self.subTest(value=value):
+                with self.assertRaises(TypeError):
+                    configparser.ConfigParser(interpolation=value)
 
 
 class ConfigParserTestCaseNonStandardDelimiters(ConfigParserTestCase):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1048,6 +1048,12 @@ class ConfigParserTestCaseLegacyInterpolation(ConfigParserTestCase):
         self.assertEqual(cf.get("sect", "option2"), "foo%%bar")
 
 
+class ConfigParserTestCaseInterpolationIsInstantiated(unittest.TestCase):
+    def test_error_on_uninstantiated_interpolation(self):
+        with self.assertRaises(configparser.InterpolationTypeError) as context:
+            cf = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation)
+
+
 class ConfigParserTestCaseNonStandardDelimiters(ConfigParserTestCase):
     delimiters = (':=', '$')
     comment_prefixes = ('//', '"')

--- a/Misc/NEWS.d/next/Library/2020-06-23-01-50-24.bpo-41086.YnOvpS.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-23-01-50-24.bpo-41086.YnOvpS.rst
@@ -1,0 +1,1 @@
+Added validation check of instantiation on ConfigParser's interpolation parameter.

--- a/Misc/NEWS.d/next/Library/2020-06-23-01-50-24.bpo-41086.YnOvpS.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-23-01-50-24.bpo-41086.YnOvpS.rst
@@ -1,1 +1,1 @@
-Added validation check of instantiation on ConfigParser's interpolation parameter.
+Make the :class:`configparser.ConfigParser` constructor raise :exc:`TypeError` if the ``interpolation`` parameter is not of type :class:`configparser.Interpolation`


### PR DESCRIPTION
The current feedback when users try to pass an uninstantiated
interpolation into a ConfigParser is an error message that does not help
users solve the problem. This current error of `TypeError: before_set()
missing 1 required positional argument: 'value'` does not display until
the parser is used, which usually results in the assumption that
instantiation of the parser was done correctly. The new exception of
InterpolationIsNotInstantiatedError, will be raised on the line where
the ConfigParser is instantiated. This will result in users see the line
that has the error in their backtrace for faster debugging.

There have been a number of bugs created in the issue tracker, which
could have been addressed by:
https://bugs.python.org/issue26831 and https://bugs.python.org/issue26469


<!-- issue-number: [bpo-41086](https://bugs.python.org/issue41086) -->
https://bugs.python.org/issue41086
<!-- /issue-number -->
