### PR TITLE
Revert "bpo-40170: PyType_HasFeature() now always calls PyType_GetFlags() (GH-19378)"

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -637,8 +637,16 @@ times.
 
 
 static inline int
-PyType_HasFeature(PyTypeObject *type, unsigned long feature) {
-    return ((PyType_GetFlags(type) & feature) != 0);
+PyType_HasFeature(PyTypeObject *type, unsigned long feature)
+{
+    unsigned long flags;
+#ifdef Py_LIMITED_API
+    // PyTypeObject is opaque in the limited C API
+    flags = PyType_GetFlags(type);
+#else
+    flags = type->tp_flags;
+#endif
+    return ((flags & feature) != 0);
 }
 
 #define PyType_FastSubclass(type, flag) PyType_HasFeature(type, flag)

--- a/Misc/NEWS.d/next/C API/2020-07-08-10-14-52.bpo-40170.N6Qx1i.rst
+++ b/Misc/NEWS.d/next/C API/2020-07-08-10-14-52.bpo-40170.N6Qx1i.rst
@@ -1,0 +1,4 @@
+Revert :c:func:`PyType_HasFeature` change: it reads again directly the
+:c:member:`PyTypeObject.tp_flags` member when the limited C API is not used,
+rather than always calling :c:func:`PyType_GetFlags` which hides implementation
+details.


### PR DESCRIPTION
This partially reverts commit 45ec5b99aefa54552947049086e87ec01bc2fc9a.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
