### PR TITLE
configure.ac: define a path for profile data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1480,8 +1480,8 @@ case $CC in
         fi
         ;;
       *)
-        PGO_PROF_GEN_FLAG="-fprofile-generate"
-        PGO_PROF_USE_FLAG="-fprofile-use -fprofile-correction"
+        PGO_PROF_GEN_FLAG="-fprofile-generate=$(pwd)"
+        PGO_PROF_USE_FLAG="-fprofile-use=$(pwd) -fprofile-correction"
         LLVM_PROF_MERGER="true"
         LLVM_PROF_FILE=""
         ;;


### PR DESCRIPTION
There comes below error when use ccache 3.7.10 to compile python3
and check [1] for more details.
 | Python-3.8.3/Modules/_contextvarsmodule.c:43:1: error: source locations for function 'PyInit__contextvars' have changed, the profile data may be out of date [-Werror=coverage-mismatch]

That's because the logic for profile directory changes a little in
[2] after ccache upgrades to 3.7.10 and it errors out if no profile 
data found per [2] and [3].

So define a profile directory path accordingly to fix the above error.

[1] https://github.com/ccache/ccache/issues/615
[2] https://github.com/ccache/ccache/commit/c9fdcef576dd13a2ea2355bcd866b5c561cb1562
[3] https://github.com/ccache/ccache/commit/91a2954eb47b4a106e2be6cf611917b895108e35


Signed-off-by: Mingli Yu <mingli.yu@windriver.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
