### PR TITLE
[3.9] bpo-38731: Fix NameError in command-line interface of py_compile

### DIFF
--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -197,12 +197,10 @@ def main(args=None):
                 compile(filename, doraise=True)
             except PyCompileError as error:
                 rv = 1
-                if quiet < 2:
-                    sys.stderr.write("%s\n" % error.msg)
+                sys.stderr.write("%s\n" % error.msg)
             except OSError as error:
                 rv = 1
-                if quiet < 2:
-                    sys.stderr.write("%s\n" % error)
+                sys.stderr.write("%s\n" % error)
     else:
         for filename in args:
             try:
@@ -210,8 +208,7 @@ def main(args=None):
             except PyCompileError as error:
                 # return value to indicate at least one failure
                 rv = 1
-                if quiet < 2:
-                    sys.stderr.write("%s\n" % error.msg)
+                sys.stderr.write("%s\n" % error.msg)
     return rv
 
 if __name__ == "__main__":

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -4,11 +4,13 @@ import os
 import py_compile
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 import unittest
 
 from test import support
+from test.support import script_helper
 
 
 def without_source_date_epoch(fxn):
@@ -214,6 +216,60 @@ class PyCompileTestsWithoutSourceEpoch(PyCompileTestsBase,
                                        metaclass=SourceDateEpochTestMeta,
                                        source_date_epoch=False):
     pass
+
+
+class PyCompileCLITestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        self.source_path = os.path.join(self.directory, '_test.py')
+        self.cache_path = importlib.util.cache_from_source(self.source_path)
+        with open(self.source_path, 'w') as file:
+            file.write('x = 123\n')
+
+    def tearDown(self):
+        support.rmtree(self.directory)
+
+    def pycompilecmd(self, *args, **kwargs):
+        # assert_python_* helpers don't return proc object. We'll just use
+        # subprocess.run() instead of spawn_python() and its friends to test
+        # stdin support of the CLI.
+        if args and args[0] == '-' and 'input' in kwargs:
+            return subprocess.run([sys.executable, '-m', 'py_compile', '-'],
+                                  input=kwargs['input'].encode(),
+                                  capture_output=True)
+        return script_helper.assert_python_ok('-m', 'py_compile', *args, **kwargs)
+
+    def pycompilecmd_failure(self, *args):
+        return script_helper.assert_python_failure('-m', 'py_compile', *args)
+
+    def test_stdin(self):
+        result = self.pycompilecmd('-', input=self.source_path)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, b'')
+        self.assertEqual(result.stderr, b'')
+        self.assertTrue(os.path.exists(self.cache_path))
+
+    def test_with_files(self):
+        rc, stdout, stderr = self.pycompilecmd(self.source_path, self.source_path)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
+        self.assertTrue(os.path.exists(self.cache_path))
+
+    def test_bad_syntax(self):
+        bad_syntax = os.path.join(os.path.dirname(__file__), 'badsyntax_3131.py')
+        rc, stdout, stderr = self.pycompilecmd_failure(bad_syntax)
+        self.assertEqual(rc, 1)
+        self.assertEqual(stdout, b'')
+        self.assertIn(b'SyntaxError', stderr)
+
+    def test_file_not_exists(self):
+        should_not_exists = os.path.join(os.path.dirname(__file__), 'should_not_exists.py')
+        rc, stdout, stderr = self.pycompilecmd_failure(self.source_path, should_not_exists)
+        self.assertEqual(rc, 1)
+        self.assertEqual(stdout, b'')
+        self.assertIn(b'No such file or directory', stderr)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2020-07-25-23-18-51.bpo-38731.Am4wp2.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-25-23-18-51.bpo-38731.Am4wp2.rst
@@ -1,0 +1,1 @@
+Fix :exc:`NameError` in command-line interface of :mod:`py_compile`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38731](https://bugs.python.org/issue38731) -->
https://bugs.python.org/issue38731
<!-- /issue-number -->
