### PR TITLE
bpo-40939: run autoreconf to fix configure{.ac,} disparity

### DIFF
--- a/configure
+++ b/configure
@@ -16806,7 +16806,7 @@ do
 done
 
 
-SRCDIRS="Parser Parser/pegen Objects Python Modules Modules/_io Programs"
+SRCDIRS="Parser Objects Python Modules Modules/_io Programs"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for build directories" >&5
 $as_echo_n "checking for build directories... " >&6; }
 for dir in $SRCDIRS; do


### PR DESCRIPTION


<!-- issue-number: [bpo-40939](https://bugs.python.org/issue40939) -->
https://bugs.python.org/issue40939
<!-- /issue-number -->
