### PR TITLE
bpo-41100: pythonw: add arm64 support

### DIFF
--- a/Mac/Tools/pythonw.c
+++ b/Mac/Tools/pythonw.c
@@ -121,6 +121,8 @@ setup_spawnattr(posix_spawnattr_t* spawnattr)
     cpu_types[0] = CPU_TYPE_POWERPC;
 #elif defined(__i386__)
     cpu_types[0] = CPU_TYPE_X86;
+#elif defined(__arm64__)
+    cpu_types[0] = CPU_TYPE_ARM64;
 #else
 #       error "Unknown CPU"
 #endif

--- a/Misc/NEWS.d/next/macOS/2020-07-01-19-03-26.bpo-41100.nrC7wk.rst
+++ b/Misc/NEWS.d/next/macOS/2020-07-01-19-03-26.bpo-41100.nrC7wk.rst
@@ -1,0 +1,1 @@
+pythonw: add arm64 support


### PR DESCRIPTION
add an #ifdef case for arm64 in pythonw.c

<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
