### PR TITLE
bpo-41540: AIX: skip test that is flaky with a default ulimit

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -5661,6 +5661,9 @@ class CWhitebox(unittest.TestCase):
             self.assertEqual(Decimal.from_float(cls(101.1)),
                              Decimal.from_float(101.1))
 
+    # Issue 41540:
+    @unittest.skipIf(sys.platform.startswith("aix"),
+                     "AIX: default ulimit: test is flaky because of extreme over-allocation")
     def test_maxcontext_exact_arith(self):
 
         # Make sure that exact operations do not raise MemoryError due


### PR DESCRIPTION


<!-- issue-number: [bpo-41540](https://bugs.python.org/issue41540) -->
https://bugs.python.org/issue41540
<!-- /issue-number -->
