### PR TITLE
[3.9] bpo-41215: Don't use NULL by default in the PEG parser keyword list (GH-21355)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-06-18-36-33.bpo-41215.vFGFIz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-06-18-36-33.bpo-41215.vFGFIz.rst
@@ -1,2 +1,2 @@
 Use non-NULL default values in the PEG parser keyword list to overcome a bug that was preventing
-Python to be properly compiled when using the XLC compiler. Patch by Pablo Galindo.
+Python from being properly compiled when using the XLC compiler. Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-06-18-36-33.bpo-41215.vFGFIz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-06-18-36-33.bpo-41215.vFGFIz.rst
@@ -1,0 +1,2 @@
+Use non-NULL default values in the PEG parser keyword list to overcome a bug that was preventing
+Python to be properly compiled when using the XLC compiler. Patch by Pablo Galindo.

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -9,8 +9,8 @@ extern int Py_DebugFlag;
 #endif
 static const int n_keyword_lists = 15;
 static KeywordToken *reserved_keywords[] = {
-    NULL,
-    NULL,
+    (KeywordToken[]) {{NULL, -1}},
+    (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {
         {"if", 510},
         {"in", 518},
@@ -65,11 +65,11 @@ static KeywordToken *reserved_keywords[] = {
         {"nonlocal", 509},
         {NULL, -1},
     },
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
+    (KeywordToken[]) {{NULL, -1}},
+    (KeywordToken[]) {{NULL, -1}},
+    (KeywordToken[]) {{NULL, -1}},
+    (KeywordToken[]) {{NULL, -1}},
+    (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {
         {"__peg_parser__", 531},
         {NULL, -1},

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -525,10 +525,13 @@ _PyPegen_dummy_name(Parser *p, ...)
 static int
 _get_keyword_or_name_type(Parser *p, const char *name, int name_len)
 {
-    if (name_len >= p->n_keyword_lists || p->keywords[name_len] == NULL) {
+    assert(name_len != 0);
+    if (name_len >= p->n_keyword_lists ||
+        p->keywords[name_len] == NULL ||
+        p->keywords[name_len]->type == -1) {
         return NAME;
     }
-    for (KeywordToken *k = p->keywords[name_len]; k->type != -1; k++) {
+    for (KeywordToken *k = p->keywords[name_len]; k != NULL && k->type != -1; k++) {
         if (strncmp(k->str, name, name_len) == 0) {
             return k->type;
         }

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -440,7 +440,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             num_groups = max(groups) + 1 if groups else 1
             for keywords_length in range(num_groups):
                 if keywords_length not in groups.keys():
-                    self.print("NULL,")
+                    self.print("(KeywordToken[]) {{NULL, -1}},")
                 else:
                     self.print("(KeywordToken[]) {")
                     with self.indent():


### PR DESCRIPTION
(cherry picked from commit 39e76c0fb07e20acad454deb86a0457b279884a9)

Co-authored-by: Pablo Galindo <pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41215](https://bugs.python.org/issue41215) -->
https://bugs.python.org/issue41215
<!-- /issue-number -->


Automerge-Triggered-By: @lysnikolaou