### PR TITLE
bpo-41100:  allow python to build for macosx-11.0-arm64

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-30-00-02-42.bpo-41164.zbzWsP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-30-00-02-42.bpo-41164.zbzWsP.rst
@@ -1,0 +1,1 @@
+Allow python to build for macosx-11.0-arm64

--- a/configure
+++ b/configure
@@ -9333,6 +9333,9 @@ fi
     	ppc)
     		MACOSX_DEFAULT_ARCH="ppc64"
     		;;
+      arm64)
+    		MACOSX_DEFAULT_ARCH="arm64"
+    		;;
     	*)
     		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
     		;;

--- a/configure.ac
+++ b/configure.ac
@@ -2478,6 +2478,9 @@ case $ac_sys_system/$ac_sys_release in
     	ppc)
     		MACOSX_DEFAULT_ARCH="ppc64"
     		;;
+      arm64)
+    		MACOSX_DEFAULT_ARCH="arm64"
+    		;;
     	*)
     		AC_MSG_ERROR([Unexpected output of 'arch' on OSX])
     		;;


### PR DESCRIPTION
allow python to build for macosx-11.0-arm64, by adding the appropriate case to configure.ac

<!-- issue-number: [bpo-41164](https://bugs.python.org/issue41164) -->
https://bugs.python.org/issue41164
<!-- /issue-number -->
