### PR TITLE
bpo-41376: Correct the documentation on ``site.getusersitepackages()`` regarding respecting PYTHONNOUSERSITE

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -231,7 +231,9 @@ Module contents
 
    Return the path of the user-specific site-packages directory,
    :data:`USER_SITE`.  If it is not initialized yet, this function will also set
-   it, respecting :envvar:`PYTHONNOUSERSITE` and :data:`USER_BASE`.
+   it, respecting :data:`USER_BASE`.  To determine if the user-specific
+   site-packages was added to ``sys.path`` :data:`ENABLE_USER_SITE` should be
+   used.
 
    .. versionadded:: 3.2
 


### PR DESCRIPTION
``site.getusersitepackages()`` returns the location of the user-specific site-packages directory
whether or not it exists, or is added to the ``sys.path``. We can see this easily with:

```
$ python  -c "import site; print(site.getusersitepackages())"
/home/user/.local/lib/python3.7/site-packages

$ python -s -c "import site; print(site.getusersitepackages())"
/home/user/.local/lib/python3.7/site-packages

```

This is even true when the user-specific site-packages doesn't exist, as is demonstrated by:

```
$ python -m site
sys.path = [
    '/home/user/conda/lib/python37.zip',
    '/home/user/conda/lib/python3.7',
    '/home/user/conda/lib/python3.7/lib-dynload',
    '/home/user/conda/lib/python3.7/site-packages',
]
USER_BASE: '/home/user/.local' (exists)
USER_SITE: '/home/user/.local/lib/python3.7/site-packages' (doesn't exist)
ENABLE_USER_SITE: True

$ python -s -m site
sys.path = [
    '/home/user/conda/lib/python37.zip',
    '/home/user/conda/lib/python3.7',
    '/home/user/conda/lib/python3.7/lib-dynload',
    '/home/user/conda/lib/python3.7/site-packages',
]
USER_BASE: '/home/user/.local' (exists)
USER_SITE: '/home/user/.local/lib/python3.7/site-packages' (doesn't exist)
ENABLE_USER_SITE: False

```

It was not practical to update the function to return None if user-specific site-packages are disabled (i.e. update the function to reflect the existing documentation), since there are other uses of the function which are relying on this behaviour (e.g. ``python -m site``) and it would amount to a breaking change.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41376](https://bugs.python.org/issue41376) -->
https://bugs.python.org/issue41376
<!-- /issue-number -->
