### PR TITLE
bpo-41199: Docstring convention not followed for dataclasses documentation page

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -23,7 +23,7 @@ using :pep:`526` type annotations.  For example this code::
 
   @dataclass
   class InventoryItem:
-      '''Class for keeping track of an item in inventory.'''
+      """Class for keeping track of an item in inventory."""
       name: str
       unit_price: float
       quantity_on_hand: int = 0

--- a/Misc/NEWS.d/next/Documentation/2020-07-09-11-23-08.bpo-41199.zNMAnZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-09-11-23-08.bpo-41199.zNMAnZ.rst
@@ -1,1 +1,0 @@
-Change single quotes to double quotes in accordance with PEP-257.

--- a/Misc/NEWS.d/next/Documentation/2020-07-09-11-23-08.bpo-41199.zNMAnZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-09-11-23-08.bpo-41199.zNMAnZ.rst
@@ -1,0 +1,1 @@
+Change single quotes to double quotes in accordance with PEP-257.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41199](https://bugs.python.org/issue41199) -->
https://bugs.python.org/issue41199
<!-- /issue-number -->


Automerge-Triggered-By: @ericvsmith