### PR TITLE
bpo-41091: Remove recommendation in curses module documentation to initialize LC_ALL and encode strings

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -27,20 +27,6 @@ Linux and the BSD variants of Unix.
    Whenever the documentation mentions a *character string* it can be specified
    as a Unicode string or a byte string.
 
-.. note::
-
-   Since version 5.4, the ncurses library decides how to interpret non-ASCII data
-   using the ``nl_langinfo`` function.  That means that you have to call
-   :func:`locale.setlocale` in the application and encode Unicode strings
-   using one of the system's available encodings.  This example uses the
-   system's default encoding::
-
-      import locale
-      locale.setlocale(locale.LC_ALL, '')
-      code = locale.getpreferredencoding()
-
-   Then use *code* as the encoding for :meth:`str.encode` calls.
-
 .. seealso::
 
    Module :mod:`curses.ascii`


### PR DESCRIPTION
The recommendation to call `locale.setlocale(locale.LC_ALL, '')` is
problematic as it initializes all locale categories to the user
settings, which might be unintended and is not necessary for curses to
work correctly. Initializing LC_CTYPE is sufficient for nl_langinfo() to
return the correct encoding. Current versions of Python initialize
LC_CTYPE at interpreter startup. Therefore calling locale.setlocale()
should not be necessary at all.

The curses module automatically encodes strings. Therefore the
recommendation to manually encode strings is outdated.

<!-- issue-number: [bpo-41091](https://bugs.python.org/issue41091) -->
https://bugs.python.org/issue41091
<!-- /issue-number -->
