### PR TITLE
bpo-41514: Fix buggy IDLE test

### DIFF
--- a/Lib/idlelib/idle_test/test_run.py
+++ b/Lib/idlelib/idle_test/test_run.py
@@ -326,11 +326,11 @@ class RecursionLimitTest(unittest.TestCase):
 
 class HandleErrorTest(unittest.TestCase):
     # Method of MyRPCServer
-    func = Func()
-    @mock.patch('idlelib.run.thread.interrupt_main', new=func)
-    def test_error(self):
+    def test_fatal_error(self):
         eq = self.assertEqual
-        with captured_output('__stderr__') as err:
+        with captured_output('__stderr__') as err,\
+             mock.patch('idlelib.run.thread.interrupt_main',
+                        new_callable=Func) as func:
             try:
                 raise EOFError
             except EOFError:
@@ -349,7 +349,7 @@ class HandleErrorTest(unittest.TestCase):
             self.assertIn('abc', msg)
             self.assertIn('123', msg)
             self.assertIn('IndexError', msg)
-            eq(self.func.called, 2)
+            eq(func.called, 2)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
test_run method test_fatal_error failed when run twice, as with
python -m test -m test_fatal_error test_idle test_idle
because func.called was not reinitialized to 0.
This bug caused a failure on a refleak buildbot.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41514](https://bugs.python.org/issue41514) -->
https://bugs.python.org/issue41514
<!-- /issue-number -->
