### PR TITLE
gh-85308: Add a parameter to argparse.ArgumentParser for file encoding

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -142,7 +142,8 @@ ArgumentParser objects
                           formatter_class=argparse.HelpFormatter, \
                           prefix_chars='-', fromfile_prefix_chars=None, \
                           argument_default=None, conflict_handler='error', \
-                          add_help=True, allow_abbrev=True, exit_on_error=True)
+                          add_help=True, allow_abbrev=True, \
+                          exit_on_error=True, fromfile_encoding=None)
 
    Create a new :class:`ArgumentParser` object. All parameters should be passed
    as keyword arguments. Each parameter has its own more detailed description
@@ -182,6 +183,9 @@ ArgumentParser objects
    * exit_on_error_ - Determines whether or not ArgumentParser exits with
      error info when an error occurs. (default: ``True``)
 
+   * fromfile_encoding_ - The encoding to use when reading files specified by
+     fromfile_prefix_chars_. (default: the system's default encoding)
+
    .. versionchanged:: 3.5
       *allow_abbrev* parameter was added.
 
@@ -191,6 +195,9 @@ ArgumentParser objects
 
    .. versionchanged:: 3.9
       *exit_on_error* parameter was added.
+
+   .. versionchanged:: 3.10
+      *fromfile_encoding* parameter was added.
 
 The following sections describe how each of these are used.
 
@@ -673,6 +680,16 @@ If the user would like catch errors manually, the feature can be enable by setti
    Catching an argumentError
 
 .. versionadded:: 3.9
+
+
+fromfile_encoding
+^^^^^^^^^^^^^^^^^
+
+The ``fromfile_encoding=`` argument specifies the encoding to use when
+reading files designated by fromfile_prefix_chars_.  By default,
+:class:`ArgumentParser` objects use the system's default encoding.
+
+.. versionadded:: 3.10
 
 
 The add_argument() method

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1681,6 +1681,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         - allow_abbrev -- Allow long options to be abbreviated unambiguously
         - exit_on_error -- Determines whether or not ArgumentParser exits with
             error info when an error occurs
+        - fromfile_encoding -- The encoding to use when reading files
+            specified by fromfile_prefix_chars
     """
 
     def __init__(self,
@@ -1696,7 +1698,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                  conflict_handler='error',
                  add_help=True,
                  allow_abbrev=True,
-                 exit_on_error=True):
+                 exit_on_error=True,
+                 fromfile_encoding=None):
 
         superinit = super(ArgumentParser, self).__init__
         superinit(description=description,
@@ -1716,6 +1719,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         self.add_help = add_help
         self.allow_abbrev = allow_abbrev
         self.exit_on_error = exit_on_error
+        self.fromfile_encoding = fromfile_encoding
 
         add_group = self.add_argument_group
         self._positionals = add_group(_('positional arguments'))
@@ -2118,7 +2122,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             # replace arguments referencing files with the file content
             else:
                 try:
-                    with open(arg_string[1:]) as args_file:
+                    with open(arg_string[1:], encoding=self.fromfile_encoding) \
+                            as args_file:
                         arg_strings = []
                         for arg_line in args_file.read().splitlines():
                             for arg in self.convert_arg_line_to_args(arg_line):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1488,6 +1488,21 @@ class TestArgumentsFromFile(TempDirMixin, ParserTestCase):
     ]
 
 
+class TestArgumentsFromFileEncoding(TempDirMixin, ParserTestCase):
+    """Test reading arguments from a file with fromfile_encoding"""
+
+    def setUp(self):
+        super().setUp()
+        with open('hello', 'w', encoding='utf-8') as f:
+            f.write('spœm\n')
+
+    parser_signature = Sig(fromfile_encoding='utf-8',
+                           fromfile_prefix_chars='@')
+    argument_signatures = [Sig('y')]
+    failures = []
+    successes = [('@hello', NS(y='spœm'))]
+
+
 class TestArgumentsFromFileConverter(TempDirMixin, ParserTestCase):
     """Test reading arguments from a file"""
 

--- a/Misc/NEWS.d/next/Library/2020-07-11-06-06-04.bpo-41136.r07yP2.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-11-06-06-04.bpo-41136.r07yP2.rst
@@ -1,0 +1,2 @@
+Add a ``fromfile_encoding`` parameter to :class:`argparse.ArgumentParser` to
+specify the file encoding when using the ``fromfile_prefix_chars`` option.


### PR DESCRIPTION
Add a parameter to argparse.ArgumentParser to specify the file
encoding when using the fromfile_prefix_chars option.


<!-- issue-number: [bpo-41136](https://bugs.python.org/issue41136) -->
https://bugs.python.org/issue41136
<!-- /issue-number -->


<!-- gh-issue-number: gh-85308 -->
* Issue: gh-85308
<!-- /gh-issue-number -->
