### PR TITLE
bpo-40275: Use new test.support helper submodules in tests

### DIFF
--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -3,7 +3,7 @@ from test.support import import_helper
 gdbm = import_helper.import_module("dbm.gnu") #skip if not supported
 import unittest
 import os
-from test.support import TESTFN, TESTFN_NONASCII, unlink
+from test.support.os_helper import TESTFN, TESTFN_NONASCII, unlink
 
 
 filename = TESTFN

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import sysconfig
 from test import support
+from test.support import os_helper
 from test.support import script_helper, is_android
 import tempfile
 import unittest
@@ -51,7 +52,7 @@ def temporary_filename():
     try:
         yield filename
     finally:
-        support.unlink(filename)
+        os_helper.unlink(filename)
 
 class FaultHandlerTests(unittest.TestCase):
     def get_output(self, code, filename=None, fd=None):

--- a/Lib/test/test_grp.py
+++ b/Lib/test/test_grp.py
@@ -1,9 +1,10 @@
 """Test script for the grp module."""
 
 import unittest
-from test import support
+from test.support import import_helper
 
-grp = support.import_module('grp')
+
+grp = import_helper.import_module('grp')
 
 class GroupDatabaseTestCase(unittest.TestCase):
 

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -3,6 +3,8 @@
 import os
 import re
 import test.support
+from test.support import os_helper
+from test.support import warnings_helper
 import time
 import unittest
 import urllib.request
@@ -328,12 +330,12 @@ def _interact(cookiejar, url, set_cookie_hdrs, hdr_name):
 
 class FileCookieJarTests(unittest.TestCase):
     def test_constructor_with_str(self):
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         c = LWPCookieJar(filename)
         self.assertEqual(c.filename, filename)
 
     def test_constructor_with_path_like(self):
-        filename = pathlib.Path(test.support.TESTFN)
+        filename = pathlib.Path(os_helper.TESTFN)
         c = LWPCookieJar(filename)
         self.assertEqual(c.filename, os.fspath(filename))
 
@@ -353,7 +355,7 @@ class FileCookieJarTests(unittest.TestCase):
 
     def test_lwp_valueless_cookie(self):
         # cookies with no value should be saved and loaded consistently
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         c = LWPCookieJar()
         interact_netscape(c, "http://www.acme.com/", 'boo')
         self.assertEqual(c._cookies["www.acme.com"]["/"]["boo"].value, None)
@@ -368,7 +370,7 @@ class FileCookieJarTests(unittest.TestCase):
 
     def test_bad_magic(self):
         # OSErrors (eg. file doesn't exist) are allowed to propagate
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         for cookiejar_class in LWPCookieJar, MozillaCookieJar:
             c = cookiejar_class()
             try:
@@ -475,7 +477,7 @@ class CookieTests(unittest.TestCase):
     def test_missing_value(self):
         # missing = sign in Cookie: header is regarded by Mozilla as a missing
         # name, and by http.cookiejar as a missing value
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         c = MozillaCookieJar(filename)
         interact_netscape(c, "http://www.acme.com/", 'eggs')
         interact_netscape(c, "http://www.acme.com/", '"spam"; path=/foo/')
@@ -599,7 +601,7 @@ class CookieTests(unittest.TestCase):
         c = CookieJar()
         future = time2netscape(time.time()+3600)
 
-        with test.support.check_no_warnings(self):
+        with warnings_helper.check_no_warnings(self):
             headers = [f"Set-Cookie: FOO=BAR; path=/; expires={future}"]
             req = urllib.request.Request("http://www.coyote.com/")
             res = FakeResponse(headers, "http://www.coyote.com/")
@@ -1713,7 +1715,7 @@ class LWPCookieTests(unittest.TestCase):
         self.assertEqual(len(c), 6)
 
         # save and restore
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
 
         try:
             c.save(filename, ignore_discard=True)
@@ -1753,7 +1755,7 @@ class LWPCookieTests(unittest.TestCase):
         # Save / load Mozilla/Netscape cookie file format.
         year_plus_one = time.localtime()[0] + 1
 
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
 
         c = MozillaCookieJar(filename,
                              policy=DefaultCookiePolicy(rfc2965=True))

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -67,7 +67,7 @@ class TestServerThread(threading.Thread):
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self._threads = threading_helper.threading_setup()
-        os.environ = support.EnvironmentVarGuard()
+        os.environ = os_helper.EnvironmentVarGuard()
         self.server_started = threading.Event()
         self.thread = TestServerThread(self, self.request_handler)
         self.thread.start()
@@ -621,7 +621,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
         # The shebang line should be pure ASCII: use symlink if possible.
         # See issue #7668.
         self._pythonexe_symlink = None
-        if support.can_symlink():
+        if os_helper.can_symlink():
             self.pythonexe = os.path.join(self.parent_dir, 'python')
             self._pythonexe_symlink = support.PythonSymlink(self.pythonexe).__enter__()
         else:

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -18,7 +18,6 @@ import time
 import unittest
 from unittest import mock
 
-import test.support
 from test.support import os_helper
 from test.support import (is_jython, swap_attr, swap_item, cpython_only)
 from test.support.import_helper import (
@@ -480,7 +479,7 @@ class ImportTests(unittest.TestCase):
             os.path.dirname(pydname),
             "sqlite3{}.dll".format("_d" if "_d" in pydname else ""))
 
-        with test.support.temp_dir() as tmp:
+        with os_helper.temp_dir() as tmp:
             tmp2 = os.path.join(tmp, "DLLs")
             os.mkdir(tmp2)
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -285,7 +285,7 @@ class TestNtpath(NtpathTestCase):
     def test_realpath_broken_symlinks(self):
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
         os.mkdir(ABSTFN)
-        self.addCleanup(support.rmtree, ABSTFN)
+        self.addCleanup(os_helper.rmtree, ABSTFN)
 
         with support.change_cwd(ABSTFN):
             os.mkdir("subdir")
@@ -427,9 +427,9 @@ class TestNtpath(NtpathTestCase):
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
 
         os_helper.unlink(ABSTFN)
-        support.rmtree(ABSTFN)
+        os_helper.rmtree(ABSTFN)
         os.mkdir(ABSTFN)
-        self.addCleanup(support.rmtree, ABSTFN)
+        self.addCleanup(os_helper.rmtree, ABSTFN)
 
         test_dir_long = ntpath.join(ABSTFN, "MyVeryLongDirectoryName")
         os.mkdir(test_dir_long)

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -7,6 +7,7 @@ executing have not been removed.
 import unittest
 import test.support
 from test import support
+from test.support import os_helper
 from test.support import socket_helper
 from test.support import captured_stderr
 from test.support.os_helper import TESTFN, EnvironmentVarGuard, change_cwd
@@ -601,7 +602,7 @@ class _pthFileTests(unittest.TestCase):
     def _create_underpth_exe(self, lines, exe_pth=True):
         import _winapi
         temp_dir = tempfile.mkdtemp()
-        self.addCleanup(test.support.rmtree, temp_dir)
+        self.addCleanup(os_helper.rmtree, temp_dir)
         exe_file = os.path.join(temp_dir, os.path.split(sys.executable)[1])
         dll_src_file = _winapi.GetModuleFileName(sys.dllhandle)
         dll_file = os.path.join(temp_dir, os.path.split(dll_src_file)[1])

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -15,6 +15,7 @@ import socketserver
 
 import test.support
 from test.support import reap_children, verbose
+from test.support import os_helper
 from test.support import socket_helper
 from test.support import threading_helper
 
@@ -299,7 +300,7 @@ class ErrorHandlerTest(unittest.TestCase):
     KeyboardInterrupt are not passed."""
 
     def tearDown(self):
-        test.support.unlink(test.support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def test_sync_handled(self):
         BaseErrorTestServer(ValueError)
@@ -329,7 +330,7 @@ class ErrorHandlerTest(unittest.TestCase):
         self.check_result(handled=False)
 
     def check_result(self, handled):
-        with open(test.support.TESTFN) as log:
+        with open(os_helper.TESTFN) as log:
             expected = 'Handler called\n' + 'Error handled\n' * handled
             self.assertEqual(log.read(), expected)
 
@@ -347,7 +348,7 @@ class BaseErrorTestServer(socketserver.TCPServer):
         self.wait_done()
 
     def handle_error(self, request, client_address):
-        with open(test.support.TESTFN, 'a') as log:
+        with open(os_helper.TESTFN, 'a') as log:
             log.write('Error handled\n')
 
     def wait_done(self):
@@ -356,7 +357,7 @@ class BaseErrorTestServer(socketserver.TCPServer):
 
 class BadHandler(socketserver.BaseRequestHandler):
     def handle(self):
-        with open(test.support.TESTFN, 'a') as log:
+        with open(os_helper.TESTFN, 'a') as log:
             log.write('Handler called\n')
         raise self.server.exception('Test error')
 

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -15,10 +15,10 @@ import random
 import sys
 import unittest
 from test import support
+from test.support import import_helper
 
 from decimal import Decimal
 from fractions import Fraction
-from test import support
 
 
 # Module to be tested.
@@ -179,8 +179,10 @@ class _DoNothing:
 # We prefer this for testing numeric values that may not be exactly equal,
 # and avoid using TestCase.assertAlmostEqual, because it sucks :-)
 
-py_statistics = support.import_fresh_module('statistics', blocked=['_statistics'])
-c_statistics = support.import_fresh_module('statistics', fresh=['_statistics'])
+py_statistics = import_helper.import_fresh_module('statistics',
+                                                  blocked=['_statistics'])
+c_statistics = import_helper.import_fresh_module('statistics',
+                                                 fresh=['_statistics'])
 
 
 class TestModules(unittest.TestCase):

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -12,7 +12,8 @@ import tokenize
 import tempfile
 import textwrap
 from test.support import (captured_stderr, captured_stdout, script_helper,
-                          findfile, unlink)
+                          findfile)
+from test.support.os_helper import unlink
 
 
 SOURCE_CODES = {

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -6,6 +6,7 @@ import os
 import warnings
 from test import support
 from test.support import import_helper
+from test.support import os_helper
 
 # Skip this test if the _tkinter module wasn't built.
 _tkinter = import_helper.import_module('_tkinter')
@@ -192,26 +193,26 @@ class TclTest(unittest.TestCase):
 
     def testEvalFile(self):
         tcl = self.interp
-        with open(support.TESTFN, 'w') as f:
-            self.addCleanup(support.unlink, support.TESTFN)
+        with open(os_helper.TESTFN, 'w') as f:
+            self.addCleanup(os_helper.unlink, os_helper.TESTFN)
             f.write("""set a 1
             set b 2
             set c [ expr $a + $b ]
             """)
-        tcl.evalfile(support.TESTFN)
+        tcl.evalfile(os_helper.TESTFN)
         self.assertEqual(tcl.eval('set a'),'1')
         self.assertEqual(tcl.eval('set b'),'2')
         self.assertEqual(tcl.eval('set c'),'3')
 
     def test_evalfile_null_in_result(self):
         tcl = self.interp
-        with open(support.TESTFN, 'w') as f:
-            self.addCleanup(support.unlink, support.TESTFN)
+        with open(os_helper.TESTFN, 'w') as f:
+            self.addCleanup(os_helper.unlink, os_helper.TESTFN)
             f.write("""
             set a "a\0b"
             set b "a\\0b"
             """)
-        tcl.evalfile(support.TESTFN)
+        tcl.evalfile(os_helper.TESTFN)
         self.assertEqual(tcl.eval('set a'), 'a\x00b')
         self.assertEqual(tcl.eval('set b'), 'a\x00b')
 
@@ -243,7 +244,7 @@ class TclTest(unittest.TestCase):
         if not os.path.exists(unc_name):
             raise unittest.SkipTest('Cannot connect to UNC Path')
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.unset("TCL_LIBRARY")
             stdout = subprocess.check_output(
                     [unc_name, '-c', 'import tkinter; print(tkinter)'])

--- a/Lib/test/test_tools/test_md5sum.py
+++ b/Lib/test/test_tools/test_md5sum.py
@@ -2,7 +2,7 @@
 
 import os
 import unittest
-from test import support
+from test.support import os_helper
 from test.support import hashlib_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
@@ -15,8 +15,8 @@ class MD5SumTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.script = os.path.join(scriptsdir, 'md5sum.py')
-        os.mkdir(support.TESTFN)
-        cls.fodder = os.path.join(support.TESTFN, 'md5sum.fodder')
+        os.mkdir(os_helper.TESTFN)
+        cls.fodder = os.path.join(os_helper.TESTFN, 'md5sum.fodder')
         with open(cls.fodder, 'wb') as f:
             f.write(b'md5sum\r\ntest file\r\n')
         cls.fodder_md5 = b'd38dae2eb1ab346a292ef6850f9e1a0d'
@@ -24,7 +24,7 @@ class MD5SumTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        support.rmtree(support.TESTFN)
+        os_helper.rmtree(os_helper.TESTFN)
 
     def test_noargs(self):
         rc, out, err = assert_python_ok(self.script)

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -2,6 +2,7 @@ import pickle
 import unittest
 from test import support
 from test.support import import_helper
+from test.support import os_helper
 
 
 turtle = import_helper.import_module('turtle')
@@ -52,10 +53,10 @@ visible = False
 class TurtleConfigTest(unittest.TestCase):
 
     def get_cfg_file(self, cfg_str):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, 'w') as f:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, 'w') as f:
             f.write(cfg_str)
-        return support.TESTFN
+        return os_helper.TESTFN
 
     def test_config_dict(self):
 

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -1,6 +1,7 @@
 import errno
 import unittest
 from test import support
+from test.support import os_helper
 from test.support import socket_helper
 from test.test_urllib2 import sanepathname2url
 
@@ -148,7 +149,7 @@ class OtherNetworkTests(unittest.TestCase):
         self._test_urls(urls, self._extra_handlers())
 
     def test_file(self):
-        TESTFN = support.TESTFN
+        TESTFN = os_helper.TESTFN
         f = open(TESTFN, 'w')
         try:
             f.write('hi there\n')

--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 from test.support import socket_helper
 
 import contextlib
@@ -162,7 +163,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
             try:
                 yield file_location, info
             finally:
-                support.unlink(file_location)
+                os_helper.unlink(file_location)
 
     def test_basic(self):
         # Test basic functionality.
@@ -176,8 +177,8 @@ class urlretrieveNetworkTests(unittest.TestCase):
     def test_specified_path(self):
         # Make sure that specifying the location of the file to write to works.
         with self.urlretrieve(self.logo,
-                              support.TESTFN) as (file_location, info):
-            self.assertEqual(file_location, support.TESTFN)
+                              os_helper.TESTFN) as (file_location, info):
+            self.assertEqual(file_location, os_helper.TESTFN)
             self.assertTrue(os.path.exists(file_location))
             with open(file_location, 'rb') as f:
                 self.assertTrue(f.read(), "reading from temporary file failed")

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -6,6 +6,7 @@ import subprocess
 from unittest import mock
 from test import support
 from test.support import import_helper
+from test.support import os_helper
 
 
 URL = 'http://www.example.com'
@@ -305,7 +306,7 @@ class ImportTest(unittest.TestCase):
             browser = webbrowser.get().name
         except (webbrowser.Error, AttributeError) as err:
             self.skipTest(str(err))
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = browser
             webbrowser = import_helper.import_fresh_module('webbrowser')
             webbrowser.get()
@@ -318,12 +319,12 @@ class ImportTest(unittest.TestCase):
         except (webbrowser.Error, AttributeError, IndexError) as err:
             self.skipTest(str(err))
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = least_preferred_browser
             webbrowser = import_helper.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, least_preferred_browser)
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = sys.executable
             webbrowser = import_helper.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, sys.executable)

--- a/Lib/test/test_winsound.py
+++ b/Lib/test/test_winsound.py
@@ -5,9 +5,11 @@ import time
 import unittest
 
 from test import support
+from test.support import import_helper
+
 
 support.requires('audio')
-winsound = support.import_module('winsound')
+winsound = import_helper.import_module('winsound')
 
 
 # Unless we actually have an ear in the room, we have no idea whether a sound

--- a/Lib/tkinter/test/test_tkinter/test_images.py
+++ b/Lib/tkinter/test/test_tkinter/test_images.py
@@ -1,6 +1,7 @@
 import unittest
 import tkinter
 from test import support
+from test.support import os_helper
 from tkinter.test.support import AbstractTkTest, requires_tcl
 
 support.requires('gui')
@@ -296,12 +297,12 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
 
     def test_write(self):
         image = self.create()
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
 
-        image.write(support.TESTFN)
+        image.write(os_helper.TESTFN)
         image2 = tkinter.PhotoImage('::img::test2', master=self.root,
                                     format='ppm',
-                                    file=support.TESTFN)
+                                    file=os_helper.TESTFN)
         self.assertEqual(str(image2), '::img::test2')
         self.assertEqual(image2.type(), 'photo')
         self.assertEqual(image2.width(), 16)
@@ -309,10 +310,10 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(image2.get(0, 0), image.get(0, 0))
         self.assertEqual(image2.get(15, 8), image.get(15, 8))
 
-        image.write(support.TESTFN, format='gif', from_coords=(4, 6, 6, 9))
+        image.write(os_helper.TESTFN, format='gif', from_coords=(4, 6, 6, 9))
         image3 = tkinter.PhotoImage('::img::test3', master=self.root,
                                     format='gif',
-                                    file=support.TESTFN)
+                                    file=os_helper.TESTFN)
         self.assertEqual(str(image3), '::img::test3')
         self.assertEqual(image3.type(), 'photo')
         self.assertEqual(image3.width(), 2)

--- a/Lib/tkinter/test/test_tkinter/test_loadtk.py
+++ b/Lib/tkinter/test/test_tkinter/test_loadtk.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import test.support as test_support
+from test.support import os_helper
 from tkinter import Tcl, TclError
 
 test_support.requires('gui')
@@ -24,7 +25,7 @@ class TkLoadTest(unittest.TestCase):
             # XXX Maybe on tk older than 8.4.13 it would be possible,
             # see tkinter.h.
             return
-        with test_support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             if 'DISPLAY' in os.environ:
                 del env['DISPLAY']
                 # on some platforms, deleting environment variables


### PR DESCRIPTION
Use test helpers in the following test cases:

* test_dbm_gnu
* test_faulthandler
* test_grp
* test_dbm_gnu
* test_faulthandler
* test_grp
* test_http_cookiejar
* test_httpservers
* test_import
* test_ntpath
* test_site
* test_socketserver
* test_statistics
* test_tabnanny
* test_tcl
* test_md5sum
* test_turtle
* test_urllib2net
* test_urllibnet
* test_webbrowser
* test_winsound
* test_tkinter


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
