### PR TITLE
bpo-41543: contextlib.nullcontext can fill in for an async context manager

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -234,6 +234,10 @@ Functions and classes provided:
 
    .. versionadded:: 3.7
 
+   .. versionchanged:: 3.10
+      :term:`asynchronous context manager` support was added.
+
+
 
 .. function:: suppress(*exceptions)
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -218,6 +218,20 @@ Functions and classes provided:
           with cm as file:
               # Perform processing on the file
 
+   It can also be used as a stand-in for
+   :ref:`asynchronous context managers <async-context-managers>`::
+
+       async def send_http(session=None):
+          if not session:
+              # If no http session, create it with aiohttp
+              cm = aiohttp.ClientSession()
+          else:
+              # Caller is responsible for closing the session
+              cm = nullcontext(session)
+
+          async with cm as session:
+              # Send http requests with session
+
    .. versionadded:: 3.7
 
 

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -681,7 +681,7 @@ class AsyncExitStack(_BaseExitStack, AbstractAsyncContextManager):
         return received_exc and suppressed_exc
 
 
-class nullcontext(AbstractContextManager):
+class nullcontext(AbstractContextManager, AbstractAsyncContextManager):
     """Context manager that does no additional processing.
 
     Used as a stand-in for a normal context manager, when a particular
@@ -699,4 +699,10 @@ class nullcontext(AbstractContextManager):
         return self.enter_result
 
     def __exit__(self, *excinfo):
+        pass
+
+    async def __aenter__(self):
+        return self.enter_result
+
+    async def __aexit__(self, *excinfo):
         pass

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -1,5 +1,7 @@
 import asyncio
-from contextlib import aclosing, asynccontextmanager, AbstractAsyncContextManager, AsyncExitStack
+from contextlib import (
+    asynccontextmanager, AbstractAsyncContextManager,
+    AsyncExitStack, nullcontext, aclosing)
 import functools
 from test import support
 import unittest
@@ -508,6 +510,16 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         inner_exc = saved_details[1]
         self.assertIsInstance(inner_exc, ValueError)
         self.assertIsInstance(inner_exc.__context__, ZeroDivisionError)
+
+
+class TestAsyncNullcontext(unittest.TestCase):
+    @_async_test
+    async def test_async_nullcontext(self):
+        class C:
+            pass
+        c = C()
+        async with nullcontext(c) as c_in:
+            self.assertIs(c_in, c)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2020-08-14-00-39-04.bpo-41543.RpcRjb.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-14-00-39-04.bpo-41543.RpcRjb.rst
@@ -1,0 +1,1 @@
+Add async context manager support for contextlib.nullcontext.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Make `contextlib.nullcontext` implement `AbstractAsyncContextManager`, so it can be used as a fill in for async context mangers.

<!-- issue-number: [bpo-41543](https://bugs.python.org/issue41543) -->
https://bugs.python.org/issue41543
<!-- /issue-number -->
