### PR TITLE
bpo-41336: Fix the error handling in zoneinfo_new_instance()

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -224,8 +224,14 @@ error:
     self = NULL;
 cleanup:
     if (file_obj != NULL) {
+        PyObject *exc, *val, *tb;
+        PyErr_Fetch(&exc, &val, &tb);
         PyObject *tmp = PyObject_CallMethod(file_obj, "close", NULL);
-        Py_DECREF(tmp);
+        _PyErr_ChainExceptions(exc, val, tb);
+        if (tmp == NULL) {
+            Py_CLEAR(self);
+        }
+        Py_XDECREF(tmp);
         Py_DECREF(file_obj);
     }
     Py_DECREF(file_path);


### PR DESCRIPTION
Do not call PyObject_CallMethod() with a live exception (like
KeyboardInterrupt).

<!-- issue-number: [bpo-41336](https://bugs.python.org/issue41336) -->
https://bugs.python.org/issue41336
<!-- /issue-number -->
