### PR TITLE
bpo-18280: Make documentation less personal.

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2020-07-27-12-57-05.bpo-18280.d3mI4n.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-27-12-57-05.bpo-18280.d3mI4n.rst
@@ -1,0 +1,6 @@
+Make documentation less personal.
+
+Rather than personal pronouns (I, you, we) re-write documentation without
+personal reference when possible - using 3rd person in other cases.
+
+Patch by M. Felt.


### PR DESCRIPTION
This is an example of how I would continue through the documentation.

Note: One element I also address is sentences (especially paragraphs) beginning with "It is ...". IMHO it is much clearer documentation when "it" is specified rather than assumed.

<!-- issue-number: [bpo-18280](https://bugs.python.org/issue18280) -->
https://bugs.python.org/issue18280
<!-- /issue-number -->
