### PR TITLE
bpo-22431: Show fully-qualified name in test runner output

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -976,7 +976,7 @@ class ArgsTestCase(BaseTestCase):
                                   randomize=True)
 
     def parse_methods(self, output):
-        regex = re.compile("^(test[^ ]+).*ok$", flags=re.MULTILINE)
+        regex = re.compile(r"\.(test[^ ]+).*ok$", flags=re.MULTILINE)
         return [match.group(1) for match in regex.finditer(output)]
 
     def test_ignorefile(self):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -461,7 +461,7 @@ class TestCase(object):
         return hash((type(self), self._testMethodName))
 
     def __str__(self):
-        return "%s (%s)" % (self._testMethodName, strclass(self.__class__))
+        return f"{strclass(self.__class__)}.{self._testMethodName}"
 
     def __repr__(self):
         return "<%s testMethod=%s>" % \

--- a/Lib/unittest/test/test_result.py
+++ b/Lib/unittest/test/test_result.py
@@ -298,33 +298,37 @@ class Test_TestResult(unittest.TestCase):
         result = unittest.TextTestResult(None, True, 1)
         self.assertEqual(
                 result.getDescription(self),
-                'testGetDescriptionWithoutDocstring (' + __name__ +
-                '.Test_TestResult)')
+                __name__ + '.Test_TestResult' +
+                '.testGetDescriptionWithoutDocstring')
 
     def testGetSubTestDescriptionWithoutDocstring(self):
         with self.subTest(foo=1, bar=2):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    'testGetSubTestDescriptionWithoutDocstring (' + __name__ +
-                    '.Test_TestResult) (foo=1, bar=2)')
+                    __name__ + '.Test_TestResult' +
+                    '.testGetSubTestDescriptionWithoutDocstring '
+                    '(foo=1, bar=2)')
         with self.subTest('some message'):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    'testGetSubTestDescriptionWithoutDocstring (' + __name__ +
-                    '.Test_TestResult) [some message]')
+                    __name__ + '.Test_TestResult' +
+                    '.testGetSubTestDescriptionWithoutDocstring '
+                    '[some message]')
 
     def testGetSubTestDescriptionWithoutDocstringAndParams(self):
         with self.subTest():
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    'testGetSubTestDescriptionWithoutDocstringAndParams '
-                    '(' + __name__ + '.Test_TestResult) (<subtest>)')
+                    __name__ + '.Test_TestResult' +
+                    '.testGetSubTestDescriptionWithoutDocstringAndParams ' +
+                    '(<subtest>)')
 
     def testGetSubTestDescriptionForFalsyValues(self):
-        expected = 'testGetSubTestDescriptionForFalsyValues (%s.Test_TestResult) [%s]'
+        expected = ('%s.Test_TestResult.'
+                    'testGetSubTestDescriptionForFalsyValues [%s]')
         result = unittest.TextTestResult(None, True, 1)
         for arg in [0, None, []]:
             with self.subTest(arg):
@@ -339,17 +343,19 @@ class Test_TestResult(unittest.TestCase):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
                         result.getDescription(self._subtest),
-                        'testGetNestedSubTestDescriptionWithoutDocstring '
-                        '(' + __name__ + '.Test_TestResult) (baz=2, bar=3, foo=1)')
+                        __name__ + '.Test_TestResult'
+                        '.testGetNestedSubTestDescriptionWithoutDocstring'
+                        ' (baz=2, bar=3, foo=1)')
 
     def testGetDuplicatedNestedSubTestDescriptionWithoutDocstring(self):
+        meth = 'testGetDuplicatedNestedSubTestDescriptionWithoutDocstring'
         with self.subTest(foo=1, bar=2):
             with self.subTest(baz=3, bar=4):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
                         result.getDescription(self._subtest),
-                        'testGetDuplicatedNestedSubTestDescriptionWithoutDocstring '
-                        '(' + __name__ + '.Test_TestResult) (baz=3, bar=4, foo=1)')
+                        __name__ + '.Test_TestResult.' + meth +
+                        ' (baz=3, bar=4, foo=1)')
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
@@ -358,8 +364,8 @@ class Test_TestResult(unittest.TestCase):
         result = unittest.TextTestResult(None, True, 1)
         self.assertEqual(
                 result.getDescription(self),
-               ('testGetDescriptionWithOneLineDocstring '
-                '(' + __name__ + '.Test_TestResult)\n'
+               (__name__ + '.Test_TestResult'
+                '.testGetDescriptionWithOneLineDocstring\n'
                 'Tests getDescription() for a method with a docstring.'))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
@@ -370,8 +376,9 @@ class Test_TestResult(unittest.TestCase):
         with self.subTest(foo=1, bar=2):
             self.assertEqual(
                 result.getDescription(self._subtest),
-               ('testGetSubTestDescriptionWithOneLineDocstring '
-                '(' + __name__ + '.Test_TestResult) (foo=1, bar=2)\n'
+               ( __name__ + '.Test_TestResult'
+                '.testGetSubTestDescriptionWithOneLineDocstring '
+                '(foo=1, bar=2)\n'
                 'Tests getDescription() for a method with a docstring.'))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
@@ -383,8 +390,8 @@ class Test_TestResult(unittest.TestCase):
         result = unittest.TextTestResult(None, True, 1)
         self.assertEqual(
                 result.getDescription(self),
-               ('testGetDescriptionWithMultiLineDocstring '
-                '(' + __name__ + '.Test_TestResult)\n'
+               (__name__ + '.Test_TestResult'
+                '.testGetDescriptionWithMultiLineDocstring\n'
                 'Tests getDescription() for a method with a longer '
                 'docstring.'))
 
@@ -398,8 +405,9 @@ class Test_TestResult(unittest.TestCase):
         with self.subTest(foo=1, bar=2):
             self.assertEqual(
                 result.getDescription(self._subtest),
-               ('testGetSubTestDescriptionWithMultiLineDocstring '
-                '(' + __name__ + '.Test_TestResult) (foo=1, bar=2)\n'
+               (__name__ + '.Test_TestResult'
+                '.testGetSubTestDescriptionWithMultiLineDocstring '
+                '(foo=1, bar=2)\n'
                 'Tests getDescription() for a method with a longer '
                 'docstring.'))
 

--- a/Misc/NEWS.d/next/Library/2020-07-24-17-49-09.bpo-22431.lObJK_.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-24-17-49-09.bpo-22431.lObJK_.rst
@@ -1,0 +1,2 @@
+Show the fully-qualified name in :mod:`unittest` test runner output (for
+example, ``test.test_set.TestBinaryOps.test_eq``).


### PR DESCRIPTION
Show
```
test.test_set.TestBinaryOps.test_eq ... ok
```
instead of
```
test_eq (test.test_set.TestBinaryOps) ... ok
```

<!-- issue-number: [bpo-22431](https://bugs.python.org/issue22431) -->
https://bugs.python.org/issue22431
<!-- /issue-number -->
