### PR TITLE
bpo-41194: Pass module state in Python-ast.c

### DIFF
--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -387,7 +387,7 @@ class PickleVisitor(EmitVisitor):
 
 class Obj2ModPrototypeVisitor(PickleVisitor):
     def visitProduct(self, prod, name):
-        code = "static int obj2ast_%s(PyObject* obj, %s* out, PyArena* arena);"
+        code = "static int obj2ast_%s(astmodulestate *state, PyObject* obj, %s* out, PyArena* arena);"
         self.emit(code % (name, get_c_type(name)), 0)
 
     visitSum = visitProduct
@@ -397,7 +397,7 @@ class Obj2ModVisitor(PickleVisitor):
     def funcHeader(self, name):
         ctype = get_c_type(name)
         self.emit("int", 0)
-        self.emit("obj2ast_%s(PyObject* obj, %s* out, PyArena* arena)" % (name, ctype), 0)
+        self.emit("obj2ast_%s(astmodulestate *state, PyObject* obj, %s* out, PyArena* arena)" % (name, ctype), 0)
         self.emit("{", 0)
         self.emit("int isinstance;", 1)
         self.emit("", 0)
@@ -419,7 +419,7 @@ class Obj2ModVisitor(PickleVisitor):
         self.funcHeader(name)
         for t in sum.types:
             line = ("isinstance = PyObject_IsInstance(obj, "
-                    "astmodulestate_global->%s_type);")
+                    "state->%s_type);")
             self.emit(line % (t.name,), 1)
             self.emit("if (isinstance == -1) {", 1)
             self.emit("return 1;", 2)
@@ -448,7 +448,7 @@ class Obj2ModVisitor(PickleVisitor):
         for a in sum.attributes:
             self.visitField(a, name, sum=sum, depth=1)
         for t in sum.types:
-            self.emit("tp = astmodulestate_global->%s_type;" % (t.name,), 1)
+            self.emit("tp = state->%s_type;" % (t.name,), 1)
             self.emit("isinstance = PyObject_IsInstance(obj, tp);", 1)
             self.emit("if (isinstance == -1) {", 1)
             self.emit("return 1;", 2)
@@ -479,7 +479,7 @@ class Obj2ModVisitor(PickleVisitor):
     def visitProduct(self, prod, name):
         ctype = get_c_type(name)
         self.emit("int", 0)
-        self.emit("obj2ast_%s(PyObject* obj, %s* out, PyArena* arena)" % (name, ctype), 0)
+        self.emit("obj2ast_%s(astmodulestate *state, PyObject* obj, %s* out, PyArena* arena)" % (name, ctype), 0)
         self.emit("{", 0)
         self.emit("PyObject* tmp = NULL;", 1)
         for f in prod.fields:
@@ -525,7 +525,7 @@ class Obj2ModVisitor(PickleVisitor):
 
     def visitField(self, field, name, sum=None, prod=None, depth=0):
         ctype = get_c_type(field.type)
-        line = "if (_PyObject_LookupAttr(obj, astmodulestate_global->%s, &tmp) < 0) {"
+        line = "if (_PyObject_LookupAttr(obj, state->%s, &tmp) < 0) {"
         self.emit(line % field.name, depth)
         self.emit("return 1;", depth+1)
         self.emit("}", depth)
@@ -568,7 +568,7 @@ class Obj2ModVisitor(PickleVisitor):
             self.emit("%s val;" % ctype, depth+2)
             self.emit("PyObject *tmp2 = PyList_GET_ITEM(tmp, i);", depth+2)
             self.emit("Py_INCREF(tmp2);", depth+2)
-            self.emit("res = obj2ast_%s(tmp2, &val, arena);" %
+            self.emit("res = obj2ast_%s(state, tmp2, &val, arena);" %
                       field.type, depth+2, reflow=False)
             self.emit("Py_DECREF(tmp2);", depth+2)
             self.emit("if (res != 0) goto failed;", depth+2)
@@ -582,7 +582,7 @@ class Obj2ModVisitor(PickleVisitor):
             self.emit("asdl_seq_SET(%s, i, val);" % field.name, depth+2)
             self.emit("}", depth+1)
         else:
-            self.emit("res = obj2ast_%s(tmp, &%s, arena);" %
+            self.emit("res = obj2ast_%s(state, tmp, &%s, arena);" %
                       (field.type, field.name), depth+1)
             self.emit("if (res != 0) goto failed;", depth+1)
 
@@ -604,7 +604,7 @@ class PyTypesDeclareVisitor(PickleVisitor):
 
     def visitProduct(self, prod, name):
         self.emit_type("%s_type" % name)
-        self.emit("static PyObject* ast2obj_%s(void*);" % name, 0)
+        self.emit("static PyObject* ast2obj_%s(astmodulestate *state, void*);" % name, 0)
         if prod.attributes:
             for a in prod.attributes:
                 self.emit_identifier(a.name)
@@ -634,7 +634,7 @@ class PyTypesDeclareVisitor(PickleVisitor):
             ptype = get_c_type(name)
             for t in sum.types:
                 self.emit_singleton("%s_singleton" % t.name)
-        self.emit("static PyObject* ast2obj_%s(%s);" % (name, ptype), 0)
+        self.emit("static PyObject* ast2obj_%s(astmodulestate *state, %s);" % (name, ptype), 0)
         for t in sum.types:
             self.visitConstructor(t, name)
 
@@ -691,7 +691,8 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), astmodulestate_global->_fields, &fields) < 0) {
+    astmodulestate *state = astmodulestate_global;
+    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
         goto cleanup;
     }
     if (fields) {
@@ -759,8 +760,9 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
 static PyObject *
 ast_type_reduce(PyObject *self, PyObject *unused)
 {
+    astmodulestate *state = astmodulestate_global;
     PyObject *dict;
-    if (_PyObject_LookupAttr(self, astmodulestate_global->__dict__, &dict) < 0) {
+    if (_PyObject_LookupAttr(self, state->__dict__, &dict) < 0) {
         return NULL;
     }
     if (dict) {
@@ -809,7 +811,8 @@ static PyType_Spec AST_type_spec = {
 };
 
 static PyObject *
-make_type(const char *type, PyObject* base, const char* const* fields, int num_fields, const char *doc)
+make_type(astmodulestate *state, const char *type, PyObject* base,
+          const char* const* fields, int num_fields, const char *doc)
 {
     PyObject *fnames, *result;
     int i;
@@ -825,16 +828,16 @@ make_type(const char *type, PyObject* base, const char* const* fields, int num_f
     }
     result = PyObject_CallFunction((PyObject*)&PyType_Type, "s(O){OOOOOs}",
                     type, base,
-                    astmodulestate_global->_fields, fnames,
-                    astmodulestate_global->__module__,
-                    astmodulestate_global->ast,
-                    astmodulestate_global->__doc__, doc);
+                    state->_fields, fnames,
+                    state->__module__,
+                    state->ast,
+                    state->__doc__, doc);
     Py_DECREF(fnames);
     return result;
 }
 
 static int
-add_attributes(PyObject *type, const char * const *attrs, int num_fields)
+add_attributes(astmodulestate *state, PyObject *type, const char * const *attrs, int num_fields)
 {
     int i, result;
     PyObject *s, *l = PyTuple_New(num_fields);
@@ -848,14 +851,14 @@ add_attributes(PyObject *type, const char * const *attrs, int num_fields)
         }
         PyTuple_SET_ITEM(l, i, s);
     }
-    result = PyObject_SetAttr(type, astmodulestate_global->_attributes, l) >= 0;
+    result = PyObject_SetAttr(type, state->_attributes, l) >= 0;
     Py_DECREF(l);
     return result;
 }
 
 /* Conversion AST -> Python */
 
-static PyObject* ast2obj_list(asdl_seq *seq, PyObject* (*func)(void*))
+static PyObject* ast2obj_list(astmodulestate *state, asdl_seq *seq, PyObject* (*func)(astmodulestate *state, void*))
 {
     Py_ssize_t i, n = asdl_seq_LEN(seq);
     PyObject *result = PyList_New(n);
@@ -863,7 +866,7 @@ static PyObject* ast2obj_list(asdl_seq *seq, PyObject* (*func)(void*))
     if (!result)
         return NULL;
     for (i = 0; i < n; i++) {
-        value = func(asdl_seq_GET(seq, i));
+        value = func(state, asdl_seq_GET(seq, i));
         if (!value) {
             Py_DECREF(result);
             return NULL;
@@ -873,7 +876,7 @@ static PyObject* ast2obj_list(asdl_seq *seq, PyObject* (*func)(void*))
     return result;
 }
 
-static PyObject* ast2obj_object(void *o)
+static PyObject* ast2obj_object(astmodulestate *Py_UNUSED(state), void *o)
 {
     if (!o)
         o = Py_None;
@@ -884,14 +887,14 @@ static PyObject* ast2obj_object(void *o)
 #define ast2obj_identifier ast2obj_object
 #define ast2obj_string ast2obj_object
 
-static PyObject* ast2obj_int(long b)
+static PyObject* ast2obj_int(astmodulestate *Py_UNUSED(state), long b)
 {
     return PyLong_FromLong(b);
 }
 
 /* Conversion Python -> AST */
 
-static int obj2ast_object(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_object(astmodulestate *Py_UNUSED(state), PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (obj == Py_None)
         obj = NULL;
@@ -906,7 +909,7 @@ static int obj2ast_object(PyObject* obj, PyObject** out, PyArena* arena)
     return 0;
 }
 
-static int obj2ast_constant(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_constant(astmodulestate *Py_UNUSED(state), PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (PyArena_AddPyObject(arena, obj) < 0) {
         *out = NULL;
@@ -917,25 +920,25 @@ static int obj2ast_constant(PyObject* obj, PyObject** out, PyArena* arena)
     return 0;
 }
 
-static int obj2ast_identifier(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_identifier(astmodulestate *state, PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (!PyUnicode_CheckExact(obj) && obj != Py_None) {
         PyErr_SetString(PyExc_TypeError, "AST identifier must be of type str");
         return 1;
     }
-    return obj2ast_object(obj, out, arena);
+    return obj2ast_object(state, obj, out, arena);
 }
 
-static int obj2ast_string(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_string(astmodulestate *state, PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (!PyUnicode_CheckExact(obj) && !PyBytes_CheckExact(obj)) {
         PyErr_SetString(PyExc_TypeError, "AST string must be of type str");
         return 1;
     }
-    return obj2ast_object(obj, out, arena);
+    return obj2ast_object(state, obj, out, arena);
 }
 
-static int obj2ast_int(PyObject* obj, int* out, PyArena* arena)
+static int obj2ast_int(astmodulestate* Py_UNUSED(state), PyObject* obj, int* out, PyArena* arena)
 {
     int i;
     if (!PyLong_Check(obj)) {
@@ -950,13 +953,13 @@ static int obj2ast_int(PyObject* obj, int* out, PyArena* arena)
     return 0;
 }
 
-static int add_ast_fields(void)
+static int add_ast_fields(astmodulestate *state)
 {
     PyObject *empty_tuple;
     empty_tuple = PyTuple_New(0);
     if (!empty_tuple ||
-        PyObject_SetAttrString(astmodulestate_global->AST_type, "_fields", empty_tuple) < 0 ||
-        PyObject_SetAttrString(astmodulestate_global->AST_type, "_attributes", empty_tuple) < 0) {
+        PyObject_SetAttrString(state->AST_type, "_fields", empty_tuple) < 0 ||
+        PyObject_SetAttrString(state->AST_type, "_attributes", empty_tuple) < 0) {
         Py_XDECREF(empty_tuple);
         return -1;
     }
@@ -968,18 +971,24 @@ static int add_ast_fields(void)
 
         self.emit("static int init_types(void)",0)
         self.emit("{", 0)
-        self.emit("PyObject *m;", 1)
-        self.emit("if (PyState_FindModule(&_astmodule) == NULL) {", 1)
-        self.emit("m = PyModule_Create(&_astmodule);", 2)
-        self.emit("if (!m) return 0;", 2)
-        self.emit("PyState_AddModule(m, &_astmodule);", 2)
+        self.emit("PyObject *module = PyState_FindModule(&_astmodule);", 1)
+        self.emit("if (module == NULL) {", 1)
+        self.emit("module = PyModule_Create(&_astmodule);", 2)
+        self.emit("if (!module) {", 2)
+        self.emit("return 0;", 3)
+        self.emit("}", 2)
+        self.emit("if (PyState_AddModule(module, &_astmodule) < 0) {", 2)
+        self.emit("return 0;", 3)
+        self.emit("}", 2)
         self.emit("}", 1)
-        self.emit("astmodulestate *state = astmodulestate_global;", 1)
+        self.emit("", 0)
+
+        self.emit("astmodulestate *state = get_ast_state(module);", 1)
         self.emit("if (state->initialized) return 1;", 1)
-        self.emit("if (init_identifiers() < 0) return 0;", 1)
+        self.emit("if (init_identifiers(state) < 0) return 0;", 1)
         self.emit("state->AST_type = PyType_FromSpec(&AST_type_spec);", 1)
         self.emit("if (!state->AST_type) return 0;", 1)
-        self.emit("if (add_ast_fields() < 0) return 0;", 1)
+        self.emit("if (add_ast_fields(state) < 0) return 0;", 1)
         for dfn in mod.dfns:
             self.visit(dfn)
         self.emit("state->initialized = 1;", 1)
@@ -991,31 +1000,31 @@ static int add_ast_fields(void)
             fields = name+"_fields"
         else:
             fields = "NULL"
-        self.emit('state->%s_type = make_type("%s", state->AST_type, %s, %d,' %
+        self.emit('state->%s_type = make_type(state, "%s", state->AST_type, %s, %d,' %
                         (name, name, fields, len(prod.fields)), 1)
         self.emit('%s);' % reflow_c_string(asdl_of(name, prod), 2), 2, reflow=False)
         self.emit("if (!state->%s_type) return 0;" % name, 1)
         self.emit_type("AST_type")
         self.emit_type("%s_type" % name)
         if prod.attributes:
-            self.emit("if (!add_attributes(state->%s_type, %s_attributes, %d)) return 0;" %
+            self.emit("if (!add_attributes(state, state->%s_type, %s_attributes, %d)) return 0;" %
                             (name, name, len(prod.attributes)), 1)
         else:
-            self.emit("if (!add_attributes(state->%s_type, NULL, 0)) return 0;" % name, 1)
+            self.emit("if (!add_attributes(state, state->%s_type, NULL, 0)) return 0;" % name, 1)
         self.emit_defaults(name, prod.fields, 1)
         self.emit_defaults(name, prod.attributes, 1)
 
     def visitSum(self, sum, name):
-        self.emit('state->%s_type = make_type("%s", state->AST_type, NULL, 0,' %
+        self.emit('state->%s_type = make_type(state, "%s", state->AST_type, NULL, 0,' %
                   (name, name), 1)
         self.emit('%s);' % reflow_c_string(asdl_of(name, sum), 2), 2, reflow=False)
         self.emit_type("%s_type" % name)
         self.emit("if (!state->%s_type) return 0;" % name, 1)
         if sum.attributes:
-            self.emit("if (!add_attributes(state->%s_type, %s_attributes, %d)) return 0;" %
+            self.emit("if (!add_attributes(state, state->%s_type, %s_attributes, %d)) return 0;" %
                             (name, name, len(sum.attributes)), 1)
         else:
-            self.emit("if (!add_attributes(state->%s_type, NULL, 0)) return 0;" % name, 1)
+            self.emit("if (!add_attributes(state, state->%s_type, NULL, 0)) return 0;" % name, 1)
         self.emit_defaults(name, sum.attributes, 1)
         simple = is_simple(sum)
         for t in sum.types:
@@ -1026,7 +1035,7 @@ static int add_ast_fields(void)
             fields = cons.name+"_fields"
         else:
             fields = "NULL"
-        self.emit('state->%s_type = make_type("%s", state->%s_type, %s, %d,' %
+        self.emit('state->%s_type = make_type(state, "%s", state->%s_type, %s, %d,' %
                             (cons.name, cons.name, name, fields, len(cons.fields)), 1)
         self.emit('%s);' % reflow_c_string(asdl_of(cons.name, cons), 2), 2, reflow=False)
         self.emit("if (!state->%s_type) return 0;" % cons.name, 1)
@@ -1056,10 +1065,13 @@ class ASTModuleVisitor(PickleVisitor):
         self.emit("if (!init_types()) return NULL;", 1)
         self.emit('m = PyState_FindModule(&_astmodule);', 1)
         self.emit("if (!m) return NULL;", 1)
-        self.emit('if (PyModule_AddObject(m, "AST", astmodulestate_global->AST_type) < 0) {', 1)
+        self.emit('astmodulestate *state = get_ast_state(m);', 1)
+        self.emit('', 1)
+
+        self.emit('if (PyModule_AddObject(m, "AST", state->AST_type) < 0) {', 1)
         self.emit('goto error;', 2)
         self.emit('}', 1)
-        self.emit('Py_INCREF(astmodulestate(m)->AST_type);', 1)
+        self.emit('Py_INCREF(state->AST_type);', 1)
         self.emit('if (PyModule_AddIntMacro(m, PyCF_ALLOW_TOP_LEVEL_AWAIT) < 0) {', 1)
         self.emit("goto error;", 2)
         self.emit('}', 1)
@@ -1090,10 +1102,10 @@ class ASTModuleVisitor(PickleVisitor):
 
     def addObj(self, name):
         self.emit("if (PyModule_AddObject(m, \"%s\", "
-                  "astmodulestate_global->%s_type) < 0) {" % (name, name), 1)
+                  "state->%s_type) < 0) {" % (name, name), 1)
         self.emit("goto error;", 2)
         self.emit('}', 1)
-        self.emit("Py_INCREF(astmodulestate(m)->%s_type);" % name, 1)
+        self.emit("Py_INCREF(state->%s_type);" % name, 1)
 
 
 _SPECIALIZED_SEQUENCES = ('stmt', 'expr')
@@ -1127,7 +1139,7 @@ class ObjVisitor(PickleVisitor):
     def func_begin(self, name):
         ctype = get_c_type(name)
         self.emit("PyObject*", 0)
-        self.emit("ast2obj_%s(void* _o)" % (name), 0)
+        self.emit("ast2obj_%s(astmodulestate *state, void* _o)" % (name), 0)
         self.emit("{", 0)
         self.emit("%s o = (%s)_o;" % (ctype, ctype), 1)
         self.emit("PyObject *result = NULL, *value = NULL;", 1)
@@ -1135,7 +1147,6 @@ class ObjVisitor(PickleVisitor):
         self.emit('if (!o) {', 1)
         self.emit("Py_RETURN_NONE;", 2)
         self.emit("}", 1)
-        self.emit('', 0)
 
     def func_end(self):
         self.emit("return result;", 1)
@@ -1157,43 +1168,43 @@ class ObjVisitor(PickleVisitor):
             self.visitConstructor(t, i + 1, name)
         self.emit("}", 1)
         for a in sum.attributes:
-            self.emit("value = ast2obj_%s(o->%s);" % (a.type, a.name), 1)
+            self.emit("value = ast2obj_%s(state, o->%s);" % (a.type, a.name), 1)
             self.emit("if (!value) goto failed;", 1)
-            self.emit('if (PyObject_SetAttr(result, astmodulestate_global->%s, value) < 0)' % a.name, 1)
+            self.emit('if (PyObject_SetAttr(result, state->%s, value) < 0)' % a.name, 1)
             self.emit('goto failed;', 2)
             self.emit('Py_DECREF(value);', 1)
         self.func_end()
 
     def simpleSum(self, sum, name):
-        self.emit("PyObject* ast2obj_%s(%s_ty o)" % (name, name), 0)
+        self.emit("PyObject* ast2obj_%s(astmodulestate *state, %s_ty o)" % (name, name), 0)
         self.emit("{", 0)
         self.emit("switch(o) {", 1)
         for t in sum.types:
             self.emit("case %s:" % t.name, 2)
-            self.emit("Py_INCREF(astmodulestate_global->%s_singleton);" % t.name, 3)
-            self.emit("return astmodulestate_global->%s_singleton;" % t.name, 3)
+            self.emit("Py_INCREF(state->%s_singleton);" % t.name, 3)
+            self.emit("return state->%s_singleton;" % t.name, 3)
         self.emit("}", 1)
         self.emit("Py_UNREACHABLE();", 1);
         self.emit("}", 0)
 
     def visitProduct(self, prod, name):
         self.func_begin(name)
-        self.emit("tp = (PyTypeObject *)astmodulestate_global->%s_type;" % name, 1)
+        self.emit("tp = (PyTypeObject *)state->%s_type;" % name, 1)
         self.emit("result = PyType_GenericNew(tp, NULL, NULL);", 1);
         self.emit("if (!result) return NULL;", 1)
         for field in prod.fields:
             self.visitField(field, name, 1, True)
         for a in prod.attributes:
-            self.emit("value = ast2obj_%s(o->%s);" % (a.type, a.name), 1)
+            self.emit("value = ast2obj_%s(state, o->%s);" % (a.type, a.name), 1)
             self.emit("if (!value) goto failed;", 1)
-            self.emit("if (PyObject_SetAttr(result, astmodulestate_global->%s, value) < 0)" % a.name, 1)
+            self.emit("if (PyObject_SetAttr(result, state->%s, value) < 0)" % a.name, 1)
             self.emit('goto failed;', 2)
             self.emit('Py_DECREF(value);', 1)
         self.func_end()
 
     def visitConstructor(self, cons, enum, name):
         self.emit("case %s_kind:" % cons.name, 1)
-        self.emit("tp = (PyTypeObject *)astmodulestate_global->%s_type;" % cons.name, 2)
+        self.emit("tp = (PyTypeObject *)state->%s_type;" % cons.name, 2)
         self.emit("result = PyType_GenericNew(tp, NULL, NULL);", 2);
         self.emit("if (!result) goto failed;", 2)
         for f in cons.fields:
@@ -1209,7 +1220,7 @@ class ObjVisitor(PickleVisitor):
             value = "o->v.%s.%s" % (name, field.name)
         self.set(field, value, depth)
         emit("if (!value) goto failed;", 0)
-        emit("if (PyObject_SetAttr(result, astmodulestate_global->%s, value) == -1)" % field.name, 0)
+        emit("if (PyObject_SetAttr(result, state->%s, value) == -1)" % field.name, 0)
         emit("goto failed;", 1)
         emit("Py_DECREF(value);", 0)
 
@@ -1237,14 +1248,14 @@ class ObjVisitor(PickleVisitor):
                 self.emit("if (!value) goto failed;", depth+1)
                 self.emit("for(i = 0; i < n; i++)", depth+1)
                 # This cannot fail, so no need for error handling
-                self.emit("PyList_SET_ITEM(value, i, ast2obj_cmpop((cmpop_ty)asdl_seq_GET(%s, i)));" % value,
+                self.emit("PyList_SET_ITEM(value, i, ast2obj_cmpop(state, (cmpop_ty)asdl_seq_GET(%s, i)));" % value,
                           depth+2, reflow=False)
                 self.emit("}", depth)
             else:
-                self.emit("value = ast2obj_list(%s, ast2obj_%s);" % (value, field.type), depth)
+                self.emit("value = ast2obj_list(state, %s, ast2obj_%s);" % (value, field.type), depth)
         else:
             ctype = get_c_type(field.type)
-            self.emit("value = ast2obj_%s(%s);" % (field.type, value), depth, reflow=False)
+            self.emit("value = ast2obj_%s(state, %s);" % (field.type, value), depth, reflow=False)
 
 
 class PartingShots(StaticVisitor):
@@ -1254,13 +1265,13 @@ PyObject* PyAST_mod2obj(mod_ty t)
 {
     if (!init_types())
         return NULL;
-    return ast2obj_mod(t);
+    astmodulestate *state = astmodulestate_global;
+    return ast2obj_mod(state, t);
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    PyObject *req_type[3];
     const char * const req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;
 
@@ -1268,9 +1279,11 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
         return NULL;
     }
 
-    req_type[0] = astmodulestate_global->Module_type;
-    req_type[1] = astmodulestate_global->Expression_type;
-    req_type[2] = astmodulestate_global->Interactive_type;
+    astmodulestate *state = astmodulestate_global;
+    PyObject *req_type[3];
+    req_type[0] = state->Module_type;
+    req_type[1] = state->Expression_type;
+    req_type[2] = state->Interactive_type;
 
     assert(0 <= mode && mode <= 2);
 
@@ -1287,7 +1300,7 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
     }
 
     mod_ty res = NULL;
-    if (obj2ast_mod(ast, &res, arena) != 0)
+    if (obj2ast_mod(state, ast, &res, arena) != 0)
         return NULL;
     else
         return res;
@@ -1297,7 +1310,8 @@ int PyAST_Check(PyObject* obj)
 {
     if (!init_types())
         return -1;
-    return PyObject_IsInstance(obj, astmodulestate_global->AST_type);
+    astmodulestate *state = astmodulestate_global;
+    return PyObject_IsInstance(obj, state->AST_type);
 }
 """
 
@@ -1347,22 +1361,31 @@ def generate_module_def(f, mod):
         f.write('    PyObject *' + s + ';\n')
     f.write('} astmodulestate;\n\n')
     f.write("""
-#define astmodulestate(o) ((astmodulestate *)PyModule_GetState(o))
+static astmodulestate *
+get_ast_state(PyObject *module)
+{
+    assert(module != NULL);
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (astmodulestate *)state;
+}
 
 static int astmodule_clear(PyObject *module)
 {
+    astmodulestate *state = get_ast_state(module);
 """)
     for s in module_state:
-        f.write("    Py_CLEAR(astmodulestate(module)->" + s + ');\n')
+        f.write("    Py_CLEAR(state->" + s + ');\n')
     f.write("""
     return 0;
 }
 
 static int astmodule_traverse(PyObject *module, visitproc visit, void* arg)
 {
+    astmodulestate *state = get_ast_state(module);
 """)
     for s in module_state:
-        f.write("    Py_VISIT(astmodulestate(module)->" + s + ');\n')
+        f.write("    Py_VISIT(state->" + s + ');\n')
     f.write("""
     return 0;
 }
@@ -1383,12 +1406,11 @@ static struct PyModuleDef _astmodule = {
     astmodule_free,
 };
 
-#define astmodulestate_global ((astmodulestate *)PyModule_GetState(PyState_FindModule(&_astmodule)))
+#define astmodulestate_global get_ast_state(PyState_FindModule(&_astmodule))
 
 """)
-    f.write('static int init_identifiers(void)\n')
+    f.write('static int init_identifiers(astmodulestate *state)\n')
     f.write('{\n')
-    f.write('    astmodulestate *state = astmodulestate_global;\n')
     for identifier in state_strings:
         f.write('    if ((state->' + identifier)
         f.write(' = PyUnicode_InternFromString("')

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -224,442 +224,451 @@ typedef struct {
 } astmodulestate;
 
 
-#define astmodulestate(o) ((astmodulestate *)PyModule_GetState(o))
+static astmodulestate *
+get_ast_state(PyObject *module)
+{
+    assert(module != NULL);
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (astmodulestate *)state;
+}
 
 static int astmodule_clear(PyObject *module)
 {
-    Py_CLEAR(astmodulestate(module)->AST_type);
-    Py_CLEAR(astmodulestate(module)->Add_singleton);
-    Py_CLEAR(astmodulestate(module)->Add_type);
-    Py_CLEAR(astmodulestate(module)->And_singleton);
-    Py_CLEAR(astmodulestate(module)->And_type);
-    Py_CLEAR(astmodulestate(module)->AnnAssign_type);
-    Py_CLEAR(astmodulestate(module)->Assert_type);
-    Py_CLEAR(astmodulestate(module)->Assign_type);
-    Py_CLEAR(astmodulestate(module)->AsyncFor_type);
-    Py_CLEAR(astmodulestate(module)->AsyncFunctionDef_type);
-    Py_CLEAR(astmodulestate(module)->AsyncWith_type);
-    Py_CLEAR(astmodulestate(module)->Attribute_type);
-    Py_CLEAR(astmodulestate(module)->AugAssign_type);
-    Py_CLEAR(astmodulestate(module)->Await_type);
-    Py_CLEAR(astmodulestate(module)->BinOp_type);
-    Py_CLEAR(astmodulestate(module)->BitAnd_singleton);
-    Py_CLEAR(astmodulestate(module)->BitAnd_type);
-    Py_CLEAR(astmodulestate(module)->BitOr_singleton);
-    Py_CLEAR(astmodulestate(module)->BitOr_type);
-    Py_CLEAR(astmodulestate(module)->BitXor_singleton);
-    Py_CLEAR(astmodulestate(module)->BitXor_type);
-    Py_CLEAR(astmodulestate(module)->BoolOp_type);
-    Py_CLEAR(astmodulestate(module)->Break_type);
-    Py_CLEAR(astmodulestate(module)->Call_type);
-    Py_CLEAR(astmodulestate(module)->ClassDef_type);
-    Py_CLEAR(astmodulestate(module)->Compare_type);
-    Py_CLEAR(astmodulestate(module)->Constant_type);
-    Py_CLEAR(astmodulestate(module)->Continue_type);
-    Py_CLEAR(astmodulestate(module)->Del_singleton);
-    Py_CLEAR(astmodulestate(module)->Del_type);
-    Py_CLEAR(astmodulestate(module)->Delete_type);
-    Py_CLEAR(astmodulestate(module)->DictComp_type);
-    Py_CLEAR(astmodulestate(module)->Dict_type);
-    Py_CLEAR(astmodulestate(module)->Div_singleton);
-    Py_CLEAR(astmodulestate(module)->Div_type);
-    Py_CLEAR(astmodulestate(module)->Eq_singleton);
-    Py_CLEAR(astmodulestate(module)->Eq_type);
-    Py_CLEAR(astmodulestate(module)->ExceptHandler_type);
-    Py_CLEAR(astmodulestate(module)->Expr_type);
-    Py_CLEAR(astmodulestate(module)->Expression_type);
-    Py_CLEAR(astmodulestate(module)->FloorDiv_singleton);
-    Py_CLEAR(astmodulestate(module)->FloorDiv_type);
-    Py_CLEAR(astmodulestate(module)->For_type);
-    Py_CLEAR(astmodulestate(module)->FormattedValue_type);
-    Py_CLEAR(astmodulestate(module)->FunctionDef_type);
-    Py_CLEAR(astmodulestate(module)->FunctionType_type);
-    Py_CLEAR(astmodulestate(module)->GeneratorExp_type);
-    Py_CLEAR(astmodulestate(module)->Global_type);
-    Py_CLEAR(astmodulestate(module)->GtE_singleton);
-    Py_CLEAR(astmodulestate(module)->GtE_type);
-    Py_CLEAR(astmodulestate(module)->Gt_singleton);
-    Py_CLEAR(astmodulestate(module)->Gt_type);
-    Py_CLEAR(astmodulestate(module)->IfExp_type);
-    Py_CLEAR(astmodulestate(module)->If_type);
-    Py_CLEAR(astmodulestate(module)->ImportFrom_type);
-    Py_CLEAR(astmodulestate(module)->Import_type);
-    Py_CLEAR(astmodulestate(module)->In_singleton);
-    Py_CLEAR(astmodulestate(module)->In_type);
-    Py_CLEAR(astmodulestate(module)->Interactive_type);
-    Py_CLEAR(astmodulestate(module)->Invert_singleton);
-    Py_CLEAR(astmodulestate(module)->Invert_type);
-    Py_CLEAR(astmodulestate(module)->IsNot_singleton);
-    Py_CLEAR(astmodulestate(module)->IsNot_type);
-    Py_CLEAR(astmodulestate(module)->Is_singleton);
-    Py_CLEAR(astmodulestate(module)->Is_type);
-    Py_CLEAR(astmodulestate(module)->JoinedStr_type);
-    Py_CLEAR(astmodulestate(module)->LShift_singleton);
-    Py_CLEAR(astmodulestate(module)->LShift_type);
-    Py_CLEAR(astmodulestate(module)->Lambda_type);
-    Py_CLEAR(astmodulestate(module)->ListComp_type);
-    Py_CLEAR(astmodulestate(module)->List_type);
-    Py_CLEAR(astmodulestate(module)->Load_singleton);
-    Py_CLEAR(astmodulestate(module)->Load_type);
-    Py_CLEAR(astmodulestate(module)->LtE_singleton);
-    Py_CLEAR(astmodulestate(module)->LtE_type);
-    Py_CLEAR(astmodulestate(module)->Lt_singleton);
-    Py_CLEAR(astmodulestate(module)->Lt_type);
-    Py_CLEAR(astmodulestate(module)->MatMult_singleton);
-    Py_CLEAR(astmodulestate(module)->MatMult_type);
-    Py_CLEAR(astmodulestate(module)->Mod_singleton);
-    Py_CLEAR(astmodulestate(module)->Mod_type);
-    Py_CLEAR(astmodulestate(module)->Module_type);
-    Py_CLEAR(astmodulestate(module)->Mult_singleton);
-    Py_CLEAR(astmodulestate(module)->Mult_type);
-    Py_CLEAR(astmodulestate(module)->Name_type);
-    Py_CLEAR(astmodulestate(module)->NamedExpr_type);
-    Py_CLEAR(astmodulestate(module)->Nonlocal_type);
-    Py_CLEAR(astmodulestate(module)->NotEq_singleton);
-    Py_CLEAR(astmodulestate(module)->NotEq_type);
-    Py_CLEAR(astmodulestate(module)->NotIn_singleton);
-    Py_CLEAR(astmodulestate(module)->NotIn_type);
-    Py_CLEAR(astmodulestate(module)->Not_singleton);
-    Py_CLEAR(astmodulestate(module)->Not_type);
-    Py_CLEAR(astmodulestate(module)->Or_singleton);
-    Py_CLEAR(astmodulestate(module)->Or_type);
-    Py_CLEAR(astmodulestate(module)->Pass_type);
-    Py_CLEAR(astmodulestate(module)->Pow_singleton);
-    Py_CLEAR(astmodulestate(module)->Pow_type);
-    Py_CLEAR(astmodulestate(module)->RShift_singleton);
-    Py_CLEAR(astmodulestate(module)->RShift_type);
-    Py_CLEAR(astmodulestate(module)->Raise_type);
-    Py_CLEAR(astmodulestate(module)->Return_type);
-    Py_CLEAR(astmodulestate(module)->SetComp_type);
-    Py_CLEAR(astmodulestate(module)->Set_type);
-    Py_CLEAR(astmodulestate(module)->Slice_type);
-    Py_CLEAR(astmodulestate(module)->Starred_type);
-    Py_CLEAR(astmodulestate(module)->Store_singleton);
-    Py_CLEAR(astmodulestate(module)->Store_type);
-    Py_CLEAR(astmodulestate(module)->Sub_singleton);
-    Py_CLEAR(astmodulestate(module)->Sub_type);
-    Py_CLEAR(astmodulestate(module)->Subscript_type);
-    Py_CLEAR(astmodulestate(module)->Try_type);
-    Py_CLEAR(astmodulestate(module)->Tuple_type);
-    Py_CLEAR(astmodulestate(module)->TypeIgnore_type);
-    Py_CLEAR(astmodulestate(module)->UAdd_singleton);
-    Py_CLEAR(astmodulestate(module)->UAdd_type);
-    Py_CLEAR(astmodulestate(module)->USub_singleton);
-    Py_CLEAR(astmodulestate(module)->USub_type);
-    Py_CLEAR(astmodulestate(module)->UnaryOp_type);
-    Py_CLEAR(astmodulestate(module)->While_type);
-    Py_CLEAR(astmodulestate(module)->With_type);
-    Py_CLEAR(astmodulestate(module)->YieldFrom_type);
-    Py_CLEAR(astmodulestate(module)->Yield_type);
-    Py_CLEAR(astmodulestate(module)->__dict__);
-    Py_CLEAR(astmodulestate(module)->__doc__);
-    Py_CLEAR(astmodulestate(module)->__module__);
-    Py_CLEAR(astmodulestate(module)->_attributes);
-    Py_CLEAR(astmodulestate(module)->_fields);
-    Py_CLEAR(astmodulestate(module)->alias_type);
-    Py_CLEAR(astmodulestate(module)->annotation);
-    Py_CLEAR(astmodulestate(module)->arg);
-    Py_CLEAR(astmodulestate(module)->arg_type);
-    Py_CLEAR(astmodulestate(module)->args);
-    Py_CLEAR(astmodulestate(module)->argtypes);
-    Py_CLEAR(astmodulestate(module)->arguments_type);
-    Py_CLEAR(astmodulestate(module)->asname);
-    Py_CLEAR(astmodulestate(module)->ast);
-    Py_CLEAR(astmodulestate(module)->attr);
-    Py_CLEAR(astmodulestate(module)->bases);
-    Py_CLEAR(astmodulestate(module)->body);
-    Py_CLEAR(astmodulestate(module)->boolop_type);
-    Py_CLEAR(astmodulestate(module)->cause);
-    Py_CLEAR(astmodulestate(module)->cmpop_type);
-    Py_CLEAR(astmodulestate(module)->col_offset);
-    Py_CLEAR(astmodulestate(module)->comparators);
-    Py_CLEAR(astmodulestate(module)->comprehension_type);
-    Py_CLEAR(astmodulestate(module)->context_expr);
-    Py_CLEAR(astmodulestate(module)->conversion);
-    Py_CLEAR(astmodulestate(module)->ctx);
-    Py_CLEAR(astmodulestate(module)->decorator_list);
-    Py_CLEAR(astmodulestate(module)->defaults);
-    Py_CLEAR(astmodulestate(module)->elt);
-    Py_CLEAR(astmodulestate(module)->elts);
-    Py_CLEAR(astmodulestate(module)->end_col_offset);
-    Py_CLEAR(astmodulestate(module)->end_lineno);
-    Py_CLEAR(astmodulestate(module)->exc);
-    Py_CLEAR(astmodulestate(module)->excepthandler_type);
-    Py_CLEAR(astmodulestate(module)->expr_context_type);
-    Py_CLEAR(astmodulestate(module)->expr_type);
-    Py_CLEAR(astmodulestate(module)->finalbody);
-    Py_CLEAR(astmodulestate(module)->format_spec);
-    Py_CLEAR(astmodulestate(module)->func);
-    Py_CLEAR(astmodulestate(module)->generators);
-    Py_CLEAR(astmodulestate(module)->handlers);
-    Py_CLEAR(astmodulestate(module)->id);
-    Py_CLEAR(astmodulestate(module)->ifs);
-    Py_CLEAR(astmodulestate(module)->is_async);
-    Py_CLEAR(astmodulestate(module)->items);
-    Py_CLEAR(astmodulestate(module)->iter);
-    Py_CLEAR(astmodulestate(module)->key);
-    Py_CLEAR(astmodulestate(module)->keys);
-    Py_CLEAR(astmodulestate(module)->keyword_type);
-    Py_CLEAR(astmodulestate(module)->keywords);
-    Py_CLEAR(astmodulestate(module)->kind);
-    Py_CLEAR(astmodulestate(module)->kw_defaults);
-    Py_CLEAR(astmodulestate(module)->kwarg);
-    Py_CLEAR(astmodulestate(module)->kwonlyargs);
-    Py_CLEAR(astmodulestate(module)->left);
-    Py_CLEAR(astmodulestate(module)->level);
-    Py_CLEAR(astmodulestate(module)->lineno);
-    Py_CLEAR(astmodulestate(module)->lower);
-    Py_CLEAR(astmodulestate(module)->mod_type);
-    Py_CLEAR(astmodulestate(module)->module);
-    Py_CLEAR(astmodulestate(module)->msg);
-    Py_CLEAR(astmodulestate(module)->name);
-    Py_CLEAR(astmodulestate(module)->names);
-    Py_CLEAR(astmodulestate(module)->op);
-    Py_CLEAR(astmodulestate(module)->operand);
-    Py_CLEAR(astmodulestate(module)->operator_type);
-    Py_CLEAR(astmodulestate(module)->ops);
-    Py_CLEAR(astmodulestate(module)->optional_vars);
-    Py_CLEAR(astmodulestate(module)->orelse);
-    Py_CLEAR(astmodulestate(module)->posonlyargs);
-    Py_CLEAR(astmodulestate(module)->returns);
-    Py_CLEAR(astmodulestate(module)->right);
-    Py_CLEAR(astmodulestate(module)->simple);
-    Py_CLEAR(astmodulestate(module)->slice);
-    Py_CLEAR(astmodulestate(module)->step);
-    Py_CLEAR(astmodulestate(module)->stmt_type);
-    Py_CLEAR(astmodulestate(module)->tag);
-    Py_CLEAR(astmodulestate(module)->target);
-    Py_CLEAR(astmodulestate(module)->targets);
-    Py_CLEAR(astmodulestate(module)->test);
-    Py_CLEAR(astmodulestate(module)->type);
-    Py_CLEAR(astmodulestate(module)->type_comment);
-    Py_CLEAR(astmodulestate(module)->type_ignore_type);
-    Py_CLEAR(astmodulestate(module)->type_ignores);
-    Py_CLEAR(astmodulestate(module)->unaryop_type);
-    Py_CLEAR(astmodulestate(module)->upper);
-    Py_CLEAR(astmodulestate(module)->value);
-    Py_CLEAR(astmodulestate(module)->values);
-    Py_CLEAR(astmodulestate(module)->vararg);
-    Py_CLEAR(astmodulestate(module)->withitem_type);
+    astmodulestate *state = get_ast_state(module);
+    Py_CLEAR(state->AST_type);
+    Py_CLEAR(state->Add_singleton);
+    Py_CLEAR(state->Add_type);
+    Py_CLEAR(state->And_singleton);
+    Py_CLEAR(state->And_type);
+    Py_CLEAR(state->AnnAssign_type);
+    Py_CLEAR(state->Assert_type);
+    Py_CLEAR(state->Assign_type);
+    Py_CLEAR(state->AsyncFor_type);
+    Py_CLEAR(state->AsyncFunctionDef_type);
+    Py_CLEAR(state->AsyncWith_type);
+    Py_CLEAR(state->Attribute_type);
+    Py_CLEAR(state->AugAssign_type);
+    Py_CLEAR(state->Await_type);
+    Py_CLEAR(state->BinOp_type);
+    Py_CLEAR(state->BitAnd_singleton);
+    Py_CLEAR(state->BitAnd_type);
+    Py_CLEAR(state->BitOr_singleton);
+    Py_CLEAR(state->BitOr_type);
+    Py_CLEAR(state->BitXor_singleton);
+    Py_CLEAR(state->BitXor_type);
+    Py_CLEAR(state->BoolOp_type);
+    Py_CLEAR(state->Break_type);
+    Py_CLEAR(state->Call_type);
+    Py_CLEAR(state->ClassDef_type);
+    Py_CLEAR(state->Compare_type);
+    Py_CLEAR(state->Constant_type);
+    Py_CLEAR(state->Continue_type);
+    Py_CLEAR(state->Del_singleton);
+    Py_CLEAR(state->Del_type);
+    Py_CLEAR(state->Delete_type);
+    Py_CLEAR(state->DictComp_type);
+    Py_CLEAR(state->Dict_type);
+    Py_CLEAR(state->Div_singleton);
+    Py_CLEAR(state->Div_type);
+    Py_CLEAR(state->Eq_singleton);
+    Py_CLEAR(state->Eq_type);
+    Py_CLEAR(state->ExceptHandler_type);
+    Py_CLEAR(state->Expr_type);
+    Py_CLEAR(state->Expression_type);
+    Py_CLEAR(state->FloorDiv_singleton);
+    Py_CLEAR(state->FloorDiv_type);
+    Py_CLEAR(state->For_type);
+    Py_CLEAR(state->FormattedValue_type);
+    Py_CLEAR(state->FunctionDef_type);
+    Py_CLEAR(state->FunctionType_type);
+    Py_CLEAR(state->GeneratorExp_type);
+    Py_CLEAR(state->Global_type);
+    Py_CLEAR(state->GtE_singleton);
+    Py_CLEAR(state->GtE_type);
+    Py_CLEAR(state->Gt_singleton);
+    Py_CLEAR(state->Gt_type);
+    Py_CLEAR(state->IfExp_type);
+    Py_CLEAR(state->If_type);
+    Py_CLEAR(state->ImportFrom_type);
+    Py_CLEAR(state->Import_type);
+    Py_CLEAR(state->In_singleton);
+    Py_CLEAR(state->In_type);
+    Py_CLEAR(state->Interactive_type);
+    Py_CLEAR(state->Invert_singleton);
+    Py_CLEAR(state->Invert_type);
+    Py_CLEAR(state->IsNot_singleton);
+    Py_CLEAR(state->IsNot_type);
+    Py_CLEAR(state->Is_singleton);
+    Py_CLEAR(state->Is_type);
+    Py_CLEAR(state->JoinedStr_type);
+    Py_CLEAR(state->LShift_singleton);
+    Py_CLEAR(state->LShift_type);
+    Py_CLEAR(state->Lambda_type);
+    Py_CLEAR(state->ListComp_type);
+    Py_CLEAR(state->List_type);
+    Py_CLEAR(state->Load_singleton);
+    Py_CLEAR(state->Load_type);
+    Py_CLEAR(state->LtE_singleton);
+    Py_CLEAR(state->LtE_type);
+    Py_CLEAR(state->Lt_singleton);
+    Py_CLEAR(state->Lt_type);
+    Py_CLEAR(state->MatMult_singleton);
+    Py_CLEAR(state->MatMult_type);
+    Py_CLEAR(state->Mod_singleton);
+    Py_CLEAR(state->Mod_type);
+    Py_CLEAR(state->Module_type);
+    Py_CLEAR(state->Mult_singleton);
+    Py_CLEAR(state->Mult_type);
+    Py_CLEAR(state->Name_type);
+    Py_CLEAR(state->NamedExpr_type);
+    Py_CLEAR(state->Nonlocal_type);
+    Py_CLEAR(state->NotEq_singleton);
+    Py_CLEAR(state->NotEq_type);
+    Py_CLEAR(state->NotIn_singleton);
+    Py_CLEAR(state->NotIn_type);
+    Py_CLEAR(state->Not_singleton);
+    Py_CLEAR(state->Not_type);
+    Py_CLEAR(state->Or_singleton);
+    Py_CLEAR(state->Or_type);
+    Py_CLEAR(state->Pass_type);
+    Py_CLEAR(state->Pow_singleton);
+    Py_CLEAR(state->Pow_type);
+    Py_CLEAR(state->RShift_singleton);
+    Py_CLEAR(state->RShift_type);
+    Py_CLEAR(state->Raise_type);
+    Py_CLEAR(state->Return_type);
+    Py_CLEAR(state->SetComp_type);
+    Py_CLEAR(state->Set_type);
+    Py_CLEAR(state->Slice_type);
+    Py_CLEAR(state->Starred_type);
+    Py_CLEAR(state->Store_singleton);
+    Py_CLEAR(state->Store_type);
+    Py_CLEAR(state->Sub_singleton);
+    Py_CLEAR(state->Sub_type);
+    Py_CLEAR(state->Subscript_type);
+    Py_CLEAR(state->Try_type);
+    Py_CLEAR(state->Tuple_type);
+    Py_CLEAR(state->TypeIgnore_type);
+    Py_CLEAR(state->UAdd_singleton);
+    Py_CLEAR(state->UAdd_type);
+    Py_CLEAR(state->USub_singleton);
+    Py_CLEAR(state->USub_type);
+    Py_CLEAR(state->UnaryOp_type);
+    Py_CLEAR(state->While_type);
+    Py_CLEAR(state->With_type);
+    Py_CLEAR(state->YieldFrom_type);
+    Py_CLEAR(state->Yield_type);
+    Py_CLEAR(state->__dict__);
+    Py_CLEAR(state->__doc__);
+    Py_CLEAR(state->__module__);
+    Py_CLEAR(state->_attributes);
+    Py_CLEAR(state->_fields);
+    Py_CLEAR(state->alias_type);
+    Py_CLEAR(state->annotation);
+    Py_CLEAR(state->arg);
+    Py_CLEAR(state->arg_type);
+    Py_CLEAR(state->args);
+    Py_CLEAR(state->argtypes);
+    Py_CLEAR(state->arguments_type);
+    Py_CLEAR(state->asname);
+    Py_CLEAR(state->ast);
+    Py_CLEAR(state->attr);
+    Py_CLEAR(state->bases);
+    Py_CLEAR(state->body);
+    Py_CLEAR(state->boolop_type);
+    Py_CLEAR(state->cause);
+    Py_CLEAR(state->cmpop_type);
+    Py_CLEAR(state->col_offset);
+    Py_CLEAR(state->comparators);
+    Py_CLEAR(state->comprehension_type);
+    Py_CLEAR(state->context_expr);
+    Py_CLEAR(state->conversion);
+    Py_CLEAR(state->ctx);
+    Py_CLEAR(state->decorator_list);
+    Py_CLEAR(state->defaults);
+    Py_CLEAR(state->elt);
+    Py_CLEAR(state->elts);
+    Py_CLEAR(state->end_col_offset);
+    Py_CLEAR(state->end_lineno);
+    Py_CLEAR(state->exc);
+    Py_CLEAR(state->excepthandler_type);
+    Py_CLEAR(state->expr_context_type);
+    Py_CLEAR(state->expr_type);
+    Py_CLEAR(state->finalbody);
+    Py_CLEAR(state->format_spec);
+    Py_CLEAR(state->func);
+    Py_CLEAR(state->generators);
+    Py_CLEAR(state->handlers);
+    Py_CLEAR(state->id);
+    Py_CLEAR(state->ifs);
+    Py_CLEAR(state->is_async);
+    Py_CLEAR(state->items);
+    Py_CLEAR(state->iter);
+    Py_CLEAR(state->key);
+    Py_CLEAR(state->keys);
+    Py_CLEAR(state->keyword_type);
+    Py_CLEAR(state->keywords);
+    Py_CLEAR(state->kind);
+    Py_CLEAR(state->kw_defaults);
+    Py_CLEAR(state->kwarg);
+    Py_CLEAR(state->kwonlyargs);
+    Py_CLEAR(state->left);
+    Py_CLEAR(state->level);
+    Py_CLEAR(state->lineno);
+    Py_CLEAR(state->lower);
+    Py_CLEAR(state->mod_type);
+    Py_CLEAR(state->module);
+    Py_CLEAR(state->msg);
+    Py_CLEAR(state->name);
+    Py_CLEAR(state->names);
+    Py_CLEAR(state->op);
+    Py_CLEAR(state->operand);
+    Py_CLEAR(state->operator_type);
+    Py_CLEAR(state->ops);
+    Py_CLEAR(state->optional_vars);
+    Py_CLEAR(state->orelse);
+    Py_CLEAR(state->posonlyargs);
+    Py_CLEAR(state->returns);
+    Py_CLEAR(state->right);
+    Py_CLEAR(state->simple);
+    Py_CLEAR(state->slice);
+    Py_CLEAR(state->step);
+    Py_CLEAR(state->stmt_type);
+    Py_CLEAR(state->tag);
+    Py_CLEAR(state->target);
+    Py_CLEAR(state->targets);
+    Py_CLEAR(state->test);
+    Py_CLEAR(state->type);
+    Py_CLEAR(state->type_comment);
+    Py_CLEAR(state->type_ignore_type);
+    Py_CLEAR(state->type_ignores);
+    Py_CLEAR(state->unaryop_type);
+    Py_CLEAR(state->upper);
+    Py_CLEAR(state->value);
+    Py_CLEAR(state->values);
+    Py_CLEAR(state->vararg);
+    Py_CLEAR(state->withitem_type);
 
     return 0;
 }
 
 static int astmodule_traverse(PyObject *module, visitproc visit, void* arg)
 {
-    Py_VISIT(astmodulestate(module)->AST_type);
-    Py_VISIT(astmodulestate(module)->Add_singleton);
-    Py_VISIT(astmodulestate(module)->Add_type);
-    Py_VISIT(astmodulestate(module)->And_singleton);
-    Py_VISIT(astmodulestate(module)->And_type);
-    Py_VISIT(astmodulestate(module)->AnnAssign_type);
-    Py_VISIT(astmodulestate(module)->Assert_type);
-    Py_VISIT(astmodulestate(module)->Assign_type);
-    Py_VISIT(astmodulestate(module)->AsyncFor_type);
-    Py_VISIT(astmodulestate(module)->AsyncFunctionDef_type);
-    Py_VISIT(astmodulestate(module)->AsyncWith_type);
-    Py_VISIT(astmodulestate(module)->Attribute_type);
-    Py_VISIT(astmodulestate(module)->AugAssign_type);
-    Py_VISIT(astmodulestate(module)->Await_type);
-    Py_VISIT(astmodulestate(module)->BinOp_type);
-    Py_VISIT(astmodulestate(module)->BitAnd_singleton);
-    Py_VISIT(astmodulestate(module)->BitAnd_type);
-    Py_VISIT(astmodulestate(module)->BitOr_singleton);
-    Py_VISIT(astmodulestate(module)->BitOr_type);
-    Py_VISIT(astmodulestate(module)->BitXor_singleton);
-    Py_VISIT(astmodulestate(module)->BitXor_type);
-    Py_VISIT(astmodulestate(module)->BoolOp_type);
-    Py_VISIT(astmodulestate(module)->Break_type);
-    Py_VISIT(astmodulestate(module)->Call_type);
-    Py_VISIT(astmodulestate(module)->ClassDef_type);
-    Py_VISIT(astmodulestate(module)->Compare_type);
-    Py_VISIT(astmodulestate(module)->Constant_type);
-    Py_VISIT(astmodulestate(module)->Continue_type);
-    Py_VISIT(astmodulestate(module)->Del_singleton);
-    Py_VISIT(astmodulestate(module)->Del_type);
-    Py_VISIT(astmodulestate(module)->Delete_type);
-    Py_VISIT(astmodulestate(module)->DictComp_type);
-    Py_VISIT(astmodulestate(module)->Dict_type);
-    Py_VISIT(astmodulestate(module)->Div_singleton);
-    Py_VISIT(astmodulestate(module)->Div_type);
-    Py_VISIT(astmodulestate(module)->Eq_singleton);
-    Py_VISIT(astmodulestate(module)->Eq_type);
-    Py_VISIT(astmodulestate(module)->ExceptHandler_type);
-    Py_VISIT(astmodulestate(module)->Expr_type);
-    Py_VISIT(astmodulestate(module)->Expression_type);
-    Py_VISIT(astmodulestate(module)->FloorDiv_singleton);
-    Py_VISIT(astmodulestate(module)->FloorDiv_type);
-    Py_VISIT(astmodulestate(module)->For_type);
-    Py_VISIT(astmodulestate(module)->FormattedValue_type);
-    Py_VISIT(astmodulestate(module)->FunctionDef_type);
-    Py_VISIT(astmodulestate(module)->FunctionType_type);
-    Py_VISIT(astmodulestate(module)->GeneratorExp_type);
-    Py_VISIT(astmodulestate(module)->Global_type);
-    Py_VISIT(astmodulestate(module)->GtE_singleton);
-    Py_VISIT(astmodulestate(module)->GtE_type);
-    Py_VISIT(astmodulestate(module)->Gt_singleton);
-    Py_VISIT(astmodulestate(module)->Gt_type);
-    Py_VISIT(astmodulestate(module)->IfExp_type);
-    Py_VISIT(astmodulestate(module)->If_type);
-    Py_VISIT(astmodulestate(module)->ImportFrom_type);
-    Py_VISIT(astmodulestate(module)->Import_type);
-    Py_VISIT(astmodulestate(module)->In_singleton);
-    Py_VISIT(astmodulestate(module)->In_type);
-    Py_VISIT(astmodulestate(module)->Interactive_type);
-    Py_VISIT(astmodulestate(module)->Invert_singleton);
-    Py_VISIT(astmodulestate(module)->Invert_type);
-    Py_VISIT(astmodulestate(module)->IsNot_singleton);
-    Py_VISIT(astmodulestate(module)->IsNot_type);
-    Py_VISIT(astmodulestate(module)->Is_singleton);
-    Py_VISIT(astmodulestate(module)->Is_type);
-    Py_VISIT(astmodulestate(module)->JoinedStr_type);
-    Py_VISIT(astmodulestate(module)->LShift_singleton);
-    Py_VISIT(astmodulestate(module)->LShift_type);
-    Py_VISIT(astmodulestate(module)->Lambda_type);
-    Py_VISIT(astmodulestate(module)->ListComp_type);
-    Py_VISIT(astmodulestate(module)->List_type);
-    Py_VISIT(astmodulestate(module)->Load_singleton);
-    Py_VISIT(astmodulestate(module)->Load_type);
-    Py_VISIT(astmodulestate(module)->LtE_singleton);
-    Py_VISIT(astmodulestate(module)->LtE_type);
-    Py_VISIT(astmodulestate(module)->Lt_singleton);
-    Py_VISIT(astmodulestate(module)->Lt_type);
-    Py_VISIT(astmodulestate(module)->MatMult_singleton);
-    Py_VISIT(astmodulestate(module)->MatMult_type);
-    Py_VISIT(astmodulestate(module)->Mod_singleton);
-    Py_VISIT(astmodulestate(module)->Mod_type);
-    Py_VISIT(astmodulestate(module)->Module_type);
-    Py_VISIT(astmodulestate(module)->Mult_singleton);
-    Py_VISIT(astmodulestate(module)->Mult_type);
-    Py_VISIT(astmodulestate(module)->Name_type);
-    Py_VISIT(astmodulestate(module)->NamedExpr_type);
-    Py_VISIT(astmodulestate(module)->Nonlocal_type);
-    Py_VISIT(astmodulestate(module)->NotEq_singleton);
-    Py_VISIT(astmodulestate(module)->NotEq_type);
-    Py_VISIT(astmodulestate(module)->NotIn_singleton);
-    Py_VISIT(astmodulestate(module)->NotIn_type);
-    Py_VISIT(astmodulestate(module)->Not_singleton);
-    Py_VISIT(astmodulestate(module)->Not_type);
-    Py_VISIT(astmodulestate(module)->Or_singleton);
-    Py_VISIT(astmodulestate(module)->Or_type);
-    Py_VISIT(astmodulestate(module)->Pass_type);
-    Py_VISIT(astmodulestate(module)->Pow_singleton);
-    Py_VISIT(astmodulestate(module)->Pow_type);
-    Py_VISIT(astmodulestate(module)->RShift_singleton);
-    Py_VISIT(astmodulestate(module)->RShift_type);
-    Py_VISIT(astmodulestate(module)->Raise_type);
-    Py_VISIT(astmodulestate(module)->Return_type);
-    Py_VISIT(astmodulestate(module)->SetComp_type);
-    Py_VISIT(astmodulestate(module)->Set_type);
-    Py_VISIT(astmodulestate(module)->Slice_type);
-    Py_VISIT(astmodulestate(module)->Starred_type);
-    Py_VISIT(astmodulestate(module)->Store_singleton);
-    Py_VISIT(astmodulestate(module)->Store_type);
-    Py_VISIT(astmodulestate(module)->Sub_singleton);
-    Py_VISIT(astmodulestate(module)->Sub_type);
-    Py_VISIT(astmodulestate(module)->Subscript_type);
-    Py_VISIT(astmodulestate(module)->Try_type);
-    Py_VISIT(astmodulestate(module)->Tuple_type);
-    Py_VISIT(astmodulestate(module)->TypeIgnore_type);
-    Py_VISIT(astmodulestate(module)->UAdd_singleton);
-    Py_VISIT(astmodulestate(module)->UAdd_type);
-    Py_VISIT(astmodulestate(module)->USub_singleton);
-    Py_VISIT(astmodulestate(module)->USub_type);
-    Py_VISIT(astmodulestate(module)->UnaryOp_type);
-    Py_VISIT(astmodulestate(module)->While_type);
-    Py_VISIT(astmodulestate(module)->With_type);
-    Py_VISIT(astmodulestate(module)->YieldFrom_type);
-    Py_VISIT(astmodulestate(module)->Yield_type);
-    Py_VISIT(astmodulestate(module)->__dict__);
-    Py_VISIT(astmodulestate(module)->__doc__);
-    Py_VISIT(astmodulestate(module)->__module__);
-    Py_VISIT(astmodulestate(module)->_attributes);
-    Py_VISIT(astmodulestate(module)->_fields);
-    Py_VISIT(astmodulestate(module)->alias_type);
-    Py_VISIT(astmodulestate(module)->annotation);
-    Py_VISIT(astmodulestate(module)->arg);
-    Py_VISIT(astmodulestate(module)->arg_type);
-    Py_VISIT(astmodulestate(module)->args);
-    Py_VISIT(astmodulestate(module)->argtypes);
-    Py_VISIT(astmodulestate(module)->arguments_type);
-    Py_VISIT(astmodulestate(module)->asname);
-    Py_VISIT(astmodulestate(module)->ast);
-    Py_VISIT(astmodulestate(module)->attr);
-    Py_VISIT(astmodulestate(module)->bases);
-    Py_VISIT(astmodulestate(module)->body);
-    Py_VISIT(astmodulestate(module)->boolop_type);
-    Py_VISIT(astmodulestate(module)->cause);
-    Py_VISIT(astmodulestate(module)->cmpop_type);
-    Py_VISIT(astmodulestate(module)->col_offset);
-    Py_VISIT(astmodulestate(module)->comparators);
-    Py_VISIT(astmodulestate(module)->comprehension_type);
-    Py_VISIT(astmodulestate(module)->context_expr);
-    Py_VISIT(astmodulestate(module)->conversion);
-    Py_VISIT(astmodulestate(module)->ctx);
-    Py_VISIT(astmodulestate(module)->decorator_list);
-    Py_VISIT(astmodulestate(module)->defaults);
-    Py_VISIT(astmodulestate(module)->elt);
-    Py_VISIT(astmodulestate(module)->elts);
-    Py_VISIT(astmodulestate(module)->end_col_offset);
-    Py_VISIT(astmodulestate(module)->end_lineno);
-    Py_VISIT(astmodulestate(module)->exc);
-    Py_VISIT(astmodulestate(module)->excepthandler_type);
-    Py_VISIT(astmodulestate(module)->expr_context_type);
-    Py_VISIT(astmodulestate(module)->expr_type);
-    Py_VISIT(astmodulestate(module)->finalbody);
-    Py_VISIT(astmodulestate(module)->format_spec);
-    Py_VISIT(astmodulestate(module)->func);
-    Py_VISIT(astmodulestate(module)->generators);
-    Py_VISIT(astmodulestate(module)->handlers);
-    Py_VISIT(astmodulestate(module)->id);
-    Py_VISIT(astmodulestate(module)->ifs);
-    Py_VISIT(astmodulestate(module)->is_async);
-    Py_VISIT(astmodulestate(module)->items);
-    Py_VISIT(astmodulestate(module)->iter);
-    Py_VISIT(astmodulestate(module)->key);
-    Py_VISIT(astmodulestate(module)->keys);
-    Py_VISIT(astmodulestate(module)->keyword_type);
-    Py_VISIT(astmodulestate(module)->keywords);
-    Py_VISIT(astmodulestate(module)->kind);
-    Py_VISIT(astmodulestate(module)->kw_defaults);
-    Py_VISIT(astmodulestate(module)->kwarg);
-    Py_VISIT(astmodulestate(module)->kwonlyargs);
-    Py_VISIT(astmodulestate(module)->left);
-    Py_VISIT(astmodulestate(module)->level);
-    Py_VISIT(astmodulestate(module)->lineno);
-    Py_VISIT(astmodulestate(module)->lower);
-    Py_VISIT(astmodulestate(module)->mod_type);
-    Py_VISIT(astmodulestate(module)->module);
-    Py_VISIT(astmodulestate(module)->msg);
-    Py_VISIT(astmodulestate(module)->name);
-    Py_VISIT(astmodulestate(module)->names);
-    Py_VISIT(astmodulestate(module)->op);
-    Py_VISIT(astmodulestate(module)->operand);
-    Py_VISIT(astmodulestate(module)->operator_type);
-    Py_VISIT(astmodulestate(module)->ops);
-    Py_VISIT(astmodulestate(module)->optional_vars);
-    Py_VISIT(astmodulestate(module)->orelse);
-    Py_VISIT(astmodulestate(module)->posonlyargs);
-    Py_VISIT(astmodulestate(module)->returns);
-    Py_VISIT(astmodulestate(module)->right);
-    Py_VISIT(astmodulestate(module)->simple);
-    Py_VISIT(astmodulestate(module)->slice);
-    Py_VISIT(astmodulestate(module)->step);
-    Py_VISIT(astmodulestate(module)->stmt_type);
-    Py_VISIT(astmodulestate(module)->tag);
-    Py_VISIT(astmodulestate(module)->target);
-    Py_VISIT(astmodulestate(module)->targets);
-    Py_VISIT(astmodulestate(module)->test);
-    Py_VISIT(astmodulestate(module)->type);
-    Py_VISIT(astmodulestate(module)->type_comment);
-    Py_VISIT(astmodulestate(module)->type_ignore_type);
-    Py_VISIT(astmodulestate(module)->type_ignores);
-    Py_VISIT(astmodulestate(module)->unaryop_type);
-    Py_VISIT(astmodulestate(module)->upper);
-    Py_VISIT(astmodulestate(module)->value);
-    Py_VISIT(astmodulestate(module)->values);
-    Py_VISIT(astmodulestate(module)->vararg);
-    Py_VISIT(astmodulestate(module)->withitem_type);
+    astmodulestate *state = get_ast_state(module);
+    Py_VISIT(state->AST_type);
+    Py_VISIT(state->Add_singleton);
+    Py_VISIT(state->Add_type);
+    Py_VISIT(state->And_singleton);
+    Py_VISIT(state->And_type);
+    Py_VISIT(state->AnnAssign_type);
+    Py_VISIT(state->Assert_type);
+    Py_VISIT(state->Assign_type);
+    Py_VISIT(state->AsyncFor_type);
+    Py_VISIT(state->AsyncFunctionDef_type);
+    Py_VISIT(state->AsyncWith_type);
+    Py_VISIT(state->Attribute_type);
+    Py_VISIT(state->AugAssign_type);
+    Py_VISIT(state->Await_type);
+    Py_VISIT(state->BinOp_type);
+    Py_VISIT(state->BitAnd_singleton);
+    Py_VISIT(state->BitAnd_type);
+    Py_VISIT(state->BitOr_singleton);
+    Py_VISIT(state->BitOr_type);
+    Py_VISIT(state->BitXor_singleton);
+    Py_VISIT(state->BitXor_type);
+    Py_VISIT(state->BoolOp_type);
+    Py_VISIT(state->Break_type);
+    Py_VISIT(state->Call_type);
+    Py_VISIT(state->ClassDef_type);
+    Py_VISIT(state->Compare_type);
+    Py_VISIT(state->Constant_type);
+    Py_VISIT(state->Continue_type);
+    Py_VISIT(state->Del_singleton);
+    Py_VISIT(state->Del_type);
+    Py_VISIT(state->Delete_type);
+    Py_VISIT(state->DictComp_type);
+    Py_VISIT(state->Dict_type);
+    Py_VISIT(state->Div_singleton);
+    Py_VISIT(state->Div_type);
+    Py_VISIT(state->Eq_singleton);
+    Py_VISIT(state->Eq_type);
+    Py_VISIT(state->ExceptHandler_type);
+    Py_VISIT(state->Expr_type);
+    Py_VISIT(state->Expression_type);
+    Py_VISIT(state->FloorDiv_singleton);
+    Py_VISIT(state->FloorDiv_type);
+    Py_VISIT(state->For_type);
+    Py_VISIT(state->FormattedValue_type);
+    Py_VISIT(state->FunctionDef_type);
+    Py_VISIT(state->FunctionType_type);
+    Py_VISIT(state->GeneratorExp_type);
+    Py_VISIT(state->Global_type);
+    Py_VISIT(state->GtE_singleton);
+    Py_VISIT(state->GtE_type);
+    Py_VISIT(state->Gt_singleton);
+    Py_VISIT(state->Gt_type);
+    Py_VISIT(state->IfExp_type);
+    Py_VISIT(state->If_type);
+    Py_VISIT(state->ImportFrom_type);
+    Py_VISIT(state->Import_type);
+    Py_VISIT(state->In_singleton);
+    Py_VISIT(state->In_type);
+    Py_VISIT(state->Interactive_type);
+    Py_VISIT(state->Invert_singleton);
+    Py_VISIT(state->Invert_type);
+    Py_VISIT(state->IsNot_singleton);
+    Py_VISIT(state->IsNot_type);
+    Py_VISIT(state->Is_singleton);
+    Py_VISIT(state->Is_type);
+    Py_VISIT(state->JoinedStr_type);
+    Py_VISIT(state->LShift_singleton);
+    Py_VISIT(state->LShift_type);
+    Py_VISIT(state->Lambda_type);
+    Py_VISIT(state->ListComp_type);
+    Py_VISIT(state->List_type);
+    Py_VISIT(state->Load_singleton);
+    Py_VISIT(state->Load_type);
+    Py_VISIT(state->LtE_singleton);
+    Py_VISIT(state->LtE_type);
+    Py_VISIT(state->Lt_singleton);
+    Py_VISIT(state->Lt_type);
+    Py_VISIT(state->MatMult_singleton);
+    Py_VISIT(state->MatMult_type);
+    Py_VISIT(state->Mod_singleton);
+    Py_VISIT(state->Mod_type);
+    Py_VISIT(state->Module_type);
+    Py_VISIT(state->Mult_singleton);
+    Py_VISIT(state->Mult_type);
+    Py_VISIT(state->Name_type);
+    Py_VISIT(state->NamedExpr_type);
+    Py_VISIT(state->Nonlocal_type);
+    Py_VISIT(state->NotEq_singleton);
+    Py_VISIT(state->NotEq_type);
+    Py_VISIT(state->NotIn_singleton);
+    Py_VISIT(state->NotIn_type);
+    Py_VISIT(state->Not_singleton);
+    Py_VISIT(state->Not_type);
+    Py_VISIT(state->Or_singleton);
+    Py_VISIT(state->Or_type);
+    Py_VISIT(state->Pass_type);
+    Py_VISIT(state->Pow_singleton);
+    Py_VISIT(state->Pow_type);
+    Py_VISIT(state->RShift_singleton);
+    Py_VISIT(state->RShift_type);
+    Py_VISIT(state->Raise_type);
+    Py_VISIT(state->Return_type);
+    Py_VISIT(state->SetComp_type);
+    Py_VISIT(state->Set_type);
+    Py_VISIT(state->Slice_type);
+    Py_VISIT(state->Starred_type);
+    Py_VISIT(state->Store_singleton);
+    Py_VISIT(state->Store_type);
+    Py_VISIT(state->Sub_singleton);
+    Py_VISIT(state->Sub_type);
+    Py_VISIT(state->Subscript_type);
+    Py_VISIT(state->Try_type);
+    Py_VISIT(state->Tuple_type);
+    Py_VISIT(state->TypeIgnore_type);
+    Py_VISIT(state->UAdd_singleton);
+    Py_VISIT(state->UAdd_type);
+    Py_VISIT(state->USub_singleton);
+    Py_VISIT(state->USub_type);
+    Py_VISIT(state->UnaryOp_type);
+    Py_VISIT(state->While_type);
+    Py_VISIT(state->With_type);
+    Py_VISIT(state->YieldFrom_type);
+    Py_VISIT(state->Yield_type);
+    Py_VISIT(state->__dict__);
+    Py_VISIT(state->__doc__);
+    Py_VISIT(state->__module__);
+    Py_VISIT(state->_attributes);
+    Py_VISIT(state->_fields);
+    Py_VISIT(state->alias_type);
+    Py_VISIT(state->annotation);
+    Py_VISIT(state->arg);
+    Py_VISIT(state->arg_type);
+    Py_VISIT(state->args);
+    Py_VISIT(state->argtypes);
+    Py_VISIT(state->arguments_type);
+    Py_VISIT(state->asname);
+    Py_VISIT(state->ast);
+    Py_VISIT(state->attr);
+    Py_VISIT(state->bases);
+    Py_VISIT(state->body);
+    Py_VISIT(state->boolop_type);
+    Py_VISIT(state->cause);
+    Py_VISIT(state->cmpop_type);
+    Py_VISIT(state->col_offset);
+    Py_VISIT(state->comparators);
+    Py_VISIT(state->comprehension_type);
+    Py_VISIT(state->context_expr);
+    Py_VISIT(state->conversion);
+    Py_VISIT(state->ctx);
+    Py_VISIT(state->decorator_list);
+    Py_VISIT(state->defaults);
+    Py_VISIT(state->elt);
+    Py_VISIT(state->elts);
+    Py_VISIT(state->end_col_offset);
+    Py_VISIT(state->end_lineno);
+    Py_VISIT(state->exc);
+    Py_VISIT(state->excepthandler_type);
+    Py_VISIT(state->expr_context_type);
+    Py_VISIT(state->expr_type);
+    Py_VISIT(state->finalbody);
+    Py_VISIT(state->format_spec);
+    Py_VISIT(state->func);
+    Py_VISIT(state->generators);
+    Py_VISIT(state->handlers);
+    Py_VISIT(state->id);
+    Py_VISIT(state->ifs);
+    Py_VISIT(state->is_async);
+    Py_VISIT(state->items);
+    Py_VISIT(state->iter);
+    Py_VISIT(state->key);
+    Py_VISIT(state->keys);
+    Py_VISIT(state->keyword_type);
+    Py_VISIT(state->keywords);
+    Py_VISIT(state->kind);
+    Py_VISIT(state->kw_defaults);
+    Py_VISIT(state->kwarg);
+    Py_VISIT(state->kwonlyargs);
+    Py_VISIT(state->left);
+    Py_VISIT(state->level);
+    Py_VISIT(state->lineno);
+    Py_VISIT(state->lower);
+    Py_VISIT(state->mod_type);
+    Py_VISIT(state->module);
+    Py_VISIT(state->msg);
+    Py_VISIT(state->name);
+    Py_VISIT(state->names);
+    Py_VISIT(state->op);
+    Py_VISIT(state->operand);
+    Py_VISIT(state->operator_type);
+    Py_VISIT(state->ops);
+    Py_VISIT(state->optional_vars);
+    Py_VISIT(state->orelse);
+    Py_VISIT(state->posonlyargs);
+    Py_VISIT(state->returns);
+    Py_VISIT(state->right);
+    Py_VISIT(state->simple);
+    Py_VISIT(state->slice);
+    Py_VISIT(state->step);
+    Py_VISIT(state->stmt_type);
+    Py_VISIT(state->tag);
+    Py_VISIT(state->target);
+    Py_VISIT(state->targets);
+    Py_VISIT(state->test);
+    Py_VISIT(state->type);
+    Py_VISIT(state->type_comment);
+    Py_VISIT(state->type_ignore_type);
+    Py_VISIT(state->type_ignores);
+    Py_VISIT(state->unaryop_type);
+    Py_VISIT(state->upper);
+    Py_VISIT(state->value);
+    Py_VISIT(state->values);
+    Py_VISIT(state->vararg);
+    Py_VISIT(state->withitem_type);
 
     return 0;
 }
@@ -680,11 +689,10 @@ static struct PyModuleDef _astmodule = {
     astmodule_free,
 };
 
-#define astmodulestate_global ((astmodulestate *)PyModule_GetState(PyState_FindModule(&_astmodule)))
+#define astmodulestate_global get_ast_state(PyState_FindModule(&_astmodule))
 
-static int init_identifiers(void)
+static int init_identifiers(astmodulestate *state)
 {
-    astmodulestate *state = astmodulestate_global;
     if ((state->__dict__ = PyUnicode_InternFromString("__dict__")) == NULL) return 0;
     if ((state->__doc__ = PyUnicode_InternFromString("__doc__")) == NULL) return 0;
     if ((state->__module__ = PyUnicode_InternFromString("__module__")) == NULL) return 0;
@@ -762,7 +770,7 @@ static int init_identifiers(void)
     return 1;
 };
 
-static PyObject* ast2obj_mod(void*);
+static PyObject* ast2obj_mod(astmodulestate *state, void*);
 static const char * const Module_fields[]={
     "body",
     "type_ignores",
@@ -783,7 +791,7 @@ static const char * const stmt_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_stmt(void*);
+static PyObject* ast2obj_stmt(astmodulestate *state, void*);
 static const char * const FunctionDef_fields[]={
     "name",
     "args",
@@ -900,7 +908,7 @@ static const char * const expr_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_expr(void*);
+static PyObject* ast2obj_expr(astmodulestate *state, void*);
 static const char * const BoolOp_fields[]={
     "op",
     "values",
@@ -1013,12 +1021,12 @@ static const char * const Slice_fields[]={
     "upper",
     "step",
 };
-static PyObject* ast2obj_expr_context(expr_context_ty);
-static PyObject* ast2obj_boolop(boolop_ty);
-static PyObject* ast2obj_operator(operator_ty);
-static PyObject* ast2obj_unaryop(unaryop_ty);
-static PyObject* ast2obj_cmpop(cmpop_ty);
-static PyObject* ast2obj_comprehension(void*);
+static PyObject* ast2obj_expr_context(astmodulestate *state, expr_context_ty);
+static PyObject* ast2obj_boolop(astmodulestate *state, boolop_ty);
+static PyObject* ast2obj_operator(astmodulestate *state, operator_ty);
+static PyObject* ast2obj_unaryop(astmodulestate *state, unaryop_ty);
+static PyObject* ast2obj_cmpop(astmodulestate *state, cmpop_ty);
+static PyObject* ast2obj_comprehension(astmodulestate *state, void*);
 static const char * const comprehension_fields[]={
     "target",
     "iter",
@@ -1031,13 +1039,13 @@ static const char * const excepthandler_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_excepthandler(void*);
+static PyObject* ast2obj_excepthandler(astmodulestate *state, void*);
 static const char * const ExceptHandler_fields[]={
     "type",
     "name",
     "body",
 };
-static PyObject* ast2obj_arguments(void*);
+static PyObject* ast2obj_arguments(astmodulestate *state, void*);
 static const char * const arguments_fields[]={
     "posonlyargs",
     "args",
@@ -1047,7 +1055,7 @@ static const char * const arguments_fields[]={
     "kwarg",
     "defaults",
 };
-static PyObject* ast2obj_arg(void*);
+static PyObject* ast2obj_arg(astmodulestate *state, void*);
 static const char * const arg_attributes[] = {
     "lineno",
     "col_offset",
@@ -1059,7 +1067,7 @@ static const char * const arg_fields[]={
     "annotation",
     "type_comment",
 };
-static PyObject* ast2obj_keyword(void*);
+static PyObject* ast2obj_keyword(astmodulestate *state, void*);
 static const char * const keyword_attributes[] = {
     "lineno",
     "col_offset",
@@ -1070,17 +1078,17 @@ static const char * const keyword_fields[]={
     "arg",
     "value",
 };
-static PyObject* ast2obj_alias(void*);
+static PyObject* ast2obj_alias(astmodulestate *state, void*);
 static const char * const alias_fields[]={
     "name",
     "asname",
 };
-static PyObject* ast2obj_withitem(void*);
+static PyObject* ast2obj_withitem(astmodulestate *state, void*);
 static const char * const withitem_fields[]={
     "context_expr",
     "optional_vars",
 };
-static PyObject* ast2obj_type_ignore(void*);
+static PyObject* ast2obj_type_ignore(astmodulestate *state, void*);
 static const char * const TypeIgnore_fields[]={
     "lineno",
     "tag",
@@ -1127,7 +1135,8 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), astmodulestate_global->_fields, &fields) < 0) {
+    astmodulestate *state = astmodulestate_global;
+    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
         goto cleanup;
     }
     if (fields) {
@@ -1195,8 +1204,9 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
 static PyObject *
 ast_type_reduce(PyObject *self, PyObject *unused)
 {
+    astmodulestate *state = astmodulestate_global;
     PyObject *dict;
-    if (_PyObject_LookupAttr(self, astmodulestate_global->__dict__, &dict) < 0) {
+    if (_PyObject_LookupAttr(self, state->__dict__, &dict) < 0) {
         return NULL;
     }
     if (dict) {
@@ -1245,7 +1255,8 @@ static PyType_Spec AST_type_spec = {
 };
 
 static PyObject *
-make_type(const char *type, PyObject* base, const char* const* fields, int num_fields, const char *doc)
+make_type(astmodulestate *state, const char *type, PyObject* base,
+          const char* const* fields, int num_fields, const char *doc)
 {
     PyObject *fnames, *result;
     int i;
@@ -1261,16 +1272,16 @@ make_type(const char *type, PyObject* base, const char* const* fields, int num_f
     }
     result = PyObject_CallFunction((PyObject*)&PyType_Type, "s(O){OOOOOs}",
                     type, base,
-                    astmodulestate_global->_fields, fnames,
-                    astmodulestate_global->__module__,
-                    astmodulestate_global->ast,
-                    astmodulestate_global->__doc__, doc);
+                    state->_fields, fnames,
+                    state->__module__,
+                    state->ast,
+                    state->__doc__, doc);
     Py_DECREF(fnames);
     return result;
 }
 
 static int
-add_attributes(PyObject *type, const char * const *attrs, int num_fields)
+add_attributes(astmodulestate *state, PyObject *type, const char * const *attrs, int num_fields)
 {
     int i, result;
     PyObject *s, *l = PyTuple_New(num_fields);
@@ -1284,14 +1295,14 @@ add_attributes(PyObject *type, const char * const *attrs, int num_fields)
         }
         PyTuple_SET_ITEM(l, i, s);
     }
-    result = PyObject_SetAttr(type, astmodulestate_global->_attributes, l) >= 0;
+    result = PyObject_SetAttr(type, state->_attributes, l) >= 0;
     Py_DECREF(l);
     return result;
 }
 
 /* Conversion AST -> Python */
 
-static PyObject* ast2obj_list(asdl_seq *seq, PyObject* (*func)(void*))
+static PyObject* ast2obj_list(astmodulestate *state, asdl_seq *seq, PyObject* (*func)(astmodulestate *state, void*))
 {
     Py_ssize_t i, n = asdl_seq_LEN(seq);
     PyObject *result = PyList_New(n);
@@ -1299,7 +1310,7 @@ static PyObject* ast2obj_list(asdl_seq *seq, PyObject* (*func)(void*))
     if (!result)
         return NULL;
     for (i = 0; i < n; i++) {
-        value = func(asdl_seq_GET(seq, i));
+        value = func(state, asdl_seq_GET(seq, i));
         if (!value) {
             Py_DECREF(result);
             return NULL;
@@ -1309,7 +1320,7 @@ static PyObject* ast2obj_list(asdl_seq *seq, PyObject* (*func)(void*))
     return result;
 }
 
-static PyObject* ast2obj_object(void *o)
+static PyObject* ast2obj_object(astmodulestate *Py_UNUSED(state), void *o)
 {
     if (!o)
         o = Py_None;
@@ -1320,14 +1331,14 @@ static PyObject* ast2obj_object(void *o)
 #define ast2obj_identifier ast2obj_object
 #define ast2obj_string ast2obj_object
 
-static PyObject* ast2obj_int(long b)
+static PyObject* ast2obj_int(astmodulestate *Py_UNUSED(state), long b)
 {
     return PyLong_FromLong(b);
 }
 
 /* Conversion Python -> AST */
 
-static int obj2ast_object(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_object(astmodulestate *Py_UNUSED(state), PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (obj == Py_None)
         obj = NULL;
@@ -1342,7 +1353,7 @@ static int obj2ast_object(PyObject* obj, PyObject** out, PyArena* arena)
     return 0;
 }
 
-static int obj2ast_constant(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_constant(astmodulestate *Py_UNUSED(state), PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (PyArena_AddPyObject(arena, obj) < 0) {
         *out = NULL;
@@ -1353,25 +1364,25 @@ static int obj2ast_constant(PyObject* obj, PyObject** out, PyArena* arena)
     return 0;
 }
 
-static int obj2ast_identifier(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_identifier(astmodulestate *state, PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (!PyUnicode_CheckExact(obj) && obj != Py_None) {
         PyErr_SetString(PyExc_TypeError, "AST identifier must be of type str");
         return 1;
     }
-    return obj2ast_object(obj, out, arena);
+    return obj2ast_object(state, obj, out, arena);
 }
 
-static int obj2ast_string(PyObject* obj, PyObject** out, PyArena* arena)
+static int obj2ast_string(astmodulestate *state, PyObject* obj, PyObject** out, PyArena* arena)
 {
     if (!PyUnicode_CheckExact(obj) && !PyBytes_CheckExact(obj)) {
         PyErr_SetString(PyExc_TypeError, "AST string must be of type str");
         return 1;
     }
-    return obj2ast_object(obj, out, arena);
+    return obj2ast_object(state, obj, out, arena);
 }
 
-static int obj2ast_int(PyObject* obj, int* out, PyArena* arena)
+static int obj2ast_int(astmodulestate* Py_UNUSED(state), PyObject* obj, int* out, PyArena* arena)
 {
     int i;
     if (!PyLong_Check(obj)) {
@@ -1386,13 +1397,13 @@ static int obj2ast_int(PyObject* obj, int* out, PyArena* arena)
     return 0;
 }
 
-static int add_ast_fields(void)
+static int add_ast_fields(astmodulestate *state)
 {
     PyObject *empty_tuple;
     empty_tuple = PyTuple_New(0);
     if (!empty_tuple ||
-        PyObject_SetAttrString(astmodulestate_global->AST_type, "_fields", empty_tuple) < 0 ||
-        PyObject_SetAttrString(astmodulestate_global->AST_type, "_attributes", empty_tuple) < 0) {
+        PyObject_SetAttrString(state->AST_type, "_fields", empty_tuple) < 0 ||
+        PyObject_SetAttrString(state->AST_type, "_attributes", empty_tuple) < 0) {
         Py_XDECREF(empty_tuple);
         return -1;
     }
@@ -1403,41 +1414,48 @@ static int add_ast_fields(void)
 
 static int init_types(void)
 {
-    PyObject *m;
-    if (PyState_FindModule(&_astmodule) == NULL) {
-        m = PyModule_Create(&_astmodule);
-        if (!m) return 0;
-        PyState_AddModule(m, &_astmodule);
+    PyObject *module = PyState_FindModule(&_astmodule);
+    if (module == NULL) {
+        module = PyModule_Create(&_astmodule);
+        if (!module) {
+            return 0;
+        }
+        if (PyState_AddModule(module, &_astmodule) < 0) {
+            return 0;
+        }
     }
-    astmodulestate *state = astmodulestate_global;
+
+    astmodulestate *state = get_ast_state(module);
     if (state->initialized) return 1;
-    if (init_identifiers() < 0) return 0;
+    if (init_identifiers(state) < 0) return 0;
     state->AST_type = PyType_FromSpec(&AST_type_spec);
     if (!state->AST_type) return 0;
-    if (add_ast_fields() < 0) return 0;
-    state->mod_type = make_type("mod", state->AST_type, NULL, 0,
+    if (add_ast_fields(state) < 0) return 0;
+    state->mod_type = make_type(state, "mod", state->AST_type, NULL, 0,
         "mod = Module(stmt* body, type_ignore* type_ignores)\n"
         "    | Interactive(stmt* body)\n"
         "    | Expression(expr body)\n"
         "    | FunctionType(expr* argtypes, expr returns)");
     if (!state->mod_type) return 0;
-    if (!add_attributes(state->mod_type, NULL, 0)) return 0;
-    state->Module_type = make_type("Module", state->mod_type, Module_fields, 2,
+    if (!add_attributes(state, state->mod_type, NULL, 0)) return 0;
+    state->Module_type = make_type(state, "Module", state->mod_type,
+                                   Module_fields, 2,
         "Module(stmt* body, type_ignore* type_ignores)");
     if (!state->Module_type) return 0;
-    state->Interactive_type = make_type("Interactive", state->mod_type,
+    state->Interactive_type = make_type(state, "Interactive", state->mod_type,
                                         Interactive_fields, 1,
         "Interactive(stmt* body)");
     if (!state->Interactive_type) return 0;
-    state->Expression_type = make_type("Expression", state->mod_type,
+    state->Expression_type = make_type(state, "Expression", state->mod_type,
                                        Expression_fields, 1,
         "Expression(expr body)");
     if (!state->Expression_type) return 0;
-    state->FunctionType_type = make_type("FunctionType", state->mod_type,
-                                         FunctionType_fields, 2,
+    state->FunctionType_type = make_type(state, "FunctionType",
+                                         state->mod_type, FunctionType_fields,
+                                         2,
         "FunctionType(expr* argtypes, expr returns)");
     if (!state->FunctionType_type) return 0;
-    state->stmt_type = make_type("stmt", state->AST_type, NULL, 0,
+    state->stmt_type = make_type(state, "stmt", state->AST_type, NULL, 0,
         "stmt = FunctionDef(identifier name, arguments args, stmt* body, expr* decorator_list, expr? returns, string? type_comment)\n"
         "     | AsyncFunctionDef(identifier name, arguments args, stmt* body, expr* decorator_list, expr? returns, string? type_comment)\n"
         "     | ClassDef(identifier name, expr* bases, keyword* keywords, stmt* body, expr* decorator_list)\n"
@@ -1464,13 +1482,13 @@ static int init_types(void)
         "     | Break\n"
         "     | Continue");
     if (!state->stmt_type) return 0;
-    if (!add_attributes(state->stmt_type, stmt_attributes, 4)) return 0;
+    if (!add_attributes(state, state->stmt_type, stmt_attributes, 4)) return 0;
     if (PyObject_SetAttr(state->stmt_type, state->end_lineno, Py_None) == -1)
         return 0;
     if (PyObject_SetAttr(state->stmt_type, state->end_col_offset, Py_None) ==
         -1)
         return 0;
-    state->FunctionDef_type = make_type("FunctionDef", state->stmt_type,
+    state->FunctionDef_type = make_type(state, "FunctionDef", state->stmt_type,
                                         FunctionDef_fields, 6,
         "FunctionDef(identifier name, arguments args, stmt* body, expr* decorator_list, expr? returns, string? type_comment)");
     if (!state->FunctionDef_type) return 0;
@@ -1480,7 +1498,7 @@ static int init_types(void)
     if (PyObject_SetAttr(state->FunctionDef_type, state->type_comment, Py_None)
         == -1)
         return 0;
-    state->AsyncFunctionDef_type = make_type("AsyncFunctionDef",
+    state->AsyncFunctionDef_type = make_type(state, "AsyncFunctionDef",
                                              state->stmt_type,
                                              AsyncFunctionDef_fields, 6,
         "AsyncFunctionDef(identifier name, arguments args, stmt* body, expr* decorator_list, expr? returns, string? type_comment)");
@@ -1491,83 +1509,91 @@ static int init_types(void)
     if (PyObject_SetAttr(state->AsyncFunctionDef_type, state->type_comment,
         Py_None) == -1)
         return 0;
-    state->ClassDef_type = make_type("ClassDef", state->stmt_type,
+    state->ClassDef_type = make_type(state, "ClassDef", state->stmt_type,
                                      ClassDef_fields, 5,
         "ClassDef(identifier name, expr* bases, keyword* keywords, stmt* body, expr* decorator_list)");
     if (!state->ClassDef_type) return 0;
-    state->Return_type = make_type("Return", state->stmt_type, Return_fields, 1,
+    state->Return_type = make_type(state, "Return", state->stmt_type,
+                                   Return_fields, 1,
         "Return(expr? value)");
     if (!state->Return_type) return 0;
     if (PyObject_SetAttr(state->Return_type, state->value, Py_None) == -1)
         return 0;
-    state->Delete_type = make_type("Delete", state->stmt_type, Delete_fields, 1,
+    state->Delete_type = make_type(state, "Delete", state->stmt_type,
+                                   Delete_fields, 1,
         "Delete(expr* targets)");
     if (!state->Delete_type) return 0;
-    state->Assign_type = make_type("Assign", state->stmt_type, Assign_fields, 3,
+    state->Assign_type = make_type(state, "Assign", state->stmt_type,
+                                   Assign_fields, 3,
         "Assign(expr* targets, expr value, string? type_comment)");
     if (!state->Assign_type) return 0;
     if (PyObject_SetAttr(state->Assign_type, state->type_comment, Py_None) ==
         -1)
         return 0;
-    state->AugAssign_type = make_type("AugAssign", state->stmt_type,
+    state->AugAssign_type = make_type(state, "AugAssign", state->stmt_type,
                                       AugAssign_fields, 3,
         "AugAssign(expr target, operator op, expr value)");
     if (!state->AugAssign_type) return 0;
-    state->AnnAssign_type = make_type("AnnAssign", state->stmt_type,
+    state->AnnAssign_type = make_type(state, "AnnAssign", state->stmt_type,
                                       AnnAssign_fields, 4,
         "AnnAssign(expr target, expr annotation, expr? value, int simple)");
     if (!state->AnnAssign_type) return 0;
     if (PyObject_SetAttr(state->AnnAssign_type, state->value, Py_None) == -1)
         return 0;
-    state->For_type = make_type("For", state->stmt_type, For_fields, 5,
+    state->For_type = make_type(state, "For", state->stmt_type, For_fields, 5,
         "For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)");
     if (!state->For_type) return 0;
     if (PyObject_SetAttr(state->For_type, state->type_comment, Py_None) == -1)
         return 0;
-    state->AsyncFor_type = make_type("AsyncFor", state->stmt_type,
+    state->AsyncFor_type = make_type(state, "AsyncFor", state->stmt_type,
                                      AsyncFor_fields, 5,
         "AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)");
     if (!state->AsyncFor_type) return 0;
     if (PyObject_SetAttr(state->AsyncFor_type, state->type_comment, Py_None) ==
         -1)
         return 0;
-    state->While_type = make_type("While", state->stmt_type, While_fields, 3,
+    state->While_type = make_type(state, "While", state->stmt_type,
+                                  While_fields, 3,
         "While(expr test, stmt* body, stmt* orelse)");
     if (!state->While_type) return 0;
-    state->If_type = make_type("If", state->stmt_type, If_fields, 3,
+    state->If_type = make_type(state, "If", state->stmt_type, If_fields, 3,
         "If(expr test, stmt* body, stmt* orelse)");
     if (!state->If_type) return 0;
-    state->With_type = make_type("With", state->stmt_type, With_fields, 3,
+    state->With_type = make_type(state, "With", state->stmt_type, With_fields,
+                                 3,
         "With(withitem* items, stmt* body, string? type_comment)");
     if (!state->With_type) return 0;
     if (PyObject_SetAttr(state->With_type, state->type_comment, Py_None) == -1)
         return 0;
-    state->AsyncWith_type = make_type("AsyncWith", state->stmt_type,
+    state->AsyncWith_type = make_type(state, "AsyncWith", state->stmt_type,
                                       AsyncWith_fields, 3,
         "AsyncWith(withitem* items, stmt* body, string? type_comment)");
     if (!state->AsyncWith_type) return 0;
     if (PyObject_SetAttr(state->AsyncWith_type, state->type_comment, Py_None)
         == -1)
         return 0;
-    state->Raise_type = make_type("Raise", state->stmt_type, Raise_fields, 2,
+    state->Raise_type = make_type(state, "Raise", state->stmt_type,
+                                  Raise_fields, 2,
         "Raise(expr? exc, expr? cause)");
     if (!state->Raise_type) return 0;
     if (PyObject_SetAttr(state->Raise_type, state->exc, Py_None) == -1)
         return 0;
     if (PyObject_SetAttr(state->Raise_type, state->cause, Py_None) == -1)
         return 0;
-    state->Try_type = make_type("Try", state->stmt_type, Try_fields, 4,
+    state->Try_type = make_type(state, "Try", state->stmt_type, Try_fields, 4,
         "Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)");
     if (!state->Try_type) return 0;
-    state->Assert_type = make_type("Assert", state->stmt_type, Assert_fields, 2,
+    state->Assert_type = make_type(state, "Assert", state->stmt_type,
+                                   Assert_fields, 2,
         "Assert(expr test, expr? msg)");
     if (!state->Assert_type) return 0;
     if (PyObject_SetAttr(state->Assert_type, state->msg, Py_None) == -1)
         return 0;
-    state->Import_type = make_type("Import", state->stmt_type, Import_fields, 1,
+    state->Import_type = make_type(state, "Import", state->stmt_type,
+                                   Import_fields, 1,
         "Import(alias* names)");
     if (!state->Import_type) return 0;
-    state->ImportFrom_type = make_type("ImportFrom", state->stmt_type,
+    state->ImportFrom_type = make_type(state, "ImportFrom", state->stmt_type,
                                        ImportFrom_fields, 3,
         "ImportFrom(identifier? module, alias* names, int? level)");
     if (!state->ImportFrom_type) return 0;
@@ -1575,26 +1601,29 @@ static int init_types(void)
         return 0;
     if (PyObject_SetAttr(state->ImportFrom_type, state->level, Py_None) == -1)
         return 0;
-    state->Global_type = make_type("Global", state->stmt_type, Global_fields, 1,
+    state->Global_type = make_type(state, "Global", state->stmt_type,
+                                   Global_fields, 1,
         "Global(identifier* names)");
     if (!state->Global_type) return 0;
-    state->Nonlocal_type = make_type("Nonlocal", state->stmt_type,
+    state->Nonlocal_type = make_type(state, "Nonlocal", state->stmt_type,
                                      Nonlocal_fields, 1,
         "Nonlocal(identifier* names)");
     if (!state->Nonlocal_type) return 0;
-    state->Expr_type = make_type("Expr", state->stmt_type, Expr_fields, 1,
+    state->Expr_type = make_type(state, "Expr", state->stmt_type, Expr_fields,
+                                 1,
         "Expr(expr value)");
     if (!state->Expr_type) return 0;
-    state->Pass_type = make_type("Pass", state->stmt_type, NULL, 0,
+    state->Pass_type = make_type(state, "Pass", state->stmt_type, NULL, 0,
         "Pass");
     if (!state->Pass_type) return 0;
-    state->Break_type = make_type("Break", state->stmt_type, NULL, 0,
+    state->Break_type = make_type(state, "Break", state->stmt_type, NULL, 0,
         "Break");
     if (!state->Break_type) return 0;
-    state->Continue_type = make_type("Continue", state->stmt_type, NULL, 0,
+    state->Continue_type = make_type(state, "Continue", state->stmt_type, NULL,
+                                     0,
         "Continue");
     if (!state->Continue_type) return 0;
-    state->expr_type = make_type("expr", state->AST_type, NULL, 0,
+    state->expr_type = make_type(state, "expr", state->AST_type, NULL, 0,
         "expr = BoolOp(boolop op, expr* values)\n"
         "     | NamedExpr(expr target, expr value)\n"
         "     | BinOp(expr left, operator op, expr right)\n"
@@ -1623,74 +1652,84 @@ static int init_types(void)
         "     | Tuple(expr* elts, expr_context ctx)\n"
         "     | Slice(expr? lower, expr? upper, expr? step)");
     if (!state->expr_type) return 0;
-    if (!add_attributes(state->expr_type, expr_attributes, 4)) return 0;
+    if (!add_attributes(state, state->expr_type, expr_attributes, 4)) return 0;
     if (PyObject_SetAttr(state->expr_type, state->end_lineno, Py_None) == -1)
         return 0;
     if (PyObject_SetAttr(state->expr_type, state->end_col_offset, Py_None) ==
         -1)
         return 0;
-    state->BoolOp_type = make_type("BoolOp", state->expr_type, BoolOp_fields, 2,
+    state->BoolOp_type = make_type(state, "BoolOp", state->expr_type,
+                                   BoolOp_fields, 2,
         "BoolOp(boolop op, expr* values)");
     if (!state->BoolOp_type) return 0;
-    state->NamedExpr_type = make_type("NamedExpr", state->expr_type,
+    state->NamedExpr_type = make_type(state, "NamedExpr", state->expr_type,
                                       NamedExpr_fields, 2,
         "NamedExpr(expr target, expr value)");
     if (!state->NamedExpr_type) return 0;
-    state->BinOp_type = make_type("BinOp", state->expr_type, BinOp_fields, 3,
+    state->BinOp_type = make_type(state, "BinOp", state->expr_type,
+                                  BinOp_fields, 3,
         "BinOp(expr left, operator op, expr right)");
     if (!state->BinOp_type) return 0;
-    state->UnaryOp_type = make_type("UnaryOp", state->expr_type,
+    state->UnaryOp_type = make_type(state, "UnaryOp", state->expr_type,
                                     UnaryOp_fields, 2,
         "UnaryOp(unaryop op, expr operand)");
     if (!state->UnaryOp_type) return 0;
-    state->Lambda_type = make_type("Lambda", state->expr_type, Lambda_fields, 2,
+    state->Lambda_type = make_type(state, "Lambda", state->expr_type,
+                                   Lambda_fields, 2,
         "Lambda(arguments args, expr body)");
     if (!state->Lambda_type) return 0;
-    state->IfExp_type = make_type("IfExp", state->expr_type, IfExp_fields, 3,
+    state->IfExp_type = make_type(state, "IfExp", state->expr_type,
+                                  IfExp_fields, 3,
         "IfExp(expr test, expr body, expr orelse)");
     if (!state->IfExp_type) return 0;
-    state->Dict_type = make_type("Dict", state->expr_type, Dict_fields, 2,
+    state->Dict_type = make_type(state, "Dict", state->expr_type, Dict_fields,
+                                 2,
         "Dict(expr* keys, expr* values)");
     if (!state->Dict_type) return 0;
-    state->Set_type = make_type("Set", state->expr_type, Set_fields, 1,
+    state->Set_type = make_type(state, "Set", state->expr_type, Set_fields, 1,
         "Set(expr* elts)");
     if (!state->Set_type) return 0;
-    state->ListComp_type = make_type("ListComp", state->expr_type,
+    state->ListComp_type = make_type(state, "ListComp", state->expr_type,
                                      ListComp_fields, 2,
         "ListComp(expr elt, comprehension* generators)");
     if (!state->ListComp_type) return 0;
-    state->SetComp_type = make_type("SetComp", state->expr_type,
+    state->SetComp_type = make_type(state, "SetComp", state->expr_type,
                                     SetComp_fields, 2,
         "SetComp(expr elt, comprehension* generators)");
     if (!state->SetComp_type) return 0;
-    state->DictComp_type = make_type("DictComp", state->expr_type,
+    state->DictComp_type = make_type(state, "DictComp", state->expr_type,
                                      DictComp_fields, 3,
         "DictComp(expr key, expr value, comprehension* generators)");
     if (!state->DictComp_type) return 0;
-    state->GeneratorExp_type = make_type("GeneratorExp", state->expr_type,
-                                         GeneratorExp_fields, 2,
+    state->GeneratorExp_type = make_type(state, "GeneratorExp",
+                                         state->expr_type, GeneratorExp_fields,
+                                         2,
         "GeneratorExp(expr elt, comprehension* generators)");
     if (!state->GeneratorExp_type) return 0;
-    state->Await_type = make_type("Await", state->expr_type, Await_fields, 1,
+    state->Await_type = make_type(state, "Await", state->expr_type,
+                                  Await_fields, 1,
         "Await(expr value)");
     if (!state->Await_type) return 0;
-    state->Yield_type = make_type("Yield", state->expr_type, Yield_fields, 1,
+    state->Yield_type = make_type(state, "Yield", state->expr_type,
+                                  Yield_fields, 1,
         "Yield(expr? value)");
     if (!state->Yield_type) return 0;
     if (PyObject_SetAttr(state->Yield_type, state->value, Py_None) == -1)
         return 0;
-    state->YieldFrom_type = make_type("YieldFrom", state->expr_type,
+    state->YieldFrom_type = make_type(state, "YieldFrom", state->expr_type,
                                       YieldFrom_fields, 1,
         "YieldFrom(expr value)");
     if (!state->YieldFrom_type) return 0;
-    state->Compare_type = make_type("Compare", state->expr_type,
+    state->Compare_type = make_type(state, "Compare", state->expr_type,
                                     Compare_fields, 3,
         "Compare(expr left, cmpop* ops, expr* comparators)");
     if (!state->Compare_type) return 0;
-    state->Call_type = make_type("Call", state->expr_type, Call_fields, 3,
+    state->Call_type = make_type(state, "Call", state->expr_type, Call_fields,
+                                 3,
         "Call(expr func, expr* args, keyword* keywords)");
     if (!state->Call_type) return 0;
-    state->FormattedValue_type = make_type("FormattedValue", state->expr_type,
+    state->FormattedValue_type = make_type(state, "FormattedValue",
+                                           state->expr_type,
                                            FormattedValue_fields, 3,
         "FormattedValue(expr value, int? conversion, expr? format_spec)");
     if (!state->FormattedValue_type) return 0;
@@ -1700,38 +1739,42 @@ static int init_types(void)
     if (PyObject_SetAttr(state->FormattedValue_type, state->format_spec,
         Py_None) == -1)
         return 0;
-    state->JoinedStr_type = make_type("JoinedStr", state->expr_type,
+    state->JoinedStr_type = make_type(state, "JoinedStr", state->expr_type,
                                       JoinedStr_fields, 1,
         "JoinedStr(expr* values)");
     if (!state->JoinedStr_type) return 0;
-    state->Constant_type = make_type("Constant", state->expr_type,
+    state->Constant_type = make_type(state, "Constant", state->expr_type,
                                      Constant_fields, 2,
         "Constant(constant value, string? kind)");
     if (!state->Constant_type) return 0;
     if (PyObject_SetAttr(state->Constant_type, state->kind, Py_None) == -1)
         return 0;
-    state->Attribute_type = make_type("Attribute", state->expr_type,
+    state->Attribute_type = make_type(state, "Attribute", state->expr_type,
                                       Attribute_fields, 3,
         "Attribute(expr value, identifier attr, expr_context ctx)");
     if (!state->Attribute_type) return 0;
-    state->Subscript_type = make_type("Subscript", state->expr_type,
+    state->Subscript_type = make_type(state, "Subscript", state->expr_type,
                                       Subscript_fields, 3,
         "Subscript(expr value, expr slice, expr_context ctx)");
     if (!state->Subscript_type) return 0;
-    state->Starred_type = make_type("Starred", state->expr_type,
+    state->Starred_type = make_type(state, "Starred", state->expr_type,
                                     Starred_fields, 2,
         "Starred(expr value, expr_context ctx)");
     if (!state->Starred_type) return 0;
-    state->Name_type = make_type("Name", state->expr_type, Name_fields, 2,
+    state->Name_type = make_type(state, "Name", state->expr_type, Name_fields,
+                                 2,
         "Name(identifier id, expr_context ctx)");
     if (!state->Name_type) return 0;
-    state->List_type = make_type("List", state->expr_type, List_fields, 2,
+    state->List_type = make_type(state, "List", state->expr_type, List_fields,
+                                 2,
         "List(expr* elts, expr_context ctx)");
     if (!state->List_type) return 0;
-    state->Tuple_type = make_type("Tuple", state->expr_type, Tuple_fields, 2,
+    state->Tuple_type = make_type(state, "Tuple", state->expr_type,
+                                  Tuple_fields, 2,
         "Tuple(expr* elts, expr_context ctx)");
     if (!state->Tuple_type) return 0;
-    state->Slice_type = make_type("Slice", state->expr_type, Slice_fields, 3,
+    state->Slice_type = make_type(state, "Slice", state->expr_type,
+                                  Slice_fields, 3,
         "Slice(expr? lower, expr? upper, expr? step)");
     if (!state->Slice_type) return 0;
     if (PyObject_SetAttr(state->Slice_type, state->lower, Py_None) == -1)
@@ -1740,244 +1783,255 @@ static int init_types(void)
         return 0;
     if (PyObject_SetAttr(state->Slice_type, state->step, Py_None) == -1)
         return 0;
-    state->expr_context_type = make_type("expr_context", state->AST_type, NULL,
-                                         0,
+    state->expr_context_type = make_type(state, "expr_context",
+                                         state->AST_type, NULL, 0,
         "expr_context = Load | Store | Del");
     if (!state->expr_context_type) return 0;
-    if (!add_attributes(state->expr_context_type, NULL, 0)) return 0;
-    state->Load_type = make_type("Load", state->expr_context_type, NULL, 0,
+    if (!add_attributes(state, state->expr_context_type, NULL, 0)) return 0;
+    state->Load_type = make_type(state, "Load", state->expr_context_type, NULL,
+                                 0,
         "Load");
     if (!state->Load_type) return 0;
     state->Load_singleton = PyType_GenericNew((PyTypeObject *)state->Load_type,
                                               NULL, NULL);
     if (!state->Load_singleton) return 0;
-    state->Store_type = make_type("Store", state->expr_context_type, NULL, 0,
+    state->Store_type = make_type(state, "Store", state->expr_context_type,
+                                  NULL, 0,
         "Store");
     if (!state->Store_type) return 0;
     state->Store_singleton = PyType_GenericNew((PyTypeObject
                                                *)state->Store_type, NULL, NULL);
     if (!state->Store_singleton) return 0;
-    state->Del_type = make_type("Del", state->expr_context_type, NULL, 0,
+    state->Del_type = make_type(state, "Del", state->expr_context_type, NULL, 0,
         "Del");
     if (!state->Del_type) return 0;
     state->Del_singleton = PyType_GenericNew((PyTypeObject *)state->Del_type,
                                              NULL, NULL);
     if (!state->Del_singleton) return 0;
-    state->boolop_type = make_type("boolop", state->AST_type, NULL, 0,
+    state->boolop_type = make_type(state, "boolop", state->AST_type, NULL, 0,
         "boolop = And | Or");
     if (!state->boolop_type) return 0;
-    if (!add_attributes(state->boolop_type, NULL, 0)) return 0;
-    state->And_type = make_type("And", state->boolop_type, NULL, 0,
+    if (!add_attributes(state, state->boolop_type, NULL, 0)) return 0;
+    state->And_type = make_type(state, "And", state->boolop_type, NULL, 0,
         "And");
     if (!state->And_type) return 0;
     state->And_singleton = PyType_GenericNew((PyTypeObject *)state->And_type,
                                              NULL, NULL);
     if (!state->And_singleton) return 0;
-    state->Or_type = make_type("Or", state->boolop_type, NULL, 0,
+    state->Or_type = make_type(state, "Or", state->boolop_type, NULL, 0,
         "Or");
     if (!state->Or_type) return 0;
     state->Or_singleton = PyType_GenericNew((PyTypeObject *)state->Or_type,
                                             NULL, NULL);
     if (!state->Or_singleton) return 0;
-    state->operator_type = make_type("operator", state->AST_type, NULL, 0,
+    state->operator_type = make_type(state, "operator", state->AST_type, NULL,
+                                     0,
         "operator = Add | Sub | Mult | MatMult | Div | Mod | Pow | LShift | RShift | BitOr | BitXor | BitAnd | FloorDiv");
     if (!state->operator_type) return 0;
-    if (!add_attributes(state->operator_type, NULL, 0)) return 0;
-    state->Add_type = make_type("Add", state->operator_type, NULL, 0,
+    if (!add_attributes(state, state->operator_type, NULL, 0)) return 0;
+    state->Add_type = make_type(state, "Add", state->operator_type, NULL, 0,
         "Add");
     if (!state->Add_type) return 0;
     state->Add_singleton = PyType_GenericNew((PyTypeObject *)state->Add_type,
                                              NULL, NULL);
     if (!state->Add_singleton) return 0;
-    state->Sub_type = make_type("Sub", state->operator_type, NULL, 0,
+    state->Sub_type = make_type(state, "Sub", state->operator_type, NULL, 0,
         "Sub");
     if (!state->Sub_type) return 0;
     state->Sub_singleton = PyType_GenericNew((PyTypeObject *)state->Sub_type,
                                              NULL, NULL);
     if (!state->Sub_singleton) return 0;
-    state->Mult_type = make_type("Mult", state->operator_type, NULL, 0,
+    state->Mult_type = make_type(state, "Mult", state->operator_type, NULL, 0,
         "Mult");
     if (!state->Mult_type) return 0;
     state->Mult_singleton = PyType_GenericNew((PyTypeObject *)state->Mult_type,
                                               NULL, NULL);
     if (!state->Mult_singleton) return 0;
-    state->MatMult_type = make_type("MatMult", state->operator_type, NULL, 0,
+    state->MatMult_type = make_type(state, "MatMult", state->operator_type,
+                                    NULL, 0,
         "MatMult");
     if (!state->MatMult_type) return 0;
     state->MatMult_singleton = PyType_GenericNew((PyTypeObject
                                                  *)state->MatMult_type, NULL,
                                                  NULL);
     if (!state->MatMult_singleton) return 0;
-    state->Div_type = make_type("Div", state->operator_type, NULL, 0,
+    state->Div_type = make_type(state, "Div", state->operator_type, NULL, 0,
         "Div");
     if (!state->Div_type) return 0;
     state->Div_singleton = PyType_GenericNew((PyTypeObject *)state->Div_type,
                                              NULL, NULL);
     if (!state->Div_singleton) return 0;
-    state->Mod_type = make_type("Mod", state->operator_type, NULL, 0,
+    state->Mod_type = make_type(state, "Mod", state->operator_type, NULL, 0,
         "Mod");
     if (!state->Mod_type) return 0;
     state->Mod_singleton = PyType_GenericNew((PyTypeObject *)state->Mod_type,
                                              NULL, NULL);
     if (!state->Mod_singleton) return 0;
-    state->Pow_type = make_type("Pow", state->operator_type, NULL, 0,
+    state->Pow_type = make_type(state, "Pow", state->operator_type, NULL, 0,
         "Pow");
     if (!state->Pow_type) return 0;
     state->Pow_singleton = PyType_GenericNew((PyTypeObject *)state->Pow_type,
                                              NULL, NULL);
     if (!state->Pow_singleton) return 0;
-    state->LShift_type = make_type("LShift", state->operator_type, NULL, 0,
+    state->LShift_type = make_type(state, "LShift", state->operator_type, NULL,
+                                   0,
         "LShift");
     if (!state->LShift_type) return 0;
     state->LShift_singleton = PyType_GenericNew((PyTypeObject
                                                 *)state->LShift_type, NULL,
                                                 NULL);
     if (!state->LShift_singleton) return 0;
-    state->RShift_type = make_type("RShift", state->operator_type, NULL, 0,
+    state->RShift_type = make_type(state, "RShift", state->operator_type, NULL,
+                                   0,
         "RShift");
     if (!state->RShift_type) return 0;
     state->RShift_singleton = PyType_GenericNew((PyTypeObject
                                                 *)state->RShift_type, NULL,
                                                 NULL);
     if (!state->RShift_singleton) return 0;
-    state->BitOr_type = make_type("BitOr", state->operator_type, NULL, 0,
+    state->BitOr_type = make_type(state, "BitOr", state->operator_type, NULL, 0,
         "BitOr");
     if (!state->BitOr_type) return 0;
     state->BitOr_singleton = PyType_GenericNew((PyTypeObject
                                                *)state->BitOr_type, NULL, NULL);
     if (!state->BitOr_singleton) return 0;
-    state->BitXor_type = make_type("BitXor", state->operator_type, NULL, 0,
+    state->BitXor_type = make_type(state, "BitXor", state->operator_type, NULL,
+                                   0,
         "BitXor");
     if (!state->BitXor_type) return 0;
     state->BitXor_singleton = PyType_GenericNew((PyTypeObject
                                                 *)state->BitXor_type, NULL,
                                                 NULL);
     if (!state->BitXor_singleton) return 0;
-    state->BitAnd_type = make_type("BitAnd", state->operator_type, NULL, 0,
+    state->BitAnd_type = make_type(state, "BitAnd", state->operator_type, NULL,
+                                   0,
         "BitAnd");
     if (!state->BitAnd_type) return 0;
     state->BitAnd_singleton = PyType_GenericNew((PyTypeObject
                                                 *)state->BitAnd_type, NULL,
                                                 NULL);
     if (!state->BitAnd_singleton) return 0;
-    state->FloorDiv_type = make_type("FloorDiv", state->operator_type, NULL, 0,
+    state->FloorDiv_type = make_type(state, "FloorDiv", state->operator_type,
+                                     NULL, 0,
         "FloorDiv");
     if (!state->FloorDiv_type) return 0;
     state->FloorDiv_singleton = PyType_GenericNew((PyTypeObject
                                                   *)state->FloorDiv_type, NULL,
                                                   NULL);
     if (!state->FloorDiv_singleton) return 0;
-    state->unaryop_type = make_type("unaryop", state->AST_type, NULL, 0,
+    state->unaryop_type = make_type(state, "unaryop", state->AST_type, NULL, 0,
         "unaryop = Invert | Not | UAdd | USub");
     if (!state->unaryop_type) return 0;
-    if (!add_attributes(state->unaryop_type, NULL, 0)) return 0;
-    state->Invert_type = make_type("Invert", state->unaryop_type, NULL, 0,
+    if (!add_attributes(state, state->unaryop_type, NULL, 0)) return 0;
+    state->Invert_type = make_type(state, "Invert", state->unaryop_type, NULL,
+                                   0,
         "Invert");
     if (!state->Invert_type) return 0;
     state->Invert_singleton = PyType_GenericNew((PyTypeObject
                                                 *)state->Invert_type, NULL,
                                                 NULL);
     if (!state->Invert_singleton) return 0;
-    state->Not_type = make_type("Not", state->unaryop_type, NULL, 0,
+    state->Not_type = make_type(state, "Not", state->unaryop_type, NULL, 0,
         "Not");
     if (!state->Not_type) return 0;
     state->Not_singleton = PyType_GenericNew((PyTypeObject *)state->Not_type,
                                              NULL, NULL);
     if (!state->Not_singleton) return 0;
-    state->UAdd_type = make_type("UAdd", state->unaryop_type, NULL, 0,
+    state->UAdd_type = make_type(state, "UAdd", state->unaryop_type, NULL, 0,
         "UAdd");
     if (!state->UAdd_type) return 0;
     state->UAdd_singleton = PyType_GenericNew((PyTypeObject *)state->UAdd_type,
                                               NULL, NULL);
     if (!state->UAdd_singleton) return 0;
-    state->USub_type = make_type("USub", state->unaryop_type, NULL, 0,
+    state->USub_type = make_type(state, "USub", state->unaryop_type, NULL, 0,
         "USub");
     if (!state->USub_type) return 0;
     state->USub_singleton = PyType_GenericNew((PyTypeObject *)state->USub_type,
                                               NULL, NULL);
     if (!state->USub_singleton) return 0;
-    state->cmpop_type = make_type("cmpop", state->AST_type, NULL, 0,
+    state->cmpop_type = make_type(state, "cmpop", state->AST_type, NULL, 0,
         "cmpop = Eq | NotEq | Lt | LtE | Gt | GtE | Is | IsNot | In | NotIn");
     if (!state->cmpop_type) return 0;
-    if (!add_attributes(state->cmpop_type, NULL, 0)) return 0;
-    state->Eq_type = make_type("Eq", state->cmpop_type, NULL, 0,
+    if (!add_attributes(state, state->cmpop_type, NULL, 0)) return 0;
+    state->Eq_type = make_type(state, "Eq", state->cmpop_type, NULL, 0,
         "Eq");
     if (!state->Eq_type) return 0;
     state->Eq_singleton = PyType_GenericNew((PyTypeObject *)state->Eq_type,
                                             NULL, NULL);
     if (!state->Eq_singleton) return 0;
-    state->NotEq_type = make_type("NotEq", state->cmpop_type, NULL, 0,
+    state->NotEq_type = make_type(state, "NotEq", state->cmpop_type, NULL, 0,
         "NotEq");
     if (!state->NotEq_type) return 0;
     state->NotEq_singleton = PyType_GenericNew((PyTypeObject
                                                *)state->NotEq_type, NULL, NULL);
     if (!state->NotEq_singleton) return 0;
-    state->Lt_type = make_type("Lt", state->cmpop_type, NULL, 0,
+    state->Lt_type = make_type(state, "Lt", state->cmpop_type, NULL, 0,
         "Lt");
     if (!state->Lt_type) return 0;
     state->Lt_singleton = PyType_GenericNew((PyTypeObject *)state->Lt_type,
                                             NULL, NULL);
     if (!state->Lt_singleton) return 0;
-    state->LtE_type = make_type("LtE", state->cmpop_type, NULL, 0,
+    state->LtE_type = make_type(state, "LtE", state->cmpop_type, NULL, 0,
         "LtE");
     if (!state->LtE_type) return 0;
     state->LtE_singleton = PyType_GenericNew((PyTypeObject *)state->LtE_type,
                                              NULL, NULL);
     if (!state->LtE_singleton) return 0;
-    state->Gt_type = make_type("Gt", state->cmpop_type, NULL, 0,
+    state->Gt_type = make_type(state, "Gt", state->cmpop_type, NULL, 0,
         "Gt");
     if (!state->Gt_type) return 0;
     state->Gt_singleton = PyType_GenericNew((PyTypeObject *)state->Gt_type,
                                             NULL, NULL);
     if (!state->Gt_singleton) return 0;
-    state->GtE_type = make_type("GtE", state->cmpop_type, NULL, 0,
+    state->GtE_type = make_type(state, "GtE", state->cmpop_type, NULL, 0,
         "GtE");
     if (!state->GtE_type) return 0;
     state->GtE_singleton = PyType_GenericNew((PyTypeObject *)state->GtE_type,
                                              NULL, NULL);
     if (!state->GtE_singleton) return 0;
-    state->Is_type = make_type("Is", state->cmpop_type, NULL, 0,
+    state->Is_type = make_type(state, "Is", state->cmpop_type, NULL, 0,
         "Is");
     if (!state->Is_type) return 0;
     state->Is_singleton = PyType_GenericNew((PyTypeObject *)state->Is_type,
                                             NULL, NULL);
     if (!state->Is_singleton) return 0;
-    state->IsNot_type = make_type("IsNot", state->cmpop_type, NULL, 0,
+    state->IsNot_type = make_type(state, "IsNot", state->cmpop_type, NULL, 0,
         "IsNot");
     if (!state->IsNot_type) return 0;
     state->IsNot_singleton = PyType_GenericNew((PyTypeObject
                                                *)state->IsNot_type, NULL, NULL);
     if (!state->IsNot_singleton) return 0;
-    state->In_type = make_type("In", state->cmpop_type, NULL, 0,
+    state->In_type = make_type(state, "In", state->cmpop_type, NULL, 0,
         "In");
     if (!state->In_type) return 0;
     state->In_singleton = PyType_GenericNew((PyTypeObject *)state->In_type,
                                             NULL, NULL);
     if (!state->In_singleton) return 0;
-    state->NotIn_type = make_type("NotIn", state->cmpop_type, NULL, 0,
+    state->NotIn_type = make_type(state, "NotIn", state->cmpop_type, NULL, 0,
         "NotIn");
     if (!state->NotIn_type) return 0;
     state->NotIn_singleton = PyType_GenericNew((PyTypeObject
                                                *)state->NotIn_type, NULL, NULL);
     if (!state->NotIn_singleton) return 0;
-    state->comprehension_type = make_type("comprehension", state->AST_type,
+    state->comprehension_type = make_type(state, "comprehension",
+                                          state->AST_type,
                                           comprehension_fields, 4,
         "comprehension(expr target, expr iter, expr* ifs, int is_async)");
     if (!state->comprehension_type) return 0;
-    if (!add_attributes(state->comprehension_type, NULL, 0)) return 0;
-    state->excepthandler_type = make_type("excepthandler", state->AST_type,
-                                          NULL, 0,
+    if (!add_attributes(state, state->comprehension_type, NULL, 0)) return 0;
+    state->excepthandler_type = make_type(state, "excepthandler",
+                                          state->AST_type, NULL, 0,
         "excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)");
     if (!state->excepthandler_type) return 0;
-    if (!add_attributes(state->excepthandler_type, excepthandler_attributes,
-        4)) return 0;
+    if (!add_attributes(state, state->excepthandler_type,
+        excepthandler_attributes, 4)) return 0;
     if (PyObject_SetAttr(state->excepthandler_type, state->end_lineno, Py_None)
         == -1)
         return 0;
     if (PyObject_SetAttr(state->excepthandler_type, state->end_col_offset,
         Py_None) == -1)
         return 0;
-    state->ExceptHandler_type = make_type("ExceptHandler",
+    state->ExceptHandler_type = make_type(state, "ExceptHandler",
                                           state->excepthandler_type,
                                           ExceptHandler_fields, 3,
         "ExceptHandler(expr? type, identifier? name, stmt* body)");
@@ -1986,19 +2040,19 @@ static int init_types(void)
         return 0;
     if (PyObject_SetAttr(state->ExceptHandler_type, state->name, Py_None) == -1)
         return 0;
-    state->arguments_type = make_type("arguments", state->AST_type,
+    state->arguments_type = make_type(state, "arguments", state->AST_type,
                                       arguments_fields, 7,
         "arguments(arg* posonlyargs, arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults, arg? kwarg, expr* defaults)");
     if (!state->arguments_type) return 0;
-    if (!add_attributes(state->arguments_type, NULL, 0)) return 0;
+    if (!add_attributes(state, state->arguments_type, NULL, 0)) return 0;
     if (PyObject_SetAttr(state->arguments_type, state->vararg, Py_None) == -1)
         return 0;
     if (PyObject_SetAttr(state->arguments_type, state->kwarg, Py_None) == -1)
         return 0;
-    state->arg_type = make_type("arg", state->AST_type, arg_fields, 3,
+    state->arg_type = make_type(state, "arg", state->AST_type, arg_fields, 3,
         "arg(identifier arg, expr? annotation, string? type_comment)");
     if (!state->arg_type) return 0;
-    if (!add_attributes(state->arg_type, arg_attributes, 4)) return 0;
+    if (!add_attributes(state, state->arg_type, arg_attributes, 4)) return 0;
     if (PyObject_SetAttr(state->arg_type, state->annotation, Py_None) == -1)
         return 0;
     if (PyObject_SetAttr(state->arg_type, state->type_comment, Py_None) == -1)
@@ -2007,11 +2061,12 @@ static int init_types(void)
         return 0;
     if (PyObject_SetAttr(state->arg_type, state->end_col_offset, Py_None) == -1)
         return 0;
-    state->keyword_type = make_type("keyword", state->AST_type, keyword_fields,
-                                    2,
+    state->keyword_type = make_type(state, "keyword", state->AST_type,
+                                    keyword_fields, 2,
         "keyword(identifier? arg, expr value)");
     if (!state->keyword_type) return 0;
-    if (!add_attributes(state->keyword_type, keyword_attributes, 4)) return 0;
+    if (!add_attributes(state, state->keyword_type, keyword_attributes, 4))
+        return 0;
     if (PyObject_SetAttr(state->keyword_type, state->arg, Py_None) == -1)
         return 0;
     if (PyObject_SetAttr(state->keyword_type, state->end_lineno, Py_None) == -1)
@@ -2019,25 +2074,28 @@ static int init_types(void)
     if (PyObject_SetAttr(state->keyword_type, state->end_col_offset, Py_None)
         == -1)
         return 0;
-    state->alias_type = make_type("alias", state->AST_type, alias_fields, 2,
+    state->alias_type = make_type(state, "alias", state->AST_type,
+                                  alias_fields, 2,
         "alias(identifier name, identifier? asname)");
     if (!state->alias_type) return 0;
-    if (!add_attributes(state->alias_type, NULL, 0)) return 0;
+    if (!add_attributes(state, state->alias_type, NULL, 0)) return 0;
     if (PyObject_SetAttr(state->alias_type, state->asname, Py_None) == -1)
         return 0;
-    state->withitem_type = make_type("withitem", state->AST_type,
+    state->withitem_type = make_type(state, "withitem", state->AST_type,
                                      withitem_fields, 2,
         "withitem(expr context_expr, expr? optional_vars)");
     if (!state->withitem_type) return 0;
-    if (!add_attributes(state->withitem_type, NULL, 0)) return 0;
+    if (!add_attributes(state, state->withitem_type, NULL, 0)) return 0;
     if (PyObject_SetAttr(state->withitem_type, state->optional_vars, Py_None)
         == -1)
         return 0;
-    state->type_ignore_type = make_type("type_ignore", state->AST_type, NULL, 0,
+    state->type_ignore_type = make_type(state, "type_ignore", state->AST_type,
+                                        NULL, 0,
         "type_ignore = TypeIgnore(int lineno, string tag)");
     if (!state->type_ignore_type) return 0;
-    if (!add_attributes(state->type_ignore_type, NULL, 0)) return 0;
-    state->TypeIgnore_type = make_type("TypeIgnore", state->type_ignore_type,
+    if (!add_attributes(state, state->type_ignore_type, NULL, 0)) return 0;
+    state->TypeIgnore_type = make_type(state, "TypeIgnore",
+                                       state->type_ignore_type,
                                        TypeIgnore_fields, 2,
         "TypeIgnore(int lineno, string tag)");
     if (!state->TypeIgnore_type) return 0;
@@ -2045,26 +2103,38 @@ static int init_types(void)
     return 1;
 }
 
-static int obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena);
-static int obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena);
-static int obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena);
-static int obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena*
-                                arena);
-static int obj2ast_boolop(PyObject* obj, boolop_ty* out, PyArena* arena);
-static int obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena);
-static int obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena);
-static int obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena);
-static int obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena*
-                                 arena);
-static int obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena*
-                                 arena);
-static int obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena);
-static int obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena);
-static int obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena);
-static int obj2ast_alias(PyObject* obj, alias_ty* out, PyArena* arena);
-static int obj2ast_withitem(PyObject* obj, withitem_ty* out, PyArena* arena);
-static int obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena*
-                               arena);
+static int obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out,
+                       PyArena* arena);
+static int obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out,
+                        PyArena* arena);
+static int obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out,
+                        PyArena* arena);
+static int obj2ast_expr_context(astmodulestate *state, PyObject* obj,
+                                expr_context_ty* out, PyArena* arena);
+static int obj2ast_boolop(astmodulestate *state, PyObject* obj, boolop_ty* out,
+                          PyArena* arena);
+static int obj2ast_operator(astmodulestate *state, PyObject* obj, operator_ty*
+                            out, PyArena* arena);
+static int obj2ast_unaryop(astmodulestate *state, PyObject* obj, unaryop_ty*
+                           out, PyArena* arena);
+static int obj2ast_cmpop(astmodulestate *state, PyObject* obj, cmpop_ty* out,
+                         PyArena* arena);
+static int obj2ast_comprehension(astmodulestate *state, PyObject* obj,
+                                 comprehension_ty* out, PyArena* arena);
+static int obj2ast_excepthandler(astmodulestate *state, PyObject* obj,
+                                 excepthandler_ty* out, PyArena* arena);
+static int obj2ast_arguments(astmodulestate *state, PyObject* obj,
+                             arguments_ty* out, PyArena* arena);
+static int obj2ast_arg(astmodulestate *state, PyObject* obj, arg_ty* out,
+                       PyArena* arena);
+static int obj2ast_keyword(astmodulestate *state, PyObject* obj, keyword_ty*
+                           out, PyArena* arena);
+static int obj2ast_alias(astmodulestate *state, PyObject* obj, alias_ty* out,
+                         PyArena* arena);
+static int obj2ast_withitem(astmodulestate *state, PyObject* obj, withitem_ty*
+                            out, PyArena* arena);
+static int obj2ast_type_ignore(astmodulestate *state, PyObject* obj,
+                               type_ignore_ty* out, PyArena* arena);
 
 mod_ty
 Module(asdl_seq * body, asdl_seq * type_ignores, PyArena *arena)
@@ -3528,7 +3598,7 @@ TypeIgnore(int lineno, string tag, PyArena *arena)
 
 
 PyObject*
-ast2obj_mod(void* _o)
+ast2obj_mod(astmodulestate *state, void* _o)
 {
     mod_ty o = (mod_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -3536,58 +3606,55 @@ ast2obj_mod(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
     switch (o->kind) {
     case Module_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Module_type;
+        tp = (PyTypeObject *)state->Module_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Module.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.Module.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Module.type_ignores, ast2obj_type_ignore);
+        value = ast2obj_list(state, o->v.Module.type_ignores,
+                             ast2obj_type_ignore);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_ignores,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_ignores, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Interactive_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Interactive_type;
+        tp = (PyTypeObject *)state->Interactive_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Interactive.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.Interactive.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Expression_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Expression_type;
+        tp = (PyTypeObject *)state->Expression_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Expression.body);
+        value = ast2obj_expr(state, o->v.Expression.body);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case FunctionType_kind:
-        tp = (PyTypeObject *)astmodulestate_global->FunctionType_type;
+        tp = (PyTypeObject *)state->FunctionType_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.FunctionType.argtypes, ast2obj_expr);
+        value = ast2obj_list(state, o->v.FunctionType.argtypes, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->argtypes, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->argtypes, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.FunctionType.returns);
+        value = ast2obj_expr(state, o->v.FunctionType.returns);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->returns, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->returns, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -3600,7 +3667,7 @@ failed:
 }
 
 PyObject*
-ast2obj_stmt(void* _o)
+ast2obj_stmt(astmodulestate *state, void* _o)
 {
     stmt_ty o = (stmt_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -3608,513 +3675,483 @@ ast2obj_stmt(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
     switch (o->kind) {
     case FunctionDef_kind:
-        tp = (PyTypeObject *)astmodulestate_global->FunctionDef_type;
+        tp = (PyTypeObject *)state->FunctionDef_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(o->v.FunctionDef.name);
+        value = ast2obj_identifier(state, o->v.FunctionDef.name);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
+        if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_arguments(o->v.FunctionDef.args);
+        value = ast2obj_arguments(state, o->v.FunctionDef.args);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
+        if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.FunctionDef.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.FunctionDef.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.FunctionDef.decorator_list, ast2obj_expr);
+        value = ast2obj_list(state, o->v.FunctionDef.decorator_list,
+                             ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->decorator_list,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.FunctionDef.returns);
+        value = ast2obj_expr(state, o->v.FunctionDef.returns);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->returns, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->returns, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.FunctionDef.type_comment);
+        value = ast2obj_string(state, o->v.FunctionDef.type_comment);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AsyncFunctionDef_kind:
-        tp = (PyTypeObject *)astmodulestate_global->AsyncFunctionDef_type;
+        tp = (PyTypeObject *)state->AsyncFunctionDef_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(o->v.AsyncFunctionDef.name);
+        value = ast2obj_identifier(state, o->v.AsyncFunctionDef.name);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
+        if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_arguments(o->v.AsyncFunctionDef.args);
+        value = ast2obj_arguments(state, o->v.AsyncFunctionDef.args);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
+        if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.AsyncFunctionDef.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.AsyncFunctionDef.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.AsyncFunctionDef.decorator_list,
+        value = ast2obj_list(state, o->v.AsyncFunctionDef.decorator_list,
                              ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->decorator_list,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.AsyncFunctionDef.returns);
+        value = ast2obj_expr(state, o->v.AsyncFunctionDef.returns);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->returns, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->returns, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.AsyncFunctionDef.type_comment);
+        value = ast2obj_string(state, o->v.AsyncFunctionDef.type_comment);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case ClassDef_kind:
-        tp = (PyTypeObject *)astmodulestate_global->ClassDef_type;
+        tp = (PyTypeObject *)state->ClassDef_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(o->v.ClassDef.name);
+        value = ast2obj_identifier(state, o->v.ClassDef.name);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
+        if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.ClassDef.bases, ast2obj_expr);
+        value = ast2obj_list(state, o->v.ClassDef.bases, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->bases, value) == -1)
+        if (PyObject_SetAttr(result, state->bases, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.ClassDef.keywords, ast2obj_keyword);
+        value = ast2obj_list(state, o->v.ClassDef.keywords, ast2obj_keyword);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->keywords, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->keywords, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.ClassDef.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.ClassDef.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.ClassDef.decorator_list, ast2obj_expr);
+        value = ast2obj_list(state, o->v.ClassDef.decorator_list, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->decorator_list,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Return_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Return_type;
+        tp = (PyTypeObject *)state->Return_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Return.value);
+        value = ast2obj_expr(state, o->v.Return.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Delete_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Delete_type;
+        tp = (PyTypeObject *)state->Delete_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Delete.targets, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Delete.targets, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->targets, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->targets, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Assign_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Assign_type;
+        tp = (PyTypeObject *)state->Assign_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Assign.targets, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Assign.targets, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->targets, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->targets, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.Assign.value);
+        value = ast2obj_expr(state, o->v.Assign.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.Assign.type_comment);
+        value = ast2obj_string(state, o->v.Assign.type_comment);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AugAssign_kind:
-        tp = (PyTypeObject *)astmodulestate_global->AugAssign_type;
+        tp = (PyTypeObject *)state->AugAssign_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.AugAssign.target);
+        value = ast2obj_expr(state, o->v.AugAssign.target);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_operator(o->v.AugAssign.op);
+        value = ast2obj_operator(state, o->v.AugAssign.op);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
+        if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.AugAssign.value);
+        value = ast2obj_expr(state, o->v.AugAssign.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AnnAssign_kind:
-        tp = (PyTypeObject *)astmodulestate_global->AnnAssign_type;
+        tp = (PyTypeObject *)state->AnnAssign_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.AnnAssign.target);
+        value = ast2obj_expr(state, o->v.AnnAssign.target);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.AnnAssign.annotation);
+        value = ast2obj_expr(state, o->v.AnnAssign.annotation);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->annotation, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->annotation, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.AnnAssign.value);
+        value = ast2obj_expr(state, o->v.AnnAssign.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_int(o->v.AnnAssign.simple);
+        value = ast2obj_int(state, o->v.AnnAssign.simple);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->simple, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->simple, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case For_kind:
-        tp = (PyTypeObject *)astmodulestate_global->For_type;
+        tp = (PyTypeObject *)state->For_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.For.target);
+        value = ast2obj_expr(state, o->v.For.target);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.For.iter);
+        value = ast2obj_expr(state, o->v.For.iter);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->iter, value) == -1)
+        if (PyObject_SetAttr(result, state->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.For.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.For.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.For.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.For.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.For.type_comment);
+        value = ast2obj_string(state, o->v.For.type_comment);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AsyncFor_kind:
-        tp = (PyTypeObject *)astmodulestate_global->AsyncFor_type;
+        tp = (PyTypeObject *)state->AsyncFor_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.AsyncFor.target);
+        value = ast2obj_expr(state, o->v.AsyncFor.target);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.AsyncFor.iter);
+        value = ast2obj_expr(state, o->v.AsyncFor.iter);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->iter, value) == -1)
+        if (PyObject_SetAttr(result, state->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.AsyncFor.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.AsyncFor.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.AsyncFor.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.AsyncFor.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.AsyncFor.type_comment);
+        value = ast2obj_string(state, o->v.AsyncFor.type_comment);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case While_kind:
-        tp = (PyTypeObject *)astmodulestate_global->While_type;
+        tp = (PyTypeObject *)state->While_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.While.test);
+        value = ast2obj_expr(state, o->v.While.test);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
+        if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.While.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.While.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.While.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.While.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case If_kind:
-        tp = (PyTypeObject *)astmodulestate_global->If_type;
+        tp = (PyTypeObject *)state->If_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.If.test);
+        value = ast2obj_expr(state, o->v.If.test);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
+        if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.If.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.If.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.If.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.If.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case With_kind:
-        tp = (PyTypeObject *)astmodulestate_global->With_type;
+        tp = (PyTypeObject *)state->With_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.With.items, ast2obj_withitem);
+        value = ast2obj_list(state, o->v.With.items, ast2obj_withitem);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->items, value) == -1)
+        if (PyObject_SetAttr(result, state->items, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.With.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.With.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.With.type_comment);
+        value = ast2obj_string(state, o->v.With.type_comment);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AsyncWith_kind:
-        tp = (PyTypeObject *)astmodulestate_global->AsyncWith_type;
+        tp = (PyTypeObject *)state->AsyncWith_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.AsyncWith.items, ast2obj_withitem);
+        value = ast2obj_list(state, o->v.AsyncWith.items, ast2obj_withitem);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->items, value) == -1)
+        if (PyObject_SetAttr(result, state->items, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.AsyncWith.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.AsyncWith.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.AsyncWith.type_comment);
+        value = ast2obj_string(state, o->v.AsyncWith.type_comment);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
-            value) == -1)
+        if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Raise_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Raise_type;
+        tp = (PyTypeObject *)state->Raise_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Raise.exc);
+        value = ast2obj_expr(state, o->v.Raise.exc);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->exc, value) == -1)
+        if (PyObject_SetAttr(result, state->exc, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.Raise.cause);
+        value = ast2obj_expr(state, o->v.Raise.cause);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->cause, value) == -1)
+        if (PyObject_SetAttr(result, state->cause, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Try_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Try_type;
+        tp = (PyTypeObject *)state->Try_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Try.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.Try.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Try.handlers, ast2obj_excepthandler);
+        value = ast2obj_list(state, o->v.Try.handlers, ast2obj_excepthandler);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->handlers, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->handlers, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Try.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.Try.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Try.finalbody, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.Try.finalbody, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->finalbody, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->finalbody, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Assert_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Assert_type;
+        tp = (PyTypeObject *)state->Assert_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Assert.test);
+        value = ast2obj_expr(state, o->v.Assert.test);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
+        if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.Assert.msg);
+        value = ast2obj_expr(state, o->v.Assert.msg);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->msg, value) == -1)
+        if (PyObject_SetAttr(result, state->msg, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Import_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Import_type;
+        tp = (PyTypeObject *)state->Import_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Import.names, ast2obj_alias);
+        value = ast2obj_list(state, o->v.Import.names, ast2obj_alias);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
+        if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case ImportFrom_kind:
-        tp = (PyTypeObject *)astmodulestate_global->ImportFrom_type;
+        tp = (PyTypeObject *)state->ImportFrom_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(o->v.ImportFrom.module);
+        value = ast2obj_identifier(state, o->v.ImportFrom.module);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->module, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->module, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.ImportFrom.names, ast2obj_alias);
+        value = ast2obj_list(state, o->v.ImportFrom.names, ast2obj_alias);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
+        if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_int(o->v.ImportFrom.level);
+        value = ast2obj_int(state, o->v.ImportFrom.level);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->level, value) == -1)
+        if (PyObject_SetAttr(result, state->level, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Global_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Global_type;
+        tp = (PyTypeObject *)state->Global_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Global.names, ast2obj_identifier);
+        value = ast2obj_list(state, o->v.Global.names, ast2obj_identifier);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
+        if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Nonlocal_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Nonlocal_type;
+        tp = (PyTypeObject *)state->Nonlocal_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Nonlocal.names, ast2obj_identifier);
+        value = ast2obj_list(state, o->v.Nonlocal.names, ast2obj_identifier);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
+        if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Expr_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Expr_type;
+        tp = (PyTypeObject *)state->Expr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Expr.value);
+        value = ast2obj_expr(state, o->v.Expr.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Pass_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Pass_type;
+        tp = (PyTypeObject *)state->Pass_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         break;
     case Break_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Break_type;
+        tp = (PyTypeObject *)state->Break_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         break;
     case Continue_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Continue_type;
+        tp = (PyTypeObject *)state->Continue_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         break;
     }
-    value = ast2obj_int(o->lineno);
+    value = ast2obj_int(state, o->lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->col_offset);
+    value = ast2obj_int(state, o->col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
+    if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_lineno);
+    value = ast2obj_int(state, o->end_lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_col_offset);
+    value = ast2obj_int(state, o->end_col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
-        < 0)
+    if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4125,7 +4162,7 @@ failed:
 }
 
 PyObject*
-ast2obj_expr(void* _o)
+ast2obj_expr(astmodulestate *state, void* _o)
 {
     expr_ty o = (expr_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -4133,245 +4170,238 @@ ast2obj_expr(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
     switch (o->kind) {
     case BoolOp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->BoolOp_type;
+        tp = (PyTypeObject *)state->BoolOp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_boolop(o->v.BoolOp.op);
+        value = ast2obj_boolop(state, o->v.BoolOp.op);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
+        if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.BoolOp.values, ast2obj_expr);
+        value = ast2obj_list(state, o->v.BoolOp.values, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->values, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->values, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case NamedExpr_kind:
-        tp = (PyTypeObject *)astmodulestate_global->NamedExpr_type;
+        tp = (PyTypeObject *)state->NamedExpr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.NamedExpr.target);
+        value = ast2obj_expr(state, o->v.NamedExpr.target);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.NamedExpr.value);
+        value = ast2obj_expr(state, o->v.NamedExpr.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case BinOp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->BinOp_type;
+        tp = (PyTypeObject *)state->BinOp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.BinOp.left);
+        value = ast2obj_expr(state, o->v.BinOp.left);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->left, value) == -1)
+        if (PyObject_SetAttr(result, state->left, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_operator(o->v.BinOp.op);
+        value = ast2obj_operator(state, o->v.BinOp.op);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
+        if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.BinOp.right);
+        value = ast2obj_expr(state, o->v.BinOp.right);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->right, value) == -1)
+        if (PyObject_SetAttr(result, state->right, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case UnaryOp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->UnaryOp_type;
+        tp = (PyTypeObject *)state->UnaryOp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_unaryop(o->v.UnaryOp.op);
+        value = ast2obj_unaryop(state, o->v.UnaryOp.op);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
+        if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.UnaryOp.operand);
+        value = ast2obj_expr(state, o->v.UnaryOp.operand);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->operand, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->operand, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Lambda_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Lambda_type;
+        tp = (PyTypeObject *)state->Lambda_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_arguments(o->v.Lambda.args);
+        value = ast2obj_arguments(state, o->v.Lambda.args);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
+        if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.Lambda.body);
+        value = ast2obj_expr(state, o->v.Lambda.body);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case IfExp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->IfExp_type;
+        tp = (PyTypeObject *)state->IfExp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.IfExp.test);
+        value = ast2obj_expr(state, o->v.IfExp.test);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
+        if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.IfExp.body);
+        value = ast2obj_expr(state, o->v.IfExp.body);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.IfExp.orelse);
+        value = ast2obj_expr(state, o->v.IfExp.orelse);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Dict_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Dict_type;
+        tp = (PyTypeObject *)state->Dict_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Dict.keys, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Dict.keys, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->keys, value) == -1)
+        if (PyObject_SetAttr(result, state->keys, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Dict.values, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Dict.values, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->values, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->values, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Set_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Set_type;
+        tp = (PyTypeObject *)state->Set_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Set.elts, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Set.elts, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->elts, value) == -1)
+        if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case ListComp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->ListComp_type;
+        tp = (PyTypeObject *)state->ListComp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.ListComp.elt);
+        value = ast2obj_expr(state, o->v.ListComp.elt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->elt, value) == -1)
+        if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.ListComp.generators, ast2obj_comprehension);
+        value = ast2obj_list(state, o->v.ListComp.generators,
+                             ast2obj_comprehension);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->generators, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case SetComp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->SetComp_type;
+        tp = (PyTypeObject *)state->SetComp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.SetComp.elt);
+        value = ast2obj_expr(state, o->v.SetComp.elt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->elt, value) == -1)
+        if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.SetComp.generators, ast2obj_comprehension);
+        value = ast2obj_list(state, o->v.SetComp.generators,
+                             ast2obj_comprehension);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->generators, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case DictComp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->DictComp_type;
+        tp = (PyTypeObject *)state->DictComp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.DictComp.key);
+        value = ast2obj_expr(state, o->v.DictComp.key);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->key, value) == -1)
+        if (PyObject_SetAttr(result, state->key, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.DictComp.value);
+        value = ast2obj_expr(state, o->v.DictComp.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.DictComp.generators, ast2obj_comprehension);
+        value = ast2obj_list(state, o->v.DictComp.generators,
+                             ast2obj_comprehension);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->generators, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case GeneratorExp_kind:
-        tp = (PyTypeObject *)astmodulestate_global->GeneratorExp_type;
+        tp = (PyTypeObject *)state->GeneratorExp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.GeneratorExp.elt);
+        value = ast2obj_expr(state, o->v.GeneratorExp.elt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->elt, value) == -1)
+        if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.GeneratorExp.generators,
+        value = ast2obj_list(state, o->v.GeneratorExp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->generators, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Await_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Await_type;
+        tp = (PyTypeObject *)state->Await_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Await.value);
+        value = ast2obj_expr(state, o->v.Await.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Yield_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Yield_type;
+        tp = (PyTypeObject *)state->Yield_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Yield.value);
+        value = ast2obj_expr(state, o->v.Yield.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case YieldFrom_kind:
-        tp = (PyTypeObject *)astmodulestate_global->YieldFrom_type;
+        tp = (PyTypeObject *)state->YieldFrom_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.YieldFrom.value);
+        value = ast2obj_expr(state, o->v.YieldFrom.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Compare_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Compare_type;
+        tp = (PyTypeObject *)state->Compare_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Compare.left);
+        value = ast2obj_expr(state, o->v.Compare.left);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->left, value) == -1)
+        if (PyObject_SetAttr(result, state->left, value) == -1)
             goto failed;
         Py_DECREF(value);
         {
@@ -4379,228 +4409,222 @@ ast2obj_expr(void* _o)
             value = PyList_New(n);
             if (!value) goto failed;
             for(i = 0; i < n; i++)
-                PyList_SET_ITEM(value, i, ast2obj_cmpop((cmpop_ty)asdl_seq_GET(o->v.Compare.ops, i)));
+                PyList_SET_ITEM(value, i, ast2obj_cmpop(state, (cmpop_ty)asdl_seq_GET(o->v.Compare.ops, i)));
         }
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->ops, value) == -1)
+        if (PyObject_SetAttr(result, state->ops, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Compare.comparators, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Compare.comparators, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->comparators, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->comparators, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Call_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Call_type;
+        tp = (PyTypeObject *)state->Call_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Call.func);
+        value = ast2obj_expr(state, o->v.Call.func);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->func, value) == -1)
+        if (PyObject_SetAttr(result, state->func, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Call.args, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Call.args, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
+        if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.Call.keywords, ast2obj_keyword);
+        value = ast2obj_list(state, o->v.Call.keywords, ast2obj_keyword);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->keywords, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->keywords, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case FormattedValue_kind:
-        tp = (PyTypeObject *)astmodulestate_global->FormattedValue_type;
+        tp = (PyTypeObject *)state->FormattedValue_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.FormattedValue.value);
+        value = ast2obj_expr(state, o->v.FormattedValue.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_int(o->v.FormattedValue.conversion);
+        value = ast2obj_int(state, o->v.FormattedValue.conversion);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->conversion, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->conversion, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.FormattedValue.format_spec);
+        value = ast2obj_expr(state, o->v.FormattedValue.format_spec);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->format_spec, value)
-            == -1)
+        if (PyObject_SetAttr(result, state->format_spec, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case JoinedStr_kind:
-        tp = (PyTypeObject *)astmodulestate_global->JoinedStr_type;
+        tp = (PyTypeObject *)state->JoinedStr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.JoinedStr.values, ast2obj_expr);
+        value = ast2obj_list(state, o->v.JoinedStr.values, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->values, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->values, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Constant_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Constant_type;
+        tp = (PyTypeObject *)state->Constant_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_constant(o->v.Constant.value);
+        value = ast2obj_constant(state, o->v.Constant.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.Constant.kind);
+        value = ast2obj_string(state, o->v.Constant.kind);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->kind, value) == -1)
+        if (PyObject_SetAttr(result, state->kind, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Attribute_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Attribute_type;
+        tp = (PyTypeObject *)state->Attribute_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Attribute.value);
+        value = ast2obj_expr(state, o->v.Attribute.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_identifier(o->v.Attribute.attr);
+        value = ast2obj_identifier(state, o->v.Attribute.attr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->attr, value) == -1)
+        if (PyObject_SetAttr(result, state->attr, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(o->v.Attribute.ctx);
+        value = ast2obj_expr_context(state, o->v.Attribute.ctx);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
+        if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Subscript_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Subscript_type;
+        tp = (PyTypeObject *)state->Subscript_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Subscript.value);
+        value = ast2obj_expr(state, o->v.Subscript.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.Subscript.slice);
+        value = ast2obj_expr(state, o->v.Subscript.slice);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->slice, value) == -1)
+        if (PyObject_SetAttr(result, state->slice, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(o->v.Subscript.ctx);
+        value = ast2obj_expr_context(state, o->v.Subscript.ctx);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
+        if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Starred_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Starred_type;
+        tp = (PyTypeObject *)state->Starred_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Starred.value);
+        value = ast2obj_expr(state, o->v.Starred.value);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+        if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(o->v.Starred.ctx);
+        value = ast2obj_expr_context(state, o->v.Starred.ctx);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
+        if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Name_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Name_type;
+        tp = (PyTypeObject *)state->Name_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(o->v.Name.id);
+        value = ast2obj_identifier(state, o->v.Name.id);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->id, value) == -1)
+        if (PyObject_SetAttr(result, state->id, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(o->v.Name.ctx);
+        value = ast2obj_expr_context(state, o->v.Name.ctx);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
+        if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case List_kind:
-        tp = (PyTypeObject *)astmodulestate_global->List_type;
+        tp = (PyTypeObject *)state->List_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.List.elts, ast2obj_expr);
+        value = ast2obj_list(state, o->v.List.elts, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->elts, value) == -1)
+        if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(o->v.List.ctx);
+        value = ast2obj_expr_context(state, o->v.List.ctx);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
+        if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Tuple_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Tuple_type;
+        tp = (PyTypeObject *)state->Tuple_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(o->v.Tuple.elts, ast2obj_expr);
+        value = ast2obj_list(state, o->v.Tuple.elts, ast2obj_expr);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->elts, value) == -1)
+        if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(o->v.Tuple.ctx);
+        value = ast2obj_expr_context(state, o->v.Tuple.ctx);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
+        if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Slice_kind:
-        tp = (PyTypeObject *)astmodulestate_global->Slice_type;
+        tp = (PyTypeObject *)state->Slice_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.Slice.lower);
+        value = ast2obj_expr(state, o->v.Slice.lower);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->lower, value) == -1)
+        if (PyObject_SetAttr(result, state->lower, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.Slice.upper);
+        value = ast2obj_expr(state, o->v.Slice.upper);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->upper, value) == -1)
+        if (PyObject_SetAttr(result, state->upper, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(o->v.Slice.step);
+        value = ast2obj_expr(state, o->v.Slice.step);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->step, value) == -1)
+        if (PyObject_SetAttr(result, state->step, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
-    value = ast2obj_int(o->lineno);
+    value = ast2obj_int(state, o->lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->col_offset);
+    value = ast2obj_int(state, o->col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
+    if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_lineno);
+    value = ast2obj_int(state, o->end_lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_col_offset);
+    value = ast2obj_int(state, o->end_col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
-        < 0)
+    if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4610,134 +4634,134 @@ failed:
     return NULL;
 }
 
-PyObject* ast2obj_expr_context(expr_context_ty o)
+PyObject* ast2obj_expr_context(astmodulestate *state, expr_context_ty o)
 {
     switch(o) {
         case Load:
-            Py_INCREF(astmodulestate_global->Load_singleton);
-            return astmodulestate_global->Load_singleton;
+            Py_INCREF(state->Load_singleton);
+            return state->Load_singleton;
         case Store:
-            Py_INCREF(astmodulestate_global->Store_singleton);
-            return astmodulestate_global->Store_singleton;
+            Py_INCREF(state->Store_singleton);
+            return state->Store_singleton;
         case Del:
-            Py_INCREF(astmodulestate_global->Del_singleton);
-            return astmodulestate_global->Del_singleton;
+            Py_INCREF(state->Del_singleton);
+            return state->Del_singleton;
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_boolop(boolop_ty o)
+PyObject* ast2obj_boolop(astmodulestate *state, boolop_ty o)
 {
     switch(o) {
         case And:
-            Py_INCREF(astmodulestate_global->And_singleton);
-            return astmodulestate_global->And_singleton;
+            Py_INCREF(state->And_singleton);
+            return state->And_singleton;
         case Or:
-            Py_INCREF(astmodulestate_global->Or_singleton);
-            return astmodulestate_global->Or_singleton;
+            Py_INCREF(state->Or_singleton);
+            return state->Or_singleton;
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_operator(operator_ty o)
+PyObject* ast2obj_operator(astmodulestate *state, operator_ty o)
 {
     switch(o) {
         case Add:
-            Py_INCREF(astmodulestate_global->Add_singleton);
-            return astmodulestate_global->Add_singleton;
+            Py_INCREF(state->Add_singleton);
+            return state->Add_singleton;
         case Sub:
-            Py_INCREF(astmodulestate_global->Sub_singleton);
-            return astmodulestate_global->Sub_singleton;
+            Py_INCREF(state->Sub_singleton);
+            return state->Sub_singleton;
         case Mult:
-            Py_INCREF(astmodulestate_global->Mult_singleton);
-            return astmodulestate_global->Mult_singleton;
+            Py_INCREF(state->Mult_singleton);
+            return state->Mult_singleton;
         case MatMult:
-            Py_INCREF(astmodulestate_global->MatMult_singleton);
-            return astmodulestate_global->MatMult_singleton;
+            Py_INCREF(state->MatMult_singleton);
+            return state->MatMult_singleton;
         case Div:
-            Py_INCREF(astmodulestate_global->Div_singleton);
-            return astmodulestate_global->Div_singleton;
+            Py_INCREF(state->Div_singleton);
+            return state->Div_singleton;
         case Mod:
-            Py_INCREF(astmodulestate_global->Mod_singleton);
-            return astmodulestate_global->Mod_singleton;
+            Py_INCREF(state->Mod_singleton);
+            return state->Mod_singleton;
         case Pow:
-            Py_INCREF(astmodulestate_global->Pow_singleton);
-            return astmodulestate_global->Pow_singleton;
+            Py_INCREF(state->Pow_singleton);
+            return state->Pow_singleton;
         case LShift:
-            Py_INCREF(astmodulestate_global->LShift_singleton);
-            return astmodulestate_global->LShift_singleton;
+            Py_INCREF(state->LShift_singleton);
+            return state->LShift_singleton;
         case RShift:
-            Py_INCREF(astmodulestate_global->RShift_singleton);
-            return astmodulestate_global->RShift_singleton;
+            Py_INCREF(state->RShift_singleton);
+            return state->RShift_singleton;
         case BitOr:
-            Py_INCREF(astmodulestate_global->BitOr_singleton);
-            return astmodulestate_global->BitOr_singleton;
+            Py_INCREF(state->BitOr_singleton);
+            return state->BitOr_singleton;
         case BitXor:
-            Py_INCREF(astmodulestate_global->BitXor_singleton);
-            return astmodulestate_global->BitXor_singleton;
+            Py_INCREF(state->BitXor_singleton);
+            return state->BitXor_singleton;
         case BitAnd:
-            Py_INCREF(astmodulestate_global->BitAnd_singleton);
-            return astmodulestate_global->BitAnd_singleton;
+            Py_INCREF(state->BitAnd_singleton);
+            return state->BitAnd_singleton;
         case FloorDiv:
-            Py_INCREF(astmodulestate_global->FloorDiv_singleton);
-            return astmodulestate_global->FloorDiv_singleton;
+            Py_INCREF(state->FloorDiv_singleton);
+            return state->FloorDiv_singleton;
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_unaryop(unaryop_ty o)
+PyObject* ast2obj_unaryop(astmodulestate *state, unaryop_ty o)
 {
     switch(o) {
         case Invert:
-            Py_INCREF(astmodulestate_global->Invert_singleton);
-            return astmodulestate_global->Invert_singleton;
+            Py_INCREF(state->Invert_singleton);
+            return state->Invert_singleton;
         case Not:
-            Py_INCREF(astmodulestate_global->Not_singleton);
-            return astmodulestate_global->Not_singleton;
+            Py_INCREF(state->Not_singleton);
+            return state->Not_singleton;
         case UAdd:
-            Py_INCREF(astmodulestate_global->UAdd_singleton);
-            return astmodulestate_global->UAdd_singleton;
+            Py_INCREF(state->UAdd_singleton);
+            return state->UAdd_singleton;
         case USub:
-            Py_INCREF(astmodulestate_global->USub_singleton);
-            return astmodulestate_global->USub_singleton;
+            Py_INCREF(state->USub_singleton);
+            return state->USub_singleton;
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_cmpop(cmpop_ty o)
+PyObject* ast2obj_cmpop(astmodulestate *state, cmpop_ty o)
 {
     switch(o) {
         case Eq:
-            Py_INCREF(astmodulestate_global->Eq_singleton);
-            return astmodulestate_global->Eq_singleton;
+            Py_INCREF(state->Eq_singleton);
+            return state->Eq_singleton;
         case NotEq:
-            Py_INCREF(astmodulestate_global->NotEq_singleton);
-            return astmodulestate_global->NotEq_singleton;
+            Py_INCREF(state->NotEq_singleton);
+            return state->NotEq_singleton;
         case Lt:
-            Py_INCREF(astmodulestate_global->Lt_singleton);
-            return astmodulestate_global->Lt_singleton;
+            Py_INCREF(state->Lt_singleton);
+            return state->Lt_singleton;
         case LtE:
-            Py_INCREF(astmodulestate_global->LtE_singleton);
-            return astmodulestate_global->LtE_singleton;
+            Py_INCREF(state->LtE_singleton);
+            return state->LtE_singleton;
         case Gt:
-            Py_INCREF(astmodulestate_global->Gt_singleton);
-            return astmodulestate_global->Gt_singleton;
+            Py_INCREF(state->Gt_singleton);
+            return state->Gt_singleton;
         case GtE:
-            Py_INCREF(astmodulestate_global->GtE_singleton);
-            return astmodulestate_global->GtE_singleton;
+            Py_INCREF(state->GtE_singleton);
+            return state->GtE_singleton;
         case Is:
-            Py_INCREF(astmodulestate_global->Is_singleton);
-            return astmodulestate_global->Is_singleton;
+            Py_INCREF(state->Is_singleton);
+            return state->Is_singleton;
         case IsNot:
-            Py_INCREF(astmodulestate_global->IsNot_singleton);
-            return astmodulestate_global->IsNot_singleton;
+            Py_INCREF(state->IsNot_singleton);
+            return state->IsNot_singleton;
         case In:
-            Py_INCREF(astmodulestate_global->In_singleton);
-            return astmodulestate_global->In_singleton;
+            Py_INCREF(state->In_singleton);
+            return state->In_singleton;
         case NotIn:
-            Py_INCREF(astmodulestate_global->NotIn_singleton);
-            return astmodulestate_global->NotIn_singleton;
+            Py_INCREF(state->NotIn_singleton);
+            return state->NotIn_singleton;
     }
     Py_UNREACHABLE();
 }
 PyObject*
-ast2obj_comprehension(void* _o)
+ast2obj_comprehension(astmodulestate *state, void* _o)
 {
     comprehension_ty o = (comprehension_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -4745,28 +4769,27 @@ ast2obj_comprehension(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
-    tp = (PyTypeObject *)astmodulestate_global->comprehension_type;
+    tp = (PyTypeObject *)state->comprehension_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_expr(o->target);
+    value = ast2obj_expr(state, o->target);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->target, value) == -1)
+    if (PyObject_SetAttr(result, state->target, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(o->iter);
+    value = ast2obj_expr(state, o->iter);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->iter, value) == -1)
+    if (PyObject_SetAttr(result, state->iter, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(o->ifs, ast2obj_expr);
+    value = ast2obj_list(state, o->ifs, ast2obj_expr);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->ifs, value) == -1)
+    if (PyObject_SetAttr(result, state->ifs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->is_async);
+    value = ast2obj_int(state, o->is_async);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->is_async, value) == -1)
+    if (PyObject_SetAttr(result, state->is_async, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4777,7 +4800,7 @@ failed:
 }
 
 PyObject*
-ast2obj_excepthandler(void* _o)
+ast2obj_excepthandler(astmodulestate *state, void* _o)
 {
     excepthandler_ty o = (excepthandler_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -4785,48 +4808,46 @@ ast2obj_excepthandler(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
     switch (o->kind) {
     case ExceptHandler_kind:
-        tp = (PyTypeObject *)astmodulestate_global->ExceptHandler_type;
+        tp = (PyTypeObject *)state->ExceptHandler_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(o->v.ExceptHandler.type);
+        value = ast2obj_expr(state, o->v.ExceptHandler.type);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->type, value) == -1)
+        if (PyObject_SetAttr(result, state->type, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_identifier(o->v.ExceptHandler.name);
+        value = ast2obj_identifier(state, o->v.ExceptHandler.name);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
+        if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(o->v.ExceptHandler.body, ast2obj_stmt);
+        value = ast2obj_list(state, o->v.ExceptHandler.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
+        if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
-    value = ast2obj_int(o->lineno);
+    value = ast2obj_int(state, o->lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->col_offset);
+    value = ast2obj_int(state, o->col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
+    if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_lineno);
+    value = ast2obj_int(state, o->end_lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_col_offset);
+    value = ast2obj_int(state, o->end_col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
-        < 0)
+    if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4837,7 +4858,7 @@ failed:
 }
 
 PyObject*
-ast2obj_arguments(void* _o)
+ast2obj_arguments(astmodulestate *state, void* _o)
 {
     arguments_ty o = (arguments_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -4845,46 +4866,42 @@ ast2obj_arguments(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
-    tp = (PyTypeObject *)astmodulestate_global->arguments_type;
+    tp = (PyTypeObject *)state->arguments_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_list(o->posonlyargs, ast2obj_arg);
+    value = ast2obj_list(state, o->posonlyargs, ast2obj_arg);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->posonlyargs, value) ==
-        -1)
+    if (PyObject_SetAttr(result, state->posonlyargs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(o->args, ast2obj_arg);
+    value = ast2obj_list(state, o->args, ast2obj_arg);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
+    if (PyObject_SetAttr(result, state->args, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_arg(o->vararg);
+    value = ast2obj_arg(state, o->vararg);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->vararg, value) == -1)
+    if (PyObject_SetAttr(result, state->vararg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(o->kwonlyargs, ast2obj_arg);
+    value = ast2obj_list(state, o->kwonlyargs, ast2obj_arg);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->kwonlyargs, value) ==
-        -1)
+    if (PyObject_SetAttr(result, state->kwonlyargs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(o->kw_defaults, ast2obj_expr);
+    value = ast2obj_list(state, o->kw_defaults, ast2obj_expr);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->kw_defaults, value) ==
-        -1)
+    if (PyObject_SetAttr(result, state->kw_defaults, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_arg(o->kwarg);
+    value = ast2obj_arg(state, o->kwarg);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->kwarg, value) == -1)
+    if (PyObject_SetAttr(result, state->kwarg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(o->defaults, ast2obj_expr);
+    value = ast2obj_list(state, o->defaults, ast2obj_expr);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->defaults, value) == -1)
+    if (PyObject_SetAttr(result, state->defaults, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4895,7 +4912,7 @@ failed:
 }
 
 PyObject*
-ast2obj_arg(void* _o)
+ast2obj_arg(astmodulestate *state, void* _o)
 {
     arg_ty o = (arg_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -4903,46 +4920,42 @@ ast2obj_arg(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
-    tp = (PyTypeObject *)astmodulestate_global->arg_type;
+    tp = (PyTypeObject *)state->arg_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_identifier(o->arg);
+    value = ast2obj_identifier(state, o->arg);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->arg, value) == -1)
+    if (PyObject_SetAttr(result, state->arg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(o->annotation);
+    value = ast2obj_expr(state, o->annotation);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->annotation, value) ==
-        -1)
+    if (PyObject_SetAttr(result, state->annotation, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_string(o->type_comment);
+    value = ast2obj_string(state, o->type_comment);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->type_comment, value) ==
-        -1)
+    if (PyObject_SetAttr(result, state->type_comment, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->lineno);
+    value = ast2obj_int(state, o->lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->col_offset);
+    value = ast2obj_int(state, o->col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
+    if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_lineno);
+    value = ast2obj_int(state, o->end_lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_col_offset);
+    value = ast2obj_int(state, o->end_col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
-        < 0)
+    if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4953,7 +4966,7 @@ failed:
 }
 
 PyObject*
-ast2obj_keyword(void* _o)
+ast2obj_keyword(astmodulestate *state, void* _o)
 {
     keyword_ty o = (keyword_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -4961,39 +4974,37 @@ ast2obj_keyword(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
-    tp = (PyTypeObject *)astmodulestate_global->keyword_type;
+    tp = (PyTypeObject *)state->keyword_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_identifier(o->arg);
+    value = ast2obj_identifier(state, o->arg);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->arg, value) == -1)
+    if (PyObject_SetAttr(result, state->arg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(o->value);
+    value = ast2obj_expr(state, o->value);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
+    if (PyObject_SetAttr(result, state->value, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->lineno);
+    value = ast2obj_int(state, o->lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->col_offset);
+    value = ast2obj_int(state, o->col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
+    if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_lineno);
+    value = ast2obj_int(state, o->end_lineno);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(o->end_col_offset);
+    value = ast2obj_int(state, o->end_col_offset);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
-        < 0)
+    if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -5004,7 +5015,7 @@ failed:
 }
 
 PyObject*
-ast2obj_alias(void* _o)
+ast2obj_alias(astmodulestate *state, void* _o)
 {
     alias_ty o = (alias_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -5012,18 +5023,17 @@ ast2obj_alias(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
-    tp = (PyTypeObject *)astmodulestate_global->alias_type;
+    tp = (PyTypeObject *)state->alias_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_identifier(o->name);
+    value = ast2obj_identifier(state, o->name);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
+    if (PyObject_SetAttr(result, state->name, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_identifier(o->asname);
+    value = ast2obj_identifier(state, o->asname);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->asname, value) == -1)
+    if (PyObject_SetAttr(result, state->asname, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -5034,7 +5044,7 @@ failed:
 }
 
 PyObject*
-ast2obj_withitem(void* _o)
+ast2obj_withitem(astmodulestate *state, void* _o)
 {
     withitem_ty o = (withitem_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -5042,20 +5052,17 @@ ast2obj_withitem(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
-    tp = (PyTypeObject *)astmodulestate_global->withitem_type;
+    tp = (PyTypeObject *)state->withitem_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_expr(o->context_expr);
+    value = ast2obj_expr(state, o->context_expr);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->context_expr, value) ==
-        -1)
+    if (PyObject_SetAttr(result, state->context_expr, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(o->optional_vars);
+    value = ast2obj_expr(state, o->optional_vars);
     if (!value) goto failed;
-    if (PyObject_SetAttr(result, astmodulestate_global->optional_vars, value)
-        == -1)
+    if (PyObject_SetAttr(result, state->optional_vars, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -5066,7 +5073,7 @@ failed:
 }
 
 PyObject*
-ast2obj_type_ignore(void* _o)
+ast2obj_type_ignore(astmodulestate *state, void* _o)
 {
     type_ignore_ty o = (type_ignore_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -5074,21 +5081,19 @@ ast2obj_type_ignore(void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-
     switch (o->kind) {
     case TypeIgnore_kind:
-        tp = (PyTypeObject *)astmodulestate_global->TypeIgnore_type;
+        tp = (PyTypeObject *)state->TypeIgnore_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_int(o->v.TypeIgnore.lineno);
+        value = ast2obj_int(state, o->v.TypeIgnore.lineno);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) ==
-            -1)
+        if (PyObject_SetAttr(result, state->lineno, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.TypeIgnore.tag);
+        value = ast2obj_string(state, o->v.TypeIgnore.tag);
         if (!value) goto failed;
-        if (PyObject_SetAttr(result, astmodulestate_global->tag, value) == -1)
+        if (PyObject_SetAttr(result, state->tag, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -5102,7 +5107,7 @@ failed:
 
 
 int
-obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
+obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
 {
     int isinstance;
 
@@ -5113,7 +5118,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    tp = astmodulestate_global->Module_type;
+    tp = state->Module_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5122,7 +5127,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* type_ignores;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5144,7 +5149,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5155,8 +5160,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_ignores,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_ignores, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5178,7 +5182,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
                 type_ignore_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_type_ignore(tmp2, &val, arena);
+                res = obj2ast_type_ignore(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5193,7 +5197,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Interactive_type;
+    tp = state->Interactive_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5201,7 +5205,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* body;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5223,7 +5227,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5238,7 +5242,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Expression_type;
+    tp = state->Expression_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5246,7 +5250,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty body;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5255,7 +5259,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &body, arena);
+            res = obj2ast_expr(state, tmp, &body, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5263,7 +5267,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->FunctionType_type;
+    tp = state->FunctionType_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5272,8 +5276,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         asdl_seq* argtypes;
         expr_ty returns;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->argtypes, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->argtypes, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5295,7 +5298,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5306,8 +5309,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->returns, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->returns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5316,7 +5318,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &returns, arena);
+            res = obj2ast_expr(state, tmp, &returns, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5332,7 +5334,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
+obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
 {
     int isinstance;
 
@@ -5347,7 +5349,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -5356,12 +5358,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &lineno, arena);
+        res = obj2ast_int(state, tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -5370,12 +5371,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &col_offset, arena);
+        res = obj2ast_int(state, tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -5384,12 +5384,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_lineno, arena);
+        res = obj2ast_int(state, tmp, &end_lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
-        < 0) {
+    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -5398,11 +5397,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_col_offset, arena);
+        res = obj2ast_int(state, tmp, &end_col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    tp = astmodulestate_global->FunctionDef_type;
+    tp = state->FunctionDef_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5415,7 +5414,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty returns;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5424,11 +5423,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_identifier(tmp, &name, arena);
+            res = obj2ast_identifier(state, tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5437,11 +5436,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_arguments(tmp, &args, arena);
+            res = obj2ast_arguments(state, tmp, &args, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5463,7 +5462,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5474,8 +5473,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->decorator_list,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->decorator_list, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5497,7 +5495,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5508,8 +5506,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->returns, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->returns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5518,12 +5515,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &returns, arena);
+            res = obj2ast_expr(state, tmp, &returns, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5532,7 +5528,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &type_comment, arena);
+            res = obj2ast_string(state, tmp, &type_comment, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5542,7 +5538,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->AsyncFunctionDef_type;
+    tp = state->AsyncFunctionDef_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5555,7 +5551,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty returns;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5564,11 +5560,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_identifier(tmp, &name, arena);
+            res = obj2ast_identifier(state, tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5577,11 +5573,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_arguments(tmp, &args, arena);
+            res = obj2ast_arguments(state, tmp, &args, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5603,7 +5599,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5614,8 +5610,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->decorator_list,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->decorator_list, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5637,7 +5632,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5648,8 +5643,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->returns, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->returns, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5658,12 +5652,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &returns, arena);
+            res = obj2ast_expr(state, tmp, &returns, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5672,7 +5665,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &type_comment, arena);
+            res = obj2ast_string(state, tmp, &type_comment, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5682,7 +5675,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->ClassDef_type;
+    tp = state->ClassDef_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5694,7 +5687,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* decorator_list;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5703,11 +5696,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_identifier(tmp, &name, arena);
+            res = obj2ast_identifier(state, tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->bases, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->bases, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5729,7 +5722,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5740,8 +5733,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->keywords, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->keywords, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5763,7 +5755,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 keyword_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_keyword(tmp2, &val, arena);
+                res = obj2ast_keyword(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5774,7 +5766,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5796,7 +5788,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5807,8 +5799,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->decorator_list,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->decorator_list, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5830,7 +5821,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5846,7 +5837,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Return_type;
+    tp = state->Return_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5854,7 +5845,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5863,7 +5854,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5872,7 +5863,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Delete_type;
+    tp = state->Delete_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5880,8 +5871,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* targets;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->targets, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->targets, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5903,7 +5893,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5919,7 +5909,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Assign_type;
+    tp = state->Assign_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -5929,8 +5919,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty value;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->targets, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->targets, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5952,7 +5941,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -5963,7 +5952,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5972,12 +5961,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5986,7 +5974,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &type_comment, arena);
+            res = obj2ast_string(state, tmp, &type_comment, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -5995,7 +5983,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->AugAssign_type;
+    tp = state->AugAssign_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6005,8 +5993,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         operator_ty op;
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6015,11 +6002,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &target, arena);
+            res = obj2ast_expr(state, tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6028,11 +6015,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_operator(tmp, &op, arena);
+            res = obj2ast_operator(state, tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6041,7 +6028,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6050,7 +6037,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->AnnAssign_type;
+    tp = state->AnnAssign_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6061,8 +6048,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty value;
         int simple;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6071,12 +6057,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &target, arena);
+            res = obj2ast_expr(state, tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->annotation, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->annotation, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6085,11 +6070,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &annotation, arena);
+            res = obj2ast_expr(state, tmp, &annotation, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6098,12 +6083,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->simple, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->simple, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6112,7 +6096,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_int(tmp, &simple, arena);
+            res = obj2ast_int(state, tmp, &simple, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6121,7 +6105,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->For_type;
+    tp = state->For_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6133,8 +6117,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* orelse;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6143,11 +6126,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &target, arena);
+            res = obj2ast_expr(state, tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->iter, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->iter, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6156,11 +6139,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &iter, arena);
+            res = obj2ast_expr(state, tmp, &iter, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6182,7 +6165,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6193,8 +6176,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6216,7 +6198,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6227,8 +6209,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6237,7 +6218,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &type_comment, arena);
+            res = obj2ast_string(state, tmp, &type_comment, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6246,7 +6227,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->AsyncFor_type;
+    tp = state->AsyncFor_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6258,8 +6239,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* orelse;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6268,11 +6248,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &target, arena);
+            res = obj2ast_expr(state, tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->iter, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->iter, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6281,11 +6261,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &iter, arena);
+            res = obj2ast_expr(state, tmp, &iter, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6307,7 +6287,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6318,8 +6298,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6341,7 +6320,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6352,8 +6331,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6362,7 +6340,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &type_comment, arena);
+            res = obj2ast_string(state, tmp, &type_comment, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6371,7 +6349,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->While_type;
+    tp = state->While_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6381,7 +6359,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6390,11 +6368,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &test, arena);
+            res = obj2ast_expr(state, tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6416,7 +6394,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6427,8 +6405,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6450,7 +6427,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6466,7 +6443,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->If_type;
+    tp = state->If_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6476,7 +6453,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6485,11 +6462,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &test, arena);
+            res = obj2ast_expr(state, tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6511,7 +6488,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6522,8 +6499,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6545,7 +6521,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6561,7 +6537,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->With_type;
+    tp = state->With_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6571,7 +6547,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->items, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->items, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6593,7 +6569,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 withitem_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_withitem(tmp2, &val, arena);
+                res = obj2ast_withitem(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6604,7 +6580,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6626,7 +6602,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6637,8 +6613,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6647,7 +6622,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &type_comment, arena);
+            res = obj2ast_string(state, tmp, &type_comment, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6656,7 +6631,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->AsyncWith_type;
+    tp = state->AsyncWith_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6666,7 +6641,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         string type_comment;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->items, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->items, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6688,7 +6663,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 withitem_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_withitem(tmp2, &val, arena);
+                res = obj2ast_withitem(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6699,7 +6674,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6721,7 +6696,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6732,8 +6707,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
-            &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6742,7 +6716,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &type_comment, arena);
+            res = obj2ast_string(state, tmp, &type_comment, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6751,7 +6725,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Raise_type;
+    tp = state->Raise_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6760,7 +6734,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty exc;
         expr_ty cause;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->exc, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->exc, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6769,11 +6743,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &exc, arena);
+            res = obj2ast_expr(state, tmp, &exc, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->cause, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->cause, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6782,7 +6756,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &cause, arena);
+            res = obj2ast_expr(state, tmp, &cause, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6791,7 +6765,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Try_type;
+    tp = state->Try_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6802,7 +6776,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* orelse;
         asdl_seq* finalbody;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6824,7 +6798,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6835,8 +6809,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->handlers, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->handlers, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6858,7 +6831,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 excepthandler_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_excepthandler(tmp2, &val, arena);
+                res = obj2ast_excepthandler(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6869,8 +6842,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6892,7 +6864,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6903,8 +6875,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->finalbody, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->finalbody, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6926,7 +6897,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -6942,7 +6913,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Assert_type;
+    tp = state->Assert_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6951,7 +6922,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty test;
         expr_ty msg;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6960,11 +6931,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &test, arena);
+            res = obj2ast_expr(state, tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->msg, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->msg, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6973,7 +6944,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &msg, arena);
+            res = obj2ast_expr(state, tmp, &msg, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -6982,7 +6953,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Import_type;
+    tp = state->Import_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -6990,7 +6961,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* names;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7012,7 +6983,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 alias_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_alias(tmp2, &val, arena);
+                res = obj2ast_alias(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7028,7 +6999,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->ImportFrom_type;
+    tp = state->ImportFrom_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7038,8 +7009,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* names;
         int level;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->module, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->module, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7048,11 +7018,11 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_identifier(tmp, &module, arena);
+            res = obj2ast_identifier(state, tmp, &module, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7074,7 +7044,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 alias_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_alias(tmp2, &val, arena);
+                res = obj2ast_alias(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7085,7 +7055,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->level, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->level, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7094,7 +7064,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_int(tmp, &level, arena);
+            res = obj2ast_int(state, tmp, &level, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7103,7 +7073,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Global_type;
+    tp = state->Global_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7111,7 +7081,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* names;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7133,7 +7103,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_identifier(tmp2, &val, arena);
+                res = obj2ast_identifier(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7149,7 +7119,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Nonlocal_type;
+    tp = state->Nonlocal_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7157,7 +7127,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* names;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7179,7 +7149,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 identifier val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_identifier(tmp2, &val, arena);
+                res = obj2ast_identifier(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7195,7 +7165,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Expr_type;
+    tp = state->Expr_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7203,7 +7173,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7212,7 +7182,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7221,7 +7191,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Pass_type;
+    tp = state->Pass_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7232,7 +7202,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Break_type;
+    tp = state->Break_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7243,7 +7213,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Continue_type;
+    tp = state->Continue_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7262,7 +7232,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
+obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
 {
     int isinstance;
 
@@ -7277,7 +7247,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -7286,12 +7256,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &lineno, arena);
+        res = obj2ast_int(state, tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -7300,12 +7269,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &col_offset, arena);
+        res = obj2ast_int(state, tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -7314,12 +7282,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_lineno, arena);
+        res = obj2ast_int(state, tmp, &end_lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
-        < 0) {
+    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -7328,11 +7295,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_col_offset, arena);
+        res = obj2ast_int(state, tmp, &end_col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    tp = astmodulestate_global->BoolOp_type;
+    tp = state->BoolOp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7341,7 +7308,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         boolop_ty op;
         asdl_seq* values;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7350,12 +7317,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_boolop(tmp, &op, arena);
+            res = obj2ast_boolop(state, tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->values, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->values, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7377,7 +7343,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7393,7 +7359,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->NamedExpr_type;
+    tp = state->NamedExpr_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7402,8 +7368,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty target;
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7412,11 +7377,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &target, arena);
+            res = obj2ast_expr(state, tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7425,7 +7390,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7434,7 +7399,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->BinOp_type;
+    tp = state->BinOp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7444,7 +7409,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         operator_ty op;
         expr_ty right;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->left, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->left, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7453,11 +7418,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &left, arena);
+            res = obj2ast_expr(state, tmp, &left, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7466,11 +7431,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_operator(tmp, &op, arena);
+            res = obj2ast_operator(state, tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->right, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->right, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7479,7 +7444,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &right, arena);
+            res = obj2ast_expr(state, tmp, &right, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7488,7 +7453,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->UnaryOp_type;
+    tp = state->UnaryOp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7497,7 +7462,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         unaryop_ty op;
         expr_ty operand;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7506,12 +7471,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_unaryop(tmp, &op, arena);
+            res = obj2ast_unaryop(state, tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->operand, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->operand, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7520,7 +7484,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &operand, arena);
+            res = obj2ast_expr(state, tmp, &operand, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7529,7 +7493,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Lambda_type;
+    tp = state->Lambda_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7538,7 +7502,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         arguments_ty args;
         expr_ty body;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7547,11 +7511,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_arguments(tmp, &args, arena);
+            res = obj2ast_arguments(state, tmp, &args, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7560,7 +7524,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &body, arena);
+            res = obj2ast_expr(state, tmp, &body, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7569,7 +7533,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->IfExp_type;
+    tp = state->IfExp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7579,7 +7543,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty body;
         expr_ty orelse;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7588,11 +7552,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &test, arena);
+            res = obj2ast_expr(state, tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7601,12 +7565,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &body, arena);
+            res = obj2ast_expr(state, tmp, &body, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->orelse, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7615,7 +7578,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &orelse, arena);
+            res = obj2ast_expr(state, tmp, &orelse, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -7624,7 +7587,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Dict_type;
+    tp = state->Dict_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7633,7 +7596,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* keys;
         asdl_seq* values;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->keys, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->keys, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7655,7 +7618,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7666,8 +7629,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->values, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->values, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7689,7 +7651,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7705,7 +7667,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Set_type;
+    tp = state->Set_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7713,7 +7675,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* elts;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->elts, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7735,7 +7697,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7750,7 +7712,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->ListComp_type;
+    tp = state->ListComp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7759,7 +7721,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->elt, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7768,12 +7730,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &elt, arena);
+            res = obj2ast_expr(state, tmp, &elt, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7795,7 +7756,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_comprehension(tmp2, &val, arena);
+                res = obj2ast_comprehension(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7811,7 +7772,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->SetComp_type;
+    tp = state->SetComp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7820,7 +7781,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->elt, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7829,12 +7790,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &elt, arena);
+            res = obj2ast_expr(state, tmp, &elt, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7856,7 +7816,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_comprehension(tmp2, &val, arena);
+                res = obj2ast_comprehension(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7872,7 +7832,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->DictComp_type;
+    tp = state->DictComp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7882,7 +7842,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->key, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->key, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7891,11 +7851,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &key, arena);
+            res = obj2ast_expr(state, tmp, &key, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7904,12 +7864,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7931,7 +7890,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_comprehension(tmp2, &val, arena);
+                res = obj2ast_comprehension(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -7947,7 +7906,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->GeneratorExp_type;
+    tp = state->GeneratorExp_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -7956,7 +7915,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->elt, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7965,12 +7924,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &elt, arena);
+            res = obj2ast_expr(state, tmp, &elt, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->generators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7992,7 +7950,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 comprehension_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_comprehension(tmp2, &val, arena);
+                res = obj2ast_comprehension(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8008,7 +7966,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Await_type;
+    tp = state->Await_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8016,7 +7974,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8025,7 +7983,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8034,7 +7992,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Yield_type;
+    tp = state->Yield_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8042,7 +8000,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8051,7 +8009,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8060,7 +8018,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->YieldFrom_type;
+    tp = state->YieldFrom_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8068,7 +8026,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8077,7 +8035,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8086,7 +8044,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Compare_type;
+    tp = state->Compare_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8096,7 +8054,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_int_seq* ops;
         asdl_seq* comparators;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->left, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->left, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8105,11 +8063,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &left, arena);
+            res = obj2ast_expr(state, tmp, &left, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->ops, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->ops, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8131,7 +8089,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 cmpop_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_cmpop(tmp2, &val, arena);
+                res = obj2ast_cmpop(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8142,8 +8100,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->comparators, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->comparators, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8165,7 +8122,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8181,7 +8138,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Call_type;
+    tp = state->Call_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8191,7 +8148,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* args;
         asdl_seq* keywords;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->func, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->func, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8200,11 +8157,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &func, arena);
+            res = obj2ast_expr(state, tmp, &func, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8226,7 +8183,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8237,8 +8194,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->keywords, &tmp) <
-            0) {
+        if (_PyObject_LookupAttr(obj, state->keywords, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8260,7 +8216,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 keyword_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_keyword(tmp2, &val, arena);
+                res = obj2ast_keyword(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8276,7 +8232,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->FormattedValue_type;
+    tp = state->FormattedValue_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8286,7 +8242,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         int conversion;
         expr_ty format_spec;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8295,12 +8251,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->conversion, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->conversion, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8309,12 +8264,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_int(tmp, &conversion, arena);
+            res = obj2ast_int(state, tmp, &conversion, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->format_spec, &tmp)
-            < 0) {
+        if (_PyObject_LookupAttr(obj, state->format_spec, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8323,7 +8277,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &format_spec, arena);
+            res = obj2ast_expr(state, tmp, &format_spec, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8332,7 +8286,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->JoinedStr_type;
+    tp = state->JoinedStr_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8340,8 +8294,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* values;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->values, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->values, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8363,7 +8316,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8379,7 +8332,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Constant_type;
+    tp = state->Constant_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8388,7 +8341,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         constant value;
         string kind;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8397,11 +8350,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_constant(tmp, &value, arena);
+            res = obj2ast_constant(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->kind, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->kind, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8410,7 +8363,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &kind, arena);
+            res = obj2ast_string(state, tmp, &kind, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8419,7 +8372,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Attribute_type;
+    tp = state->Attribute_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8429,7 +8382,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         identifier attr;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8438,11 +8391,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->attr, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->attr, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8451,11 +8404,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_identifier(tmp, &attr, arena);
+            res = obj2ast_identifier(state, tmp, &attr, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8464,7 +8417,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr_context(tmp, &ctx, arena);
+            res = obj2ast_expr_context(state, tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8473,7 +8426,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Subscript_type;
+    tp = state->Subscript_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8483,7 +8436,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty slice;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8492,11 +8445,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->slice, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->slice, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8505,11 +8458,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &slice, arena);
+            res = obj2ast_expr(state, tmp, &slice, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8518,7 +8471,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr_context(tmp, &ctx, arena);
+            res = obj2ast_expr_context(state, tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8527,7 +8480,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Starred_type;
+    tp = state->Starred_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8536,7 +8489,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8545,11 +8498,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &value, arena);
+            res = obj2ast_expr(state, tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8558,7 +8511,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr_context(tmp, &ctx, arena);
+            res = obj2ast_expr_context(state, tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8567,7 +8520,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Name_type;
+    tp = state->Name_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8576,7 +8529,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         identifier id;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->id, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->id, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8585,11 +8538,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_identifier(tmp, &id, arena);
+            res = obj2ast_identifier(state, tmp, &id, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8598,7 +8551,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr_context(tmp, &ctx, arena);
+            res = obj2ast_expr_context(state, tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8607,7 +8560,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->List_type;
+    tp = state->List_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8616,7 +8569,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* elts;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->elts, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8638,7 +8591,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8649,7 +8602,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8658,7 +8611,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr_context(tmp, &ctx, arena);
+            res = obj2ast_expr_context(state, tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8667,7 +8620,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Tuple_type;
+    tp = state->Tuple_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8676,7 +8629,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* elts;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->elts, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8698,7 +8651,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 expr_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_expr(tmp2, &val, arena);
+                res = obj2ast_expr(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -8709,7 +8662,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8718,7 +8671,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr_context(tmp, &ctx, arena);
+            res = obj2ast_expr_context(state, tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8727,7 +8680,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    tp = astmodulestate_global->Slice_type;
+    tp = state->Slice_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -8737,7 +8690,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty upper;
         expr_ty step;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->lower, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->lower, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8746,11 +8699,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &lower, arena);
+            res = obj2ast_expr(state, tmp, &lower, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->upper, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->upper, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8759,11 +8712,11 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &upper, arena);
+            res = obj2ast_expr(state, tmp, &upper, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->step, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->step, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8772,7 +8725,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &step, arena);
+            res = obj2ast_expr(state, tmp, &step, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -8789,11 +8742,12 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
+obj2ast_expr_context(astmodulestate *state, PyObject* obj, expr_context_ty*
+                     out, PyArena* arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Load_type);
+    isinstance = PyObject_IsInstance(obj, state->Load_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8801,7 +8755,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
         *out = Load;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Store_type);
+    isinstance = PyObject_IsInstance(obj, state->Store_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8809,7 +8763,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
         *out = Store;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Del_type);
+    isinstance = PyObject_IsInstance(obj, state->Del_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8823,11 +8777,12 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_boolop(PyObject* obj, boolop_ty* out, PyArena* arena)
+obj2ast_boolop(astmodulestate *state, PyObject* obj, boolop_ty* out, PyArena*
+               arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->And_type);
+    isinstance = PyObject_IsInstance(obj, state->And_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8835,7 +8790,7 @@ obj2ast_boolop(PyObject* obj, boolop_ty* out, PyArena* arena)
         *out = And;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Or_type);
+    isinstance = PyObject_IsInstance(obj, state->Or_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8849,11 +8804,12 @@ obj2ast_boolop(PyObject* obj, boolop_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
+obj2ast_operator(astmodulestate *state, PyObject* obj, operator_ty* out,
+                 PyArena* arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Add_type);
+    isinstance = PyObject_IsInstance(obj, state->Add_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8861,7 +8817,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Add;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Sub_type);
+    isinstance = PyObject_IsInstance(obj, state->Sub_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8869,7 +8825,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Sub;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Mult_type);
+    isinstance = PyObject_IsInstance(obj, state->Mult_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8877,7 +8833,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Mult;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->MatMult_type);
+    isinstance = PyObject_IsInstance(obj, state->MatMult_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8885,7 +8841,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = MatMult;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Div_type);
+    isinstance = PyObject_IsInstance(obj, state->Div_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8893,7 +8849,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Div;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Mod_type);
+    isinstance = PyObject_IsInstance(obj, state->Mod_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8901,7 +8857,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Mod;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Pow_type);
+    isinstance = PyObject_IsInstance(obj, state->Pow_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8909,7 +8865,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Pow;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->LShift_type);
+    isinstance = PyObject_IsInstance(obj, state->LShift_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8917,7 +8873,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = LShift;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->RShift_type);
+    isinstance = PyObject_IsInstance(obj, state->RShift_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8925,7 +8881,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = RShift;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->BitOr_type);
+    isinstance = PyObject_IsInstance(obj, state->BitOr_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8933,7 +8889,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = BitOr;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->BitXor_type);
+    isinstance = PyObject_IsInstance(obj, state->BitXor_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8941,7 +8897,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = BitXor;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->BitAnd_type);
+    isinstance = PyObject_IsInstance(obj, state->BitAnd_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8949,7 +8905,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = BitAnd;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->FloorDiv_type);
+    isinstance = PyObject_IsInstance(obj, state->FloorDiv_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8963,11 +8919,12 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
+obj2ast_unaryop(astmodulestate *state, PyObject* obj, unaryop_ty* out, PyArena*
+                arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Invert_type);
+    isinstance = PyObject_IsInstance(obj, state->Invert_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8975,7 +8932,7 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
         *out = Invert;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Not_type);
+    isinstance = PyObject_IsInstance(obj, state->Not_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8983,7 +8940,7 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
         *out = Not;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->UAdd_type);
+    isinstance = PyObject_IsInstance(obj, state->UAdd_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8991,7 +8948,7 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
         *out = UAdd;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->USub_type);
+    isinstance = PyObject_IsInstance(obj, state->USub_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9005,11 +8962,12 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
+obj2ast_cmpop(astmodulestate *state, PyObject* obj, cmpop_ty* out, PyArena*
+              arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Eq_type);
+    isinstance = PyObject_IsInstance(obj, state->Eq_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9017,7 +8975,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Eq;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->NotEq_type);
+    isinstance = PyObject_IsInstance(obj, state->NotEq_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9025,7 +8983,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = NotEq;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Lt_type);
+    isinstance = PyObject_IsInstance(obj, state->Lt_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9033,7 +8991,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Lt;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->LtE_type);
+    isinstance = PyObject_IsInstance(obj, state->LtE_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9041,7 +8999,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = LtE;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Gt_type);
+    isinstance = PyObject_IsInstance(obj, state->Gt_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9049,7 +9007,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Gt;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->GtE_type);
+    isinstance = PyObject_IsInstance(obj, state->GtE_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9057,7 +9015,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = GtE;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Is_type);
+    isinstance = PyObject_IsInstance(obj, state->Is_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9065,7 +9023,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Is;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->IsNot_type);
+    isinstance = PyObject_IsInstance(obj, state->IsNot_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9073,7 +9031,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = IsNot;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->In_type);
+    isinstance = PyObject_IsInstance(obj, state->In_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9081,7 +9039,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = In;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, astmodulestate_global->NotIn_type);
+    isinstance = PyObject_IsInstance(obj, state->NotIn_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -9095,7 +9053,8 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
+obj2ast_comprehension(astmodulestate *state, PyObject* obj, comprehension_ty*
+                      out, PyArena* arena)
 {
     PyObject* tmp = NULL;
     expr_ty target;
@@ -9103,7 +9062,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
     asdl_seq* ifs;
     int is_async;
 
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9112,11 +9071,11 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_expr(tmp, &target, arena);
+        res = obj2ast_expr(state, tmp, &target, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->iter, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->iter, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9125,11 +9084,11 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_expr(tmp, &iter, arena);
+        res = obj2ast_expr(state, tmp, &iter, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->ifs, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->ifs, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9151,7 +9110,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            res = obj2ast_expr(tmp2, &val, arena);
+            res = obj2ast_expr(state, tmp2, &val, arena);
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9162,7 +9121,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->is_async, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->is_async, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9171,7 +9130,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &is_async, arena);
+        res = obj2ast_int(state, tmp, &is_async, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9183,7 +9142,8 @@ failed:
 }
 
 int
-obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
+obj2ast_excepthandler(astmodulestate *state, PyObject* obj, excepthandler_ty*
+                      out, PyArena* arena)
 {
     int isinstance;
 
@@ -9198,7 +9158,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9207,12 +9167,11 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &lineno, arena);
+        res = obj2ast_int(state, tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9221,12 +9180,11 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &col_offset, arena);
+        res = obj2ast_int(state, tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9235,12 +9193,11 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_lineno, arena);
+        res = obj2ast_int(state, tmp, &end_lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
-        < 0) {
+    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9249,11 +9206,11 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_col_offset, arena);
+        res = obj2ast_int(state, tmp, &end_col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    tp = astmodulestate_global->ExceptHandler_type;
+    tp = state->ExceptHandler_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -9263,7 +9220,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         identifier name;
         asdl_seq* body;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->type, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->type, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -9272,11 +9229,11 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_expr(tmp, &type, arena);
+            res = obj2ast_expr(state, tmp, &type, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -9285,11 +9242,11 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_identifier(tmp, &name, arena);
+            res = obj2ast_identifier(state, tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9311,7 +9268,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
                 stmt_ty val;
                 PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
                 Py_INCREF(tmp2);
-                res = obj2ast_stmt(tmp2, &val, arena);
+                res = obj2ast_stmt(state, tmp2, &val, arena);
                 Py_DECREF(tmp2);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
@@ -9335,7 +9292,8 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
 }
 
 int
-obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
+obj2ast_arguments(astmodulestate *state, PyObject* obj, arguments_ty* out,
+                  PyArena* arena)
 {
     PyObject* tmp = NULL;
     asdl_seq* posonlyargs;
@@ -9346,8 +9304,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
     arg_ty kwarg;
     asdl_seq* defaults;
 
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->posonlyargs, &tmp) <
-        0) {
+    if (_PyObject_LookupAttr(obj, state->posonlyargs, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9369,7 +9326,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            res = obj2ast_arg(tmp2, &val, arena);
+            res = obj2ast_arg(state, tmp2, &val, arena);
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9380,7 +9337,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->args, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9402,7 +9359,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            res = obj2ast_arg(tmp2, &val, arena);
+            res = obj2ast_arg(state, tmp2, &val, arena);
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9413,7 +9370,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->vararg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->vararg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9422,12 +9379,11 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_arg(tmp, &vararg, arena);
+        res = obj2ast_arg(state, tmp, &vararg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->kwonlyargs, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->kwonlyargs, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9449,7 +9405,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             arg_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            res = obj2ast_arg(tmp2, &val, arena);
+            res = obj2ast_arg(state, tmp2, &val, arena);
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9460,8 +9416,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->kw_defaults, &tmp) <
-        0) {
+    if (_PyObject_LookupAttr(obj, state->kw_defaults, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9483,7 +9438,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            res = obj2ast_expr(tmp2, &val, arena);
+            res = obj2ast_expr(state, tmp2, &val, arena);
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9494,7 +9449,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->kwarg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->kwarg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9503,11 +9458,11 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_arg(tmp, &kwarg, arena);
+        res = obj2ast_arg(state, tmp, &kwarg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->defaults, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->defaults, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9529,7 +9484,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             expr_ty val;
             PyObject *tmp2 = PyList_GET_ITEM(tmp, i);
             Py_INCREF(tmp2);
-            res = obj2ast_expr(tmp2, &val, arena);
+            res = obj2ast_expr(state, tmp2, &val, arena);
             Py_DECREF(tmp2);
             if (res != 0) goto failed;
             if (len != PyList_GET_SIZE(tmp)) {
@@ -9549,7 +9504,7 @@ failed:
 }
 
 int
-obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
+obj2ast_arg(astmodulestate *state, PyObject* obj, arg_ty* out, PyArena* arena)
 {
     PyObject* tmp = NULL;
     identifier arg;
@@ -9560,7 +9515,7 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     int end_lineno;
     int end_col_offset;
 
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->arg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->arg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9569,12 +9524,11 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_identifier(tmp, &arg, arena);
+        res = obj2ast_identifier(state, tmp, &arg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->annotation, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->annotation, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9583,12 +9537,11 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_expr(tmp, &annotation, arena);
+        res = obj2ast_expr(state, tmp, &annotation, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment, &tmp) <
-        0) {
+    if (_PyObject_LookupAttr(obj, state->type_comment, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9597,11 +9550,11 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_string(tmp, &type_comment, arena);
+        res = obj2ast_string(state, tmp, &type_comment, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9610,12 +9563,11 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &lineno, arena);
+        res = obj2ast_int(state, tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9624,12 +9576,11 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &col_offset, arena);
+        res = obj2ast_int(state, tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9638,12 +9589,11 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_lineno, arena);
+        res = obj2ast_int(state, tmp, &end_lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
-        < 0) {
+    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9652,7 +9602,7 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_col_offset, arena);
+        res = obj2ast_int(state, tmp, &end_col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9665,7 +9615,8 @@ failed:
 }
 
 int
-obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
+obj2ast_keyword(astmodulestate *state, PyObject* obj, keyword_ty* out, PyArena*
+                arena)
 {
     PyObject* tmp = NULL;
     identifier arg;
@@ -9675,7 +9626,7 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     int end_lineno;
     int end_col_offset;
 
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->arg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->arg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9684,11 +9635,11 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_identifier(tmp, &arg, arena);
+        res = obj2ast_identifier(state, tmp, &arg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->value, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9697,11 +9648,11 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_expr(tmp, &value, arena);
+        res = obj2ast_expr(state, tmp, &value, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9710,12 +9661,11 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &lineno, arena);
+        res = obj2ast_int(state, tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9724,12 +9674,11 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &col_offset, arena);
+        res = obj2ast_int(state, tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
-        {
+    if (_PyObject_LookupAttr(obj, state->end_lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9738,12 +9687,11 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_lineno, arena);
+        res = obj2ast_int(state, tmp, &end_lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
-        < 0) {
+    if (_PyObject_LookupAttr(obj, state->end_col_offset, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9752,7 +9700,7 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_int(tmp, &end_col_offset, arena);
+        res = obj2ast_int(state, tmp, &end_col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9765,13 +9713,14 @@ failed:
 }
 
 int
-obj2ast_alias(PyObject* obj, alias_ty* out, PyArena* arena)
+obj2ast_alias(astmodulestate *state, PyObject* obj, alias_ty* out, PyArena*
+              arena)
 {
     PyObject* tmp = NULL;
     identifier name;
     identifier asname;
 
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9780,11 +9729,11 @@ obj2ast_alias(PyObject* obj, alias_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_identifier(tmp, &name, arena);
+        res = obj2ast_identifier(state, tmp, &name, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->asname, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, state->asname, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9793,7 +9742,7 @@ obj2ast_alias(PyObject* obj, alias_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_identifier(tmp, &asname, arena);
+        res = obj2ast_identifier(state, tmp, &asname, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9805,14 +9754,14 @@ failed:
 }
 
 int
-obj2ast_withitem(PyObject* obj, withitem_ty* out, PyArena* arena)
+obj2ast_withitem(astmodulestate *state, PyObject* obj, withitem_ty* out,
+                 PyArena* arena)
 {
     PyObject* tmp = NULL;
     expr_ty context_expr;
     expr_ty optional_vars;
 
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->context_expr, &tmp) <
-        0) {
+    if (_PyObject_LookupAttr(obj, state->context_expr, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -9821,12 +9770,11 @@ obj2ast_withitem(PyObject* obj, withitem_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_expr(tmp, &context_expr, arena);
+        res = obj2ast_expr(state, tmp, &context_expr, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttr(obj, astmodulestate_global->optional_vars, &tmp) <
-        0) {
+    if (_PyObject_LookupAttr(obj, state->optional_vars, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -9835,7 +9783,7 @@ obj2ast_withitem(PyObject* obj, withitem_ty* out, PyArena* arena)
     }
     else {
         int res;
-        res = obj2ast_expr(tmp, &optional_vars, arena);
+        res = obj2ast_expr(state, tmp, &optional_vars, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
@@ -9847,7 +9795,8 @@ failed:
 }
 
 int
-obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
+obj2ast_type_ignore(astmodulestate *state, PyObject* obj, type_ignore_ty* out,
+                    PyArena* arena)
 {
     int isinstance;
 
@@ -9858,7 +9807,7 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    tp = astmodulestate_global->TypeIgnore_type;
+    tp = state->TypeIgnore_type;
     isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
@@ -9867,8 +9816,7 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
         int lineno;
         string tag;
 
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0)
-            {
+        if (_PyObject_LookupAttr(obj, state->lineno, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9877,11 +9825,11 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_int(tmp, &lineno, arena);
+            res = obj2ast_int(state, tmp, &lineno, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttr(obj, astmodulestate_global->tag, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, state->tag, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -9890,7 +9838,7 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &tag, arena);
+            res = obj2ast_string(state, tmp, &tag, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
@@ -9913,10 +9861,12 @@ PyInit__ast(void)
     if (!init_types()) return NULL;
     m = PyState_FindModule(&_astmodule);
     if (!m) return NULL;
-    if (PyModule_AddObject(m, "AST", astmodulestate_global->AST_type) < 0) {
+    astmodulestate *state = get_ast_state(m);
+
+    if (PyModule_AddObject(m, "AST", state->AST_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->AST_type);
+    Py_INCREF(state->AST_type);
     if (PyModule_AddIntMacro(m, PyCF_ALLOW_TOP_LEVEL_AWAIT) < 0) {
         goto error;
     }
@@ -9926,485 +9876,432 @@ PyInit__ast(void)
     if (PyModule_AddIntMacro(m, PyCF_TYPE_COMMENTS) < 0) {
         goto error;
     }
-    if (PyModule_AddObject(m, "mod", astmodulestate_global->mod_type) < 0) {
+    if (PyModule_AddObject(m, "mod", state->mod_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->mod_type);
-    if (PyModule_AddObject(m, "Module", astmodulestate_global->Module_type) <
-        0) {
+    Py_INCREF(state->mod_type);
+    if (PyModule_AddObject(m, "Module", state->Module_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Module_type);
-    if (PyModule_AddObject(m, "Interactive",
-        astmodulestate_global->Interactive_type) < 0) {
+    Py_INCREF(state->Module_type);
+    if (PyModule_AddObject(m, "Interactive", state->Interactive_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Interactive_type);
-    if (PyModule_AddObject(m, "Expression",
-        astmodulestate_global->Expression_type) < 0) {
+    Py_INCREF(state->Interactive_type);
+    if (PyModule_AddObject(m, "Expression", state->Expression_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Expression_type);
-    if (PyModule_AddObject(m, "FunctionType",
-        astmodulestate_global->FunctionType_type) < 0) {
+    Py_INCREF(state->Expression_type);
+    if (PyModule_AddObject(m, "FunctionType", state->FunctionType_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->FunctionType_type);
-    if (PyModule_AddObject(m, "stmt", astmodulestate_global->stmt_type) < 0) {
+    Py_INCREF(state->FunctionType_type);
+    if (PyModule_AddObject(m, "stmt", state->stmt_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->stmt_type);
-    if (PyModule_AddObject(m, "FunctionDef",
-        astmodulestate_global->FunctionDef_type) < 0) {
+    Py_INCREF(state->stmt_type);
+    if (PyModule_AddObject(m, "FunctionDef", state->FunctionDef_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->FunctionDef_type);
-    if (PyModule_AddObject(m, "AsyncFunctionDef",
-        astmodulestate_global->AsyncFunctionDef_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->AsyncFunctionDef_type);
-    if (PyModule_AddObject(m, "ClassDef", astmodulestate_global->ClassDef_type)
+    Py_INCREF(state->FunctionDef_type);
+    if (PyModule_AddObject(m, "AsyncFunctionDef", state->AsyncFunctionDef_type)
         < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->ClassDef_type);
-    if (PyModule_AddObject(m, "Return", astmodulestate_global->Return_type) <
+    Py_INCREF(state->AsyncFunctionDef_type);
+    if (PyModule_AddObject(m, "ClassDef", state->ClassDef_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->ClassDef_type);
+    if (PyModule_AddObject(m, "Return", state->Return_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Return_type);
+    if (PyModule_AddObject(m, "Delete", state->Delete_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Delete_type);
+    if (PyModule_AddObject(m, "Assign", state->Assign_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Assign_type);
+    if (PyModule_AddObject(m, "AugAssign", state->AugAssign_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->AugAssign_type);
+    if (PyModule_AddObject(m, "AnnAssign", state->AnnAssign_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->AnnAssign_type);
+    if (PyModule_AddObject(m, "For", state->For_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->For_type);
+    if (PyModule_AddObject(m, "AsyncFor", state->AsyncFor_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->AsyncFor_type);
+    if (PyModule_AddObject(m, "While", state->While_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->While_type);
+    if (PyModule_AddObject(m, "If", state->If_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->If_type);
+    if (PyModule_AddObject(m, "With", state->With_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->With_type);
+    if (PyModule_AddObject(m, "AsyncWith", state->AsyncWith_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->AsyncWith_type);
+    if (PyModule_AddObject(m, "Raise", state->Raise_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Raise_type);
+    if (PyModule_AddObject(m, "Try", state->Try_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Try_type);
+    if (PyModule_AddObject(m, "Assert", state->Assert_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Assert_type);
+    if (PyModule_AddObject(m, "Import", state->Import_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Import_type);
+    if (PyModule_AddObject(m, "ImportFrom", state->ImportFrom_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->ImportFrom_type);
+    if (PyModule_AddObject(m, "Global", state->Global_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Global_type);
+    if (PyModule_AddObject(m, "Nonlocal", state->Nonlocal_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Nonlocal_type);
+    if (PyModule_AddObject(m, "Expr", state->Expr_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Expr_type);
+    if (PyModule_AddObject(m, "Pass", state->Pass_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Pass_type);
+    if (PyModule_AddObject(m, "Break", state->Break_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Break_type);
+    if (PyModule_AddObject(m, "Continue", state->Continue_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Continue_type);
+    if (PyModule_AddObject(m, "expr", state->expr_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->expr_type);
+    if (PyModule_AddObject(m, "BoolOp", state->BoolOp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->BoolOp_type);
+    if (PyModule_AddObject(m, "NamedExpr", state->NamedExpr_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->NamedExpr_type);
+    if (PyModule_AddObject(m, "BinOp", state->BinOp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->BinOp_type);
+    if (PyModule_AddObject(m, "UnaryOp", state->UnaryOp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->UnaryOp_type);
+    if (PyModule_AddObject(m, "Lambda", state->Lambda_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Lambda_type);
+    if (PyModule_AddObject(m, "IfExp", state->IfExp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->IfExp_type);
+    if (PyModule_AddObject(m, "Dict", state->Dict_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Dict_type);
+    if (PyModule_AddObject(m, "Set", state->Set_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Set_type);
+    if (PyModule_AddObject(m, "ListComp", state->ListComp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->ListComp_type);
+    if (PyModule_AddObject(m, "SetComp", state->SetComp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->SetComp_type);
+    if (PyModule_AddObject(m, "DictComp", state->DictComp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->DictComp_type);
+    if (PyModule_AddObject(m, "GeneratorExp", state->GeneratorExp_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->GeneratorExp_type);
+    if (PyModule_AddObject(m, "Await", state->Await_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Await_type);
+    if (PyModule_AddObject(m, "Yield", state->Yield_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Yield_type);
+    if (PyModule_AddObject(m, "YieldFrom", state->YieldFrom_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->YieldFrom_type);
+    if (PyModule_AddObject(m, "Compare", state->Compare_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Compare_type);
+    if (PyModule_AddObject(m, "Call", state->Call_type) < 0) {
+        goto error;
+    }
+    Py_INCREF(state->Call_type);
+    if (PyModule_AddObject(m, "FormattedValue", state->FormattedValue_type) <
         0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Return_type);
-    if (PyModule_AddObject(m, "Delete", astmodulestate_global->Delete_type) <
-        0) {
+    Py_INCREF(state->FormattedValue_type);
+    if (PyModule_AddObject(m, "JoinedStr", state->JoinedStr_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Delete_type);
-    if (PyModule_AddObject(m, "Assign", astmodulestate_global->Assign_type) <
-        0) {
+    Py_INCREF(state->JoinedStr_type);
+    if (PyModule_AddObject(m, "Constant", state->Constant_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Assign_type);
-    if (PyModule_AddObject(m, "AugAssign",
-        astmodulestate_global->AugAssign_type) < 0) {
+    Py_INCREF(state->Constant_type);
+    if (PyModule_AddObject(m, "Attribute", state->Attribute_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->AugAssign_type);
-    if (PyModule_AddObject(m, "AnnAssign",
-        astmodulestate_global->AnnAssign_type) < 0) {
+    Py_INCREF(state->Attribute_type);
+    if (PyModule_AddObject(m, "Subscript", state->Subscript_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->AnnAssign_type);
-    if (PyModule_AddObject(m, "For", astmodulestate_global->For_type) < 0) {
+    Py_INCREF(state->Subscript_type);
+    if (PyModule_AddObject(m, "Starred", state->Starred_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->For_type);
-    if (PyModule_AddObject(m, "AsyncFor", astmodulestate_global->AsyncFor_type)
-        < 0) {
+    Py_INCREF(state->Starred_type);
+    if (PyModule_AddObject(m, "Name", state->Name_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->AsyncFor_type);
-    if (PyModule_AddObject(m, "While", astmodulestate_global->While_type) < 0) {
+    Py_INCREF(state->Name_type);
+    if (PyModule_AddObject(m, "List", state->List_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->While_type);
-    if (PyModule_AddObject(m, "If", astmodulestate_global->If_type) < 0) {
+    Py_INCREF(state->List_type);
+    if (PyModule_AddObject(m, "Tuple", state->Tuple_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->If_type);
-    if (PyModule_AddObject(m, "With", astmodulestate_global->With_type) < 0) {
+    Py_INCREF(state->Tuple_type);
+    if (PyModule_AddObject(m, "Slice", state->Slice_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->With_type);
-    if (PyModule_AddObject(m, "AsyncWith",
-        astmodulestate_global->AsyncWith_type) < 0) {
+    Py_INCREF(state->Slice_type);
+    if (PyModule_AddObject(m, "expr_context", state->expr_context_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->AsyncWith_type);
-    if (PyModule_AddObject(m, "Raise", astmodulestate_global->Raise_type) < 0) {
+    Py_INCREF(state->expr_context_type);
+    if (PyModule_AddObject(m, "Load", state->Load_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Raise_type);
-    if (PyModule_AddObject(m, "Try", astmodulestate_global->Try_type) < 0) {
+    Py_INCREF(state->Load_type);
+    if (PyModule_AddObject(m, "Store", state->Store_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Try_type);
-    if (PyModule_AddObject(m, "Assert", astmodulestate_global->Assert_type) <
-        0) {
+    Py_INCREF(state->Store_type);
+    if (PyModule_AddObject(m, "Del", state->Del_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Assert_type);
-    if (PyModule_AddObject(m, "Import", astmodulestate_global->Import_type) <
-        0) {
+    Py_INCREF(state->Del_type);
+    if (PyModule_AddObject(m, "boolop", state->boolop_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Import_type);
-    if (PyModule_AddObject(m, "ImportFrom",
-        astmodulestate_global->ImportFrom_type) < 0) {
+    Py_INCREF(state->boolop_type);
+    if (PyModule_AddObject(m, "And", state->And_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->ImportFrom_type);
-    if (PyModule_AddObject(m, "Global", astmodulestate_global->Global_type) <
-        0) {
+    Py_INCREF(state->And_type);
+    if (PyModule_AddObject(m, "Or", state->Or_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Global_type);
-    if (PyModule_AddObject(m, "Nonlocal", astmodulestate_global->Nonlocal_type)
-        < 0) {
+    Py_INCREF(state->Or_type);
+    if (PyModule_AddObject(m, "operator", state->operator_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Nonlocal_type);
-    if (PyModule_AddObject(m, "Expr", astmodulestate_global->Expr_type) < 0) {
+    Py_INCREF(state->operator_type);
+    if (PyModule_AddObject(m, "Add", state->Add_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Expr_type);
-    if (PyModule_AddObject(m, "Pass", astmodulestate_global->Pass_type) < 0) {
+    Py_INCREF(state->Add_type);
+    if (PyModule_AddObject(m, "Sub", state->Sub_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Pass_type);
-    if (PyModule_AddObject(m, "Break", astmodulestate_global->Break_type) < 0) {
+    Py_INCREF(state->Sub_type);
+    if (PyModule_AddObject(m, "Mult", state->Mult_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Break_type);
-    if (PyModule_AddObject(m, "Continue", astmodulestate_global->Continue_type)
-        < 0) {
+    Py_INCREF(state->Mult_type);
+    if (PyModule_AddObject(m, "MatMult", state->MatMult_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Continue_type);
-    if (PyModule_AddObject(m, "expr", astmodulestate_global->expr_type) < 0) {
+    Py_INCREF(state->MatMult_type);
+    if (PyModule_AddObject(m, "Div", state->Div_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->expr_type);
-    if (PyModule_AddObject(m, "BoolOp", astmodulestate_global->BoolOp_type) <
-        0) {
+    Py_INCREF(state->Div_type);
+    if (PyModule_AddObject(m, "Mod", state->Mod_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->BoolOp_type);
-    if (PyModule_AddObject(m, "NamedExpr",
-        astmodulestate_global->NamedExpr_type) < 0) {
+    Py_INCREF(state->Mod_type);
+    if (PyModule_AddObject(m, "Pow", state->Pow_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->NamedExpr_type);
-    if (PyModule_AddObject(m, "BinOp", astmodulestate_global->BinOp_type) < 0) {
+    Py_INCREF(state->Pow_type);
+    if (PyModule_AddObject(m, "LShift", state->LShift_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->BinOp_type);
-    if (PyModule_AddObject(m, "UnaryOp", astmodulestate_global->UnaryOp_type) <
-        0) {
+    Py_INCREF(state->LShift_type);
+    if (PyModule_AddObject(m, "RShift", state->RShift_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->UnaryOp_type);
-    if (PyModule_AddObject(m, "Lambda", astmodulestate_global->Lambda_type) <
-        0) {
+    Py_INCREF(state->RShift_type);
+    if (PyModule_AddObject(m, "BitOr", state->BitOr_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Lambda_type);
-    if (PyModule_AddObject(m, "IfExp", astmodulestate_global->IfExp_type) < 0) {
+    Py_INCREF(state->BitOr_type);
+    if (PyModule_AddObject(m, "BitXor", state->BitXor_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->IfExp_type);
-    if (PyModule_AddObject(m, "Dict", astmodulestate_global->Dict_type) < 0) {
+    Py_INCREF(state->BitXor_type);
+    if (PyModule_AddObject(m, "BitAnd", state->BitAnd_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Dict_type);
-    if (PyModule_AddObject(m, "Set", astmodulestate_global->Set_type) < 0) {
+    Py_INCREF(state->BitAnd_type);
+    if (PyModule_AddObject(m, "FloorDiv", state->FloorDiv_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Set_type);
-    if (PyModule_AddObject(m, "ListComp", astmodulestate_global->ListComp_type)
-        < 0) {
+    Py_INCREF(state->FloorDiv_type);
+    if (PyModule_AddObject(m, "unaryop", state->unaryop_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->ListComp_type);
-    if (PyModule_AddObject(m, "SetComp", astmodulestate_global->SetComp_type) <
-        0) {
+    Py_INCREF(state->unaryop_type);
+    if (PyModule_AddObject(m, "Invert", state->Invert_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->SetComp_type);
-    if (PyModule_AddObject(m, "DictComp", astmodulestate_global->DictComp_type)
-        < 0) {
+    Py_INCREF(state->Invert_type);
+    if (PyModule_AddObject(m, "Not", state->Not_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->DictComp_type);
-    if (PyModule_AddObject(m, "GeneratorExp",
-        astmodulestate_global->GeneratorExp_type) < 0) {
+    Py_INCREF(state->Not_type);
+    if (PyModule_AddObject(m, "UAdd", state->UAdd_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->GeneratorExp_type);
-    if (PyModule_AddObject(m, "Await", astmodulestate_global->Await_type) < 0) {
+    Py_INCREF(state->UAdd_type);
+    if (PyModule_AddObject(m, "USub", state->USub_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Await_type);
-    if (PyModule_AddObject(m, "Yield", astmodulestate_global->Yield_type) < 0) {
+    Py_INCREF(state->USub_type);
+    if (PyModule_AddObject(m, "cmpop", state->cmpop_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Yield_type);
-    if (PyModule_AddObject(m, "YieldFrom",
-        astmodulestate_global->YieldFrom_type) < 0) {
+    Py_INCREF(state->cmpop_type);
+    if (PyModule_AddObject(m, "Eq", state->Eq_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->YieldFrom_type);
-    if (PyModule_AddObject(m, "Compare", astmodulestate_global->Compare_type) <
-        0) {
+    Py_INCREF(state->Eq_type);
+    if (PyModule_AddObject(m, "NotEq", state->NotEq_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Compare_type);
-    if (PyModule_AddObject(m, "Call", astmodulestate_global->Call_type) < 0) {
+    Py_INCREF(state->NotEq_type);
+    if (PyModule_AddObject(m, "Lt", state->Lt_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Call_type);
-    if (PyModule_AddObject(m, "FormattedValue",
-        astmodulestate_global->FormattedValue_type) < 0) {
+    Py_INCREF(state->Lt_type);
+    if (PyModule_AddObject(m, "LtE", state->LtE_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->FormattedValue_type);
-    if (PyModule_AddObject(m, "JoinedStr",
-        astmodulestate_global->JoinedStr_type) < 0) {
+    Py_INCREF(state->LtE_type);
+    if (PyModule_AddObject(m, "Gt", state->Gt_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->JoinedStr_type);
-    if (PyModule_AddObject(m, "Constant", astmodulestate_global->Constant_type)
-        < 0) {
+    Py_INCREF(state->Gt_type);
+    if (PyModule_AddObject(m, "GtE", state->GtE_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Constant_type);
-    if (PyModule_AddObject(m, "Attribute",
-        astmodulestate_global->Attribute_type) < 0) {
+    Py_INCREF(state->GtE_type);
+    if (PyModule_AddObject(m, "Is", state->Is_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Attribute_type);
-    if (PyModule_AddObject(m, "Subscript",
-        astmodulestate_global->Subscript_type) < 0) {
+    Py_INCREF(state->Is_type);
+    if (PyModule_AddObject(m, "IsNot", state->IsNot_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Subscript_type);
-    if (PyModule_AddObject(m, "Starred", astmodulestate_global->Starred_type) <
-        0) {
+    Py_INCREF(state->IsNot_type);
+    if (PyModule_AddObject(m, "In", state->In_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Starred_type);
-    if (PyModule_AddObject(m, "Name", astmodulestate_global->Name_type) < 0) {
+    Py_INCREF(state->In_type);
+    if (PyModule_AddObject(m, "NotIn", state->NotIn_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Name_type);
-    if (PyModule_AddObject(m, "List", astmodulestate_global->List_type) < 0) {
+    Py_INCREF(state->NotIn_type);
+    if (PyModule_AddObject(m, "comprehension", state->comprehension_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->List_type);
-    if (PyModule_AddObject(m, "Tuple", astmodulestate_global->Tuple_type) < 0) {
+    Py_INCREF(state->comprehension_type);
+    if (PyModule_AddObject(m, "excepthandler", state->excepthandler_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Tuple_type);
-    if (PyModule_AddObject(m, "Slice", astmodulestate_global->Slice_type) < 0) {
+    Py_INCREF(state->excepthandler_type);
+    if (PyModule_AddObject(m, "ExceptHandler", state->ExceptHandler_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Slice_type);
-    if (PyModule_AddObject(m, "expr_context",
-        astmodulestate_global->expr_context_type) < 0) {
+    Py_INCREF(state->ExceptHandler_type);
+    if (PyModule_AddObject(m, "arguments", state->arguments_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->expr_context_type);
-    if (PyModule_AddObject(m, "Load", astmodulestate_global->Load_type) < 0) {
+    Py_INCREF(state->arguments_type);
+    if (PyModule_AddObject(m, "arg", state->arg_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Load_type);
-    if (PyModule_AddObject(m, "Store", astmodulestate_global->Store_type) < 0) {
+    Py_INCREF(state->arg_type);
+    if (PyModule_AddObject(m, "keyword", state->keyword_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Store_type);
-    if (PyModule_AddObject(m, "Del", astmodulestate_global->Del_type) < 0) {
+    Py_INCREF(state->keyword_type);
+    if (PyModule_AddObject(m, "alias", state->alias_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Del_type);
-    if (PyModule_AddObject(m, "boolop", astmodulestate_global->boolop_type) <
-        0) {
+    Py_INCREF(state->alias_type);
+    if (PyModule_AddObject(m, "withitem", state->withitem_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->boolop_type);
-    if (PyModule_AddObject(m, "And", astmodulestate_global->And_type) < 0) {
+    Py_INCREF(state->withitem_type);
+    if (PyModule_AddObject(m, "type_ignore", state->type_ignore_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->And_type);
-    if (PyModule_AddObject(m, "Or", astmodulestate_global->Or_type) < 0) {
+    Py_INCREF(state->type_ignore_type);
+    if (PyModule_AddObject(m, "TypeIgnore", state->TypeIgnore_type) < 0) {
         goto error;
     }
-    Py_INCREF(astmodulestate(m)->Or_type);
-    if (PyModule_AddObject(m, "operator", astmodulestate_global->operator_type)
-        < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->operator_type);
-    if (PyModule_AddObject(m, "Add", astmodulestate_global->Add_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Add_type);
-    if (PyModule_AddObject(m, "Sub", astmodulestate_global->Sub_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Sub_type);
-    if (PyModule_AddObject(m, "Mult", astmodulestate_global->Mult_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Mult_type);
-    if (PyModule_AddObject(m, "MatMult", astmodulestate_global->MatMult_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->MatMult_type);
-    if (PyModule_AddObject(m, "Div", astmodulestate_global->Div_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Div_type);
-    if (PyModule_AddObject(m, "Mod", astmodulestate_global->Mod_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Mod_type);
-    if (PyModule_AddObject(m, "Pow", astmodulestate_global->Pow_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Pow_type);
-    if (PyModule_AddObject(m, "LShift", astmodulestate_global->LShift_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->LShift_type);
-    if (PyModule_AddObject(m, "RShift", astmodulestate_global->RShift_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->RShift_type);
-    if (PyModule_AddObject(m, "BitOr", astmodulestate_global->BitOr_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->BitOr_type);
-    if (PyModule_AddObject(m, "BitXor", astmodulestate_global->BitXor_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->BitXor_type);
-    if (PyModule_AddObject(m, "BitAnd", astmodulestate_global->BitAnd_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->BitAnd_type);
-    if (PyModule_AddObject(m, "FloorDiv", astmodulestate_global->FloorDiv_type)
-        < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->FloorDiv_type);
-    if (PyModule_AddObject(m, "unaryop", astmodulestate_global->unaryop_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->unaryop_type);
-    if (PyModule_AddObject(m, "Invert", astmodulestate_global->Invert_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Invert_type);
-    if (PyModule_AddObject(m, "Not", astmodulestate_global->Not_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Not_type);
-    if (PyModule_AddObject(m, "UAdd", astmodulestate_global->UAdd_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->UAdd_type);
-    if (PyModule_AddObject(m, "USub", astmodulestate_global->USub_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->USub_type);
-    if (PyModule_AddObject(m, "cmpop", astmodulestate_global->cmpop_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->cmpop_type);
-    if (PyModule_AddObject(m, "Eq", astmodulestate_global->Eq_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Eq_type);
-    if (PyModule_AddObject(m, "NotEq", astmodulestate_global->NotEq_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->NotEq_type);
-    if (PyModule_AddObject(m, "Lt", astmodulestate_global->Lt_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Lt_type);
-    if (PyModule_AddObject(m, "LtE", astmodulestate_global->LtE_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->LtE_type);
-    if (PyModule_AddObject(m, "Gt", astmodulestate_global->Gt_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Gt_type);
-    if (PyModule_AddObject(m, "GtE", astmodulestate_global->GtE_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->GtE_type);
-    if (PyModule_AddObject(m, "Is", astmodulestate_global->Is_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->Is_type);
-    if (PyModule_AddObject(m, "IsNot", astmodulestate_global->IsNot_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->IsNot_type);
-    if (PyModule_AddObject(m, "In", astmodulestate_global->In_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->In_type);
-    if (PyModule_AddObject(m, "NotIn", astmodulestate_global->NotIn_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->NotIn_type);
-    if (PyModule_AddObject(m, "comprehension",
-        astmodulestate_global->comprehension_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->comprehension_type);
-    if (PyModule_AddObject(m, "excepthandler",
-        astmodulestate_global->excepthandler_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->excepthandler_type);
-    if (PyModule_AddObject(m, "ExceptHandler",
-        astmodulestate_global->ExceptHandler_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->ExceptHandler_type);
-    if (PyModule_AddObject(m, "arguments",
-        astmodulestate_global->arguments_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->arguments_type);
-    if (PyModule_AddObject(m, "arg", astmodulestate_global->arg_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->arg_type);
-    if (PyModule_AddObject(m, "keyword", astmodulestate_global->keyword_type) <
-        0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->keyword_type);
-    if (PyModule_AddObject(m, "alias", astmodulestate_global->alias_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->alias_type);
-    if (PyModule_AddObject(m, "withitem", astmodulestate_global->withitem_type)
-        < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->withitem_type);
-    if (PyModule_AddObject(m, "type_ignore",
-        astmodulestate_global->type_ignore_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->type_ignore_type);
-    if (PyModule_AddObject(m, "TypeIgnore",
-        astmodulestate_global->TypeIgnore_type) < 0) {
-        goto error;
-    }
-    Py_INCREF(astmodulestate(m)->TypeIgnore_type);
+    Py_INCREF(state->TypeIgnore_type);
     return m;
 error:
     Py_DECREF(m);
@@ -10416,13 +10313,13 @@ PyObject* PyAST_mod2obj(mod_ty t)
 {
     if (!init_types())
         return NULL;
-    return ast2obj_mod(t);
+    astmodulestate *state = astmodulestate_global;
+    return ast2obj_mod(state, t);
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    PyObject *req_type[3];
     const char * const req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;
 
@@ -10430,9 +10327,11 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
         return NULL;
     }
 
-    req_type[0] = astmodulestate_global->Module_type;
-    req_type[1] = astmodulestate_global->Expression_type;
-    req_type[2] = astmodulestate_global->Interactive_type;
+    astmodulestate *state = astmodulestate_global;
+    PyObject *req_type[3];
+    req_type[0] = state->Module_type;
+    req_type[1] = state->Expression_type;
+    req_type[2] = state->Interactive_type;
 
     assert(0 <= mode && mode <= 2);
 
@@ -10449,7 +10348,7 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
     }
 
     mod_ty res = NULL;
-    if (obj2ast_mod(ast, &res, arena) != 0)
+    if (obj2ast_mod(state, ast, &res, arena) != 0)
         return NULL;
     else
         return res;
@@ -10459,7 +10358,8 @@ int PyAST_Check(PyObject* obj)
 {
     if (!init_types())
         return -1;
-    return PyObject_IsInstance(obj, astmodulestate_global->AST_type);
+    astmodulestate *state = astmodulestate_global;
+    return PyObject_IsInstance(obj, state->AST_type);
 }
 
 


### PR DESCRIPTION
Rework asdl_c.py to pass the module state to functions in
Python-ast.c, instead of using astmodulestate_global.

Handle also PyState_AddModule() failure in init_types().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41194](https://bugs.python.org/issue41194) -->
https://bugs.python.org/issue41194
<!-- /issue-number -->
