### PR TITLE
[3.8] bpo-39699: Remove accidentally commited test change

### DIFF
--- a/Doc/whatsnew/3.0.rst
+++ b/Doc/whatsnew/3.0.rst
@@ -2,8 +2,6 @@
   What's New In Python 3.0
 ****************************
 
-TEST CHANGE TO BE UNDONE
-
 .. XXX Add trademark info for Apple, Microsoft.
 
 :Author: Guido van Rossum


### PR DESCRIPTION
This change was added during the 3.8 backport to verify that the CI still built successfully. Seems like it was forgotten to be reverted before pushing: https://github.com/python/cpython/pull/18670

<!-- issue-number: [bpo-39699](https://bugs.python.org/issue39699) -->
https://bugs.python.org/issue39699
<!-- /issue-number -->
