### PR TITLE
[doc] Stick with the phrase "default parameter value"

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -571,9 +571,9 @@ value --- this is a syntactic restriction that is not expressed by the grammar.
 **Default parameter values are evaluated from left to right when the function
 definition is executed.** This means that the expression is evaluated once, when
 the function is defined, and that the same "pre-computed" value is used for each
-call.  This is especially important to understand when a default parameter is a
+call.  This is especially important to understand when a default parameter value is a
 mutable object, such as a list or a dictionary: if the function modifies the
-object (e.g. by appending an item to a list), the default value is in effect
+object (e.g. by appending an item to a list), the default parameter value is in effect
 modified.  This is generally not what was intended.  A way around this is to use
 ``None`` as the default, and explicitly test for it in the body of the function,
 e.g.::


### PR DESCRIPTION
This changes two instances of the doc that talk about default parameter values: the first one I think is a fix and the second one I think is better as proposed.