### PR TITLE
bpo-41193: Ignore OSError in readline write_history()

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -462,9 +462,9 @@ def enablerlcompleter():
             def write_history():
                 try:
                     readline.write_history_file(history)
-                except (FileNotFoundError, PermissionError):
-                    # home directory does not exist or is not writable
-                    # https://bugs.python.org/issue19891
+                except OSError:
+                    # bpo-19891, bpo-41193: Home directory does not exist
+                    # or is not writable, or the filesystem is read-only.
                     pass
 
             atexit.register(write_history)

--- a/Misc/NEWS.d/next/Library/2020-07-02-11-53-45.bpo-41193.8-Tnql.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-02-11-53-45.bpo-41193.8-Tnql.rst
@@ -1,0 +1,4 @@
+The ``write_history()`` atexit function of the readline completer now
+ignores any :exc:`OSError` to ignore error if the filesystem is read-only,
+instead of only ignoring :exc:`FileNotFoundError` and
+:exc:`PermissionError`.


### PR DESCRIPTION
The write_history() atexit function of the readline completer now
ignores any OSError to ignore error if the filesystem is read-only,
instead of only ignoring FileNotFoundError and PermissionError.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41193](https://bugs.python.org/issue41193) -->
https://bugs.python.org/issue41193
<!-- /issue-number -->
