### PR TITLE
bpo-40204: Allow pre-Sphinx 3 syntax in the doc

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -228,3 +228,13 @@ linkcheck_ignore = [r'https://bugs.python.org/(issue)?\d+',
 
 # Relative filename of the reference count data file.
 refcount_file = 'data/refcounts.dat'
+
+# Sphinx 2 and Sphinx 3 compatibility
+# -----------------------------------
+
+# bpo-40204: Allow Sphinx 2 syntax in the C domain
+c_allow_pre_v3 = True
+
+# bpo-40204: Disable warnings on Sphinx 2 syntax of the C domain since the
+# documentation is built with -W (warnings treated as errors).
+c_warn_on_allowed_pre_v3 = False

--- a/Misc/NEWS.d/next/Documentation/2020-08-12-18-35-40.bpo-40204.C8A_pe.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-08-12-18-35-40.bpo-40204.C8A_pe.rst
@@ -1,0 +1,3 @@
+Enable Sphinx 3.2 ``c_allow_pre_v3`` option and disable
+``c_warn_on_allowed_pre_v3`` option to make the documentation compatible
+with Sphinx 2 and Sphinx 3.


### PR DESCRIPTION
Enable Sphinx 3.2 "c_allow_pre_v3" option and disable the
c_warn_on_allowed_pre_v3 option to make the documentation compatible
with Sphinx 2 and Sphinx 3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40204](https://bugs.python.org/issue40204) -->
https://bugs.python.org/issue40204
<!-- /issue-number -->
