### PR TITLE
bpo-41520: codeop no longer ignores SyntaxWarning

### DIFF
--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -84,9 +84,11 @@ def _maybe_compile(compiler, source, filename, symbol):
     except SyntaxError:
         pass
 
-    # Suppress warnings after the first compile to avoid duplication.
+    # Catch syntax warnings after the first compile
+    # to emit SyntaxWarning at most once.
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter("error", SyntaxWarning)
+
         try:
             code1 = compiler(source + "\n", filename, symbol)
         except SyntaxError as e:

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -4,6 +4,7 @@
 """
 import sys
 import unittest
+import warnings
 from test import support
 from test.support import warnings_helper
 
@@ -309,6 +310,12 @@ class CodeopTests(unittest.TestCase):
         with warnings_helper.check_warnings((".*literal", SyntaxWarning)) as w:
             compile_command("0 is 0")
             self.assertEqual(len(w.warnings), 1)
+
+        # bpo-41520: check SyntaxWarning treated as an SyntaxError
+        with self.assertRaises(SyntaxError):
+            warnings.simplefilter('error', SyntaxWarning)
+            compile_command('1 is 1\n', symbol='exec')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-08-12-13-25-16.bpo-41520.BEUWa4.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-12-13-25-16.bpo-41520.BEUWa4.rst
@@ -1,0 +1,1 @@
+Fix :mod:`codeop` regression: it no longer ignores :exc:`SyntaxWarning`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41520](https://bugs.python.org/issue41520) -->
https://bugs.python.org/issue41520
<!-- /issue-number -->
