### PR TITLE
bpo-41295: Reimplement the Carlo Verre "hackcheck"

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4308,6 +4308,42 @@ order (MRO) for bases """
         else:
             self.fail("Carlo Verre __delattr__ succeeded!")
 
+    def test_carloverre_multiinherit_valid(self):
+        class A(type):
+            def __setattr__(cls, key, value):
+                type.__setattr__(cls, key, value)
+
+        class B:
+            pass
+
+        class C(B, A):
+            pass
+
+        obj = C('D', (object,), {})
+        try:
+            obj.test = True
+        except TypeError:
+            self.fail("setattr through direct base types should be legal")
+
+    def test_carloverre_multiinherit_invalid(self):
+        class A(type):
+            def __setattr__(cls, key, value):
+                object.__setattr__(cls, key, value)  # this should fail!
+
+        class B:
+            pass
+
+        class C(B, A):
+            pass
+
+        obj = C('D', (object,), {})
+        try:
+            obj.test = True
+        except TypeError:
+            pass
+        else:
+            self.fail("setattr through indirect base types should be rejected")
+
     def test_weakref_segfault(self):
         # Testing weakref segfault...
         # SF 742911

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4308,7 +4308,7 @@ order (MRO) for bases """
         else:
             self.fail("Carlo Verre __delattr__ succeeded!")
 
-    def test_carloverre_multiinherit_valid(self):
+    def test_carloverre_multi_inherit_valid(self):
         class A(type):
             def __setattr__(cls, key, value):
                 type.__setattr__(cls, key, value)
@@ -4325,7 +4325,7 @@ order (MRO) for bases """
         except TypeError:
             self.fail("setattr through direct base types should be legal")
 
-    def test_carloverre_multiinherit_invalid(self):
+    def test_carloverre_multi_inherit_invalid(self):
         class A(type):
             def __setattr__(cls, key, value):
                 object.__setattr__(cls, key, value)  # this should fail!

--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-18-08-15-32.bpo-41295.pu8Ezo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-18-08-15-32.bpo-41295.pu8Ezo.rst
@@ -1,0 +1,3 @@
+Resolve a regression in CPython 3.8.4 where defining "__setattr__" in a
+multi-inheritance setup and calling up the hierarchy chain could fail
+if builtins/extension types were involved in the base types.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5978,9 +5978,12 @@ hackcheck(PyObject *self, setattrofunc func, const char *what)
     }
 
     /* Reject calls that jump over intermediate C-level overrides. */
-    PyTypeObject *base = defining_type;
-    while (base && base->tp_setattro != func) {
-        if (base->tp_setattro != slot_tp_setattro) {
+    for (PyTypeObject *base = defining_type; base; base = base->tp_base) {
+        if (base->tp_setattro == func) {
+            /* 'func' is the right slot function to call. */
+            break;
+        }
+        else if (base->tp_setattro != slot_tp_setattro) {
             /* 'base' is not a Python class and overrides 'func'.
                Its tp_setattro should be called instead. */
             PyErr_Format(PyExc_TypeError,
@@ -5989,7 +5992,6 @@ hackcheck(PyObject *self, setattrofunc func, const char *what)
                          type->tp_name);
             return 0;
         }
-        base = base->tp_base;
     }
     return 1;
 }


### PR DESCRIPTION
Walk down the MRO backwards to find the type that originally defined the final `tp_setattro`, then make sure we are not jumping over intermediate C-level bases with the Python-level call.

<!-- issue-number: [bpo-41295](https://bugs.python.org/issue41295) -->
https://bugs.python.org/issue41295
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum