### PR TITLE
bpo-41303:  Use mac_continuous_time for perf_counter on macOS 10.12+

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -295,6 +295,7 @@ Functions
    point of the returned value is undefined, so that only the difference between
    the results of consecutive calls is valid.
 
+   .. note:: On macOS versions prior to 10.12, perf_counter does not track time elapsed during sleep.
    .. versionadded:: 3.3
 
 .. function:: perf_counter_ns() -> int

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -940,6 +940,7 @@ Dave Kuhlman
 Jon Kuhn
 Ilya Kulakov
 Upendra Kumar
+Rishav Kundu
 Toshio Kuratomi
 Ilia Kurenkov
 Vladimir Kushnir

--- a/Misc/NEWS.d/next/Library/2020-08-04-03-20-08.bpo-41303.yA0SYM.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-04-03-20-08.bpo-41303.yA0SYM.rst
@@ -1,0 +1,1 @@
+time.perf_counter now tracks time elapsed during sleep on macOS 10.12+.

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -835,17 +835,30 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
             return -1;
         }
 
+#ifdef __MAC_10_12
+        t0 = mach_continuous_time();
+#else
         t0 = mach_absolute_time();
+#endif
     }
 
     if (info) {
+#ifdef __MAC_10_12
+        info->implementation = "mach_continuous_time()";
+#else
         info->implementation = "mach_absolute_time()";
+#endif
         info->resolution = (double)timebase.numer / (double)timebase.denom * 1e-9;
         info->monotonic = 1;
         info->adjustable = 0;
     }
 
+#ifdef __MAC_10_12
+    ticks = mach_continuous_time();
+#else
     ticks = mach_absolute_time();
+#endif
+
     /* Use a "time zero" to reduce precision loss when converting time
        to floatting point number, as in time.monotonic(). */
     ticks -= t0;


### PR DESCRIPTION
I’m unable to add tests as the only way to reproduce the difference between the two methods is by actually shutting the lid on the computer. Any ideas on how to test are welcome. 

In my testing, `pmset sleepnow` did not work even though it did put the computer to sleep.

<!-- issue-number: [bpo-41303](https://bugs.python.org/issue41303) -->
https://bugs.python.org/issue41303
<!-- /issue-number -->
