### PR TITLE
Update link in SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,9 +10,8 @@ https://devguide.python.org/#status-of-python-branches
 ## Reporting a Vulnerability
 
 Please read the guidelines on reporting security issues [on the
-official website](
-https://www.python.org/news/security/#reporting-security-issues-in-python
-) for instructions on how to report a security-related problem to
+official website](https://www.python.org/dev/security/) for
+instructions on how to report a security-related problem to
 the Python team responsibly.
 
 To reach the response team, email `security at python dot org`. 


### PR DESCRIPTION
The old link redirects to the generic blog website.

Automerge-Triggered-By: GH:ned-deily