### PR TITLE
bpo-41426 Fix grammar in curses.getmouse() documentation

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -214,7 +214,7 @@ The module :mod:`curses` defines the following functions:
 .. function:: getmouse()
 
    After :meth:`~window.getch` returns :const:`KEY_MOUSE` to signal a mouse event, this
-   method should be call to retrieve the queued mouse event, represented as a
+   method should be called to retrieve the queued mouse event, represented as a
    5-tuple ``(id, x, y, z, bstate)``. *id* is an ID value used to distinguish
    multiple devices, and *x*, *y*, *z* are the event's coordinates.  (*z* is
    currently unused.)  *bstate* is an integer value whose bits will be set to

--- a/Misc/NEWS.d/next/Documentation/2020-07-29-19-24-40.bpo-41426.nwNiNy.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-29-19-24-40.bpo-41426.nwNiNy.rst
@@ -1,0 +1,1 @@
+Fix grammar error 'call' -> 'called'

--- a/Misc/NEWS.d/next/Documentation/2020-07-29-19-24-40.bpo-41426.nwNiNy.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-07-29-19-24-40.bpo-41426.nwNiNy.rst
@@ -1,1 +1,0 @@
-Fix grammar error 'call' -> 'called'


### PR DESCRIPTION
<!-- issue-number: [bpo-41426](https://bugs.python.org/issue41426) -->
https://bugs.python.org/issue41426
<!-- /issue-number -->


Automerge-Triggered-By: @brettcannon