### PR TITLE
bpo-40989: Fix compiler warning in winreg.c

### DIFF
--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -463,7 +463,7 @@ PyHKEY_FromHKEY(HKEY h)
     if (op == NULL) {
         return PyErr_NoMemory();
     }
-    _PyObject_Init(op, &PyHKEY_Type);
+    _PyObject_Init((PyObject*)op, &PyHKEY_Type);
     op->hkey = h;
     return (PyObject *)op;
 }


### PR DESCRIPTION
Explicitly cast PyHKEYObject* to PyObject* to call _PyObject_Init().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40989](https://bugs.python.org/issue40989) -->
https://bugs.python.org/issue40989
<!-- /issue-number -->
