### PR TITLE
bpo-40773: Fix rendering for 'retval' on the pdb page

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -538,6 +538,7 @@ by the local file.
    executed in the current environment).
 
 .. pdbcommand:: retval
+
    Print the return value for the last return of a function.
 
 .. rubric:: Footnotes


### PR DESCRIPTION
Fix rendering for 'retval' on the pdb page

https://bugs.python.org/issue40773

<!-- issue-number: [bpo-40773](https://bugs.python.org/issue40773) -->
https://bugs.python.org/issue40773
<!-- /issue-number -->
