### PR TITLE
bpo-41165: unittest: Remove assertion aliases

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1598,15 +1598,15 @@ Test cases
 
 .. _deprecated-aliases:
 
-Deprecated aliases
+Removed aliases
 ##################
 
 For historical reasons, some of the :class:`TestCase` methods had one or more
-aliases that are now deprecated.  The following table lists the correct names
+aliases that are now removed.  The following table lists the correct names
 along with their deprecated aliases:
 
    ==============================  ====================== =======================
-    Method Name                     Deprecated alias       Deprecated alias
+    Method Name                     Removed alias          Removed alias
    ==============================  ====================== =======================
     :meth:`.assertEqual`            failUnlessEqual        assertEquals
     :meth:`.assertNotEqual`         failIfEqual            assertNotEquals
@@ -1620,15 +1620,9 @@ along with their deprecated aliases:
     :meth:`.assertRaisesRegex`                             assertRaisesRegexp
    ==============================  ====================== =======================
 
-   .. deprecated:: 3.1
-         The fail* aliases listed in the second column have been deprecated.
-   .. deprecated:: 3.2
-         The assert* aliases listed in the third column have been deprecated.
-   .. deprecated:: 3.2
-         ``assertRegexpMatches`` and ``assertRaisesRegexp`` have been renamed to
-         :meth:`.assertRegex` and :meth:`.assertRaisesRegex`.
-   .. deprecated:: 3.5
-         The ``assertNotRegexpMatches`` name is deprecated in favor of :meth:`.assertNotRegex`.
+   .. versionchanged:: 3.10
+      Many deprecated aliases are removed.
+
 
 .. _testsuite-objects:
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -134,6 +134,9 @@ Deprecated
 Removed
 =======
 
+* Many assertion method aliases in :class:`unittest.TestCase` are removed.
+  (Contributed by Inada Naoki in :issue:`41165`.)
+
 
 Porting to Python 3.10
 ======================

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1137,35 +1137,6 @@ class TestCase(object):
             standardMsg = self._truncateMessage(standardMsg, diff)
             self.fail(self._formatMessage(msg, standardMsg))
 
-    def assertDictContainsSubset(self, subset, dictionary, msg=None):
-        """Checks whether dictionary is a superset of subset."""
-        warnings.warn('assertDictContainsSubset is deprecated',
-                      DeprecationWarning)
-        missing = []
-        mismatched = []
-        for key, value in subset.items():
-            if key not in dictionary:
-                missing.append(key)
-            elif value != dictionary[key]:
-                mismatched.append('%s, expected: %s, actual: %s' %
-                                  (safe_repr(key), safe_repr(value),
-                                   safe_repr(dictionary[key])))
-
-        if not (missing or mismatched):
-            return
-
-        standardMsg = ''
-        if missing:
-            standardMsg = 'Missing: %s' % ','.join(safe_repr(m) for m in
-                                                    missing)
-        if mismatched:
-            if standardMsg:
-                standardMsg += '; '
-            standardMsg += 'Mismatched values: %s' % ','.join(mismatched)
-
-        self.fail(self._formatMessage(msg, standardMsg))
-
-
     def assertCountEqual(self, first, second, msg=None):
         """Asserts that two iterables have the same elements, the same number of
         times, without regard to order.
@@ -1327,28 +1298,6 @@ class TestCase(object):
             # _formatMessage ensures the longMessage option is respected
             msg = self._formatMessage(msg, standardMsg)
             raise self.failureException(msg)
-
-
-    def _deprecate(original_func):
-        def deprecated_func(*args, **kwargs):
-            warnings.warn(
-                'Please use {0} instead.'.format(original_func.__name__),
-                DeprecationWarning, 2)
-            return original_func(*args, **kwargs)
-        return deprecated_func
-
-    # see #9424
-    failUnlessEqual = assertEquals = _deprecate(assertEqual)
-    failIfEqual = assertNotEquals = _deprecate(assertNotEqual)
-    failUnlessAlmostEqual = assertAlmostEquals = _deprecate(assertAlmostEqual)
-    failIfAlmostEqual = assertNotAlmostEquals = _deprecate(assertNotAlmostEqual)
-    failUnless = assert_ = _deprecate(assertTrue)
-    failUnlessRaises = _deprecate(assertRaises)
-    failIf = _deprecate(assertFalse)
-    assertRaisesRegexp = _deprecate(assertRaisesRegex)
-    assertRegexpMatches = _deprecate(assertRegex)
-    assertNotRegexpMatches = _deprecate(assertNotRegex)
-
 
 
 class FunctionTestCase(TestCase):

--- a/Lib/unittest/test/_test_warnings.py
+++ b/Lib/unittest/test/_test_warnings.py
@@ -18,17 +18,6 @@ def warnfun():
     warnings.warn('rw', RuntimeWarning)
 
 class TestWarnings(unittest.TestCase):
-    # unittest warnings will be printed at most once per type (max one message
-    # for the fail* methods, and one for the assert* methods)
-    def test_assert(self):
-        self.assertEquals(2+2, 4)
-        self.assertEquals(2*2, 4)
-        self.assertEquals(2**2, 4)
-
-    def test_fail(self):
-        self.failUnless(1)
-        self.failUnless(True)
-
     def test_other_unittest(self):
         self.assertAlmostEqual(2+2, 4)
         self.assertNotAlmostEqual(4+4, 2)

--- a/Lib/unittest/test/test_assertions.py
+++ b/Lib/unittest/test/test_assertions.py
@@ -268,15 +268,6 @@ class TestLongMessage(unittest.TestCase):
                              r"\+ \{'key': 'value'\}$",
                              r"\+ \{'key': 'value'\} : oops$"])
 
-    def testAssertDictContainsSubset(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-
-            self.assertMessages('assertDictContainsSubset', ({'key': 'value'}, {}),
-                                ["^Missing: 'key'$", "^oops$",
-                                 "^Missing: 'key'$",
-                                 "^Missing: 'key' : oops$"])
-
     def testAssertMultiLineEqual(self):
         self.assertMessages('assertMultiLineEqual', ("", "foo"),
                             [r"\+ foo$", "^oops$",

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -676,36 +676,6 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertRaises(self.failureException, self.assertNotIn, 'cow',
                           animals)
 
-    def testAssertDictContainsSubset(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-
-            self.assertDictContainsSubset({}, {})
-            self.assertDictContainsSubset({}, {'a': 1})
-            self.assertDictContainsSubset({'a': 1}, {'a': 1})
-            self.assertDictContainsSubset({'a': 1}, {'a': 1, 'b': 2})
-            self.assertDictContainsSubset({'a': 1, 'b': 2}, {'a': 1, 'b': 2})
-
-            with self.assertRaises(self.failureException):
-                self.assertDictContainsSubset({1: "one"}, {})
-
-            with self.assertRaises(self.failureException):
-                self.assertDictContainsSubset({'a': 2}, {'a': 1})
-
-            with self.assertRaises(self.failureException):
-                self.assertDictContainsSubset({'c': 1}, {'a': 1})
-
-            with self.assertRaises(self.failureException):
-                self.assertDictContainsSubset({'a': 1, 'c': 1}, {'a': 1})
-
-            with self.assertRaises(self.failureException):
-                self.assertDictContainsSubset({'a': 1, 'c': 1}, {'a': 1})
-
-            one = ''.join(chr(i) for i in range(255))
-            # this used to cause a UnicodeDecodeError constructing the failure msg
-            with self.assertRaises(self.failureException):
-                self.assertDictContainsSubset({'foo': one}, {'foo': '\uFFFD'})
-
     def testAssertEqual(self):
         equal_pairs = [
                 ((), ()),
@@ -1755,46 +1725,6 @@ test case
         with self.assertNoLogs() as value:
             pass
         self.assertIsNone(value)
-
-    def testDeprecatedMethodNames(self):
-        """
-        Test that the deprecated methods raise a DeprecationWarning. See #9424.
-        """
-        old = (
-            (self.failIfEqual, (3, 5)),
-            (self.assertNotEquals, (3, 5)),
-            (self.failUnlessEqual, (3, 3)),
-            (self.assertEquals, (3, 3)),
-            (self.failUnlessAlmostEqual, (2.0, 2.0)),
-            (self.assertAlmostEquals, (2.0, 2.0)),
-            (self.failIfAlmostEqual, (3.0, 5.0)),
-            (self.assertNotAlmostEquals, (3.0, 5.0)),
-            (self.failUnless, (True,)),
-            (self.assert_, (True,)),
-            (self.failUnlessRaises, (TypeError, lambda _: 3.14 + 'spam')),
-            (self.failIf, (False,)),
-            (self.assertDictContainsSubset, (dict(a=1, b=2), dict(a=1, b=2, c=3))),
-            (self.assertRaisesRegexp, (KeyError, 'foo', lambda: {}['foo'])),
-            (self.assertRegexpMatches, ('bar', 'bar')),
-        )
-        for meth, args in old:
-            with self.assertWarns(DeprecationWarning):
-                meth(*args)
-
-    # disable this test for now. When the version where the fail* methods will
-    # be removed is decided, re-enable it and update the version
-    def _testDeprecatedFailMethods(self):
-        """Test that the deprecated fail* methods get removed in 3.x"""
-        if sys.version_info[:2] < (3, 3):
-            return
-        deprecated_names = [
-            'failIfEqual', 'failUnlessEqual', 'failUnlessAlmostEqual',
-            'failIfAlmostEqual', 'failUnless', 'failUnlessRaises', 'failIf',
-            'assertDictContainsSubset',
-        ]
-        for deprecated_name in deprecated_names:
-            with self.assertRaises(AttributeError):
-                getattr(self, deprecated_name)  # remove these in 3.x
 
     def testDeepcopy(self):
         # Issue: 5660

--- a/Lib/unittest/test/test_runner.py
+++ b/Lib/unittest/test/test_runner.py
@@ -945,8 +945,6 @@ class Test_TextTestRunner(unittest.TestCase):
             return [b.splitlines() for b in p.communicate()]
         opts = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                     cwd=os.path.dirname(__file__))
-        ae_msg = b'Please use assertEqual instead.'
-        at_msg = b'Please use assertTrue instead.'
 
         # no args -> all the warnings are printed, unittest warnings only once
         p = subprocess.Popen([sys.executable, '-E', '_test_warnings.py'], **opts)
@@ -954,11 +952,11 @@ class Test_TextTestRunner(unittest.TestCase):
             out, err = get_parse_out_err(p)
         self.assertIn(b'OK', err)
         # check that the total number of warnings in the output is correct
-        self.assertEqual(len(out), 12)
+        self.assertEqual(len(out), 10)
         # check that the numbers of the different kind of warnings is correct
         for msg in [b'dw', b'iw', b'uw']:
             self.assertEqual(out.count(msg), 3)
-        for msg in [ae_msg, at_msg, b'rw']:
+        for msg in [b'rw']:
             self.assertEqual(out.count(msg), 1)
 
         args_list = (
@@ -985,11 +983,9 @@ class Test_TextTestRunner(unittest.TestCase):
         with p:
             out, err = get_parse_out_err(p)
         self.assertIn(b'OK', err)
-        self.assertEqual(len(out), 14)
+        self.assertEqual(len(out), 12)
         for msg in [b'dw', b'iw', b'uw', b'rw']:
             self.assertEqual(out.count(msg), 3)
-        for msg in [ae_msg, at_msg]:
-            self.assertEqual(out.count(msg), 1)
 
     def testStdErrLookedUpAtInstantiationTime(self):
         # see issue 10786

--- a/Misc/NEWS.d/next/Library/2020-07-02-15-19-46.bpo-41165.M81FBj.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-02-15-19-46.bpo-41165.M81FBj.rst
@@ -1,0 +1,1 @@
+Remove deprecated aliases of assertion methods in ``unittest.TestCase``.


### PR DESCRIPTION


<!-- issue-number: [bpo-41165](https://bugs.python.org/issue41165) -->
https://bugs.python.org/issue41165
<!-- /issue-number -->
