### PR TITLE
bpo-32528: Document the change in inheritance of asyncio.CancelledError

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -646,7 +646,8 @@ loop on every invocation:
 (Contributed by Yury Selivanov in :issue:`37028`.)
 
 The exception :class:`asyncio.CancelledError` now inherits from
-:class:`BaseException` rather than :class:`Exception`.
+:class:`BaseException` rather than :class:`Exception` and no longer inherits
+from :class:`concurrent.futures.CancelledError`.
 (Contributed by Yury Selivanov in :issue:`32528`.)
 
 On Windows, the default event loop is now :class:`~asyncio.ProactorEventLoop`.
@@ -1951,7 +1952,8 @@ Changes in the Python API
   (Contributed by Anthony Sottile in :issue:`36264`.)
 
 * The exception :class:`asyncio.CancelledError` now inherits from
-  :class:`BaseException` rather than :class:`Exception`.
+  :class:`BaseException` rather than :class:`Exception` and no longer inherits
+  from :class:`concurrent.futures.CancelledError`.
   (Contributed by Yury Selivanov in :issue:`32528`.)
 
 * The function :func:`asyncio.wait_for` now correctly waits for cancellation


### PR DESCRIPTION
https://bugs.python.org/issue32528#msg373510

[bpo-32528](https://bugs.python.org/issue32528)/#13528 changed `asyncio.CancelledError` such that it no longer inherits from `concurrent.futures.CancelledError`. As this affects existing code, specifically when catching the latter instead of the former in exception handling, it should be documented in the "What's new in 3.8?" document.

<!-- issue-number: [bpo-32528](https://bugs.python.org/issue32528) -->
https://bugs.python.org/issue32528
<!-- /issue-number -->


Automerge-Triggered-By: @1st1