### PR TITLE
bpo-40521: Make the empty frozenset per interpreter

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -238,6 +238,8 @@ struct _is {
     /* Using a cache is very effective since typically only a single slice is
        created and then deleted again. */
     PySliceObject *slice_cache;
+    // The empty frozenset is a singleton.
+    PyObject *empty_frozenset;
 
     struct _Py_tuple_state tuple;
     struct _Py_list_state list;

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -62,7 +62,7 @@ extern void _PyFrame_Fini(PyThreadState *tstate);
 extern void _PyDict_Fini(PyThreadState *tstate);
 extern void _PyTuple_Fini(PyThreadState *tstate);
 extern void _PyList_Fini(PyThreadState *tstate);
-extern void _PySet_Fini(void);
+extern void _PySet_Fini(PyThreadState *tstate);
 extern void _PyBytes_Fini(void);
 extern void _PyFloat_Fini(PyThreadState *tstate);
 extern void _PySlice_Fini(PyThreadState *tstate);

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
@@ -1,5 +1,5 @@
-The tuple free lists, the empty tuple singleton, the list free list, the float
-free list, the slice cache, the dict free lists, the frame free list, the
-asynchronous generator free lists, and the context free list are no longer
-shared by all interpreters: each interpreter now its has own free lists and
-caches.
+The tuple free lists, the empty tuple singleton, the list free list, the empty
+frozenset singleton, the float free list, the slice cache, the dict free lists,
+the frame free list, the asynchronous generator free lists, and the context
+free list are no longer shared by all interpreters: each interpreter now its
+has own free lists and caches.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1255,9 +1255,7 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     _PyAsyncGen_Fini(tstate);
     _PyContext_Fini(tstate);
 
-    if (is_main_interp) {
-        _PySet_Fini();
-    }
+    _PySet_Fini(tstate);
     _PyDict_Fini(tstate);
     _PyList_Fini(tstate);
     _PyTuple_Fini(tstate);


### PR DESCRIPTION
Each interpreter now has its own empty frozenset singleton.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
