### PR TITLE
[3.9] bpo-41520: Fix second codeop regression (GH-21848)

### DIFF
--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -85,9 +85,9 @@ def _maybe_compile(compiler, source, filename, symbol):
         pass
 
     # Catch syntax warnings after the first compile
-    # to emit SyntaxWarning at most once.
+    # to emit warnings (SyntaxWarning, DeprecationWarning) at most once.
     with warnings.catch_warnings():
-        warnings.simplefilter("error", SyntaxWarning)
+        warnings.simplefilter("error")
 
         try:
             code1 = compiler(source + "\n", filename, symbol)

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -306,14 +306,17 @@ class CodeopTests(unittest.TestCase):
 
     def test_warning(self):
         # Test that the warning is only returned once.
-        with support.check_warnings((".*literal", SyntaxWarning)) as w:
-            compile_command("0 is 0")
-            self.assertEqual(len(w.warnings), 1)
+        with support.check_warnings(
+                (".*literal", SyntaxWarning),
+                (".*invalid", DeprecationWarning),
+                ) as w:
+            compile_command(r"'\e' is 0")
+            self.assertEqual(len(w.warnings), 2)
 
         # bpo-41520: check SyntaxWarning treated as an SyntaxError
-        with self.assertRaises(SyntaxError):
+        with warnings.catch_warnings(), self.assertRaises(SyntaxError):
             warnings.simplefilter('error', SyntaxWarning)
-            compile_command('1 is 1\n', symbol='exec')
+            compile_command('1 is 1', symbol='exec')
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2020-08-12-13-25-16.bpo-41520.BEUWa4.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-12-13-25-16.bpo-41520.BEUWa4.rst
@@ -1,1 +1,1 @@
-Fix :mod:`codeop` regression: it no longer ignores :exc:`SyntaxWarning`.
+Fix :mod:`codeop` regression that prevented turning compile warnings into errors.


### PR DESCRIPTION
Fix the repression introduced by the initial regression fix.

(cherry picked from commit c818b15)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41520](https://bugs.python.org/issue41520) -->
https://bugs.python.org/issue41520
<!-- /issue-number -->
