### PR TITLE
Call _PyWarnings_InitState() in subinterpreters

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -685,24 +685,22 @@ pycore_init_import_warnings(PyThreadState *tstate, PyObject *sysmod)
         return status;
     }
 
-    const PyConfig *config = _PyInterpreterState_GetConfig(tstate->interp);
-    if (_Py_IsMainInterpreter(tstate)) {
-        /* Initialize _warnings. */
-        status = _PyWarnings_InitState(tstate);
-        if (_PyStatus_EXCEPTION(status)) {
-            return status;
-        }
+    /* Initialize _warnings. */
+    status = _PyWarnings_InitState(tstate);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
 
-        if (config->_install_importlib) {
+    const PyConfig *config = _PyInterpreterState_GetConfig(tstate->interp);
+    if (config->_install_importlib) {
+        if (_Py_IsMainInterpreter(tstate)) {
             status = _PyConfig_WritePathConfig(config);
             if (_PyStatus_EXCEPTION(status)) {
                 return status;
             }
         }
-    }
 
-    /* This call sets up builtin and frozen import support */
-    if (config->_install_importlib) {
+        /* This call sets up builtin and frozen import support */
         status = init_importlib(tstate, sysmod);
         if (_PyStatus_EXCEPTION(status)) {
             return status;


### PR DESCRIPTION
Py_InitializeFromConfig() now calls also _PyWarnings_InitState() in
subinterpreters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
