### PR TITLE
bpo-41217: Fix incorrect note in the asyncio.create_subprocess_shell() docs

### DIFF
--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -110,10 +110,8 @@ Creating Subprocesses
 
 .. note::
 
-   The default asyncio event loop implementation on **Windows** does not
-   support subprocesses. Subprocesses are available for Windows if a
-   :class:`ProactorEventLoop` is used.
-   See :ref:`Subprocess Support on Windows <asyncio-windows-subprocess>`
+   Subprocesses are available for Windows if a :class:`ProactorEventLoop` is
+   used. See :ref:`Subprocess Support on Windows <asyncio-windows-subprocess>`
    for details.
 
 .. seealso::


### PR DESCRIPTION
On Windows, the default asyncio event loop is ProactorEventLoop (as
of 3.8).

<!-- issue-number: [bpo-41217](https://bugs.python.org/issue41217) -->
https://bugs.python.org/issue41217
<!-- /issue-number -->
