### PR TITLE
bpo-41440: add os.cpu_count() support for VxWorks RTOS

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -110,6 +110,11 @@ Added the *root_dir* and *dir_fd* parameters in :func:`~glob.glob` and
 :func:`~glob.iglob` which allow to specify the root directory for searching.
 (Contributed by Serhiy Storchaka in :issue:`38144`.)
 
+os
+----
+Added :func:`os.cpu_count()` support for VxWorks RTOS.
+(Contributed by Peixing Xin in :issue:`41440`.)
+
 py_compile
 ----------
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -154,10 +154,7 @@ Removed
 Porting to Python 3.10
 ======================
 
-This section lists previously described changes and other bugfixes
-that may require changes to your code.
-
-
+* Add :func:`os.cpu_count()` support for VxWorks RTOS.
 
 Build Changes
 =============

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -154,7 +154,10 @@ Removed
 Porting to Python 3.10
 ======================
 
-* Add :func:`os.cpu_count()` support for VxWorks RTOS.
+This section lists previously described changes and other bugfixes
+that may require changes to your code.
+
+
 
 Build Changes
 =============

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -111,7 +111,8 @@ Added the *root_dir* and *dir_fd* parameters in :func:`~glob.glob` and
 (Contributed by Serhiy Storchaka in :issue:`38144`.)
 
 os
-----
+--
+
 Added :func:`os.cpu_count()` support for VxWorks RTOS.
 (Contributed by Peixing Xin in :issue:`41440`.)
 

--- a/Misc/NEWS.d/next/Library/2020-07-30-14-56-58.bpo-41440.rju34k.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-30-14-56-58.bpo-41440.rju34k.rst
@@ -1,1 +1,1 @@
-Add os.cpu_count() support for VxWorks RTOS.
+Add :func:`os.cpu_count()` support for VxWorks RTOS.

--- a/Misc/NEWS.d/next/Library/2020-07-30-14-56-58.bpo-41440.rju34k.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-30-14-56-58.bpo-41440.rju34k.rst
@@ -1,0 +1,1 @@
+Add os.cpu_count() support for VxWorks RTOS.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12607,6 +12607,8 @@ os_cpu_count_impl(PyObject *module)
     ncpu = mpctl(MPC_GETNUMSPUS, NULL, NULL);
 #elif defined(HAVE_SYSCONF) && defined(_SC_NPROCESSORS_ONLN)
     ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+#elif defined(__VXWORKS__)
+    ncpu = __builtin_popcount(vxCpuEnabledGet());
 #elif defined(__DragonFly__) || \
       defined(__OpenBSD__)   || \
       defined(__FreeBSD__)   || \

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -33,7 +33,7 @@
 #endif
 
 #ifdef __VXWORKS__
-#include "pycore_bitutils.h"      // _Py_popcount32()
+#  include "pycore_bitutils.h"    // _Py_popcount32()
 #endif
 #include "pycore_ceval.h"         // _PyEval_ReInitThreads()
 #include "pycore_import.h"        // _PyImport_ReInitLock()

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -32,6 +32,9 @@
 #  include <windows.h>
 #endif
 
+#ifdef __VXWORKS__
+#include "pycore_bitutils.h"      // _Py_popcount32()
+#endif
 #include "pycore_ceval.h"         // _PyEval_ReInitThreads()
 #include "pycore_import.h"        // _PyImport_ReInitLock()
 #include "pycore_initconfig.h"    // _PyStatus_EXCEPTION()
@@ -12608,7 +12611,7 @@ os_cpu_count_impl(PyObject *module)
 #elif defined(HAVE_SYSCONF) && defined(_SC_NPROCESSORS_ONLN)
     ncpu = sysconf(_SC_NPROCESSORS_ONLN);
 #elif defined(__VXWORKS__)
-    ncpu = __builtin_popcount(vxCpuEnabledGet());
+    ncpu = _Py_popcount32(vxCpuEnabledGet());
 #elif defined(__DragonFly__) || \
       defined(__OpenBSD__)   || \
       defined(__FreeBSD__)   || \


### PR DESCRIPTION
VxWorks RTOS provides API vxCpuEnabledGet() to get the set of running CPUs in the system. The return value of vxCpuEnabledGet() is the type cpuset_t defined as shown below. Every bit in the cpuset_t represents the individual CPU No. That is bit 0 corresponds to cpu0, bit 1 corresponds to cpu1, etc. So counting the ones count with __builtin_popcount will get the running CPU count.

typedef  unsigned int  cpuset_t;

<!-- issue-number: [bpo-41440](https://bugs.python.org/issue41440) -->
https://bugs.python.org/issue41440
<!-- /issue-number -->
