### PR TITLE
bpo-41084: Adjust message when an f-string expression causes a SyntaxError

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -524,7 +524,7 @@ non-important content
                              # This looks like a nested format spec.
                              ])
 
-        self.assertAllRaise(SyntaxError, "invalid syntax",
+        self.assertAllRaise(SyntaxError, "f-string: invalid syntax",
                             [# Invalid syntax inside a nested spec.
                              "f'{4:{/5}}'",
                              ])
@@ -598,7 +598,7 @@ non-important content
         #  are added around it. But we shouldn't go from an invalid
         #  expression to a valid one. The added parens are just
         #  supposed to allow whitespace (including newlines).
-        self.assertAllRaise(SyntaxError, 'invalid syntax',
+        self.assertAllRaise(SyntaxError, 'f-string: invalid syntax',
                             ["f'{,}'",
                              "f'{,}'",  # this is (,), which is an error
                              ])
@@ -716,7 +716,7 @@ non-important content
 
         # lambda doesn't work without parens, because the colon
         #  makes the parser think it's a format_spec
-        self.assertAllRaise(SyntaxError, 'invalid syntax',
+        self.assertAllRaise(SyntaxError, 'f-string: invalid syntax',
                             ["f'{lambda x:x}'",
                              ])
 
@@ -1192,6 +1192,10 @@ non-important content
         # This is an assignment expression, which requires parens.
         self.assertEqual(f'{(x:=10)}', '10')
         self.assertEqual(x, 10)
+
+    def test_invalid_syntax_error_message(self):
+        with self.assertRaisesRegex(SyntaxError, "f-string: invalid syntax"):
+            compile("f'{a $ b}'", "?", "exec")
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-23-15-10-19.bpo-41084.pt3y7F.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-23-15-10-19.bpo-41084.pt3y7F.rst
@@ -1,1 +1,1 @@
-Prefix the error message with 'f-string: ', when parsing an f-string expression throws a :exc:`SyntaxError`.
+Prefix the error message with 'f-string: ', when parsing an f-string expression which throws a :exc:`SyntaxError`.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-23-15-10-19.bpo-41084.pt3y7F.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-23-15-10-19.bpo-41084.pt3y7F.rst
@@ -1,1 +1,1 @@
-Prefix the error message with `fstring: `, when parsing an f-string expression throws a :exc:`SyntaxError`.
+Prefix the error message with 'f-string: ', when parsing an f-string expression throws a :exc:`SyntaxError`.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-23-15-10-19.bpo-41084.pt3y7F.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-23-15-10-19.bpo-41084.pt3y7F.rst
@@ -1,0 +1,1 @@
+Prefix the error message with `fstring: `, when parsing an f-string expression throws a :exc:`SyntaxError`.


### PR DESCRIPTION
Prefix the error message with `f-string: `, when parsing an f-string
expression which throws a `SyntaxError`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41084](https://bugs.python.org/issue41084) -->
https://bugs.python.org/issue41084
<!-- /issue-number -->
