### PR TITLE
bpo-37322: Fix ResourceWarning in test_ssl

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4447,6 +4447,11 @@ class TestPostHandshakeAuth(unittest.TestCase):
                             'tlsv13 alert certificate required'):
                         s.recv(1024)
 
+            # If there was an exception, manually close the socket to avoid a
+            # ResourceWarning
+            if cm.exc_type == ssl.SSLError:
+                cm.thread.sslconn.close()
+
     def test_pha_optional(self):
         if support.verbose:
             sys.stdout.write("\n")


### PR DESCRIPTION
https://bugs.python.org/issue37322

This is a minor change to a test so I didn't think it warranted a NEWS entry, but happy to add one if I am mistaken.

-----

This warning was caused by a socket being left unclosed on the threaded
server in the event of an exception. See issue37322

This exception was observed on my machine running Debian10, output on
master:

    $ ./python -m test test_ssl -m test_pha_required_nocert
    0:00:00 load avg: 0.08 Run tests sequentially
    0:00:00 load avg: 0.08 [1/1] test_ssl
    /home/mjh/src/cpython/Lib/test/support/threading_helper.py:209: ResourceWarning: unclosed <ssl.SSLSocket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 35919), raddr=('127.0.0.1', 54592)>
      del self.thread
    ResourceWarning: Enable tracemalloc to get the object allocation traceback

    == Tests result: SUCCESS ==

    1 test OK.

    Total duration: 215 ms
    Tests result: SUCCESS

Output with this patch:

    $ ./python -m test test_ssl -m test_pha_required_nocert
    0:00:00 load avg: 0.24 Run tests sequentially
    0:00:00 load avg: 0.24 [1/1] test_ssl

    == Tests result: SUCCESS ==

    1 test OK.

    Total duration: 214 ms
    Tests result: SUCCESS

<!-- issue-number: [bpo-37322](https://bugs.python.org/issue37322) -->
https://bugs.python.org/issue37322
<!-- /issue-number -->
