### PR TITLE
bpo-40521: Make MemoryError free list per interpreter

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -152,6 +152,13 @@ struct _Py_context_state {
     int numfree;
 };
 
+struct _Py_exc_state {
+    // The dict mapping from errno codes to OSError subclasses
+    PyObject *errnomap;
+    PyBaseExceptionObject *memerrors_freelist;
+    int memerrors_numfree;
+};
+
 
 /* interpreter state */
 
@@ -251,6 +258,7 @@ struct _is {
     struct _Py_frame_state frame;
     struct _Py_async_gen_state async_gen;
     struct _Py_context_state context;
+    struct _Py_exc_state exc_state;
 };
 
 /* Used by _PyImport_Cleanup() */

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -43,7 +43,7 @@ extern PyStatus _PySys_Create(
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_InitMain(PyThreadState *tstate);
-extern PyStatus _PyExc_Init(void);
+extern PyStatus _PyExc_Init(PyThreadState *tstate);
 extern PyStatus _PyErr_Init(void);
 extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);
 extern PyStatus _PyImportHooks_Init(PyThreadState *tstate);
@@ -69,7 +69,7 @@ extern void _PyAsyncGen_Fini(PyThreadState *tstate);
 
 extern void PyOS_FiniInterrupts(void);
 
-extern void _PyExc_Fini(void);
+extern void _PyExc_Fini(PyThreadState *tstate);
 extern void _PyImport_Fini(void);
 extern void _PyImport_Fini2(void);
 extern void _PyGC_Fini(PyThreadState *tstate);

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-20-01-17-34.bpo-40521.wvAehI.rst
@@ -1,10 +1,9 @@
 Each interpreter now its has own free lists, singletons and caches:
 
 * Free lists: float, tuple, list, dict, frame, context,
-  asynchronous generator.
+  asynchronous generator, MemoryError.
 * Singletons: empty tuple, empty bytes string,
   single byte character.
 * Slice cache.
 
 They are no longer shared by all interpreters.
-

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -602,7 +602,7 @@ pycore_init_types(PyThreadState *tstate)
         }
     }
 
-    status = _PyExc_Init();
+    status = _PyExc_Init(tstate);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -1249,6 +1249,7 @@ flush_std_files(void)
 static void
 finalize_interp_types(PyThreadState *tstate, int is_main_interp)
 {
+    _PyExc_Fini(tstate);
     _PyFrame_Fini(tstate);
     _PyAsyncGen_Fini(tstate);
     _PyContext_Fini(tstate);
@@ -1288,10 +1289,6 @@ finalize_interp_clear(PyThreadState *tstate)
     }
 
     _PyWarnings_Fini(tstate->interp);
-
-    if (is_main_interp) {
-        _PyExc_Fini();
-    }
 
     finalize_interp_types(tstate, is_main_interp);
 }


### PR DESCRIPTION
Each interpreter now has its own MemoryError free list: it is not
longer shared by all interpreters.

Add _Py_exc_state structure and PyInterpreterState.exc_state member.
Move also errnomap into _Py_exc_state.

Rename MEMERRORS_SAVE macro to _PY_MEMERRORS_SAVE.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
