### PR TITLE
bpo-41572: Documentation wording fix

### DIFF
--- a/Lib/asyncio/transports.py
+++ b/Lib/asyncio/transports.py
@@ -29,8 +29,8 @@ class BaseTransport:
 
         Buffered data will be flushed asynchronously.  No more data
         will be received.  After all buffered data is flushed, the
-        protocol's connection_lost() method will (eventually) called
-        with None as its argument.
+        protocol's connection_lost() method will (eventually) be
+        called with None as its argument.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
The docstring on asyncio.transports.BaseTransport.close() is missing a
verb.

https://bugs.python.org/issue41572

Signed-off-by: Cleber Rosa <crosa@redhat.com>


<!-- issue-number: [bpo-41572](https://bugs.python.org/issue41572) -->
https://bugs.python.org/issue41572
<!-- /issue-number -->
