### PR TITLE
bpo-41100: add support for "universal2" ie arm64,x86_64 universal build

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -491,6 +491,8 @@ def get_platform_osx(_config_vars, osname, release, machine):
                 machine = 'fat64'
             elif archs == ('i386', 'ppc', 'ppc64', 'x86_64'):
                 machine = 'universal'
+            elif archs == ('arm64', 'x86_64'):
+                machine = 'universal2'
             else:
                 raise ValueError(
                    "Don't know machine value for archs=%r" % (archs,))

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-30-22-52-21.bpo-41100.54fd3u.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-30-22-52-21.bpo-41100.54fd3u.rst
@@ -1,0 +1,1 @@
+Mac OS 11: add support for "universal2" ie arm64,x86_64 universal build

--- a/configure
+++ b/configure
@@ -7492,6 +7492,11 @@ $as_echo "$CC" >&6; }
                LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
                ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
                ;;
+            universal2)
+               UNIVERSAL_ARCH_FLAGS="-arch arm64 -arch x86_64"
+               LIPO_32BIT_FLAGS=""
+               ARCH_RUN_32BIT="true"
+               ;;
             *)
                as_fn_error $? "proper usage is --with-universal-arch=32-bit|64-bit|all|intel|3-way" "$LINENO" 5
                ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1899,6 +1899,11 @@ yes)
                LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
                ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
                ;;
+            universal2)
+               UNIVERSAL_ARCH_FLAGS="-arch arm64 -arch x86_64"
+               LIPO_32BIT_FLAGS=""
+               ARCH_RUN_32BIT="true"
+               ;;
             *)
                AC_MSG_ERROR([proper usage is --with-universal-arch=32-bit|64-bit|all|intel|3-way])
                ;;


### PR DESCRIPTION
Mac OS 11: add support for "universal2" ie arm64,x86_64 universal build.

<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
