### PR TITLE
bpo-40563: Support pathlike objects on dbm/shelve

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -33,6 +33,8 @@ the Oracle Berkeley DB.
    file's format can't be guessed; or a string containing the required module
    name, such as ``'dbm.ndbm'`` or ``'dbm.gnu'``.
 
+.. versionchanged:: 3.10
+   Accepts :term:`path-like object` for filename.
 
 .. function:: open(file, flag='r', mode=0o666)
 
@@ -76,6 +78,9 @@ available, as well as :meth:`get` and :meth:`setdefault`.
 .. versionchanged:: 3.8
    Deleting a key from a read-only database raises database module specific error
    instead of :exc:`KeyError`.
+
+.. versionchanged:: 3.10
+   Accepts :term:`path-like object` for file.
 
 Key and values are always stored as bytes. This means that when
 strings are used they are implicitly converted to the default encoding before
@@ -202,6 +207,9 @@ supported.
    In addition to the dictionary-like methods, ``gdbm`` objects have the
    following methods:
 
+   .. versionchanged:: 3.10
+      Accepts :term:`path-like object` for filename.
+
    .. method:: gdbm.firstkey()
 
       It's possible to loop over every key in the database using this method  and the
@@ -298,6 +306,9 @@ to locate the appropriate header file to simplify building this module.
    In addition to the dictionary-like methods, ``ndbm`` objects
    provide the following method:
 
+   .. versionchanged:: 3.10
+      Accepts :term:`path-like object` for filename.
+
    .. method:: ndbm.close()
 
       Close the ``ndbm`` database.
@@ -378,6 +389,9 @@ The module defines the following:
       A database opened with flags ``'r'`` is now read-only.  Opening with
       flags ``'r'`` and ``'w'`` no longer creates a database if it does not
       exist.
+
+   .. versionchanged:: 3.10
+      Accepts :term:`path-like object` for filename.
 
    In addition to the methods provided by the
    :class:`collections.abc.MutableMapping` class, :class:`dumbdbm` objects

--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -33,7 +33,7 @@ the Oracle Berkeley DB.
    file's format can't be guessed; or a string containing the required module
    name, such as ``'dbm.ndbm'`` or ``'dbm.gnu'``.
 
-.. versionchanged:: 3.10
+.. versionchanged:: 3.11
    Accepts :term:`path-like object` for filename.
 
 .. function:: open(file, flag='r', mode=0o666)
@@ -79,7 +79,7 @@ available, as well as :meth:`get` and :meth:`setdefault`.
    Deleting a key from a read-only database raises database module specific error
    instead of :exc:`KeyError`.
 
-.. versionchanged:: 3.10
+.. versionchanged:: 3.11
    Accepts :term:`path-like object` for file.
 
 Key and values are always stored as bytes. This means that when
@@ -207,7 +207,7 @@ supported.
    In addition to the dictionary-like methods, ``gdbm`` objects have the
    following methods:
 
-   .. versionchanged:: 3.10
+   .. versionchanged:: 3.11
       Accepts :term:`path-like object` for filename.
 
    .. method:: gdbm.firstkey()
@@ -306,7 +306,7 @@ to locate the appropriate header file to simplify building this module.
    In addition to the dictionary-like methods, ``ndbm`` objects
    provide the following method:
 
-   .. versionchanged:: 3.10
+   .. versionchanged:: 3.11
       Accepts :term:`path-like object` for filename.
 
    .. method:: ndbm.close()
@@ -390,7 +390,7 @@ The module defines the following:
       flags ``'r'`` and ``'w'`` no longer creates a database if it does not
       exist.
 
-   .. versionchanged:: 3.10
+   .. versionchanged:: 3.11
       Accepts :term:`path-like object` for filename.
 
    In addition to the methods provided by the

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -45,6 +45,9 @@ lots of shared  sub-objects.  The keys are ordinary strings.
       :data:`pickle.DEFAULT_PROTOCOL` is now used as the default pickle
       protocol.
 
+   .. versionchanged:: 3.11
+      Accepts :term:`path-like object` for filename.
+
    .. note::
 
       Do not rely on the shelf being closed automatically; always call

--- a/Lib/dbm/__init__.py
+++ b/Lib/dbm/__init__.py
@@ -75,6 +75,7 @@ def open(file, flag='r', mode=0o666):
             raise ImportError("no dbm clone found; tried %s" % _names)
 
     # guess the type of an existing database, if not creating a new one
+    file = os.fspath(file)
     result = whichdb(file) if 'n' not in flag else None
     if result is None:
         # db doesn't exist or 'n' flag was specified to create a new db
@@ -109,6 +110,7 @@ def whichdb(filename):
     """
 
     # Check for ndbm first -- this has a .pag and a .dir file
+    filename = os.fspath(filename)
     try:
         f = io.open(filename + ".pag", "rb")
         f.close()

--- a/Lib/dbm/__init__.py
+++ b/Lib/dbm/__init__.py
@@ -75,7 +75,6 @@ def open(file, flag='r', mode=0o666):
             raise ImportError("no dbm clone found; tried %s" % _names)
 
     # guess the type of an existing database, if not creating a new one
-    file = os.fsencode(file)
     result = whichdb(file) if 'n' not in flag else None
     if result is None:
         # db doesn't exist or 'n' flag was specified to create a new db

--- a/Lib/dbm/__init__.py
+++ b/Lib/dbm/__init__.py
@@ -75,7 +75,7 @@ def open(file, flag='r', mode=0o666):
             raise ImportError("no dbm clone found; tried %s" % _names)
 
     # guess the type of an existing database, if not creating a new one
-    file = os.fspath(file)
+    file = os.fsencode(file)
     result = whichdb(file) if 'n' not in flag else None
     if result is None:
         # db doesn't exist or 'n' flag was specified to create a new db
@@ -110,18 +110,18 @@ def whichdb(filename):
     """
 
     # Check for ndbm first -- this has a .pag and a .dir file
-    filename = os.fspath(filename)
+    filename = os.fsencode(filename)
     try:
-        f = io.open(filename + ".pag", "rb")
+        f = io.open(filename + b".pag", "rb")
         f.close()
-        f = io.open(filename + ".dir", "rb")
+        f = io.open(filename + b".dir", "rb")
         f.close()
         return "dbm.ndbm"
     except OSError:
         # some dbm emulations based on Berkeley DB generate a .db file
         # some do not, but they should be caught by the bsd checks
         try:
-            f = io.open(filename + ".db", "rb")
+            f = io.open(filename + b".db", "rb")
             f.close()
             # guarantee we can actually open the file using dbm
             # kind of overkill, but since we are dealing with emulations
@@ -136,12 +136,12 @@ def whichdb(filename):
     # Check for dumbdbm next -- this has a .dir and a .dat file
     try:
         # First check for presence of files
-        os.stat(filename + ".dat")
-        size = os.stat(filename + ".dir").st_size
+        os.stat(filename + b".dat")
+        size = os.stat(filename + b".dir").st_size
         # dumbdbm files with no keys are empty
         if size == 0:
             return "dbm.dumb"
-        f = io.open(filename + ".dir", "rb")
+        f = io.open(filename + b".dir", "rb")
         try:
             if f.read(1) in (b"'", b'"'):
                 return "dbm.dumb"

--- a/Lib/dbm/dumb.py
+++ b/Lib/dbm/dumb.py
@@ -46,6 +46,7 @@ class _Database(collections.abc.MutableMapping):
     _io = _io       # for _commit()
 
     def __init__(self, filebasename, mode, flag='c'):
+        filebasename = self._os.fspath(filebasename)
         self._mode = mode
         self._readonly = (flag == 'r')
 

--- a/Lib/dbm/dumb.py
+++ b/Lib/dbm/dumb.py
@@ -46,7 +46,7 @@ class _Database(collections.abc.MutableMapping):
     _io = _io       # for _commit()
 
     def __init__(self, filebasename, mode, flag='c'):
-        filebasename = self._os.fspath(filebasename)
+        filebasename = self._os.fsencode(filebasename)
         self._mode = mode
         self._readonly = (flag == 'r')
 
@@ -55,14 +55,14 @@ class _Database(collections.abc.MutableMapping):
         # where key is the string key, pos is the offset into the dat
         # file of the associated value's first byte, and siz is the number
         # of bytes in the associated value.
-        self._dirfile = filebasename + '.dir'
+        self._dirfile = filebasename + b'.dir'
 
         # The data file is a binary file pointed into by the directory
         # file, and holds the values associated with keys.  Each value
         # begins at a _BLOCKSIZE-aligned byte offset, and is a raw
         # binary 8-bit string value.
-        self._datfile = filebasename + '.dat'
-        self._bakfile = filebasename + '.bak'
+        self._datfile = filebasename + b'.dat'
+        self._bakfile = filebasename + b'.bak'
 
         # The index is an in-memory dict, mirroring the directory file.
         self._index = None  # maps keys to (pos, siz) pairs

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -4,6 +4,7 @@ import unittest
 import glob
 from test.support import import_helper
 from test.support import os_helper
+from pathlib import Path
 
 # Skip tests if dbm module doesn't exist.
 dbm = import_helper.import_module('dbm')
@@ -129,6 +130,9 @@ class AnyDBMTestCase:
         assert(f[key] == b"Python:")
         f.close()
 
+    def test_open_with_patlib_path(self):
+        dbm.open(Path(_fname), "c").close()
+
     def read_helper(self, f):
         keys = self.keys_helper(f)
         for key in self._dict:
@@ -144,34 +148,36 @@ class AnyDBMTestCase:
 
 class WhichDBTestCase(unittest.TestCase):
     def test_whichdb(self):
-        for module in dbm_iterator():
-            # Check whether whichdb correctly guesses module name
-            # for databases opened with "module" module.
-            # Try with empty files first
-            name = module.__name__
-            if name == 'dbm.dumb':
-                continue   # whichdb can't support dbm.dumb
-            delete_files()
-            f = module.open(_fname, 'c')
-            f.close()
-            self.assertEqual(name, self.dbm.whichdb(_fname))
-            # Now add a key
-            f = module.open(_fname, 'w')
-            f[b"1"] = b"1"
-            # and test that we can find it
-            self.assertIn(b"1", f)
-            # and read it
-            self.assertEqual(f[b"1"], b"1")
-            f.close()
-            self.assertEqual(name, self.dbm.whichdb(_fname))
+        for path in [_fname, Path(_fname)]:
+            for module in dbm_iterator():
+                # Check whether whichdb correctly guesses module name
+                # for databases opened with "module" module.
+                # Try with empty files first
+                name = module.__name__
+                if name == 'dbm.dumb':
+                    continue   # whichdb can't support dbm.dumb
+                delete_files()
+                f = module.open(path, 'c')
+                f.close()
+                self.assertEqual(name, self.dbm.whichdb(path))
+                # Now add a key
+                f = module.open(path, 'w')
+                f[b"1"] = b"1"
+                # and test that we can find it
+                self.assertIn(b"1", f)
+                # and read it
+                self.assertEqual(f[b"1"], b"1")
+                f.close()
+                self.assertEqual(name, self.dbm.whichdb(path))
 
     @unittest.skipUnless(ndbm, reason='Test requires ndbm')
     def test_whichdb_ndbm(self):
         # Issue 17198: check that ndbm which is referenced in whichdb is defined
         db_file = '{}_ndbm.db'.format(_fname)
-        with open(db_file, 'w'):
-            self.addCleanup(os_helper.unlink, db_file)
-        self.assertIsNone(self.dbm.whichdb(db_file[:-3]))
+        for path in [db_file, Path(db_file)]:
+            with open(path, 'w'):
+                self.addCleanup(test.support.unlink, path)
+            self.assertIsNone(self.dbm.whichdb(path[:-3]))
 
     def tearDown(self):
         delete_files()

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -130,7 +130,7 @@ class AnyDBMTestCase:
         assert(f[key] == b"Python:")
         f.close()
 
-    def test_open_with_patlib_path(self):
+    def test_open_with_pathlib_path(self):
         dbm.open(Path(_fname), "c").close()
 
     def read_helper(self, f):

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -174,10 +174,13 @@ class WhichDBTestCase(unittest.TestCase):
     def test_whichdb_ndbm(self):
         # Issue 17198: check that ndbm which is referenced in whichdb is defined
         db_file = '{}_ndbm.db'.format(_fname)
-        for path in [db_file, Path(db_file)]:
-            with open(path, 'w'):
-                self.addCleanup(test.support.unlink, path)
-            self.assertIsNone(self.dbm.whichdb(path[:-3]))
+        with open(db_file, 'w'):
+            self.addCleanup(os_helper.unlink, db_file)
+        self.assertIsNone(self.dbm.whichdb(db_file[:-3]))
+        path = Path(db_file)
+        with open(path, 'w'):
+            self.addCleanup(os_helper.unlink, path)
+        self.assertIsNone(self.dbm.whichdb(path.stem))
 
     def tearDown(self):
         delete_files()

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -4,7 +4,6 @@ import unittest
 import glob
 from test.support import import_helper
 from test.support import os_helper
-from pathlib import Path
 
 # Skip tests if dbm module doesn't exist.
 dbm = import_helper.import_module('dbm')
@@ -131,7 +130,7 @@ class AnyDBMTestCase:
         f.close()
 
     def test_open_with_pathlib_path(self):
-        dbm.open(Path(_fname), "c").close()
+        dbm.open(os_helper.FakePath(_fname), "c").close()
 
     def read_helper(self, f):
         keys = self.keys_helper(f)
@@ -148,7 +147,7 @@ class AnyDBMTestCase:
 
 class WhichDBTestCase(unittest.TestCase):
     def test_whichdb(self):
-        for path in [_fname, Path(_fname)]:
+        for path in [_fname, os_helper.FakePath(_fname)]:
             for module in dbm_iterator():
                 # Check whether whichdb correctly guesses module name
                 # for databases opened with "module" module.
@@ -177,10 +176,10 @@ class WhichDBTestCase(unittest.TestCase):
         with open(db_file, 'w'):
             self.addCleanup(os_helper.unlink, db_file)
         self.assertIsNone(self.dbm.whichdb(db_file[:-3]))
-        path = Path(db_file)
+        path = os_helper.FakePath(db_file)
         with open(path, 'w'):
             self.addCleanup(os_helper.unlink, path)
-        self.assertIsNone(self.dbm.whichdb(path.stem))
+        self.assertIsNone(self.dbm.whichdb(db_file[:-3]))
 
     def tearDown(self):
         delete_files()

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -294,6 +294,10 @@ class DumbDBMTestCase(unittest.TestCase):
             self.assertTrue(b'key' in db)
             self.assertEqual(db[b'key'], b'value')
 
+    def test_open_with_patlib_path(self):
+        from pathlib import Path
+        dumbdbm.open(Path(_fname), "c").close()
+
     def tearDown(self):
         _delete_files()
 

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -294,7 +294,7 @@ class DumbDBMTestCase(unittest.TestCase):
             self.assertTrue(b'key' in db)
             self.assertEqual(db[b'key'], b'value')
 
-    def test_open_with_patlib_path(self):
+    def test_open_with_pathlib_path(self):
         from pathlib import Path
         dumbdbm.open(Path(_fname), "c").close()
 

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -297,6 +297,12 @@ class DumbDBMTestCase(unittest.TestCase):
     def test_open_with_pathlib_path(self):
         dumbdbm.open(os_helper.FakePath(_fname), "c").close()
 
+    def test_open_with_bytes_path(self):
+        dumbdbm.open(os.fsencode(_fname), "c").close()
+
+    def test_open_with_pathlib_bytes_path(self):
+        dumbdbm.open(os_helper.FakePath(os.fsencode(_fname)), "c").close()
+
     def tearDown(self):
         _delete_files()
 

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -295,8 +295,7 @@ class DumbDBMTestCase(unittest.TestCase):
             self.assertEqual(db[b'key'], b'value')
 
     def test_open_with_pathlib_path(self):
-        from pathlib import Path
-        dumbdbm.open(Path(_fname), "c").close()
+        dumbdbm.open(os_helper.FakePath(_fname), "c").close()
 
     def tearDown(self):
         _delete_files()

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -3,7 +3,7 @@ from test.support import import_helper, cpython_only
 gdbm = import_helper.import_module("dbm.gnu") #skip if not supported
 import unittest
 import os
-from test.support.os_helper import TESTFN, TESTFN_NONASCII, unlink
+from test.support.os_helper import TESTFN, TESTFN_NONASCII, unlink, FakePath
 
 
 filename = TESTFN
@@ -170,8 +170,7 @@ class TestGdbm(unittest.TestCase):
         self.assertEqual(cm.exception.filename, nonexisting_file)
 
     def test_open_with_pathlib_path(self):
-        from pathlib import Path
-        gdbm.open(Path(filename), "c").close()
+        gdbm.open(FakePath(filename), "c").close()
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -169,7 +169,7 @@ class TestGdbm(unittest.TestCase):
         self.assertIn(nonexisting_file, str(cm.exception))
         self.assertEqual(cm.exception.filename, nonexisting_file)
 
-    def test_open_with_patlib_path(self):
+    def test_open_with_pathlib_path(self):
         from pathlib import Path
         gdbm.open(Path(filename), "c").close()
 

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -169,6 +169,10 @@ class TestGdbm(unittest.TestCase):
         self.assertIn(nonexisting_file, str(cm.exception))
         self.assertEqual(cm.exception.filename, nonexisting_file)
 
+    def test_open_with_patlib_path(self):
+        from pathlib import Path
+        gdbm.open(Path(filename), "c").close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -172,6 +172,12 @@ class TestGdbm(unittest.TestCase):
     def test_open_with_pathlib_path(self):
         gdbm.open(FakePath(filename), "c").close()
 
+    def test_open_with_bytes_path(self):
+        gdbm.open(os.fsencode(filename), "c").close()
+
+    def test_open_with_pathlib_bytes_path(self):
+        gdbm.open(FakePath(os.fsencode(filename)), "c").close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -124,6 +124,10 @@ class DbmTestCase(unittest.TestCase):
         self.assertIn(nonexisting_file, str(cm.exception))
         self.assertEqual(cm.exception.filename, nonexisting_file)
 
+    def test_open_with_patlib_path(self):
+        from pathlib import Path
+        dbm.ndbm.open(Path(self.filename), "c").close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -124,7 +124,7 @@ class DbmTestCase(unittest.TestCase):
         self.assertIn(nonexisting_file, str(cm.exception))
         self.assertEqual(cm.exception.filename, nonexisting_file)
 
-    def test_open_with_patlib_path(self):
+    def test_open_with_pathlib_path(self):
         from pathlib import Path
         dbm.ndbm.open(Path(self.filename), "c").close()
 

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -127,6 +127,12 @@ class DbmTestCase(unittest.TestCase):
     def test_open_with_pathlib_path(self):
         dbm.ndbm.open(os_helper.FakePath(self.filename), "c").close()
 
+    def test_open_with_bytes_path(self):
+        dbm.ndbm.open(os.fsencode(self.filename), "c").close()
+
+    def test_open_with_pathlib_bytes_path(self):
+        dbm.ndbm.open(os_helper.FakePath(os.fsencode(self.filename)), "c").close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -125,8 +125,7 @@ class DbmTestCase(unittest.TestCase):
         self.assertEqual(cm.exception.filename, nonexisting_file)
 
     def test_open_with_pathlib_path(self):
-        from pathlib import Path
-        dbm.ndbm.open(Path(self.filename), "c").close()
+        dbm.ndbm.open(os_helper.FakePath(self.filename), "c").close()
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -2,6 +2,7 @@ import unittest
 import shelve
 import glob
 import pickle
+import os
 
 from test import support
 from test.support import os_helper
@@ -85,6 +86,12 @@ class TestCase(unittest.TestCase):
 
     def test_pathlib_path_file_shelf(self):
         self.test_open_template(filename=os_helper.FakePath(self.fn))
+
+    def test_bytes_path_file_shelf(self):
+        self.test_open_template(filename=os.fsencode(self.fn))
+
+    def test_pathlib_bytes_path_file_shelf(self):
+        self.test_open_template(filename=os_helper.FakePath(os.fsencode(self.fn)))
 
     def test_in_memory_shelf(self):
         d1 = byteskeydict()

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -65,29 +65,32 @@ class TestCase(unittest.TestCase):
         else:
             self.fail('Closed shelf should not find a key')
 
-    def test_ascii_file_shelf(self):
-        s = shelve.open(self.fn, protocol=0)
+    def test_open_template(self, filename=None, protocol=None):
+        kwargs = {
+            "filename": filename or self.fn,
+        }
+        if protocol:
+            kwargs["protocol"] = protocol
+        s = shelve.open(**kwargs)
         try:
             s['key1'] = (1,2,3,4)
             self.assertEqual(s['key1'], (1,2,3,4))
         finally:
             s.close()
+
+    def test_ascii_file_shelf(self):
+        self.test_open_template(protocol=0)
 
     def test_binary_file_shelf(self):
-        s = shelve.open(self.fn, protocol=1)
-        try:
-            s['key1'] = (1,2,3,4)
-            self.assertEqual(s['key1'], (1,2,3,4))
-        finally:
-            s.close()
+        self.test_open_template(protocol=1)
 
     def test_proto2_file_shelf(self):
-        s = shelve.open(self.fn, protocol=2)
-        try:
-            s['key1'] = (1,2,3,4)
-            self.assertEqual(s['key1'], (1,2,3,4))
-        finally:
-            s.close()
+        self.test_open_template(protocol=2)
+
+    def test_patlib_path_file_shelf(self):
+        from pathlib import Path
+        self.test_open_template(filename=Path(self.fn))
+
 
     def test_in_memory_shelf(self):
         d1 = byteskeydict()

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -66,12 +66,8 @@ class TestCase(unittest.TestCase):
             self.fail('Closed shelf should not find a key')
 
     def test_open_template(self, filename=None, protocol=None):
-        kwargs = {
-            "filename": filename or self.fn,
-        }
-        if protocol:
-            kwargs["protocol"] = protocol
-        s = shelve.open(**kwargs)
+        s = shelve.open(filename=filename if filename is not None else self.fn,
+                        protocol=protocol)
         try:
             s['key1'] = (1,2,3,4)
             self.assertEqual(s['key1'], (1,2,3,4))
@@ -88,9 +84,7 @@ class TestCase(unittest.TestCase):
         self.test_open_template(protocol=2)
 
     def test_pathlib_path_file_shelf(self):
-        from pathlib import Path
-        self.test_open_template(filename=Path(self.fn))
-
+        self.test_open_template(filename=os_helper.FakePath(self.fn))
 
     def test_in_memory_shelf(self):
         d1 = byteskeydict()

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -87,7 +87,7 @@ class TestCase(unittest.TestCase):
     def test_proto2_file_shelf(self):
         self.test_open_template(protocol=2)
 
-    def test_patlib_path_file_shelf(self):
+    def test_pathlib_path_file_shelf(self):
         from pathlib import Path
         self.test_open_template(filename=Path(self.fn))
 

--- a/Misc/NEWS.d/next/Library/2020-05-21-01-42-32.bpo-40563.fDn5bP.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-21-01-42-32.bpo-40563.fDn5bP.rst
@@ -1,0 +1,1 @@
+Support pathlike objects on dbm/shelve. Patch by Hakan Çelik.

--- a/Misc/NEWS.d/next/Library/2020-05-21-01-42-32.bpo-40563.fDn5bP.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-21-01-42-32.bpo-40563.fDn5bP.rst
@@ -1,1 +1,1 @@
-Support pathlike objects on dbm/shelve. Patch by Hakan Çelik.
+Support pathlike objects on dbm/shelve. Patch by Hakan Çelik and Henry-Joseph Audéoud.

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -479,17 +479,17 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         return NULL;
     }
 
-    PyObject *filenamebytes = PyOS_FSPath(filename);
-    if (filenamebytes == NULL)
+    PyObject *filenamechars = PyOS_FSPath(filename);
+    if (filenamechars == NULL)
         return NULL;
-    if (PyUnicode_Check(filenamebytes)) {
-        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamebytes);
-        Py_DECREF(filenamebytes);
-        filenamebytes = tmp;
+    if (PyUnicode_Check(filenamechars)) {
+        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamechars);
+        Py_DECREF(filenamechars);
+        filenamechars = tmp;
         if (tmp == NULL)
             return NULL;
     }
-    PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filename);
+    PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filenamechars);
     if (filenamebytes == NULL) {
         return NULL;
     }

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -479,20 +479,9 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         return NULL;
     }
 
-    PyObject *filenamecharsorbytes = PyOS_FSPath(filename);
-    if (filenamecharsorbytes == NULL) {
-        return NULL;
-    }
-
     PyObject *filenamebytes;
-    if (PyUnicode_Check(filenamecharsorbytes)) {
-        filenamebytes = PyUnicode_EncodeFSDefault(filenamecharsorbytes);
-        Py_DECREF(filenamecharsorbytes);
-        if (filenamebytes == NULL) {
-            return NULL;
-        }
-    } else {
-        filenamebytes = filenamecharsorbytes;
+    if (!PyUnicode_FSConverter(filename, &filenamebytes)) {
+        return NULL;
     }
 
     const char *name = PyBytes_AS_STRING(filenamebytes);

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -479,6 +479,16 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         return NULL;
     }
 
+    PyObject *filenamebytes = PyOS_FSPath(filename);
+    if (filenamebytes == NULL)
+        return NULL;
+    if (PyUnicode_Check(filenamebytes)) {
+        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamebytes);
+        Py_DECREF(filenamebytes);
+        filenamebytes = tmp;
+        if (tmp == NULL)
+            return NULL;
+    }
     PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filename);
     if (filenamebytes == NULL) {
         return NULL;

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -433,7 +433,7 @@ static PyType_Spec dbmtype_spec = {
 
 _dbm.open as dbmopen
 
-    filename: unicode
+    filename: object
         The filename to open.
 
     flags: str="r"
@@ -479,20 +479,22 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         return NULL;
     }
 
-    PyObject *filenamechars = PyOS_FSPath(filename);
-    if (filenamechars == NULL)
+    PyObject *filenamecharsorbytes = PyOS_FSPath(filename);
+    if (filenamecharsorbytes == NULL) {
         return NULL;
-    if (PyUnicode_Check(filenamechars)) {
-        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamechars);
-        Py_DECREF(filenamechars);
-        filenamechars = tmp;
-        if (tmp == NULL)
+    }
+
+    PyObject *filenamebytes;
+    if (PyUnicode_Check(filenamecharsorbytes)) {
+        filenamebytes = PyUnicode_EncodeFSDefault(filenamecharsorbytes);
+        Py_DECREF(filenamecharsorbytes);
+        if (filenamebytes == NULL) {
             return NULL;
+        }
+    } else {
+        filenamebytes = filenamecharsorbytes;
     }
-    PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filenamechars);
-    if (filenamebytes == NULL) {
-        return NULL;
-    }
+
     const char *name = PyBytes_AS_STRING(filenamebytes);
     if (strlen(name) != (size_t)PyBytes_GET_SIZE(filenamebytes)) {
         Py_DECREF(filenamebytes);

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -452,7 +452,7 @@ Return a database object.
 static PyObject *
 dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
              int mode)
-/*[clinic end generated code: output=9527750f5df90764 input=376a9d903a50df59]*/
+/*[clinic end generated code: output=9527750f5df90764 input=d8cf50a9f81218c8]*/
 {
     int iflags;
     _dbm_state *state =  get_dbm_state(module);

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -672,20 +672,22 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         }
     }
 
-    PyObject *filenamechars = PyOS_FSPath(filename);
-    if (filenamechars == NULL)
+    PyObject *filenamecharsorbytes = PyOS_FSPath(filename);
+    if (filenamecharsorbytes == NULL) {
         return NULL;
-    if (PyUnicode_Check(filenamechars)) {
-        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamechars);
-        Py_DECREF(filenamechars);
-        filenamechars = tmp;
-        if (tmp == NULL)
+    }
+
+    PyObject *filenamebytes;
+    if (PyUnicode_Check(filenamecharsorbytes)) {
+        filenamebytes = PyUnicode_EncodeFSDefault(filenamecharsorbytes);
+        Py_DECREF(filenamecharsorbytes);
+        if (filenamebytes == NULL) {
             return NULL;
+        }
+    } else {
+        filenamebytes = filenamecharsorbytes;
     }
-    PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filenamechars);
-    if (filenamebytes == NULL) {
-        return NULL;
-    }
+
     const char *name = PyBytes_AS_STRING(filenamebytes);
     if (strlen(name) != (size_t)PyBytes_GET_SIZE(filenamebytes)) {
         Py_DECREF(filenamebytes);

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -672,17 +672,17 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         }
     }
 
-    PyObject *filenamebytes = PyOS_FSPath(filename);
-    if (filenamebytes == NULL)
+    PyObject *filenamechars = PyOS_FSPath(filename);
+    if (filenamechars == NULL)
         return NULL;
-    if (PyUnicode_Check(filenamebytes)) {
-        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamebytes);
-        Py_DECREF(filenamebytes);
-        filenamebytes = tmp;
+    if (PyUnicode_Check(filenamechars)) {
+        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamechars);
+        Py_DECREF(filenamechars);
+        filenamechars = tmp;
         if (tmp == NULL)
             return NULL;
     }
-    PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filename);
+    PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filenamechars);
     if (filenamebytes == NULL) {
         return NULL;
     }

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -675,7 +675,7 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
     PyObject *filenamebytes = PyOS_FSPath(filename);
     if (filenamebytes == NULL)
         return NULL;
-    if (PyUnicode_Check(filenamebytes) {
+    if (PyUnicode_Check(filenamebytes)) {
         PyObject *tmp = PyUnicode_EncodeFSDefault(filenamebytes);
         Py_DECREF(filenamebytes);
         filenamebytes = tmp;

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -590,7 +590,7 @@ static PyType_Spec gdbmtype_spec = {
 /*[clinic input]
 _gdbm.open as dbmopen
 
-    filename: unicode
+    filename: object
     flags: str="r"
     mode: int(py_default="0o666") = 0o666
     /
@@ -672,6 +672,16 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         }
     }
 
+    PyObject *filenamebytes = PyOS_FSPath(filename);
+    if (filenamebytes == NULL)
+        return NULL;
+    if (PyUnicode_Check(filenamebytes) {
+        PyObject *tmp = PyUnicode_EncodeFSDefault(filenamebytes);
+        Py_DECREF(filenamebytes);
+        filenamebytes = tmp;
+        if (tmp == NULL)
+            return NULL;
+    }
     PyObject *filenamebytes = PyUnicode_EncodeFSDefault(filename);
     if (filenamebytes == NULL) {
         return NULL;

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -622,7 +622,7 @@ when the database has to be created.  It defaults to octal 0o666.
 static PyObject *
 dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
              int mode)
-/*[clinic end generated code: output=9527750f5df90764 input=812b7d74399ceb0e]*/
+/*[clinic end generated code: output=9527750f5df90764 input=bca6ec81dc49292c]*/
 {
     int iflags;
     _gdbm_state *state = get_gdbm_state(module);

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -672,20 +672,9 @@ dbmopen_impl(PyObject *module, PyObject *filename, const char *flags,
         }
     }
 
-    PyObject *filenamecharsorbytes = PyOS_FSPath(filename);
-    if (filenamecharsorbytes == NULL) {
-        return NULL;
-    }
-
     PyObject *filenamebytes;
-    if (PyUnicode_Check(filenamecharsorbytes)) {
-        filenamebytes = PyUnicode_EncodeFSDefault(filenamecharsorbytes);
-        Py_DECREF(filenamecharsorbytes);
-        if (filenamebytes == NULL) {
-            return NULL;
-        }
-    } else {
-        filenamebytes = filenamecharsorbytes;
+    if (!PyUnicode_FSConverter(filename, &filenamebytes)) {
+        return NULL;
     }
 
     const char *name = PyBytes_AS_STRING(filenamebytes);

--- a/Modules/clinic/_dbmmodule.c.h
+++ b/Modules/clinic/_dbmmodule.c.h
@@ -179,4 +179,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=13b6d821416be228 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=32ef6c0f8f2d3db9 input=a9049054013a1b77]*/

--- a/Modules/clinic/_dbmmodule.c.h
+++ b/Modules/clinic/_dbmmodule.c.h
@@ -149,13 +149,6 @@ dbmopen(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("open", nargs, 1, 3)) {
         goto exit;
     }
-    if (!PyUnicode_Check(args[0])) {
-        _PyArg_BadArgument("open", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     filename = args[0];
     if (nargs < 2) {
         goto skip_optional;

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -303,13 +303,6 @@ dbmopen(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("open", nargs, 1, 3)) {
         goto exit;
     }
-    if (!PyUnicode_Check(args[0])) {
-        _PyArg_BadArgument("open", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[0]) == -1) {
-        goto exit;
-    }
     filename = args[0];
     if (nargs < 2) {
         goto skip_optional;

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -333,4 +333,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1fed9ed50ad23551 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=63c507f93d84a3a4 input=a9049054013a1b77]*/


### PR DESCRIPTION
Refers to https://bugs.python.org/issue40563.

This work continues @hakancelik96's work from #20274.

<!-- issue-number: [bpo-40563](https://bugs.python.org/issue40563) -->
https://bugs.python.org/issue40563
<!-- /issue-number -->
