### PR TITLE
bpo-41314: fixed annotations __future__ version

### DIFF
--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -90,7 +90,7 @@ language using this mechanism:
 | generator_stop   | 3.5.0b1     | 3.7          | :pep:`479`:                                 |
 |                  |             |              | *StopIteration handling inside generators*  |
 +------------------+-------------+--------------+---------------------------------------------+
-| annotations      | 3.7.0b1     | 4.0          | :pep:`563`:                                 |
+| annotations      | 3.7.0b1     | 3.10         | :pep:`563`:                                 |
 |                  |             |              | *Postponed evaluation of annotations*       |
 +------------------+-------------+--------------+---------------------------------------------+
 

--- a/Lib/__future__.py
+++ b/Lib/__future__.py
@@ -66,18 +66,20 @@ __all__ = ["all_feature_names"] + all_feature_names
 # code.h and used by compile.h, so that an editor search will find them here.
 # However, they're not exported in __all__, because they don't really belong to
 # this module.
-CO_NESTED            = 0x0010   # nested_scopes
-CO_GENERATOR_ALLOWED = 0        # generators (obsolete, was 0x1000)
-CO_FUTURE_DIVISION   = 0x20000   # division
-CO_FUTURE_ABSOLUTE_IMPORT = 0x40000 # perform absolute imports by default
-CO_FUTURE_WITH_STATEMENT  = 0x80000   # with statement
-CO_FUTURE_PRINT_FUNCTION  = 0x100000   # print function
-CO_FUTURE_UNICODE_LITERALS = 0x200000 # unicode string literals
+CO_NESTED = 0x0010                      # nested_scopes
+CO_GENERATOR_ALLOWED = 0                # generators (obsolete, was 0x1000)
+CO_FUTURE_DIVISION = 0x20000            # division
+CO_FUTURE_ABSOLUTE_IMPORT = 0x40000     # perform absolute imports by default
+CO_FUTURE_WITH_STATEMENT = 0x80000      # with statement
+CO_FUTURE_PRINT_FUNCTION = 0x100000     # print function
+CO_FUTURE_UNICODE_LITERALS = 0x200000   # unicode string literals
 CO_FUTURE_BARRY_AS_BDFL = 0x400000
-CO_FUTURE_GENERATOR_STOP  = 0x800000 # StopIteration becomes RuntimeError in generators
-CO_FUTURE_ANNOTATIONS     = 0x1000000  # annotations become strings at runtime
+CO_FUTURE_GENERATOR_STOP = 0x800000     # StopIteration becomes RuntimeError in generators
+CO_FUTURE_ANNOTATIONS = 0x1000000       # annotations become strings at runtime
+
 
 class _Feature:
+
     def __init__(self, optionalRelease, mandatoryRelease, compiler_flag):
         self.optional = optionalRelease
         self.mandatory = mandatoryRelease
@@ -88,7 +90,6 @@ class _Feature:
 
         This is a 5-tuple, of the same form as sys.version_info.
         """
-
         return self.optional
 
     def getMandatoryRelease(self):
@@ -97,13 +98,13 @@ class _Feature:
         This is a 5-tuple, of the same form as sys.version_info, or, if
         the feature was dropped, is None.
         """
-
         return self.mandatory
 
     def __repr__(self):
         return "_Feature" + repr((self.optional,
                                   self.mandatory,
                                   self.compiler_flag))
+
 
 nested_scopes = _Feature((2, 1, 0, "beta",  1),
                          (2, 2, 0, "alpha", 0),
@@ -142,5 +143,5 @@ generator_stop = _Feature((3, 5, 0, "beta", 1),
                           CO_FUTURE_GENERATOR_STOP)
 
 annotations = _Feature((3, 7, 0, "beta", 1),
-                       (4, 0, 0, "alpha", 0),
+                       (3, 10, 0, "alpha", 0),
                        CO_FUTURE_ANNOTATIONS)

--- a/Misc/NEWS.d/next/Documentation/2020-07-25-14-20-00.bpo-41314.yrjko0.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-25-14-20-00.bpo-41314.yrjko0.rst
@@ -1,0 +1,1 @@
+changed mandatory `annotations` version from ``4.0`` to ``3.10``, also in :mod:`__future__`

--- a/Misc/NEWS.d/next/Documentation/2020-07-25-14-20-00.bpo-41314.yrjko0.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-25-14-20-00.bpo-41314.yrjko0.rst
@@ -1,1 +1,1 @@
-changed mandatory `annotations` version from ``4.0`` to ``3.10``, also in :mod:`__future__`
+Changed the release when ``from __future__ import annotations`` becomes the default from ``4.0`` to ``3.10`` (following a change in PEP 563).


### PR DESCRIPTION
PEP 563 was updated to change the release where `from __future__ import annotations` becomes the default (and only) behavior from 4.0 to 3.10. Update `__future__.py` and its docs to reflect this.

<!-- issue-number: [bpo-41314](https://bugs.python.org/issue41314) -->
https://bugs.python.org/issue41314
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum