### PR TITLE
gh-85644: webbrowser: Use $XDG_CURRENT_DESKTOP to check desktop

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -418,12 +418,18 @@ def register_X_browsers():
     if shutil.which("gio"):
         register("gio", None, BackgroundBrowser(["gio", "open", "--", "%s"]))
 
-    # Equivalent of gio open before 2015
-    if "GNOME_DESKTOP_SESSION_ID" in os.environ and shutil.which("gvfs-open"):
+    xdg_desktop = os.getenv("XDG_CURRENT_DESKTOP", "").split(":")
+
+    # The default GNOME3 browser
+    if (("GNOME" in xdg_desktop or
+         "GNOME_DESKTOP_SESSION_ID" in os.environ) and
+            shutil.which("gvfs-open")):
         register("gvfs-open", None, BackgroundBrowser("gvfs-open"))
 
     # The default KDE browser
-    if "KDE_FULL_SESSION" in os.environ and shutil.which("kfmclient"):
+    if (("KDE" in xdg_desktop or
+         "KDE_FULL_SESSION" in os.environ) and
+            shutil.which("kfmclient")):
         register("kfmclient", Konqueror, Konqueror("kfmclient"))
 
     # Common symbolic link for the default X11 browser

--- a/Misc/NEWS.d/next/Library/2024-02-27-20-11-29.gh-issue-85644.3rgcBm.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-27-20-11-29.gh-issue-85644.3rgcBm.rst
@@ -1,7 +1,2 @@
-webbrowser: Use ``$XDG_CURRENT_DESKTOP`` to check desktop
-
-Usage of ``$GNOME_DESKTOP_SESSION_ID`` env variable is deprecated since
-`GNOME 3.30.0`_, so while python will still support it, prefer use
-``$XDG_CURRENT_DESKTOP`` instead.
-
-.. _GNOME 3.30.0: https://gitlab.gnome.org/GNOME/gnome-session/-/commit/00e0e6226371d53f65
+Use the ``XDG_CURRENT_DESKTOP`` environment variable in :mod:`webbrowser` to check desktop.
+Prefer it to the deprecated ``GNOME_DESKTOP_SESSION_ID`` for GNOME detection.

--- a/Misc/NEWS.d/next/Library/2024-02-27-20-11-29.gh-issue-85644.3rgcBm.rst
+++ b/Misc/NEWS.d/next/Library/2024-02-27-20-11-29.gh-issue-85644.3rgcBm.rst
@@ -1,0 +1,7 @@
+webbrowser: Use ``$XDG_CURRENT_DESKTOP`` to check desktop
+
+Usage of ``$GNOME_DESKTOP_SESSION_ID`` env variable is deprecated since
+`GNOME 3.30.0`_, so while python will still support it, prefer use
+``$XDG_CURRENT_DESKTOP`` instead.
+
+.. _GNOME 3.30.0: https://gitlab.gnome.org/GNOME/gnome-session/-/commit/00e0e6226371d53f65


### PR DESCRIPTION
Usage of $GNOME_DESKTOP_SESSION_ID env variable is deprecated since
GNOME 3.30.0 [1], so should not be used, while the standard
XDG_CURRENT_DESKTOP should be instead preferred.

[1] https://gitlab.gnome.org/GNOME/gnome-session/-/commit/00e0e6226371d53f65


<!-- issue-number: [bpo-41472](https://bugs.python.org/issue41472) -->
https://bugs.python.org/issue41472
<!-- /issue-number -->


<!-- gh-issue-number: gh-85644 -->
* Issue: gh-85644
<!-- /gh-issue-number -->
