### PR TITLE
bpo-41503: Fix race between setTarget and flush in logging.handlers.MemoryHandler (GH-21765)

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1324,7 +1324,11 @@ class MemoryHandler(BufferingHandler):
         """
         Set the target handler for this handler.
         """
-        self.target = target
+        self.acquire()
+        try:
+            self.target = target
+        finally:
+            self.release()
 
     def flush(self):
         """

--- a/Misc/NEWS.d/next/Library/2020-08-07-15-18-16.bpo-41503.IYftcu.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-07-15-18-16.bpo-41503.IYftcu.rst
@@ -1,0 +1,1 @@
+Fixed a race between setTarget and flush in logging.handlers.MemoryHandler.


### PR DESCRIPTION
…yHandler

The logging.handlers.MemoryHandler.setTarget() method does not acquire the lock, so it can change the target while flush is processing the buffer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41503](https://bugs.python.org/issue41503) -->
https://bugs.python.org/issue41503
<!-- /issue-number -->


