### PR TITLE
bpo-12800: tarfile: Restore fix from 011525ee9

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2233,6 +2233,7 @@ class TarFile(object):
             # For systems that support symbolic and hard links.
             if tarinfo.issym():
                 if os.path.lexists(targetpath):
+                    # Avoid FileExistsError on following os.symlink.
                     os.unlink(targetpath)
                 os.symlink(tarinfo.linkname, targetpath)
             else:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2232,6 +2232,8 @@ class TarFile(object):
         try:
             # For systems that support symbolic and hard links.
             if tarinfo.issym():
+                if os.path.lexists(targetpath):
+                    os.unlink(targetpath)
                 os.symlink(tarinfo.linkname, targetpath)
             else:
                 # See extract().

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1339,10 +1339,10 @@ class WriteTest(WriteTestBase, unittest.TestCase):
                 f.write('something\n')
             os.symlink(source_file, target_file)
             with tarfile.open(temparchive, 'w') as tar:
-                tar.add(source_file)
-                tar.add(target_file)
+                tar.add(source_file, arcname="source")
+                tar.add(target_file, arcname="symlink")
             # Let's extract it to the location which contains the symlink
-            with tarfile.open(temparchive) as tar:
+            with tarfile.open(temparchive, errorlevel=2) as tar:
                 # this should not raise OSError: [Errno 17] File exists
                 try:
                     tar.extractall(path=tempdir)

--- a/Misc/NEWS.d/next/Library/2020-07-09-11-32-28.bpo-12800.fNgWwx.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-09-11-32-28.bpo-12800.fNgWwx.rst
@@ -1,0 +1,4 @@
+Extracting a symlink from a tarball should succeed and overwrite the symlink
+if it already exists. The fix is to remove the existing file or symlink
+before extraction. Based on patch by Chris AtLee, Jeffrey Kintscher, and
+Senthil Kumaran.


### PR DESCRIPTION
While reviewing https://github.com/python/cpython/pull/20972 I spotted the code already existed, the test already existed, but was not seeing the error due to:
- The test not testing the actual condition of having the extracted symlink where a symlink already existed
- The test was running with errorlevel=1 and expecting an exception, while errorlevel=1 does log instead of raising for this error.


<!-- issue-number: [bpo-12800](https://bugs.python.org/issue12800) -->
https://bugs.python.org/issue12800
<!-- /issue-number -->
