### PR TITLE
bpo-40521: Optimize PyBytes_FromStringAndSize(str, 0)

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -66,13 +66,13 @@ struct _Py_unicode_fs_codec {
 };
 
 struct _Py_bytes_state {
+    PyObject *empty_string;
     PyBytesObject *characters[256];
-    PyBytesObject *empty_string;
 };
 
 struct _Py_unicode_state {
     // The empty Unicode object is a singleton to improve performance.
-    PyObject *empty;
+    PyObject *empty_string;
     /* Single character Unicode strings in the Latin-1 range are being
        shared as well. */
     PyObject *latin1[256];

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -32,6 +32,7 @@ PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 /* Various one-time initializers */
 
 extern PyStatus _PyUnicode_Init(PyThreadState *tstate);
+extern PyStatus _PyBytes_Init(PyThreadState *tstate);
 extern int _PyStructSequence_Init(void);
 extern int _PyLong_Init(PyThreadState *tstate);
 extern PyStatus _PyTuple_Init(PyThreadState *tstate);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -607,6 +607,11 @@ pycore_init_types(PyThreadState *tstate)
         return status;
     }
 
+    status = _PyBytes_Init(tstate);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     status = _PyExc_Init(tstate);
     if (_PyStatus_EXCEPTION(status)) {
         return status;


### PR DESCRIPTION
Always create the empty bytes string singleton.

Optimize PyBytes_FromStringAndSize(str, 0): it no longer has to check
if the empty string singleton was created or not, it is always
available.

Add functions:

* _PyBytes_Init()
* bytes_get_empty(), bytes_new_empty()
* bytes_create_empty_string_singleton()
* unicode_create_empty_string_singleton()
* _Py_unicode_state: rename empty member to empty_string

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
