### PR TITLE
bpo-41374: Include netinet/tcp.h on Cygwin

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-07-27-19-21-05.bpo-41374.cd-kFL.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-27-19-21-05.bpo-41374.cd-kFL.rst
@@ -1,0 +1,2 @@
+Ensure that ``socket.TCP_*`` constants are exposed on Cygwin 3.1.6 and
+greater.

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -8,9 +8,7 @@
 #   include <sys/socket.h>
 # endif
 # include <netinet/in.h>
-# if !defined(__CYGWIN__)
-#  include <netinet/tcp.h>
-# endif
+# include <netinet/tcp.h>
 
 #else /* MS_WINDOWS */
 # include <winsock2.h>


### PR DESCRIPTION
On Cygwin, constants like TCP_NODELAY are no longer provided by
sys/socket.h.


<!-- issue-number: [bpo-41374](https://bugs.python.org/issue41374) -->
https://bugs.python.org/issue41374
<!-- /issue-number -->
