### PR TITLE
bpo-1635741: Enable unicode_release_interned() without insure or valgrind.

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15661,7 +15661,7 @@ static void
 unicode_release_interned(void)
 {
     Py_ssize_t pos = 0;
-    PyObject *key, *value;
+    PyObject *s, *ignored_value;
 
     if (interned == NULL || !PyDict_Check(interned)) {
         return;
@@ -15676,21 +15676,21 @@ unicode_release_interned(void)
 
     Py_ssize_t immortal_size = 0, mortal_size = 0;
 #endif
-    while (PyDict_Next(interned, &pos, &key, &value)) {
-        if (PyUnicode_READY(key) == -1) {
+    while (PyDict_Next(interned, &pos, &s, &ignored_value)) {
+        if (PyUnicode_READY(s) == -1) {
             Py_UNREACHABLE();
         }
-        switch (PyUnicode_CHECK_INTERNED(key)) {
+        switch (PyUnicode_CHECK_INTERNED(s)) {
             case SSTATE_INTERNED_IMMORTAL:
-                Py_SET_REFCNT(key, Py_REFCNT(key) + 1);
+                Py_SET_REFCNT(s, Py_REFCNT(s) + 1);
 #ifdef INTERNED_STATS
-                immortal_size += PyUnicode_GET_LENGTH(key);
+                immortal_size += PyUnicode_GET_LENGTH(s);
 #endif
                 break;
             case SSTATE_INTERNED_MORTAL:
-                Py_SET_REFCNT(key, Py_REFCNT(key) + 2);
+                Py_SET_REFCNT(s, Py_REFCNT(s) + 2);
 #ifdef INTERNED_STATS
-                mortal_size += PyUnicode_GET_LENGTH(key);
+                mortal_size += PyUnicode_GET_LENGTH(s);
 #endif
                 break;
             case SSTATE_NOT_INTERNED:
@@ -15698,7 +15698,7 @@ unicode_release_interned(void)
             default:
                 Py_UNREACHABLE();
         }
-        _PyUnicode_STATE(key).interned = SSTATE_NOT_INTERNED;
+        _PyUnicode_STATE(s).interned = SSTATE_NOT_INTERNED;
     }
 #ifdef INTERNED_STATS
     fprintf(stderr,

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15657,7 +15657,6 @@ PyUnicode_InternFromString(const char *cp)
 }
 
 
-#if defined(WITH_VALGRIND) || defined(__INSURE__)
 static void
 unicode_release_interned(void)
 {
@@ -15715,7 +15714,6 @@ unicode_release_interned(void)
     PyDict_Clear(interned);
     Py_CLEAR(interned);
 }
-#endif
 
 
 /********************* Unicode Iterator **************************/
@@ -16209,18 +16207,7 @@ _PyUnicode_Fini(PyThreadState *tstate)
 
     int is_main_interp = _Py_IsMainInterpreter(tstate);
     if (is_main_interp) {
-#if defined(WITH_VALGRIND) || defined(__INSURE__)
-        /* Insure++ is a memory analysis tool that aids in discovering
-         * memory leaks and other memory problems.  On Python exit, the
-         * interned string dictionaries are flagged as being in use at exit
-         * (which it is).  Under normal circumstances, this is fine because
-         * the memory will be automatically reclaimed by the system.  Under
-         * memory debugging, it's a huge source of useless noise, so we
-         * trade off slower shutdown for less distraction in the memory
-         * reports.  -baw
-         */
         unicode_release_interned();
-#endif /* __INSURE__ */
     }
 
     Py_CLEAR(state->empty);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15657,7 +15657,6 @@ PyUnicode_InternFromString(const char *cp)
 }
 
 
-#if defined(WITH_VALGRIND) || defined(__INSURE__)
 static void
 unicode_release_interned(void)
 {
@@ -15715,7 +15714,6 @@ unicode_release_interned(void)
     PyDict_Clear(interned);
     Py_CLEAR(interned);
 }
-#endif
 
 
 /********************* Unicode Iterator **************************/
@@ -16206,18 +16204,7 @@ void
 _PyUnicode_Fini(PyThreadState *tstate)
 {
     if (_Py_IsMainInterpreter(tstate)) {
-#if defined(WITH_VALGRIND) || defined(__INSURE__)
-        /* Insure++ is a memory analysis tool that aids in discovering
-         * memory leaks and other memory problems.  On Python exit, the
-         * interned string dictionaries are flagged as being in use at exit
-         * (which it is).  Under normal circumstances, this is fine because
-         * the memory will be automatically reclaimed by the system.  Under
-         * memory debugging, it's a huge source of useless noise, so we
-         * trade off slower shutdown for less distraction in the memory
-         * reports.  -baw
-         */
         unicode_release_interned();
-#endif /* __INSURE__ */
 
         Py_CLEAR(unicode_empty);
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1259,14 +1259,14 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     _PyAsyncGen_Fini(tstate);
     _PyContext_Fini(tstate);
 
-    _PyDict_Fini(tstate);
     _PyList_Fini(tstate);
+    _PyUnicode_Fini(tstate);
+    _PyDict_Fini(tstate);
     _PyTuple_Fini(tstate);
 
     _PySlice_Fini(tstate);
 
     _PyBytes_Fini(tstate);
-    _PyUnicode_Fini(tstate);
     _PyFloat_Fini(tstate);
     _PyLong_Fini(tstate);
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1260,13 +1260,13 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     _PyContext_Fini(tstate);
 
     _PyDict_Fini(tstate);
+    _PyList_Fini(tstate);
     _PyTuple_Fini(tstate);
 
     _PySlice_Fini(tstate);
 
     _PyBytes_Fini(tstate);
     _PyUnicode_Fini(tstate);
-    _PyList_Fini(tstate);
     _PyFloat_Fini(tstate);
     _PyLong_Fini(tstate);
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1261,7 +1261,6 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
     if (is_main_interp) {
         _PyDict_Fini();
     }
-    _PyList_Fini(tstate);
     _PyTuple_Fini(tstate);
 
     _PySlice_Fini(tstate);
@@ -1270,6 +1269,7 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
         _PyBytes_Fini();
     }
     _PyUnicode_Fini(tstate);
+    _PyList_Fini(tstate);
     _PyFloat_Fini(tstate);
     _PyLong_Fini(tstate);
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
