### PR TITLE
bpo-41100: deploy to an earlier version of macOS

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -149,6 +149,16 @@ perf_counter(_Py_clock_info_t *info)
 }
 
 #ifdef HAVE_CLOCK_GETTIME
+
+#ifdef __APPLE__
+/* 
+ * The clock_* functions will be removed from the module
+ * dict entirely when the C API is not available.
+ */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+#endif
+
 static PyObject *
 time_clock_gettime(PyObject *self, PyObject *args)
 {
@@ -297,6 +307,11 @@ PyDoc_STRVAR(clock_getres_doc,
 "clock_getres(clk_id) -> floating point number\n\
 \n\
 Return the resolution (precision) of the specified clock clk_id.");
+
+#ifdef __APPLE__
+#pragma clang diagnostic pop
+#endif
+
 #endif   /* HAVE_CLOCK_GETRES */
 
 #ifdef HAVE_PTHREAD_GETCPUCLOCKID
@@ -1162,6 +1177,11 @@ _PyTime_GetProcessTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 #if defined(HAVE_CLOCK_GETTIME) \
     && (defined(CLOCK_PROCESS_CPUTIME_ID) || defined(CLOCK_PROF))
     struct timespec ts;
+
+#ifdef __APPLE__
+  if (__builtin_available(macos 10.12, *)) {
+#endif
+
 #ifdef CLOCK_PROF
     const clockid_t clk_id = CLOCK_PROF;
     const char *function = "clock_gettime(CLOCK_PROF)";
@@ -1188,6 +1208,9 @@ _PyTime_GetProcessTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
         }
         return 0;
     }
+#ifdef __APPLE__
+  }
+#endif
 #endif
 
     /* getrusage(RUSAGE_SELF) */
@@ -1373,6 +1396,12 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 
 #elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_PROCESS_CPUTIME_ID)
 #define HAVE_THREAD_TIME
+
+#ifdef __APPLE__
+static int
+_PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info) __attribute__((availability(macos, introduced=10.12)));
+#endif
+
 static int
 _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 {
@@ -1404,6 +1433,15 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 #endif
 
 #ifdef HAVE_THREAD_TIME
+#ifdef __APPLE__
+/* 
+ * The clock_* functions will be removed from the module
+ * dict entirely when the C API is not available.
+ */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+#endif
+
 static PyObject *
 time_thread_time(PyObject *self, PyObject *unused)
 {
@@ -1434,6 +1472,11 @@ PyDoc_STRVAR(thread_time_ns_doc,
 \n\
 Thread time for profiling as nanoseconds:\n\
 sum of the kernel and user-space CPU time.");
+
+#ifdef __APPLE__
+#pragma clang diagnostic pop
+#endif
+
 #endif
 
 
@@ -1483,9 +1526,19 @@ time_get_clock_info(PyObject *self, PyObject *args)
     }
 #ifdef HAVE_THREAD_TIME
     else if (strcmp(name, "thread_time") == 0) {
+
+#ifdef __APPLE__
+     if (__builtin_available(macos 10.12, *)) {
+#endif
         if (_PyTime_GetThreadTimeWithInfo(&t, &info) < 0) {
             return NULL;
         }
+#ifdef __APPLE__
+     } else {
+        PyErr_SetString(PyExc_ValueError, "unknown clock");
+        return NULL;
+     }
+#endif
     }
 #endif
     else {
@@ -1774,34 +1827,70 @@ time_exec(PyObject *module)
 #if defined(HAVE_CLOCK_GETTIME) || defined(HAVE_CLOCK_SETTIME) || defined(HAVE_CLOCK_GETRES)
 
 #ifdef CLOCK_REALTIME
+#ifdef __APPLE__
+  if (__builtin_available(macOS 10.12, *)) {
+#endif
     if (PyModule_AddIntMacro(module, CLOCK_REALTIME) < 0) {
         return -1;
     }
+#ifdef __APPLE__
+  }
 #endif
+#endif
+
 #ifdef CLOCK_MONOTONIC
+
+#ifdef __APPLE__
+  if (__builtin_available(macOS 10.12, *)) {
+#endif
     if (PyModule_AddIntMacro(module, CLOCK_MONOTONIC) < 0) {
         return -1;
     }
+
+#ifdef __APPLE__
+  }
+#endif
+
 #endif
 #ifdef CLOCK_MONOTONIC_RAW
+#ifdef __APPLE__
+  if (__builtin_available(macOS 10.12, *)) {
+#endif
     if (PyModule_AddIntMacro(module, CLOCK_MONOTONIC_RAW) < 0) {
         return -1;
     }
+#ifdef __APPLE__
+  }
 #endif
+#endif
+
 #ifdef CLOCK_HIGHRES
     if (PyModule_AddIntMacro(module, CLOCK_HIGHRES) < 0) {
         return -1;
     }
 #endif
 #ifdef CLOCK_PROCESS_CPUTIME_ID
+#ifdef __APPLE__
+  if (__builtin_available(macOS 10.12, *)) {
+#endif
     if (PyModule_AddIntMacro(module, CLOCK_PROCESS_CPUTIME_ID) < 0) {
         return -1;
     }
+#ifdef __APPLE__
+  }
 #endif
+#endif
+
 #ifdef CLOCK_THREAD_CPUTIME_ID
+#ifdef __APPLE__
+  if (__builtin_available(macOS 10.12, *)) {
+#endif
     if (PyModule_AddIntMacro(module, CLOCK_THREAD_CPUTIME_ID) < 0) {
         return -1;
     }
+#ifdef __APPLE__
+  }
+#endif
 #endif
 #ifdef CLOCK_PROF
     if (PyModule_AddIntMacro(module, CLOCK_PROF) < 0) {
@@ -1824,9 +1913,17 @@ time_exec(PyObject *module)
     }
 #endif
 #ifdef CLOCK_UPTIME_RAW
+
+#ifdef __APPLE__
+  if (__builtin_available(macOS 10.12, *)) {
+#endif
     if (PyModule_AddIntMacro(module, CLOCK_UPTIME_RAW) < 0) {
         return -1;
     }
+
+#ifdef __APPLE__
+  }
+#endif
 #endif
 
 #endif  /* defined(HAVE_CLOCK_GETTIME) || defined(HAVE_CLOCK_SETTIME) || defined(HAVE_CLOCK_GETRES) */
@@ -1877,7 +1974,47 @@ static struct PyModuleDef timemodule = {
 PyMODINIT_FUNC
 PyInit_time(void)
 {
-    return PyModuleDef_Init(&timemodule);
+    PyObject* module = PyModuleDef_Init(&timemodule);
+
+#if defined(__APPLE__) && defined(HAVE_CLOCK_GETTIME)
+    if (__builtin_available(macOS 10.12, *)) {
+        /* pass: ^^^ cannot use '!' here */
+    } else {
+        PyObject* dct = PyModule_GetDict(module);
+
+        if (PyDict_DelItemString(dct, "clock_gettime") == -1) {
+            PyErr_Clear();
+        }
+        if (PyDict_DelItemString(dct, "clock_gettime_ns") == -1) {
+            PyErr_Clear();
+        }
+        if (PyDict_DelItemString(dct, "clock_settime") == -1) {
+            PyErr_Clear();
+        }
+        if (PyDict_DelItemString(dct, "clock_settime_ns") == -1) {
+            PyErr_Clear();
+        }
+        if (PyDict_DelItemString(dct, "clock_getres") == -1) {
+            PyErr_Clear();
+        }
+    }
+#endif
+#if defined(__APPLE__) && defined(HAVE_THREAD_TIME)
+    if (__builtin_available(macOS 10.12, *)) {
+        /* pass: ^^^ cannot use '!' here */
+    } else {
+        PyObject* dct = PyModule_GetDict(module);
+
+        if (PyDict_DelItemString(dct, "thread_time") == -1) {
+            PyErr_Clear();
+        }
+        if (PyDict_DelItemString(dct, "thread_time_ns") == -1) {
+            PyErr_Clear();
+        }
+    }
+#endif
+
+    return module;
 }
 
 /* Implement pysleep() for various platforms.

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -208,6 +208,11 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
      error.
 
    getentropy() is retried if it failed with EINTR: interrupted by a signal. */
+#ifdef __APPLE__
+static int
+py_getentropy(char *buffer, Py_ssize_t size, int raise) __attribute__((availability(macos,introduced=10.12)));
+#endif
+
 static int
 py_getentropy(char *buffer, Py_ssize_t size, int raise)
 {
@@ -498,6 +503,9 @@ pyurandom(void *buffer, Py_ssize_t size, int blocking, int raise)
 #else
 
 #if defined(PY_GETRANDOM) || defined(PY_GETENTROPY)
+#ifdef __APPLE__
+    if (__builtin_available(macOS 10.12, *)) {
+#endif
 #ifdef PY_GETRANDOM
     res = py_getrandom(buffer, size, blocking, raise);
 #else
@@ -511,6 +519,9 @@ pyurandom(void *buffer, Py_ssize_t size, int blocking, int raise)
     }
     /* getrandom() or getentropy() function is not available: failed with
        ENOSYS or EPERM. Fall back on reading from /dev/urandom. */
+#ifdef __APPLE__
+    } /* end of availability block */
+#endif
 #endif
 
     return dev_urandom(buffer, size, raise);


### PR DESCRIPTION
These are most of the C changes needed to build on macOS 11.0 and deploy to macOS 10.9 (and technically even earlier, this should even work back to macOS 10.6).

This patch is currently in a very rough state and is incomplete.

TODO:

- [ ] The code that exports availability status from posixmodule.c to os.py needs to be updated
- [ ] Testing, possibly adding more tests


NOTE: This should be merged with PR21577, which does something similar but only back to macOS 10.10.


<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
