### PR TITLE
bpo-40275: Use new test.support helper submodules in tests

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -672,7 +672,7 @@ The module defines the following classes, functions and decorators:
    A generic version of :class:`collections.abc.ByteString`.
 
    This type represents the types :class:`bytes`, :class:`bytearray`,
-   and :class:`memoryview`.
+   and :class:`memoryview` of byte sequences.
 
    As a shorthand for this type, :class:`bytes` can be used to
    annotate arguments of any of the types mentioned above.

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -22,10 +22,13 @@ except ImportError:
     _testbuffer = None
 
 from test import support
+from test.support import os_helper
 from test.support import (
-    TestFailed, TESTFN, run_with_locale, no_tracing,
-    _2G, _4G, bigmemtest, forget,
+    TestFailed, run_with_locale, no_tracing,
+    _2G, _4G, bigmemtest
     )
+from test.support.import_helper import forget 
+from test.support.os_helper import TESTFN
 from test.support import threading_helper
 from test.support.warnings_helper import save_restore_warnings_filters
 
@@ -3100,7 +3103,7 @@ class AbstractPickleModuleTests(unittest.TestCase):
             f.close()
             self.assertRaises(ValueError, self.dump, 123, f)
         finally:
-            support.unlink(TESTFN)
+            os_helper.unlink(TESTFN)
 
     def test_load_closed_file(self):
         f = open(TESTFN, "wb")
@@ -3108,7 +3111,7 @@ class AbstractPickleModuleTests(unittest.TestCase):
             f.close()
             self.assertRaises(ValueError, self.dump, 123, f)
         finally:
-            support.unlink(TESTFN)
+            os_helper.unlink(TESTFN)
 
     def test_load_from_and_dump_to_file(self):
         stream = io.BytesIO()
@@ -3139,7 +3142,7 @@ class AbstractPickleModuleTests(unittest.TestCase):
                 self.assertRaises(TypeError, self.dump, 123, f, proto)
         finally:
             f.close()
-            support.unlink(TESTFN)
+            os_helper.unlink(TESTFN)
 
     def test_incomplete_input(self):
         s = io.BytesIO(b"X''.")

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -27,7 +27,7 @@ from test.support import (
     TestFailed, run_with_locale, no_tracing,
     _2G, _4G, bigmemtest
     )
-from test.support.import_helper import forget 
+from test.support.import_helper import forget
 from test.support.os_helper import TESTFN
 from test.support import threading_helper
 from test.support.warnings_helper import save_restore_warnings_filters

--- a/Lib/test/test_binhex.py
+++ b/Lib/test/test_binhex.py
@@ -5,23 +5,27 @@
 """
 import unittest
 from test import support
+from test.support import import_helper
+from test.support import os_helper
+from test.support import warnings_helper
 
-with support.check_warnings(('', DeprecationWarning)):
-    binhex = support.import_fresh_module('binhex')
+
+with warnings_helper.check_warnings(('', DeprecationWarning)):
+    binhex = import_helper.import_fresh_module('binhex')
 
 
 class BinHexTestCase(unittest.TestCase):
 
     def setUp(self):
         # binhex supports only file names encodable to Latin1
-        self.fname1 = support.TESTFN_ASCII + "1"
-        self.fname2 = support.TESTFN_ASCII + "2"
-        self.fname3 = support.TESTFN_ASCII + "very_long_filename__very_long_filename__very_long_filename__very_long_filename__"
+        self.fname1 = os_helper.TESTFN_ASCII + "1"
+        self.fname2 = os_helper.TESTFN_ASCII + "2"
+        self.fname3 = os_helper.TESTFN_ASCII + "very_long_filename__very_long_filename__very_long_filename__very_long_filename__"
 
     def tearDown(self):
-        support.unlink(self.fname1)
-        support.unlink(self.fname2)
-        support.unlink(self.fname3)
+        os_helper.unlink(self.fname1)
+        os_helper.unlink(self.fname2)
+        os_helper.unlink(self.fname3)
 
     DATA = b'Jack is my hero'
 

--- a/Lib/test/test_bufio.py
+++ b/Lib/test/test_bufio.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 
 import io # C implementation.
 import _pyio as pyio # Python implementation.
@@ -17,18 +18,18 @@ class BufferSizeTest:
         # .readline()s deliver what we wrote.
 
         # Ensure we can open TESTFN for writing.
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
         # Since C doesn't guarantee we can write/read arbitrary bytes in text
         # files, use binary mode.
-        f = self.open(support.TESTFN, "wb")
+        f = self.open(os_helper.TESTFN, "wb")
         try:
             # write once with \n and once without
             f.write(s)
             f.write(b"\n")
             f.write(s)
             f.close()
-            f = open(support.TESTFN, "rb")
+            f = open(os_helper.TESTFN, "rb")
             line = f.readline()
             self.assertEqual(line, s + b"\n")
             line = f.readline()
@@ -37,7 +38,7 @@ class BufferSizeTest:
             self.assertFalse(line) # Must be at EOF
             f.close()
         finally:
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def drive_one(self, pattern):
         for length in lengths:

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -17,6 +17,7 @@ import importlib.machinery
 import importlib.util
 from test import support
 from test.support import MISSING_C_DOCSTRINGS
+from test.support import import_helper
 from test.support import threading_helper
 from test.support.script_helper import assert_python_failure, assert_python_ok
 try:
@@ -25,7 +26,7 @@ except ImportError:
     _posixsubprocess = None
 
 # Skip this test if the _testcapi module isn't available.
-_testcapi = support.import_module('_testcapi')
+_testcapi = import_helper.import_module('_testcapi')
 
 import _testinternalcapi
 

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -23,6 +23,7 @@ except ImportError:
     _have_multiprocessing = False
 
 from test import support
+from test.support import os_helper
 from test.support import script_helper
 
 from .test_py_compile import without_source_date_epoch
@@ -356,7 +357,7 @@ class CompileallTestsBase:
                 except Exception:
                     pass
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_ignore_symlink_destination(self):
         # Create folders for allowed files, symlinks and prohibited area
         allowed_path = os.path.join(self.directory, "test", "dir", "allowed")
@@ -438,7 +439,7 @@ class CommandLineTestsBase:
                 sys_path_writable = False
                 break
             finally:
-                support.unlink(str(path))
+                os_helper.unlink(str(path))
                 if directory_created:
                     directory.rmdir()
         else:
@@ -477,7 +478,7 @@ class CommandLineTestsBase:
 
     def setUp(self):
         self.directory = tempfile.mkdtemp()
-        self.addCleanup(support.rmtree, self.directory)
+        self.addCleanup(os_helper.rmtree, self.directory)
         self.pkgdir = os.path.join(self.directory, 'foo')
         os.mkdir(self.pkgdir)
         self.pkgdir_cachedir = os.path.join(self.pkgdir, '__pycache__')
@@ -625,7 +626,7 @@ class CommandLineTestsBase:
         self.assertCompiled(spamfn)
         self.assertCompiled(eggfn)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_symlink_loop(self):
         # Currently, compileall ignores symlinks to directories.
         # If that limitation is ever lifted, it should protect against
@@ -823,7 +824,7 @@ class CommandLineTestsBase:
                 except Exception:
                     pass
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_ignore_symlink_destination(self):
         # Create folders for allowed files, symlinks and prohibited area
         allowed_path = os.path.join(self.directory, "test", "dir", "allowed")

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -9,8 +9,9 @@ from array import array
 from weakref import proxy
 from functools import wraps
 
-from test.support import (TESTFN, TESTFN_UNICODE, check_warnings, run_unittest,
-                          make_bad_fd, cpython_only, swap_attr)
+from test.support import (run_unittest, cpython_only, swap_attr)
+from test.support.os_helper import (TESTFN, TESTFN_UNICODE, make_bad_fd)
+from test.support.warnings_helper import check_warnings
 from collections import UserList
 
 import _io  # C implementation of io

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -5,11 +5,12 @@ import unittest
 import doctest
 
 from test import support
+from test.support import import_helper
 from unittest import TestCase, skipUnless
 from operator import itemgetter
 
-py_heapq = support.import_fresh_module('heapq', blocked=['_heapq'])
-c_heapq = support.import_fresh_module('heapq', fresh=['_heapq'])
+py_heapq = import_helper.import_fresh_module('heapq', blocked=['_heapq'])
+c_heapq = import_helper.import_fresh_module('heapq', fresh=['_heapq'])
 
 # _heapq.nlargest/nsmallest are saved in heapq._nlargest/_smallest when
 # _heapq is imported, so check them there

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -13,7 +13,10 @@ import unittest
 TestCase = unittest.TestCase
 
 from test import support
+from test.support import os_helper
 from test.support import socket_helper
+from test.support import warnings_helper
+
 
 here = os.path.dirname(__file__)
 # Self-signed cert file for 'localhost'
@@ -1766,14 +1769,14 @@ class HTTPSTest(TestCase):
         with self.assertRaises(ssl.CertificateError):
             h.request('GET', '/')
         # Same with explicit check_hostname=True
-        with support.check_warnings(('', DeprecationWarning)):
+        with warnings_helper.check_warnings(('', DeprecationWarning)):
             h = client.HTTPSConnection('localhost', server.port,
                                        context=context, check_hostname=True)
         with self.assertRaises(ssl.CertificateError):
             h.request('GET', '/')
         # With check_hostname=False, the mismatching is ignored
         context.check_hostname = False
-        with support.check_warnings(('', DeprecationWarning)):
+        with warnings_helper.check_warnings(('', DeprecationWarning)):
             h = client.HTTPSConnection('localhost', server.port,
                                        context=context, check_hostname=False)
         h.request('GET', '/nonexistent')
@@ -1792,7 +1795,7 @@ class HTTPSTest(TestCase):
         h.close()
         # Passing check_hostname to HTTPSConnection should override the
         # context's setting.
-        with support.check_warnings(('', DeprecationWarning)):
+        with warnings_helper.check_warnings(('', DeprecationWarning)):
             h = client.HTTPSConnection('localhost', server.port,
                                        context=context, check_hostname=True)
         with self.assertRaises(ssl.CertificateError):
@@ -1908,10 +1911,10 @@ class RequestBodyTest(TestCase):
         self.assertEqual(b'body\xc1', f.read())
 
     def test_text_file_body(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as f:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "w") as f:
             f.write("body")
-        with open(support.TESTFN) as f:
+        with open(os_helper.TESTFN) as f:
             self.conn.request("PUT", "/url", f)
             message, f = self.get_headers_and_fp()
             self.assertEqual("text/plain", message.get_content_type())
@@ -1923,10 +1926,10 @@ class RequestBodyTest(TestCase):
             self.assertEqual(b'4\r\nbody\r\n0\r\n\r\n', f.read())
 
     def test_binary_file_body(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "wb") as f:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "wb") as f:
             f.write(b"body\xc1")
-        with open(support.TESTFN, "rb") as f:
+        with open(os_helper.TESTFN, "rb") as f:
             self.conn.request("PUT", "/url", f)
             message, f = self.get_headers_and_fp()
             self.assertEqual("text/plain", message.get_content_type())

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -12,6 +12,7 @@ import os
 import os.path
 from pathlib import Path, PurePath
 from test import support
+from test.support import import_helper
 import unittest
 import sys
 import tempfile
@@ -55,8 +56,8 @@ _extension_details()
 def import_importlib(module_name):
     """Import a module from importlib both w/ and w/o _frozen_importlib."""
     fresh = ('importlib',) if '.' in module_name else ()
-    frozen = support.import_fresh_module(module_name)
-    source = support.import_fresh_module(module_name, fresh=fresh,
+    frozen = import_helper.import_fresh_module(module_name)
+    source = import_helper.import_fresh_module(module_name, fresh=fresh,
                                          blocked=('_frozen_importlib', '_frozen_importlib_external'))
     return {'Frozen': frozen, 'Source': source}
 

--- a/Lib/test/test_json/__init__.py
+++ b/Lib/test/test_json/__init__.py
@@ -4,10 +4,12 @@ import doctest
 import unittest
 
 from test import support
+from test.support import import_helper
+
 
 # import json with and without accelerations
-cjson = support.import_fresh_module('json', fresh=['_json'])
-pyjson = support.import_fresh_module('json', blocked=['_json'])
+cjson = import_helper.import_fresh_module('json', fresh=['_json'])
+pyjson = import_helper.import_fresh_module('json', blocked=['_json'])
 # JSONDecodeError is cached inside the _json module
 cjson.JSONDecodeError = cjson.decoder.JSONDecodeError = json.JSONDecodeError
 

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -6,6 +6,7 @@ import unittest
 import subprocess
 
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok
 
 
@@ -91,7 +92,7 @@ class TestTool(unittest.TestCase):
         self.assertEqual(process.stderr, '')
 
     def _create_infile(self, data=None):
-        infile = support.TESTFN
+        infile = os_helper.TESTFN
         with open(infile, "w", encoding="utf-8") as fp:
             self.addCleanup(os.remove, infile)
             fp.write(data or self.data)
@@ -121,7 +122,7 @@ class TestTool(unittest.TestCase):
 
     def test_infile_outfile(self):
         infile = self._create_infile()
-        outfile = support.TESTFN + '.out'
+        outfile = os_helper.TESTFN + '.out'
         rc, out, err = assert_python_ok('-m', 'json.tool', infile, outfile)
         self.addCleanup(os.remove, outfile)
         with open(outfile, "r") as fp:
@@ -189,7 +190,7 @@ class TestTool(unittest.TestCase):
 
     def test_no_ensure_ascii_flag(self):
         infile = self._create_infile('{"key":"💩"}')
-        outfile = support.TESTFN + '.out'
+        outfile = os_helper.TESTFN + '.out'
         self.addCleanup(os.remove, outfile)
         assert_python_ok('-m', 'json.tool', '--no-ensure-ascii', infile, outfile)
         with open(outfile, "rb") as f:
@@ -200,7 +201,7 @@ class TestTool(unittest.TestCase):
 
     def test_ensure_ascii_default(self):
         infile = self._create_infile('{"key":"💩"}')
-        outfile = support.TESTFN + '.out'
+        outfile = os_helper.TESTFN + '.out'
         self.addCleanup(os.remove, outfile)
         assert_python_ok('-m', 'json.tool', infile, outfile)
         with open(outfile, "rb") as f:

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,5 +1,6 @@
 import netrc, os, unittest, sys, tempfile, textwrap
 from test import support
+from test.support import os_helper
 
 
 class NetrcTestCase(unittest.TestCase):
@@ -108,16 +109,16 @@ class NetrcTestCase(unittest.TestCase):
     def test_security(self):
         # This test is incomplete since we are normally not run as root and
         # therefore can't test the file ownership being wrong.
-        d = support.TESTFN
+        d = os_helper.TESTFN
         os.mkdir(d)
-        self.addCleanup(support.rmtree, d)
+        self.addCleanup(os_helper.rmtree, d)
         fn = os.path.join(d, '.netrc')
         with open(fn, 'wt') as f:
             f.write("""\
                 machine foo.domain.com login bar password pass
                 default login foo password pass
                 """)
-        with support.EnvironmentVarGuard() as environ:
+        with os_helper.EnvironmentVarGuard() as environ:
             environ.set('HOME', d)
             os.chmod(fn, 0o600)
             nrc = netrc.netrc()
@@ -127,10 +128,10 @@ class NetrcTestCase(unittest.TestCase):
             self.assertRaises(netrc.NetrcParseError, netrc.netrc)
 
     def test_file_not_found_in_home(self):
-        d = support.TESTFN
+        d = os_helper.TESTFN
         os.mkdir(d)
-        self.addCleanup(support.rmtree, d)
-        with support.EnvironmentVarGuard() as environ:
+        self.addCleanup(os_helper.rmtree, d)
+        with os_helper.EnvironmentVarGuard() as environ:
             environ.set('HOME', d)
             self.assertRaises(FileNotFoundError, netrc.netrc)
 
@@ -139,9 +140,9 @@ class NetrcTestCase(unittest.TestCase):
                           file='unlikely_netrc')
 
     def test_home_not_set(self):
-        fake_home = support.TESTFN
+        fake_home = os_helper.TESTFN
         os.mkdir(fake_home)
-        self.addCleanup(support.rmtree, fake_home)
+        self.addCleanup(os_helper.rmtree, fake_home)
         fake_netrc_path = os.path.join(fake_home, '.netrc')
         with open(fake_netrc_path, 'w') as f:
             f.write('machine foo.domain.com login bar password pass')
@@ -152,7 +153,7 @@ class NetrcTestCase(unittest.TestCase):
 
         def fake_expanduser(s):
             called.append(s)
-            with support.EnvironmentVarGuard() as environ:
+            with os_helper.EnvironmentVarGuard() as environ:
                 environ.set('HOME', fake_home)
                 environ.set('USERPROFILE', fake_home)
                 result = orig_expanduser(s)

--- a/Lib/test/test_nis.py
+++ b/Lib/test/test_nis.py
@@ -1,8 +1,10 @@
 from test import support
+from test.support import import_helper
 import unittest
 
+
 # Skip test if nis module does not exist.
-nis = support.import_module('nis')
+nis = import_helper.import_module('nis')
 
 
 class NisTests(unittest.TestCase):

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -10,6 +10,7 @@ import weakref
 
 import unittest
 from test import support
+from test.support import import_helper
 
 from test.pickletester import AbstractHookTests
 from test.pickletester import AbstractUnpickleTests
@@ -499,7 +500,7 @@ class CompatPickleTests(unittest.TestCase):
                                      ('builtins', name))
 
     def test_multiprocessing_exceptions(self):
-        module = support.import_module('multiprocessing.context')
+        module = import_helper.import_module('multiprocessing.context')
         for name, exc in get_exceptions(module):
             with self.subTest(name):
                 self.assertEqual(reverse_mapping('multiprocessing.context', name),

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -9,13 +9,14 @@ import tempfile
 import unittest
 
 from test import support
+from test.support import os_helper
 
 
 def without_source_date_epoch(fxn):
     """Runs function with SOURCE_DATE_EPOCH unset."""
     @functools.wraps(fxn)
     def wrapper(*args, **kwargs):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.unset('SOURCE_DATE_EPOCH')
             return fxn(*args, **kwargs)
     return wrapper
@@ -25,7 +26,7 @@ def with_source_date_epoch(fxn):
     """Runs function with SOURCE_DATE_EPOCH set."""
     @functools.wraps(fxn)
     def wrapper(*args, **kwargs):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['SOURCE_DATE_EPOCH'] = '123456789'
             return fxn(*args, **kwargs)
     return wrapper

--- a/Lib/test/test_sqlite.py
+++ b/Lib/test/test_sqlite.py
@@ -1,7 +1,8 @@
 import test.support
+from test.support import import_helper
 
 # Skip test if _sqlite3 module not installed
-test.support.import_module('_sqlite3')
+import_helper.import_module('_sqlite3')
 
 import unittest
 import sqlite3

--- a/Lib/test/test_univnewlines.py
+++ b/Lib/test/test_univnewlines.py
@@ -5,6 +5,8 @@ import unittest
 import os
 import sys
 from test import support
+from test.support import os_helper
+
 
 if not hasattr(sys.stdin, 'newlines'):
     raise unittest.SkipTest(
@@ -46,29 +48,29 @@ class TestGenericUnivNewlines:
         data = self.DATA
         if "b" in self.WRITEMODE:
             data = data.encode("ascii")
-        with self.open(support.TESTFN, self.WRITEMODE) as fp:
+        with self.open(os_helper.TESTFN, self.WRITEMODE) as fp:
             fp.write(data)
 
     def tearDown(self):
         try:
-            os.unlink(support.TESTFN)
+            os.unlink(os_helper.TESTFN)
         except:
             pass
 
     def test_read(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(os_helper.TESTFN, self.READMODE) as fp:
             data = fp.read()
         self.assertEqual(data, DATA_LF)
         self.assertEqual(repr(fp.newlines), repr(self.NEWLINE))
 
     def test_readlines(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(os_helper.TESTFN, self.READMODE) as fp:
             data = fp.readlines()
         self.assertEqual(data, DATA_SPLIT)
         self.assertEqual(repr(fp.newlines), repr(self.NEWLINE))
 
     def test_readline(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(os_helper.TESTFN, self.READMODE) as fp:
             data = []
             d = fp.readline()
             while d:
@@ -78,7 +80,7 @@ class TestGenericUnivNewlines:
         self.assertEqual(repr(fp.newlines), repr(self.NEWLINE))
 
     def test_seek(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(os_helper.TESTFN, self.READMODE) as fp:
             fp.readline()
             pos = fp.tell()
             data = fp.readlines()
@@ -105,7 +107,7 @@ class TestCRLFNewlines(TestGenericUnivNewlines):
     DATA = DATA_CRLF
 
     def test_tell(self):
-        with self.open(support.TESTFN, self.READMODE) as fp:
+        with self.open(os_helper.TESTFN, self.READMODE) as fp:
             self.assertEqual(repr(fp.newlines), repr(None))
             data = fp.readline()
             pos = fp.tell()

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import import_helper
 import builtins
 import contextlib
 import copy
@@ -10,8 +11,8 @@ import sys
 import weakref
 from unittest import mock
 
-py_uuid = support.import_fresh_module('uuid', blocked=['_uuid'])
-c_uuid = support.import_fresh_module('uuid', fresh=['_uuid'])
+py_uuid = import_helper.import_fresh_module('uuid', blocked=['_uuid'])
+c_uuid = import_helper.import_fresh_module('uuid', fresh=['_uuid'])
 
 def importable(name):
     try:


### PR DESCRIPTION
Use test helpers in the following test cases and test framework:
* pickletester
* test_binhex
* test_bufio
* test_capi
* test_compileall
* test_fileio
* test_heapq
* test_httplib
* test_importlib's util
* test_io
* test_json
* test_netrc
* test_nis
* test_pickle
* test_py_compile
* test_sqlite
* test_univnewlines
* test_uuid

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
