### PR TITLE
bpo-41341: Recursive evaluation of ForwardRef in get_type_hints

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2456,6 +2456,12 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(get_type_hints(foo, globals(), locals()),
                          {'a': tuple[T]})
 
+    def test_double_forward(self):
+        def foo(a: 'List[\'int\']'):
+            pass
+        self.assertEqual(get_type_hints(foo, globals(), locals()),
+                         {'a': List[int]})
+
     def test_forward_recursion_actually(self):
         def namespace1():
             a = typing.ForwardRef('A')

--- a/Misc/NEWS.d/next/Library/2020-07-20-19-13-17.bpo-41341.wqrj8C.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-20-19-13-17.bpo-41341.wqrj8C.rst
@@ -1,0 +1,1 @@
+Recursive evaluation of `typing.ForwardRef` in `get_type_hints`.


### PR DESCRIPTION
The issue raised by recursive evaluation is infinite recursion with
recursive types. In that case, only the first recursive ForwardRef is
evaluated.

<!-- issue-number: [bpo-41341](https://bugs.python.org/issue41341) -->
https://bugs.python.org/issue41341
<!-- /issue-number -->
