### PR TITLE
bpo-41241: Change "if bool(val)" to "if val"

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -115,7 +115,7 @@ class Future:
 
     @_log_traceback.setter
     def _log_traceback(self, val):
-        if bool(val):
+        if val:
             raise ValueError('_log_traceback can only be set to False')
         self.__log_traceback = False
 


### PR DESCRIPTION
if bool(val) is annoying and same as if val.


<!-- issue-number: [bpo-41241](https://bugs.python.org/issue41241) -->
https://bugs.python.org/issue41241
<!-- /issue-number -->
