### PR TITLE
bpo-41090: Add support for building "Universal 2" binaries on macOS 11.

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -481,6 +481,8 @@ def get_platform_osx(_config_vars, osname, release, machine):
 
             if len(archs) == 1:
                 machine = archs[0]
+            elif archs == ('arm64', 'x86_64'):
+                machine = 'universal2'
             elif archs == ('i386', 'ppc'):
                 machine = 'fat'
             elif archs == ('i386', 'x86_64'):

--- a/Mac/README.rst
+++ b/Mac/README.rst
@@ -120,6 +120,8 @@ support ppc (Xcode 4 on 10.6 and later systems).  The flavor can be specified
 using the configure option ``--with-universal-archs=VALUE``. The following
 values are available:
 
+  * ``universal2``: ``arm64``, ``x86_64``
+
   * ``intel``:	  ``i386``, ``x86_64``
 
   * ``intel-32``: ``i386``

--- a/Misc/NEWS.d/next/macOS/2020-06-24-14-48-30.bpo-41090.ZxTgqS.rst
+++ b/Misc/NEWS.d/next/macOS/2020-06-24-14-48-30.bpo-41090.ZxTgqS.rst
@@ -1,0 +1,3 @@
+Support building "Universal 2" binaries on macOS 11 using
+"--with-universal-archs=universal2". This results in binaries that contain
+both x86_64 and arm64 code.

--- a/configure
+++ b/configure
@@ -1509,8 +1509,8 @@ Optional Packages:
                           specify the kind of universal binary that should be
                           created. this option is only valid when
                           --enable-universalsdk is set; options are:
-                          ("32-bit", "64-bit", "3-way", "intel", "intel-32",
-                          "intel-64", or "all") see Mac/README.rst
+                          ("universal2", "32-bit", "64-bit", "3-way", "intel",
+                          "intel-32", "intel-64", or "all") see Mac/README.rst
   --with-framework-name=FRAMEWORK
                           specify the name for the python framework on macOS
                           only valid when --enable-framework is set. see
@@ -7457,6 +7457,11 @@ $as_echo "$CC" >&6; }
         if test "${enable_universalsdk}"
         then
             case "$UNIVERSAL_ARCHS" in
+            universal2)
+               UNIVERSAL_ARCH_FLAGS="-arch arm64 -arch x86_64"
+               LIPO_32BIT_FLAGS=""
+               ARCH_RUN_32BIT="true"
+               ;;
             32-bit)
                UNIVERSAL_ARCH_FLAGS="-arch ppc -arch i386"
                LIPO_32BIT_FLAGS=""
@@ -16806,7 +16811,7 @@ do
 done
 
 
-SRCDIRS="Parser Parser/pegen Objects Python Modules Modules/_io Programs"
+SRCDIRS="Parser Objects Python Modules Modules/_io Programs"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for build directories" >&5
 $as_echo_n "checking for build directories... " >&6; }
 for dir in $SRCDIRS; do

--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AC_ARG_WITH(universal-archs,
     AS_HELP_STRING([--with-universal-archs=ARCH],
                    [specify the kind of universal binary that should be created. this option is
                     only valid when --enable-universalsdk is set; options are:
-                    ("32-bit", "64-bit", "3-way", "intel", "intel-32", "intel-64", or "all")
+                    ("universal2", "32-bit", "64-bit", "3-way", "intel", "intel-32", "intel-64", or "all")
                     see Mac/README.rst]),
 [
 	UNIVERSAL_ARCHS="$withval"
@@ -1864,6 +1864,11 @@ yes)
         if test "${enable_universalsdk}"
         then
             case "$UNIVERSAL_ARCHS" in
+            universal2)
+               UNIVERSAL_ARCH_FLAGS="-arch arm64 -arch x86_64"
+               LIPO_32BIT_FLAGS=""
+               ARCH_RUN_32BIT="true"
+               ;;
             32-bit)
                UNIVERSAL_ARCH_FLAGS="-arch ppc -arch i386"
                LIPO_32BIT_FLAGS=""


### PR DESCRIPTION
Add a new option to "--with-universal-archs": "universal2". This will build binaries supporting the arm64 and x86_64 architectures, in preparation for "Apple Silicon" systems.


<!-- issue-number: [bpo-41090](https://bugs.python.org/issue41090) -->
https://bugs.python.org/issue41090
<!-- /issue-number -->
