### PR TITLE
[3.9] bpo-38912: regrtest logs unraisable exception into sys.__stderr__ (GH-21718)

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -72,7 +72,12 @@ def regrtest_unraisable_hook(unraisable):
     global orig_unraisablehook
     support.environment_altered = True
     print_warning("Unraisable exception")
-    orig_unraisablehook(unraisable)
+    old_stderr = sys.stderr
+    try:
+        sys.stderr = sys.__stderr__
+        orig_unraisablehook(unraisable)
+    finally:
+        sys.stderr = old_stderr
 
 
 def setup_unraisable_hook():

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1234,10 +1234,12 @@ class ArgsTestCase(BaseTestCase):
                          re.compile('%s timed out' % testname, re.MULTILINE))
 
     def test_unraisable_exc(self):
-        # --fail-env-changed must catch unraisable exception
+        # --fail-env-changed must catch unraisable exception.
+        # The exceptioin must be displayed even if sys.stderr is redirected.
         code = textwrap.dedent(r"""
             import unittest
             import weakref
+            from test.support import captured_stderr
 
             class MyObject:
                 pass
@@ -1249,9 +1251,11 @@ class ArgsTestCase(BaseTestCase):
                 def test_unraisable_exc(self):
                     obj = MyObject()
                     ref = weakref.ref(obj, weakref_callback)
-                    # call weakref_callback() which logs
-                    # an unraisable exception
-                    obj = None
+                    with captured_stderr() as stderr:
+                        # call weakref_callback() which logs
+                        # an unraisable exception
+                        obj = None
+                    self.assertEqual(stderr.getvalue(), '')
         """)
         testname = self.create_test(code=code)
 
@@ -1260,6 +1264,7 @@ class ArgsTestCase(BaseTestCase):
                                   env_changed=[testname],
                                   fail_env_changed=True)
         self.assertIn("Warning -- Unraisable exception", output)
+        self.assertIn("Exception: weakref callback bug", output)
 
     def test_cleanup(self):
         dirname = os.path.join(self.tmptestdir, "test_python_123")


### PR DESCRIPTION
regrtest_unraisable_hook() temporarily replaces sys.stderr with
sys.__stderr__ to help to display errors when a test captures stderr.

(cherry picked from commit 701b63894fdb75b12865b9be6261ce4913da76f5)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38912](https://bugs.python.org/issue38912) -->
https://bugs.python.org/issue38912
<!-- /issue-number -->
