### PR TITLE
bpo-41100: bugfix, arm64 Mac OS, missing #include <AvailabilityMacros.h>

### DIFF
--- a/Misc/NEWS.d/next/macOS/2020-07-21-22-31-07.bpo-41100.DpyP6E.rst
+++ b/Misc/NEWS.d/next/macOS/2020-07-21-22-31-07.bpo-41100.DpyP6E.rst
@@ -1,0 +1,1 @@
+fix a bug in getpath.c for arm64 Mac OS

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -11,6 +11,7 @@
 
 #ifdef __APPLE__
 #  include <mach-o/dyld.h>
+#  include <AvailabilityMacros.h>
 #endif
 
 /* Search in some common locations for the associated Python libraries.


### PR DESCRIPTION
MAC_OS_X_VERSION_MAX_ALLOWED is defined in this header.   Because it is
not included nsexeclength is defined as the wrong type, causing an
incompatible pointer to be passed to _NSGetExecutablePath on arm64

<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
