### PR TITLE
[3.9] bpo-41123: Remove PyUnicode_AsUnicodeCopy in 3.10

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -705,6 +705,8 @@ Extension modules can continue using them, as they will not be removed in Python
    :c:func:`PyUnicode_AsWideChar`, :c:func:`PyUnicode_ReadChar` or similar new
    APIs.
 
+   .. deprecated-removed:: 3.3 3.10
+
 
 .. c:function:: PyObject* PyUnicode_TransformDecimalToASCII(Py_UNICODE *s, Py_ssize_t size)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-41123](https://bugs.python.org/issue41123) -->
https://bugs.python.org/issue41123
<!-- /issue-number -->
