### PR TITLE
bpo-36346: Undeprecate private function _PyUnicode_AsUnicode().

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -581,7 +581,7 @@ Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
 
 /* Similar to PyUnicode_AsUnicode(), but raises a ValueError if the string
    contains null characters. */
-Py_DEPRECATED(3.3) PyAPI_FUNC(const Py_UNICODE *) _PyUnicode_AsUnicode(
+PyAPI_FUNC(const Py_UNICODE *) _PyUnicode_AsUnicode(
     PyObject *unicode           /* Unicode object */
     );
 

--- a/Misc/NEWS.d/next/C API/2020-06-17-11-24-00.bpo-36346.fTMr3S.rst
+++ b/Misc/NEWS.d/next/C API/2020-06-17-11-24-00.bpo-36346.fTMr3S.rst
@@ -1,4 +1,4 @@
 Mark ``Py_UNICODE_COPY``, ``Py_UNICODE_FILL``, ``PyUnicode_WSTR_LENGTH``,
-``PyUnicode_FromUnicode``, ``PyUnicode_AsUnicode``, ``_PyUnicode_AsUnicode``,
+``PyUnicode_FromUnicode``, ``PyUnicode_AsUnicode``,
 and ``PyUnicode_AsUnicodeAndSize`` as deprecated in C. Remove ``Py_UNICODE_MATCH``
 which was deprecated and broken since Python 3.3.

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1688,10 +1688,7 @@ os_system(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     command = _PyUnicode_AsUnicode(args[0]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     command = PyUnicode_AsWideCharString(args[0], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -7040,10 +7037,7 @@ os_startfile(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     operation = _PyUnicode_AsUnicode(args[1]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     operation = PyUnicode_AsWideCharString(args[1], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -8925,4 +8919,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=ba3d4b35fda2c208 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a0fbdea47249ee0c input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3310,14 +3310,11 @@ _PyUnicode_WideCharString_Converter(PyObject *obj, void *ptr)
     }
     if (PyUnicode_Check(obj)) {
 #if USE_UNICODE_WCHAR_CACHE
-_Py_COMP_DIAG_PUSH
-_Py_COMP_DIAG_IGNORE_DEPR_DECLS
         *p = (wchar_t *)_PyUnicode_AsUnicode(obj);
         if (*p == NULL) {
             return 0;
         }
         return 1;
-_Py_COMP_DIAG_POP
 #else /* USE_UNICODE_WCHAR_CACHE */
         *p = PyUnicode_AsWideCharString(obj, NULL);
         if (*p == NULL) {
@@ -3349,14 +3346,11 @@ _PyUnicode_WideCharString_Opt_Converter(PyObject *obj, void *ptr)
     }
     if (PyUnicode_Check(obj)) {
 #if USE_UNICODE_WCHAR_CACHE
-_Py_COMP_DIAG_PUSH
-_Py_COMP_DIAG_IGNORE_DEPR_DECLS
         *p = (wchar_t *)_PyUnicode_AsUnicode(obj);
         if (*p == NULL) {
             return 0;
         }
         return 1;
-_Py_COMP_DIAG_POP
 #else /* USE_UNICODE_WCHAR_CACHE */
         *p = PyUnicode_AsWideCharString(obj, NULL);
         if (*p == NULL) {

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -758,10 +758,7 @@ _msi_SummaryInformation_SetProperty_impl(msiobj *self, int field,
 
     if (PyUnicode_Check(data)) {
 #if USE_UNICODE_WCHAR_CACHE
-_Py_COMP_DIAG_PUSH
-_Py_COMP_DIAG_IGNORE_DEPR_DECLS
         const WCHAR *value = _PyUnicode_AsUnicode(data);
-_Py_COMP_DIAG_POP
 #else /* USE_UNICODE_WCHAR_CACHE */
         WCHAR *value = PyUnicode_AsWideCharString(data, NULL);
 #endif /* USE_UNICODE_WCHAR_CACHE */

--- a/PC/clinic/_msi.c.h
+++ b/PC/clinic/_msi.c.h
@@ -209,10 +209,7 @@ _msi_Record_SetString(msiobj *self, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     value = _PyUnicode_AsUnicode(args[1]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     value = PyUnicode_AsWideCharString(args[1], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -261,10 +258,7 @@ _msi_Record_SetStream(msiobj *self, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     value = _PyUnicode_AsUnicode(args[1]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     value = PyUnicode_AsWideCharString(args[1], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -568,10 +562,7 @@ _msi_Database_OpenView(msiobj *self, PyObject *arg)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     sql = _PyUnicode_AsUnicode(arg);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     sql = PyUnicode_AsWideCharString(arg, NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -670,10 +661,7 @@ _msi_OpenDatabase(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     path = _PyUnicode_AsUnicode(args[0]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     path = PyUnicode_AsWideCharString(args[0], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -725,4 +713,4 @@ _msi_CreateRecord(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=39807788326ad0e9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=49debf733ee5cab2 input=a9049054013a1b77]*/

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -160,10 +160,7 @@ winreg_ConnectRegistry(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     }
     else if (PyUnicode_Check(args[0])) {
         #if USE_UNICODE_WCHAR_CACHE
-        _Py_COMP_DIAG_PUSH
-        _Py_COMP_DIAG_IGNORE_DEPR_DECLS
         computer_name = _PyUnicode_AsUnicode(args[0]);
-        _Py_COMP_DIAG_POP
         #else /* USE_UNICODE_WCHAR_CACHE */
         computer_name = PyUnicode_AsWideCharString(args[0], NULL);
         #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -237,10 +234,7 @@ winreg_CreateKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     else if (PyUnicode_Check(args[1])) {
         #if USE_UNICODE_WCHAR_CACHE
-        _Py_COMP_DIAG_PUSH
-        _Py_COMP_DIAG_IGNORE_DEPR_DECLS
         sub_key = _PyUnicode_AsUnicode(args[1]);
-        _Py_COMP_DIAG_POP
         #else /* USE_UNICODE_WCHAR_CACHE */
         sub_key = PyUnicode_AsWideCharString(args[1], NULL);
         #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -373,10 +367,7 @@ winreg_DeleteKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     sub_key = _PyUnicode_AsUnicode(args[1]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     sub_key = PyUnicode_AsWideCharString(args[1], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -488,10 +479,7 @@ winreg_DeleteValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     else if (PyUnicode_Check(args[1])) {
         #if USE_UNICODE_WCHAR_CACHE
-        _Py_COMP_DIAG_PUSH
-        _Py_COMP_DIAG_IGNORE_DEPR_DECLS
         value = _PyUnicode_AsUnicode(args[1]);
-        _Py_COMP_DIAG_POP
         #else /* USE_UNICODE_WCHAR_CACHE */
         value = PyUnicode_AsWideCharString(args[1], NULL);
         #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -635,10 +623,7 @@ winreg_ExpandEnvironmentStrings(PyObject *module, PyObject *arg)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     string = _PyUnicode_AsUnicode(arg);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     string = PyUnicode_AsWideCharString(arg, NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -750,10 +735,7 @@ winreg_LoadKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     sub_key = _PyUnicode_AsUnicode(args[1]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     sub_key = PyUnicode_AsWideCharString(args[1], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -765,10 +747,7 @@ winreg_LoadKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     file_name = _PyUnicode_AsUnicode(args[2]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     file_name = PyUnicode_AsWideCharString(args[2], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -984,10 +963,7 @@ winreg_QueryValue(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     else if (PyUnicode_Check(args[1])) {
         #if USE_UNICODE_WCHAR_CACHE
-        _Py_COMP_DIAG_PUSH
-        _Py_COMP_DIAG_IGNORE_DEPR_DECLS
         sub_key = _PyUnicode_AsUnicode(args[1]);
-        _Py_COMP_DIAG_POP
         #else /* USE_UNICODE_WCHAR_CACHE */
         sub_key = PyUnicode_AsWideCharString(args[1], NULL);
         #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -1050,10 +1026,7 @@ winreg_QueryValueEx(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     }
     else if (PyUnicode_Check(args[1])) {
         #if USE_UNICODE_WCHAR_CACHE
-        _Py_COMP_DIAG_PUSH
-        _Py_COMP_DIAG_IGNORE_DEPR_DECLS
         name = _PyUnicode_AsUnicode(args[1]);
-        _Py_COMP_DIAG_POP
         #else /* USE_UNICODE_WCHAR_CACHE */
         name = PyUnicode_AsWideCharString(args[1], NULL);
         #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -1121,10 +1094,7 @@ winreg_SaveKey(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
     #if USE_UNICODE_WCHAR_CACHE
-    _Py_COMP_DIAG_PUSH
-    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
     file_name = _PyUnicode_AsUnicode(args[1]);
-    _Py_COMP_DIAG_POP
     #else /* USE_UNICODE_WCHAR_CACHE */
     file_name = PyUnicode_AsWideCharString(args[1], NULL);
     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -1378,4 +1348,4 @@ winreg_QueryReflectionKey(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=fa5f21ea6a75d0e9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=30b1311886c13907 input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3414,10 +3414,7 @@ PyMem_Free((void *){name});
                         goto exit;
                     }}}}
                     #if USE_UNICODE_WCHAR_CACHE
-                    _Py_COMP_DIAG_PUSH
-                    _Py_COMP_DIAG_IGNORE_DEPR_DECLS
                     {paramname} = _PyUnicode_AsUnicode({argname});
-                    _Py_COMP_DIAG_POP
                     #else /* USE_UNICODE_WCHAR_CACHE */
                     {paramname} = PyUnicode_AsWideCharString({argname}, NULL);
                     #endif /* USE_UNICODE_WCHAR_CACHE */
@@ -3432,10 +3429,7 @@ PyMem_Free((void *){name});
                     }}}}
                     else if (PyUnicode_Check({argname})) {{{{
                         #if USE_UNICODE_WCHAR_CACHE
-                        _Py_COMP_DIAG_PUSH
-                        _Py_COMP_DIAG_IGNORE_DEPR_DECLS
                         {paramname} = _PyUnicode_AsUnicode({argname});
-                        _Py_COMP_DIAG_POP
                         #else /* USE_UNICODE_WCHAR_CACHE */
                         {paramname} = PyUnicode_AsWideCharString({argname}, NULL);
                         #endif /* USE_UNICODE_WCHAR_CACHE */


### PR DESCRIPTION


<!-- issue-number: [bpo-36346](https://bugs.python.org/issue36346) -->
https://bugs.python.org/issue36346
<!-- /issue-number -->
