### PR TITLE
bpo-41513:  More accurate hypot()

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-08-23-14-23-18.bpo-41513.DGqc_I.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-23-14-23-18.bpo-41513.DGqc_I.rst
@@ -1,0 +1,3 @@
+Improved the accuracy of math.hypot().  Internally, each step is computed
+with extra precision so that the result is now almost always correctly
+rounded.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2479,22 +2479,23 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             t = x * T27;
             hi = t - (t - x);
             lo = x - hi;
-            assert (hi + lo == x);
+            assert(hi + lo == x);
 
             x = hi * hi;
-            assert(csum >= x);
+            assert(x <= 1.0);
+            assert(fabs(csum) >= fabs(x));
             oldcsum = csum;
             csum += x;
             frac += (oldcsum - csum) + x;
 
             x = 2.0 * hi * lo;
-            assert(csum >= x);
+            assert(fabs(csum) >= fabs(x));
             oldcsum = csum;
             csum += x;
             frac += (oldcsum - csum) + x;
 
             x = lo * lo;
-            assert(csum >= x);
+            assert(fabs(csum) >= fabs(x));
             oldcsum = csum;
             csum += x;
             frac += (oldcsum - csum) + x;
@@ -2508,19 +2509,19 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert (hi + lo == x);
 
         x = -lo * lo;
-        assert(csum >= x);
+        assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;
 
         x = -2.0 * hi * lo;
-        assert(csum >= x);
+        assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;
 
         x = -hi * hi;
-        assert(csum >= x);
+        assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;
@@ -2538,7 +2539,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         x /= max;
         x = x*x;
         assert(x <= 1.0);
-        assert(csum >= x);
+        assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2474,11 +2474,10 @@ References:
 
 */
 
-static const double T27 = 134217729.0;   /* T27=ldexp(1.0, 27)+1.0) */
-
 static inline double
 vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 {
+    const double T27 = 134217729.0;     /* ldexp(1.0, 27)+1.0) */
     double x, csum = 1.0, oldcsum, frac = 0.0, scale;
     double t, hi, lo, h;
     int max_e;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2472,9 +2472,9 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert(max * scale < 1.0);
         for (i=0 ; i < n ; i++) {
             x = vec[i];
-            assert(Py_IS_FINITE(x) && fabs(x) <= max);
+            assert(Py_IS_FINITE(x) && x >= 0.0 && fabs(x) <= max);
             x *= scale;
-            assert(x <= 1.0);
+            assert(x < 1.0);
 
             t = x * T27;
             hi = t - (t - x);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2474,7 +2474,6 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             x = vec[i];
             assert(Py_IS_FINITE(x) && fabs(x) <= max);
             x *= scale;
-            x = x*x;
             assert(x <= 1.0);
             assert(csum >= x);
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2533,7 +2533,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         lo = x - hi;
         assert (hi + lo == x);
 
-        x = -lo * lo;
+        x = -hi * hi;
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
@@ -2545,7 +2545,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         csum += x;
         frac += (oldcsum - csum) + x;
 
-        x = -hi * hi;
+        x = -lo * lo;
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2475,24 +2475,26 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             assert(Py_IS_FINITE(x) && fabs(x) <= max);
             x *= scale;
             assert(x <= 1.0);
-            assert(csum >= x);
 
             t = x * T27;
             hi = t - (t - x);
             lo = x - hi;
             assert (hi + lo == x);
 
-            x = lo * lo;
+            x = hi * hi;
+            assert(csum >= x);
             oldcsum = csum;
             csum += x;
             frac += (oldcsum - csum) + x;
 
             x = 2.0 * hi * lo;
+            assert(csum >= x);
             oldcsum = csum;
             csum += x;
             frac += (oldcsum - csum) + x;
 
-            x = hi * hi;
+            x = lo * lo;
+            assert(csum >= x);
             oldcsum = csum;
             csum += x;
             frac += (oldcsum - csum) + x;
@@ -2506,16 +2508,19 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert (hi + lo == x);
 
         x = -lo * lo;
+        assert(csum >= x);
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;
 
         x = -2.0 * hi * lo;
+        assert(csum >= x);
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;
 
         x = -hi * hi;
+        assert(csum >= x);
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2455,7 +2455,7 @@ The differential correction starts with a value *x* that is
 the difference between the square of *h*, the possibly inaccurately
 rounded square root, and the accurately computed sum of squares.
 The correction is the first order term of the Maclaurin series
-expansion of sqrt(h**2 - x) == h - x/(2*h) + O(x**2).
+expansion of sqrt(h**2 + x) == h + x/(2*h) + O(x**2).
 
 Essentially, this differential correction is equivalent to one
 refinement step in the Newton divide-and-average square root

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2404,45 +2404,73 @@ math_fmod_impl(PyObject *module, double x, double y)
 }
 
 /*
-Given an *n* length *vec* of values and a value *max*, compute:
+Given an *n* length *vec* of values, compute the vector norm:
 
-    sqrt(sum((x * scale) ** 2 for x in vec)) / scale
+    sqrt(sum(x ** 2 for x in vec)
 
-           where scale is the first power of two
-           greater than max.
-
-or compute:
-
-    max * sqrt(sum((x / max) ** 2 for x in vec))
-
-The value of the *max* variable must be non-negative and
-equal to the absolute value of the largest magnitude
-entry in the vector.  If n==0, then *max* should be 0.0.
+The *vec* values should be non-negative.
+The *max* variable should be equal to the largest *x*.
+The *n* variable is the length of *vec*.
+If n==0, then *max* should be 0.0.
 If an infinity is present in the vec, *max* should be INF.
-
 The *found_nan* variable indicates whether some member of
 the *vec* is a NaN.
 
-To improve accuracy and to increase the number of cases where
-vector_norm() is commutative, we use a variant of Neumaier
-summation specialized to exploit that we always know that
-|csum| >= |x|.
+To achieve high accuracy, where results are almost always correctly
+rounded, and to avoid overflow/underflow, four techniques are used:
 
-The *csum* variable tracks the cumulative sum and *frac* tracks
-the cumulative fractional errors at each step.  Since this
-variant assumes that |csum| >= |x| at each step, we establish
-the precondition by starting the accumulation from 1.0 which
-represents the largest possible value of (x*scale)**2 or (x/max)**2.
+* lossless scaling using a power-of-two scaling factor
+* accurate squaring using Veltkamp-Dekker splitting
+* compensated summation using a variant of the Neumaier algorithm
+* differential correction of the square root
 
-After the loop is finished, the initial 1.0 is subtracted out
-for a net zero effect on the final sum.  Since *csum* will be
-greater than 1.0, the subtraction of 1.0 will not cause
-fractional digits to be dropped from *csum*.
+The usual presentation of the Neumaier summation algorithm has an
+expensive branch depending on which operand has the larger
+magnitude.  We avoid this cost by arranging the calculation so that
+fabs(csum) is always as large as fabs(x).
 
-To get the full benefit from compensated summation, the
-largest addend should be in the range:   0.5 <= x <= 1.0.
-Accordingly, scaling or division by *max* should not be skipped
-even if not otherwise needed to prevent overflow or loss of precision.
+To establish the invariant, *csum* is initialized to 1.0 which is
+always larger than x**2 after scaling or division by *max*.
+After the loop is finished, the initial 1.0 is subtracted out for a
+net zero effect on the final sum.  Since *csum* will be greater than
+1.0, the subtraction of 1.0 will not cause fractional digits to be
+dropped from *csum*.
+
+To get the full benefit from compensated summation, the largest
+addend should be in the range: 0.5 <= x <= 1.0.  Accordingly,
+scaling or division by *max* should not be skipped even if not
+otherwise needed to prevent overflow or loss of precision.
+
+The assertion that hi*hi >= 1.0 is a bit subtle.  Each vector
+element gets scaled to be below 1.0.  The Veltkamp-Dekker splitting
+algorithm gives a *hi* value that is correctly rounded to half
+precision.  When a value at or below 1.0 is correctly rounded, it
+never goes above 1.0.  And when values at or below 1.0 are squared,
+they remain at or below 1.0, thus preserving the summation
+invariant.
+
+The square root differential correction is needed because a
+correctly rounded square root of the correctly rounded sum of
+squares can still be off by as much as one ulp.
+
+The differential correction starts with a value *x* that is
+the difference between the square of *h*, the possibly inaccurately
+rounded square root, and the accurate computed sum of squares.
+The correction is the first order term of the Maclaurin series
+expansion of sqrt(h**2 - x) == h - x/(2*h) + O(x**2).
+
+Essentially, this differential correction is equivalent to one
+refinement step in the Newton divide-and-average square root
+algorithm, effectively doubling the number of accurate bits.
+
+This technique is used in Dekker's SQRT2 algorithm and again in
+Borges' ALGORITHM 4 and 5.
+
+References:
+
+1. Veltkamp-Dekker splitting: http://csclub.uwaterloo.ca/~pbarfuss/dekker1971.pdf
+2. Compensated summation:  http://www.ti3.tu-harburg.de/paper/rump/Ru08b.pdf
+3. Square root diffential correction:  https://arxiv.org/pdf/1904.09481.pdf
 
 */
 
@@ -2452,7 +2480,7 @@ static inline double
 vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 {
     double x, csum = 1.0, oldcsum, frac = 0.0, scale;
-    double t, hi, lo, result;
+    double t, hi, lo, h;
     int max_e;
     Py_ssize_t i;
 
@@ -2473,6 +2501,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         for (i=0 ; i < n ; i++) {
             x = vec[i];
             assert(Py_IS_FINITE(x) && x >= 0.0 && fabs(x) <= max);
+
             x *= scale;
             assert(x < 1.0);
 
@@ -2500,9 +2529,9 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             csum += x;
             frac += (oldcsum - csum) + x;
         }
-        result = sqrt(csum - 1.0 + frac);
+        h = sqrt(csum - 1.0 + frac);
 
-        x = result;
+        x = h;
         t = x * T27;
         hi = t - (t - x);
         lo = x - hi;
@@ -2527,8 +2556,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         frac += (oldcsum - csum) + x;
 
         x = csum - 1.0 + frac;
-        result += x / (2.0 * result);
-        return result / scale;
+        return (h + x / (2.0 * h)) / scale;
     }
     /* When max_e < -1023, ldexp(1.0, -max_e) overflows.
        So instead of multiplying by a scale, we just divide by *max*.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2497,7 +2497,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             csum += x;
             frac += (oldcsum - csum) + x;
         }
-        result = sqrt(csum - 1.0 + frac) / scale;
+        result = sqrt(csum - 1.0 + frac);
 
         x = result;
         t = x * T27;


### PR DESCRIPTION
Draft PR for discussion.   

Algorithm combines:
* lossless scaling using a power-of-two scaling factor
* accurate squaring using Veltkamp-Dekker splitting
* accurate summation using a variant of the Neumaier algorithm
* differential correction of the square root calculation

Together, these allow the algorithm to simulate 128-bit quad precision throughout.

On my build, the speed slows 50-60%.   I've tested with millions of inputs and not yet found a single 1-ulp error.  It seems to always be correctly rounded.

<!-- issue-number: [bpo-41513](https://bugs.python.org/issue41513) -->
https://bugs.python.org/issue41513
<!-- /issue-number -->
