### PR TITLE
On path with a known exact float, extract the double with a fast macro.

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1256,9 +1256,15 @@ static PyObject *
 math_floor(PyObject *module, PyObject *number)
 /*[clinic end generated code: output=c6a65c4884884b8a input=63af6b5d7ebcc3d6]*/
 {
+    double x;
+
     _Py_IDENTIFIER(__floor__);
 
-    if (!PyFloat_CheckExact(number)) {
+    if (PyFloat_CheckExact(number)) {
+        x = PyFloat_AS_DOUBLE(number);
+    }
+    else
+    {
         PyObject *method = _PyObject_LookupSpecial(number, &PyId___floor__);
         if (method != NULL) {
             PyObject *result = _PyObject_CallNoArg(method);
@@ -1267,11 +1273,10 @@ math_floor(PyObject *module, PyObject *number)
         }
         if (PyErr_Occurred())
             return NULL;
+        x = PyFloat_AsDouble(number);
+        if (x == -1.0 && PyErr_Occurred())
+            return NULL;
     }
-    double x = PyFloat_AsDouble(number);
-    if (x == -1.0 && PyErr_Occurred())
-        return NULL;
-
     return PyLong_FromDouble(floor(x));
 }
 


### PR DESCRIPTION
We're already testing for an exact float, so take advantage of that information and extract the double with the fast macro.

Baseline timings

```
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=3.14' 'floor(x)'
10000000 loops, best of 11: 38.5 nsec per loop
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=0.0' 'floor(x)'
10000000 loops, best of 11: 38.3 nsec per loop
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=-3.14E32' 'floor(x)'
5000000 loops, best of 11: 69.3 nsec per loop
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=-323452345.14' 'floor(x)'
5000000 loops, best of 11: 53.4 nsec per loop
```

Timings with the patch:
```
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=3.14' 'floor(x)'
10000000 loops, best of 11: 36.5 nsec per loop
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=0.0' 'floor(x)'
10000000 loops, best of 11: 36.5 nsec per loop
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=-3.14E32' 'floor(x)'
5000000 loops, best of 11: 64.4 nsec per loop
$ ./python.exe -m timeit -r 11 -s 'from math import floor' -s 'x=-323452345.14' 'floor(x)'
5000000 loops, best of 11: 47 nsec per loop
```

While the timings all show improvements, I don't understand why the timings for *floor()* also depend on the magnitude of the inputs.