### PR TITLE
[3.7] bpo-41048: mimetypes should read the rule file using UTF-8, not the locale encoding (GH-20998).

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -372,7 +372,7 @@ def init(files=None):
 
 def read_mime_types(file):
     try:
-        f = open(file)
+        f = open(file, encoding='utf-8')
     except OSError:
         return None
     with f:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1627,6 +1627,7 @@ Mikhail Terekhov
 Victor Terrón
 Pablo Galindo
 Richard M. Tew
+Srinivas Reddy Thatiparthy
 Tobias Thelen
 Christian Theune
 Févry Thibault

--- a/Misc/NEWS.d/next/Library/2020-06-20-10-16-57.bpo-41048.hEXB-B.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-20-10-16-57.bpo-41048.hEXB-B.rst
@@ -1,0 +1,2 @@
+:func:`mimetypes.read_mime_types` function reads the rule file using UTF-8 encoding, not the locale encoding.
+Patch by Srinivas Reddy Thatiparthy.


### PR DESCRIPTION


(cherry picked from commit 7f569c9bc0079906012b3034d30fe8abc742e7fc)

Co-authored-by: Srinivas Reddy Thatiparthy (శ్రీనివాస్  రెడ్డి తాటిపర్తి) <thatiparthysreenivas@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41048](https://bugs.python.org/issue41048) -->
https://bugs.python.org/issue41048
<!-- /issue-number -->
