### PR TITLE
bpo-41391: Make test_unicodedata pass when running without network

### DIFF
--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -12,7 +12,7 @@ import sys
 import unicodedata
 import unittest
 from test.support import (open_urlresource, requires_resource, script_helper,
-                          cpython_only, check_disallow_instantiation)
+                          cpython_only, check_disallow_instantiation, socket_helper)
 
 
 class UnicodeMethodsTest(unittest.TestCase):
@@ -333,8 +333,9 @@ class NormalizationTest(unittest.TestCase):
 
         # Hit the exception early
         try:
-            testdata = open_urlresource(TESTDATAURL, encoding="utf-8",
-                                        check=self.check_version)
+            with socket_helper.transient_internet(TESTDATAURL):
+                testdata = open_urlresource(TESTDATAURL, encoding="utf-8",
+                                            check=self.check_version)
         except PermissionError:
             self.skipTest(f"Permission error when downloading {TESTDATAURL} "
                           f"into the test data directory")

--- a/Misc/NEWS.d/next/Tests/2020-07-25-18-40-34.bpo-41391.ThBvWT.rst
+++ b/Misc/NEWS.d/next/Tests/2020-07-25-18-40-34.bpo-41391.ThBvWT.rst
@@ -1,0 +1,1 @@
+Make ``test_unicodedata`` pass when running without network.


### PR DESCRIPTION
The `self.fail()` statement below was added to make HTTP 404 error visible
[1]. After this patch HTTP 404 still fails the test as
transient_internet() does not filter 4xx errors.

[1] https://bugs.python.org/issue29887

A sample failure log before patch:
```
0:05:28 load avg: 1.21 [376/423/11] test_unicodedata failed
test test_unicodedata failed -- Traceback (most recent call last):
  File "/data/local/tmp/lib/python3.10/urllib/request.py", line 1342, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
socket.gaierror: [Errno 7] No address associated with hostname

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/local/tmp/lib/python3.10/test/test_unicodedata.py", line 329, in test_normalization
    testdata = open_urlresource(TESTDATAURL, encoding="utf-8",
urllib.error.URLError: <urlopen error [Errno 7] No address associated with hostname>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/local/tmp/lib/python3.10/test/test_unicodedata.py", line 335, in test_normalization
    self.fail(f"Could not retrieve {TESTDATAURL}")
AssertionError: Could not retrieve http://www.pythontest.net/unicode/13.0.0/NormalizationTest.txt
```
The log is grabbed from an Android emulator running Android 10 x86_64
and testing CPython commit af08db7bac3087aac313d052c1a6302bee7c9c89.

<!-- issue-number: [bpo-41391](https://bugs.python.org/issue41391) -->
https://bugs.python.org/issue41391
<!-- /issue-number -->
