### PR TITLE
Fix error in docstrings in bisect module

### DIFF
--- a/Lib/bisect.py
+++ b/Lib/bisect.py
@@ -16,7 +16,7 @@ def bisect_right(a, x, lo=0, hi=None):
     """Return the index where to insert item x in list a, assuming a is sorted.
 
     The return value i is such that all e in a[:i] have e <= x, and all e in
-    a[i:] have e > x.  So if x already appears in the list, a.insert(x) will
+    a[i:] have e > x.  So if x already appears in the list, a.insert(i, x) will
     insert just after the rightmost x already there.
 
     Optional args lo (default 0) and hi (default len(a)) bound the
@@ -51,7 +51,7 @@ def bisect_left(a, x, lo=0, hi=None):
     """Return the index where to insert item x in list a, assuming a is sorted.
 
     The return value i is such that all e in a[:i] have e < x, and all e in
-    a[i:] have e >= x.  So if x already appears in the list, a.insert(x) will
+    a[i:] have e >= x.  So if x already appears in the list, a.insert(i, x) will
     insert just before the leftmost x already there.
 
     Optional args lo (default 0) and hi (default len(a)) bound the


### PR DESCRIPTION
The docstrings for `bisect_right()` and `bisect_left()` contain sample code that has a bug: `a.insert(x)` should be `a.insert(i, x)`.

Not creating/citing an issue as this is minor.