### PR TITLE
bpo-41524: fix pointer bug in PyOS_mystr{n}icmp

### DIFF
--- a/Misc/NEWS.d/next/C API/2020-08-12-17-09-06.bpo-41524.u6Xfr2.rst
+++ b/Misc/NEWS.d/next/C API/2020-08-12-17-09-06.bpo-41524.u6Xfr2.rst
@@ -1,0 +1,2 @@
+Fix bug in PyOS_mystrnicmp and PyOS_mystricmp that incremented
+pointers beyond the end of a string.

--- a/Python/pystrcmp.c
+++ b/Python/pystrcmp.c
@@ -9,11 +9,11 @@ PyOS_mystrnicmp(const char *s1, const char *s2, Py_ssize_t size)
     const unsigned char *p1, *p2;
     if (size == 0)
         return 0;
-    p1 = (void *)s1;
-    p2 = (void *)s2;
-    for (; (--size > 0) && (tolower(*p1) == tolower(*p2)); p1++, p2++) {
-        if (!*p1 || !*p2)
-            break;
+    p1 = (const unsigned char *)s1;
+    p2 = (const unsigned char *)s2;
+    for (; (--size > 0) && *p1 && *p2 && (tolower(*p1) == tolower(*p2));
+         p1++, p2++) {
+        ;
     }
     return tolower(*p1) - tolower(*p2);
 }
@@ -21,8 +21,9 @@ PyOS_mystrnicmp(const char *s1, const char *s2, Py_ssize_t size)
 int
 PyOS_mystricmp(const char *s1, const char *s2)
 {
-    const unsigned char *p1 = (void *)s1, *p2 = (void *)s2;
-    for (; *p1 && (tolower(*p1) == tolower(*p2)); p1++, p2++) {
+    const unsigned char *p1 = (const unsigned char *)s1;
+    const unsigned char *p2 = (const unsigned char *)s2;
+    for (; *p1 && *p2 && (tolower(*p1) == tolower(*p2)); p1++, p2++) {
         ;
     }
     return (tolower(*p1) - tolower(*p2));

--- a/Python/pystrcmp.c
+++ b/Python/pystrcmp.c
@@ -6,21 +6,24 @@
 int
 PyOS_mystrnicmp(const char *s1, const char *s2, Py_ssize_t size)
 {
+    const unsigned char *p1, *p2;
     if (size == 0)
         return 0;
-    while ((--size > 0) &&
-           (tolower((unsigned)*s1) == tolower((unsigned)*s2))) {
-        if (!*s1++ || !*s2++)
+    p1 = (void *)s1;
+    p2 = (void *)s2;
+    for (; (--size > 0) && (tolower(*p1) == tolower(*p2)); p1++, p2++) {
+        if (!*p1 || !*p2)
             break;
     }
-    return tolower((unsigned)*s1) - tolower((unsigned)*s2);
+    return tolower(*p1) - tolower(*p2);
 }
 
 int
 PyOS_mystricmp(const char *s1, const char *s2)
 {
-    while (*s1 && (tolower((unsigned)*s1++) == tolower((unsigned)*s2++))) {
+    const unsigned char *p1 = (void *)s1, *p2 = (void *)s2;
+    for (; *p1 && (tolower(*p1) == tolower(*p2)); p1++, p2++) {
         ;
     }
-    return (tolower((unsigned)*s1) - tolower((unsigned)*s2));
+    return (tolower(*p1) - tolower(*p2));
 }


### PR DESCRIPTION
The existing implementations of PyOS_mystrnicmp and PyOS_mystricmp
can increment pointers beyond the end of a string.

This fixes those cases by moving the mutation out of the condition.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41524](https://bugs.python.org/issue41524) -->
https://bugs.python.org/issue41524
<!-- /issue-number -->
