### PR TITLE
[3.8] bpo-41066: Update the comparison section for os vs pathlib (GH-21261)

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1139,9 +1139,12 @@ os and os.path                         pathlib
 :func:`os.path.exists`                 :meth:`Path.exists`
 :func:`os.path.expanduser`             :meth:`Path.expanduser` and
                                        :meth:`Path.home`
+:func:`os.listdir`                     :meth:`Path.iterdir`
 :func:`os.path.isdir`                  :meth:`Path.is_dir`
 :func:`os.path.isfile`                 :meth:`Path.is_file`
 :func:`os.path.islink`                 :meth:`Path.is_symlink`
+:func:`os.link`                        :meth:`Path.link_to`
+:func:`os.symlink`                     :meth:`Path.symlink_to`
 :func:`os.stat`                        :meth:`Path.stat`,
                                        :meth:`Path.owner`,
                                        :meth:`Path.group`


### PR DESCRIPTION
(cherry picked from commit 0eb9deb4a62e6d9daa82bc2f67d1075864ca8ece)

Co-authored-by: Srinivas Reddy Thatiparthy (శ్రీనివాస్  రెడ్డి తాటిపర్తి) <thatiparthysreenivas@gmail.com>


<!-- issue-number: [bpo-41066](https://bugs.python.org/issue41066) -->
https://bugs.python.org/issue41066
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou