### PR TITLE
[doc] Remove old Python version from future stmt and name annotations PEP

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -874,8 +874,8 @@ can appear before a future statement are:
 * blank lines, and
 * other future statements.
 
-The only feature in Python 3.7 that requires using the future statement is
-``annotations``.
+The only feature that can be enabled using the future statement is
+``annotations`` (see :pep:`563`).
 
 All historical features enabled by the future statement are still recognized
 by Python 3.  The list includes ``absolute_import``, ``division``,

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -874,7 +874,7 @@ can appear before a future statement are:
 * blank lines, and
 * other future statements.
 
-The only feature that can be enabled using the future statement is
+The only feature that requires using the future statement is
 ``annotations`` (see :pep:`563`).
 
 All historical features enabled by the future statement are still recognized


### PR DESCRIPTION
Remove old Python version and name the PEP related to the feature.

If merged, this would go to 3.9/3.8/3.7.