### PR TITLE
bpo-41182 selector: use DefaultSelector based upon implementation

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-07-01-17-33-50.bpo-41182.FPFI0N.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-01-17-33-50.bpo-41182.FPFI0N.rst
@@ -1,0 +1,1 @@
+selector: use DefaultSelector based upon implementation


### PR DESCRIPTION
On some platform such as VMware ESXi, DefaultSelector fails
to detect selector due to default value.
This fix adds a check and uses the correct selector depending upon
select implementation and actual call.

Fixes: [bpo-41182](https://bugs.python.org/issue41182)

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41182](https://bugs.python.org/issue41182) -->
https://bugs.python.org/issue41182
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum