### PR TITLE
bpo-41541: Make pty.spawn set window size

### DIFF
--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -165,10 +165,14 @@ def _setwinsz(fd):
     try:
         from struct import pack
         from fcntl import ioctl
-        strct = pack('HHHH', 0, 0, 0, 0)
+    except ImportError:
+        return
+    
+    strct = pack('HHHH', 0, 0, 0, 0)
+    try:    
         winsz = ioctl(STDIN_FILENO, tty.TIOCGWINSZ, strct)
         ioctl(fd, tty.TIOCSWINSZ, winsz)
-    except (ImportError, AttributeError, OSError):
+    except (AttributeError, OSError):
         pass
 
 def spawn(argv, master_read=_read, stdin_read=_read):

--- a/Misc/NEWS.d/next/Library/2020-08-13-17-48-58.bpo-41541.vKJSeV.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-13-17-48-58.bpo-41541.vKJSeV.rst
@@ -1,0 +1,1 @@
+Make pty.spawn set window size.


### PR DESCRIPTION
- Test environment: Linux 4.19.0-9-amd64 Debian 10 GNU/Linux; xterm; bash; Docker python:latest/3.8.5-buster.
- Bug addressed: window size is not set by pty.spawn().
- How to reproduce issue: Use "stty -F <terminal-device-file-name> rows x cols y" to change window size.
- Issue description: Without the patch, when the number of columns is very small, the output of "ls" is hard to visually parse. After the patch is applied, the output of "ls" is rendered as expected.
- Patch summary: make pty.spawn set window size ( TIOCSWINSZ ).

<!-- issue-number: [bpo-41541](https://bugs.python.org/issue41541) -->
https://bugs.python.org/issue41541
<!-- /issue-number -->
