### PR TITLE
gh-82300: Disable resource tracking & auto-destruction of SharedMemory blocks on POSIX

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -1316,14 +1316,6 @@ if HAS_SHMEM:
         _Server = SharedMemoryServer
 
         def __init__(self, *args, **kwargs):
-            if os.name == "posix":
-                # bpo-36867: Ensure the resource_tracker is running before
-                # launching the manager process, so that concurrent
-                # shared_memory manipulation both in the manager and in the
-                # current process does not create two resource_tracker
-                # processes.
-                from . import resource_tracker
-                resource_tracker.ensure_running()
             BaseManager.__init__(self, *args, **kwargs)
             util.debug(f"{self.__class__.__name__} created by pid {getpid()}")
 

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -39,7 +39,6 @@ if os.name == 'posix':
 
     _CLEANUP_FUNCS.update({
         'semaphore': _multiprocessing.sem_unlink,
-        'shared_memory': _posixshmem.shm_unlink,
     })
 
 

--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -114,9 +114,6 @@ class SharedMemory:
                 self.unlink()
                 raise
 
-            from .resource_tracker import register
-            register(self._name, "shared_memory")
-
         else:
 
             # Windows Named Shared Memory
@@ -235,9 +232,7 @@ class SharedMemory:
         called once (and only once) across all processes which have access
         to the shared memory block."""
         if _USE_POSIX and self._name:
-            from .resource_tracker import unregister
             _posixshmem.shm_unlink(self._name)
-            unregister(self._name, "shared_memory")
 
 
 _encoding = "utf8"

--- a/Misc/NEWS.d/next/Library/2019-09-11-11-08-53.bpo-38119.da_hwK.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-11-11-08-53.bpo-38119.da_hwK.rst
@@ -1,0 +1,1 @@
+Fix resource tracker treatment of shared memory as if it were a semaphore.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Eliminates the use of the resource tracker on shared memory segments but preserves its use on semaphores, etc. where it is appropriately applied.

Adds a test that fails with the current code (an independent Python process started via subprocess accesses shared memory created by a different Python process, then exits normally, expecting the original creator process to continue to be able to access that shared memory) but passes with this patch to defend against future regressions.

<!-- issue-number: [bpo-38119](https://bugs.python.org/issue38119) -->
https://bugs.python.org/issue38119
<!-- /issue-number -->


<!-- gh-issue-number: gh-82300 -->
* Issue: gh-82300
<!-- /gh-issue-number -->
