### PR TITLE
[3.9] Fixed comment about pathlib.link_to: it was added in 3.8, not changed. (GH-21851)

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1134,7 +1134,7 @@ call fails (for example because the path doesn't exist).
 
    Create a hard link pointing to a path named *target*.
 
-   .. versionchanged:: 3.8
+   .. versionadded:: 3.8
 
 
 .. method:: Path.write_bytes(data)


### PR DESCRIPTION
(cherry picked from commit a3eae43)