### PR TITLE
bpo-41175: Guard against a possible NULL pointer dereference within bytearrayobject

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-30-20-17-31.bpo-41175.acJoXB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-30-20-17-31.bpo-41175.acJoXB.rst
@@ -1,0 +1,2 @@
+Guard against a NULL pointer dereference within bytearrayobject triggered by
+the ``bytearray() + bytearray()`` operation.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -266,7 +266,9 @@ PyByteArray_Concat(PyObject *a, PyObject *b)
 
     result = (PyByteArrayObject *) \
         PyByteArray_FromStringAndSize(NULL, va.len + vb.len);
-    if (result != NULL) {
+    // result->ob_bytes is NULL if result is an empty string:
+    // if va.len + vb.len equals zero.
+    if (result != NULL && result->ob_bytes != NULL) {
         memcpy(result->ob_bytes, va.buf, va.len);
         memcpy(result->ob_bytes + va.len, vb.buf, vb.len);
     }


### PR DESCRIPTION
Detected by GCC 10 static analysis tool



<!-- issue-number: [bpo-41175](https://bugs.python.org/issue41175) -->
https://bugs.python.org/issue41175
<!-- /issue-number -->
