### PR TITLE
bpo-41521: Replace denylist with blocklist is http.cookiejar doc

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -462,8 +462,8 @@ receiving cookies.  There are also some strictness switches that allow you to
 tighten up the rather loose Netscape protocol rules a little bit (at the cost of
 blocking some benign cookies).
 
-A domain denylist and allowlist is provided (both off by default). Only domains
-not in the denylist and present in the allowlist (if the allowlist is active)
+A domain blocklist and allowlist is provided (both off by default). Only domains
+not in the blocklist and present in the allowlist (if the allowlist is active)
 participate in cookie setting and returning.  Use the *blocked_domains*
 constructor argument, and :meth:`blocked_domains` and
 :meth:`set_blocked_domains` methods (and the corresponding argument and methods
@@ -471,7 +471,7 @@ for *allowed_domains*).  If you set an allowlist, you can turn it off again by
 setting it to :const:`None`.
 
 Domains in block or allow lists that do not start with a dot must equal the
-cookie domain to be matched.  For example, ``"example.com"`` matches a denylist
+cookie domain to be matched.  For example, ``"example.com"`` matches a blocklist
 entry of ``"example.com"``, but ``"www.example.com"`` does not.  Domains that do
 start with a dot are matched by more specific domains too. For example, both
 ``"www.example.com"`` and ``"www.coyote.example.com"`` match ``".example.com"``
@@ -494,7 +494,7 @@ and ``".168.1.2"``, 192.168.1.2 is blocked, but 193.168.1.2 is not.
 
 .. method:: DefaultCookiePolicy.is_blocked(domain)
 
-   Return whether *domain* is on the denylist for setting or receiving cookies.
+   Return whether *domain* is on the blocklist for setting or receiving cookies.
 
 
 .. method:: DefaultCookiePolicy.allowed_domains()

--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -85,13 +85,13 @@ class AllTest(unittest.TestCase):
         lib_dir = os.path.dirname(os.path.dirname(__file__))
         for path, modname in self.walk_modules(lib_dir, ""):
             m = modname
-            denylisted = False
+            denied = False
             while m:
                 if m in denylist:
-                    denylisted = True
+                    denied = True
                     break
                 m = m.rpartition('.')[0]
-            if denylisted:
+            if denied:
                 continue
             if support.verbose:
                 print(modname)


### PR DESCRIPTION
The http.cookiejar module has is_blocked() and blocked_domains()
methods, so "blocklist" term sounds better than "denylist" in this
module.

Replace also denylisted with denied in test___all__.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41521](https://bugs.python.org/issue41521) -->
https://bugs.python.org/issue41521
<!-- /issue-number -->
