### PR TITLE
bpo-41100: Support macOS 11 when building

### DIFF
--- a/Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst
+++ b/Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst
@@ -1,0 +1,1 @@
+Support macOS 11 when building.

--- a/configure
+++ b/configure
@@ -3387,7 +3387,7 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
   # has no effect, don't bother defining them
   Darwin/[6789].*)
     define_xopen_source=no;;
-  Darwin/1[0-9].*)
+  Darwin/[12][0-9].*)
     define_xopen_source=no;;
   # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
   # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined

--- a/configure.ac
+++ b/configure.ac
@@ -498,7 +498,7 @@ case $ac_sys_system/$ac_sys_release in
   # has no effect, don't bother defining them
   Darwin/@<:@6789@:>@.*)
     define_xopen_source=no;;
-  Darwin/1@<:@0-9@:>@.*)
+  Darwin/@<:@[12]@:>@@<:@0-9@:>@.*)
     define_xopen_source=no;;
   # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
   # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined


### PR DESCRIPTION
The description says it all: This PR is needed to build on macOS 11, because the release of Darwin is now 20.0.0, which doesn't match any of the Darwin cases used to disable _POSIX_C_SOURCE on macOS.

<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
