### PR TITLE
bpo-41100: add runtime checks for MACOSX_DEPLOYMENT_TARGET=10.10

### DIFF
--- a/Misc/NEWS.d/next/macOS/2020-07-21-02-29-17.bpo-41100.kFtqID.rst
+++ b/Misc/NEWS.d/next/macOS/2020-07-21-02-29-17.bpo-41100.kFtqID.rst
@@ -1,0 +1,1 @@
+Add runtime checks for MACOSX_DEPLOYMENT_TARGET=10.10 so backwards compatible python can be built with latest Xcode

--- a/configure
+++ b/configure
@@ -12190,6 +12190,41 @@ $as_echo "yes" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking to see if the compiler supports __builtin_available" >&5
+$as_echo_n "checking to see if the compiler supports __builtin_available... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+int
+main ()
+{
+
+     if (__builtin_available(macOS 10.8, iOS 5.0, *)) {}
+
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_BUILTIN_AVAILABLE 1
+_ACEOF
+
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 for ac_prog in true
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.

--- a/configure.ac
+++ b/configure.ac
@@ -3825,6 +3825,19 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
    AC_MSG_RESULT(yes)
 ])
 
+AC_MSG_CHECKING([to see if the compiler supports __builtin_available])
+AC_COMPILE_IFELSE([
+  AC_LANG_PROGRAM([[]],[[
+     if (__builtin_available(macOS 10.8, iOS 5.0, *)) {}
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE_UNQUOTED(HAVE_BUILTIN_AVAILABLE, 1,
+        [Define to 1 if the compiler supports __builtin_available])
+  ],[
+    AC_MSG_RESULT([no])
+])
+
 dnl check for true
 AC_CHECK_PROGS(TRUE, true, /bin/true)
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -115,6 +115,9 @@
 /* Define if `unsetenv` does not return an int. */
 #undef HAVE_BROKEN_UNSETENV
 
+#undef HAVE_BUILTIN_AVAILABLE
+/* Define to 1 if the compiler supports __builtin_available */
+
 /* Has builtin atomics */
 #undef HAVE_BUILTIN_ATOMIC
 


### PR DESCRIPTION
In order to support a universal2 build, supporting Mac OS 11 on arm64 and Mac OS on
x86_64 going back to 10.10, we need to add in runtime checks for functions that will
be detected as present by autoconf, because they are in the SDK, but which did not
exist  in Mac OS 10.10.    This fixes all the instances of -WWunguarded-availability-new
when building with MACOSX_DEPLOYMENT_TARGET=10.10

<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
