### PR TITLE
bpo-41123: Remove PyUnicode_GetMax()

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -223,3 +223,6 @@ Removed
    * ``Py_UNICODE_strncmp``: use :c:func:`PyUnicode_Tailmatch`
    * ``Py_UNICODE_strchr``, ``Py_UNICODE_strrchr``: use
      :c:func:`PyUnicode_FindChar`
+
+* Removed ``PyUnicode_GetMax()``. Please migrate to new (:pep:`393`) APIs.
+  (Contributed by Inada Naoki in :issue:`41103`.)

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -593,9 +593,6 @@ Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicodeAndSize(
     Py_ssize_t *size            /* location where to save the length */
     );
 
-/* Get the maximum ordinal for a Unicode character. */
-Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE) PyUnicode_GetMax(void);
-
 
 /* --- _PyUnicodeWriter API ----------------------------------------------- */
 

--- a/Misc/NEWS.d/next/C API/2020-06-28-11-39-22.bpo-41123.sjJWjQ.rst
+++ b/Misc/NEWS.d/next/C API/2020-06-28-11-39-22.bpo-41123.sjJWjQ.rst
@@ -1,0 +1,1 @@
+Removed ``PyUnicode_GetMax()``.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -497,20 +497,6 @@ unicode_check_encoding_errors(const char *encoding, const char *errors)
 }
 
 
-/* The max unicode value is always 0x10FFFF while using the PEP-393 API.
-   This function is kept for backward compatibility with the old API. */
-Py_UNICODE
-PyUnicode_GetMax(void)
-{
-#ifdef Py_UNICODE_WIDE
-    return 0x10FFFF;
-#else
-    /* This is actually an illegal character, so it should
-       not be passed to unichr. */
-    return 0xFFFF;
-#endif
-}
-
 int
 _PyUnicode_CheckConsistency(PyObject *op, int check_content)
 {


### PR DESCRIPTION


<!-- issue-number: [bpo-41123](https://bugs.python.org/issue41123) -->
https://bugs.python.org/issue41123
<!-- /issue-number -->
