### PR TITLE
README: Add link to LICENSE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,8 +259,9 @@ rights reserved.
 
 Copyright (c) 1991-1995 Stichting Mathematisch Centrum.  All rights reserved.
 
-See the file "LICENSE" for information on the history of this software, terms &
-conditions for usage, and a DISCLAIMER OF ALL WARRANTIES.
+See the `LICENSE <https://github.com/python/cpython/blob/master/LICENSE>`_ for
+information on the history of this software, terms & conditions for usage, and a
+DISCLAIMER OF ALL WARRANTIES.
 
 This Python distribution contains *no* GNU General Public License (GPL) code,
 so it may be used in proprietary projects.  There are interfaces to some GNU


### PR DESCRIPTION
Hi there! Since this is a trivial change, I've titled this without an issue number. This adds a hyperlink to the `LICENSE` in `README.rst`, so users don't have to scroll around and can easily navigate to it.

Automerge-Triggered-By: @csabella