### PR TITLE
bpo-38156: Fix compiler warning in PyOS_StdioReadline()

### DIFF
--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -317,7 +317,7 @@ PyOS_StdioReadline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
             return NULL;
         }
         p = pr;
-        int err = my_fgets(tstate, p + n, incr, sys_stdin);
+        int err = my_fgets(tstate, p + n, (int)incr, sys_stdin);
         if (err == 1) {
             // Interrupt
             PyMem_RawFree(p);


### PR DESCRIPTION
incr cannot be larger than INT_MAX: downcast to int explicitly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38156](https://bugs.python.org/issue38156) -->
https://bugs.python.org/issue38156
<!-- /issue-number -->
