### PR TITLE
bpo-40994: Ungroup items in collections.abc documentation for improved clarity

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -98,12 +98,20 @@ ABC                        Inherits from          Abstract Methods        Mixin 
 
 
 .. class:: Container
-           Hashable
-           Sized
-           Callable
 
-   ABCs for classes that provide respectively the methods :meth:`__contains__`,
-   :meth:`__hash__`, :meth:`__len__`, and :meth:`__call__`.
+   ABC for classes that provide the :meth:`__contains__` method.
+
+.. class:: Hashable
+
+   ABC for classes that provide the :meth:`__hash__` method.
+
+.. class:: Sized
+
+   ABC for classes that provide the :meth:`__len__` method.
+
+.. class:: Callable
+
+   ABC for classes that provide the :meth:`__call__` method.
 
 .. class:: Iterable
 


### PR DESCRIPTION
Use a less surprising document structure.

<!-- issue-number: [bpo-40994](https://bugs.python.org/issue40994) -->
https://bugs.python.org/issue40994
<!-- /issue-number -->


Automerge-Triggered-By: @csabella