### PR TITLE
bpo-41355: Raise if os.link is used with 'follow_symlinks=False' and linkat() is not available

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-28-00-24-01.bpo-41355.lP79Zq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-28-00-24-01.bpo-41355.lP79Zq.rst
@@ -1,0 +1,3 @@
+The function :func:`os.link` noq raises if *follow_symlinks* is ``False``
+and the :c:func:`linkat` function is not available on the platform. Patch
+by Pablo Galindo.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3731,6 +3731,9 @@ os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
     if ((src_dir_fd != DEFAULT_DIR_FD) || (dst_dir_fd != DEFAULT_DIR_FD)) {
         argument_unavailable_error("link", "src_dir_fd and dst_dir_fd");
         return NULL;
+    } else if (!follow_symlinks) {
+        argument_unavailable_error("link", "follow_symlinks");
+        return NULL;
     }
 #endif
 


### PR DESCRIPTION


<!-- issue-number: [bpo-41355](https://bugs.python.org/issue41355) -->
https://bugs.python.org/issue41355
<!-- /issue-number -->
