### PR TITLE
bpo-41165: Remove PyEval_AcquireLock and PyEval_ReleaseLock

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1221,39 +1221,6 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    available (even when threads have not been initialized).
 
 
-.. c:function:: void PyEval_AcquireLock()
-
-   Acquire the global interpreter lock.  The lock must have been created earlier.
-   If this thread already has the lock, a deadlock ensues.
-
-   .. deprecated:: 3.2
-      This function does not update the current thread state.  Please use
-      :c:func:`PyEval_RestoreThread` or :c:func:`PyEval_AcquireThread`
-      instead.
-
-   .. note::
-      Calling this function from a thread when the runtime is finalizing
-      will terminate the thread, even if the thread was not created by Python.
-      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
-      check if the interpreter is in process of being finalized before calling
-      this function to avoid unwanted termination.
-
-   .. versionchanged:: 3.8
-      Updated to be consistent with :c:func:`PyEval_RestoreThread`,
-      :c:func:`Py_END_ALLOW_THREADS`, and :c:func:`PyGILState_Ensure`,
-      and terminate the current thread if called while the interpreter is finalizing.
-
-
-.. c:function:: void PyEval_ReleaseLock()
-
-   Release the global interpreter lock.  The lock must have been created earlier.
-
-   .. deprecated:: 3.2
-      This function does not update the current thread state.  Please use
-      :c:func:`PyEval_SaveThread` or :c:func:`PyEval_ReleaseThread`
-      instead.
-
-
 .. _sub-interpreter-support:
 
 Sub-interpreter support

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -761,8 +761,6 @@ PyErr_WarnFormat::...::
 PyErr_WriteUnraisable:void:::
 PyErr_WriteUnraisable:PyObject*:obj:0:
 
-PyEval_AcquireLock:void:::
-
 PyEval_AcquireThread:void:::
 PyEval_AcquireThread:PyThreadState*:tstate::
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -249,3 +249,7 @@ Removed
 * Removed ``PyUnicode_AsUnicodeCopy()``. Please use :c:func:`PyUnicode_AsUCS4Copy` or
   :c:func:`PyUnicode_AsWideCharString`
   (Contributed by Inada Naoki in :issue:`41103`.)
+
+* Removed ``PyEval_AcquireLock()`` and ``PyEval_ReleaseLock()`` from header file.
+  They are still exported by library since they are part of stable ABI.
+  (Contributed by Inada Naoki in :issue:`41165`.)

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -128,8 +128,6 @@ PyAPI_FUNC(void) PyEval_RestoreThread(PyThreadState *);
 
 Py_DEPRECATED(3.9) PyAPI_FUNC(int) PyEval_ThreadsInitialized(void);
 Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
-Py_DEPRECATED(3.2) PyAPI_FUNC(void) PyEval_AcquireLock(void);
-/* Py_DEPRECATED(3.2) */ PyAPI_FUNC(void) PyEval_ReleaseLock(void);
 PyAPI_FUNC(void) PyEval_AcquireThread(PyThreadState *tstate);
 PyAPI_FUNC(void) PyEval_ReleaseThread(PyThreadState *tstate);
 

--- a/Misc/NEWS.d/next/C API/2020-07-02-13-31-33.bpo-41165.3b0k7_.rst
+++ b/Misc/NEWS.d/next/C API/2020-07-02-13-31-33.bpo-41165.3b0k7_.rst
@@ -1,0 +1,2 @@
+Remove ``PyEval_AcquireLock`` and ``PyEval_ReleaseLock`` from header file.
+Since they are part of stable ABI, they are still exported.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -368,7 +368,8 @@ _PyEval_Fini(void)
 #endif
 }
 
-void
+/* This function is a part of stable ABI. We can not remove this until 4.0 */
+Py_DEPRECATED(3.2) PyAPI_FUNC(void)
 PyEval_AcquireLock(void)
 {
     _PyRuntimeState *runtime = &_PyRuntime;
@@ -378,7 +379,8 @@ PyEval_AcquireLock(void)
     take_gil(tstate);
 }
 
-void
+/* This function is a part of stable ABI. We can not remove this until 4.0 */
+Py_DEPRECATED(3.2) PyAPI_FUNC(void)
 PyEval_ReleaseLock(void)
 {
     _PyRuntimeState *runtime = &_PyRuntime;


### PR DESCRIPTION
They are removed from only header file. Implementations will be removed
in Python 4.0.

<!-- issue-number: [bpo-41165](https://bugs.python.org/issue41165) -->
https://bugs.python.org/issue41165
<!-- /issue-number -->
