### PR TITLE
[3.9] bpo-41504: Add links to asttokens, leoAst, LibCST and parso to ast docs (GH-21773)

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1800,5 +1800,24 @@ to stdout.  Otherwise, the content is read from stdin.
 
 .. seealso::
 
-    `Green Tree Snakes <https://greentreesnakes.readthedocs.io/>`_, an external documentation resource, has good
-    details on working with Python ASTs.
+    `Green Tree Snakes <https://greentreesnakes.readthedocs.io/>`_, an external
+    documentation resource, has good details on working with Python ASTs.
+
+    `ASTTokens <https://asttokens.readthedocs.io/en/latest/user-guide.html>`_
+    annotates Python ASTs with the positions of tokens and text in the source
+    code that generated them. This is helpful for tools that make source code
+    transformations.
+
+    `leoAst.py <http://leoeditor.com/appendices.html#leoast-py>`_ unifies the
+    token-based and parse-tree-based views of python programs by inserting
+    two-way links between tokens and ast nodes.
+
+    `LibCST <https://libcst.readthedocs.io/>`_ parses code as a Concrete Syntax
+    Tree that looks like an ast tree and keeps all formatting details. It's
+    useful for building automated refactoring (codemod) applications and
+    linters.
+
+    `Parso <https://parso.readthedocs.io>`_ is a Python parser that supports
+    error recovery and round-trip parsing for different Python versions (in
+    multiple Python versions). Parso is also able to list multiple syntax errors
+    in your python file.


### PR DESCRIPTION
(cherry picked from commit e3c971ccfa58afcb2656b71b95e10b9703f2ad32)

Co-authored-by: Edward K. Ream <edreamleo@gmail.com>

https://bugs.python.org/issue41504

<!-- issue-number: [bpo-41504](https://bugs.python.org/issue41504) -->
https://bugs.python.org/issue41504
<!-- /issue-number -->
