### PR TITLE
bpo-41453: Fix a possible reference leak in _locale.localeconv()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-07-31-23-39-07.bpo-41453.i-HNbG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-07-31-23-39-07.bpo-41453.i-HNbG.rst
@@ -1,0 +1,1 @@
+Fix a possible reference leak in :func:`locale.localeconv`.

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -289,8 +289,10 @@ _locale_localeconv_impl(PyObject *module)
     RESULT_INT(n_sign_posn);
 
     /* Numeric information: LC_NUMERIC encoding */
-    PyObject *decimal_point, *thousands_sep;
+    PyObject *decimal_point = NULL, *thousands_sep = NULL;
     if (_Py_GetLocaleconvNumeric(lc, &decimal_point, &thousands_sep) < 0) {
+        Py_XDECREF(decimal_point);
+        Py_XDECREF(thousands_sep);
         goto failed;
     }
 


### PR DESCRIPTION
If the _Py_GetLocaleconvNumeric() call fails in _locale_localeconv_impl(),
"decimal_point" may be leaked.

<!-- issue-number: [bpo-41453](https://bugs.python.org/issue41453) -->
https://bugs.python.org/issue41453
<!-- /issue-number -->
