### PR TITLE
bpo-41295: Allow overriding __setattr__ on multiple inheritance

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4308,6 +4308,41 @@ order (MRO) for bases """
         else:
             self.fail("Carlo Verre __delattr__ succeeded!")
 
+        class A(type):
+            def __setattr__(cls, key, value):
+                type.__setattr__(cls, key, value)
+
+        class B:
+            pass
+
+        class C(B, A):
+            pass
+
+        obj = C('D', (object,), {})
+        try:
+            obj.test = True
+        except TypeError:
+            self.fail("assignment to classes that override __setattr__ should be legal")
+
+        class A(type):
+            def __setattr__(cls, key, value):
+                object.__setattr__(cls, key, value)
+
+        class B:
+            pass
+
+        class C(B, A):
+            pass
+
+        obj = C('D', (object,), {})
+        try:
+            obj.test = True
+        except TypeError:
+            pass
+        else:
+            self.fail("it should be illegal to use object.__setattr__ if type is closer in the MRO")
+
+
     def test_weakref_segfault(self):
         # Testing weakref segfault...
         # SF 742911

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -268,6 +268,7 @@ Giovanni Cappellotto
 Brett Cannon
 Tristan Carel
 Mike Carlton
+David Caro
 Pierre Carrier
 Terry Carroll
 Edward Catmur

--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-14-18-15-32.bpo-41295.TXQmfk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-14-18-15-32.bpo-41295.TXQmfk.rst
@@ -1,0 +1,1 @@
+Allow overriding __setattr__ somewhere other than the next class in the MRO.


### PR DESCRIPTION
The change introduced in [bpo-39960](https://bugs.python.org/issue39960), broke being able to override the
`__setattr__` function unless it's done by the next class in the MRO.

For example:
```
class Meta(type):
    def __setattr__(cls, key, value):
        type.__setattr__(cls, key, value)

class OtherClass:
    pass

class DefaultMeta(OtherClass, Meta):
    pass

obj = DefaultMeta('A', (object,), {})
obj.test = True
print(obj.test)
```

Would break as it would first check if `OtherClass` has a custom
`__setattr__` and if not would raise error right away.

This change goes through the whole MRO to find out if there's any class
that overrides it before throwing error.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-41295](https://bugs.python.org/issue41295) -->
https://bugs.python.org/issue41295
<!-- /issue-number -->
