### PR TITLE
bpo-41235: Fix the error handling in SSLContext.load_dh_params()

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-07-07-21-56-26.bpo-41235.H2csMU.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-07-21-56-26.bpo-41235.H2csMU.rst
@@ -1,0 +1,1 @@
+Fix the error handling in :meth:`ssl.SSLContext.load_dh_params`.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4309,8 +4309,10 @@ _ssl__SSLContext_load_dh_params(PySSLContext *self, PyObject *filepath)
         }
         return NULL;
     }
-    if (SSL_CTX_set_tmp_dh(self->ctx, dh) == 0)
-        _setSSLError(NULL, 0, __FILE__, __LINE__);
+    if (!SSL_CTX_set_tmp_dh(self->ctx, dh)) {
+        DH_free(dh);
+        return _setSSLError(NULL, 0, __FILE__, __LINE__);
+    }
     DH_free(dh);
     Py_RETURN_NONE;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-41235](https://bugs.python.org/issue41235) -->
https://bugs.python.org/issue41235
<!-- /issue-number -->
