### PR TITLE
bpo-41100:  test fixes for Mac OS 11

### DIFF
--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -492,7 +492,7 @@ class BuildExtTestCase(TempdirManager,
         # format the target value as defined in the Apple
         # Availability Macros.  We can't use the macro names since
         # at least one value we test with will not exist yet.
-        if target[1] < 10:
+        if target < (10,10):
             # for 10.1 through 10.9.x -> "10n0"
             target = '%02d%01d0' % target
         else:

--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -492,7 +492,7 @@ class BuildExtTestCase(TempdirManager,
         # format the target value as defined in the Apple
         # Availability Macros.  We can't use the macro names since
         # at least one value we test with will not exist yet.
-        if target < (10,10):
+        if target < (10, 10):
             # for 10.1 through 10.9.x -> "10n0"
             target = '%02d%01d0' % target
         else:

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -246,7 +246,7 @@ class PlatformTest(unittest.TestCase):
             self.assertEqual(res[1], ('', '', ''))
 
             if sys.byteorder == 'little':
-                self.assertIn(res[2], ('i386', 'x86_64'))
+                self.assertIn(res[2], ('i386', 'x86_64', 'arm64'))
             else:
                 self.assertEqual(res[2], 'PowerPC')
 

--- a/Misc/NEWS.d/next/Tests/2020-07-01-17-40-32.bpo-41100.lGf8DF.rst
+++ b/Misc/NEWS.d/next/Tests/2020-07-01-17-40-32.bpo-41100.lGf8DF.rst
@@ -1,0 +1,1 @@
+test fixes for Mac OS 11


### PR DESCRIPTION
test_platform: add arm64 to list of expected arches on Mac OS

test_distutils: don't assume Mac OS major version is always 10


<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
