### PR TITLE
bpo-41530: Handle unhandled IsADirectoryError and PermissionError in zoneinfo.ZoneInfo

### DIFF
--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -3,7 +3,7 @@ import struct
 
 def load_tzdata(key):
     import importlib.resources
-    
+
     components = key.split("/")
     package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
     resource_name = components[-1]

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -12,7 +12,8 @@ def load_tzdata(key):
     
     try:
         return importlib.resources.open_binary(package_name, resource_name)
-    except (IsADirectoryError, ImportError, FileNotFoundError, PermissionError, UnicodeEncodeError, ValueError):
+    except (IsADirectoryError, ImportError, FileNotFoundError, 
+            PermissionError, UnicodeEncodeError, ValueError):
         # There are six types of exception that can be raised that all amount
         # to "we cannot find this key":
         #

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -7,8 +7,6 @@ def load_tzdata(key):
     components = key.split("/")
     package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
     resource_name = components[-1]
-
-    path = importlib.resources.path(package_name, resource_name)
     
     try:
         return importlib.resources.open_binary(package_name, resource_name)

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -29,13 +29,9 @@ def load_tzdata(key):
         #   (e.g. Australia)
         # PermissionError: If the resource_name links to a directory on Windows
         #   (e.g. Pacific)
-        import os
-        import importlib.util
+        resource_path = importlib.resources.files(package_name).joinpath(key)
 
-        package_spec = importlib.util.find_spec(package_name)
-        resource_path = os.path.join(os.path.dirname(package_spec.origin), key)
-
-        if os.path.isdir(resource_path):
+        if resource_path.is_dir():
             raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
         else:
             raise

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -8,19 +8,27 @@ def load_tzdata(key):
     package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
     resource_name = components[-1]
 
+    path = importlib.resources.path(package_name, resource_name)
+    
     try:
         return importlib.resources.open_binary(package_name, resource_name)
-    except (ImportError, FileNotFoundError, UnicodeEncodeError):
-        # There are three types of exception that can be raised that all amount
+    except (IsADirectoryError, ImportError, FileNotFoundError, PermissionError, UnicodeEncodeError, ValueError):
+        # There are six types of exception that can be raised that all amount
         # to "we cannot find this key":
         #
+        # IsADirectoryError: If resource_name is the name of a folder
+        # (e.g. Australia)
         # ImportError: If package_name doesn't exist (e.g. if tzdata is not
         #   installed, or if there's an error in the folder name like
         #   Amrica/New_York)
         # FileNotFoundError: If resource_name doesn't exist in the package
         #   (e.g. Europe/Krasnoy)
+        # PermissionError: If resource_name is the name of a folder on Windows
+        #   (e.g. Pacific)
         # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
         #   such as keys containing a surrogate character.
+        # ValueError: If resource_name is not a valid TZif file
+        #   (e.g. __init__.py)
         raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
 
 

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -31,7 +31,7 @@ def load_tzdata(key):
         #   (e.g. Pacific)
         import os
         import importlib.util
-        
+
         package_spec = importlib.util.find_spec(package_name)
         resource_path = os.path.join(os.path.dirname(package_spec.origin), key)
 

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -2,17 +2,14 @@ import struct
 
 
 def load_tzdata(key):
-    try:
-        import importlib.resources as importlib_resources
-    except ImportError:
-        import importlib_resources
-
+    import importlib.resources
+    
     components = key.split("/")
     package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
     resource_name = components[-1]
 
     try:
-        return importlib_resources.open_binary(package_name, resource_name)
+        return importlib.resources.open_binary(package_name, resource_name)
     except (ImportError, FileNotFoundError, UnicodeEncodeError):
         # There are some types of exception that can be raised that all amount
         # to "we cannot find this key":
@@ -33,12 +30,9 @@ def load_tzdata(key):
         # PermissionError: If the resource_name links to a directory on Windows
         #   (e.g. Pacific)
         import os
-        try:
-            import importlib.util as importlib_util
-        except ImportError:
-            import importlib_util
+        import importlib.util
         
-        package_spec = importlib_util.find_spec(package_name)
+        package_spec = importlib.util.find_spec(package_name)
         resource_path = os.path.join(os.path.dirname(package_spec.origin), key)
 
         if os.path.isdir(resource_path):

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -11,8 +11,8 @@ def load_tzdata(key):
     try:
         return importlib.resources.open_binary(package_name, resource_name)
     except (IsADirectoryError, ImportError, FileNotFoundError, 
-            PermissionError, UnicodeEncodeError, ValueError):
-        # There are six types of exception that can be raised that all amount
+    PermissionError, UnicodeEncodeError):
+        # There are five types of exception that can be raised that all amount
         # to "we cannot find this key":
         #
         # IsADirectoryError: If resource_name is the name of a folder
@@ -26,8 +26,6 @@ def load_tzdata(key):
         #   (e.g. Pacific)
         # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
         #   such as keys containing a surrogate character.
-        # ValueError: If resource_name is not a valid TZif file
-        #   (e.g. __init__.py)
         raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
 
 

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -11,7 +11,7 @@ def load_tzdata(key):
     try:
         return importlib.resources.open_binary(package_name, resource_name)
     except (IsADirectoryError, ImportError, FileNotFoundError, 
-    PermissionError, UnicodeEncodeError):
+        PermissionError, UnicodeEncodeError):
         # There are five types of exception that can be raised that all amount
         # to "we cannot find this key":
         #

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -7,7 +7,7 @@ def load_tzdata(key):
     components = key.split("/")
     package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
     resource_name = components[-1]
-    
+
     try:
         return importlib.resources.open_binary(package_name, resource_name)
     except (IsADirectoryError, ImportError, FileNotFoundError, 

--- a/Lib/zoneinfo/_common.py
+++ b/Lib/zoneinfo/_common.py
@@ -22,8 +22,8 @@ def load_tzdata(key):
         # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
         #   such as keys containing a surrogate character.
         raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
-    except OSError as exc:
-        # Exceptions inherited from OSError can be raised in various scenarios:
+    except (IsADirectoryError, PermissionError):
+        # A few exceptions inherited from OSError can be raised in various scenarios:
         #
         # IsADirectoryError: If the resource_name links to a directory
         #   (e.g. Australia)

--- a/Misc/NEWS.d/next/Library/2020-08-13-01-17-31.bpo-41530.WYqwKz.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-13-01-17-31.bpo-41530.WYqwKz.rst
@@ -1,0 +1,1 @@
+zoneinfo ZoneInfo no longer raises IsADirectoryError or PermissionError when attempting to parse certain keys.


### PR DESCRIPTION
Handles `IsADirectoryError` and `PermissionError` raised when accessing specific resource names.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41530](https://bugs.python.org/issue41530) -->
https://bugs.python.org/issue41530
<!-- /issue-number -->
