### PR TITLE
bpo-41206: Fix EmailMessage.set_content for empty content.

### DIFF
--- a/Lib/email/contentmanager.py
+++ b/Lib/email/contentmanager.py
@@ -146,6 +146,9 @@ def _encode_text(string, charset, cte, policy):
     def normal_body(lines): return b'\n'.join(lines) + b'\n'
     if cte==None:
         # Use heuristics to decide on the "best" encoding.
+        if not lines:
+            return '7bit', normal_body(lines).decode('ascii')
+
         if max(len(x) for x in lines) <= policy.max_line_length:
             try:
                 return '7bit', normal_body(lines).decode('ascii')

--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -344,6 +344,19 @@ class TestRawDataManager(TestEmailBase):
         self.assertEqual(m.get_payload(decode=True).decode('utf-8'), content)
         self.assertEqual(m.get_content(), content)
 
+    def test_set_text_plain_empty_content_heuristics(self):
+        m = self._make_message()
+        content = ""
+        raw_data_manager.set_content(m, content)
+        self.assertEqual(str(m), textwrap.dedent("""\
+            Content-Type: text/plain; charset="utf-8"
+            Content-Transfer-Encoding: 7bit
+
+
+            """))
+        self.assertEqual(m.get_payload(decode=True).decode('utf-8'), "\n")
+        self.assertEqual(m.get_content(), "\n")
+
     def test_set_text_short_line_minimal_non_ascii_heuristics(self):
         m = self._make_message()
         content = "et là il est monté sur moi et il commence à m'éto.\n"

--- a/Misc/NEWS.d/next/Library/2020-07-06-12-56-16.bpo-41206.i-tXA-.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-06-12-56-16.bpo-41206.i-tXA-.rst
@@ -1,0 +1,2 @@
+Fix :exc:`ValueError` caused due to empty content passed to
+:meth:`EmailMessage.set_content`.


### PR DESCRIPTION
Fix `ValueError` caused due to empty content passed to `EmailMessage.set_content`


<!-- issue-number: [bpo-41206](https://bugs.python.org/issue41206) -->
https://bugs.python.org/issue41206
<!-- /issue-number -->
