### PR TITLE
bpo-41394: State special _ in appendix of tutorial

### DIFF
--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -36,11 +36,17 @@ statement.
 Special ``_`` variable
 -------------------------
 
-There is a special variable ``_`` in interactive mode. It stores the result of the 
-last evaluation (*except* ``None``), stored in the :mod:`builtins` module.
+There is a special variable ``_`` in interactive mode, stored in the :mod:`builtins` 
+module. It stores the result of the last evaluated expression (*except* ``None``
+-- it remains unchanged).
 
 For example:
 
+   >>> _  # Not defined yet
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+       _
+   NameError: name '_' is not defined
    >>> 1 + 2
    3
    >>> _

--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -31,6 +31,26 @@ Typing an interrupt while a command is executing raises the
 :exc:`KeyboardInterrupt` exception, which may be handled by a :keyword:`try`
 statement.
 
+.. _special-var:
+
+Special ``_`` variable
+-------------------------
+
+There is a special variable ``_`` in interactive mode. It stores the result of the 
+last evaluation (*except* ``None``), stored in the :mod:`builtins` module.
+
+For example:
+
+   >>> 1 + 2
+   3
+   >>> _
+   3
+   >>> print("1+2=3")
+   1+2=3
+   >>> _  # Doesn't store None returned by print()
+   3
+   >>> _+4
+   7
 
 .. _tut-scripts:
 

--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -38,7 +38,7 @@ Special ``_`` variable
 
 There is a special variable ``_`` in interactive mode, stored in the :mod:`builtins` 
 module. It stores the result of the last evaluated expression (*except* ``None``
--- it remains unchanged).
+— it remains unchanged).
 
 For example:
 

--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -31,7 +31,7 @@ Typing an interrupt while a command is executing raises the
 :exc:`KeyboardInterrupt` exception, which may be handled by a :keyword:`try`
 statement.
 
-.. _special-var:
+.. _tut-var:
 
 Special ``_`` variable
 -------------------------

--- a/Misc/NEWS.d/next/Documentation/2020-07-27-23-05-02.bpo-41394.BEos8A.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-27-23-05-02.bpo-41394.BEos8A.rst
@@ -1,2 +1,2 @@
-Added "Special  ``_`` Variable`` section to the 16. Appendix part of Python tutorial. 
+Added "Special  ``_`` Variable" section to the "16. Appendix" part of Python tutorial. 
 It includes the definition of ``_`` and an example.

--- a/Misc/NEWS.d/next/Documentation/2020-07-27-23-05-02.bpo-41394.BEos8A.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-27-23-05-02.bpo-41394.BEos8A.rst
@@ -1,0 +1,2 @@
+Added "Special  ``_`` Variable`` section to the 16. Appendix part of Python tutorial. 
+It includes the define of ``_`` and an example.

--- a/Misc/NEWS.d/next/Documentation/2020-07-27-23-05-02.bpo-41394.BEos8A.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-27-23-05-02.bpo-41394.BEos8A.rst
@@ -1,2 +1,2 @@
 Added "Special  ``_`` Variable`` section to the 16. Appendix part of Python tutorial. 
-It includes the define of ``_`` and an example.
+It includes the definition of ``_`` and an example.


### PR DESCRIPTION
This patch states the special variable ``_`` in interactive mode and also includes an example.


<!-- issue-number: [bpo-41394](https://bugs.python.org/issue41394) -->
https://bugs.python.org/issue41394
<!-- /issue-number -->
