### PR TITLE
[3.7] bpo-41304: Ensure python3x._pth is loaded on Windows (GH-21495)

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -573,12 +573,19 @@ class StartupImportTests(unittest.TestCase):
 @unittest.skipUnless(sys.platform == 'win32', "only supported on Windows")
 class _pthFileTests(unittest.TestCase):
 
-    def _create_underpth_exe(self, lines):
+    def _create_underpth_exe(self, lines, exe_pth=True):
+        import _winapi
         temp_dir = tempfile.mkdtemp()
         self.addCleanup(test.support.rmtree, temp_dir)
         exe_file = os.path.join(temp_dir, os.path.split(sys.executable)[1])
+        dll_src_file = _winapi.GetModuleFileName(sys.dllhandle)
+        dll_file = os.path.join(temp_dir, os.path.split(dll_src_file)[1])
         shutil.copy(sys.executable, exe_file)
-        _pth_file = os.path.splitext(exe_file)[0] + '._pth'
+        shutil.copy(dll_src_file, dll_file)
+        if exe_pth:
+            _pth_file = os.path.splitext(exe_file)[0] + '._pth'
+        else:
+            _pth_file = os.path.splitext(dll_file)[0] + '._pth'
         with open(_pth_file, 'w') as f:
             for line in lines:
                 print(line, file=f)
@@ -631,6 +638,31 @@ class _pthFileTests(unittest.TestCase):
             '# comment',
             'import site'
         ])
+        sys_prefix = os.path.dirname(exe_file)
+        env = os.environ.copy()
+        env['PYTHONPATH'] = 'from-env'
+        env['PATH'] = '{};{}'.format(exe_prefix, os.getenv('PATH'))
+        rc = subprocess.call([exe_file, '-c',
+            'import sys; sys.exit(not sys.flags.no_site and '
+            '%r in sys.path and %r in sys.path and %r not in sys.path and '
+            'all("\\r" not in p and "\\n" not in p for p in sys.path))' % (
+                os.path.join(sys_prefix, 'fake-path-name'),
+                libpath,
+                os.path.join(sys_prefix, 'from-env'),
+            )], env=env)
+        self.assertTrue(rc, "sys.path is incorrect")
+
+
+    def test_underpth_dll_file(self):
+        libpath = os.path.dirname(os.path.dirname(encodings.__file__))
+        exe_prefix = os.path.dirname(sys.executable)
+        exe_file = self._create_underpth_exe([
+            'fake-path-name',
+            *[libpath for _ in range(200)],
+            '',
+            '# comment',
+            'import site'
+        ], exe_pth=False)
         sys_prefix = os.path.dirname(exe_file)
         env = os.environ.copy()
         env['PYTHONPATH'] = 'from-env'

--- a/Misc/NEWS.d/next/Security/2020-07-15-20-15-08.bpo-41304.vNEeYA.rst
+++ b/Misc/NEWS.d/next/Security/2020-07-15-20-15-08.bpo-41304.vNEeYA.rst
@@ -1,0 +1,1 @@
+Fixes `python3x._pth` being ignored on Windows

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -673,7 +673,7 @@ calculate_init(PyCalculatePath *calculate,
 static int
 get_pth_filename(wchar_t *spbuffer, _PyPathConfig *config)
 {
-    if (get_dllpath(spbuffer) &&
+    if (!get_dllpath(spbuffer) &&
         !change_ext(spbuffer, spbuffer, L"._pth") &&
         exists(spbuffer))
     {


### PR DESCRIPTION


<!-- issue-number: [bpo-41304](https://bugs.python.org/issue41304) -->
https://bugs.python.org/issue41304
<!-- /issue-number -->
