### PR TITLE
Validate the AST produced by the parser in debug mode

### DIFF
--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -4,6 +4,7 @@
 
 #include "pegen.h"
 #include "string_parser.h"
+#include "ast.h"
 
 PyObject *
 _PyPegen_new_type_comment(Parser *p, char *s)
@@ -1137,6 +1138,13 @@ _PyPegen_run_parser(Parser *p)
         return RAISE_SYNTAX_ERROR("multiple statements found while compiling a single statement");
     }
 
+#if defined(Py_DEBUG) && defined(Py_BUILD_CORE)
+    if (p->start_rule == Py_single_input ||
+        p->start_rule == Py_file_input ||
+        p->start_rule == Py_eval_input) {
+        assert(PyAST_Validate(res));
+    }
+#endif
     return res;
 }
 

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1141,7 +1141,8 @@ _PyPegen_run_parser(Parser *p)
 #if defined(Py_DEBUG) && defined(Py_BUILD_CORE)
     if (p->start_rule == Py_single_input ||
         p->start_rule == Py_file_input ||
-        p->start_rule == Py_eval_input) {
+        p->start_rule == Py_eval_input)
+    {
         assert(PyAST_Validate(res));
     }
 #endif


### PR DESCRIPTION
This will improve the debug experience if something fails in the produced AST. Previously, errors in the produced AST can be felt much later like in the garbage collector or the compiler, making debugging them much more difficult.

