### PR TITLE
bpo-40360: Handle PendingDeprecationWarning in test_lib2to3.

### DIFF
--- a/Lib/test/test_lib2to3.py
+++ b/Lib/test/test_lib2to3.py
@@ -1,5 +1,8 @@
-from lib2to3.tests import load_tests
 import unittest
+from test.support.warnings_helper import check_warnings
+
+with check_warnings(("", PendingDeprecationWarning)):
+    from lib2to3.tests import load_tests
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION


<!-- issue-number: [bpo-40360](https://bugs.python.org/issue40360) -->
https://bugs.python.org/issue40360
<!-- /issue-number -->
