### PR TITLE
gh-85710: Make python interpreter customizable for EnvBuilder

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -98,7 +98,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
 .. class:: EnvBuilder(system_site_packages=False, clear=False, \
                       symlinks=False, upgrade=False, with_pip=False, \
-                      prompt=None, upgrade_deps=False)
+                      prompt=None, upgrade_deps=False, python_interpreter=None)
 
     The :class:`EnvBuilder` class accepts the following keyword arguments on
     instantiation:
@@ -127,6 +127,8 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     * ``upgrade_deps`` -- Update the base venv modules to the latest on PyPI
 
+    * ``python_interpreter`` -- a path to the python interpreter to use for this virtualenv.
+
     .. versionchanged:: 3.4
        Added the ``with_pip`` parameter
 
@@ -135,6 +137,9 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     .. versionadded:: 3.9
        Added the ``upgrade_deps`` parameter
+
+    .. versionadded:: 3.10
+       Added the ``python_interpreter`` parameter
 
     Creators of third-party virtual environment tools will be free to use the
     provided :class:`EnvBuilder` class as a base class.

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -98,7 +98,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
 .. class:: EnvBuilder(system_site_packages=False, clear=False, \
                       symlinks=False, upgrade=False, with_pip=False, \
-                      prompt=None, upgrade_deps=False, python_interpreter=None)
+                      prompt=None, upgrade_deps=False, executable=None)
 
     The :class:`EnvBuilder` class accepts the following keyword arguments on
     instantiation:
@@ -127,7 +127,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     * ``upgrade_deps`` -- Update the base venv modules to the latest on PyPI
 
-    * ``python_interpreter`` -- a path to the python interpreter to use for this virtualenv.
+    * ``executable`` -- a path to the python interpreter to use for this virtualenv.
 
     .. versionchanged:: 3.4
        Added the ``with_pip`` parameter
@@ -139,7 +139,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
        Added the ``upgrade_deps`` parameter
 
     .. versionadded:: 3.10
-       Added the ``python_interpreter`` parameter
+       Added the ``executable`` parameter
 
     Creators of third-party virtual environment tools will be free to use the
     provided :class:`EnvBuilder` class as a base class.

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -41,13 +41,13 @@ class EnvBuilder:
                      environment
     :param prompt: Alternative terminal prefix for the environment.
     :param upgrade_deps: Update the base venv modules to the latest on PyPI
-    :param python_interpreter: Optional path to a python interpreter to use instead of the default
+    :param executable: Optional path to a python interpreter to use instead of the default
                                sys._base_executable
     """
 
     def __init__(self, system_site_packages=False, clear=False,
                  symlinks=False, upgrade=False, with_pip=False, prompt=None,
-                 upgrade_deps=False, python_interpreter=None):
+                 upgrade_deps=False, executable=None):
         self.system_site_packages = system_site_packages
         self.clear = clear
         self.symlinks = symlinks
@@ -57,7 +57,7 @@ class EnvBuilder:
             prompt = os.path.basename(os.getcwd())
         self.prompt = prompt
         self.upgrade_deps = upgrade_deps
-        self.python_interpreter = python_interpreter or sys._base_executable
+        self.executable = executable or sys._base_executable
 
     def create(self, env_dir):
         """
@@ -117,7 +117,7 @@ class EnvBuilder:
         prompt = self.prompt if self.prompt is not None else context.env_name
         context.prompt = '(%s) ' % prompt
         create_if_needed(env_dir)
-        executable = self.python_interpreter
+        executable = self.executable
         dirname, exename = os.path.split(os.path.abspath(executable))
         context.executable = executable
         context.python_dir = dirname

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -407,9 +407,10 @@ class EnvBuilder:
 
 
 def create(env_dir, system_site_packages=False, clear=False,
-           symlinks=False, with_pip=False, prompt=None, upgrade_deps=False):
+           symlinks=False, with_pip=False, prompt=None, upgrade_deps=False, executable=None):
     """Create a virtual environment in a directory."""
     builder = EnvBuilder(system_site_packages=system_site_packages,
+                         executable=executable,
                          clear=clear, symlinks=symlinks, with_pip=with_pip,
                          prompt=prompt, upgrade_deps=upgrade_deps)
     builder.create(env_dir)
@@ -437,6 +438,8 @@ def main(args=None):
                                                 'in its bin directory.')
         parser.add_argument('dirs', metavar='ENV_DIR', nargs='+',
                             help='A directory to create the environment in.')
+        parser.add_argument('--executable', help='Python executable to use for'
+                                                 'this virtualenv')
         parser.add_argument('--system-site-packages', default=False,
                             action='store_true', dest='system_site',
                             help='Give the virtual environment access to the '
@@ -483,6 +486,7 @@ def main(args=None):
         if options.upgrade and options.clear:
             raise ValueError('you cannot supply --upgrade and --clear together.')
         builder = EnvBuilder(system_site_packages=options.system_site,
+                             executable=executable,
                              clear=options.clear,
                              symlinks=options.symlinks,
                              upgrade=options.upgrade,

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -41,11 +41,13 @@ class EnvBuilder:
                      environment
     :param prompt: Alternative terminal prefix for the environment.
     :param upgrade_deps: Update the base venv modules to the latest on PyPI
+    :param python_interpreter: Optional path to a python interpreter to use instead of the default
+                               sys._base_executable
     """
 
     def __init__(self, system_site_packages=False, clear=False,
                  symlinks=False, upgrade=False, with_pip=False, prompt=None,
-                 upgrade_deps=False):
+                 upgrade_deps=False, python_interpreter=None):
         self.system_site_packages = system_site_packages
         self.clear = clear
         self.symlinks = symlinks
@@ -55,6 +57,7 @@ class EnvBuilder:
             prompt = os.path.basename(os.getcwd())
         self.prompt = prompt
         self.upgrade_deps = upgrade_deps
+        self.python_interpreter = python_interpreter or sys._base_executable
 
     def create(self, env_dir):
         """
@@ -114,7 +117,7 @@ class EnvBuilder:
         prompt = self.prompt if self.prompt is not None else context.env_name
         context.prompt = '(%s) ' % prompt
         create_if_needed(env_dir)
-        executable = sys._base_executable
+        executable = self.python_interpreter
         dirname, exename = os.path.split(os.path.abspath(executable))
         context.executable = executable
         context.python_dir = dirname

--- a/Misc/NEWS.d/next/Library/2020-08-13-17-03-10.bpo-41538.pqp9fg.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-13-17-03-10.bpo-41538.pqp9fg.rst
@@ -1,3 +1,3 @@
-Add `python_interpreter` argument to `venv.EnvBuilder` to control which
+Add `executable` argument to `venv.EnvBuilder` to control which
 python interpreter to use for creating the virtualenv much like the `-p`
 parameter of the `virtualenv` command.

--- a/Misc/NEWS.d/next/Library/2020-08-13-17-03-10.bpo-41538.pqp9fg.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-13-17-03-10.bpo-41538.pqp9fg.rst
@@ -1,3 +1,4 @@
-Add `executable` argument to `venv.EnvBuilder` to control which
-python interpreter to use for creating the virtualenv much like the `-p`
+Add `executable` argument to `venv.EnvBuilder`, `venv.create` and as a
+command line argument `--executable` to control which python
+interpreter to use for creating the virtualenv much like the `-p`
 parameter of the `virtualenv` command.

--- a/Misc/NEWS.d/next/Library/2020-08-13-17-03-10.bpo-41538.pqp9fg.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-13-17-03-10.bpo-41538.pqp9fg.rst
@@ -1,0 +1,3 @@
+Add `python_interpreter` argument to `venv.EnvBuilder` to control which
+python interpreter to use for creating the virtualenv much like the `-p`
+parameter of the `virtualenv` command.


### PR DESCRIPTION
This adds a new keyword parameter `python_interpreter` to
`venv.EnvBuilder` that lets the user customize which python to use when
creating the virtualenv, much like the virtualenv command's `-p` flag.

The reason that this is needed is that for some embedded cases (Blender
being one example), `sys._base_executable` is not set to a valid Python
executable.

<!-- issue-number: [bpo-41538](https://bugs.python.org/issue41538) -->
https://bugs.python.org/issue41538
<!-- /issue-number -->

<!-- gh-issue-number: gh-85710 -->
* Issue: gh-85710
<!-- /gh-issue-number -->
