### PR TITLE
bpo-41395: Close file objects in pickle and pickletools

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1814,4 +1814,5 @@ if __name__ == "__main__":
             import pprint
             for f in args.pickle_file:
                 obj = load(f)
+                f.close()
                 pprint.pprint(obj)

--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -2882,9 +2882,11 @@ if __name__ == "__main__":
         elif len(args.pickle_file) == 1:
             dis(args.pickle_file[0], args.output, None,
                 args.indentlevel, annotate)
+            args.pickle_file[0].close()
         else:
             memo = {} if args.memo else None
             for f in args.pickle_file:
                 preamble = args.preamble.format(name=f.name)
                 args.output.write(preamble + '\n')
                 dis(f, args.output, memo, args.indentlevel, annotate)
+                f.close()

--- a/Misc/NEWS.d/next/Library/2020-07-29-18-38-41.bpo-41395.jl9BXl.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-29-18-38-41.bpo-41395.jl9BXl.rst
@@ -1,0 +1,2 @@
+Close file object after reading contents in pickle and pickletools cli.
+This removes the ResourceWarning.


### PR DESCRIPTION
File objects were not closed after reading their contents resulting in the following resource warning:
```python
$ ./python.exe -Wall -m pickle mypickle
{'a': 1}
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name='mypickle'>
```
This change ensures that the file is closed after reading the contents.
```python
$ ./python.exe -Wall -m pickle mypickle
{'a': 1}
```

closes: https://bugs.python.org/issue41395


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41395](https://bugs.python.org/issue41395) -->
https://bugs.python.org/issue41395
<!-- /issue-number -->
