### PR TITLE
bpo-40275: Use new test.support helper submodules in tests

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -14,24 +14,24 @@ import time
 import types
 import unittest
 
-from .import_helper import (
-    CleanImport, DirsOnSysPath, _ignore_deprecated_imports,
-    _save_and_block_module, _save_and_remove_module,
-    forget, import_fresh_module, import_module, make_legacy_pyc,
-    modules_cleanup, modules_setup, unload)
-from .os_helper import (
-    FS_NONASCII, SAVEDCWD, TESTFN, TESTFN_ASCII, TESTFN_NONASCII,
-    TESTFN_UNENCODABLE, TESTFN_UNDECODABLE,
-    TESTFN_UNICODE, can_symlink, can_xattr,
-    change_cwd, create_empty_file, fd_count,
-    fs_is_case_insensitive, make_bad_fd, rmdir,
-    rmtree, skip_unless_symlink, skip_unless_xattr,
-    temp_cwd, temp_dir, temp_umask, unlink,
-    EnvironmentVarGuard, FakePath, _longpath)
-from .warnings_helper import (
-    WarningsRecorder, _filterwarnings,
-    check_no_resource_warning, check_no_warnings,
-    check_syntax_warning, check_warnings, ignore_warnings)
+#from .import_helper import (
+#    CleanImport, DirsOnSysPath, _ignore_deprecated_imports,
+#    _save_and_block_module, _save_and_remove_module,
+#    forget, import_fresh_module, import_module, make_legacy_pyc,
+#    modules_cleanup, modules_setup, unload)
+#from .os_helper import (
+#    FS_NONASCII, SAVEDCWD, TESTFN, TESTFN_ASCII, TESTFN_NONASCII,
+#    TESTFN_UNENCODABLE, TESTFN_UNDECODABLE,
+#    TESTFN_UNICODE, can_symlink, can_xattr,
+#    change_cwd, create_empty_file, fd_count,
+#    fs_is_case_insensitive, make_bad_fd, rmdir,
+#    rmtree, skip_unless_symlink, skip_unless_xattr,
+#    temp_cwd, temp_dir, temp_umask, unlink,
+#    EnvironmentVarGuard, FakePath, _longpath)
+#from .warnings_helper import (
+#    WarningsRecorder, _filterwarnings,
+#    check_no_resource_warning, check_no_warnings,
+#    check_syntax_warning, check_warnings, ignore_warnings)
 
 from .testresult import get_test_runner
 
@@ -1316,6 +1316,7 @@ def skip_if_buggy_ucrt_strfptime(test):
 class PythonSymlink:
     """Creates a symlink for the current Python executable"""
     def __init__(self, link=None):
+        from .os_helper import TESTFN
         self.link = link or os.path.abspath(TESTFN)
         self._linked = []
         self.real = os.path.realpath(sys.executable)
@@ -1964,6 +1965,7 @@ def skip_if_broken_multiprocessing_synchronize():
     is no available semaphore implementation, or if creating a lock raises an
     OSError (on Linux only).
     """
+    from .import_helper import import_module
 
     # Skip tests if the _multiprocessing extension is missing.
     import_module('_multiprocessing')

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -14,24 +14,24 @@ import time
 import types
 import unittest
 
-#from .import_helper import (
-#    CleanImport, DirsOnSysPath, _ignore_deprecated_imports,
-#    _save_and_block_module, _save_and_remove_module,
-#    forget, import_fresh_module, import_module, make_legacy_pyc,
-#    modules_cleanup, modules_setup, unload)
-#from .os_helper import (
-#    FS_NONASCII, SAVEDCWD, TESTFN, TESTFN_ASCII, TESTFN_NONASCII,
-#    TESTFN_UNENCODABLE, TESTFN_UNDECODABLE,
-#    TESTFN_UNICODE, can_symlink, can_xattr,
-#    change_cwd, create_empty_file, fd_count,
-#    fs_is_case_insensitive, make_bad_fd, rmdir,
-#    rmtree, skip_unless_symlink, skip_unless_xattr,
-#    temp_cwd, temp_dir, temp_umask, unlink,
-#    EnvironmentVarGuard, FakePath, _longpath)
-#from .warnings_helper import (
-#    WarningsRecorder, _filterwarnings,
-#    check_no_resource_warning, check_no_warnings,
-#    check_syntax_warning, check_warnings, ignore_warnings)
+from .import_helper import (
+    CleanImport, DirsOnSysPath, _ignore_deprecated_imports,
+    _save_and_block_module, _save_and_remove_module,
+    forget, import_fresh_module, import_module, make_legacy_pyc,
+    modules_cleanup, modules_setup, unload)
+from .os_helper import (
+    FS_NONASCII, SAVEDCWD, TESTFN, TESTFN_ASCII, TESTFN_NONASCII,
+    TESTFN_UNENCODABLE, TESTFN_UNDECODABLE,
+    TESTFN_UNICODE, can_symlink, can_xattr,
+    change_cwd, create_empty_file, fd_count,
+    fs_is_case_insensitive, make_bad_fd, rmdir,
+    rmtree, skip_unless_symlink, skip_unless_xattr,
+    temp_cwd, temp_dir, temp_umask, unlink,
+    EnvironmentVarGuard, FakePath, _longpath)
+from .warnings_helper import (
+    WarningsRecorder, _filterwarnings,
+    check_no_resource_warning, check_no_warnings,
+    check_syntax_warning, check_warnings, ignore_warnings)
 
 from .testresult import get_test_runner
 
@@ -1316,7 +1316,6 @@ def skip_if_buggy_ucrt_strfptime(test):
 class PythonSymlink:
     """Creates a symlink for the current Python executable"""
     def __init__(self, link=None):
-        from .os_helper import TESTFN
         self.link = link or os.path.abspath(TESTFN)
         self._linked = []
         self.real = os.path.realpath(sys.executable)
@@ -1965,7 +1964,6 @@ def skip_if_broken_multiprocessing_synchronize():
     is no available semaphore implementation, or if creating a lock raises an
     OSError (on Linux only).
     """
-    from .import_helper import import_module
 
     # Skip tests if the _multiprocessing extension is missing.
     import_module('_multiprocessing')

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -14,6 +14,8 @@ import io
 
 import textwrap
 from test import support
+from test.support import import_helper
+from test.support import os_helper
 from test.support.script_helper import (
     make_pkg, make_script, make_zip_pkg, make_zip_script,
     assert_python_ok, assert_python_failure, spawn_python, kill_python)
@@ -214,7 +216,7 @@ class CmdLineTest(unittest.TestCase):
         self.check_repl_stderr_flush(True)
 
     def test_basic_script(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
             self._check_script(script_name, script_name, script_name,
                                script_dir, None,
@@ -224,7 +226,7 @@ class CmdLineTest(unittest.TestCase):
     def test_script_abspath(self):
         # pass the script using the relative path, expect the absolute path
         # in __file__
-        with support.temp_cwd() as script_dir:
+        with os_helper.temp_cwd() as script_dir:
             self.assertTrue(os.path.isabs(script_dir), script_dir)
 
             script_name = _make_test_script(script_dir, 'script')
@@ -234,46 +236,46 @@ class CmdLineTest(unittest.TestCase):
                                importlib.machinery.SourceFileLoader)
 
     def test_script_compiled(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(pyc_file, pyc_file,
                                pyc_file, script_dir, None,
                                importlib.machinery.SourcelessFileLoader)
 
     def test_directory(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             self._check_script(script_dir, script_name, script_dir,
                                script_dir, '',
                                importlib.machinery.SourceFileLoader)
 
     def test_directory_compiled(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(script_dir, pyc_file, script_dir,
                                script_dir, '',
                                importlib.machinery.SourcelessFileLoader)
 
     def test_directory_error(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             msg = "can't find '__main__' module in %r" % script_dir
             self._check_import_error(script_dir, msg)
 
     def test_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             zip_name, run_name = make_zip_script(script_dir, 'test_zip', script_name)
             self._check_script(zip_name, run_name, zip_name, zip_name, '',
                                zipimport.zipimporter)
 
     def test_zipfile_compiled_timestamp(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             compiled_name = py_compile.compile(
                 script_name, doraise=True,
@@ -283,7 +285,7 @@ class CmdLineTest(unittest.TestCase):
                                zipimport.zipimporter)
 
     def test_zipfile_compiled_checked_hash(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             compiled_name = py_compile.compile(
                 script_name, doraise=True,
@@ -293,7 +295,7 @@ class CmdLineTest(unittest.TestCase):
                                zipimport.zipimporter)
 
     def test_zipfile_compiled_unchecked_hash(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             compiled_name = py_compile.compile(
                 script_name, doraise=True,
@@ -303,14 +305,14 @@ class CmdLineTest(unittest.TestCase):
                                zipimport.zipimporter)
 
     def test_zipfile_error(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'not_main')
             zip_name, run_name = make_zip_script(script_dir, 'test_zip', script_name)
             msg = "can't find '__main__' module in %r" % zip_name
             self._check_import_error(zip_name, msg)
 
     def test_module_in_package(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, 'script')
@@ -320,14 +322,14 @@ class CmdLineTest(unittest.TestCase):
                                cwd=script_dir)
 
     def test_module_in_package_in_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script')
             self._check_script(["-m", "test_pkg.script"], run_name, run_name,
                                script_dir, 'test_pkg', zipimport.zipimporter,
                                PYTHONPATH=zip_name, cwd=script_dir)
 
     def test_module_in_subpackage_in_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script', depth=2)
             self._check_script(["-m", "test_pkg.test_pkg.script"], run_name, run_name,
                                script_dir, 'test_pkg.test_pkg',
@@ -335,7 +337,7 @@ class CmdLineTest(unittest.TestCase):
                                PYTHONPATH=zip_name, cwd=script_dir)
 
     def test_package(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, '__main__')
@@ -345,20 +347,20 @@ class CmdLineTest(unittest.TestCase):
                                cwd=script_dir)
 
     def test_package_compiled(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, '__main__')
             compiled_name = py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(["-m", "test_pkg"], pyc_file,
                                pyc_file, script_dir, 'test_pkg',
                                importlib.machinery.SourcelessFileLoader,
                                cwd=script_dir)
 
     def test_package_error(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             msg = ("'test_pkg' is a package and cannot "
@@ -366,7 +368,7 @@ class CmdLineTest(unittest.TestCase):
             self._check_import_error(["-m", "test_pkg"], msg, cwd=script_dir)
 
     def test_package_recursion(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             main_dir = os.path.join(pkg_dir, '__main__')
@@ -379,8 +381,8 @@ class CmdLineTest(unittest.TestCase):
     def test_issue8202(self):
         # Make sure package __init__ modules see "-m" in sys.argv0 while
         # searching for the module to execute
-        with support.temp_dir() as script_dir:
-            with support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir:
+            with os_helper.change_cwd(path=script_dir):
                 pkg_dir = os.path.join(script_dir, 'test_pkg')
                 make_pkg(pkg_dir, "import sys; print('init_argv0==%r' % sys.argv[0])")
                 script_name = _make_test_script(pkg_dir, 'script')
@@ -396,8 +398,8 @@ class CmdLineTest(unittest.TestCase):
     def test_issue8202_dash_c_file_ignored(self):
         # Make sure a "-c" file in the current directory
         # does not alter the value of sys.path[0]
-        with support.temp_dir() as script_dir:
-            with support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir:
+            with os_helper.change_cwd(path=script_dir):
                 with open("-c", "w") as f:
                     f.write("data")
                     rc, out, err = assert_python_ok('-c',
@@ -411,9 +413,9 @@ class CmdLineTest(unittest.TestCase):
     def test_issue8202_dash_m_file_ignored(self):
         # Make sure a "-m" file in the current directory
         # does not alter the value of sys.path[0]
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'other')
-            with support.change_cwd(path=script_dir):
+            with os_helper.change_cwd(path=script_dir):
                 with open("-m", "w") as f:
                     f.write("data")
                     rc, out, err = assert_python_ok('-m', 'other', *example_args,
@@ -425,7 +427,7 @@ class CmdLineTest(unittest.TestCase):
     def test_issue20884(self):
         # On Windows, script with encoding cookie and LF line ending
         # will be failed.
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = os.path.join(script_dir, "issue20884.py")
             with open(script_name, "w", newline='\n') as f:
                 f.write("#coding: iso-8859-1\n")
@@ -434,15 +436,15 @@ class CmdLineTest(unittest.TestCase):
                     f.write('x'*80 + '\n')
                 f.write('"""\n')
 
-            with support.change_cwd(path=script_dir):
+            with os_helper.change_cwd(path=script_dir):
                 rc, out, err = assert_python_ok(script_name)
             self.assertEqual(b"", out)
             self.assertEqual(b"", err)
 
     @contextlib.contextmanager
     def setup_test_pkg(self, *args):
-        with support.temp_dir() as script_dir, \
-                support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir, \
+                os_helper.change_cwd(path=script_dir):
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir, *args)
             yield pkg_dir
@@ -486,8 +488,8 @@ class CmdLineTest(unittest.TestCase):
                 self.assertNotIn(b'Traceback', err)
 
     def test_dash_m_bad_pyc(self):
-        with support.temp_dir() as script_dir, \
-                support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir, \
+                os_helper.change_cwd(path=script_dir):
             os.mkdir('test_pkg')
             # Create invalid *.pyc as empty file
             with open('test_pkg/__init__.pyc', 'wb'):
@@ -500,8 +502,8 @@ class CmdLineTest(unittest.TestCase):
             self.assertNotIn(b'Traceback', err)
 
     def test_hint_when_triying_to_import_a_py_file(self):
-        with support.temp_dir() as script_dir, \
-                support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir, \
+                os_helper.change_cwd(path=script_dir):
             # Create invalid *.pyc as empty file
             with open('asyncio.py', 'wb'):
                 pass
@@ -542,7 +544,7 @@ class CmdLineTest(unittest.TestCase):
             except:
                 raise NameError from None
             """)
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = stderr.decode('ascii').split('\n')
@@ -555,18 +557,18 @@ class CmdLineTest(unittest.TestCase):
         # Mac OS X denies the creation of a file with an invalid UTF-8 name.
         # Windows allows creating a name with an arbitrary bytes name, but
         # Python cannot a undecodable bytes argument to a subprocess.
-        if (support.TESTFN_UNDECODABLE
+        if (os_helper.TESTFN_UNDECODABLE
         and sys.platform not in ('win32', 'darwin')):
-            name = os.fsdecode(support.TESTFN_UNDECODABLE)
-        elif support.TESTFN_NONASCII:
-            name = support.TESTFN_NONASCII
+            name = os.fsdecode(os_helper.TESTFN_UNDECODABLE)
+        elif os_helper.TESTFN_NONASCII:
+            name = os_helper.TESTFN_NONASCII
         else:
-            self.skipTest("need support.TESTFN_NONASCII")
+            self.skipTest("need os_helper.TESTFN_NONASCII")
 
         # Issue #16218
         source = 'print(ascii(__file__))\n'
         script_name = _make_test_script(os.getcwd(), name, source)
-        self.addCleanup(support.unlink, script_name)
+        self.addCleanup(os_helper.unlink, script_name)
         rc, stdout, stderr = assert_python_ok(script_name)
         self.assertEqual(
             ascii(script_name),
@@ -586,7 +588,7 @@ class CmdLineTest(unittest.TestCase):
             if error:
                 sys.exit(error)
             """)
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = stderr.decode('ascii')
@@ -594,7 +596,7 @@ class CmdLineTest(unittest.TestCase):
 
     def test_syntaxerror_unindented_caret_position(self):
         script = "1 + 1 = 2\n"
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = io.TextIOWrapper(io.BytesIO(stderr), 'ascii').read()
@@ -606,7 +608,7 @@ class CmdLineTest(unittest.TestCase):
             if True:
                 1 + 1 = 2
             """)
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = io.TextIOWrapper(io.BytesIO(stderr), 'ascii').read()
@@ -626,7 +628,7 @@ class CmdLineTest(unittest.TestCase):
 
     def test_syntaxerror_multi_line_fstring(self):
         script = 'foo = f"""{}\nfoo"""\n'
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             self.assertEqual(
@@ -640,7 +642,7 @@ class CmdLineTest(unittest.TestCase):
 
     def test_syntaxerror_invalid_escape_sequence_multi_line(self):
         script = 'foo = """\\q"""\n'
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(
                 '-Werror', script_name,
@@ -667,7 +669,7 @@ class CmdLineTest(unittest.TestCase):
             """)
         # Always show full path diffs on errors
         self.maxDiff = None
-        with support.temp_dir() as work_dir, support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as work_dir, os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__', script)
             # Reference output comes from directly executing __main__.py
             # We omit PYTHONPATH and user site to align with isolated mode
@@ -699,7 +701,7 @@ class CmdLineTest(unittest.TestCase):
             """)
         # Always show full path diffs on errors
         self.maxDiff = None
-        with support.temp_dir() as work_dir:
+        with os_helper.temp_dir() as work_dir:
             script_dir = os.path.join(work_dir, "script_pkg")
             os.mkdir(script_dir)
             script_name = _make_test_script(script_dir, '__main__', script)

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -5,6 +5,7 @@
 import sys
 import unittest
 from test import support
+from test.support import warnings_helper
 
 from codeop import compile_command, PyCF_DONT_IMPLY_DEDENT
 import io
@@ -305,7 +306,7 @@ class CodeopTests(unittest.TestCase):
 
     def test_warning(self):
         # Test that the warning is only returned once.
-        with support.check_warnings((".*literal", SyntaxWarning)) as w:
+        with warnings_helper.check_warnings((".*literal", SyntaxWarning)) as w:
             compile_command("0 is 0")
             self.assertEqual(len(w.warnings), 1)
 

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -7,6 +7,7 @@ import threading
 import unittest
 from contextlib import *  # Tests __all__
 from test import support
+from test.support import os_helper
 import weakref
 
 
@@ -327,7 +328,7 @@ class FileContextTestCase(unittest.TestCase):
                     1 / 0
             self.assertTrue(f.closed)
         finally:
-            support.unlink(tfn)
+            os_helper.unlink(tfn)
 
 class LockContextTestCase(unittest.TestCase):
 

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -1,5 +1,6 @@
 from test import support
-support.import_module("dbm.ndbm") #skip if not supported
+from test.support import import_helper
+import_helper.import_module("dbm.ndbm") #skip if not supported
 import os
 import unittest
 import dbm.ndbm

--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -3,8 +3,9 @@ import math
 import string
 import sys
 from test import support
+from test.support import import_helper
 # Skip this test if the _testcapi module isn't available.
-_testcapi = support.import_module('_testcapi')
+_testcapi = import_helper.import_module('_testcapi')
 from _testcapi import getargs_keywords, getargs_keyword_only
 
 # > How about the following counterproposal. This also changes some of

--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -5,6 +5,7 @@ import gettext
 import unittest
 
 from test import support
+from test.support import os_helper
 
 
 # TODO:
@@ -129,14 +130,14 @@ class GettextBaseTest(unittest.TestCase):
             fp.write(base64.decodebytes(UMO_DATA))
         with open(MMOFILE, 'wb') as fp:
             fp.write(base64.decodebytes(MMO_DATA))
-        self.env = support.EnvironmentVarGuard()
+        self.env = os_helper.EnvironmentVarGuard()
         self.env['LANGUAGE'] = 'xx'
         gettext._translations.clear()
 
     def tearDown(self):
         self.env.__exit__()
         del self.env
-        support.rmtree(os.path.split(LOCALEDIR)[0])
+        os_helper.rmtree(os.path.split(LOCALEDIR)[0])
 
 GNU_MO_DATA_ISSUE_17898 = b'''\
 3hIElQAAAAABAAAAHAAAACQAAAAAAAAAAAAAAAAAAAAsAAAAggAAAC0AAAAAUGx1cmFsLUZvcm1z

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -4,8 +4,8 @@ import shutil
 import sys
 import unittest
 
-from test.support import (TESTFN, skip_unless_symlink,
-                          can_symlink, create_empty_file, change_cwd)
+from test.support.os_helper import (TESTFN, skip_unless_symlink,
+                                    can_symlink, create_empty_file, change_cwd)
 
 
 class GlobTests(unittest.TestCase):

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -19,11 +19,12 @@ import unittest
 from unittest import mock
 
 import test.support
-from test.support import (
-    TESTFN, forget, is_jython,
-    make_legacy_pyc, rmtree, swap_attr, swap_item, temp_umask,
-    unlink, unload, cpython_only, TESTFN_UNENCODABLE,
-    temp_dir, DirsOnSysPath)
+from test.support import os_helper
+from test.support import (is_jython, swap_attr, swap_item, cpython_only)
+from test.support.import_helper import (
+    forget, make_legacy_pyc, unlink, unload, DirsOnSysPath)
+from test.support.os_helper import (
+    TESTFN, rmtree, temp_umask, TESTFN_UNENCODABLE, temp_dir)
 from test.support import script_helper
 from test.support import threading_helper
 from test.test_importlib.util import uncache
@@ -997,22 +998,22 @@ class TestSymbolicallyLinkedPackage(unittest.TestCase):
     tagged = package_name + '-tagged'
 
     def setUp(self):
-        test.support.rmtree(self.tagged)
-        test.support.rmtree(self.package_name)
+        os_helper.rmtree(self.tagged)
+        os_helper.rmtree(self.package_name)
         self.orig_sys_path = sys.path[:]
 
         # create a sample package; imagine you have a package with a tag and
         #  you want to symbolically link it from its untagged name.
         os.mkdir(self.tagged)
-        self.addCleanup(test.support.rmtree, self.tagged)
+        self.addCleanup(os_helper.rmtree, self.tagged)
         init_file = os.path.join(self.tagged, '__init__.py')
-        test.support.create_empty_file(init_file)
+        os_helper.create_empty_file(init_file)
         assert os.path.exists(init_file)
 
         # now create a symlink to the tagged package
         # sample -> sample-tagged
         os.symlink(self.tagged, self.package_name, target_is_directory=True)
-        self.addCleanup(test.support.unlink, self.package_name)
+        self.addCleanup(os_helper.unlink, self.package_name)
         importlib.invalidate_caches()
 
         self.assertEqual(os.path.isdir(self.package_name), True)
@@ -1027,7 +1028,7 @@ class TestSymbolicallyLinkedPackage(unittest.TestCase):
         not hasattr(sys, 'getwindowsversion')
         or sys.getwindowsversion() >= (6, 0),
         "Windows Vista or later required")
-    @test.support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_symlinked_dir_importable(self):
         # make sure sample can only be imported from the current directory.
         sys.path[:] = ['.']

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -1,4 +1,5 @@
-from test.support import verbose, is_android, check_warnings
+from test.support import verbose, is_android
+from test.support.warnings_helper import check_warnings
 import unittest
 import locale
 import sys

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -9,6 +9,7 @@ import re
 import io
 import tempfile
 from test import support
+from test.support import os_helper
 import unittest
 import textwrap
 import mailbox
@@ -38,9 +39,9 @@ class TestBase:
     def _delete_recursively(self, target):
         # Delete a file or delete a directory recursively
         if os.path.isdir(target):
-            support.rmtree(target)
+            os_helper.rmtree(target)
         elif os.path.exists(target):
-            support.unlink(target)
+            os_helper.unlink(target)
 
 
 class TestMailbox(TestBase):
@@ -51,7 +52,7 @@ class TestMailbox(TestBase):
     _template = 'From: foo\n\n%s\n'
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = os_helper.TESTFN
         self._delete_recursively(self._path)
         self._box = self._factory(self._path)
 
@@ -926,7 +927,7 @@ class TestMaildir(TestMailbox, unittest.TestCase):
         # the mtime and should cause a re-read. Note that "sleep
         # emulation" is still in effect, as skewfactor is -3.
         filename = os.path.join(self._path, 'cur', 'stray-file')
-        support.create_empty_file(filename)
+        os_helper.create_empty_file(filename)
         os.unlink(filename)
         self._box._refresh()
         self.assertTrue(refreshed())
@@ -980,7 +981,7 @@ class _TestMboxMMDF(_TestSingleFile):
         self._box.close()
         self._delete_recursively(self._path)
         for lock_remnant in glob.glob(glob.escape(self._path) + '.*'):
-            support.unlink(lock_remnant)
+            os_helper.unlink(lock_remnant)
 
     def assertMailboxEmpty(self):
         with open(self._path) as f:
@@ -1312,7 +1313,7 @@ class TestBabyl(_TestSingleFile, unittest.TestCase):
         self._box.close()
         self._delete_recursively(self._path)
         for lock_remnant in glob.glob(glob.escape(self._path) + '.*'):
-            support.unlink(lock_remnant)
+            os_helper.unlink(lock_remnant)
 
     def test_labels(self):
         # Get labels from the mailbox
@@ -1369,7 +1370,7 @@ class TestMessage(TestBase, unittest.TestCase):
     _factory = mailbox.Message      # Overridden by subclasses to reuse tests
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = os_helper.TESTFN
 
     def tearDown(self):
         self._delete_recursively(self._path)
@@ -2019,7 +2020,7 @@ class TestProxyFileBase(TestBase):
 class TestProxyFile(TestProxyFileBase, unittest.TestCase):
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = os_helper.TESTFN
         self._file = open(self._path, 'wb+')
 
     def tearDown(self):
@@ -2068,7 +2069,7 @@ class TestProxyFile(TestProxyFileBase, unittest.TestCase):
 class TestPartialFile(TestProxyFileBase, unittest.TestCase):
 
     def setUp(self):
-        self._path = support.TESTFN
+        self._path = os_helper.TESTFN
         self._file = open(self._path, 'wb+')
 
     def tearDown(self):
@@ -2131,11 +2132,11 @@ class MaildirTestCase(unittest.TestCase):
 
     def setUp(self):
         # create a new maildir mailbox to work with:
-        self._dir = support.TESTFN
+        self._dir = os_helper.TESTFN
         if os.path.isdir(self._dir):
-            support.rmtree(self._dir)
+            os_helper.rmtree(self._dir)
         elif os.path.isfile(self._dir):
-            support.unlink(self._dir)
+            os_helper.unlink(self._dir)
         os.mkdir(self._dir)
         os.mkdir(os.path.join(self._dir, "cur"))
         os.mkdir(os.path.join(self._dir, "tmp"))
@@ -2145,10 +2146,10 @@ class MaildirTestCase(unittest.TestCase):
 
     def tearDown(self):
         list(map(os.unlink, self._msgfiles))
-        support.rmdir(os.path.join(self._dir, "cur"))
-        support.rmdir(os.path.join(self._dir, "tmp"))
-        support.rmdir(os.path.join(self._dir, "new"))
-        support.rmdir(self._dir)
+        os_helper.rmdir(os.path.join(self._dir, "cur"))
+        os_helper.rmdir(os.path.join(self._dir, "tmp"))
+        os_helper.rmdir(os.path.join(self._dir, "new"))
+        os_helper.rmdir(self._dir)
 
     def createMessage(self, dir, mbox=False):
         t = int(time.time() % 1000000)
@@ -2174,7 +2175,7 @@ class MaildirTestCase(unittest.TestCase):
         """Test an empty maildir mailbox"""
         # Test for regression on bug #117490:
         # Make sure the boxes attribute actually gets set.
-        self.mbox = mailbox.Maildir(support.TESTFN)
+        self.mbox = mailbox.Maildir(os_helper.TESTFN)
         #self.assertTrue(hasattr(self.mbox, "boxes"))
         #self.assertEqual(len(self.mbox.boxes), 0)
         self.assertIsNone(self.mbox.next())
@@ -2182,7 +2183,7 @@ class MaildirTestCase(unittest.TestCase):
 
     def test_nonempty_maildir_cur(self):
         self.createMessage("cur")
-        self.mbox = mailbox.Maildir(support.TESTFN)
+        self.mbox = mailbox.Maildir(os_helper.TESTFN)
         #self.assertEqual(len(self.mbox.boxes), 1)
         self.assertIsNotNone(self.mbox.next())
         self.assertIsNone(self.mbox.next())
@@ -2190,7 +2191,7 @@ class MaildirTestCase(unittest.TestCase):
 
     def test_nonempty_maildir_new(self):
         self.createMessage("new")
-        self.mbox = mailbox.Maildir(support.TESTFN)
+        self.mbox = mailbox.Maildir(os_helper.TESTFN)
         #self.assertEqual(len(self.mbox.boxes), 1)
         self.assertIsNotNone(self.mbox.next())
         self.assertIsNone(self.mbox.next())
@@ -2199,7 +2200,7 @@ class MaildirTestCase(unittest.TestCase):
     def test_nonempty_maildir_both(self):
         self.createMessage("cur")
         self.createMessage("new")
-        self.mbox = mailbox.Maildir(support.TESTFN)
+        self.mbox = mailbox.Maildir(os_helper.TESTFN)
         #self.assertEqual(len(self.mbox.boxes), 2)
         self.assertIsNotNone(self.mbox.next())
         self.assertIsNotNone(self.mbox.next())

--- a/Lib/test/test_multiprocessing_main_handling.py
+++ b/Lib/test/test_multiprocessing_main_handling.py
@@ -1,7 +1,8 @@
 # tests __main__ module handling in multiprocessing
 from test import support
+from test.support import import_helper
 # Skip tests if _multiprocessing wasn't built.
-support.import_module('_multiprocessing')
+import_helper.import_module('_multiprocessing')
 
 import importlib
 import importlib.machinery
@@ -11,6 +12,7 @@ import os
 import os.path
 import py_compile
 
+from test.support import os_helper
 from test.support.script_helper import (
     make_pkg, make_script, make_zip_pkg, make_zip_script,
     assert_python_ok)
@@ -167,12 +169,12 @@ class MultiProcessingCmdLineMixin():
         self._check_output(script_name, rc, out, err)
 
     def test_basic_script(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
             self._check_script(script_name)
 
     def test_basic_script_no_suffix(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script',
                                             omit_suffix=True)
             self._check_script(script_name)
@@ -183,7 +185,7 @@ class MultiProcessingCmdLineMixin():
         # a workaround for that case
         # See https://github.com/ipython/ipython/issues/4698
         source = test_source_main_skipped_in_children
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'ipython',
                                             source=source)
             self._check_script(script_name)
@@ -193,33 +195,33 @@ class MultiProcessingCmdLineMixin():
             self._check_script(script_no_suffix)
 
     def test_script_compiled(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(pyc_file)
 
     def test_directory(self):
         source = self.main_in_children_source
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__',
                                             source=source)
             self._check_script(script_dir)
 
     def test_directory_compiled(self):
         source = self.main_in_children_source
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__',
                                             source=source)
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(script_dir)
 
     def test_zipfile(self):
         source = self.main_in_children_source
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__',
                                             source=source)
             zip_name, run_name = make_zip_script(script_dir, 'test_zip', script_name)
@@ -227,7 +229,7 @@ class MultiProcessingCmdLineMixin():
 
     def test_zipfile_compiled(self):
         source = self.main_in_children_source
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__',
                                             source=source)
             compiled_name = py_compile.compile(script_name, doraise=True)
@@ -235,7 +237,7 @@ class MultiProcessingCmdLineMixin():
             self._check_script(zip_name)
 
     def test_module_in_package(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, 'check_sibling')
@@ -244,20 +246,20 @@ class MultiProcessingCmdLineMixin():
             self._check_script(launch_name)
 
     def test_module_in_package_in_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script')
             launch_name = _make_launch_script(script_dir, 'launch', 'test_pkg.script', zip_name)
             self._check_script(launch_name)
 
     def test_module_in_subpackage_in_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script', depth=2)
             launch_name = _make_launch_script(script_dir, 'launch', 'test_pkg.test_pkg.script', zip_name)
             self._check_script(launch_name)
 
     def test_package(self):
         source = self.main_in_children_source
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, '__main__',
@@ -267,14 +269,14 @@ class MultiProcessingCmdLineMixin():
 
     def test_package_compiled(self):
         source = self.main_in_children_source
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, '__main__',
                                             source=source)
             compiled_name = py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             launch_name = _make_launch_script(script_dir, 'launch', 'test_pkg')
             self._check_script(launch_name)
 

--- a/Lib/test/test_osx_env.py
+++ b/Lib/test/test_osx_env.py
@@ -2,7 +2,7 @@
 Test suite for OS X interpreter environment variables.
 """
 
-from test.support import EnvironmentVarGuard
+from test.support.os_helper import EnvironmentVarGuard
 import subprocess
 import sys
 import sysconfig

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -1,4 +1,6 @@
-from test.support import run_unittest, unload, check_warnings, CleanImport
+from test.support import run_unittest
+from test.support.import_helper import unload, CleanImport
+from test.support.warnings_helper import check_warnings
 import unittest
 import sys
 import importlib

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -10,6 +10,7 @@ import codecs
 import binascii
 import collections
 from test import support
+from test.support import os_helper
 from io import BytesIO
 
 from plistlib import UID
@@ -110,7 +111,7 @@ class TestPlistlib(unittest.TestCase):
 
     def tearDown(self):
         try:
-            os.unlink(support.TESTFN)
+            os.unlink(os_helper.TESTFN)
         except:
             pass
 
@@ -148,10 +149,10 @@ class TestPlistlib(unittest.TestCase):
 
     def test_io(self):
         pl = self._create()
-        with open(support.TESTFN, 'wb') as fp:
+        with open(os_helper.TESTFN, 'wb') as fp:
             plistlib.dump(pl, fp)
 
-        with open(support.TESTFN, 'rb') as fp:
+        with open(os_helper.TESTFN, 'rb') as fp:
             pl2 = plistlib.load(fp)
 
         self.assertEqual(dict(pl), dict(pl2))

--- a/Lib/test/test_ttk_guionly.py
+++ b/Lib/test/test_ttk_guionly.py
@@ -1,8 +1,9 @@
 import unittest
 from test import support
+from test.support import import_helper
 
 # Skip this test if _tkinter wasn't built.
-support.import_module('_tkinter')
+import_helper.import_module('_tkinter')
 
 # Skip test if tk cannot be initialized.
 support.requires('gui')

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -1,8 +1,10 @@
 import pickle
 import unittest
 from test import support
+from test.support import import_helper
 
-turtle = support.import_module('turtle')
+
+turtle = import_helper.import_module('turtle')
 Vec2D = turtle.Vec2D
 
 test_config = """\

--- a/Lib/test/test_xxtestfuzz.py
+++ b/Lib/test/test_xxtestfuzz.py
@@ -1,8 +1,8 @@
 import faulthandler
-import test.support
+from test.support import import_helper
 import unittest
 
-_xxtestfuzz = test.support.import_module('_xxtestfuzz')
+_xxtestfuzz = import_helper.import_module('_xxtestfuzz')
 
 
 class TestFuzzer(unittest.TestCase):

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -9,6 +9,8 @@ import unittest
 import unittest.mock
 
 from test import support
+from test.support import import_helper
+from test.support import os_helper
 
 from zipfile import ZipFile, ZipInfo, ZIP_STORED, ZIP_DEFLATED
 
@@ -68,14 +70,14 @@ class ImportHooksBaseTestCase(unittest.TestCase):
         self.meta_path = sys.meta_path[:]
         self.path_hooks = sys.path_hooks[:]
         sys.path_importer_cache.clear()
-        self.modules_before = support.modules_setup()
+        self.modules_before = import_helper.modules_setup()
 
     def tearDown(self):
         sys.path[:] = self.path
         sys.meta_path[:] = self.meta_path
         sys.path_hooks[:] = self.path_hooks
         sys.path_importer_cache.clear()
-        support.modules_cleanup(*self.modules_before)
+        import_helper.modules_cleanup(*self.modules_before)
 
 
 class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
@@ -92,7 +94,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
     def makeTree(self, files, dirName=TEMP_DIR):
         # Create a filesystem based set of modules/packages
         # defined by files under the directory dirName.
-        self.addCleanup(support.rmtree, dirName)
+        self.addCleanup(os_helper.rmtree, dirName)
 
         for name, (mtime, data) in files.items():
             path = os.path.join(dirName, name)
@@ -110,7 +112,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         # Create a zip archive based set of modules/packages
         # defined by files in the zip file zipName.  If the
         # key 'stuff' exists in kw it is prepended to the archive.
-        self.addCleanup(support.unlink, zipName)
+        self.addCleanup(os_helper.unlink, zipName)
 
         with ZipFile(zipName, "w") as z:
             for name, (mtime, data) in files.items():
@@ -438,7 +440,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc),
                  "spam" + pyc_ext: (NOW, test_pyc)}
 
-        self.addCleanup(support.unlink, TEMP_ZIP)
+        self.addCleanup(os_helper.unlink, TEMP_ZIP)
         with ZipFile(TEMP_ZIP, "w") as z:
             for name, (mtime, data) in files.items():
                 zinfo = ZipInfo(name, time.localtime(mtime))
@@ -492,7 +494,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         files = {packdir2 + "__init__" + pyc_ext: (NOW, test_pyc),
                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
 
-        self.addCleanup(support.unlink, TEMP_ZIP)
+        self.addCleanup(os_helper.unlink, TEMP_ZIP)
         with ZipFile(TEMP_ZIP, "w") as z:
             for name, (mtime, data) in files.items():
                 zinfo = ZipInfo(name, time.localtime(mtime))
@@ -536,7 +538,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         self.assertEqual(loader.get_filename(mod_name), mod.__file__)
 
     def testGetData(self):
-        self.addCleanup(support.unlink, TEMP_ZIP)
+        self.addCleanup(os_helper.unlink, TEMP_ZIP)
         with ZipFile(TEMP_ZIP, "w") as z:
             z.compression = self.compression
             name = "testdata.dat"
@@ -644,11 +646,11 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         files = {TESTMOD + ".py": (NOW, raise_src)}
         self.doTest(None, files, TESTMOD, call=self.doTraceback)
 
-    @unittest.skipIf(support.TESTFN_UNENCODABLE is None,
+    @unittest.skipIf(os_helper.TESTFN_UNENCODABLE is None,
                      "need an unencodable filename")
     def testUnencodable(self):
-        filename = support.TESTFN_UNENCODABLE + ".zip"
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN_UNENCODABLE + ".zip"
+        self.addCleanup(os_helper.unlink, filename)
         with ZipFile(filename, "w") as z:
             zinfo = ZipInfo(TESTMOD + ".py", time.localtime(NOW))
             zinfo.compress_type = self.compression
@@ -656,8 +658,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         zipimport.zipimporter(filename).load_module(TESTMOD)
 
     def testBytesPath(self):
-        filename = support.TESTFN + ".zip"
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN + ".zip"
+        self.addCleanup(os_helper.unlink, filename)
         with ZipFile(filename, "w") as z:
             zinfo = ZipInfo(TESTMOD + ".py", time.localtime(NOW))
             zinfo.compress_type = self.compression
@@ -709,12 +711,12 @@ class BadFileZipImportTestCase(unittest.TestCase):
         self.assertZipFailure('A' * 33000)
 
     def testEmptyFile(self):
-        support.unlink(TESTMOD)
-        support.create_empty_file(TESTMOD)
+        os_helper.unlink(TESTMOD)
+        os_helper.create_empty_file(TESTMOD)
         self.assertZipFailure(TESTMOD)
 
     def testFileUnreadable(self):
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
         fd = os.open(TESTMOD, os.O_CREAT, 000)
         try:
             os.close(fd)
@@ -725,10 +727,10 @@ class BadFileZipImportTestCase(unittest.TestCase):
             # If we leave "the read-only bit" set on Windows, nothing can
             # delete TESTMOD, and later tests suffer bogus failures.
             os.chmod(TESTMOD, 0o666)
-            support.unlink(TESTMOD)
+            os_helper.unlink(TESTMOD)
 
     def testNotZipFile(self):
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
         fp = open(TESTMOD, 'w+')
         fp.write('a' * 22)
         fp.close()
@@ -736,7 +738,7 @@ class BadFileZipImportTestCase(unittest.TestCase):
 
     # XXX: disabled until this works on Big-endian machines
     def _testBogusZipFile(self):
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
         fp = open(TESTMOD, 'w+')
         fp.write(struct.pack('=I', 0x06054B50))
         fp.write('a' * 18)
@@ -771,7 +773,7 @@ def test_main():
               BadFileZipImportTestCase,
             )
     finally:
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
 
 if __name__ == "__main__":
     test_main()


### PR DESCRIPTION
Use test helpers in the following test cases:
* test_cmd_line_script
* test_codeop
* test_contextlib
* test_dbm_ndbm
* test_getargs2
* test_gettext
* test_glob
* test_import
* test_locale
* test_mailbox
* test_multiprocessing_main_handling
* test_osx_env
* test_pkgutil
* test_plistlib
* test_ttk_guionly
* test_turtle
* test_xxtestfuzz
* test_zipimport


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
