### PR TITLE
bpo-41394: State None is not stored in special var _ in interpreter

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -364,10 +364,11 @@ classes are identified by the patterns of leading and trailing underscore
 characters:
 
 ``_*``
-   Not imported by ``from module import *``.  The special identifier ``_`` is used
-   in the interactive interpreter to store the result of the last non-``None`` evaluation; it is
-   stored in the :mod:`builtins` module.  When not in interactive mode, ``_``
-   has no special meaning and is not defined. See section :ref:`import`.
+   Not imported by ``from module import *``.  The special identifier ``_`` 
+   is used in the interactive interpreter to store the result of the last 
+   non-``None`` evaluation; it is stored in the :mod:`builtins` module.  
+   When not in interactive mode, ``_`` has no special meaning and is not 
+   defined. See section :ref:`import`.
 
    .. note::
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -365,7 +365,7 @@ characters:
 
 ``_*``
    Not imported by ``from module import *``.  The special identifier ``_`` is used
-   in the interactive interpreter to store the result of the last evaluation; it is
+   in the interactive interpreter to store the result of the last non-``None`` evaluation; it is
    stored in the :mod:`builtins` module.  When not in interactive mode, ``_``
    has no special meaning and is not defined. See section :ref:`import`.
 


### PR DESCRIPTION
The ``_`` documentation doesn't state ``None`` isn't stored.
<!-- (The fix for mentioning ``_`` in tutorial is another patch.) -->

<!-- issue-number: [bpo-41394](https://bugs.python.org/issue41394) -->
https://bugs.python.org/issue41394
<!-- /issue-number -->
