### PR TITLE
[3.8] bpo-39960: Allow heap types in the "Carlo Verre" hack check that override "tp_setattro()" (GH-21092)

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -473,6 +473,14 @@ class CAPITest(unittest.TestCase):
         # Test that subtype_dealloc decref the newly assigned __class__ only once
         self.assertEqual(new_type_refcnt, sys.getrefcount(_testcapi.HeapCTypeSubclass))
 
+    def test_heaptype_with_setattro(self):
+        obj = _testcapi.HeapCTypeSetattr()
+        self.assertEqual(obj.pvalue, 10)
+        obj.value = 12
+        self.assertEqual(obj.pvalue, 12)
+        del obj.value
+        self.assertEqual(obj.pvalue, 0)
+
     def test_pynumber_tobase(self):
         from _testcapi import pynumber_tobase
         self.assertEqual(pynumber_tobase(123, 2), '0b1111011')

--- a/Misc/NEWS.d/next/Core and Builtins/2020-06-23-18-32-41.bpo-39960.Kez3fP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-23-18-32-41.bpo-39960.Kez3fP.rst
@@ -1,0 +1,2 @@
+The "hackcheck" that prevents sneaking around a type's __setattr__() by calling the
+superclass method was rewritten to allow C implemented heap types.


### PR DESCRIPTION
Backport of https://github.com/python/cpython/pull/21092 to Py3.8.


<!-- issue-number: [bpo-39960](https://bugs.python.org/issue39960) -->
https://bugs.python.org/issue39960
<!-- /issue-number -->
