### PR TITLE
bpo-41220: Add make key lru cache

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -486,8 +486,8 @@ def lru_cache(maxsize=128, typed=False, key=None):
     For example, f(3.0) and f(3) will be treated as distinct calls with
     distinct results.
 
-    If *key* is a callable, it will be called with the given arguments of 
-    function. It is expected to return a hashable object. If *key* is 
+    If *key* is a callable, it will be called with the given arguments of
+    function. It is expected to return a hashable object. If *key* is
     provided, arguments of the function doesn't have to be hashable.
 
     Arguments to the cached function must be hashable.
@@ -518,10 +518,10 @@ def lru_cache(maxsize=128, typed=False, key=None):
     elif maxsize is not None:
         raise TypeError(
             'Expected first argument to be an integer, a callable, or None')
-    
+
     if key and not callable(key):
         raise TypeError("Expected key argument to be a callable, or None")
-    
+
     if key and typed:
         raise ValueError(
             "Using typed with key is ambiguous. key should be aware of type")

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -476,7 +476,7 @@ def _make_key(args, kwds, typed,
         return key[0]
     return _HashedSeq(key)
 
-def lru_cache(maxsize=128, typed=False):
+def lru_cache(maxsize=128, typed=False, make_key=None):
     """Least-recently-used cache decorator.
 
     If *maxsize* is set to None, the LRU features are disabled and the cache
@@ -485,6 +485,10 @@ def lru_cache(maxsize=128, typed=False):
     If *typed* is True, arguments of different types will be cached separately.
     For example, f(3.0) and f(3) will be treated as distinct calls with
     distinct results.
+
+    If *make_key* is a callable, it will be called with the given arguments of 
+    function. It is expected to return a hashable object. If *make_key* is 
+    provided, arguments of the function doesn't have to be hashable.
 
     Arguments to the cached function must be hashable.
 
@@ -508,24 +512,30 @@ def lru_cache(maxsize=128, typed=False):
     elif callable(maxsize) and isinstance(typed, bool):
         # The user_function was passed in directly via the maxsize argument
         user_function, maxsize = maxsize, 128
-        wrapper = _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo)
+        wrapper = _lru_cache_wrapper(user_function, maxsize, typed, make_key, _CacheInfo)
         wrapper.cache_parameters = lambda : {'maxsize': maxsize, 'typed': typed}
         return update_wrapper(wrapper, user_function)
     elif maxsize is not None:
         raise TypeError(
             'Expected first argument to be an integer, a callable, or None')
+    
+    if not make_key and not callable(make_key):
+        raise TypeError("Expected make_key argument to be a callable, or None")
+    
+    if make_key and typed:
+        raise ValueError(
+            "Using typed with make_key is ambiguous. make_key should be aware of type")
 
     def decorating_function(user_function):
-        wrapper = _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo)
+        wrapper = _lru_cache_wrapper(user_function, maxsize, typed, make_key, _CacheInfo)
         wrapper.cache_parameters = lambda : {'maxsize': maxsize, 'typed': typed}
         return update_wrapper(wrapper, user_function)
 
     return decorating_function
 
-def _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo):
+def _lru_cache_wrapper(user_function, maxsize, typed, make_key, _CacheInfo):
     # Constants shared by all lru cache instances:
     sentinel = object()          # unique object used to signal cache misses
-    make_key = _make_key         # build a key from the function arguments
     PREV, NEXT, KEY, RESULT = 0, 1, 2, 3   # names for the link fields
 
     cache = {}
@@ -536,6 +546,9 @@ def _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo):
     lock = RLock()           # because linkedlist updates aren't threadsafe
     root = []                # root of the circular doubly linked list
     root[:] = [root, root, None, None]     # initialize by pointing to self
+
+    if not make_key:
+        make_key = _make_key
 
     if maxsize == 0:
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1723,17 +1723,17 @@ class TestLRU:
         for ref in refs:
             self.assertIsNone(ref())
 
-    def test_lru_make_key(self):
-        lst = [1,2,3]
-        def last_item_key(lst):
-            return lst[-1]
+    def test_lru_key_func(self):
 
-        @self.module.lru_cache(maxsize=2, make_key=last_item_key)
-        def func(lst):
-            return sum(lst)
+        def key_maker(item):
+            return tuple(item.keys())
 
-        self.assertEqual(func([1,2,3]), 6)
-        self.assertEqual(func([3,3,3]), 6)
+        @self.module.lru_cache(maxsize=2, key=key_maker)
+        def func(item):
+            return min(item.values())
+
+        self.assertEqual(func({"a": 1, "b": 2}), 1)
+        self.assertEqual(func({"a": 3, "b": 2}), 1)
 
 
 @py_functools.lru_cache()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1723,6 +1723,18 @@ class TestLRU:
         for ref in refs:
             self.assertIsNone(ref())
 
+    def test_lru_make_key(self):
+        lst = [1,2,3]
+        def last_item_key(lst):
+            return lst[-1]
+
+        @self.module.lru_cache(maxsize=2, make_key=last_item_key)
+        def func(lst):
+            return sum(lst)
+
+        self.assertEqual(func([1,2,3]), 6)
+        self.assertEqual(func([3,3,3]), 6)
+
 
 @py_functools.lru_cache()
 def py_cached_func(x, y):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -79,6 +79,7 @@ Aymeric Augustin
 Andres Ayala
 Cathy Avery
 John Aycock
+Itay Azolay
 Donovan Baarda
 Arne Babenhauserheide
 Attila Babo

--- a/Misc/NEWS.d/next/Library/2020-07-08-10-28-06.bpo-41220.ZtLkM-.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-08-10-28-06.bpo-41220.ZtLkM-.rst
@@ -1,0 +1,1 @@
+Add an optional key argument to lru_cache, to support user defined funcion that can create a custom key for "lru_cache" cache table.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1211,8 +1211,7 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     obj->root.next = &obj->root;
     obj->wrapper = wrapper;
     obj->typed = typed;
-    if (key != NULL)
-        Py_INCREF(key);
+    Py_XINCREF(key);
     obj->key = key;
     obj->cache = cachedict;
     Py_INCREF(func);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1191,7 +1191,7 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
             PyErr_SetString(PyExc_TypeError, "the key argument must be callable");
             return NULL; 
         }
-        if (key && typed){
+        if (typed){
             PyErr_SetString(PyExc_ValueError, 
                 "Using typed with key is ambiguous. key should be aware of type");
             return NULL;
@@ -1260,8 +1260,7 @@ lru_cache_dealloc(lru_cache_object *obj)
     list = lru_cache_unlink_list(obj);
     Py_XDECREF(obj->cache);
     Py_XDECREF(obj->func);
-    if (obj->key != NULL)
-        Py_XDECREF(obj->key);
+    Py_XDECREF(obj->key);
     Py_XDECREF(obj->cache_info_type);
     Py_XDECREF(obj->dict);
     lru_cache_clear_list(list);
@@ -1341,8 +1340,7 @@ lru_cache_tp_traverse(lru_cache_object *self, visitproc visit, void *arg)
     Py_VISIT(self->cache);
     Py_VISIT(self->cache_info_type);
     Py_VISIT(self->dict);
-    //if (self->key != NULL)
-    //   Py_VISIT(self->key);
+    Py_VISIT(self->key);
     return 0;
 }
 
@@ -1354,8 +1352,7 @@ lru_cache_tp_clear(lru_cache_object *self)
     Py_CLEAR(self->cache);
     Py_CLEAR(self->cache_info_type);
     Py_CLEAR(self->dict);
-   if (self->key != NULL)
-       Py_CLEAR(self->key);
+    Py_CLEAR(self->key);
     lru_cache_clear_list(list);
     return 0;
 }


### PR DESCRIPTION
[bpo-41220](https://bugs.python.org/issue41220): added additional make_key argument to lru_cache

I'd like to add optional argument to lru_cache.
This argument is a user given function that will replace the default behaviour of creating a key from the args/kwds of the function.

for example:

def my_make_key(my_list):
  return my_list[0]

@lru_cache(128, make_key=my_make_key)
def cached_func(my_list):
  return sum(my_list)

This will creating a cached function that accepts immutable.
Also, It will allow user to add custom functions from knowledge about the expected function input, without the need to create custom classes and/or overriding __hash__



<!-- issue-number: [bpo-41220](https://bugs.python.org/issue41220) -->
https://bugs.python.org/issue41220
<!-- /issue-number -->
