### PR TITLE
bpo-41473: Skip test_gdb with gdb 9.2 to work around gdb bug

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -51,6 +51,11 @@ if gdb_major_version < 7:
                             "embedding. Saw %s.%s:\n%s"
                             % (gdb_major_version, gdb_minor_version,
                                gdb_version))
+if (gdb_major_version, gdb_minor_version) >= (9, 2):
+    # gdb 9.2 on Fedora Rawhide is not reliable, see:
+    # * https://bugs.python.org/issue41473
+    # * https://bugzilla.redhat.com/show_bug.cgi?id=1866884
+    raise unittest.SkipTest("https://bugzilla.redhat.com/show_bug.cgi?id=1866884")
 
 if not sysconfig.is_python_build():
     raise unittest.SkipTest("test_gdb only works on source builds at the moment.")


### PR DESCRIPTION
gdb 9.2 on Fedora Rawhide is not reliable, see:

* https://bugs.python.org/issue41473
* https://bugzilla.redhat.com/show_bug.cgi?id=1866884

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41473](https://bugs.python.org/issue41473) -->
https://bugs.python.org/issue41473
<!-- /issue-number -->
