### PR TITLE
Remove trailing >>> in enum docs

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -113,7 +113,6 @@ The *type* of an enumeration member is the enumeration it belongs to::
     <enum 'Color'>
     >>> isinstance(Color.GREEN, Color)
     True
-    >>>
 
 Enum members also have a property that contains just their item name::
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1266,6 +1266,7 @@ Richard Oudkerk
 Russel Owen
 Joonas Paalasmaa
 Martin Packman
+Elisha Paine
 Shriphani Palakodety
 Julien Palard
 Aviv Palivoda


### PR DESCRIPTION
The enum docs has a trailing >>> which is not expected by sphinx and so is not coloured correctly (it is left black).