### PR TITLE
bpo-40782: Change asyncio.AbstractEventLoop.run_in_executor to be a method not a coroutine

### DIFF
--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -283,7 +283,7 @@ class AbstractEventLoop:
     def call_soon_threadsafe(self, callback, *args):
         raise NotImplementedError
 
-    async def run_in_executor(self, executor, func, *args):
+    def run_in_executor(self, executor, func, *args):
         raise NotImplementedError
 
     def set_default_executor(self, executor):

--- a/Misc/NEWS.d/next/Library/2020-08-13-08-07-25.bpo-40782.aGZqmB.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-13-08-07-25.bpo-40782.aGZqmB.rst
@@ -1,0 +1,1 @@
+Change the method asyncio.AbstractEventLoop.run_in_executor to not be a coroutine.


### PR DESCRIPTION
asyncio.AbstractEventLoop.run_in_executor should be a method that returns an asyncio Future, not an async method.
This matches the concrete implementations, and the documentation better.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40782](https://bugs.python.org/issue40782) -->
https://bugs.python.org/issue40782
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum