### PR TITLE
bpo-41513: Improve speed and accuracy of math.hypot()

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -795,7 +795,8 @@ class MathTests(unittest.TestCase):
         # Verify scaling for extremely large values
         fourthmax = FLOAT_MAX / 4.0
         for n in range(32):
-            self.assertEqual(hypot(*([fourthmax]*n)), fourthmax * math.sqrt(n))
+            self.assertTrue(math.isclose(hypot(*([fourthmax]*n)),
+                                         fourthmax * math.sqrt(n)))
 
         # Verify scaling for extremely small values
         for exp in range(32):

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -904,8 +904,8 @@ class MathTests(unittest.TestCase):
         for n in range(32):
             p = (fourthmax,) * n
             q = (0.0,) * n
-            self.assertEqual(dist(p, q), fourthmax * math.sqrt(n))
-            self.assertEqual(dist(q, p), fourthmax * math.sqrt(n))
+            self.assertTrue(math.isclose(dist(p, q), fourthmax * math.sqrt(n)))
+            self.assertTrue(math.isclose(dist(q, p), fourthmax * math.sqrt(n)))
 
         # Verify scaling for extremely small values
         for exp in range(32):

--- a/Misc/NEWS.d/next/Library/2020-08-09-18-16-05.bpo-41513.e6K6EK.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-09-18-16-05.bpo-41513.e6K6EK.rst
@@ -1,0 +1,2 @@
+Minor algorithmic improvement to math.hypot() and math.dist() giving small
+gains in speed and accuracy.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -56,7 +56,6 @@ raised for division by zero and mod by zero.
 #include "pycore_bitutils.h"      // _Py_bit_length()
 #include "pycore_dtoa.h"
 #include "_math.h"
-#include <stdio.h>
 
 #include "clinic/mathmodule.c.h"
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2438,6 +2438,7 @@ static inline double
 vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 {
     double x, csum = 1.0, oldcsum, frac = 0.0;
+    int max_e;
     Py_ssize_t i;
 
     if (Py_IS_INFINITY(max)) {
@@ -2449,17 +2450,21 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
     if (max == 0.0 || n <= 1) {
         return max;
     }
+    frexp(max, &max_e);
     for (i=0 ; i < n ; i++) {
+        int e;
+
         x = vec[i];
         assert(Py_IS_FINITE(x) && fabs(x) <= max);
-        x /= max;
+        x = frexp(x, &e);
+        x = ldexp(x, e - max_e);
         x = x*x;
         oldcsum = csum;
         csum += x;
         assert(csum >= x);
         frac += (oldcsum - csum) + x;
     }
-    return max * sqrt(csum - 1.0 + frac);
+    return ldexp(sqrt(csum - 1.0 + frac), max_e);
 }
 
 #define NUM_STACK_ELEMS 16

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2437,7 +2437,7 @@ fractional digits to be dropped from *csum*.
 static inline double
 vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 {
-    double x, csum = 1.0, oldcsum, frac = 0.0;
+    double x, csum = 1.0, oldcsum, frac = 0.0, scale;
     int max_e;
     Py_ssize_t i;
 
@@ -2451,20 +2451,18 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         return max;
     }
     frexp(max, &max_e);
+    scale = ldexp(1.0, -max_e);
     for (i=0 ; i < n ; i++) {
-        int e;
-
         x = vec[i];
         assert(Py_IS_FINITE(x) && fabs(x) <= max);
-        x = frexp(x, &e);
-        x = ldexp(x, e - max_e);
+        x *= scale;
         x = x*x;
         oldcsum = csum;
         csum += x;
         assert(csum >= x);
         frac += (oldcsum - csum) + x;
     }
-    return ldexp(sqrt(csum - 1.0 + frac), max_e);
+    return sqrt(csum - 1.0 + frac) / scale;
 }
 
 #define NUM_STACK_ELEMS 16

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2452,14 +2452,17 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
     }
     frexp(max, &max_e);
     scale = ldexp(1.0, -max_e);
+    assert(max * scale >= 0.5);
+    assert(max * scale < 1.0);
     for (i=0 ; i < n ; i++) {
         x = vec[i];
         assert(Py_IS_FINITE(x) && fabs(x) <= max);
         x *= scale;
         x = x*x;
+        assert(x <= 1.0);
+        assert(csum >= x);
         oldcsum = csum;
         csum += x;
-        assert(csum >= x);
         frac += (oldcsum - csum) + x;
     }
     return sqrt(csum - 1.0 + frac) / scale;


### PR DESCRIPTION


<!-- issue-number: [bpo-41513](https://bugs.python.org/issue41513) -->
https://bugs.python.org/issue41513
<!-- /issue-number -->
