### PR TITLE
bpo-21041: Add negative indexing to pathlib path parents

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -337,7 +337,7 @@ Pure paths provide the following methods and properties:
       PureWindowsPath('c:/')
 
    .. versionchanged:: 3.10
-      Slice support was added.
+      The parents sequence now supports :term:`slices <slice>` and negative index values.
 
 .. data:: PurePath.parent
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -247,8 +247,12 @@ pipe. (Contributed by Pablo Galindo in :issue:`41625`.)
 pathlib
 -------
 
-Added slice support to :meth:`~pathlib.Path.parents`.
+Added slice support to :attr:`PurePath.parents <pathlib.PurePath.parents>`.
 (Contributed by Joshua Cannon in :issue:`35498`)
+
+Added negative indexing support to :attr:`PurePath.parents
+<pathlib.PurePath.parents>`.
+(Contributed by Yaroslav Pankovych in :issue:`21041`)
 
 py_compile
 ----------

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -632,7 +632,8 @@ class _PathParents(Sequence):
     def __getitem__(self, idx):
         if isinstance(idx, slice):
             return tuple(self[i] for i in range(*idx.indices(len(self))))
-        if idx < 0 or idx >= len(self):
+
+        if idx >= len(self) or idx < -len(self):
             raise IndexError(idx)
         return self._pathcls._from_parsed_parts(self._drv, self._root,
                                                 self._parts[:-idx - 1])

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -440,6 +440,9 @@ class _BasePurePathTest(object):
         self.assertEqual(par[0], P('a/b'))
         self.assertEqual(par[1], P('a'))
         self.assertEqual(par[2], P('.'))
+        self.assertEqual(par[-1], P('.'))
+        self.assertEqual(par[-2], P('a'))
+        self.assertEqual(par[-3], P('a/b'))
         self.assertEqual(par[0:1], (P('a/b'),))
         self.assertEqual(par[:2], (P('a/b'), P('a')))
         self.assertEqual(par[:-1], (P('a/b'), P('a')))
@@ -448,7 +451,7 @@ class _BasePurePathTest(object):
         self.assertEqual(par[::-1], (P('.'), P('a'), P('a/b')))
         self.assertEqual(list(par), [P('a/b'), P('a'), P('.')])
         with self.assertRaises(IndexError):
-            par[-1]
+            par[-4]
         with self.assertRaises(IndexError):
             par[3]
         with self.assertRaises(TypeError):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1282,6 +1282,7 @@ Michael Otteneder
 Richard Oudkerk
 Russel Owen
 Joonas Paalasmaa
+Yaroslav Pankovych
 Martin Packman
 Elisha Paine
 Shriphani Palakodety

--- a/Misc/NEWS.d/next/Library/2018-12-14-13-29-17.bpo-35498.LEJHl7.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-14-13-29-17.bpo-35498.LEJHl7.rst
@@ -1,1 +1,1 @@
-Add slice support to :meth:`~pathlib.Path.parents`.
+Add slice support to :attr:`pathlib.PurePath.parents`.

--- a/Misc/NEWS.d/next/Library/2020-08-10-15-06-55.bpo-21041.cYz1eL.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-10-15-06-55.bpo-21041.cYz1eL.rst
@@ -1,0 +1,1 @@
+:attr:`pathlib.PurePath.parents` now supports negative indexing. Patch contributed by Yaroslav Pankovych.


### PR DESCRIPTION
As I can see, pathlib path parents don't support negative indexing: 
```python
>>> import pathlib
>>> path = pathlib.PosixPath("some/very/long/path/here")
>>> path.parents[-1]
...
    raise IndexError(idx)
IndexError: -1
```

That's kinda weird for python. I mean, in regular list/etc if I need the last element, I'd normally do list[-1], but here to get the last parent, I need to actually know how many parents do I have. 

So now, I can do something like this:
```python
>>> parents_count = len(path.parents) - 1
>>> path.parents[parents_count]
PosixPath('.')
```

So that's how I can get the last parent. But is it pythonic? No.

So, I decided to fix this, and now we can do negative indexing:
```python
>>> path.parents[-1] == path.parents[parents_count]
True
>>> path.parents[-2] == path.parents[parents_count - 1]
True
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-21041](https://bugs.python.org/issue21041) -->
https://bugs.python.org/issue21041
<!-- /issue-number -->
