### PR TITLE
Add the Spanish translation to language switch

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -21,6 +21,7 @@
 
   var all_languages = {
       'en': 'English',
+      'es': 'Spanish',
       'fr': 'French',
       'ja': 'Japanese',
       'ko': 'Korean',


### PR DESCRIPTION
Spanish language switcher for Python documentation.

> Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.
> Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

@JulienPalard Should I create an issue under bpo for this change?

Related to https://github.com/python/docsbuild-scripts/pull/93