### PR TITLE
bpo-40275: Remove test helpers import in test.support

### DIFF
--- a/Lib/ctypes/test/test_loading.py
+++ b/Lib/ctypes/test/test_loading.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 import test.support
 from test.support import import_helper
+from test.support import os_helper
 from ctypes.util import find_library
 
 libc_name = None
@@ -125,7 +126,7 @@ class LoaderTest(unittest.TestCase):
         else:
             ext = ".dll"
 
-        with test.support.temp_dir() as tmp:
+        with os_helper.temp_dir() as tmp:
             # We copy two files and load _sqlite3.dll (formerly .pyd),
             # which has a dependency on sqlite3.dll. Then we test
             # loading it in subprocesses to avoid it starting in memory

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -14,25 +14,6 @@ import time
 import types
 import unittest
 
-from .import_helper import (
-    CleanImport, DirsOnSysPath, _ignore_deprecated_imports,
-    _save_and_block_module, _save_and_remove_module,
-    forget, import_fresh_module, import_module, make_legacy_pyc,
-    modules_cleanup, modules_setup, unload)
-from .os_helper import (
-    FS_NONASCII, SAVEDCWD, TESTFN, TESTFN_ASCII, TESTFN_NONASCII,
-    TESTFN_UNENCODABLE, TESTFN_UNDECODABLE,
-    TESTFN_UNICODE, can_symlink, can_xattr,
-    change_cwd, create_empty_file, fd_count,
-    fs_is_case_insensitive, make_bad_fd, rmdir,
-    rmtree, skip_unless_symlink, skip_unless_xattr,
-    temp_cwd, temp_dir, temp_umask, unlink,
-    EnvironmentVarGuard, FakePath, _longpath)
-from .warnings_helper import (
-    WarningsRecorder, _filterwarnings,
-    check_no_resource_warning, check_no_warnings,
-    check_syntax_warning, check_warnings, ignore_warnings)
-
 from .testresult import get_test_runner
 
 
@@ -506,6 +487,7 @@ def check_syntax_error(testcase, statement, errtext='', *, lineno=None, offset=N
 
 def open_urlresource(url, *args, **kw):
     import urllib.request, urllib.parse
+    from .os_helper import unlink
     try:
         import gzip
     except ImportError:
@@ -1326,6 +1308,8 @@ def skip_if_buggy_ucrt_strfptime(test):
 class PythonSymlink:
     """Creates a symlink for the current Python executable"""
     def __init__(self, link=None):
+        from .os_helper import TESTFN
+
         self.link = link or os.path.abspath(TESTFN)
         self._linked = []
         self.real = os.path.realpath(sys.executable)
@@ -1980,6 +1964,7 @@ def skip_if_broken_multiprocessing_synchronize():
     is no available semaphore implementation, or if creating a lock raises an
     OSError (on Linux only).
     """
+    from .import_helper import import_module
 
     # Skip tests if the _multiprocessing extension is missing.
     import_module('_multiprocessing')

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -30,6 +30,7 @@ import unittest
 import uuid
 import warnings
 from test import support
+from test.support import import_helper
 from test.support import os_helper
 from test.support import socket_helper
 from test.support import threading_helper
@@ -2674,8 +2675,8 @@ class Win32JunctionTests(unittest.TestCase):
 @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 class Win32NtTests(unittest.TestCase):
     def test_getfinalpathname_handles(self):
-        nt = support.import_module('nt')
-        ctypes = support.import_module('ctypes')
+        nt = import_helper.import_module('nt')
+        ctypes = import_helper.import_module('ctypes')
         import ctypes.wintypes
 
         kernel = ctypes.WinDLL('Kernel32.dll', use_last_error=True)

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -5,7 +5,7 @@ from posixpath import realpath, abspath, dirname, basename
 from test import test_genericpath
 from test.support import import_helper
 from test.support import os_helper
-from test.support import FakePath
+from test.support.os_helper import FakePath
 from unittest import mock
 
 try:


### PR DESCRIPTION
* The following test cases use new test helpers: test_loading, test_os, test_posixpath
* Remove test helpers import in test.support

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
