### PR TITLE
bpo-41467: Fix asyncio recv_into() on Windows

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -469,7 +469,7 @@ class IocpProactor:
             else:
                 ov.ReadFileInto(conn.fileno(), buf)
         except BrokenPipeError:
-            return self._result(b'')
+            return self._result(0)
 
         def finish_recv(trans, key, ov):
             try:

--- a/Misc/NEWS.d/next/Library/2020-08-04-00-20-30.bpo-41467.Z8DgTL.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-04-00-20-30.bpo-41467.Z8DgTL.rst
@@ -1,0 +1,3 @@
+On Windows, fix asyncio ``recv_into()`` return value when the socket/pipe is
+closed (:exc:`BrokenPipeError`): return ``0`` rather than an empty byte
+string (``b''``).


### PR DESCRIPTION
On Windows, fix asyncio recv_into() return value when the socket/pipe
is closed (BrokenPipeError): return 0 rather than an empty byte
string (b'').

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41467](https://bugs.python.org/issue41467) -->
https://bugs.python.org/issue41467
<!-- /issue-number -->
