### PR TITLE
gh-85269: allow io.BufferIO.write() operations when there are buffer views and no buffer resize is required

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-08-08-21-55-39.bpo-41097.tBuST7.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-08-21-55-39.bpo-41097.tBuST7.rst
@@ -1,0 +1,2 @@
+:func:`io.BytesIO.write` no longer raises :exc:`BufferError` when one or
+more buffer views exist as long as the buffer does not need to be resized.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -124,6 +124,10 @@ unshare_buffer(bytesio *self, size_t size)
 static int
 resize_buffer(bytesio *self, size_t size)
 {
+    if (check_exports(self)) {
+        return -1;
+    }
+
     /* Here, unsigned types are used to avoid dealing with signed integer
        overflow, which is undefined in C. */
     size_t alloc = PyBytes_GET_SIZE(self->buf);
@@ -180,9 +184,6 @@ _Py_NO_INLINE static Py_ssize_t
 write_bytes(bytesio *self, PyObject *b)
 {
     if (check_closed(self)) {
-        return -1;
-    }
-    if (check_exports(self)) {
         return -1;
     }
 


### PR DESCRIPTION
io.BytesIO prevents writes when there are buffer view objects.  All calls to io.BytesIO.write() raise BufferError with the message "BufferError: Existing exports of data: object cannot be re-sized" even when no resize operation is required.  This patch moves the check for existing buffer views from the beginning of the write_bytes() function to the beginning of the resize_buffer() function so that writes can be performed when the output is small enough to fit within the existing buffer.

This change conforms with the behavior implied by the documentation, which merely states that the BytesIO buffer cannot be resized or closed when a view exists.  The alternative to this change in behavior is to change the documentation to clarify that write operations are not allowed when there are buffer view objects.

<!-- issue-number: [bpo-41097](https://bugs.python.org/issue41097) -->
https://bugs.python.org/issue41097
<!-- /issue-number -->

<!-- gh-issue-number: gh-85269 -->
* Issue: gh-85269
<!-- /gh-issue-number -->
