### PR TITLE
msg374339: Catch AttributeError in mock._get_target

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1558,7 +1558,7 @@ class _patch(object):
 def _get_target(target):
     try:
         target, attribute = target.rsplit('.', 1)
-    except (TypeError, ValueError):
+    except (AttributeError, TypeError, ValueError):
         raise TypeError("Need a valid target to patch. You supplied: %r" %
                         (target,))
     getter = lambda: _importer(target)


### PR DESCRIPTION
When calling `mock.patch` incorrectly, as in the following example, an uncaught error is thrown:

```py
>>> from unittest import mock
>>>
>>> class Foo:
...     pass
... 
>>> mock.patch(Foo())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/mock.py", line 1624, in patch
    getter, attribute = _get_target(target)
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/mock.py", line 1469, in _get_target
    target, attribute = target.rsplit('.', 1)
AttributeError: 'Foo' object has no attribute 'rsplit'
```
This can happen when confusing `mock.patch`, which expects a string, with `mock.patch.object`, which expects an object. However, the uncaught error is not informative, as it does not indicate what the actual problem is, namely that `mock.patch` received an invalid target (an object not a string).

This PR proposes to address the above problem by simply catching `AttributeError` in `_get_target`, so that a more explicit error is raised instead, as is already the case in the event of a `TypeError` or `ValueError`.