### PR TITLE
bpo-40064 update documentation for elementtree

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -24,6 +24,10 @@ for parsing and creating XML data.
    maliciously constructed data.  If you need to parse untrusted or
    unauthenticated data see :ref:`xml-vulnerabilities`.
 
+.. warning::
+
+   The :mod:`xml.etree.ElementTree` will be removed from python 3.9.
+
 Tutorial
 --------
 

--- a/Misc/NEWS.d/next/Documentation/2020-08-08-06-13-19.bpo-40064.-X9ski.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-08-08-06-13-19.bpo-40064.-X9ski.rst
@@ -1,0 +1,5 @@
+update documentation to add warning in documentation about  `xml.etree.cElementTree` removal in python 3.9
+
+<!-- issue-number: [bpo-40064](https://bugs.python.org/issue40064) -->
+https://bugs.python.org/issue40064
+<!-- /issue-number -->


### PR DESCRIPTION
update documentation to add warning in documentation about  `xml.etree.cElementTree` removal in python 3.9

<!-- issue-number: [bpo-40064](https://bugs.python.org/issue40064) -->
https://bugs.python.org/issue40064
<!-- /issue-number -->
