### PR TITLE
[3.9] bpo-38870: Extend subject of ast.unparse warnings (GH-21053)

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1553,7 +1553,12 @@ and classes for traversing abstract syntax trees:
 
    .. warning::
       The produced code string will not necessarily be equal to the original
-      code that generated the :class:`ast.AST` object.
+      code that generated the :class:`ast.AST` object (without any compiler
+      optimizations, such as constant tuples/frozensets).
+
+   .. warning::
+      Trying to unparse a highly complex expression would result with
+      :exc:`RecursionError`.
 
    .. versionadded:: 3.9
 


### PR DESCRIPTION
- Mention that some compiler optimizations might not roundtrip
exactly (such as constant tuples and frozensets).

- Add a warning about it might raise RecursionError on very
complex expressions due to recursive unparsing aspect of ast.unparse
(cherry picked from commit 8df1016)

Co-authored-by: Batuhan Taskaya <batuhanosmantaskaya@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
