### PR TITLE
bpo-41218: Only mark async code with CO_COROUTINE.

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -371,6 +371,25 @@ class BuiltinTest(unittest.TestCase):
                 rv = ns['f']()
                 self.assertEqual(rv, tuple(expected))
 
+    def test_compile_top_level_await_no_coro(self):
+        """Make sure top level non-await codes get the correct coroutine flags.
+        """
+        modes = ('single', 'exec')
+        code_samples = [
+            '''def f():pass\n''',
+            '''[x for x in l]'''
+        ]
+        for mode, code_sample in product(modes, code_samples):
+            source = dedent(code_sample)
+            co = compile(source,
+                            '?',
+                            mode,
+                            flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+
+            self.assertNotEqual(co.co_flags & CO_COROUTINE, CO_COROUTINE,
+                                msg=f"source={source} mode={mode}")
+
+
     def test_compile_top_level_await(self):
         """Test whether code some top level await can be compiled.
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-06-13-35-17.bpo-41218.oKnSr2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-06-13-35-17.bpo-41218.oKnSr2.rst
@@ -1,0 +1,4 @@
+Python 3.8.3 had a regression where compiling with
+ast.PyCF_ALLOW_TOP_LEVEL_AWAIT would aggressively mark list comprehension
+with CO_COROUTINE. Now only list comprehension making use of async/await
+will tagged as so.


### PR DESCRIPTION
3.8.3 had a regression where compiling with
ast.PyCF_ALLOW_TOP_LEVEL_AWAIT would agressively mark things are
coroutine even if there were not.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41218](https://bugs.python.org/issue41218) -->
https://bugs.python.org/issue41218
<!-- /issue-number -->
