### PR TITLE
bpo-41401: Fix test_fspath_support in test_io.

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -928,7 +928,7 @@ class IOTest(unittest.TestCase):
                 self.assertEqual(f.read(), "egg\n")
 
         check_path_succeeds(FakePath(os_helper.TESTFN))
-        check_path_succeeds(FakePath(os_helper.TESTFN.encode('utf-8')))
+        check_path_succeeds(FakePath(os.fsencode(os_helper.TESTFN)))
 
         with self.open(os_helper.TESTFN, "w") as f:
             bad_path = FakePath(f.fileno())


### PR DESCRIPTION
The error is exposed on non-UTF-8 locales.


<!-- issue-number: [bpo-41401](https://bugs.python.org/issue41401) -->
https://bugs.python.org/issue41401
<!-- /issue-number -->
