### PR TITLE
bpo-41352: Raise UnsupportedOperation for FileIO.readall() in "w" mode

### DIFF
--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -73,6 +73,24 @@ class AutoFileTests:
             blksize = getattr(fst, 'st_blksize', blksize)
         self.assertEqual(self.f._blksize, blksize)
 
+    def testReadWithWritingMode(self):
+        r, w = os.pipe()
+        w = os.fdopen(w, "w")
+        w.write("hello")
+        w.close()
+        with io.FileIO(r, mode="w") as f:
+            with self.assertRaises(_io.UnsupportedOperation):
+                f.read()
+
+    def testReadallWithWritingMode(self):
+        r, w = os.pipe()
+        w = os.fdopen(w, "w")
+        w.write("hello")
+        w.close()
+        with io.FileIO(r, mode="w") as f:
+            with self.assertRaises(_io.UnsupportedOperation):
+                f.readall()
+
     # verify readinto
     def testReadintoByteArray(self):
         self.f.write(bytes([1, 2, 0, 255]))

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -74,16 +74,16 @@ class AutoFileTests:
         self.assertEqual(self.f._blksize, blksize)
 
     def testReadWithWritingMode(self):
-        with os.pipe() as r, w:
-            w = os.fdopen(w, "w")
+        r, w = os.pipe()
+        with os.fdopen(w, "w") as w:
             w.write("hello")
         with io.FileIO(r, mode="w") as f:
             with self.assertRaises(_io.UnsupportedOperation):
                 f.read()
 
     def testReadallWithWritingMode(self):
-        with os.pipe() as r, w
-            w = os.fdopen(w, "w")
+        r, w = os.pipe()
+        with os.fdopen(w, "w") as w:
             w.write("hello")
         with io.FileIO(r, mode="w") as f:
             with self.assertRaises(_io.UnsupportedOperation):

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -74,19 +74,17 @@ class AutoFileTests:
         self.assertEqual(self.f._blksize, blksize)
 
     def testReadWithWritingMode(self):
-        r, w = os.pipe()
-        w = os.fdopen(w, "w")
-        w.write("hello")
-        w.close()
+        with os.pipe() as r, w:
+            w = os.fdopen(w, "w")
+            w.write("hello")
         with io.FileIO(r, mode="w") as f:
             with self.assertRaises(_io.UnsupportedOperation):
                 f.read()
 
     def testReadallWithWritingMode(self):
-        r, w = os.pipe()
-        w = os.fdopen(w, "w")
-        w.write("hello")
-        w.close()
+        with os.pipe() as r, w
+            w = os.fdopen(w, "w")
+            w.write("hello")
         with io.FileIO(r, mode="w") as f:
             with self.assertRaises(_io.UnsupportedOperation):
                 f.readall()

--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-17-22-05-07.bpo-41352.8WfyQ6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-17-22-05-07.bpo-41352.8WfyQ6.rst
@@ -1,0 +1,1 @@
+Fix "FileIO.readall()" to check for "readable" and raise "UnsupportedOperation" for not readable file in "w" mode.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -699,6 +699,8 @@ _io_FileIO_readall_impl(fileio *self)
 
     if (self->fd < 0)
         return err_closed();
+    if (!self->readable)
+        return err_mode("reading");
 
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -699,8 +699,9 @@ _io_FileIO_readall_impl(fileio *self)
 
     if (self->fd < 0)
         return err_closed();
-    if (!self->readable)
+    if (!self->readable) {
         return err_mode("reading");
+    }
 
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH


### PR DESCRIPTION
check self->readable

added tests for FileIO.read and FileIO.readall

<!-- issue-number: [bpo-41352](https://bugs.python.org/issue41352) -->
https://bugs.python.org/issue41352
<!-- /issue-number -->
