### PR TITLE
[doc] Be more clear on super() regarding multiple base classes methods

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1644,7 +1644,7 @@ are always available.  They are listed here in alphabetical order.
    not found in statically compiled languages or languages that only support
    single inheritance.  This makes it possible to implement "diamond diagrams"
    where multiple base classes implement the same method.  Good design dictates
-   that this method have the same calling signature in every case (because the
+   that such implementations have the same calling signature in every case (because the
    order of calls is determined at runtime, because that order adapts
    to changes in the class hierarchy, and because that order can include
    sibling classes that are unknown prior to runtime).


### PR DESCRIPTION
At first I was going to fix the "method have" to "method has" but I think "such implementations" better conveys the different possible methods than "this method" (as there's not only one method).