### PR TITLE
bpo-41504: Add links to asttokens, leoAst, LibCST and parso

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -378,5 +378,24 @@ to stdout.  Otherwise, the content is read from stdin.
 
 .. seealso::
 
-    `Green Tree Snakes <https://greentreesnakes.readthedocs.io/>`_, an external documentation resource, has good
-    details on working with Python ASTs.
+    `Green Tree Snakes <https://greentreesnakes.readthedocs.io/>`_, an external
+    documentation resource, has good details on working with Python ASTs.
+
+    `ASTTokens <https://asttokens.readthedocs.io/en/latest/user-guide.html>`_
+    annotates Python ASTs with the positions of tokens and text in the source
+    code that generated them. This is helpful for tools that make source code
+    transformations.
+
+    `leoAst.py <http://leoeditor.com/appendices.html#leoast-py>`_ unifies the
+    token-based and parse-tree-based views of python programs by inserting
+    two-way links between tokens and ast nodes.
+
+    `LibCST <https://libcst.readthedocs.io/>`_ parses code as a Concrete Syntax
+    Tree that looks like an ast tree and keeps all formatting details. It's
+    useful for building automated refactoring (codemod) applications and
+    linters.
+
+    `Parso <https://parso.readthedocs.io>`_ is a Python parser that supports
+    error recovery and round-trip parsing for different Python versions (in
+    multiple Python versions). Parso is also able to list multiple syntax errors
+    in your python file.


### PR DESCRIPTION
@gvanrossum Here are the links we discussed.  Except for the formatting of the rST links, the text is exactly as provided by these devs:

asttokens: Dmitry Sagalovskiy, dmitry@getgrist.com

parso: Dave Halter, davidhalter88@gmail.com

libCst: jimmylai, jimmylai@fb.com

Note 1: I submitted [this CLA](https://secure.na1.echosign.com/public/viewAgreement?tsid=CBFCIBAA3AAABLblqZhAgwX00GTrZr_uAm9XZlYBGAY1OVw--eeyyYOLO74p_wSFO53INAkoM7mVcEGl14Xkur8azRN9-Rmsnd036x879&) four hours ago. Is this the correct agreement?

Note 2: I have no idea why the bot thinks my user name is `@edreamleo`. My user name is simply edreamleo.

<!-- issue-number: [bpo-41504](https://bugs.python.org/issue41504) -->
https://bugs.python.org/issue41504
<!-- /issue-number -->
