### PR TITLE
[3.8] bpo-41302: Support system libmpdec 2.5 for Python 3.8

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-07-15-17-56-32.bpo-41302.S3o-x9.rst
+++ b/Misc/NEWS.d/next/Build/2020-07-15-17-56-32.bpo-41302.S3o-x9.rst
@@ -1,0 +1,1 @@
+Enable building Python 3.8 with libmpdec-2.5.0 to ease maintenance for Linux distributions. Patch by Felix Yan.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -58,6 +58,13 @@
 
 #define BOUNDS_CHECK(x, MIN, MAX) x = (x < MIN || MAX < x) ? MAX : x
 
+#ifndef UNUSED
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
+  #define UNUSED __attribute__((unused))
+#else
+  #define UNUSED
+#endif
+#endif
 
 /* _Py_DEC_MINALLOC >= MPD_MINALLOC */
 #define _Py_DEC_MINALLOC 4


### PR DESCRIPTION
Define UNUSED only when mpdecimal.h doesn't define it. This would support
building with system libmpdec 2.5 while retaining compatibility with system
libmpdec 2.4 or the vendored copy.

Tested to build fine with either system libmpdec or the vendored one.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41302](https://bugs.python.org/issue41302) -->
https://bugs.python.org/issue41302
<!-- /issue-number -->
