### PR TITLE
gh-85572: Remove references to nonexisting __ne__ methods

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -61,7 +61,7 @@ ABC                        Inherits from          Abstract Methods        Mixin 
 :class:`ByteString`        :class:`Sequence`      ``__getitem__``,        Inherited :class:`Sequence` methods
                                                   ``__len__``
 
-:class:`Set`               :class:`Collection`    ``__contains__``,       ``__le__``, ``__lt__``, ``__eq__``, ``__ne__``,
+:class:`Set`               :class:`Collection`    ``__contains__``,       ``__le__``, ``__lt__``, ``__eq__``,
                                                   ``__iter__``,           ``__gt__``, ``__ge__``, ``__and__``, ``__or__``,
                                                   ``__len__``             ``__sub__``, ``__xor__``, and ``isdisjoint``
 
@@ -72,7 +72,7 @@ ABC                        Inherits from          Abstract Methods        Mixin 
                                                   ``discard``
 
 :class:`Mapping`           :class:`Collection`    ``__getitem__``,        ``__contains__``, ``keys``, ``items``, ``values``,
-                                                  ``__iter__``,           ``get``, ``__eq__``, and ``__ne__``
+                                                  ``__iter__``,           ``get``, and ``__eq__``
                                                   ``__len__``
 
 :class:`MutableMapping`    :class:`Mapping`       ``__getitem__``,        Inherited :class:`Mapping` methods and

--- a/Doc/library/email.charset.rst
+++ b/Doc/library/email.charset.rst
@@ -158,12 +158,6 @@ Import this class from the :mod:`email.charset` module.
       This method allows you to compare two :class:`Charset` instances for
       equality.
 
-
-   .. method:: __ne__(other)
-
-      This method allows you to compare two :class:`Charset` instances for
-      inequality.
-
 The :mod:`email.charset` module also provides the following functions for adding
 new entries to the global character set, alias, and codec registries:
 

--- a/Doc/library/email.header.rst
+++ b/Doc/library/email.header.rst
@@ -164,12 +164,6 @@ Here is the :class:`Header` class description:
       This method allows you to compare two :class:`Header` instances for
       equality.
 
-
-   .. method:: __ne__(other)
-
-      This method allows you to compare two :class:`Header` instances for
-      inequality.
-
 The :mod:`email.header` module also provides the following convenient functions.
 
 

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -339,7 +339,7 @@ Binary Objects
       XML-RPC spec was written.
 
    It also supports certain of Python's built-in operators through :meth:`__eq__`
-   and :meth:`__ne__` methods.
+   method.
 
 Example usage of the binary objects.  We're going to transfer an image over
 XMLRPC::


### PR DESCRIPTION


<!-- issue-number: [bpo-41400](https://bugs.python.org/issue41400) -->
https://bugs.python.org/issue41400
<!-- /issue-number -->


<!-- gh-issue-number: gh-85572 -->
* Issue: gh-85572
<!-- /gh-issue-number -->
