### PR TITLE
bpo-41142: Add support of non-ASCII paths for CAB files.

### DIFF
--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -112,6 +112,16 @@ class MsiDatabaseTestCase(unittest.TestCase):
         with self.assertRaises(msilib.MSIError):
             si.GetProperty(-1)
 
+    def test_FCICreate(self):
+        filepath = TESTFN + '.txt'
+        cabpath = TESTFN + '.cab'
+        self.addCleanup(unlink, filepath)
+        with open(filepath, 'wb'):
+            pass
+        self.addCleanup(unlink, cabpath)
+        msilib.FCICreate(cabpath, [(filepath, 'test.txt')])
+        self.assertTrue(os.path.isfile(cabpath))
+
 
 class Test_make_id(unittest.TestCase):
     #http://msdn.microsoft.com/en-us/library/aa369212(v=vs.85).aspx

--- a/Misc/NEWS.d/next/Windows/2020-06-28-12-40-41.bpo-41142.jpZzzh.rst
+++ b/Misc/NEWS.d/next/Windows/2020-06-28-12-40-41.bpo-41142.jpZzzh.rst
@@ -1,0 +1,2 @@
+:mod:`msilib` now supports creating CAB files with non-ASCII file path and
+adding files with non-ASCII file path to them.


### PR DESCRIPTION
* The path to the CAB file can be non-ASCII.
* Paths of added files can be non-ASCII.


<!-- issue-number: [bpo-41142](https://bugs.python.org/issue41142) -->
https://bugs.python.org/issue41142
<!-- /issue-number -->
