### PR TITLE
bpo-1635741: Fix refleaks of encodings module by removing the encodings._aliases

### DIFF
--- a/Lib/encodings/__init__.py
+++ b/Lib/encodings/__init__.py
@@ -35,7 +35,7 @@ from . import aliases
 _cache = {}
 _unknown = '--unknown--'
 _import_tail = ['*']
-_aliases = aliases.aliases
+
 
 class CodecRegistryError(LookupError, SystemError):
     pass
@@ -69,6 +69,7 @@ def normalize_encoding(encoding):
 
 def search_function(encoding):
 
+    _aliases = aliases.aliases
     # Cache lookup
     entry = _cache.get(encoding, _unknown)
     if entry is not _unknown:

--- a/Lib/encodings/__init__.py
+++ b/Lib/encodings/__init__.py
@@ -69,7 +69,6 @@ def normalize_encoding(encoding):
 
 def search_function(encoding):
 
-    _aliases = aliases.aliases
     # Cache lookup
     entry = _cache.get(encoding, _unknown)
     if entry is not _unknown:
@@ -83,8 +82,8 @@ def search_function(encoding):
     # try in the encodings package, then at top-level.
     #
     norm_encoding = normalize_encoding(encoding)
-    aliased_encoding = _aliases.get(norm_encoding) or \
-                       _aliases.get(norm_encoding.replace('.', '_'))
+    aliased_encoding = aliases.aliases.get(norm_encoding) or \
+                       aliases.aliases.get(norm_encoding.replace('.', '_'))
     if aliased_encoding is not None:
         modnames = [aliased_encoding,
                     norm_encoding]
@@ -146,8 +145,8 @@ def search_function(encoding):
         pass
     else:
         for alias in codecaliases:
-            if alias not in _aliases:
-                _aliases[alias] = modname
+            if alias not in aliases.aliases:
+                aliases.aliases[alias] = modname
 
     # Return the registry entry
     return entry

--- a/Misc/NEWS.d/next/Library/2020-08-16-11-11-30.bpo-1635741.Q5Zrx3.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-16-11-11-30.bpo-1635741.Q5Zrx3.rst
@@ -1,2 +1,2 @@
-Fix refleaks of `encodings.aliases` by Moving `encodings._aliases` to
+Fix refleaks of `encodings.aliases` by Using `encodings.aliases` directly in
 :func:`encodings.search_function`.

--- a/Misc/NEWS.d/next/Library/2020-08-16-11-11-30.bpo-1635741.Q5Zrx3.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-16-11-11-30.bpo-1635741.Q5Zrx3.rst
@@ -1,2 +1,2 @@
-Fix refleaks of `encodings.aliases` by Using `encodings.aliases` directly in
+Fix refleaks of `encodings.aliases` by using `encodings.aliases` directly in
 :func:`encodings.search_function`.

--- a/Misc/NEWS.d/next/Library/2020-08-16-11-11-30.bpo-1635741.Q5Zrx3.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-16-11-11-30.bpo-1635741.Q5Zrx3.rst
@@ -1,0 +1,2 @@
+Fix refleaks of `encodings.aliases` by Moving `encodings._aliases` to
+:func:`encodings.search_function`.


### PR DESCRIPTION
Fix refleaks of `encodings._aliases` by using `encodings.aliases` directly in `encodings.search_function`.

Co-authored-by: Victor Stinner <vstinner@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```

bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
