### PR TITLE
bpo-41340: Removed strcpy from strdup function

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-23-19-13-03.bpo-41340.en20DT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-23-19-13-03.bpo-41340.en20DT.rst
@@ -1,0 +1,1 @@
+Optimized strdup

--- a/Python/strdup.c
+++ b/Python/strdup.c
@@ -4,9 +4,10 @@ char *
 strdup(const char *str)
 {
     if (str != NULL) {
-        char *copy = malloc(strlen(str) + 1);
+        size_t len = strlen(str) + 1;
+        char *copy = malloc(len);
         if (copy != NULL)
-            return strcpy(copy, str);
+            return memcpy(copy, str, len);
     }
     return NULL;
 }


### PR DESCRIPTION
strdup implementation inside cpython/Python/strdup.c is not the best one.
It calls strlen + strcpy, which is the same as calling strlen twice + memcpy.
So I replaced it by the call of strlen + memcpy.

It is easy to look any implementation in any library.
Here for example:
https://code.woboq.org/userspace/glibc/string/strdup.c.html

<!-- issue-number: [bpo-41340](https://bugs.python.org/issue41340) -->
https://bugs.python.org/issue41340
<!-- /issue-number -->
