### PR TITLE
bpo-41373: IDLE: Fix saving files loaded with no newlines or mixed newlines

### DIFF
--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -155,6 +155,17 @@ class IOBinding:
                                    parent=self.text)
             return False
 
+        if not isinstance(eol_convention, str):
+            # If the file does not contain line separators, it is None.
+            # If the file contains mixed line separators, it is a tuple.
+            eol_convention = os.linesep  # default
+            if eol_convention is not None:
+                tkMessageBox.showwarning("Mixed Newlines",
+                                         "Mixed newlines detected.\n"
+                                         "The file will be changed on save.",
+                                         parent=self.text)
+                converted = True
+
         self.text.delete("1.0", "end")
         self.set_filename(None)
         self.fileencoding = fileencoding

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -158,13 +158,13 @@ class IOBinding:
         if not isinstance(eol_convention, str):
             # If the file does not contain line separators, it is None.
             # If the file contains mixed line separators, it is a tuple.
-            eol_convention = os.linesep  # default
             if eol_convention is not None:
                 tkMessageBox.showwarning("Mixed Newlines",
                                          "Mixed newlines detected.\n"
                                          "The file will be changed on save.",
                                          parent=self.text)
                 converted = True
+            eol_convention = os.linesep  # default
 
         self.text.delete("1.0", "end")
         self.set_filename(None)

--- a/Misc/NEWS.d/next/IDLE/2020-07-24-17-49-58.bpo-41373.YQIPu_.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-07-24-17-49-58.bpo-41373.YQIPu_.rst
@@ -1,0 +1,3 @@
+Save files loaded with no line ending, as when blank, or different line
+endings, by setting its line ending to the system default. Fix regression in
+3.8.4 and 3.9.0b4.


### PR DESCRIPTION


<!-- issue-number: [bpo-41373](https://bugs.python.org/issue41373) -->
https://bugs.python.org/issue41373
<!-- /issue-number -->
