### PR TITLE
bpo-41457: Add random.shuffled to make a shuffled copy of an iterable

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -84,6 +84,7 @@ __all__ = [
     "seed",
     "setstate",
     "shuffle",
+    "shuffled",
     "triangular",
     "uniform",
     "vonmisesvariate",
@@ -370,6 +371,13 @@ class Random(_random.Random):
                 # pick an element in x[:i+1] with which to exchange x[i]
                 j = floor(random() * (i + 1))
                 x[i], x[j] = x[j], x[i]
+
+    def shuffled(self, iterable):
+        """Get a list of items from iterable in a random order."""
+        result = list(iterable)
+        self.shuffle(result)
+        return result
+
 
     def sample(self, population, k, *, counts=None):
         """Chooses k unique random elements from a population sequence or set.
@@ -821,6 +829,7 @@ choice = _inst.choice
 randrange = _inst.randrange
 sample = _inst.sample
 shuffle = _inst.shuffle
+shuffled = _inst.shuffled
 choices = _inst.choices
 normalvariate = _inst.normalvariate
 lognormvariate = _inst.lognormvariate

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -79,7 +79,7 @@ class TestBasicOps:
         shuffled_seqs = [list(range(n)) for n in range(10)]
         for shuffled_seq in shuffled_seqs:
             shuffle(shuffled_seq)
-        for (seq, shuffled_seq) in zip(seqs, shuffled_seqs):
+        for (seq, shuffled_seq) in zip(seqs, shuffled_seqs, strict=True):
             self.assertEqual(len(seq), len(shuffled_seq))
             self.assertEqual(set(seq), set(shuffled_seq))
         # The above tests all would pass if the shuffle was a
@@ -99,6 +99,37 @@ class TestBasicOps:
         shuffle(lst)
         self.assertTrue(lst != shuffled_lst)
         self.assertRaises(TypeError, shuffle, (1, 2, 3))
+
+    def test_shuffled(self):
+        shuffled = self.gen.shuffled
+        lst = []
+        new = shuffled(lst)
+        self.assertEqual(new, [])
+        self.assertIsNot(lst, new)
+        lst = [37]
+        new = shuffled(lst)
+        self.assertEqual(new, [37])
+        seqs = [list(range(n)) for n in range(10)]
+        shuffled_seqs = [shuffled(list(range(n))) for n in range(10)]
+        for (seq, shuffled_seq) in zip(seqs, shuffled_seqs, strict=True):
+            self.assertEqual(len(seq), len(shuffled_seq))
+            self.assertEqual(set(seq), set(shuffled_seq))
+        # The above tests all would pass if the shuffle was a
+        # no-op. The following non-deterministic test covers that.  It
+        # asserts that the shuffled sequence of 1000 distinct elements
+        # must be different from the original one. Although there is
+        # mathematically a non-zero probability that this could
+        # actually happen in a genuinely random shuffle, it is
+        # completely negligible, given that the number of possible
+        # permutations of 1000 objects is 1000! (factorial of 1000),
+        # which is considerably larger than the number of atoms in the
+        # universe...
+        lst = list(range(1000))
+        shuffled_lst = shuffled(lst)
+        self.assertTrue(lst != shuffled_lst)
+        another_shuffled_list = shuffled(lst)
+        self.assertTrue(another_shuffled_list != shuffled_lst)
+        assert sorted(shuffled(iter(range(3)))) == [1, 2, 3] # Supports iterators
 
     def test_shuffle_random_argument(self):
         # Test random argument to shuffle.

--- a/Misc/NEWS.d/next/Library/2020-08-02-12-49-42.bpo-41457.yJnYu2.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-02-12-49-42.bpo-41457.yJnYu2.rst
@@ -1,0 +1,1 @@
+Add :func:`random.shuffled` to make a shuffled copy of an iterable.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41457](https://bugs.python.org/issue41457) -->
https://bugs.python.org/issue41457
<!-- /issue-number -->
