### PR TITLE
bpo-20684: Remove unused inspect._signature_get_bound_param

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1886,29 +1886,6 @@ def _signature_is_functionlike(obj):
             isinstance(annotations, dict))
 
 
-def _signature_get_bound_param(spec):
-    """ Private helper to get first parameter name from a
-    __text_signature__ of a builtin method, which should
-    be in the following format: '($param1, ...)'.
-    Assumptions are that the first argument won't have
-    a default value or an annotation.
-    """
-
-    assert spec.startswith('($')
-
-    pos = spec.find(',')
-    if pos == -1:
-        pos = spec.find(')')
-
-    cpos = spec.find(':')
-    assert cpos == -1 or cpos > pos
-
-    cpos = spec.find('=')
-    assert cpos == -1 or cpos > pos
-
-    return spec[2:pos]
-
-
 def _signature_strip_non_python_syntax(signature):
     """
     Private helper function. Takes a signature in Argument Clinic's

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3735,13 +3735,6 @@ class TestBoundArguments(unittest.TestCase):
         self.assertIs(type(ba.arguments), dict)
 
 class TestSignaturePrivateHelpers(unittest.TestCase):
-    def test_signature_get_bound_param(self):
-        getter = inspect._signature_get_bound_param
-
-        self.assertEqual(getter('($self)'), 'self')
-        self.assertEqual(getter('($self, obj)'), 'self')
-        self.assertEqual(getter('($cls, /, obj)'), 'cls')
-
     def _strip_non_python_syntax(self, input,
         clean_signature, self_parameter, last_positional_only):
         computed_clean_signature, \

--- a/Misc/NEWS.d/next/Library/2020-07-30-14-37-15.bpo-20684.qV35GU.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-30-14-37-15.bpo-20684.qV35GU.rst
@@ -1,0 +1,2 @@
+Remove unused ``_signature_get_bound_param`` function from :mod:`inspect` -
+by Anthony Sottile.


### PR DESCRIPTION
last referenced in 57d240ef645c4d78432ce722844c150e5ba25fbb

<!-- issue-number: [bpo-20684](https://bugs.python.org/issue20684) -->
https://bugs.python.org/issue20684
<!-- /issue-number -->
