### PR TITLE
bpo-40275: Use new test.support helper submodules in tests

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -13,6 +13,7 @@ import argparse
 from io import StringIO
 
 from test import support
+from test.support import os_helper
 from unittest import mock
 class StdIOBuffer(StringIO):
     pass
@@ -23,7 +24,7 @@ class TestCase(unittest.TestCase):
         # The tests assume that line wrapping occurs at 80 columns, but this
         # behaviour can be overridden by setting the COLUMNS environment
         # variable.  To ensure that this width is used, set COLUMNS to 80.
-        env = support.EnvironmentVarGuard()
+        env = os_helper.EnvironmentVarGuard()
         env['COLUMNS'] = '80'
         self.addCleanup(env.__exit__)
 
@@ -3244,7 +3245,7 @@ class TestShortColumns(HelpTestCase):
     but we don't want any exceptions thrown in such cases. Only ugly representation.
     '''
     def setUp(self):
-        env = support.EnvironmentVarGuard()
+        env = os_helper.EnvironmentVarGuard()
         env.set("COLUMNS", '15')
         self.addCleanup(env.__exit__)
 

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -2,7 +2,7 @@ import inspect
 import types
 import unittest
 
-from test.support import import_module
+from test.support.import_helper import import_module
 asyncio = import_module("asyncio")
 
 

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -3,6 +3,7 @@
 # Licensed to the PSF under a contributor agreement.
 
 from test import support, test_tools
+from test.support import os_helper
 from unittest import TestCase
 import collections
 import inspect
@@ -797,7 +798,7 @@ class ClinicExternalTest(TestCase):
         source = support.findfile('clinic.test')
         with open(source, 'r', encoding='utf-8') as f:
             original = f.read()
-        with support.temp_dir() as testdir:
+        with os_helper.temp_dir() as testdir:
             testfile = os.path.join(testdir, 'clinic.test.c')
             with open(testfile, 'w', encoding='utf-8') as f:
                 f.write(original)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -8,6 +8,8 @@ import encodings
 from unittest import mock
 
 from test import support
+from test.support import os_helper
+from test.support import warnings_helper
 
 try:
     import _testcapi
@@ -709,11 +711,11 @@ class UTF16Test(ReadTest, unittest.TestCase):
         s1 = 'Hello\r\nworld\r\n'
 
         s = s1.encode(self.encoding)
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, 'wb') as fp:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, 'wb') as fp:
             fp.write(s)
-        with support.check_warnings(('', DeprecationWarning)):
-            reader = codecs.open(support.TESTFN, 'U', encoding=self.encoding)
+        with warnings_helper.check_warnings(('', DeprecationWarning)):
+            reader = codecs.open(os_helper.TESTFN, 'U', encoding=self.encoding)
         with reader:
             self.assertEqual(reader.read(), s1)
 
@@ -1697,10 +1699,10 @@ class CodecsModuleTest(unittest.TestCase):
             getattr(codecs, api)
 
     def test_open(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         for mode in ('w', 'r', 'r+', 'w+', 'a', 'a+'):
             with self.subTest(mode), \
-                    codecs.open(support.TESTFN, mode, 'ascii') as file:
+                    codecs.open(os_helper.TESTFN, mode, 'ascii') as file:
                 self.assertIsInstance(file, codecs.StreamReaderWriter)
 
     def test_undefined(self):
@@ -1718,7 +1720,7 @@ class CodecsModuleTest(unittest.TestCase):
         mock_open = mock.mock_open()
         with mock.patch('builtins.open', mock_open) as file:
             with self.assertRaises(LookupError):
-                codecs.open(support.TESTFN, 'wt', 'invalid-encoding')
+                codecs.open(os_helper.TESTFN, 'wt', 'invalid-encoding')
 
             file().close.assert_called()
 
@@ -2516,10 +2518,10 @@ class BomTest(unittest.TestCase):
                  "utf-32",
                  "utf-32-le",
                  "utf-32-be")
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         for encoding in tests:
             # Check if the BOM is written only once
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.write(data)
                 f.write(data)
                 f.seek(0)
@@ -2528,7 +2530,7 @@ class BomTest(unittest.TestCase):
                 self.assertEqual(f.read(), data * 2)
 
             # Check that the BOM is written after a seek(0)
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.write(data[0])
                 self.assertNotEqual(f.tell(), 0)
                 f.seek(0)
@@ -2537,7 +2539,7 @@ class BomTest(unittest.TestCase):
                 self.assertEqual(f.read(), data)
 
             # (StreamWriter) Check that the BOM is written after a seek(0)
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.writer.write(data[0])
                 self.assertNotEqual(f.writer.tell(), 0)
                 f.writer.seek(0)
@@ -2547,7 +2549,7 @@ class BomTest(unittest.TestCase):
 
             # Check that the BOM is not written after a seek() at a position
             # different than the start
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.write(data)
                 f.seek(f.tell())
                 f.write(data)
@@ -2556,7 +2558,7 @@ class BomTest(unittest.TestCase):
 
             # (StreamWriter) Check that the BOM is not written after a seek()
             # at a position different than the start
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.writer.write(data)
                 f.writer.seek(f.writer.tell())
                 f.writer.write(data)

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3,6 +3,7 @@ Test script for doctest.
 """
 
 from test import support
+from test.support import os_helper
 import doctest
 import functools
 import os
@@ -2758,7 +2759,7 @@ whitespace if doctest does not correctly do the newline conversion.
     >>> dn = tempfile.mkdtemp()
     >>> pkg = os.path.join(dn, "doctest_testpkg")
     >>> os.mkdir(pkg)
-    >>> support.create_empty_file(os.path.join(pkg, "__init__.py"))
+    >>> os_helper.create_empty_file(os.path.join(pkg, "__init__.py"))
     >>> fn = os.path.join(pkg, "doctest_testfile.txt")
     >>> with open(fn, 'wb') as f:
     ...     f.write(
@@ -2840,7 +2841,8 @@ With those preliminaries out of the way, we'll start with a file with two
 simple tests and no errors.  We'll run both the unadorned doctest command, and
 the verbose version, and then check the output:
 
-    >>> from test.support import script_helper, temp_dir
+    >>> from test.support import script_helper
+    >>> from test.support.os_helper import temp_dir
     >>> with temp_dir() as tmpdir:
     ...     fn = os.path.join(tmpdir, 'myfile.doc')
     ...     with open(fn, 'w') as f:
@@ -2891,7 +2893,8 @@ ability to process more than one file on the command line and, since the second
 file ends in '.py', its handling of python module files (as opposed to straight
 text files).
 
-    >>> from test.support import script_helper, temp_dir
+    >>> from test.support import script_helper
+    >>> from test.support.os_helper import temp_dir
     >>> with temp_dir() as tmpdir:
     ...     fn = os.path.join(tmpdir, 'myfile.doc')
     ...     with open(fn, 'w') as f:

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3,6 +3,7 @@ Test script for doctest.
 """
 
 from test import support
+from test.support import import_helper
 from test.support import os_helper
 import doctest
 import functools
@@ -442,7 +443,7 @@ We'll simulate a __file__ attr that ends in pyc:
     >>> tests = finder.find(sample_func)
 
     >>> print(tests)  # doctest: +ELLIPSIS
-    [<DocTest sample_func from ...:25 (1 example)>]
+    [<DocTest sample_func from ...:27 (1 example)>]
 
 The exact name depends on how test_doctest was invoked, so allow for
 leading path components.
@@ -706,7 +707,7 @@ class TestDocTestFinder(unittest.TestCase):
             try:
                 mod = importlib.import_module(pkg_name)
             finally:
-                support.forget(pkg_name)
+                import_helper.forget(pkg_name)
                 sys.path.pop()
 
             include_empty_finder = doctest.DocTestFinder(exclude_empty=False)
@@ -3112,7 +3113,7 @@ def test_main():
 
 
 def test_coverage(coverdir):
-    trace = support.import_module('trace')
+    trace = import_helper.import_module('trace')
     tracer = trace.Trace(ignoredirs=[sys.base_prefix, sys.base_exec_prefix,],
                          trace=0, count=1)
     tracer.run('test_main()')

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -8,10 +8,13 @@ import pickle
 import weakref
 import errno
 
-from test.support import (TESTFN, captured_stderr, check_impl_detail,
-                          check_warnings, cpython_only, gc_collect,
-                          no_tracing, unlink, import_module, script_helper,
+from test.support import (captured_stderr, check_impl_detail,
+                          cpython_only, gc_collect,
+                          no_tracing, script_helper,
                           SuppressCrashReport)
+from test.support.import_helper import import_module
+from test.support.os_helper import TESTFN, unlink
+from test.support.warnings_helper import check_warnings
 from test import support
 
 

--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -21,6 +21,7 @@ from unittest import TestCase, skipUnless
 from test import support
 from test.support import threading_helper
 from test.support import socket_helper
+from test.support import warnings_helper
 from test.support.socket_helper import HOST, HOSTv6
 
 TIMEOUT = support.LOOPBACK_TIMEOUT
@@ -623,7 +624,7 @@ class TestFTPClass(TestCase):
 
         f = io.StringIO(RETR_DATA.replace('\r\n', '\n'))
         # storlines() expects a binary file, not a text file
-        with support.check_warnings(('', BytesWarning), quiet=True):
+        with warnings_helper.check_warnings(('', BytesWarning), quiet=True):
             self.assertRaises(TypeError, self.client.storlines, 'stor foo', f)
 
     def test_nlst(self):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1,8 +1,9 @@
 import unittest
 import unittest.mock
 from test.support import (verbose, refcount_test, run_unittest,
-                          cpython_only, temp_dir, TESTFN, unlink,
-                          import_module)
+                          cpython_only)
+from test.support.import_helper import import_module
+from test.support.os_helper import temp_dir, TESTFN, unlink
 from test.support.script_helper import assert_python_ok, make_script
 from test.support import threading_helper
 

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -7,9 +7,10 @@ import os
 import sys
 import unittest
 import warnings
-from test import support
+from test.support import os_helper
+from test.support import warnings_helper
 from test.support.script_helper import assert_python_ok
-from test.support import FakePath
+from test.support.os_helper import FakePath
 
 
 def create_file(filename, data=b'foo'):
@@ -97,8 +98,8 @@ class GenericTest:
                     self.assertNotEqual(s1[n:n+1], s2[n:n+1])
 
     def test_getsize(self):
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         create_file(filename, b'Hello')
         self.assertEqual(self.pathmodule.getsize(filename), 5)
@@ -108,8 +109,8 @@ class GenericTest:
         self.assertEqual(self.pathmodule.getsize(filename), 12)
 
     def test_filetime(self):
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         create_file(filename, b'foo')
 
@@ -126,9 +127,9 @@ class GenericTest:
         )
 
     def test_exists(self):
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         bfilename = os.fsencode(filename)
-        self.addCleanup(support.unlink, filename)
+        self.addCleanup(os_helper.unlink, filename)
 
         self.assertIs(self.pathmodule.exists(filename), False)
         self.assertIs(self.pathmodule.exists(bfilename), False)
@@ -163,7 +164,7 @@ class GenericTest:
         self.assertFalse(self.pathmodule.exists(r))
 
     def test_isdir(self):
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         bfilename = os.fsencode(filename)
         self.assertIs(self.pathmodule.isdir(filename), False)
         self.assertIs(self.pathmodule.isdir(bfilename), False)
@@ -178,17 +179,17 @@ class GenericTest:
             self.assertIs(self.pathmodule.isdir(filename), False)
             self.assertIs(self.pathmodule.isdir(bfilename), False)
         finally:
-            support.unlink(filename)
+            os_helper.unlink(filename)
 
         try:
             os.mkdir(filename)
             self.assertIs(self.pathmodule.isdir(filename), True)
             self.assertIs(self.pathmodule.isdir(bfilename), True)
         finally:
-            support.rmdir(filename)
+            os_helper.rmdir(filename)
 
     def test_isfile(self):
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         bfilename = os.fsencode(filename)
         self.assertIs(self.pathmodule.isfile(filename), False)
         self.assertIs(self.pathmodule.isfile(bfilename), False)
@@ -203,20 +204,20 @@ class GenericTest:
             self.assertIs(self.pathmodule.isfile(filename), True)
             self.assertIs(self.pathmodule.isfile(bfilename), True)
         finally:
-            support.unlink(filename)
+            os_helper.unlink(filename)
 
         try:
             os.mkdir(filename)
             self.assertIs(self.pathmodule.isfile(filename), False)
             self.assertIs(self.pathmodule.isfile(bfilename), False)
         finally:
-            support.rmdir(filename)
+            os_helper.rmdir(filename)
 
     def test_samefile(self):
-        file1 = support.TESTFN
-        file2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, file1)
-        self.addCleanup(support.unlink, file2)
+        file1 = os_helper.TESTFN
+        file2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, file1)
+        self.addCleanup(os_helper.unlink, file2)
 
         create_file(file1)
         self.assertTrue(self.pathmodule.samefile(file1, file1))
@@ -227,10 +228,10 @@ class GenericTest:
         self.assertRaises(TypeError, self.pathmodule.samefile)
 
     def _test_samefile_on_link_func(self, func):
-        test_fn1 = support.TESTFN
-        test_fn2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, test_fn1)
-        self.addCleanup(support.unlink, test_fn2)
+        test_fn1 = os_helper.TESTFN
+        test_fn2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, test_fn1)
+        self.addCleanup(os_helper.unlink, test_fn2)
 
         create_file(test_fn1)
 
@@ -241,7 +242,7 @@ class GenericTest:
         create_file(test_fn2)
         self.assertFalse(self.pathmodule.samefile(test_fn1, test_fn2))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_samefile_on_symlink(self):
         self._test_samefile_on_link_func(os.symlink)
 
@@ -252,10 +253,10 @@ class GenericTest:
             self.skipTest('os.link(): %s' % e)
 
     def test_samestat(self):
-        test_fn1 = support.TESTFN
-        test_fn2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, test_fn1)
-        self.addCleanup(support.unlink, test_fn2)
+        test_fn1 = os_helper.TESTFN
+        test_fn2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, test_fn1)
+        self.addCleanup(os_helper.unlink, test_fn2)
 
         create_file(test_fn1)
         stat1 = os.stat(test_fn1)
@@ -268,10 +269,10 @@ class GenericTest:
         self.assertRaises(TypeError, self.pathmodule.samestat)
 
     def _test_samestat_on_link_func(self, func):
-        test_fn1 = support.TESTFN + "1"
-        test_fn2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, test_fn1)
-        self.addCleanup(support.unlink, test_fn2)
+        test_fn1 = os_helper.TESTFN + "1"
+        test_fn2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, test_fn1)
+        self.addCleanup(os_helper.unlink, test_fn2)
 
         create_file(test_fn1)
         func(test_fn1, test_fn2)
@@ -283,7 +284,7 @@ class GenericTest:
         self.assertFalse(self.pathmodule.samestat(os.stat(test_fn1),
                                                   os.stat(test_fn2)))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_samestat_on_symlink(self):
         self._test_samestat_on_link_func(os.symlink)
 
@@ -294,8 +295,8 @@ class GenericTest:
             self.skipTest('os.link(): %s' % e)
 
     def test_sameopenfile(self):
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
         create_file(filename)
 
         with open(filename, "rb", 0) as fp1:
@@ -374,7 +375,7 @@ class CommonTest(GenericTest):
 
     def test_expandvars(self):
         expandvars = self.pathmodule.expandvars
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
             env["foo"] = "bar"
             env["{foo"] = "baz1"
@@ -403,14 +404,14 @@ class CommonTest(GenericTest):
             self.assertEqual(expandvars(b"$foo$foo"), b"barbar")
             self.assertEqual(expandvars(b"$bar$bar"), b"$bar$bar")
 
-    @unittest.skipUnless(support.FS_NONASCII, 'need support.FS_NONASCII')
+    @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_expandvars_nonascii(self):
         expandvars = self.pathmodule.expandvars
         def check(value, expected):
             self.assertEqual(expandvars(value), expected)
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
-            nonascii = support.FS_NONASCII
+            nonascii = os_helper.FS_NONASCII
             env['spam'] = nonascii
             env[nonascii] = 'ham' + nonascii
             check(nonascii, nonascii)
@@ -469,31 +470,31 @@ class CommonTest(GenericTest):
             # FS encoding is probably ASCII
             pass
         else:
-            with support.temp_cwd(unicwd):
+            with os_helper.temp_cwd(unicwd):
                 for path in ('', 'fuu', 'f\xf9\xf9', '/fuu', 'U:\\'):
                     self.assertIsInstance(abspath(path), str)
 
     def test_nonascii_abspath(self):
-        if (support.TESTFN_UNDECODABLE
+        if (os_helper.TESTFN_UNDECODABLE
         # Mac OS X denies the creation of a directory with an invalid
         # UTF-8 name. Windows allows creating a directory with an
         # arbitrary bytes name, but fails to enter this directory
         # (when the bytes name is used).
         and sys.platform not in ('win32', 'darwin')):
-            name = support.TESTFN_UNDECODABLE
-        elif support.TESTFN_NONASCII:
-            name = support.TESTFN_NONASCII
+            name = os_helper.TESTFN_UNDECODABLE
+        elif os_helper.TESTFN_NONASCII:
+            name = os_helper.TESTFN_NONASCII
         else:
-            self.skipTest("need support.TESTFN_NONASCII")
+            self.skipTest("need os_helper.TESTFN_NONASCII")
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            with support.temp_cwd(name):
+            with os_helper.temp_cwd(name):
                 self.test_abspath()
 
     def test_join_errors(self):
         # Check join() raises friendly TypeErrors.
-        with support.check_warnings(('', BytesWarning), quiet=True):
+        with warnings_helper.check_warnings(('', BytesWarning), quiet=True):
             errmsg = "Can't mix strings and bytes in path components"
             with self.assertRaisesRegex(TypeError, errmsg):
                 self.pathmodule.join(b'bytes', 'str')
@@ -513,8 +514,8 @@ class CommonTest(GenericTest):
 
     def test_relpath_errors(self):
         # Check relpath() raises friendly TypeErrors.
-        with support.check_warnings(('', (BytesWarning, DeprecationWarning)),
-                                    quiet=True):
+        with warnings_helper.check_warnings(
+                ('', (BytesWarning, DeprecationWarning)), quiet=True):
             errmsg = "Can't mix strings and bytes in path components"
             with self.assertRaisesRegex(TypeError, errmsg):
                 self.pathmodule.relpath(b'bytes', 'str')
@@ -534,9 +535,9 @@ class CommonTest(GenericTest):
 class PathLikeTests(unittest.TestCase):
 
     def setUp(self):
-        self.file_name = support.TESTFN
-        self.file_path = FakePath(support.TESTFN)
-        self.addCleanup(support.unlink, self.file_name)
+        self.file_name = os_helper.TESTFN
+        self.file_path = FakePath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, self.file_name)
         create_file(self.file_name, b"test_genericpath.PathLikeTests")
 
     def assertPathEqual(self, func):

--- a/Lib/test/test_imghdr.py
+++ b/Lib/test/test_imghdr.py
@@ -4,7 +4,9 @@ import os
 import pathlib
 import unittest
 import warnings
-from test.support import findfile, TESTFN, unlink
+from test.support import findfile
+from test.support.os_helper import TESTFN, unlink
+
 
 TEST_FILES = (
     ('python.png', 'png'),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 
 from test import support
+from test.support import os_helper
 from platform import win32_edition
 
 
@@ -60,7 +61,7 @@ class MimeTypesTestCase(unittest.TestCase):
         # Unreadable file returns None
         self.assertIsNone(mimetypes.read_mime_types("non-existent"))
 
-        with support.temp_dir() as directory:
+        with os_helper.temp_dir() as directory:
             data = "x-application/x-unittest pyunit\n"
             file = pathlib.Path(directory, "sample.mimetype")
             file.write_text(data)
@@ -70,7 +71,7 @@ class MimeTypesTestCase(unittest.TestCase):
         # bpo-41048: read_mime_types should read the rule file with 'utf-8' encoding.
         # Not with locale encoding. _bootlocale has been imported because io.open(...)
         # uses it.
-        with support.temp_dir() as directory:
+        with os_helper.temp_dir() as directory:
             data = "application/no-mans-land  Fran\u00E7ais"
             file = pathlib.Path(directory, "sample.mimetype")
             file.write_text(data, encoding='utf-8')

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -3,7 +3,9 @@ import os
 import sys
 import unittest
 import warnings
-from test.support import TestFailed, FakePath
+from test.support import os_helper
+from test.support import TestFailed
+from test.support.os_helper import FakePath
 from test import support, test_genericpath
 from tempfile import TemporaryFile
 
@@ -254,34 +256,34 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.realpath('\\'.join(['..'] * 50))",
                ntpath.splitdrive(expected)[0] + '\\')
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_basic(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
         open(ABSTFN, "wb").close()
-        self.addCleanup(support.unlink, ABSTFN)
-        self.addCleanup(support.unlink, ABSTFN + "1")
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "1")
 
         os.symlink(ABSTFN, ABSTFN + "1")
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1"), ABSTFN)
         self.assertPathEqual(ntpath.realpath(os.fsencode(ABSTFN + "1")),
                          os.fsencode(ABSTFN))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_relative(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
         open(ABSTFN, "wb").close()
-        self.addCleanup(support.unlink, ABSTFN)
-        self.addCleanup(support.unlink, ABSTFN + "1")
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "1")
 
         os.symlink(ABSTFN, ntpath.relpath(ABSTFN + "1"))
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1"), ABSTFN)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_broken_symlinks(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
         os.mkdir(ABSTFN)
         self.addCleanup(support.rmtree, ABSTFN)
 
@@ -335,18 +337,18 @@ class TestNtpath(NtpathTestCase):
             self.assertPathEqual(ntpath.realpath(b"broken5"),
                                  os.fsencode(ABSTFN + r"\missing"))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_symlink_loops(self):
         # Symlink loops are non-deterministic as to which path is returned, but
         # it will always be the fully resolved path of one member of the cycle
-        ABSTFN = ntpath.abspath(support.TESTFN)
-        self.addCleanup(support.unlink, ABSTFN)
-        self.addCleanup(support.unlink, ABSTFN + "1")
-        self.addCleanup(support.unlink, ABSTFN + "2")
-        self.addCleanup(support.unlink, ABSTFN + "y")
-        self.addCleanup(support.unlink, ABSTFN + "c")
-        self.addCleanup(support.unlink, ABSTFN + "a")
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "1")
+        self.addCleanup(os_helper.unlink, ABSTFN + "2")
+        self.addCleanup(os_helper.unlink, ABSTFN + "y")
+        self.addCleanup(os_helper.unlink, ABSTFN + "c")
+        self.addCleanup(os_helper.unlink, ABSTFN + "a")
 
         os.symlink(ABSTFN, ABSTFN)
         self.assertPathEqual(ntpath.realpath(ABSTFN), ABSTFN)
@@ -381,14 +383,14 @@ class TestNtpath(NtpathTestCase):
         # Test using relative path as well.
         self.assertPathEqual(ntpath.realpath(ntpath.basename(ABSTFN)), ABSTFN)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_symlink_prefix(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
-        self.addCleanup(support.unlink, ABSTFN + "3")
-        self.addCleanup(support.unlink, "\\\\?\\" + ABSTFN + "3.")
-        self.addCleanup(support.unlink, ABSTFN + "3link")
-        self.addCleanup(support.unlink, ABSTFN + "3.link")
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "3")
+        self.addCleanup(os_helper.unlink, "\\\\?\\" + ABSTFN + "3.")
+        self.addCleanup(os_helper.unlink, ABSTFN + "3link")
+        self.addCleanup(os_helper.unlink, ABSTFN + "3.link")
 
         with open(ABSTFN + "3", "wb") as f:
             f.write(b'0')
@@ -422,9 +424,9 @@ class TestNtpath(NtpathTestCase):
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     @unittest.skipUnless(HAVE_GETSHORTPATHNAME, 'need _getshortpathname')
     def test_realpath_cwd(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
 
-        support.unlink(ABSTFN)
+        os_helper.unlink(ABSTFN)
         support.rmtree(ABSTFN)
         os.mkdir(ABSTFN)
         self.addCleanup(support.rmtree, ABSTFN)
@@ -449,7 +451,7 @@ class TestNtpath(NtpathTestCase):
             self.assertPathEqual(test_file_long, ntpath.realpath("file.txt"))
 
     def test_expandvars(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
             env["foo"] = "bar"
             env["{foo"] = "baz1"
@@ -474,13 +476,13 @@ class TestNtpath(NtpathTestCase):
             tester('ntpath.expandvars("\'%foo%\'%bar")', "\'%foo%\'%bar")
             tester('ntpath.expandvars("bar\'%foo%")', "bar\'%foo%")
 
-    @unittest.skipUnless(support.FS_NONASCII, 'need support.FS_NONASCII')
+    @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_expandvars_nonascii(self):
         def check(value, expected):
             tester('ntpath.expandvars(%r)' % value, expected)
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
-            nonascii = support.FS_NONASCII
+            nonascii = os_helper.FS_NONASCII
             env['spam'] = nonascii
             env[nonascii] = 'ham' + nonascii
             check('$spam bar', '%s bar' % nonascii)
@@ -497,7 +499,7 @@ class TestNtpath(NtpathTestCase):
     def test_expanduser(self):
         tester('ntpath.expanduser("test")', 'test')
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
             tester('ntpath.expanduser("~test")', '~test')
 
@@ -533,7 +535,7 @@ class TestNtpath(NtpathTestCase):
     @unittest.skipUnless(nt, "abspath requires 'nt' module")
     def test_abspath(self):
         tester('ntpath.abspath("C:\\")', "C:\\")
-        with support.temp_cwd(support.TESTFN) as cwd_dir: # bpo-31047
+        with os_helper.temp_cwd(os_helper.TESTFN) as cwd_dir: # bpo-31047
             tester('ntpath.abspath("")', cwd_dir)
             tester('ntpath.abspath(" ")', cwd_dir + "\\ ")
             tester('ntpath.abspath("?")', cwd_dir + "\\?")
@@ -545,7 +547,7 @@ class TestNtpath(NtpathTestCase):
         tester('ntpath.relpath(ntpath.abspath("a"))', 'a')
         tester('ntpath.relpath("a/b")', 'a\\b')
         tester('ntpath.relpath("../a/b")', '..\\a\\b')
-        with support.temp_cwd(support.TESTFN) as cwd_dir:
+        with os_helper.temp_cwd(os_helper.TESTFN) as cwd_dir:
             currentdir = ntpath.basename(cwd_dir)
             tester('ntpath.relpath("a", "../b")', '..\\'+currentdir+'\\a')
             tester('ntpath.relpath("a/b", "../c")', '..\\'+currentdir+'\\a\\b')
@@ -661,7 +663,7 @@ class TestNtpath(NtpathTestCase):
         self.assertTrue(ntpath.ismount(b"\\\\.\\c:\\"))
         self.assertTrue(ntpath.ismount(b"\\\\.\\C:\\"))
 
-        with support.temp_dir() as d:
+        with os_helper.temp_dir() as d:
             self.assertFalse(ntpath.ismount(d))
 
         if sys.platform == "win32":
@@ -725,9 +727,9 @@ class PathLikeTests(NtpathTestCase):
     path = ntpath
 
     def setUp(self):
-        self.file_name = support.TESTFN
-        self.file_path = FakePath(support.TESTFN)
-        self.addCleanup(support.unlink, self.file_name)
+        self.file_name = os_helper.TESTFN
+        self.file_path = FakePath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, self.file_name)
         with open(self.file_name, 'xb', 0) as file:
             file.write(b"test_ntpath.PathLikeTests")
 

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -3,9 +3,13 @@ import pickle
 import sys
 
 from test import support
+from test.support import import_helper
 
-py_operator = support.import_fresh_module('operator', blocked=['_operator'])
-c_operator = support.import_fresh_module('operator', fresh=['_operator'])
+
+py_operator = import_helper.import_fresh_module('operator',
+                                                blocked=['_operator'])
+c_operator = import_helper.import_fresh_module('operator',
+                                               fresh=['_operator'])
 
 class Seq1:
     def __init__(self, lst):

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -14,6 +14,7 @@ import unittest
 
 from io import StringIO
 from test import support
+from test.support import os_helper
 
 
 import optparse
@@ -1021,10 +1022,10 @@ class TestExtendAddTypes(BaseTest):
         self.parser.add_option("-f", "--file", type="file", dest="file")
 
     def tearDown(self):
-        if os.path.isdir(support.TESTFN):
-            os.rmdir(support.TESTFN)
-        elif os.path.isfile(support.TESTFN):
-            os.unlink(support.TESTFN)
+        if os.path.isdir(os_helper.TESTFN):
+            os.rmdir(os_helper.TESTFN)
+        elif os.path.isfile(os_helper.TESTFN):
+            os.unlink(os_helper.TESTFN)
 
     class MyOption (Option):
         def check_file(option, opt, value):
@@ -1039,21 +1040,21 @@ class TestExtendAddTypes(BaseTest):
         TYPE_CHECKER["file"] = check_file
 
     def test_filetype_ok(self):
-        support.create_empty_file(support.TESTFN)
-        self.assertParseOK(["--file", support.TESTFN, "-afoo"],
-                           {'file': support.TESTFN, 'a': 'foo'},
+        os_helper.create_empty_file(os_helper.TESTFN)
+        self.assertParseOK(["--file", os_helper.TESTFN, "-afoo"],
+                           {'file': os_helper.TESTFN, 'a': 'foo'},
                            [])
 
     def test_filetype_noexist(self):
-        self.assertParseFail(["--file", support.TESTFN, "-afoo"],
+        self.assertParseFail(["--file", os_helper.TESTFN, "-afoo"],
                              "%s: file does not exist" %
-                             support.TESTFN)
+                             os_helper.TESTFN)
 
     def test_filetype_notfile(self):
-        os.mkdir(support.TESTFN)
-        self.assertParseFail(["--file", support.TESTFN, "-afoo"],
+        os.mkdir(os_helper.TESTFN)
+        self.assertParseFail(["--file", os_helper.TESTFN, "-afoo"],
                              "%s: not a regular file" %
-                             support.TESTFN)
+                             os_helper.TESTFN)
 
 
 class TestExtendAddActions(BaseTest):
@@ -1497,7 +1498,7 @@ class TestHelp(BaseTest):
         # we must restore its original value -- otherwise, this test
         # screws things up for other tests when it's part of the Python
         # test suite.
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['COLUMNS'] = str(columns)
             return InterceptingOptionParser(option_list=options)
 
@@ -1522,7 +1523,7 @@ class TestHelp(BaseTest):
         self.assertHelpEquals(_expected_help_long_opts_first)
 
     def test_help_title_formatter(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["COLUMNS"] = "80"
             self.parser.formatter = TitledHelpFormatter()
             self.assertHelpEquals(_expected_help_title_formatter)

--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from test import test_tools
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok
 
 test_tools.skip_if_missing("peg_generator")
@@ -68,7 +69,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
             self.skipTest("The %r command is not found" % cmd)
         super(TestCParser, self).setUp()
         self.tmp_path = self.mkdtemp()
-        change_cwd = support.change_cwd(self.tmp_path)
+        change_cwd = os_helper.change_cwd(self.tmp_path)
         change_cwd.__enter__()
         self.addCleanup(change_cwd.__exit__, None, None, None)
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -6,11 +6,12 @@ import threading
 import time
 import unittest
 import weakref
-from test import support
+from test.support import import_helper
 from test.support import threading_helper
 
-py_queue = support.import_fresh_module('queue', blocked=['_queue'])
-c_queue = support.import_fresh_module('queue', fresh=['_queue'])
+
+py_queue = import_helper.import_fresh_module('queue', blocked=['_queue'])
+c_queue = import_helper.import_fresh_module('queue', fresh=['_queue'])
 need_c_queue = unittest.skipUnless(c_queue, "No _queue module found")
 
 QUEUE_SIZE = 5

--- a/Lib/test/test_spwd.py
+++ b/Lib/test/test_spwd.py
@@ -1,8 +1,9 @@
 import os
 import unittest
-from test import support
+from test.support import import_helper
 
-spwd = support.import_module('spwd')
+
+spwd = import_helper.import_module('spwd')
 
 
 @unittest.skipUnless(hasattr(os, 'geteuid') and os.geteuid() == 0,

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -3,7 +3,9 @@ import os
 import socket
 import sys
 from test.support import socket_helper
-from test.support import TESTFN, import_fresh_module
+from test.support.import_helper import import_fresh_module
+from test.support.os_helper import TESTFN
+
 
 c_stat = import_fresh_module('stat', fresh=['_stat'])
 py_stat = import_fresh_module('stat', blocked=['_stat'])

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1,4 +1,5 @@
 from test import support
+from test.support import os_helper
 from tokenize import (tokenize, _tokenize, untokenize, NUMBER, NAME, OP,
                      STRING, ENDMARKER, ENCODING, tok_name, detect_encoding,
                      open as tokenize_open, Untokenizer, generate_tokens,
@@ -1265,8 +1266,8 @@ class TestDetectEncoding(TestCase):
         self.assertEqual(consumed_lines, [b'print("#coding=fake")'])
 
     def test_open(self):
-        filename = support.TESTFN + '.py'
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN + '.py'
+        self.addCleanup(os_helper.unlink, filename)
 
         # test coding cookie
         for encoding in ('iso-8859-15', 'utf-8'):

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -5,6 +5,7 @@ import sys
 import subprocess
 from unittest import mock
 from test import support
+from test.support import import_helper
 
 
 URL = 'http://www.example.com'
@@ -270,7 +271,7 @@ class BrowserRegistrationTest(unittest.TestCase):
 
 class ImportTest(unittest.TestCase):
     def test_register(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         self.assertIsNone(webbrowser._tryorder)
         self.assertFalse(webbrowser._browsers)
 
@@ -284,7 +285,7 @@ class ImportTest(unittest.TestCase):
         self.assertEqual(webbrowser._browsers['example1'], [ExampleBrowser, None])
 
     def test_get(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         self.assertIsNone(webbrowser._tryorder)
         self.assertFalse(webbrowser._browsers)
 
@@ -293,24 +294,24 @@ class ImportTest(unittest.TestCase):
         self.assertIsNotNone(webbrowser._tryorder)
 
     def test_synthesize(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         name = os.path.basename(sys.executable).lower()
         webbrowser.register(name, None, webbrowser.GenericBrowser(name))
         webbrowser.get(sys.executable)
 
     def test_environment(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         try:
             browser = webbrowser.get().name
         except (webbrowser.Error, AttributeError) as err:
             self.skipTest(str(err))
         with support.EnvironmentVarGuard() as env:
             env["BROWSER"] = browser
-            webbrowser = support.import_fresh_module('webbrowser')
+            webbrowser = import_helper.import_fresh_module('webbrowser')
             webbrowser.get()
 
     def test_environment_preferred(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         try:
             webbrowser.get()
             least_preferred_browser = webbrowser.get(webbrowser._tryorder[-1]).name
@@ -319,12 +320,12 @@ class ImportTest(unittest.TestCase):
 
         with support.EnvironmentVarGuard() as env:
             env["BROWSER"] = least_preferred_browser
-            webbrowser = support.import_fresh_module('webbrowser')
+            webbrowser = import_helper.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, least_preferred_browser)
 
         with support.EnvironmentVarGuard() as env:
             env["BROWSER"] = sys.executable
-            webbrowser = support.import_fresh_module('webbrowser')
+            webbrowser = import_helper.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, sys.executable)
 
 


### PR DESCRIPTION
Use test helpers in the following test cases:
* test_argparse
* test_asyncgen
* test_clinic
* test_codecs
* test_doctest
* test_exceptions
* test_ftplib
* test_gc
* test_genericpath
* test_imghdr
* test_mimetypes
* test_ntpath
* test_operator
* test_optparse
* test_c_parser
* test_queue
* test_spwd
* test_stat
* test_tokenize
* test_webbrowser

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
