### PR TITLE
gh-85451: Add StreamReaderBufferedProtocol

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -180,11 +180,16 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
 
     def __init__(self, loop, sock, protocol, waiter=None,
                  extra=None, server=None, buffer_size=65536):
-        self._pending_data_length = -1
         self._paused = True
         super().__init__(loop, sock, protocol, waiter, extra, server)
 
-        self._data = bytearray(buffer_size)
+        if isinstance(protocol, protocols.BufferedProtocol):
+            self._data = protocol.get_buffer(-1)
+            self._pending_data_length = -1
+        else:
+            self._buffer_size = buffer_size
+            self._pending_data = None
+
         self._loop.call_soon(self._loop_reading)
         self._paused = False
 
@@ -218,12 +223,20 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
         if self._read_fut is None:
             self._loop.call_soon(self._loop_reading, None)
 
-        length = self._pending_data_length
-        self._pending_data_length = -1
-        if length > -1:
-            # Call the protocol method after calling _loop_reading(),
-            # since the protocol can decide to pause reading again.
-            self._loop.call_soon(self._data_received, self._data[:length], length)
+        if isinstance(self._protocol, protocols.BufferedProtocol):
+            length = self._pending_data_length
+            self._pending_data_length = -1
+            if length > -1:
+                # Call the protocol method after calling _loop_reading(),
+                # since the protocol can decide to pause reading again.
+                self._loop.call_soon(self._buffer_updated, length)
+        else:
+            data = self._pending_data
+            self._pending_data = None
+            if data is not None:
+                # Call the protocol method after calling _loop_reading(),
+                # since the protocol can decide to pause reading again.
+                self._loop.call_soon(self._data_received, data)
 
         if self._loop.get_debug():
             logger.debug("%r resumes reading", self)
@@ -244,7 +257,7 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
         if not keep_open:
             self.close()
 
-    def _data_received(self, data, length):
+    def _buffer_updated(self, length):
         if self._paused:
             # Don't call any protocol method while reading is paused.
             # The protocol will be called on resume_reading().
@@ -256,35 +269,47 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
             self._eof_received()
             return
 
-        if isinstance(self._protocol, protocols.BufferedProtocol):
-            try:
-                protocols._feed_data_to_buffered_proto(self._protocol, data)
-            except (SystemExit, KeyboardInterrupt):
-                raise
-            except BaseException as exc:
-                self._fatal_error(exc,
-                                  'Fatal error: protocol.buffer_updated() '
-                                  'call failed.')
-                return
-        else:
-            self._protocol.data_received(data)
+        try:
+            self._protocol.buffer_updated(length)
+        except BaseException as exc:
+            self._fatal_error(exc,
+                              'Fatal error: protocol.buffer_updated() '
+                              'call failed.')
+
+    def _data_received(self, data):
+        if self._paused:
+            # Don't call any protocol method while reading is paused.
+            # The protocol will be called on resume_reading().
+            assert self._pending_data is None
+            self._pending_data = data
+            return
+
+        if not data:
+            self._eof_received()
+            return
+
+        self._protocol.data_received(data)
 
     def _loop_reading(self, fut=None):
-        length = -1
-        data = None
         try:
             if fut is not None:
                 assert self._read_fut is fut or (self._read_fut is None and
                                                  self._closing)
                 self._read_fut = None
                 if fut.done():
-                    # deliver data later in "finally" clause
-                    length = fut.result()
-                    if length == 0:
-                        # we got end-of-file so no need to reschedule a new read
-                        return
-
-                    data = self._data[:length]
+                    if isinstance(self._protocol, protocols.BufferedProtocol):
+                        length = fut.result()
+                        if length > -1:
+                            self._buffer_updated(length)
+                            if length == 0:
+                                # we got end-of-file so no need to reschedule a new read
+                                return
+                    else:
+                        data = fut.result()
+                        self._data_received(data)
+                        if not data:
+                            # we got end-of-file so no need to reschedule a new read
+                            return
                 else:
                     # the future will be replaced by next proactor.recv call
                     fut.cancel()
@@ -298,7 +323,12 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
 
             if not self._paused:
                 # reschedule a new read
-                self._read_fut = self._loop._proactor.recv_into(self._sock, self._data)
+                if isinstance(self._protocol, protocols.BufferedProtocol):
+                    self._read_fut = self._loop._proactor.recv_into(
+                        self._sock, self._data)
+                else:
+                    self._read_fut = self._loop._proactor.recv(
+                        self._sock, self._buffer_size)
         except ConnectionAbortedError as exc:
             if not self._closing:
                 self._fatal_error(exc, 'Fatal read error on pipe transport')
@@ -315,9 +345,6 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
         else:
             if not self._paused:
                 self._read_fut.add_done_callback(self._loop_reading)
-        finally:
-            if length > -1:
-                self._data_received(data, length)
 
 
 class _ProactorBaseWritePipeTransport(_ProactorBasePipeTransport,

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -315,6 +315,25 @@ def make_test_protocol(base):
     return type('TestProtocol', (base,) + base.__bases__, dct)()
 
 
+def make_test_buffered_protocol(base, buffer_size):
+    protocol = make_test_protocol(base)
+    protocol._buffer = bytearray(buffer_size)
+    protocol._last_called_buffer = None
+
+    def get_buffer(*_, **__):
+        return protocol._buffer
+
+    def buffer_updated(nbytes):
+        protocol.buffer_updated.called = True
+        protocol._last_called_buffer = protocol._buffer[:nbytes]
+
+    protocol.get_buffer = get_buffer
+
+    protocol.buffer_updated = buffer_updated
+    protocol.buffer_updated.called = False
+    return protocol
+
+
 class TestSelector(selectors.BaseSelector):
 
     def __init__(self):

--- a/Misc/NEWS.d/next/Library/2020-07-11-20-15-29.bpo-41279.M4OEou.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-11-20-15-29.bpo-41279.M4OEou.rst
@@ -1,0 +1,1 @@
+Add ``StreamReaderBufferedProtocol``.

--- a/Misc/NEWS.d/next/Library/2020-07-11-20-16-56.bpo-41279.PYW8U8.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-11-20-16-56.bpo-41279.PYW8U8.rst
@@ -1,0 +1,1 @@
+Add ``BufferedProtocol`` support to ``_UnixReadPipeTransport``.

--- a/Misc/NEWS.d/next/Library/2020-07-14-23-35-08.bpo-41279.Beuyjq.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-14-23-35-08.bpo-41279.Beuyjq.rst
@@ -1,0 +1,3 @@
+Call ``protocol.get_buffer`` on the protocol given to
+``_ProactorReadPipeTransport`` if the protocol is of instance
+``BufferedProtocol`` instead of creating a new buffer.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41279](https://bugs.python.org/issue41279) -->
https://bugs.python.org/issue41279
<!-- /issue-number -->

I got way better performance on ``await reader.read()`` using this branch on linux (check out the chart on the ``server.py`` script's comments).

The way I tested was writing a server / client:
``server.py``:

```python
import asyncio
import contextlib
import time


async def client_connected(reader, writer):
    start = time.time()

    with contextlib.closing(writer):
        for i in range(1000):
            # the more this parameter's distance from 65536 is greater the better the performance global_buffer gives
            # On linux:
            # 65536 * 2 -> Gives about 160% better performance
            # 4096 -> Gives about 155% better performance
            # 65536 -> Gives about 125% better performance

            # On windows using 65536 gives the same performance for some reason, which is interesting
            # But any other value gives a bit better performance, for example 65536 * 2 gives about 120% better performance
            await reader.read(65536 * 2)

    print(f'{time.time() - start}')


async def main():
    server = await asyncio.start_server(client_connected, '127.0.0.1', 8888, global_buffer=True)

    addr = server.sockets[0].getsockname()
    print(f'Serving on {addr}')

    async with server:
        await server.serve_forever()


if __name__ == "__main__":
    asyncio.run(main())
```

``client.py``:
```python
import asyncio
import contextlib


async def flood(ip, port):
    message = b'A' * 1024 * 64  # tweak this parameter as much as you want
    reader, writer = await asyncio.open_connection(ip, port)
    with contextlib.closing(writer):
        while True:
            writer.write(message)
            await writer.drain()


if __name__ == "__main__":
    asyncio.run(flood('127.0.0.1', 8888))

```

<!-- gh-issue-number: gh-85451 -->
* Issue: gh-85451
<!-- /gh-issue-number -->
