### PR TITLE
bpo-41170: Use strnlen instead of strlen when the size i known.

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3835,7 +3835,7 @@ static PyObject*
 unicode_decode_locale(const char *str, Py_ssize_t len,
                       _Py_error_handler errors, int current_locale)
 {
-    if (str[len] != '\0' || (size_t)len != strlen(str))  {
+    if ((size_t)len != strnlen(str, len+1))  {
         PyErr_SetString(PyExc_ValueError, "embedded null byte");
         return NULL;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Use strnlen when the length is known

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
# Use strnlen instead of strlen when the size i known: 

Functions as `unicode_decode_locale` ~and `_PyUnicodeWriter_WriteASCIIString`~ takes a `char*` and a size, yet `strlen` is used.
This PR changes `strlen` to `strnlen` so no buffer overruns are made when there's no null terminator. 

<!-- issue-number: [bpo-41170](https://bugs.python.org/issue41170) -->
https://bugs.python.org/issue41170
<!-- /issue-number -->
