### PR TITLE
Trivial changes: improved documentations for __contains__

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1825,7 +1825,7 @@ set_direct_contains(PySetObject *so, PyObject *key)
     return PyBool_FromLong(result);
 }
 
-PyDoc_STRVAR(contains_doc, "x.__contains__(y) <==> y in x.");
+PyDoc_STRVAR(contains_doc, "True if the set has the specified key, else False.");
 
 static PyObject *
 set_remove(PySetObject *so, PyObject *key)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7299,7 +7299,7 @@ static slotdef slotdefs[] = {
     SQSLOT("__delitem__", sq_ass_item, slot_sq_ass_item, wrap_sq_delitem,
            "__delitem__($self, key, /)\n--\n\nDelete self[key]."),
     SQSLOT("__contains__", sq_contains, slot_sq_contains, wrap_objobjproc,
-           "__contains__($self, key, /)\n--\n\nReturn key in self."),
+           "__contains__($self, key, /)\n--\n\nTrue if self has the specified key, else False."),
     SQSLOT("__iadd__", sq_inplace_concat, NULL,
            wrap_binaryfunc,
            "__iadd__($self, value, /)\n--\n\nImplement self+=value."),


### PR DESCRIPTION
The previous strings for `list.__contains__.__doc__` and `tuple.__contains__.__doc__` were `"Return key in self."`. This is misleading, because `__contains__`  returns a boolean. 

I modified these strings and the string in `set.__contains__.__doc__` to a semilar format of that in `dict.__contains__.__doc__`.