### PR TITLE
bpo-35773: Fix test_bdb on non-UTF-8 locales.

### DIFF
--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -726,7 +726,7 @@ class StateTestCase(BaseTestCase):
                 ('line', 2, 'tfunc_import'), ('step', ),
                 ('line', 3, 'tfunc_import'), ('quit', ),
             ]
-            skip = ('importlib*', 'zipimport', TEST_MODULE)
+            skip = ('importlib*', 'zipimport', 'encodings.*', TEST_MODULE)
             with TracerRun(self, skip=skip) as tracer:
                 tracer.runcall(tfunc_import)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-35773](https://bugs.python.org/issue35773) -->
https://bugs.python.org/issue35773
<!-- /issue-number -->
