### PR TITLE
bpo-41494: Adds window resizing support to pty.spawn [ SIGWINCH ]

### DIFF
--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -237,6 +237,9 @@ def _ekill(child_pid):
         os.kill(child_pid, signal.SIGTERM)
         time.sleep(1)
         os.kill(child_pid, signal.SIGKILL)
+    except:
+        pass
+    try:
         os.waitpid(child_pid, 0)
     except:
         pass

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -1,6 +1,6 @@
 """Pseudo terminal utilities."""
 
-# Bugs: No signal handling.  Doesn't set slave termios and window size.
+# Bugs: No signal handling.  Doesn't set slave termios.
 #       Only tested on Linux.
 # See:  W. Richard Stevens. 1992.  Advanced Programming in the
 #       UNIX Environment.  Chapter 19.
@@ -10,8 +10,13 @@ from select import select
 import os
 import sys
 import tty
+import signal
+import struct
+import fcntl
+import termios
+import time
 
-__all__ = ["openpty","fork","spawn"]
+__all__ = ["openpty","fork","spawn","wspawn"]
 
 STDIN_FILENO = 0
 STDOUT_FILENO = 1
@@ -170,3 +175,125 @@ def spawn(argv, master_read=_read, stdin_read=_read):
 
     os.close(master_fd)
     return os.waitpid(pid, 0)[1]
+
+# Author: Soumendra Ganguly.
+SIGWINCH = signal.SIGWINCH
+
+def _login_pty(master_fd, slave_fd):
+    """Given a pty, makes the calling process a session leader, makes the pty slave
+    its controlling terminal, stdin, stdout, and stderr. Closes both pty ends."""
+    # Establish a new session.
+    os.setsid()
+    os.close(master_fd)
+
+    try:
+        fcntl.ioctl(slave_fd, termios.TIOCSCTTY) # Make the pty slave the controlling terminal.
+    except:
+        os.close(slave_fd)
+        raise
+
+    # Slave becomes stdin/stdout/stderr.
+    os.dup2(slave_fd, STDIN_FILENO)
+    os.dup2(slave_fd, STDOUT_FILENO)
+    os.dup2(slave_fd, STDERR_FILENO)
+    if (slave_fd > STDERR_FILENO):
+        os.close(slave_fd)
+
+def _winresz(pty_slave):
+    """Resize window."""
+    w = struct.pack('HHHH', 0, 0, 0, 0)
+    s = fcntl.ioctl(STDIN_FILENO, termios.TIOCGWINSZ, w)
+    fcntl.ioctl(pty_slave, termios.TIOCSWINSZ, s)
+
+def _create_hwinch(pty_slave):
+    """Creates SIGWINCH handler."""
+    def _hwinch(signum, frame):
+        try:
+            _winresz(pty_slave)
+        except:
+            pass
+    return _hwinch
+
+def _cleanup(master_fd, slave_fd, old_hwinch, tty_mode):
+    """Performs cleanup in wspawn."""
+
+    # Close both pty ends.
+    os.close(master_fd)
+    os.close(slave_fd)
+
+    # Restore original tty attributes.
+    if tty_mode != None:
+        tty.tcsetattr(STDIN_FILENO, tty.TCSAFLUSH, tty_mode)
+
+    # Restore original SIGWINCH signal handler.
+    try:
+        signal.signal(SIGWINCH, old_hwinch)
+    except:
+        pass
+
+def _ekill(child_pid):
+    """Kill spawned process due to exception."""
+    try:
+        os.kill(child_pid, signal.SIGTERM)
+        time.sleep(1)
+        os.kill(child_pid, signal.SIGKILL)
+        os.waitpid(child_pid, 0)
+    except:
+        pass
+
+def _wcopy(master_fd, child_pid, master_read=_read, stdin_read=_read, timeout=0.01):
+    """Parent copy loop for wspawn."""
+    fds = [master_fd, STDIN_FILENO]
+    ret = (0,0)
+    while True:
+        rfds, wfds, xfds = select(fds, [], [], timeout)
+        if ret == (0,0):
+            ret = os.waitpid(child_pid, os.WNOHANG)
+        elif len(rfds) == 0:
+            break;
+        if master_fd in rfds:
+            data = master_read(master_fd)
+            if not data:  # Reached EOF.
+                fds.remove(master_fd)
+            else:
+                os.write(STDOUT_FILENO, data)
+        if STDIN_FILENO in rfds:
+            data = stdin_read(STDIN_FILENO)
+            if not data:
+                fds.remove(STDIN_FILENO)
+            else:
+                _writen(master_fd, data)
+    return ret
+
+def wspawn(argv, master_read=_read, stdin_read=_read, timeout=0.01):
+    """Create a spawned process with
+    terminal window resizing enabled."""
+    if type(argv) == type(''):
+        argv = (argv,)
+    sys.audit('pty.wspawn', argv)
+    bk_hwinch = signal.getsignal(SIGWINCH)
+    master_fd, slave_fd = openpty()
+    try:
+        _winresz(slave_fd)
+        signal.signal(SIGWINCH, _create_hwinch(slave_fd))
+    except:     # User should handle exception and try spawn instead.
+        _cleanup(master_fd, slave_fd, bk_hwinch, None)
+        raise
+    pid = os.fork()
+    if pid == CHILD:
+        _login_pty(master_fd, slave_fd)
+        os.execlp(argv[0], *argv)
+    try:
+        mode = tty.tcgetattr(STDIN_FILENO)
+        tty.setraw(STDIN_FILENO)
+    except tty.error:    # This is the same as termios.error
+        mode = None
+    try:
+        ret = _wcopy(master_fd, pid, master_read, stdin_read, timeout)[1]
+    except:
+        _ekill(pid)
+        _cleanup(master_fd, slave_fd, bk_hwinch, mode)
+        raise
+
+    _cleanup(master_fd, slave_fd, bk_hwinch, mode)
+    return ret

--- a/Misc/NEWS.d/next/Library/2020-08-07-08-47-08.bpo-41494.ql-kB9.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-07-08-47-08.bpo-41494.ql-kB9.rst
@@ -1,0 +1,1 @@
+Adds pty.wspawn, which is like pty.spawn with window resizing support [ handles SIGWINCH ].

--- a/Misc/NEWS.d/next/Library/2020-08-07-08-47-08.bpo-41494.ql-kB9.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-07-08-47-08.bpo-41494.ql-kB9.rst
@@ -1,1 +1,1 @@
-Adds pty.wspawn, which is like pty.spawn with window resizing support [ handles SIGWINCH ].
+Adds pty.wspawn, which is like pty.spawn + window resizing support [ handles SIGWINCH ].


### PR DESCRIPTION
This was tested using Python 3.7 after commenting out the sys.audit lines.

https://docs.python.org/3/library/pty.html presents us with an example usage of pty.spawn. This example mimics script(1). However, the script(1) from util-linux has fantastic signal handing that pty.spawn does not directly provide. In fact, Lib/pty.py says "Bugs: No signal handling. Doesn't set slave termios and window size."

xterm(1) on Debian 10 GNU/Linux was used to test the pty.spawn example mentioned above; upon resizing the xterm(1) window, the output of programs such as ls(1) became scattered and hard to visually parse.

Currently, this patch does not modify any of the functions that are already present in Lib/pty.py. Instead, it exposes a new function called "wspawn" [ pty.wspawn ]. This is like pty.spawn + the following differences.

1. Window size is set at the beginning.
2. A SIGWINCH handler is registered. The old handler is saved and restored later.
3. If the above two steps fail, then cleanup is done, and an exception is raised, so that the programmer can catch the exception and use pty.spawn instead.
4. Unlike pty.spawn, this does not depend on OSError to break out of the parent mainloop. Instead, the main loop calls select with an adjustable  timeout, so that waitpid with WNOHANG can be called periodically to check if the spawned child process has undergone an alteration of state. This might be a possible solution to https://bugs.python.org/issue26228, which is mentioned in the docs [ https://docs.python.org/3/library/pty.html ].
5. While the return value is same as that of pty.spawn, this accepts an extra optional "timeout" argument for the select call.

The aforementioned pty.spawn example now works well with window resizing if pty.wspawn is used in place of pty.spawn.

Signed-off-by: Soumendra Ganguly <soumendraganguly@gmail.com>

<!-- issue-number: [bpo-41494](https://bugs.python.org/issue41494) -->
https://bugs.python.org/issue41494
<!-- /issue-number -->
