### PR TITLE
bpo-41402: Fix email ContentManager calling .encode() on bytes

### DIFF
--- a/Lib/email/contentmanager.py
+++ b/Lib/email/contentmanager.py
@@ -238,9 +238,7 @@ def set_bytes_content(msg, data, maintype, subtype, cte='base64',
         data = binascii.b2a_qp(data, istext=False, header=False, quotetabs=True)
         data = data.decode('ascii')
     elif cte == '7bit':
-        # Make sure it really is only ASCII.  The early warning here seems
-        # worth the overhead...if you care write your own content manager :).
-        data.encode('ascii')
+        data = data.decode('ascii')
     elif cte in ('8bit', 'binary'):
         data = data.decode('ascii', 'surrogateescape')
     msg.set_payload(data)

--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -776,6 +776,18 @@ class TestRawDataManager(TestEmailBase):
             foo
             """).encode('ascii'))
 
+    def test_set_content_bytes_cte_7bit(self):
+        m = self._make_message()
+        m.set_content(b'ASCII-only message.\n',
+            maintype='application', subtype='octet-stream', cte='7bit')
+        self.assertEqual(str(m), textwrap.dedent("""\
+            Content-Type: application/octet-stream
+            Content-Transfer-Encoding: 7bit
+            MIME-Version: 1.0
+
+            ASCII-only message.
+            """))
+
     content_object_params = {
         'text_plain': ('content', ()),
         'text_html': ('content', ('html',)),

--- a/Misc/NEWS.d/next/Library/2020-07-26-18-17-30.bpo-41402.YRkVkp.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-26-18-17-30.bpo-41402.YRkVkp.rst
@@ -1,1 +1,1 @@
-Fix ``email.message.EmailMessage.set_content()`` when called with binary data and ``7bit`` content transfer encoding.
+Fix :meth:`email.message.EmailMessage.set_content` when called with binary data and ``7bit`` content transfer encoding.

--- a/Misc/NEWS.d/next/Library/2020-07-26-18-17-30.bpo-41402.YRkVkp.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-26-18-17-30.bpo-41402.YRkVkp.rst
@@ -1,0 +1,1 @@
+Fix ``email.message.EmailMessage.set_content()`` when called with binary data and ``7bit`` content transfer encoding.


### PR DESCRIPTION
If assigning binary content to an `EmailMessage` via `set_content()`, the function `email.contentmanager.set_bytes_content()` is called. This function fails when choosing the `7bit` transfer encoding because of a call to `data.decode('ascii')`. Since `bytes` does not have a method `.decode()`, an exception is raised.

By changing `data.decode('ascii')` to `data = data.encode('ascii')`, we make sure that the input data really is `7bit` and at the same time remove an inefficiency since `set_payload()` would have decoded the data anyway.

<!-- issue-number: [bpo-41402](https://bugs.python.org/issue41402) -->
https://bugs.python.org/issue41402
<!-- /issue-number -->
