### PR TITLE
bpo-41101: Support "arm64" in Mac/Tools/pythonw

### DIFF
--- a/Mac/Tools/pythonw.c
+++ b/Mac/Tools/pythonw.c
@@ -119,10 +119,16 @@ setup_spawnattr(posix_spawnattr_t* spawnattr)
 
 #elif defined(__ppc__)
     cpu_types[0] = CPU_TYPE_POWERPC;
+
 #elif defined(__i386__)
     cpu_types[0] = CPU_TYPE_X86;
+
+#elif defined(__arm64__)
+    cpu_types[0] = CPU_TYPE_ARM64;
+
 #else
 #       error "Unknown CPU"
+
 #endif
 
     if (posix_spawnattr_setbinpref_np(spawnattr, count,

--- a/Misc/NEWS.d/next/macOS/2020-06-24-14-21-17.bpo-41101.z9hCsP.rst
+++ b/Misc/NEWS.d/next/macOS/2020-06-24-14-21-17.bpo-41101.z9hCsP.rst
@@ -1,0 +1,2 @@
+Support the new "arm64" architecture for macOS in the pythonw executable in
+framework builds.


### PR DESCRIPTION
Apple introduced a new CPU architecture for macOS at WWDC2020 (marketing name "Apple Silicon"), which is "arm64".

This PR adds support for this new architecture to Mac/Tools/pythonw which is used in framework builds to launch the real python interpreter (hidden in an Python.app inside the framework) using the same architecture as it is currently using.

<!-- issue-number: [bpo-41101](https://bugs.python.org/issue41101) -->
https://bugs.python.org/issue41101
<!-- /issue-number -->
