### PR TITLE
bpo-38782: Use typing.Protocol in the importlib.abc module

### DIFF
--- a/Lib/importlib/_abc.py
+++ b/Lib/importlib/_abc.py
@@ -1,9 +1,10 @@
 """Subset of importlib.abc used to reduce importlib.util imports."""
 from . import _bootstrap
-import abc
+from typing import Protocol, runtime_checkable
 
 
-class Loader(metaclass=abc.ABCMeta):
+@runtime_checkable
+class Loader(Protocol):
 
     """Abstract base class for import loaders."""
 

--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -29,7 +29,8 @@ def _register(abstract_cls, *classes):
             abstract_cls.register(frozen_cls)
 
 
-class Finder(metaclass=abc.ABCMeta):
+@runtime_checkable
+class Finder(Protocol):
 
     """Legacy abstract base class for import finders.
 
@@ -297,7 +298,8 @@ class SourceLoader(_bootstrap_external.SourceLoader, ResourceLoader, ExecutionLo
 _register(SourceLoader, machinery.SourceFileLoader)
 
 
-class ResourceReader(metaclass=abc.ABCMeta):
+@runtime_checkable
+class ResourceReader(Protocol):
 
     """Abstract base class to provide resource-reading support.
 

--- a/Misc/NEWS.d/next/Library/2020-06-30-14-55-59.bpo-38782.pbxiZV.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-30-14-55-59.bpo-38782.pbxiZV.rst
@@ -1,0 +1,1 @@
+Use :class:`typing.Protocol` in the :mod:`importlib.abc` module.


### PR DESCRIPTION


<!-- issue-number: [bpo-38782](https://bugs.python.org/issue38782) -->
https://bugs.python.org/issue38782
<!-- /issue-number -->
