### PR TITLE
bpo-41085: Fixed 'array.array.index' downcasting 'Py_ssize_t' to 'long'.

### DIFF
--- a/Misc/NEWS.d/next/Tests/2020-06-23-12-02-45.bpo-41085.JZKsyz.rst
+++ b/Misc/NEWS.d/next/Tests/2020-06-23-12-02-45.bpo-41085.JZKsyz.rst
@@ -1,0 +1,2 @@
+Fix integer overflow in the :meth:`array.array.index` method on 64-bit Windows
+for index larger than ``2**31``.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1130,7 +1130,7 @@ array_array_index(arrayobject *self, PyObject *v)
         cmp = PyObject_RichCompareBool(selfi, v, Py_EQ);
         Py_DECREF(selfi);
         if (cmp > 0) {
-            return PyLong_FromLong((long)i);
+            return PyLong_FromSsize_t(i);
         }
         else if (cmp < 0)
             return NULL;


### PR DESCRIPTION
Fix integer overflow in the array.array.index() method on 64-bit Windows for index larger than 2**31.

<!-- issue-number: [bpo-41085](https://bugs.python.org/issue41085) -->
https://bugs.python.org/issue41085
<!-- /issue-number -->
