### PR TITLE
bpo-40521: Cleanup finalize_interp_types()

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1257,7 +1257,7 @@ flush_std_files(void)
 
 
 static void
-finalize_interp_types(PyThreadState *tstate, int is_main_interp)
+finalize_interp_types(PyThreadState *tstate)
 {
     _PyExc_Fini(tstate);
     _PyFrame_Fini(tstate);
@@ -1300,7 +1300,7 @@ finalize_interp_clear(PyThreadState *tstate)
 
     _PyWarnings_Fini(tstate->interp);
 
-    finalize_interp_types(tstate, is_main_interp);
+    finalize_interp_types(tstate);
 }
 
 


### PR DESCRIPTION
Remove the now unused is_main_interp parameter of
finalize_interp_types().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
