### PR TITLE
bpo-40521: Empty frozenset is no longer a singleton

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -244,8 +244,6 @@ struct _is {
     /* Using a cache is very effective since typically only a single slice is
        created and then deleted again. */
     PySliceObject *slice_cache;
-    // The empty frozenset is a singleton.
-    PyObject *empty_frozenset;
 
     struct _Py_tuple_state tuple;
     struct _Py_list_state list;

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -62,7 +62,6 @@ extern void _PyFrame_Fini(PyThreadState *tstate);
 extern void _PyDict_Fini(PyThreadState *tstate);
 extern void _PyTuple_Fini(PyThreadState *tstate);
 extern void _PyList_Fini(PyThreadState *tstate);
-extern void _PySet_Fini(PyThreadState *tstate);
 extern void _PyBytes_Fini(PyThreadState *tstate);
 extern void _PyFloat_Fini(PyThreadState *tstate);
 extern void _PySlice_Fini(PyThreadState *tstate);

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -158,13 +158,6 @@ class ContainerTestCase(unittest.TestCase, HelperMixin):
         for constructor in (set, frozenset):
             self.helper(constructor(self.d.keys()))
 
-    @support.cpython_only
-    def test_empty_frozenset_singleton(self):
-        # marshal.loads() must reuse the empty frozenset singleton
-        obj = frozenset()
-        obj2 = marshal.loads(marshal.dumps(obj))
-        self.assertIs(obj2, obj)
-
 
 class BufferTestCase(unittest.TestCase, HelperMixin):
 

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -661,15 +661,6 @@ class TestFrozenSet(TestJointOps, unittest.TestCase):
         s.__init__(self.otherword)
         self.assertEqual(s, set(self.word))
 
-    def test_singleton_empty_frozenset(self):
-        f = frozenset()
-        efs = [frozenset(), frozenset([]), frozenset(()), frozenset(''),
-               frozenset(), frozenset([]), frozenset(()), frozenset(''),
-               frozenset(range(0)), frozenset(frozenset()),
-               frozenset(f), f]
-        # All of the empty frozensets should have just one id()
-        self.assertEqual(len(set(map(id, efs))), 1)
-
     def test_constructor_identity(self):
         s = self.thetype(range(3))
         t = self.thetype(s)

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
@@ -2,8 +2,9 @@ Each interpreter now its has own free lists, singletons and caches:
 
 * Free lists: float, tuple, list, dict, frame, context,
   asynchronous generator.
-* Singletons: empty tuple, empty frozenset, empty bytes string,
+* Singletons: empty tuple, empty bytes string,
   single byte character.
 * Slice cache.
 
 They are no longer shared by all interpreters.
+

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-23-07-35-11.bpo-40521.dMNA6k.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-23-07-35-11.bpo-40521.dMNA6k.rst
@@ -1,0 +1,1 @@
+Empty frozensets are no longer singletons.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -975,9 +975,6 @@ make_new_set_basetype(PyTypeObject *type, PyObject *iterable)
     return make_new_set(type, iterable);
 }
 
-/* The empty frozenset is a singleton */
-static PyObject *emptyfrozenset = NULL;
-
 static PyObject *
 make_new_frozenset(PyTypeObject *type, PyObject *iterable)
 {
@@ -985,26 +982,12 @@ make_new_frozenset(PyTypeObject *type, PyObject *iterable)
         return make_new_set(type, iterable);
     }
 
-    if (iterable != NULL) {
-        if (PyFrozenSet_CheckExact(iterable)) {
-            /* frozenset(f) is idempotent */
-            Py_INCREF(iterable);
-            return iterable;
+    if (iterable != NULL && PyFrozenSet_CheckExact(iterable)) {
+        /* frozenset(f) is idempotent */
+        Py_INCREF(iterable);
+        return iterable;
         }
-        PyObject *res = make_new_set((PyTypeObject *)type, iterable);
-        if (res == NULL || PySet_GET_SIZE(res) != 0) {
-            return res;
-        }
-        /* If the created frozenset is empty, return the empty frozenset singleton instead */
-        Py_DECREF(res);
-    }
-
-    // The empty frozenset is a singleton
-    if (emptyfrozenset == NULL) {
-        emptyfrozenset = make_new_set((PyTypeObject *)type, NULL);
-    }
-    Py_XINCREF(emptyfrozenset);
-    return emptyfrozenset;
+    return make_new_set((PyTypeObject *)type, iterable);
 }
 
 static PyObject *

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -986,7 +986,7 @@ make_new_frozenset(PyTypeObject *type, PyObject *iterable)
         /* frozenset(f) is idempotent */
         Py_INCREF(iterable);
         return iterable;
-        }
+    }
     return make_new_set((PyTypeObject *)type, iterable);
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1253,9 +1253,6 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     _PyAsyncGen_Fini(tstate);
     _PyContext_Fini(tstate);
 
-    if (is_main_interp) {
-        _PySet_Fini();
-    }
     _PyDict_Fini(tstate);
     _PyList_Fini(tstate);
     _PyTuple_Fini(tstate);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1253,7 +1253,9 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     _PyAsyncGen_Fini(tstate);
     _PyContext_Fini(tstate);
 
-    _PySet_Fini(tstate);
+    if (is_main_interp) {
+        _PySet_Fini();
+    }
     _PyDict_Fini(tstate);
     _PyList_Fini(tstate);
     _PyTuple_Fini(tstate);


### PR DESCRIPTION
Making the empty frozenset a singleton wasn't worth it. Unlike empty strings and empty tuples, these are not common and don't warrant a special case. Taking it out makes the code simpler.

<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
