### PR TITLE
bpo-41318: Refine error message to help developer find the problem when overflowing while overflow.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-30-06-43-43.bpo-41318.St-GTv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-30-06-43-43.bpo-41318.St-GTv.rst
@@ -1,0 +1,1 @@
+Update the error message for the FatalError "Cannot recover from stack overflow."

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -830,7 +830,10 @@ _Py_CheckRecursiveCall(PyThreadState *tstate, const char *where)
     if (tstate->overflowed) {
         if (tstate->recursion_depth > recursion_limit + 50) {
             /* Overflowing while handling an overflow. Give up. */
-            Py_FatalError("Cannot recover from stack overflow.");
+            Py_FatalError("Cannot recover from stack overflow, "
+                          "this might be caused by catching RecursionError "
+                          "but reaching the limit again before properly handling it, "
+                          "see ceval.h for more details.");
         }
         return 0;
     }


### PR DESCRIPTION
Currently, when FatalError "Cannot recover from stack overflow" occurs,
it is hard to understand what happened only with the message "Cannot recover from stack overflow".

This PR refines the error message to help developer find the problem when overflowing while handling an overflow.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41318](https://bugs.python.org/issue41318) -->
https://bugs.python.org/issue41318
<!-- /issue-number -->
