### PR TITLE
bpo-41098: Doc: Add missing deprecated directives

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -637,6 +637,12 @@ The following functions are used to create and modify Unicode exceptions from C.
    *object*, *length*, *start*, *end* and *reason*. *encoding* and *reason* are
    UTF-8 encoded strings.
 
+   .. deprecated:: 3.3
+
+      ``Py_UNICODE`` is deprecated since Python 3.3. This API will be removed
+      in Python 3.11. Please migrate to
+      ``PyObject_CallFunction(PyExc_UnicodeEncodeError, "sOnns", ...)``.
+
 .. c:function:: PyObject* PyUnicodeTranslateError_Create(const Py_UNICODE *object, Py_ssize_t length, Py_ssize_t start, Py_ssize_t end, const char *reason)
 
    Create a :class:`UnicodeTranslateError` object with the attributes *object*,

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -648,6 +648,12 @@ The following functions are used to create and modify Unicode exceptions from C.
    Create a :class:`UnicodeTranslateError` object with the attributes *object*,
    *length*, *start*, *end* and *reason*. *reason* is a UTF-8 encoded string.
 
+   .. deprecated:: 3.3
+
+      ``Py_UNICODE`` is deprecated since Python 3.3. This API will be removed
+      in Python 3.11. Please migrate to
+      ``PyObject_CallFunction(PyExc_UnicodeTranslateError, "Onns", ...)``.
+
 .. c:function:: PyObject* PyUnicodeDecodeError_GetEncoding(PyObject *exc)
                 PyObject* PyUnicodeEncodeError_GetEncoding(PyObject *exc)
 

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -637,10 +637,9 @@ The following functions are used to create and modify Unicode exceptions from C.
    *object*, *length*, *start*, *end* and *reason*. *encoding* and *reason* are
    UTF-8 encoded strings.
 
-   .. deprecated:: 3.3
+   .. deprecated:: 3.3 3.11
 
-      ``Py_UNICODE`` is deprecated since Python 3.3. This API will be removed
-      in Python 3.11. Please migrate to
+      ``Py_UNICODE`` is deprecated since Python 3.3. Please migrate to
       ``PyObject_CallFunction(PyExc_UnicodeEncodeError, "sOnns", ...)``.
 
 .. c:function:: PyObject* PyUnicodeTranslateError_Create(const Py_UNICODE *object, Py_ssize_t length, Py_ssize_t start, Py_ssize_t end, const char *reason)
@@ -648,10 +647,9 @@ The following functions are used to create and modify Unicode exceptions from C.
    Create a :class:`UnicodeTranslateError` object with the attributes *object*,
    *length*, *start*, *end* and *reason*. *reason* is a UTF-8 encoded string.
 
-   .. deprecated:: 3.3
+   .. deprecated:: 3.3 3.11
 
-      ``Py_UNICODE`` is deprecated since Python 3.3. This API will be removed
-      in Python 3.11. Please migrate to
+      ``Py_UNICODE`` is deprecated since Python 3.3. Please migrate to
       ``PyObject_CallFunction(PyExc_UnicodeTranslateError, "Onns", ...)``.
 
 .. c:function:: PyObject* PyUnicodeDecodeError_GetEncoding(PyObject *exc)

--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -145,7 +145,7 @@ PyAPI_FUNC(PyObject *) PyErr_ProgramTextObject(
     PyObject *filename,
     int lineno);
 
-/* Create a UnicodeEncodeError object
+/* Create a UnicodeEncodeError object.
  *
  * TODO: This API will be removed in Python 3.11.
  */
@@ -158,7 +158,10 @@ Py_DEPRECATED(3.3) PyAPI_FUNC(PyObject *) PyUnicodeEncodeError_Create(
     const char *reason          /* UTF-8 encoded string */
     );
 
-/* Create a UnicodeTranslateError object */
+/* Create a UnicodeTranslateError object.
+ *
+ * TODO: This API will be removed in Python 3.11.
+ */
 Py_DEPRECATED(3.3) PyAPI_FUNC(PyObject *) PyUnicodeTranslateError_Create(
     const Py_UNICODE *object,
     Py_ssize_t length,

--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -145,7 +145,10 @@ PyAPI_FUNC(PyObject *) PyErr_ProgramTextObject(
     PyObject *filename,
     int lineno);
 
-/* Create a UnicodeEncodeError object */
+/* Create a UnicodeEncodeError object
+ *
+ * TODO: This API will be removed in Python 3.11.
+ */
 Py_DEPRECATED(3.3) PyAPI_FUNC(PyObject *) PyUnicodeEncodeError_Create(
     const char *encoding,       /* UTF-8 encoded string */
     const Py_UNICODE *object,

--- a/Misc/NEWS.d/next/Documentation/2020-06-26-08-27-34.bpo-41098.u3-eRb.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-06-26-08-27-34.bpo-41098.u3-eRb.rst
@@ -1,1 +1,0 @@
-Added missing ``deprecated`` directive for ``PyUnicodeEncodeError_Create``.

--- a/Misc/NEWS.d/next/Documentation/2020-06-26-08-27-34.bpo-41098.u3-eRb.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-06-26-08-27-34.bpo-41098.u3-eRb.rst
@@ -1,0 +1,1 @@
+Added missing ``deprecated`` directive for ``PyUnicodeEncodeError_Create``.


### PR DESCRIPTION
PyUnicodeEncodeError_Create and PyExc_UnicodeTranslateError has been deprecated with
`Py_DEPRECATED` macro. But it was not documented.

<!-- issue-number: [bpo-41098](https://bugs.python.org/issue41098) -->
https://bugs.python.org/issue41098
<!-- /issue-number -->
