### PR TITLE
bpo-41533: Fix a potential memory leak when allocating a stack

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-12-20-29-57.bpo-41533.4pcVAc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-12-20-29-57.bpo-41533.4pcVAc.rst
@@ -1,0 +1,2 @@
+Free the stack allocated in ``va_build_stack`` if ``do_mkstack`` fails and
+the stack is not a ``small_stack``.

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -622,6 +622,9 @@ va_build_stack(PyObject **small_stack, Py_ssize_t small_stack_len,
     va_end(lva);
 
     if (res < 0) {
+        if (stack != small_stack) {
+            PyMem_Free(stack);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
Free the stack allocated in va_build_stack if do_mkstack fails
and the stack is not a small_stack

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41533](https://bugs.python.org/issue41533) -->
https://bugs.python.org/issue41533
<!-- /issue-number -->
