### PR TITLE
bpo-40932: Note security caveat of shlex.quote on Windows

### DIFF
--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -67,7 +67,7 @@ The :mod:`shlex` module defines the following functions:
 
       The ``shlex`` module is **only designed for Unix shells**.
 
-      The :func:`quote` function is not guaranteed to be safe on non-POSIX
+      The :func:`quote` function is not guaranteed to be correct on non-POSIX
       compliant shells or shells from other operating systems such as Windows.
       Executing commands quoted by this module on such shells can open up the
       possibility of a command injection vulnerability.

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -61,6 +61,18 @@ The :mod:`shlex` module defines the following functions:
    string that can safely be used as one token in a shell command line, for
    cases where you cannot use a list.
 
+   .. warning::
+
+      The ``shlex`` module is **only designed for Unix systems**.
+
+      The :func:`quote` function is not garaunteed to be safe on other operating
+      systems such as Windows. Executing commands quoted by this module on
+      other operating systems can open the possibility of a command injection
+      vulnerability.
+
+      Consider using functions that pass command arguments with lists such as
+      :func:`subprocess.run` with ``shell=False``.
+
    This idiom would be unsafe:
 
       >>> filename = 'somefile; rm -rf ~'

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -61,6 +61,8 @@ The :mod:`shlex` module defines the following functions:
    string that can safely be used as one token in a shell command line, for
    cases where you cannot use a list.
 
+   .. _shlex-quote-warning:
+
    .. warning::
 
       The ``shlex`` module is **only designed for Unix shells**.

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -67,7 +67,7 @@ The :mod:`shlex` module defines the following functions:
 
       The ``shlex`` module is **only designed for Unix shells**.
 
-      The :func:`quote` function is not garaunteed to be safe on non-POSIX
+      The :func:`quote` function is not guaranteed to be safe on non-POSIX
       compliant shells or shells from other operating systems such as Windows.
       Executing commands quoted by this module on such shells can open up the
       possibility of a command injection vulnerability.

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -63,12 +63,12 @@ The :mod:`shlex` module defines the following functions:
 
    .. warning::
 
-      The ``shlex`` module is **only designed for Unix systems**.
+      The ``shlex`` module is **only designed for Unix shells**.
 
-      The :func:`quote` function is not garaunteed to be safe on other operating
-      systems such as Windows. Executing commands quoted by this module on
-      other operating systems can open the possibility of a command injection
-      vulnerability.
+      The :func:`quote` function is not garaunteed to be safe on non-compliant
+      shells or shells from other operating systems such as Windows. Executing
+      commands quoted by this module on such shells can open up the possibility
+      of a command injection vulnerability.
 
       Consider using functions that pass command arguments with lists such as
       :func:`subprocess.run` with ``shell=False``.

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -65,10 +65,10 @@ The :mod:`shlex` module defines the following functions:
 
       The ``shlex`` module is **only designed for Unix shells**.
 
-      The :func:`quote` function is not garaunteed to be safe on non-compliant
-      shells or shells from other operating systems such as Windows. Executing
-      commands quoted by this module on such shells can open up the possibility
-      of a command injection vulnerability.
+      The :func:`quote` function is not garaunteed to be safe on non-POSIX
+      compliant shells or shells from other operating systems such as Windows.
+      Executing commands quoted by this module on such shells can open up the
+      possibility of a command injection vulnerability.
 
       Consider using functions that pass command arguments with lists such as
       :func:`subprocess.run` with ``shell=False``.

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -693,9 +693,12 @@ quoted appropriately to avoid
 `shell injection <https://en.wikipedia.org/wiki/Shell_injection#Shell_injection>`_
 vulnerabilities.
 
-When using ``shell=True``, the :func:`shlex.quote` function can be
-used to properly escape whitespace and shell metacharacters in strings
-that are going to be used to construct shell commands.
+When using ``shell=True`` on **Unix** systems, the :func:`shlex.quote`
+function can be used to properly escape whitespace and shell metacharacters in
+strings that are going to be used to construct shell commands. Note that
+the :mod:`shlex` module is *only meant for Unix systems* and using it on other
+operating systems such as Windows can create a command injection vulnerability
+when coupled with ``shell=True``.
 
 
 Popen Objects

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -691,14 +691,8 @@ If the shell is invoked explicitly, via ``shell=True``, it is the application's
 responsibility to ensure that all whitespace and metacharacters are
 quoted appropriately to avoid
 `shell injection <https://en.wikipedia.org/wiki/Shell_injection#Shell_injection>`_
-vulnerabilities.
-
-When using ``shell=True`` on **Unix** systems, the :func:`shlex.quote`
-function can be used to properly escape whitespace and shell metacharacters in
-strings that are going to be used to construct shell commands. Note that
-the :mod:`shlex` module is *only meant for Unix systems* and using it on other
-operating systems such as Windows can create a command injection vulnerability
-when coupled with ``shell=True``.
+vulnerabilities. On :ref:`some platforms <shlex-quote-warning>`, it is possible
+to use :func:`shlex.quote` for this escaping.
 
 
 Popen Objects


### PR DESCRIPTION
Added a note in the `subprocess` docs that recommend using `shlex.quote` without mentioning that this is only applicable to Unix. 

Also added a warning straight into the `shlex` docs since it only says "for simple syntaxes resembling that of the Unix shell" and says using `quote` plugs the security hole without mentioning this important caveat.


<!-- issue-number: [bpo-40932](https://bugs.python.org/issue40932) -->
https://bugs.python.org/issue40932
<!-- /issue-number -->

Automerge-Triggered-By: GH:zware