### PR TITLE
bpo-41160: Support cross-compiling for GNU/Hurd.

### DIFF
--- a/configure
+++ b/configure
@@ -3303,6 +3303,9 @@ then
 	*-*-cygwin*)
 		ac_sys_system=Cygwin
 		;;
+	*-*-gnu)
+		ac_sys_system=GNU
+		;;
 	*-*-vxworks*)
 	    ac_sys_system=VxWorks
 	    ;;

--- a/configure.ac
+++ b/configure.ac
@@ -391,6 +391,9 @@ then
 	*-*-cygwin*)
 		ac_sys_system=Cygwin
 		;;
+	*-*-gnu)
+		ac_sys_system=GNU
+		;;
 	*-*-vxworks*)
 	    ac_sys_system=VxWorks
 	    ;;


### PR DESCRIPTION
Hello!

This is a trivial fix for https://bugs.python.org/issue41160.

<!-- issue-number: [bpo-41160](https://bugs.python.org/issue41160) -->
https://bugs.python.org/issue41160
<!-- /issue-number -->
