### PR TITLE
gh-85682: Updated documentation to add `header` kw-argument of pdb.set_trace()

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -134,9 +134,9 @@ are always available.  They are listed here in alphabetical order.
    This function drops you into the debugger at the call site.  Specifically,
    it calls :func:`sys.breakpointhook`, passing ``args`` and ``kws`` straight
    through.  By default, ``sys.breakpointhook()`` calls
-   :func:`pdb.set_trace()` expecting no arguments.  In this case, it is
-   purely a convenience function so you don't have to explicitly import
-   :mod:`pdb` or type as much code to enter the debugger.  However,
+   :func:`pdb.set_trace()` expecting an optional keyword argument `header`.  In
+   this case, it is purely a convenience function so you don't have to explicitly
+   import :mod:`pdb` or type as much code to enter the debugger.  However,
    :func:`sys.breakpointhook` can be set to some other function and
    :func:`breakpoint` will automatically call that, allowing you to drop into
    the debugger of choice.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -189,10 +189,10 @@ always available.
    function so that you can choose which debugger gets used.
 
    The signature of this function is dependent on what it calls.  For example,
-   the default binding (e.g. ``pdb.set_trace()``) expects no arguments, but
-   you might bind it to a function that expects additional arguments
-   (positional and/or keyword).  The built-in ``breakpoint()`` function passes
-   its ``*args`` and ``**kws`` straight through.  Whatever
+   the default binding (e.g. ``pdb.set_trace()``) expects only an optional keyword
+   argument `header`, but you might bind it to a function that expects additional
+   arguments (positional and/or keyword).  The built-in ``breakpoint()`` function
+   passes its ``*args`` and ``**kws`` straight through.  Whatever
    ``breakpointhooks()`` returns is returned from ``breakpoint()``.
 
    The default implementation first consults the environment variable


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41510](https://bugs.python.org/issue41510) -->
https://bugs.python.org/issue41510
<!-- /issue-number -->

<!-- gh-issue-number: gh-85682 -->
* Issue: gh-85682
<!-- /gh-issue-number -->
