### PR TITLE
Document optional 'task'/'asyncgen' fields in call_exception_handler

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1188,7 +1188,9 @@ Allows customizing how exceptions are handled in the event loop.
    * 'handle' (optional): :class:`asyncio.Handle` instance;
    * 'protocol' (optional): :ref:`Protocol <asyncio-protocol>` instance;
    * 'transport' (optional): :ref:`Transport <asyncio-transport>` instance;
-   * 'socket' (optional): :class:`socket.socket` instance.
+   * 'socket' (optional): :class:`socket.socket` instance;
+   * 'asyncgen' (optional): Asynchronous generator that caused
+                            the exception.
 
    .. note::
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1184,6 +1184,7 @@ Allows customizing how exceptions are handled in the event loop.
    * 'message': Error message;
    * 'exception' (optional): Exception object;
    * 'future' (optional): :class:`asyncio.Future` instance;
+   * 'task' (optional): :class:`asyncio.Task` instance;
    * 'handle' (optional): :class:`asyncio.Handle` instance;
    * 'protocol' (optional): :ref:`Protocol <asyncio-protocol>` instance;
    * 'transport' (optional): :ref:`Transport <asyncio-transport>` instance;


### PR DESCRIPTION
This change documents the optional "task" field in call_exception_handler. For example I noticed this `context` while working on [Motor](https://github.com/mongodb/motor/pull/66):
```python
>>> context
{'message': 'Task was destroyed but it is pending!', 'task': <Task pending name='Task-2' coro=<TestAsyncIOCursor.test_cancelled_error_fetch_next_aggregate() running at /Users/shane/git/motor/test/asyncio_tests/test_asyncio_cursor.py:261> wait_for=<Future finished result={'$clusterTime': {'clusterTime': Timestamp(1596567456, 202), 'signature': {'hash': b'\x00\x00\x0...0\x00\x00\x00', 'keyId': 0}}, 'count': 7, 'ok': 1.0, 'operationTime': Timestamp(1596567456, 202)} created at /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py:418> created at /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/tasks.py:470>, 'source_traceback': [<FrameSummary file setup.py, line 128 in <module>>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/setuptools/__init__.py, line 145 in setup>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/distutils/core.py, line 148 in setup>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/distutils/dist.py, line 966 in run_commands>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/distutils/dist.py, line 985 in run_command>, <FrameSummary file setup.py, line 120 in run>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/runner.py, line 176 in run>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/suite.py, line 84 in __call__>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/suite.py, line 122 in run>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/case.py, line 736 in __call__>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/case.py, line 676 in run>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/case.py, line 633 in _callTestMethod>, <FrameSummary file /Users/shane/git/motor/test/asyncio_tests/__init__.py, line 48 in __call__>, <FrameSummary file /Users/shane/git/motor/test/test_environment.py, line 283 in wrap>, <FrameSummary file /Users/shane/git/motor/test/asyncio_tests/__init__.py, line 214 in wrapped>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py, line 595 in run_until_complete>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py, line 563 in run_forever>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py, line 1836 in _run_once>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/events.py, line 81 in _run>, <FrameSummary file /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/tasks.py, line 470 in wait_for>]}
```

> Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

This change seems trivial enough to not need an issue. Let me know if you disagree and I'll create one.