### PR TITLE
[3.8] bpo-40204: Pin Sphinx version to 2.3.1 in ``Doc/Makefile``. (GH-21141)

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -143,7 +143,7 @@ clean:
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
 	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
-	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==1.8.2 blurb python-docs-theme
+	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb python-docs-theme
 	@echo "The venv has been created in the $(VENVDIR) directory"
 
 dist:

--- a/Misc/NEWS.d/next/Build/2020-06-25-06-59-13.bpo-40204.GpD04D.rst
+++ b/Misc/NEWS.d/next/Build/2020-06-25-06-59-13.bpo-40204.GpD04D.rst
@@ -1,0 +1,1 @@
+Pin Sphinx version to 2.3.1 in ``Doc/Makefile``.


### PR DESCRIPTION


<!-- issue-number: [bpo-40204](https://bugs.python.org/issue40204) -->
https://bugs.python.org/issue40204
<!-- /issue-number -->
