### PR TITLE
bpo-41141: Remove unneeded handling of '.' and '..' from pathlib.Path.iterdir()

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1144,9 +1144,6 @@ class Path(PurePath):
         result for the special paths '.' and '..'.
         """
         for name in self._accessor.listdir(self):
-            if name in {'.', '..'}:
-                # Yielding a path object for these makes little sense
-                continue
             yield self._make_child_relpath(name)
 
     def glob(self, pattern):


### PR DESCRIPTION


<!-- issue-number: [bpo-41141](https://bugs.python.org/issue41141) -->
https://bugs.python.org/issue41141
<!-- /issue-number -->
