### PR TITLE
add a missing period in json module's command lines options' documentation

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -745,7 +745,7 @@ Command line options
 
 .. cmdoption:: --indent, --tab, --no-indent, --compact
 
-   Mutually exclusive options for whitespace control
+   Mutually exclusive options for whitespace control.
 
    .. versionadded:: 3.9
 


### PR DESCRIPTION
All other command lines options sections end with a dot.