### PR TITLE
Fix typo in Object/listobject.c

### DIFF
--- a/Misc/NEWS.d/3.9.0a5.rst
+++ b/Misc/NEWS.d/3.9.0a5.rst
@@ -176,7 +176,7 @@ convention. Patch by Dong-hee Na.
 .. section: Core and Builtins
 
 Chaged list overallocation strategy. It no longer overallocates if the new
-size is closer to overalocated size than to the old size and adds padding.
+size is closer to overallocated size than to the old size and adds padding.
 
 ..
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -60,7 +60,7 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
      *       is PY_SSIZE_T_MAX * (9 / 8) + 6 which always fits in a size_t.
      */
     new_allocated = ((size_t)newsize + (newsize >> 3) + 6) & ~(size_t)3;
-    /* Do not overallocate if the new size is closer to overalocated size
+    /* Do not overallocate if the new size is closer to overallocated size
      * than to the old size.
      */
     if (newsize - Py_SIZE(self) > (Py_ssize_t)(new_allocated - newsize))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Fix `overalocated` to `overallocated`.