### PR TITLE
bpo-41110: Fixed lib2to3 reporting some unchanged files as needing modification

### DIFF
--- a/Lib/lib2to3/fixes/fix_dict.py
+++ b/Lib/lib2to3/fixes/fix_dict.py
@@ -65,6 +65,8 @@ class FixDict(fixer_base.BaseFix):
         head = [n.clone() for n in head]
         tail = [n.clone() for n in tail]
         special = not tail and self.in_special_context(node, isiter)
+        if special and not (isiter or isview):
+            return None
         args = head + [pytree.Node(syms.trailer,
                                    [Dot(),
                                     Name(method_name,

--- a/Lib/lib2to3/fixes/fix_except.py
+++ b/Lib/lib2to3/fixes/fix_except.py
@@ -50,10 +50,12 @@ class FixExcept(fixer_base.BaseFix):
         tail = [n.clone() for n in results["tail"]]
 
         try_cleanup = [ch.clone() for ch in results["cleanup"]]
+        changed = False
         for except_clause, e_suite in find_excepts(try_cleanup):
             if len(except_clause.children) == 4:
                 (E, comma, N) = except_clause.children[1:4]
                 comma.replace(Name("as", prefix=" "))
+                changed = True
 
                 if N.type != token.NAME:
                     # Generate a new N for the except clause
@@ -87,6 +89,9 @@ class FixExcept(fixer_base.BaseFix):
                     # No space after a comma is legal; no space after "as",
                     # not so much.
                     N.prefix = " "
+
+        if not changed:
+            return None
 
         #TODO(cwinter) fix this when children becomes a smart list
         children = [c.clone() for c in node.children[:3]] + try_cleanup + tail

--- a/Lib/lib2to3/fixes/fix_isinstance.py
+++ b/Lib/lib2to3/fixes/fix_isinstance.py
@@ -32,8 +32,10 @@ class FixIsinstance(fixer_base.BaseFix):
         args = testlist.children
         new_args = []
         iterator = enumerate(args)
+        changed = False
         for idx, arg in iterator:
             if arg.type == token.NAME and arg.value in names_inserted:
+                changed = True
                 if idx < len(args) - 1 and args[idx + 1].type == token.COMMA:
                     next(iterator)
                     continue
@@ -42,11 +44,13 @@ class FixIsinstance(fixer_base.BaseFix):
                 if arg.type == token.NAME:
                     names_inserted.add(arg.value)
         if new_args and new_args[-1].type == token.COMMA:
+            changed = True
             del new_args[-1]
-        if len(new_args) == 1:
-            atom = testlist.parent
+        atom = testlist.parent
+        if len(new_args) == 1 and new_args[0].prefix != atom.prefix:
+            changed = True
             new_args[0].prefix = atom.prefix
             atom.replace(new_args[0])
-        else:
+        if changed:
             args[:] = new_args
             node.changed()

--- a/Lib/lib2to3/fixes/fix_raise.py
+++ b/Lib/lib2to3/fixes/fix_raise.py
@@ -37,6 +37,7 @@ class FixRaise(fixer_base.BaseFix):
 
     def transform(self, node, results):
         syms = self.syms
+        changed = False
 
         exc = results["exc"].clone()
         if exc.type == token.STRING:
@@ -56,8 +57,12 @@ class FixRaise(fixer_base.BaseFix):
                 # exc.children[1].children[0] is the first element of the tuple
                 exc = exc.children[1].children[0].clone()
             exc.prefix = " "
+            changed = True
 
         if "val" not in results:
+            if not changed:
+                return None
+
             # One-argument raise
             new = pytree.Node(syms.raise_stmt, [Name("raise"), exc])
             new.prefix = node.prefix

--- a/Lib/lib2to3/fixes/fix_unicode.py
+++ b/Lib/lib2to3/fixes/fix_unicode.py
@@ -36,7 +36,7 @@ class FixUnicode(fixer_base.BaseFix):
             if val[0] in 'uU':
                 val = val[1:]
             if val == node.value:
-                return node
+                return
             new = node.clone()
             new.value = val
             return new

--- a/Lib/lib2to3/fixes/fix_ws_comma.py
+++ b/Lib/lib2to3/fixes/fix_ws_comma.py
@@ -24,16 +24,19 @@ class FixWsComma(fixer_base.BaseFix):
     def transform(self, node, results):
         new = node.clone()
         comma = False
+        changed = False
         for child in new.children:
             if child in self.SEPS:
                 prefix = child.prefix
                 if prefix.isspace() and "\n" not in prefix:
                     child.prefix = ""
+                    changed = True
                 comma = True
             else:
                 if comma:
                     prefix = child.prefix
                     if not prefix:
                         child.prefix = " "
+                        changed = True
                 comma = False
-        return new
+        return new if changed else None

--- a/Lib/lib2to3/tests/test_fixers.py
+++ b/Lib/lib2to3/tests/test_fixers.py
@@ -48,7 +48,8 @@ class FixerTestCase(support.TestCase):
         self.warns(before, before, message, unchanged=True)
 
     def unchanged(self, before, ignore_warnings=False):
-        self._check(before, before)
+        tree = self._check(before, before)
+        self.assertFalse(tree.was_changed)
         if not ignore_warnings:
             self.assertEqual(self.fixer_log, [])
 
@@ -954,6 +955,10 @@ class Test_raise(FixerTestCase):
         b = """raise (E1, (E2, E3), E4), V"""
         a = """raise E1(V)"""
         self.check(b, a)
+
+    def test_unchanged(self):
+        a = """raise E1(V)"""
+        self.unchanged(a)
 
     # These should produce a warning
 
@@ -2776,6 +2781,10 @@ class Test_numliterals(FixerTestCase):
     def test_unchanged_float(self):
         s = """5.0"""
         self.unchanged(s)
+        s = """0.1"""
+        self.unchanged(s)
+        s = """000"""
+        self.unchanged(s)
 
     def test_unchanged_octal(self):
         s = """0o755"""
@@ -2895,18 +2904,15 @@ class Test_unicode(FixerTestCase):
         a = r"""'\\\\u20ac\\U0001d121\\u20ac'"""
         self.check(b, a)
 
-        b = r"""r'\\\u20ac\U0001d121\\u20ac'"""
         a = r"""r'\\\u20ac\U0001d121\\u20ac'"""
-        self.check(b, a)
+        self.unchanged(a)
 
     def test_bytes_literal_escape_u(self):
-        b = r"""b'\\\u20ac\U0001d121\\u20ac'"""
         a = r"""b'\\\u20ac\U0001d121\\u20ac'"""
-        self.check(b, a)
+        self.unchanged(a)
 
-        b = r"""br'\\\u20ac\U0001d121\\u20ac'"""
         a = r"""br'\\\u20ac\U0001d121\\u20ac'"""
-        self.check(b, a)
+        self.unchanged(a)
 
     def test_unicode_literal_escape_u(self):
         b = r"""u'\\\u20ac\U0001d121\\u20ac'"""
@@ -2919,13 +2925,15 @@ class Test_unicode(FixerTestCase):
 
     def test_native_unicode_literal_escape_u(self):
         f = 'from __future__ import unicode_literals\n'
-        b = f + r"""'\\\u20ac\U0001d121\\u20ac'"""
         a = f + r"""'\\\u20ac\U0001d121\\u20ac'"""
-        self.check(b, a)
+        self.unchanged(a)
 
-        b = f + r"""r'\\\u20ac\U0001d121\\u20ac'"""
         a = f + r"""r'\\\u20ac\U0001d121\\u20ac'"""
-        self.check(b, a)
+        self.unchanged(a)
+
+    def test_unchanged(self):
+        a = """'h'"""
+        self.unchanged(a)
 
 
 class Test_filter(FixerTestCase):

--- a/Misc/NEWS.d/next/Library/2020-07-03-10-45-39.bpo-41110.GId8oe.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-03-10-45-39.bpo-41110.GId8oe.rst
@@ -1,0 +1,1 @@
+Fixed lib2to3 reporting some unchanged files as needing modification.


### PR DESCRIPTION
This changes prevents lib2to3 fixers from changing the tree unnecessarily, which results in no visible diff and the file still being reported as needing modifications.

This partially addresses an issue in `python-modernize` where a non-zero exit code is returned even when no changes to files need to be made: https://github.com/python-modernize/python-modernize/issues/161

Given that lib2to3 is on its way out, I don't know if this should be fixed in 3.8 and 3.9 only?

<!-- issue-number: [bpo-41110](https://bugs.python.org/issue41110) -->
https://bugs.python.org/issue41110
<!-- /issue-number -->
