### PR TITLE
bpo-40275: Use new test.support helper submodules in tests

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -27,6 +27,10 @@ from test.support.os_helper import (
     TESTFN, rmtree, temp_umask, TESTFN_UNENCODABLE, temp_dir)
 from test.support import script_helper
 from test.support import threading_helper
+from test.support.import_helper import (forget, make_legacy_pyc, unlink,
+                                        unload, DirsOnSysPath)
+from test.support.os_helper import (TESTFN, rmtree, temp_umask,
+                                    TESTFN_UNENCODABLE, temp_dir)
 from test.test_importlib.util import uncache
 from types import ModuleType
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -27,10 +27,6 @@ from test.support.os_helper import (
     TESTFN, rmtree, temp_umask, TESTFN_UNENCODABLE, temp_dir)
 from test.support import script_helper
 from test.support import threading_helper
-from test.support.import_helper import (forget, make_legacy_pyc, unlink,
-                                        unload, DirsOnSysPath)
-from test.support.os_helper import (TESTFN, rmtree, temp_umask,
-                                    TESTFN_UNENCODABLE, temp_dir)
 from test.test_importlib.util import uncache
 from types import ModuleType
 

--- a/Lib/test/test_importlib/fixtures.py
+++ b/Lib/test/test_importlib/fixtures.py
@@ -213,11 +213,11 @@ def build_files(file_defs, prefix=pathlib.Path()):
 class FileBuilder:
     def unicode_filename(self):
         try:
-            import test.support
+            from test.support import os_helper
         except ImportError:
             # outside CPython, hard-code a unicode snowman
             return '☃'
-        return test.support.FS_NONASCII or \
+        return os_helper.FS_NONASCII or \
             self.skip("File system does not support non-ascii.")
 
 

--- a/Lib/test/test_importlib/import_/test_packages.py
+++ b/Lib/test/test_importlib/import_/test_packages.py
@@ -2,6 +2,7 @@ from .. import util
 import sys
 import unittest
 from test import support
+from test.support import import_helper
 
 
 class ParentModuleTests:
@@ -98,7 +99,7 @@ class ParentModuleTests:
                 try:
                     submodule = self.__import__(subname)
                 finally:
-                    support.unload(subname)
+                    import_helper.unload(subname)
 
 
 (Frozen_ParentTests,

--- a/Lib/test/test_importlib/source/test_file_loader.py
+++ b/Lib/test/test_importlib/source/test_file_loader.py
@@ -17,7 +17,7 @@ import types
 import unittest
 import warnings
 
-from test.support import make_legacy_pyc, unload
+from test.support.import_helper import make_legacy_pyc, unload
 
 from test.test_py_compile import without_source_date_epoch
 from test.test_py_compile import SourceDateEpochTestMeta

--- a/Lib/test/test_importlib/source/test_finder.py
+++ b/Lib/test/test_importlib/source/test_finder.py
@@ -9,7 +9,7 @@ import py_compile
 import stat
 import sys
 import tempfile
-from test.support import make_legacy_pyc
+from test.support.import_helper import make_legacy_pyc
 import unittest
 import warnings
 

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -3,6 +3,7 @@ import marshal
 import os
 import sys
 from test import support
+from test.support import import_helper
 import types
 import unittest
 from unittest import mock
@@ -579,8 +580,8 @@ class InspectLoaderLoadModuleTests:
     module_name = 'blah'
 
     def setUp(self):
-        support.unload(self.module_name)
-        self.addCleanup(support.unload, self.module_name)
+        import_helper.unload(self.module_name)
+        self.addCleanup(import_helper.unload, self.module_name)
 
     def load(self, loader):
         spec = self.util.spec_from_loader(self.module_name, loader)

--- a/Lib/test/test_importlib/test_api.py
+++ b/Lib/test/test_importlib/test_api.py
@@ -7,6 +7,8 @@ machinery = test_util.import_importlib('importlib.machinery')
 import os.path
 import sys
 from test import support
+from test.support import import_helper
+from test.support import os_helper
 import types
 import unittest
 import warnings
@@ -200,7 +202,7 @@ class ReloadTests:
     def test_reload_modules(self):
         for mod in ('tokenize', 'time', 'marshal'):
             with self.subTest(module=mod):
-                with support.CleanImport(mod):
+                with import_helper.CleanImport(mod):
                     module = self.init.import_module(mod)
                     self.init.reload(module)
 
@@ -221,7 +223,7 @@ class ReloadTests:
                 self.assertEqual(reloaded.spam, 3)
 
     def test_reload_missing_loader(self):
-        with support.CleanImport('types'):
+        with import_helper.CleanImport('types'):
             import types
             loader = types.__loader__
             del types.__loader__
@@ -232,7 +234,7 @@ class ReloadTests:
             self.assertEqual(reloaded.__loader__.path, loader.path)
 
     def test_reload_loader_replaced(self):
-        with support.CleanImport('types'):
+        with import_helper.CleanImport('types'):
             import types
             types.__loader__ = None
             self.init.invalidate_caches()
@@ -244,9 +246,9 @@ class ReloadTests:
 
     def test_reload_location_changed(self):
         name = 'spam'
-        with support.temp_cwd(None) as cwd:
+        with os_helper.temp_cwd(None) as cwd:
             with test_util.uncache('spam'):
-                with support.DirsOnSysPath(cwd):
+                with import_helper.DirsOnSysPath(cwd):
                     # Start as a plain module.
                     self.init.invalidate_caches()
                     path = os.path.join(cwd, name + '.py')
@@ -257,7 +259,7 @@ class ReloadTests:
                                 '__cached__': cached,
                                 '__doc__': None,
                                 }
-                    support.create_empty_file(path)
+                    os_helper.create_empty_file(path)
                     module = self.init.import_module(name)
                     ns = vars(module).copy()
                     loader = ns.pop('__loader__')
@@ -295,9 +297,9 @@ class ReloadTests:
 
     def test_reload_namespace_changed(self):
         name = 'spam'
-        with support.temp_cwd(None) as cwd:
+        with os_helper.temp_cwd(None) as cwd:
             with test_util.uncache('spam'):
-                with support.DirsOnSysPath(cwd):
+                with import_helper.DirsOnSysPath(cwd):
                     # Start as a namespace package.
                     self.init.invalidate_caches()
                     bad_path = os.path.join(cwd, name, '__init.py')

--- a/Lib/test/test_importlib/test_pkg_import.py
+++ b/Lib/test/test_importlib/test_pkg_import.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 from importlib.util import cache_from_source
-from test.support import create_empty_file
+from test.support.os_helper import create_empty_file
 
 class TestImport(unittest.TestCase):
 

--- a/Lib/test/test_importlib/test_spec.py
+++ b/Lib/test/test_importlib/test_spec.py
@@ -6,7 +6,7 @@ util = test_util.import_importlib('importlib.util')
 
 import os.path
 import pathlib
-from test.support import CleanImport
+from test.support.import_helper import CleanImport
 import unittest
 import sys
 import warnings

--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -14,9 +14,9 @@ import shutil
 import threading
 import unittest
 from unittest import mock
-from test.support import (
-    verbose, run_unittest, TESTFN,
-    forget, unlink, rmtree)
+from test.support import (verbose, run_unittest)
+from test.support.import_helper import forget
+from test.support.os_helper import (TESTFN, unlink, rmtree)
 from test.support import threading_helper
 
 def task(N, done, done_tasks, errors):

--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -6,11 +6,12 @@ import re
 import sys
 import unittest
 from test import support
+from test.support import import_helper
 from distutils.util import get_platform
 from contextlib import contextmanager
 from .util import temp_module
 
-support.import_module('winreg', required_on=['win'])
+import_helper.import_module('winreg', required_on=['win'])
 from winreg import (
     CreateKey, HKEY_CURRENT_USER,
     SetValue, REG_SZ, KEY_ALL_ACCESS,

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -13,6 +13,7 @@ import os.path
 from pathlib import Path, PurePath
 from test import support
 from test.support import import_helper
+from test.support import os_helper
 import unittest
 import sys
 import tempfile
@@ -159,9 +160,9 @@ def uncache(*names):
 @contextlib.contextmanager
 def temp_module(name, content='', *, pkg=False):
     conflicts = [n for n in sys.modules if n.partition('.')[0] == name]
-    with support.temp_cwd(None) as cwd:
+    with os_helper.temp_cwd(None) as cwd:
         with uncache(name, *conflicts):
-            with support.DirsOnSysPath(cwd):
+            with import_helper.DirsOnSysPath(cwd):
                 invalidate_caches()
 
                 location = os.path.join(cwd, name)
@@ -397,7 +398,7 @@ def create_modules(*names):
             state_manager.__exit__(None, None, None)
         if uncache_manager is not None:
             uncache_manager.__exit__(None, None, None)
-        support.rmtree(temp_dir)
+        os_helper.rmtree(temp_dir)
 
 
 def mock_path_hook(*entries, importer):
@@ -573,8 +574,8 @@ class ZipSetupBase:
             pass
 
     def setUp(self):
-        modules = support.modules_setup()
-        self.addCleanup(support.modules_cleanup, *modules)
+        modules = import_helper.modules_setup()
+        self.addCleanup(import_helper.modules_cleanup, *modules)
 
 
 class ZipSetup(ZipSetupBase):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -24,8 +24,10 @@ try:
 except ImportError:
     ThreadPoolExecutor = None
 
-from test.support import run_unittest, TESTFN, DirsOnSysPath, cpython_only
+from test.support import run_unittest, cpython_only
 from test.support import MISSING_C_DOCSTRINGS, ALWAYS_EQ
+from test.support.import_helper import DirsOnSysPath
+from test.support.os_helper import TESTFN
 from test.support.script_helper import assert_python_ok, assert_python_failure
 from test import inspect_fodder as mod
 from test import inspect_fodder2 as mod2

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -8,8 +8,8 @@ import unittest
 import test.support
 from test import support
 from test.support import socket_helper
-from test.support import (captured_stderr, TESTFN, EnvironmentVarGuard,
-                          change_cwd)
+from test.support import captured_stderr
+from test.support.os_helper import TESTFN, EnvironmentVarGuard, change_cwd
 import builtins
 import encodings
 import glob

--- a/Lib/test/test_tools/test_fixcid.py
+++ b/Lib/test/test_tools/test_fixcid.py
@@ -5,6 +5,7 @@ import os, os.path
 import runpy
 import sys
 from test import support
+from test.support import os_helper
 from test.test_tools import skip_if_missing, scriptsdir
 import unittest
 
@@ -57,15 +58,15 @@ class Test(unittest.TestCase):
         )
 
     def test_directory(self):
-        os.mkdir(support.TESTFN)
-        self.addCleanup(support.rmtree, support.TESTFN)
-        c_filename = os.path.join(support.TESTFN, "file.c")
+        os.mkdir(os_helper.TESTFN)
+        self.addCleanup(os_helper.rmtree, os_helper.TESTFN)
+        c_filename = os.path.join(os_helper.TESTFN, "file.c")
         with open(c_filename, "w") as file:
             file.write("int xx;\n")
-        with open(os.path.join(support.TESTFN, "file.py"), "w") as file:
+        with open(os.path.join(os_helper.TESTFN, "file.py"), "w") as file:
             file.write("xx = 'unaltered'\n")
         script = os.path.join(scriptsdir, "fixcid.py")
-        output = self.run_script(args=(support.TESTFN,))
+        output = self.run_script(args=(os_helper.TESTFN,))
         self.assertMultiLineEqual(output,
             "{}:\n"
             "1\n"
@@ -74,10 +75,10 @@ class Test(unittest.TestCase):
         )
 
     def run_script(self, input="", *, args=("-",), substfile="xx yy\n"):
-        substfilename = support.TESTFN + ".subst"
+        substfilename = os_helper.TESTFN + ".subst"
         with open(substfilename, "w") as file:
             file.write(substfile)
-        self.addCleanup(support.unlink, substfilename)
+        self.addCleanup(os_helper.unlink, substfilename)
 
         argv = ["fixcid.py", "-s", substfilename] + list(args)
         script = os.path.join(scriptsdir, "fixcid.py")

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 from test.support.script_helper import assert_python_ok
 from test.test_tools import skip_if_missing, toolsdir
-from test.support import temp_cwd, temp_dir
+from test.support.os_helper import temp_cwd, temp_dir
 
 
 skip_if_missing()

--- a/Lib/test/test_tools/test_lll.py
+++ b/Lib/test/test_tools/test_lll.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 from test import support
+from test.support import os_helper
 from test.test_tools import skip_if_missing, import_tool
 import unittest
 
@@ -14,7 +15,7 @@ class lllTests(unittest.TestCase):
     def setUp(self):
         self.lll = import_tool('lll')
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_lll_multiple_dirs(self):
         with tempfile.TemporaryDirectory() as dir1, \
              tempfile.TemporaryDirectory() as dir2:

--- a/Lib/test/test_tools/test_pathfix.py
+++ b/Lib/test/test_tools/test_pathfix.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import unittest
 from test import support
+from test.support import os_helper
 from test.test_tools import scriptsdir, skip_if_missing
 
 
@@ -14,7 +15,7 @@ class TestPathfixFunctional(unittest.TestCase):
     script = os.path.join(scriptsdir, 'pathfix.py')
 
     def setUp(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
 
     def pathfix(self, shebang, pathfix_flags, exitcode=0, stdout='', stderr='',
                 directory=''):
@@ -24,7 +25,7 @@ class TestPathfixFunctional(unittest.TestCase):
             filename = os.path.join(directory, 'script-A_1.py')
             pathfix_arg = directory
         else:
-            filename = support.TESTFN
+            filename = os_helper.TESTFN
             pathfix_arg = filename
 
         with open(filename, 'w', encoding='utf8') as f:
@@ -56,8 +57,8 @@ class TestPathfixFunctional(unittest.TestCase):
         return new_shebang
 
     def test_recursive(self):
-        tmpdir = support.TESTFN + '.d'
-        self.addCleanup(support.rmtree, tmpdir)
+        tmpdir = os_helper.TESTFN + '.d'
+        self.addCleanup(os_helper.rmtree, tmpdir)
         os.mkdir(tmpdir)
         expected_stderr = f"recursedown('{os.path.basename(tmpdir)}')\n"
         self.assertEqual(

--- a/Lib/test/test_tools/test_pindent.py
+++ b/Lib/test/test_tools/test_pindent.py
@@ -6,6 +6,7 @@ import unittest
 import subprocess
 import textwrap
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok
 
 from test.test_tools import scriptsdir, skip_if_missing
@@ -34,7 +35,7 @@ class PindentTests(unittest.TestCase):
 
     def test_selftest(self):
         self.maxDiff = None
-        with support.temp_dir() as directory:
+        with os_helper.temp_dir() as directory:
             data_path = os.path.join(directory, '_test.py')
             with open(self.script) as f:
                 closed = f.read()

--- a/Lib/test/test_tools/test_sundry.py
+++ b/Lib/test/test_tools/test_sundry.py
@@ -8,9 +8,7 @@ tests of their own.
 import os
 import sys
 import unittest
-from test import support
 from test.support import import_helper
-from test.support import os_helper
 
 from test.test_tools import scriptsdir, import_tool, skip_if_missing
 

--- a/Lib/test/test_tools/test_sundry.py
+++ b/Lib/test/test_tools/test_sundry.py
@@ -9,6 +9,8 @@ import os
 import sys
 import unittest
 from test import support
+from test.support import import_helper
+from test.support import os_helper
 
 from test.test_tools import scriptsdir, import_tool, skip_if_missing
 
@@ -30,7 +32,7 @@ class TestSundryScripts(unittest.TestCase):
     skiplist = blacklist + whitelist + windows_only + other
 
     def test_sundry(self):
-        old_modules = support.modules_setup()
+        old_modules = import_helper.modules_setup()
         try:
             for fn in os.listdir(scriptsdir):
                 if not fn.endswith('.py'):
@@ -43,7 +45,7 @@ class TestSundryScripts(unittest.TestCase):
                 import_tool(name)
         finally:
             # Unload all modules loaded in this test
-            support.modules_cleanup(*old_modules)
+            import_helper.modules_cleanup(*old_modules)
 
     @unittest.skipIf(sys.platform != "win32", "Windows-only test")
     def test_sundry_windows(self):


### PR DESCRIPTION
Use test helpers in the following test cases:
* test_importlib
* test_inspect
* test_site
* test_fixcid
* test_i18n
* test_lll
* test_pathfix
* test_pindent
* test_sundry

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
