### PR TITLE
bpo-41045: Add documentation for f-string's self documenting expressions

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -778,9 +778,9 @@ expression. You can use the repr() with the !r format specifier
    >>> f"{line = }"
    'line = "The mill\'s closed"'
    >>> f"{line = :20}"
-   "line = "The mill's closed   "
+   "line = The mill's closed   "
    >>> f"{line = !r:20}"
-   'line = "The mill\s closed" '
+   'line = "The mill\'s closed" '
 
 See also :pep:`498` for the proposal that added formatted string literals,
 and :meth:`str.format`, which uses a related format string mechanism.

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -758,6 +758,16 @@ include expressions.
    >>> foo.__doc__ is None
    True
 
+F-strings can also help with "printf-style" debugging.
+
+::
+
+   >>> foo = "bar"
+   >>> print(f"{foo=}")
+   "foo='bar'"
+   >>> print(f"{foo = }") # preserves whitespace before and after equals sign
+   "foo = 'bar'"
+
 See also :pep:`498` for the proposal that added formatted string literals,
 and :meth:`str.format`, which uses a related format string mechanism.
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -768,6 +768,20 @@ F-strings can also help with "printf-style" debugging.
    >>> print(f"{foo = }") # preserves whitespace before and after equals sign
    "foo = 'bar'"
 
+Optional format specifiers can be placed after the equals sign.
+If no format specifiers are used then :meth:`repr` is used on the expression.
+If format specifier (like :20) is given, then :meth:`str` is used on the
+expression. You can use the repr() with the !r format specifier
+::
+
+   >>> line = "The mill's closed"
+   >>> f"{line = }"
+   'line = "The mill\'s closed"'
+   >>> f"{line = :20}"
+   "line = "The mill's closed   "
+   >>> f"{line = !r:20}"
+   'line = "The mill\s closed" '
+
 See also :pep:`498` for the proposal that added formatted string literals,
 and :meth:`str.format`, which uses a related format string mechanism.
 


### PR DESCRIPTION
Missing documentation describing the = specifier for f-strings has been added

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41045](https://bugs.python.org/issue41045) -->
https://bugs.python.org/issue41045
<!-- /issue-number -->
