### PR TITLE
bpo-16396: Allow wintypes to be imported on non-Windows systems.

### DIFF
--- a/Lib/ctypes/test/test_wintypes.py
+++ b/Lib/ctypes/test/test_wintypes.py
@@ -1,12 +1,13 @@
-import sys
 import unittest
 
-from ctypes import *
+# also work on POSIX
 
-@unittest.skipUnless(sys.platform.startswith('win'), 'Windows-only test')
+from ctypes import *
+from ctypes import wintypes
+
+
 class WinTypesTest(unittest.TestCase):
     def test_variant_bool(self):
-        from ctypes import wintypes
         # reads 16-bits from memory, anything non-zero is True
         for true_value in (1, 32767, 32768, 65535, 65537):
             true = POINTER(c_int16)(c_int16(true_value))
@@ -36,6 +37,7 @@ class WinTypesTest(unittest.TestCase):
         self.assertIs(vb.value, True)
         vb.value = []
         self.assertIs(vb.value, False)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-07-08-09-45-00.bpo-16936.z8o8Pn.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-08-09-45-00.bpo-16936.z8o8Pn.rst
@@ -1,0 +1,1 @@
+Allow ``ctypes.wintypes`` to be imported on non-Windows systems.

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -658,7 +658,11 @@ i_get_sw(void *ptr, Py_ssize_t size)
     return PyLong_FromLong(val);
 }
 
-#ifdef MS_WIN32
+#ifndef MS_WIN32
+/* http://msdn.microsoft.com/en-us/library/cc237864.aspx */
+#define VARIANT_FALSE 0x0000
+#define VARIANT_TRUE 0xFFFF
+#endif
 /* short BOOL - VARIANT_BOOL */
 static PyObject *
 vBOOL_set(void *ptr, PyObject *value, Py_ssize_t size)
@@ -680,7 +684,6 @@ vBOOL_get(void *ptr, Py_ssize_t size)
 {
     return PyBool_FromLong((long)*(short int *)ptr);
 }
-#endif
 
 static PyObject *
 bool_set(void *ptr, PyObject *value, Py_ssize_t size)
@@ -1514,8 +1517,8 @@ static struct fielddesc formattable[] = {
 #endif
 #ifdef MS_WIN32
     { 'X', BSTR_set, BSTR_get, &ffi_type_pointer},
-    { 'v', vBOOL_set, vBOOL_get, &ffi_type_sshort},
 #endif
+    { 'v', vBOOL_set, vBOOL_get, &ffi_type_sshort},
 #if SIZEOF__BOOL == 1
     { '?', bool_set, bool_get, &ffi_type_uchar}, /* Also fallback for no native _Bool support */
 #elif SIZEOF__BOOL == SIZEOF_SHORT


### PR DESCRIPTION


<!-- issue-number: [bpo-16396](https://bugs.python.org/issue16396) -->
https://bugs.python.org/issue16396
<!-- /issue-number -->


