### PR TITLE
bpo-41421: Algebraic simplification for random.paretovariate()

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -749,7 +749,7 @@ class Random(_random.Random):
         # Jain, pg. 495
 
         u = 1.0 - self.random()
-        return 1.0 / u ** (1.0 / alpha)
+        return u ** (-1.0 / alpha)
 
     def weibullvariate(self, alpha, beta):
         """Weibull distribution.

--- a/Misc/NEWS.d/next/Library/2020-08-01-00-51-15.bpo-41421.dHKRVB.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-01-00-51-15.bpo-41421.dHKRVB.rst
@@ -1,0 +1,3 @@
+Make an algebraic simplification to random.paretovariate().  It now is
+slightly less subject to round-off error and is slightly faster. Inputs that
+used to cause ZeroDivisionError now cause an OverflowError instead.


### PR DESCRIPTION


<!-- issue-number: [bpo-41421](https://bugs.python.org/issue41421) -->
https://bugs.python.org/issue41421
<!-- /issue-number -->
