### PR TITLE
bpo-41147 Document that redirect_stdout provides the new stream as context var

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -236,8 +236,8 @@ Functions and classes provided:
 
    For example, the output of :func:`help` normally is sent to *sys.stdout*.
    You can capture that output in a string by redirecting the output to an
-   :class:`io.StringIO` object. For convenience, the new stream is returned
-   from the ``__enter__`` method and so is available as the target of the
+   :class:`io.StringIO` object. The replacement stream is returned from the
+   ``__enter__`` method and so is available as the target of the
    :keyword:`with` statement::
 
         with redirect_stdout(io.StringIO()) as f:

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -236,8 +236,9 @@ Functions and classes provided:
 
    For example, the output of :func:`help` normally is sent to *sys.stdout*.
    You can capture that output in a string by redirecting the output to an
-   :class:`io.StringIO` object. For convenience, the new stream is available
-   as the context variable::
+   :class:`io.StringIO` object. For convenience, the new stream is returned
+   from the `__enter__` method and so is available as the target of the
+   :keyword:`with` statementt::
 
         with redirect_stdout(io.StringIO()) as f:
             help(pow)

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -236,7 +236,8 @@ Functions and classes provided:
 
    For example, the output of :func:`help` normally is sent to *sys.stdout*.
    You can capture that output in a string by redirecting the output to an
-   :class:`io.StringIO` object::
+   :class:`io.StringIO` object. For convenience, the new stream is available
+   as the context variable::
 
         with redirect_stdout(io.StringIO()) as f:
             help(pow)

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -238,8 +238,7 @@ Functions and classes provided:
    You can capture that output in a string by redirecting the output to an
    :class:`io.StringIO` object::
 
-        f = io.StringIO()
-        with redirect_stdout(f):
+        with redirect_stdout(io.StringIO()) as f:
             help(pow)
         s = f.getvalue()
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -237,7 +237,7 @@ Functions and classes provided:
    For example, the output of :func:`help` normally is sent to *sys.stdout*.
    You can capture that output in a string by redirecting the output to an
    :class:`io.StringIO` object. For convenience, the new stream is returned
-   from the `__enter__` method and so is available as the target of the
+   from the ``__enter__`` method and so is available as the target of the
    :keyword:`with` statementt::
 
         with redirect_stdout(io.StringIO()) as f:

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -238,7 +238,7 @@ Functions and classes provided:
    You can capture that output in a string by redirecting the output to an
    :class:`io.StringIO` object. For convenience, the new stream is returned
    from the ``__enter__`` method and so is available as the target of the
-   :keyword:`with` statementt::
+   :keyword:`with` statement::
 
         with redirect_stdout(io.StringIO()) as f:
             help(pow)


### PR DESCRIPTION
In `contextlib`, `_RedirectStream` (the class behind `redirect_stdout` and `redirect_stderr`) returns the current stream target as its context variable, which allows code like this:

``` python
with redirect_stdout(io.StringIO()) as buffer:
    do_stuff()

use(buffer.getvalue())
```

where you capture the redirected stream without a separate line to declare the variable.

This PR intends to document this functionality.

<!-- issue-number: [bpo-41147](https://bugs.python.org/issue41147) -->
https://bugs.python.org/issue41147
<!-- /issue-number -->

See also https://github.com/python/typeshed/issues/4283