### PR TITLE
bpo-41455: Fix docs according to sources and devguide

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -107,7 +107,7 @@ The :mod:`gc` module provides the following functions:
    starts.  Initially only generation ``0`` is examined.  If generation ``0`` has
    been examined more than *threshold1* times since generation ``1`` has been
    examined, then generation ``1`` is examined as well.
-   With the third generation, things are a bit more complicated, 
+   With the third generation, things are a bit more complicated,
    see `Collecting the oldest generation <https://devguide.python.org/garbage_collector/#collecting-the-oldest-generation>`_ for more information.
 
 

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -107,24 +107,24 @@ The :mod:`gc` module provides the following functions:
    starts.  Initially only generation ``0`` is examined.  If generation ``0`` has
    been examined more than *threshold1* times since generation ``1`` has been
    examined, then generation ``1`` is examined as well.
-   In addition to the various configurable thresholds, the GC only triggers 
-   a full collection of the oldest generation 
-   if the ratio ``long_lived_pending / long_lived_total`` is above a given value 
+   In addition to the various configurable thresholds, the GC only triggers
+   a full collection of the oldest generation
+   if the ratio ``long_lived_pending / long_lived_total`` is above a given value
    (hardwired to ``25%``). The reason is that, while "non-full" collections
    (i.e., collections of the young and middle generations) will always examine
-   roughly the same number of objects 
-   (determined by the aforementioned thresholds) 
-   the cost of a full collection is proportional to the total number 
+   roughly the same number of objects
+   (determined by the aforementioned thresholds)
+   the cost of a full collection is proportional to the total number
    of long-lived objects, which is virtually unbounded.
    Indeed, it has been remarked that doing a full collection every
-   ``<constant number>`` of object creations 
+   ``<constant number>`` of object creations
    entails a dramatic performance degradation in workloads which consist
-   of creating and storing lots of long-lived objects (e.g. building a large 
-   list of GC-tracked objects would show quadratic performance, 
+   of creating and storing lots of long-lived objects (e.g. building a large
+   list of GC-tracked objects would show quadratic performance,
    instead of linear as expected). Using the above ratio, instead, yields
    amortized linear performance in the total number of objects (the effect
-   of which can be summarized thusly: "each full garbage collection is more 
-   and more costly as the number of objects grows, but we do 
+   of which can be summarized thusly: "each full garbage collection is more
+   and more costly as the number of objects grows, but we do
    fewer and fewer of them").
 
 

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -107,17 +107,24 @@ The :mod:`gc` module provides the following functions:
    starts.  Initially only generation ``0`` is examined.  If generation ``0`` has
    been examined more than *threshold1* times since generation ``1`` has been
    examined, then generation ``1`` is examined as well.
-   In addition to the various configurable thresholds, the GC only triggers a full collection of the oldest generation 
-   if the ratio ``long_lived_pending / long_lived_total`` is above a given value (hardwired to ``25%``). 
-   The reason is that, while "non-full" collections (i.e., collections of the young and middle generations) 
-   will always examine roughly the same number of objects (determined by the aforementioned thresholds) 
-   the cost of a full collection is proportional to the total number of long-lived objects, which is virtually unbounded.
-   Indeed, it has been remarked that doing a full collection every ``<constant number>`` of object creations 
-   entails a dramatic performance degradation in workloads which consist of creating and storing
-   lots of long-lived objects (e.g. building a large list of GC-tracked objects would show quadratic performance, 
-   instead of linear as expected). Using the above ratio, instead, yields amortized linear performance 
-   in the total number of objects (the effect of which can be summarized thusly:
-   "each full garbage collection is more and more costly as the number of objects grows, but we do fewer and fewer of them").
+   In addition to the various configurable thresholds, the GC only triggers 
+   a full collection of the oldest generation 
+   if the ratio ``long_lived_pending / long_lived_total`` is above a given value 
+   (hardwired to ``25%``). The reason is that, while "non-full" collections
+   (i.e., collections of the young and middle generations) will always examine
+   roughly the same number of objects 
+   (determined by the aforementioned thresholds) 
+   the cost of a full collection is proportional to the total number 
+   of long-lived objects, which is virtually unbounded.
+   Indeed, it has been remarked that doing a full collection every
+   ``<constant number>`` of object creations 
+   entails a dramatic performance degradation in workloads which consist
+   of creating and storing lots of long-lived objects (e.g. building a large 
+   list of GC-tracked objects would show quadratic performance, 
+   instead of linear as expected). Using the above ratio, instead, yields
+   amortized linear performance in the total number of objects (the effect
+   of which can be summarized thusly: "each full garbage collection is more 
+   and more costly as the number of objects grows, but we do fewer and fewer of them").
 
 
 .. function:: get_count()

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -107,25 +107,8 @@ The :mod:`gc` module provides the following functions:
    starts.  Initially only generation ``0`` is examined.  If generation ``0`` has
    been examined more than *threshold1* times since generation ``1`` has been
    examined, then generation ``1`` is examined as well.
-   In addition to the various configurable thresholds, the GC only triggers
-   a full collection of the oldest generation
-   if the ratio ``long_lived_pending / long_lived_total`` is above a given value
-   (hardwired to ``25%``). The reason is that, while "non-full" collections
-   (i.e., collections of the young and middle generations) will always examine
-   roughly the same number of objects
-   (determined by the aforementioned thresholds)
-   the cost of a full collection is proportional to the total number
-   of long-lived objects, which is virtually unbounded.
-   Indeed, it has been remarked that doing a full collection every
-   ``<constant number>`` of object creations
-   entails a dramatic performance degradation in workloads which consist
-   of creating and storing lots of long-lived objects (e.g. building a large
-   list of GC-tracked objects would show quadratic performance,
-   instead of linear as expected). Using the above ratio, instead, yields
-   amortized linear performance in the total number of objects (the effect
-   of which can be summarized thusly: "each full garbage collection is more
-   and more costly as the number of objects grows, but we do
-   fewer and fewer of them").
+   With the third generation things a bit complicated, 
+   see `Collecting the oldest generation <https://devguide.python.org/garbage_collector/#collecting-the-oldest-generation>`_ for more information.
 
 
 .. function:: get_count()

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -124,7 +124,8 @@ The :mod:`gc` module provides the following functions:
    instead of linear as expected). Using the above ratio, instead, yields
    amortized linear performance in the total number of objects (the effect
    of which can be summarized thusly: "each full garbage collection is more 
-   and more costly as the number of objects grows, but we do fewer and fewer of them").
+   and more costly as the number of objects grows, but we do 
+   fewer and fewer of them").
 
 
 .. function:: get_count()

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -106,9 +106,18 @@ The :mod:`gc` module provides the following functions:
    allocations minus the number of deallocations exceeds *threshold0*, collection
    starts.  Initially only generation ``0`` is examined.  If generation ``0`` has
    been examined more than *threshold1* times since generation ``1`` has been
-   examined, then generation ``1`` is examined as well.  Similarly, *threshold2*
-   controls the number of collections of generation ``1`` before collecting
-   generation ``2``.
+   examined, then generation ``1`` is examined as well.
+   In addition to the various configurable thresholds, the GC only triggers a full collection of the oldest generation 
+   if the ratio ``long_lived_pending / long_lived_total`` is above a given value (hardwired to ``25%``). 
+   The reason is that, while "non-full" collections (i.e., collections of the young and middle generations) 
+   will always examine roughly the same number of objects (determined by the aforementioned thresholds) 
+   the cost of a full collection is proportional to the total number of long-lived objects, which is virtually unbounded.
+   Indeed, it has been remarked that doing a full collection every ``<constant number>`` of object creations 
+   entails a dramatic performance degradation in workloads which consist of creating and storing
+   lots of long-lived objects (e.g. building a large list of GC-tracked objects would show quadratic performance, 
+   instead of linear as expected). Using the above ratio, instead, yields amortized linear performance 
+   in the total number of objects (the effect of which can be summarized thusly:
+   "each full garbage collection is more and more costly as the number of objects grows, but we do fewer and fewer of them").
 
 
 .. function:: get_count()

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -107,7 +107,7 @@ The :mod:`gc` module provides the following functions:
    starts.  Initially only generation ``0`` is examined.  If generation ``0`` has
    been examined more than *threshold1* times since generation ``1`` has been
    examined, then generation ``1`` is examined as well.
-   With the third generation things a bit complicated, 
+   With the third generation, things are a bit more complicated, 
    see `Collecting the oldest generation <https://devguide.python.org/garbage_collector/#collecting-the-oldest-generation>`_ for more information.
 
 


### PR DESCRIPTION
I've noticed that python docs differ from devguide (https://github.com/python/devguide/blob/master/garbage_collector.rst#collecting-the-oldest-generation)
and source code (https://github.com/python/cpython/blob/master/Modules/gcmodule.c#L1409). 

So, I decided to fix python docs according to those sources (actually still not quite sure if it's correct now, but we definitely should make some changes). 

This is my first contribution, so any critic is welcome.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41455](https://bugs.python.org/issue41455) -->
https://bugs.python.org/issue41455
<!-- /issue-number -->
