### PR TITLE
bpo-40548: Fix "Check for source changes (pull_request)" GH Action job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,15 @@ jobs:
             echo '::set-output name=run_tests::true'
           else
             git fetch origin $GITHUB_BASE_REF --depth=1
-            git diff --name-only origin/$GITHUB_BASE_REF... | grep -qvE '(\.rst$|^Doc|^Misc)' && echo '::set-output name=run_tests::true' || true
+            # git diff "origin/$GITHUB_BASE_REF..." (3 dots) may be more reliable,
+            # but it requires to download more commits.
+            #
+            # git diff "origin/$GITHUB_BASE_REF.." (2 dots) should be enough on
+            # GitHub, since GitHub starts by merging origin/$GITHUB_BASE_REF
+            # into the PR branch anyway.
+            #
+            # https://github.com/python/core-workflow/issues/373
+            git diff --name-only origin/$GITHUB_BASE_REF.. | grep -qvE '(\.rst$|^Doc|^Misc)' && echo '::set-output name=run_tests::true' || true
           fi
   build_win32:
     name: 'Windows (x86)'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,13 @@ jobs:
             echo '::set-output name=run_tests::true'
           else
             git fetch origin $GITHUB_BASE_REF --depth=1
-            # git diff "origin/$GITHUB_BASE_REF..." (3 dots) may be more reliable,
-            # but it requires to download more commits.
+            # git diff "origin/$GITHUB_BASE_REF..." (3 dots) may be more
+            # reliable than git diff "origin/$GITHUB_BASE_REF.." (2 dots),
+            # but it requires to download more commits (this job uses
+            # "git fetch --depth=1").
+            #
+            # git diff "origin/$GITHUB_BASE_REF..." (3 dots) works with Git
+            # 2.26, but Git 2.28 is stricter and fails with "no merge base".
             #
             # git diff "origin/$GITHUB_BASE_REF.." (2 dots) should be enough on
             # GitHub, since GitHub starts by merging origin/$GITHUB_BASE_REF


### PR DESCRIPTION
On Git 2.28, "git diff master..." (3 dots) no longer works when
"fetch --depth=1" is used, whereas it works on Git 2.26.

Replace "..." (3 dots) with ".." (2 dots) in the "git diff" command
computing the list of modified files between the base branch and the
PR branch.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40548](https://bugs.python.org/issue40548) -->
https://bugs.python.org/issue40548
<!-- /issue-number -->
