### PR TITLE
bpo-41482: Fix error in ipaddress.IPv4Network docstring

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1466,7 +1466,7 @@ class IPv4Network(_BaseV4, _BaseNetwork):
             address: A string or integer representing the IP [& network].
               '192.0.2.0/24'
               '192.0.2.0/255.255.255.0'
-              '192.0.0.2/0.0.0.255'
+              '192.0.2.0/0.0.0.255'
               are all functionally the same in IPv4. Similarly,
               '192.0.2.1'
               '192.0.2.1/255.255.255.255'


### PR DESCRIPTION
I think I did this right.

<!-- issue-number: [bpo-41482](https://bugs.python.org/issue41482) -->
https://bugs.python.org/issue41482
<!-- /issue-number -->
