### PR TITLE
`import tempfile` in Lib/shutil.py

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -10,6 +10,7 @@ import stat
 import fnmatch
 import collections
 import errno
+import tempfile
 
 try:
     import zlib

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -10,7 +10,6 @@ import stat
 import fnmatch
 import collections
 import errno
-import tempfile
 
 try:
     import zlib
@@ -61,8 +60,12 @@ __all__ = ["copyfileobj", "copyfile", "copymode", "copystat", "copy", "copy2",
            "get_unpack_formats", "register_unpack_format",
            "unregister_unpack_format", "unpack_archive",
            "ignore_patterns", "chown", "which", "get_terminal_size",
-           "SameFileError"]
+           "SameFileError", "import_tempfile"]
            # disk_usage is added later, if available on the platform
+
+def import_tempfile():
+    import tempfile
+    pass
 
 class Error(OSError):
     pass


### PR DESCRIPTION
# `import tempfile` in `Lib/shutil.py` causes build failure

Demonstrate build failure by adding into `Lib/shutil.py` only:

    import tempfile

Can be replicated on command line via this change, then:

```
make sharedmods
```
 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
