### PR TITLE
gh-83074: Ignore EACCES, ENOSYS in copyxattr

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -317,7 +317,8 @@ if hasattr(os, 'listxattr'):
         try:
             names = os.listxattr(src, follow_symlinks=follow_symlinks)
         except OSError as e:
-            if e.errno not in (errno.ENOTSUP, errno.ENODATA, errno.EINVAL):
+            if e.errno not in (errno.ENOTSUP, errno.ENODATA, errno.EINVAL,
+                               errno.ENOSYS):
                 raise
             return
         for name in names:
@@ -325,8 +326,8 @@ if hasattr(os, 'listxattr'):
                 value = os.getxattr(src, name, follow_symlinks=follow_symlinks)
                 os.setxattr(dst, name, value, follow_symlinks=follow_symlinks)
             except OSError as e:
-                if e.errno not in (errno.EPERM, errno.ENOTSUP, errno.ENODATA,
-                                   errno.EINVAL):
+                if e.errno not in (errno.EPERM, errno.EACCES, errno.ENOTSUP,
+                                   errno.ENODATA, errno.EINVAL):
                     raise
 else:
     def _copyxattr(*args, **kwargs):

--- a/Misc/NEWS.d/next/Library/2020-07-10-11-01-44.bpo-38893.HNE1L4.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-10-11-01-44.bpo-38893.HNE1L4.rst
@@ -1,0 +1,5 @@
+:func:`shutil.copystat` now ignores :const:`errno.ENOSYS` and
+:const:`errno.EACCES` when copying extended file attributes.
+:func:`os.listxattr` can fail with ENOSYS on some file systems (e.g. NFS).
+An LSM may block :func:`os.setxattr` for security attributes like
+``security.selinux``.


### PR DESCRIPTION
:func:`shutil.copystat` now ignores :const:`errno.ENOSYS` and
:const:`errno.EACCES` when copying extended file attributes.
:func:`os.listxattr` can fail with ENOSYS on some file systems (e.g. NFS).
An LSM may block :func:`os.setxattr` for security attributes like
``security.selinux``.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38893](https://bugs.python.org/issue38893) -->
https://bugs.python.org/issue38893
<!-- /issue-number -->


<!-- gh-issue-number: gh-83074 -->
* Issue: gh-83074
<!-- /gh-issue-number -->
