### PR TITLE
bpo-41568: Fix refleaks in zoneinfo subclasses

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -412,7 +412,6 @@ zoneinfo_clear_cache(PyObject *cls, PyObject *args, PyObject *kwargs)
         }
 
         clear_strong_cache(type);
-        ZONEINFO_STRONG_CACHE = NULL;
     }
     else {
         PyObject *item = NULL;
@@ -2471,6 +2470,7 @@ clear_strong_cache(const PyTypeObject *const type)
     }
 
     strong_cache_free(ZONEINFO_STRONG_CACHE);
+    ZONEINFO_STRONG_CACHE = NULL;
 }
 
 static PyObject *
@@ -2617,8 +2617,7 @@ module_free()
         Py_CLEAR(ZONEINFO_WEAK_CACHE);
     }
 
-    strong_cache_free(ZONEINFO_STRONG_CACHE);
-    ZONEINFO_STRONG_CACHE = NULL;
+    clear_strong_cache(&PyZoneInfo_ZoneInfoType);
 }
 
 static int

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2525,6 +2525,7 @@ zoneinfo_init_subclass(PyTypeObject *cls, PyObject *args, PyObject **kwargs)
     }
 
     PyObject_SetAttrString((PyObject *)cls, "_weak_cache", weak_cache);
+    Py_DECREF(weak_cache);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
 There are two refleaks related to subclassing the C implementation of `ZoneInfo`:

1. `__init_subclass__` leaks a reference to the subclass's weak cache.
2. `ZoneinfoSubclass.clear_cache()` incidentally sets `zoneinfo.ZoneInfo`'s pointer to its strong cache to `NULL`, thus leaking the old strong cache (and forcing `ZoneInfo` to create a new one).

This fixes both of these issues.

<!-- issue-number: [bpo-41568](https://bugs.python.org/issue41568) -->
https://bugs.python.org/issue41568
<!-- /issue-number -->
