### PR TITLE
bpo-40204: Fix Sphinx sytanx in howto/instrumentation.rst

### DIFF
--- a/Doc/howto/instrumentation.rst
+++ b/Doc/howto/instrumentation.rst
@@ -272,9 +272,7 @@ should instead read:
 Available static markers
 ------------------------
 
-.. I'm reusing the "c:function" type for markers
-
-.. c:function:: function__entry(str filename, str funcname, int lineno)
+.. object:: function__entry(str filename, str funcname, int lineno)
 
    This marker indicates that execution of a Python function has begun.
    It is only triggered for pure-Python (bytecode) functions.
@@ -290,7 +288,7 @@ Available static markers
 
        * ``$arg3`` : ``int`` line number
 
-.. c:function:: function__return(str filename, str funcname, int lineno)
+.. object:: function__return(str filename, str funcname, int lineno)
 
    This marker is the converse of :c:func:`function__entry`, and indicates that
    execution of a Python function has ended (either via ``return``, or via an
@@ -298,7 +296,7 @@ Available static markers
 
    The arguments are the same as for :c:func:`function__entry`
 
-.. c:function:: line(str filename, str funcname, int lineno)
+.. object:: line(str filename, str funcname, int lineno)
 
    This marker indicates a Python line is about to be executed.  It is
    the equivalent of line-by-line tracing with a Python profiler.  It is
@@ -306,24 +304,24 @@ Available static markers
 
    The arguments are the same as for :c:func:`function__entry`.
 
-.. c:function:: gc__start(int generation)
+.. object:: gc__start(int generation)
 
    Fires when the Python interpreter starts a garbage collection cycle.
    ``arg0`` is the generation to scan, like :func:`gc.collect()`.
 
-.. c:function:: gc__done(long collected)
+.. object:: gc__done(long collected)
 
    Fires when the Python interpreter finishes a garbage collection
    cycle. ``arg0`` is the number of collected objects.
 
-.. c:function:: import__find__load__start(str modulename)
+.. object:: import__find__load__start(str modulename)
 
    Fires before :mod:`importlib` attempts to find and load the module.
    ``arg0`` is the module name.
 
    .. versionadded:: 3.7
 
-.. c:function:: import__find__load__done(str modulename, int found)
+.. object:: import__find__load__done(str modulename, int found)
 
    Fires after :mod:`importlib`'s find_and_load function is called.
    ``arg0`` is the module name, ``arg1`` indicates if module was
@@ -332,7 +330,7 @@ Available static markers
    .. versionadded:: 3.7
 
 
-.. c:function:: audit(str event, void *tuple)
+.. object:: audit(str event, void *tuple)
 
    Fires when :func:`sys.audit` or :c:func:`PySys_Audit` is called.
    ``arg0`` is the event name as C string, ``arg1`` is a :c:type:`PyObject`
@@ -375,14 +373,14 @@ If this file is installed in SystemTap's tapset directory (e.g.
 ``/usr/share/systemtap/tapset``), then these additional probepoints become
 available:
 
-.. c:function:: python.function.entry(str filename, str funcname, int lineno, frameptr)
+.. object:: python.function.entry(str filename, str funcname, int lineno, frameptr)
 
    This probe point indicates that execution of a Python function has begun.
    It is only triggered for pure-Python (bytecode) functions.
 
-.. c:function:: python.function.return(str filename, str funcname, int lineno, frameptr)
+.. object:: python.function.return(str filename, str funcname, int lineno, frameptr)
 
-   This probe point is the converse of :c:func:`python.function.return`, and
+   This probe point is the converse of ``python.function.return``, and
    indicates that execution of a Python function has ended (either via
    ``return``, or via an exception).  It is only triggered for pure-Python
    (bytecode) functions.


### PR DESCRIPTION
Use generic '.. object::' to declare markers, rather than abusing
'..  c:function::' which fails on these markers on Sphinx 3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40204](https://bugs.python.org/issue40204) -->
https://bugs.python.org/issue40204
<!-- /issue-number -->
