### PR TITLE
bpo-41386 Fixed Popen.wait does not account for negative return codes

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1468,8 +1468,11 @@ class Popen(object):
                 if result == _winapi.WAIT_TIMEOUT:
                     raise TimeoutExpired(self.args, timeout)
                 self.returncode = _winapi.GetExitCodeProcess(self._handle)
-                if self.returncode != 0:
+                # Check for negative return codes from a C-Style program
+                if self.returncode > 2**32 - 1:
+                    # Convert to signed int
                     self.returncode -= 2**32
+                    # Unfortunaly we cannot use ctypes here
             return self.returncode
 
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1468,6 +1468,8 @@ class Popen(object):
                 if result == _winapi.WAIT_TIMEOUT:
                     raise TimeoutExpired(self.args, timeout)
                 self.returncode = _winapi.GetExitCodeProcess(self._handle)
+                if self.returncode != 0:
+                    self.returncode -= 2**32
             return self.returncode
 
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1469,7 +1469,7 @@ class Popen(object):
                     raise TimeoutExpired(self.args, timeout)
                 self.returncode = _winapi.GetExitCodeProcess(self._handle)
                 # Check for negative return codes from a C-Style program
-                if self.returncode > 2**32 - 1:
+                if self.returncode > 2**31 - 1:
                     # Convert to signed int
                     self.returncode -= 2**32
                     # Unfortunaly we cannot use ctypes here

--- a/Misc/NEWS.d/next/Library/2020-07-24-19-25-43.bpo-41386.dkkbVJ.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-24-19-25-43.bpo-41386.dkkbVJ.rst
@@ -1,0 +1,2 @@
+A bug was fixed where negative return codes would be shown as positive
+unsigned values


### PR DESCRIPTION
#  Popen.wait does not account for negative return codes

Added signed conversion

<!-- issue-number: [bpo-41386](https://bugs.python.org/issue41386) -->
https://bugs.python.org/issue41386
<!-- /issue-number -->
