### PR TITLE
bpo-41283: Fix mismatched argument name for imghdr.what

### DIFF
--- a/Doc/library/imghdr.rst
+++ b/Doc/library/imghdr.rst
@@ -14,11 +14,11 @@ byte stream.
 The :mod:`imghdr` module defines the following function:
 
 
-.. function:: what(filename, h=None)
+.. function:: what(file, h=None)
 
-   Tests the image data contained in the file named by *filename*, and returns a
-   string describing the image type.  If optional *h* is provided, the *filename*
-   is ignored and *h* is assumed to contain the byte stream to test.
+   Tests the image data contained in the file named by *file*, and returns a
+   string describing the image type.  If optional *h* is provided, the *file*
+   argument is ignored and *h* is assumed to contain the byte stream to test.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.


### PR DESCRIPTION
Changes over the argument name to match the code and adjusts the wording a little bit since `file` isn't as clear as `filename` in the second sentence.

<!-- issue-number: [bpo-41283](https://bugs.python.org/issue41283) -->
https://bugs.python.org/issue41283
<!-- /issue-number -->
