### PR TITLE
Adding "stale" GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,4 +16,4 @@ jobs:
         stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
         stale-pr-label: 'stale'
         days-before-stale: 30
-        days-before-close: 5
+        days-before-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3.0.7
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/stale@v3.0.7
       with:
-        repo-token: ${{ secrets.BEDEVERE_GH_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
         stale-pr-label: 'stale-pr'
         days-before-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Mark stale pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3.0.7
+      with:
+        repo-token: ${{ secrets.BEDEVERE_GH_TOKEN }}
+        stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        stale-pr-label: 'stale-pr'
+        days-before-stale: 30
+        days-before-close: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,6 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
-        stale-pr-label: 'stale-pr'
+        stale-pr-label: 'stale'
         days-before-stale: 30
         days-before-close: 5


### PR DESCRIPTION
Added the "stale" GitHub action to the CPython repo.
PR's older than 30 days will be labeld as stale using the "stale-pr" label.
If needed, it can be configured to more than 30 days.

I've added bedevere-bot's GitHub token to the repo's secret settings as ``BEDEVERE_GH_TOKEN``

https://github.com/actions/stale

Closes https://github.com/python/core-workflow/issues/372


