### PR TITLE
[3.8] bpo-41247: asyncio.set_running_loop() cache running loop holder

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-08-22-03-54.bpo-41247.PndYIk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-08-22-03-54.bpo-41247.PndYIk.rst
@@ -1,0 +1,2 @@
+Always cache the running loop holder when running
+``asyncio.set_running_loop``.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -289,9 +289,6 @@ error:
 static int
 set_running_loop(PyObject *loop)
 {
-    cached_running_holder = NULL;
-    cached_running_holder_tsid = 0;
-
     PyObject *ts_dict = PyThreadState_GetDict();  // borrowed
     if (ts_dict == NULL) {
         PyErr_SetString(
@@ -311,6 +308,12 @@ set_running_loop(PyObject *loop)
         return -1;
     }
     Py_DECREF(rl);
+
+    cached_running_holder = (PyObject *)rl;
+
+    /* safe to assume state is not NULL as the call to PyThreadState_GetDict()
+       above already checks if state is NULL */
+    cached_running_holder_tsid = PyThreadState_Get()->id;
 
     return 0;
 }


### PR DESCRIPTION
The running loop holder cache variable was always set to NULL when
calling set_running_loop.

Now set_running_loop saves the newly created running loop holder in the
cache variable for faster access in get_running_loop.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41247](https://bugs.python.org/issue41247) -->
https://bugs.python.org/issue41247
<!-- /issue-number -->
