### PR TITLE
bpo-40275: Use new test.support helper submodules in tests

### DIFF
--- a/Lib/ctypes/test/__init__.py
+++ b/Lib/ctypes/test/__init__.py
@@ -1,9 +1,11 @@
 import os
 import unittest
 from test import support
+from test.support import import_helper
+
 
 # skip tests if _ctypes was not built
-ctypes = support.import_module('ctypes')
+ctypes = import_helper.import_module('ctypes')
 ctypes_symbols = dir(ctypes)
 
 def need_symbol(name):

--- a/Lib/ctypes/test/test_find.py
+++ b/Lib/ctypes/test/test_find.py
@@ -2,6 +2,7 @@ import unittest
 import os.path
 import sys
 import test.support
+from test.support import os_helper
 from ctypes import *
 from ctypes.util import find_library
 
@@ -65,8 +66,8 @@ class Test_OpenGL_libs(unittest.TestCase):
         self.gle.gleGetJoinStyle
 
     def test_shell_injection(self):
-        result = find_library('; echo Hello shell > ' + test.support.TESTFN)
-        self.assertFalse(os.path.lexists(test.support.TESTFN))
+        result = find_library('; echo Hello shell > ' + os_helper.TESTFN)
+        self.assertFalse(os.path.lexists(os_helper.TESTFN))
         self.assertIsNone(result)
 
 
@@ -100,7 +101,7 @@ class LibPathFindTest(unittest.TestCase):
             # LD_LIBRARY_PATH)
             self.assertIsNone(find_library(libname))
             # now add the location to LD_LIBRARY_PATH
-            with test.support.EnvironmentVarGuard() as env:
+            with os_helper.EnvironmentVarGuard() as env:
                 KEY = 'LD_LIBRARY_PATH'
                 if KEY not in env:
                     v = d

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -16,6 +16,7 @@ import textwrap
 import unittest
 
 import test.support
+from test.support import import_helper
 import test.string_tests
 import test.list_tests
 from test.support import bigaddrspacetest, MAX_Py_ssize_t
@@ -967,7 +968,7 @@ class BaseBytesTest:
         self.assertEqual(c, b'hllo')
 
     def test_sq_item(self):
-        _testcapi = test.support.import_module('_testcapi')
+        _testcapi = import_helper.import_module('_testcapi')
         obj = self.type2test((42,))
         with self.assertRaises(IndexError):
             _testcapi.sequence_getitem(obj, -2)
@@ -1024,8 +1025,8 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
 
     # Test PyBytes_FromFormat()
     def test_from_format(self):
-        ctypes = test.support.import_module('ctypes')
-        _testcapi = test.support.import_module('_testcapi')
+        ctypes = import_helper.import_module('ctypes')
+        _testcapi = import_helper.import_module('_testcapi')
         from ctypes import pythonapi, py_object
         from ctypes import (
             c_int, c_uint,

--- a/Lib/test/test_cgitb.py
+++ b/Lib/test/test_cgitb.py
@@ -1,4 +1,4 @@
-from test.support import temp_dir
+from test.support.os_helper import temp_dir
 from test.support.script_helper import assert_python_failure
 import unittest
 import sys

--- a/Lib/test/test_ctypes.py
+++ b/Lib/test/test_ctypes.py
@@ -1,5 +1,6 @@
 import unittest
-from test.support import import_module
+from test.support.import_helper import import_module
+
 
 ctypes_test = import_module('ctypes.test')
 

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -2,17 +2,18 @@
 
 import unittest
 import glob
-import test.support
+from test.support import import_helper
+from test.support import os_helper
 
 # Skip tests if dbm module doesn't exist.
-dbm = test.support.import_module('dbm')
+dbm = import_helper.import_module('dbm')
 
 try:
     from dbm import ndbm
 except ImportError:
     ndbm = None
 
-_fname = test.support.TESTFN
+_fname = os_helper.TESTFN
 
 #
 # Iterates over every database module supported by dbm currently available,
@@ -34,7 +35,7 @@ def delete_files():
     # we don't know the precise name the underlying database uses
     # so we use glob to locate all names
     for f in glob.glob(glob.escape(_fname) + "*"):
-        test.support.unlink(f)
+        os_helper.unlink(f)
 
 
 class AnyDBMTestCase:
@@ -74,7 +75,7 @@ class AnyDBMTestCase:
 
     def test_anydbm_creation_n_file_exists_with_invalid_contents(self):
         # create an empty file
-        test.support.create_empty_file(_fname)
+        os_helper.create_empty_file(_fname)
         with dbm.open(_fname, 'n') as f:
             self.assertEqual(len(f), 0)
 
@@ -169,7 +170,7 @@ class WhichDBTestCase(unittest.TestCase):
         # Issue 17198: check that ndbm which is referenced in whichdb is defined
         db_file = '{}_ndbm.db'.format(_fname)
         with open(db_file, 'w'):
-            self.addCleanup(test.support.unlink, db_file)
+            self.addCleanup(os_helper.unlink, db_file)
         self.assertIsNone(self.dbm.whichdb(db_file[:-3]))
 
     def tearDown(self):
@@ -177,10 +178,10 @@ class WhichDBTestCase(unittest.TestCase):
 
     def setUp(self):
         delete_files()
-        self.filename = test.support.TESTFN
+        self.filename = os_helper.TESTFN
         self.d = dbm.open(self.filename, 'c')
         self.d.close()
-        self.dbm = test.support.import_fresh_module('dbm')
+        self.dbm = import_helper.import_fresh_module('dbm')
 
     def test_keys(self):
         self.d = dbm.open(self.filename, 'c')

--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -6,8 +6,10 @@ import struct
 import sys
 import unittest
 from multiprocessing import Process
-from test.support import (verbose, TESTFN, unlink, run_unittest, import_module,
-                          cpython_only)
+from test.support import (verbose, run_unittest, cpython_only)
+from test.support.import_helper import import_module
+from test.support.os_helper import TESTFN, unlink
+
 
 # Skip test if no fcntl module.
 fcntl = import_module('fcntl')

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -7,8 +7,9 @@ from weakref import proxy
 import io
 import _pyio as pyio
 
-from test.support import TESTFN
-from test import support
+from test.support.os_helper import TESTFN
+from test.support import os_helper
+from test.support import warnings_helper
 from collections import UserList
 
 class AutoFileTests:
@@ -20,7 +21,7 @@ class AutoFileTests:
     def tearDown(self):
         if self.f:
             self.f.close()
-        support.unlink(TESTFN)
+        os_helper.unlink(TESTFN)
 
     def testWeakRefs(self):
         # verify weak references
@@ -139,7 +140,7 @@ class PyAutoFileTests(AutoFileTests, unittest.TestCase):
 class OtherFileTests:
 
     def tearDown(self):
-        support.unlink(TESTFN)
+        os_helper.unlink(TESTFN)
 
     def testModeStrings(self):
         # check invalid mode strings
@@ -187,7 +188,7 @@ class OtherFileTests:
         # make sure that explicitly setting the buffer size doesn't cause
         # misbehaviour especially with repeated close() calls
         for s in (-1, 0, 512):
-            with support.check_no_warnings(self,
+            with warnings_helper.check_no_warnings(self,
                                            message='line buffering',
                                            category=RuntimeWarning):
                 self._checkBufferSize(s)

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -12,7 +12,7 @@ import os
 import types
 import decimal
 import unittest
-from test.support import temp_cwd
+from test.support.os_helper import temp_cwd
 from test.support.script_helper import assert_python_failure
 
 a_global = 'global variable'

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -30,6 +30,7 @@ from io import BytesIO
 
 import unittest
 from test import support
+from test.support import os_helper
 from test.support import threading_helper
 
 
@@ -391,13 +392,13 @@ class SimpleHTTPServerTestCase(BaseTestCase):
                      'undecodable name cannot always be decoded on macOS')
     @unittest.skipIf(sys.platform == 'win32',
                      'undecodable name cannot be decoded on win32')
-    @unittest.skipUnless(support.TESTFN_UNDECODABLE,
-                         'need support.TESTFN_UNDECODABLE')
+    @unittest.skipUnless(os_helper.TESTFN_UNDECODABLE,
+                         'need os_helper.TESTFN_UNDECODABLE')
     def test_undecodable_filename(self):
         enc = sys.getfilesystemencoding()
-        filename = os.fsdecode(support.TESTFN_UNDECODABLE) + '.txt'
+        filename = os.fsdecode(os_helper.TESTFN_UNDECODABLE) + '.txt'
         with open(os.path.join(self.tempdir, filename), 'wb') as f:
-            f.write(support.TESTFN_UNDECODABLE)
+            f.write(os_helper.TESTFN_UNDECODABLE)
         response = self.request(self.base_url + '/')
         if sys.platform == 'darwin':
             # On Mac OS the HFS+ filesystem replaces bytes that aren't valid
@@ -414,7 +415,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
                       .encode(enc, 'surrogateescape'), body)
         response = self.request(self.base_url + '/' + quotedname)
         self.check_status_and_reason(response, HTTPStatus.OK,
-                                     data=support.TESTFN_UNDECODABLE)
+                                     data=os_helper.TESTFN_UNDECODABLE)
 
     def test_get(self):
         #constructs the path relative to the root directory of the HTTPServer

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -6,6 +6,7 @@ import os.path
 import tempfile
 import tokenize
 from test import support
+from test.support import os_helper
 
 
 FILENAME = linecache.__file__
@@ -44,7 +45,7 @@ class TempFile:
         with tempfile.NamedTemporaryFile(delete=False) as fp:
             self.file_name = fp.name
             fp.write(self.file_byte_string)
-        self.addCleanup(support.unlink, self.file_name)
+        self.addCleanup(os_helper.unlink, self.file_name)
 
 
 class GetLineTestsGoodData(TempFile):
@@ -124,10 +125,10 @@ class LineCacheTests(unittest.TestCase):
         self.assertEqual(empty, [])
 
     def test_no_ending_newline(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as fp:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "w") as fp:
             fp.write(SOURCE_3)
-        lines = linecache.getlines(support.TESTFN)
+        lines = linecache.getlines(os_helper.TESTFN)
         self.assertEqual(lines, ["\n", "def f():\n", "    return 3\n"])
 
     def test_clearcache(self):
@@ -150,8 +151,8 @@ class LineCacheTests(unittest.TestCase):
     def test_checkcache(self):
         getline = linecache.getline
         # Create a source file and cache its contents
-        source_name = support.TESTFN + '.py'
-        self.addCleanup(support.unlink, source_name)
+        source_name = os_helper.TESTFN + '.py'
+        self.addCleanup(os_helper.unlink, source_name)
         with open(source_name, 'w') as source:
             source.write(SOURCE_1)
         getline(source_name, 1)

--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -1,7 +1,8 @@
 """ Test suite for the code in msilib """
 import os
 import unittest
-from test.support import TESTFN, import_module, unlink
+from test.support.import_helper import import_module
+from test.support.os_helper import TESTFN, unlink
 msilib = import_module('msilib')
 import msilib.schema
 

--- a/Lib/test/test_picklebuffer.py
+++ b/Lib/test/test_picklebuffer.py
@@ -8,7 +8,7 @@ from pickle import PickleBuffer
 import weakref
 import unittest
 
-from test import support
+from test.support import import_helper
 
 
 class B(bytes):
@@ -75,7 +75,7 @@ class PickleBufferTest(unittest.TestCase):
 
     def test_ndarray_2d(self):
         # C-contiguous
-        ndarray = support.import_module("_testbuffer").ndarray
+        ndarray = import_helper.import_module("_testbuffer").ndarray
         arr = ndarray(list(range(12)), shape=(4, 3), format='<i')
         self.assertTrue(arr.c_contiguous)
         self.assertFalse(arr.f_contiguous)
@@ -109,7 +109,7 @@ class PickleBufferTest(unittest.TestCase):
 
     def test_raw_ndarray(self):
         # 1-D, contiguous
-        ndarray = support.import_module("_testbuffer").ndarray
+        ndarray = import_helper.import_module("_testbuffer").ndarray
         arr = ndarray(list(range(3)), shape=(3,), format='<h')
         equiv = b"\x00\x00\x01\x00\x02\x00"
         self.check_raw(arr, equiv)
@@ -135,7 +135,7 @@ class PickleBufferTest(unittest.TestCase):
 
     def test_raw_non_contiguous(self):
         # 1-D
-        ndarray = support.import_module("_testbuffer").ndarray
+        ndarray = import_helper.import_module("_testbuffer").ndarray
         arr = ndarray(list(range(6)), shape=(6,), format='<i')[::2]
         self.check_raw_non_contiguous(arr)
         # 2-D

--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -6,7 +6,8 @@ import unittest
 import os
 from difflib import unified_diff
 from io import StringIO
-from test.support import TESTFN, run_unittest, unlink
+from test.support import run_unittest
+from test.support.os_helper import TESTFN, unlink
 from contextlib import contextmanager
 
 import profile

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -1,4 +1,5 @@
-from test.support import verbose, import_module, reap_children
+from test.support import verbose, reap_children
+from test.support.import_helper import import_module
 
 # Skip these tests if termios is not available
 import_module('termios')

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -10,7 +10,8 @@ import importlib
 import importlib.util
 import unittest
 
-from test.support import create_empty_file, verbose
+from test.support import verbose
+from test.support.os_helper import create_empty_file
 from reprlib import repr as r # Don't shadow builtin repr
 from reprlib import Repr
 from reprlib import recursive_repr

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -2,6 +2,7 @@ import unittest
 import shelve
 import glob
 from test import support
+from test.support import os_helper
 from collections.abc import MutableMapping
 from test.test_dbm import dbm_iterator
 
@@ -45,7 +46,7 @@ class TestCase(unittest.TestCase):
 
     def tearDown(self):
         for f in glob.glob(self.fn+"*"):
-            support.unlink(f)
+            os_helper.unlink(f)
 
     def test_close(self):
         d1 = {}
@@ -186,7 +187,7 @@ class TestShelveBase(mapping_tests.BasicTestMappingProtocol):
         self._db = []
         if not self._in_mem:
             for f in glob.glob(self.fn+"*"):
-                support.unlink(f)
+                os_helper.unlink(f)
 
 class TestAsciiFileShelve(TestShelveBase):
     _args={'protocol':0}

--- a/Lib/test/test_tk.py
+++ b/Lib/test/test_tk.py
@@ -1,6 +1,7 @@
 from test import support
+from test.support import import_helper
 # Skip test if _tkinter wasn't built.
-support.import_module('_tkinter')
+import_helper.import_module('_tkinter')
 
 # Skip test if tk cannot be initialized.
 support.requires('gui')

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from test import support
 from test.support import socket_helper
+from test.support import warnings_helper
 from test.test_httpservers import NoLogRequestHandler
 from unittest import TestCase
 from wsgiref.util import setup_testing_defaults
@@ -339,7 +340,7 @@ class UtilityTests(TestCase):
         util.setup_testing_defaults(kw)
         self.assertEqual(util.request_uri(kw,query),uri)
 
-    @support.ignore_warnings(category=DeprecationWarning)
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def checkFW(self,text,size,match):
 
         def make_it(text=text,size=size):

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import import_helper
 import binascii
 import copy
 import pickle
@@ -7,7 +8,8 @@ import random
 import sys
 from test.support import bigmemtest, _1G, _4G
 
-zlib = support.import_module('zlib')
+
+zlib = import_helper.import_module('zlib')
 
 requires_Compress_copy = unittest.skipUnless(
         hasattr(zlib.compressobj(), "copy"),


### PR DESCRIPTION
Use test helpers in the following test cases:
* tests of ctypes
* test_bytes
* test_cgitb
* test_ctypes
* test_dbm
* test_fcntl
* test_file
* test_fstring
* test_httpservers
* test_linecache
* test_msilib
* test_picklebuffer
* test_profile
* test_pty
* test_reprlib
* test_shelve
* test_tk
* test_wsgiref
* test_zlib

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
