### PR TITLE
[3.8] venv: Update Aspen URL in 'activate' script comment

### DIFF
--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -59,7 +59,7 @@ if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
     else
     if [ "`basename \"$VIRTUAL_ENV\"`" = "__" ] ; then
         # special case for Aspen magic directories
-        # see http://www.zetadev.com/software/aspen/
+        # see https://aspen.io/
         PS1="[`basename \`dirname \"$VIRTUAL_ENV\"\``] $PS1"
     else
         PS1="(`basename \"$VIRTUAL_ENV\"`)$PS1"

--- a/Lib/venv/scripts/posix/activate.csh
+++ b/Lib/venv/scripts/posix/activate.csh
@@ -22,7 +22,7 @@ if (! "$?VIRTUAL_ENV_DISABLE_PROMPT") then
     else
         if (`basename "VIRTUAL_ENV"` == "__") then
             # special case for Aspen magic directories
-            # see http://www.zetadev.com/software/aspen/
+            # see https://aspen.io/
             set env_name = `basename \`dirname "$VIRTUAL_ENV"\``
         else
             set env_name = `basename "$VIRTUAL_ENV"`

--- a/Lib/venv/scripts/posix/activate.fish
+++ b/Lib/venv/scripts/posix/activate.fish
@@ -59,7 +59,7 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
             set -l _checkbase (basename "$VIRTUAL_ENV")
             if test $_checkbase = "__"
                 # special case for Aspen magic directories
-                # see http://www.zetadev.com/software/aspen/
+                # see https://aspen.io/
                 printf "%s[%s]%s " (set_color -b blue white) (basename (dirname "$VIRTUAL_ENV")) (set_color normal)
             else
                 printf "%s(%s)%s" (set_color -b blue white) (basename "$VIRTUAL_ENV") (set_color normal)


### PR DESCRIPTION
A comment in the venv `activate` script (as well as `activate.csh` and `activate.fish`) referencing Aspen magic directories lists a "further information" URL for Aspen at the zetadev.com website. zetadev.com changed ownership in 2019, and now redirects to a server in China with an expired security certificate.

Out of an abundance of caution, while not changing the _code_ for the activate scripts, this PR updates the URL in those comments to reference Aspen's new documentation home at https://aspen.io/.

No issue created, as I suspect this falls within the definition of a "trivial" change. Please let me know if I'm wrong about that, and I'll open the necessary issue(s).

While filed against the 3.8 branch, strictly speaking this is not a backported PR. The comment in question was entirely removed from the script between Python 3.8 and 3.9.

(IMHO this _should_ probably be backported to 3.7 and 3.6, as well. I'll happily file those PRs if needed.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


Automerge-Triggered-By: @vsajip