### PR TITLE
bpo-41112: Fix test_peg_generator on non-UTF-8 locales.

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -365,8 +365,8 @@ class TestCParser(TempdirManager, unittest.TestCase):
         start: expr+ NEWLINE? ENDMARKER
         expr: NAME
         """
-        test_source = """
-        for text in ("a b 42 b a", "名 名 42 名 名"):
+        test_source = r"""
+        for text in ("a b 42 b a", "\u540d \u540d 42 \u540d \u540d"):
             try:
                 parse.parse_string(text, mode=0)
             except SyntaxError as e:


### PR DESCRIPTION


<!-- issue-number: [bpo-41112](https://bugs.python.org/issue41112) -->
https://bugs.python.org/issue41112
<!-- /issue-number -->
