### PR TITLE
bpo-41045: Document debug feature of f-strings ('=')

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -659,7 +659,7 @@ for the contents of the string is:
 
 .. productionlist::
    f_string: (`literal_char` | "{{" | "}}" | `replacement_field`)*
-   replacement_field: "{" `f_expression` ["!" `conversion`] [":" `format_spec`] "}"
+   replacement_field: "{" `f_expression` ["="] ["!" `conversion`] [":" `format_spec`] "}"
    f_expression: (`conditional_expression` | "*" `or_expr`)
                :   ("," `conditional_expression` | "," "*" `or_expr`)* [","]
                : | `yield_expression`
@@ -671,8 +671,9 @@ The parts of the string outside curly braces are treated literally,
 except that any doubled curly braces ``'{{'`` or ``'}}'`` are replaced
 with the corresponding single curly brace.  A single opening curly
 bracket ``'{'`` marks a replacement field, which starts with a
-Python expression.  After the expression, there may be a conversion field,
-introduced by an exclamation point ``'!'``.  A format specifier may also
+Python expression. To display both the expression text and its value after evaluation,
+(useful in debugging), an equals ``'='`` may be added after the expression. A conversion field,
+introduced by an exclamation point ``'!'`` may follow.  A format specifier may also
 be appended, introduced by a colon ``':'``.  A replacement field ends
 with a closing curly bracket ``'}'``.
 
@@ -689,6 +690,16 @@ left to right.
    Prior to Python 3.7, an :keyword:`await` expression and comprehensions
    containing an :keyword:`async for` clause were illegal in the expressions
    in formatted string literals due to a problem with the implementation.
+
+When the equals ``'='`` is provided, the output will have the expression text, the
+``'='`` and the evaluated value. Spaces after the opening brace ``'{'``, within the
+expression and after the ``'='`` are all retained in the output. By default, the
+``'='`` causes the :func:`repr` of the expression to be provided, unless there is a
+format specified. When a format is specified it defaults to the :func:`str` of the
+expression unless a conversion ``'!r'`` is declared.
+
+.. versionchanged:: 3.8
+   The equals ``'='`` was added in Python 3.8.
 
 If a conversion is specified, the result of evaluating the expression
 is converted before formatting.  Conversion ``'!s'`` calls :func:`str` on
@@ -724,9 +735,22 @@ Some examples of formatted string literals::
    >>> today = datetime(year=2017, month=1, day=27)
    >>> f"{today:%B %d, %Y}"  # using date format specifier
    'January 27, 2017'
+   >>> f"{today=:%B %d, %Y}" # using date format specifier and debugging
+   'today=January 27, 2017'
    >>> number = 1024
    >>> f"{number:#0x}"  # using integer format specifier
    '0x400'
+   >>> foo = "bar"
+   >>> f"{ foo = }" # preserves whitespace
+   " foo = 'bar'"
+   >>> line = "The mill's closed"
+   >>> f"{line = }"
+   'line = "The mill\'s closed"'
+   >>> f"{line = :20}"
+   "line = The mill's closed   "
+   >>> f"{line = !r:20}"
+   'line = "The mill\'s closed" '
+   
 
 A consequence of sharing the same syntax as regular string literals is
 that characters in the replacement fields must not conflict with the

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -698,7 +698,7 @@ expression and after the ``'='`` are all retained in the output. By default, the
 format specified. When a format is specified it defaults to the :func:`str` of the
 expression unless a conversion ``'!r'`` is declared.
 
-.. versionchanged:: 3.8
+.. versionadded:: 3.8
    The equals ``'='`` was added in Python 3.8.
 
 If a conversion is specified, the result of evaluating the expression

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -640,6 +640,7 @@ and formatted string literals may be concatenated with plain string literals.
    single: {} (curly brackets); in formatted string literal
    single: ! (exclamation); in formatted string literal
    single: : (colon); in formatted string literal
+   single: = (equal); for help in debugging using string literals
 .. _f-strings:
 
 Formatted string literals

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -673,7 +673,7 @@ The parts of the string outside curly braces are treated literally,
 except that any doubled curly braces ``'{{'`` or ``'}}'`` are replaced
 with the corresponding single curly brace.  A single opening curly
 bracket ``'{'`` marks a replacement field, which starts with a
-Python expression. To display both the expression text and its value after 
+Python expression. To display both the expression text and its value after
 evaluation, (useful in debugging), an equal sign ``'='`` may be added after the
 expression. A conversion field, introduced by an exclamation point ``'!'`` may
 follow.  A format specifier may also be appended, introduced by a colon ``':'``.
@@ -753,7 +753,7 @@ Some examples of formatted string literals::
    "line = The mill's closed   "
    >>> f"{line = !r:20}"
    'line = "The mill\'s closed" '
-   
+
 
 A consequence of sharing the same syntax as regular string literals is
 that characters in the replacement fields must not conflict with the

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -672,11 +672,11 @@ The parts of the string outside curly braces are treated literally,
 except that any doubled curly braces ``'{{'`` or ``'}}'`` are replaced
 with the corresponding single curly brace.  A single opening curly
 bracket ``'{'`` marks a replacement field, which starts with a
-Python expression. To display both the expression text and its value after evaluation,
-(useful in debugging), an equals ``'='`` may be added after the expression. A conversion field,
-introduced by an exclamation point ``'!'`` may follow.  A format specifier may also
-be appended, introduced by a colon ``':'``.  A replacement field ends
-with a closing curly bracket ``'}'``.
+Python expression. To display both the expression text and its value after 
+evaluation, (useful in debugging), an equal sign ``'='`` may be added after the
+expression. A conversion field, introduced by an exclamation point ``'!'`` may
+follow.  A format specifier may also be appended, introduced by a colon ``':'``.
+A replacement field ends with a closing curly bracket ``'}'``.
 
 Expressions in formatted string literals are treated like regular
 Python expressions surrounded by parentheses, with a few exceptions.
@@ -692,15 +692,16 @@ left to right.
    containing an :keyword:`async for` clause were illegal in the expressions
    in formatted string literals due to a problem with the implementation.
 
-When the equals ``'='`` is provided, the output will have the expression text, the
-``'='`` and the evaluated value. Spaces after the opening brace ``'{'``, within the
-expression and after the ``'='`` are all retained in the output. By default, the
-``'='`` causes the :func:`repr` of the expression to be provided, unless there is a
-format specified. When a format is specified it defaults to the :func:`str` of the
-expression unless a conversion ``'!r'`` is declared.
+When the equal sign ``'='`` is provided, the output will have the expression
+text, the ``'='`` and the evaluated value. Spaces after the opening brace
+``'{'``, within the expression and after the ``'='`` are all retained in the
+output. By default, the ``'='`` causes the :func:`repr` of the expression to be
+provided, unless there is a format specified. When a format is specified it
+defaults to the :func:`str` of the expression unless a conversion ``'!r'`` is
+declared.
 
 .. versionadded:: 3.8
-   The equals ``'='`` was added in Python 3.8.
+   The equal sign ``'='`` was added in Python 3.8.
 
 If a conversion is specified, the result of evaluating the expression
 is converted before formatting.  Conversion ``'!s'`` calls :func:`str` on

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -640,7 +640,7 @@ and formatted string literals may be concatenated with plain string literals.
    single: {} (curly brackets); in formatted string literal
    single: ! (exclamation); in formatted string literal
    single: : (colon); in formatted string literal
-   single: = (equal); for help in debugging using string literals
+   single: = (equals); for help in debugging using string literals
 .. _f-strings:
 
 Formatted string literals

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -637,6 +637,7 @@ and formatted string literals may be concatenated with plain string literals.
    single: string; formatted literal
    single: string; interpolated literal
    single: f-string
+   single: fstring
    single: {} (curly brackets); in formatted string literal
    single: ! (exclamation); in formatted string literal
    single: : (colon); in formatted string literal

--- a/Misc/NEWS.d/next/Documentation/2020-07-27-20-46-17.bpo-41045.GFF6Ul.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-27-20-46-17.bpo-41045.GFF6Ul.rst
@@ -1,0 +1,1 @@
+Add documentation for debug feature of f-strings.


### PR DESCRIPTION
Co-Authored-By: Rishi <rishi93dev@gmail.com>

<!-- issue-number: [bpo-41045](https://bugs.python.org/issue41045) -->
https://bugs.python.org/issue41045
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum