### PR TITLE
bpo-41252: Fix incorrect refcounting in _ssl.c's _servername_callback()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-08-21-55-23.bpo-41252.nBWL-Y.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-08-21-55-23.bpo-41252.nBWL-Y.rst
@@ -1,0 +1,1 @@
+Fix incorrect refcounting in _ssl.c's ``_servername_callback()``.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4545,11 +4545,12 @@ _servername_callback(SSL *s, int *al, void *args)
          * back into a str object, but still as an A-label (bpo-28414)
          */
         servername_str = PyUnicode_FromEncodedObject(servername_bytes, "ascii", NULL);
-        Py_DECREF(servername_bytes);
         if (servername_str == NULL) {
             PyErr_WriteUnraisable(servername_bytes);
+            Py_DECREF(servername_bytes);
             goto error;
         }
+        Py_DECREF(servername_bytes);
         result = PyObject_CallFunctionObjArgs(
             ssl_ctx->set_sni_cb, ssl_socket, servername_str,
             ssl_ctx, NULL);


### PR DESCRIPTION


<!-- issue-number: [bpo-41252](https://bugs.python.org/issue41252) -->
https://bugs.python.org/issue41252
<!-- /issue-number -->


Automerge-Triggered-By: @tiran