### PR TITLE
bpo-41181: macOS build script uses LTO and PGO

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1122,6 +1122,7 @@ def buildPython():
 
     print("Running configure...")
     runCommand("%s -C --enable-framework --enable-universalsdk=/ "
+               "--with-lto --enable-optimizations "
                "--with-universal-archs=%s "
                "%s "
                "%s "

--- a/Misc/NEWS.d/next/macOS/2020-07-01-12-38-44.bpo-41181.uYIwxp.rst
+++ b/Misc/NEWS.d/next/macOS/2020-07-01-12-38-44.bpo-41181.uYIwxp.rst
@@ -1,0 +1,2 @@
+The script to build the macOS installer now configures Python with Link Time
+Optimization (LTO) and Profile-Guided Optimizatio (PGO).


### PR DESCRIPTION
The script to build the macOS installer now configures Python with
Link Time Optimization (LTO) and Profile-Guided Optimizatio (PGO).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41181](https://bugs.python.org/issue41181) -->
https://bugs.python.org/issue41181
<!-- /issue-number -->
