### PR TITLE
bpo-41109: subclasses of pathlib.Path and pathlib.PurePath now call the subclass's __init__() and __new__() functions when returning new objects

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -120,6 +120,14 @@ Added the *root_dir* and *dir_fd* parameters in :func:`~glob.glob` and
 :func:`~glob.iglob` which allow to specify the root directory for searching.
 (Contributed by Serhiy Storchaka in :issue:`38144`.)
 
+pathlib
+-------
+Subclasses of :class:`Path` and :class:`PurePath` now call the
+:func:`__new__` and :func:`__init__` functions of the subclasses when
+instantiating new subclass objects returned by various :class:`Path` and
+:class:`PurePath` functions and properties.  (Contributed by Jeffrey Kintscher
+in :issue:`41109`.)
+
 py_compile
 ----------
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -134,11 +134,11 @@ Added :func:`os.cpu_count()` support for VxWorks RTOS.
 
 pathlib
 -------
-Subclasses of :class:`Path` and :class:`PurePath` now call the
+Subclasses of :class:`pathlib.Path` and :class:`pathlib.PurePath` now call the
 :func:`__new__` and :func:`__init__` functions of the subclasses when
-instantiating new subclass objects returned by various :class:`Path` and
-:class:`PurePath` functions and properties.  (Contributed by Jeffrey Kintscher
-in :issue:`41109`.)
+instantiating new subclass objects returned by various :class:`pathlib.Path` and
+:class:`pathlib.PurePath` functions and properties.  (Contributed by Jeffrey
+Kintscher in :issue:`41109`.)
 
 py_compile
 ----------

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1105,7 +1105,7 @@ class Path(PurePath):
                                       % (cls.__name__,))
         return self
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args):
         super().__init__(*args, init=False)
         self._init()
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -660,13 +660,11 @@ class PurePath(object):
             cls = PureWindowsPath if os.name == 'nt' else PurePosixPath
         return object.__new__(cls)
 
-    def __init__(self, *args, init=True):
+    def __init__(self, *args):
         drv, root, parts = self._parse_args(args)
         self._drv = drv
         self._root = root
         self._parts = parts
-        if init:
-            self._init()
 
     def __reduce__(self):
         # Using the parts tuple helps share interned path parts
@@ -1105,7 +1103,7 @@ class Path(PurePath):
         return self
 
     def __init__(self, *args):
-        super().__init__(*args, init=False)
+        super().__init__(*args)
         self._init()
 
     def _init(self,

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -720,23 +720,15 @@ class PurePath(object):
             self._init()
         return self
 
-    def _new_from_parts(self, args, init=True):
-        obj = type(self)()
-        drv, root, parts = obj._parse_args(args)
-        obj._drv = drv
-        obj._root = root
-        obj._parts = parts
-        if init:
-            obj._init()
+    def _new_from_parts(self, args):
+        obj = type(self)(*args)
         return obj
 
-    def _new_from_parsed_parts(self, drv, root, parts, init=True):
+    def _new_from_parsed_parts(self, drv, root, parts):
         obj = type(self)()
         obj._drv = drv
         obj._root = root
         obj._parts = parts
-        if init:
-            obj._init()
         return obj
 
     @classmethod
@@ -1222,7 +1214,7 @@ class Path(PurePath):
             return self
         # FIXME this must defer to the specific flavour (and, under Windows,
         # use nt._getfullpathname())
-        obj = self._new_from_parts([os.getcwd()] + self._parts, init=False)
+        obj = self._new_from_parts([os.getcwd()] + self._parts)
         obj._init(template=self)
         return obj
 
@@ -1240,7 +1232,7 @@ class Path(PurePath):
             s = str(self.absolute())
         # Now we have no symlinks in the path, it's safe to normalize it.
         normed = self._flavour.pathmod.normpath(s)
-        obj = self._new_from_parts((normed,), init=False)
+        obj = self._new_from_parts((normed,))
         obj._init(template=self)
         return obj
 
@@ -1310,7 +1302,7 @@ class Path(PurePath):
         Return the path to which the symbolic link points.
         """
         path = self._accessor.readlink(self)
-        obj = self._new_from_parts((path,), init=False)
+        obj = self._new_from_parts((path,))
         obj._init(template=self)
         return obj
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -666,7 +666,7 @@ class PurePath(object):
         self._root = root
         self._parts = parts
         if init:
-            self._init()        
+            self._init()
 
     def __reduce__(self):
         # Using the parts tuple helps share interned path parts

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1098,7 +1098,6 @@ class Path(PurePath):
     def __new__(cls, *args, **kwargs):
         if cls is Path:
             cls = WindowsPath if os.name == 'nt' else PosixPath
-        self = cls._from_parts(args, init=False)
         self = object.__new__(cls)
         if not self._flavour.is_supported:
             raise NotImplementedError("cannot instantiate %r on your system"

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2585,10 +2585,10 @@ class CompatiblePathTest(unittest.TestCase):
             10 / pathlib.PurePath("test")
 
 
-class PurePosixSubclassNewAndInitTest(unittest.TestCase):
+class PurePosixPathSubclassNewAndInitTest(unittest.TestCase):
     """
     Test that the __init__() and __new__() functions of subclasses
-    of PurePosixPath get called when PosixPath functions
+    of PurePosixPath get called when PurePosixPath functions
     and properties instantiate new objects of the subclass.
     """
     cls = pathlib.PurePosixPath
@@ -2646,10 +2646,10 @@ class PurePosixSubclassNewAndInitTest(unittest.TestCase):
                              'a/b/c.bar')
 
 
-class PureWindowsSubclassNewAndInitTest(unittest.TestCase):
+class PureWindowsPathSubclassNewAndInitTest(unittest.TestCase):
     """
     Test that the __init__() and __new__() functions of subclasses
-    of PureWindowsPath get called when PosixPath functions
+    of PureWindowsPath get called when PureWindowsPath functions
     and properties instantiate new objects of the subclass.
     """
     cls = pathlib.PureWindowsPath

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2781,9 +2781,10 @@ class _BasePathSubclassNewAndInitTest(object):
     def test_resolve(self):
         # create a file in a temp directory
         d = BASE
-        filename = 'fileA'
-        self.validate_object(self.ASubclass(d, filename).resolve(strict=True),
-                             join(d, filename))
+        filename = join(d, 'fileA')
+        path = self.ASubclass(d, filename)
+        self.validate_object(path, filename)
+        self.validate_object(path.resolve(strict=True), filename)
 
 
 @only_posix

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2769,14 +2769,14 @@ class _BasePathSubclassNewAndInitTest(object):
     def test_readlink(self):
         d = BASE
         filename = 'fileA'
-        linkname = 'linkA'
-
-        # create a symlink to the file
-        os.symlink(join(d, filename), join(d, linkname))
-
-        path = (self.ASubclass(d) / linkname).readlink()
-        self.validate_object(path, join(d, filename))
-        os.unlink(path)
+        linkname = join(d, 'linkA')
+        path = self.ASubclass(linkname)
+        self.validate_object(path, linkname)
+        os.symlink(filename, linkname)
+        try:
+            self.validate_object(path.readlink(), filename)
+        finally:
+            os.unlink(linkname)
 
     def test_resolve(self):
         # create a file in a temp directory

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2612,7 +2612,10 @@ class PurePosixPathSubclassNewAndInitTest(unittest.TestCase):
         self.assertEqual(str(path), value)
 
     def test_class_initialization(self):
-        self.validate_object(self.ASubclass('a/b/c.foo'), 'a/b/c.foo')
+        self.validate_object(self.ASubclass('/a/b/c.foo'), '/a/b/c.foo')
+        self.validate_object(self.ASubclass('/', 'a', 'b', 'c.foo'),
+                                            '/a/b/c.foo')
+        self.validate_object(self.ASubclass(self.cls('/a/b')), '/a/b')
 
     def test_joinpath(self):
         self.validate_object(self.ASubclass('a/b/c.foo').parent.joinpath('d/e'),
@@ -2673,7 +2676,11 @@ class PureWindowsPathSubclassNewAndInitTest(unittest.TestCase):
         self.assertEqual(str(path), value)
 
     def test_class_initialization(self):
-        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo'), 'c:\\a\\b\\c.foo')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo'),
+                                            'c:\\a\\b\\c.foo')
+        self.validate_object(self.ASubclass('c:', '\\', 'a', 'b', 'c.foo'),
+                                            'c:\\a\\b\\c.foo')
+        self.validate_object(self.ASubclass(self.cls('c:\\a')), 'c:\\a')
 
     def test_joinpath(self):
         self.validate_object(self.ASubclass('c:\\a\\b\\c.foo').parent.joinpath('d\\e'),
@@ -2810,7 +2817,10 @@ class PosixPathSubclassNewAndInitTest(_BasePathSubclassNewAndInitTest,
             super().__init__(*args, **kwargs)
 
     def test_class_initialization(self):
-        self.validate_object(self.ASubclass('a/b/c.foo'), 'a/b/c.foo')
+        self.validate_object(self.ASubclass('/a/b/c.foo'), '/a/b/c.foo')
+        self.validate_object(self.ASubclass('/', 'a', 'b', 'c.foo'),
+                                            '/a/b/c.foo')
+        self.validate_object(self.ASubclass(self.cls('/a/b')), '/a/b')
 
     def test_absolute(self):
         relpath = 'a/b/c.foo'
@@ -2851,7 +2861,11 @@ class WindowsPathSubclassNewAndInitTest(_BasePathSubclassNewAndInitTest,
             super().__init__(*args, **kwargs)
 
     def test_class_initialization(self):
-        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo'), 'c:\\a\\b\\c.foo')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo'),
+                                            'c:\\a\\b\\c.foo')
+        self.validate_object(self.ASubclass('c:', '\\', 'a', 'b', 'c.foo'),
+                                            'c:\\a\\b\\c.foo')
+        self.validate_object(self.ASubclass(self.cls('c:\\a')), 'c:\\a')
 
     def test_absolute(self):
         relpath = 'a\\b\\c.foo'

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2649,7 +2649,7 @@ class PurePosixSubclassNewAndInitTest(unittest.TestCase):
 class PureWindowsSubclassNewAndInitTest(unittest.TestCase):
     """
     Test that the __init__() and __new__() functions of subclasses
-    of PurePosixPath get called when PosixPath functions
+    of PureWindowsPath get called when PosixPath functions
     and properties instantiate new objects of the subclass.
     """
     cls = pathlib.PureWindowsPath

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2797,5 +2797,100 @@ class PosixPathSubclassNewAndInitTest(unittest.TestCase):
         self.validate_object(path, join(d, 'fileA'))
 
 
+@only_nt
+class WindowsPathSubclassNewAndInitTest(unittest.TestCase):
+    """
+    Test that the __init__() and __new__() functions of subclasses
+    of WindowsPath get called when WindowsPath functions
+    and properties instantiate new objects of the subclass.
+    """
+    cls = pathlib.WindowsPath
+
+    class ASubclass(cls):
+        new_called = False
+        init_called = False
+
+        def __new__(cls, *args, **kwargs):
+            cls.new_called = True
+            return super().__new__(cls, *args, **kwargs)
+
+        def __init__(self, *args, **kwargs):
+            self.init_called = True
+            super().__init__()
+
+    def validate_object(self, path, value):
+        self.assertIs(type(path), self.ASubclass)
+        self.assertTrue(path.new_called)
+        self.assertTrue(path.init_called)
+        self.assertEqual(str(path), value)
+
+    def test_class_initialization(self):
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo'), 'c:\\a\\b\\c.foo')
+
+    def test_absolute(self):
+        relpath = 'a\\b\\c.foo'
+        self.validate_object(self.ASubclass(relpath).absolute(),
+                             join(os.getcwd(), relpath))
+
+    def test_expanduser(self):
+        import_helper.import_module('pwd')
+        import pwd
+        pwdent = pwd.getpwuid(os.getuid())
+        userhome = pwdent.pw_dir.rstrip('\\') or '\\'
+        path = self.ASubclass('~\\Documents')
+        with os_helper.EnvironmentVarGuard() as env:
+            env.pop('HOME', None)
+            self.validate_object(path.expanduser(), join(userhome, 'Documents'))
+
+    def test_glob_rglob_iterdir(self):
+        # create a file in a temp directory
+        d = tempfile.mkdtemp()
+        filename = 'fileA'
+        with open(join(d, filename), 'wb') as f:
+            f.write(b"this is file A\n")
+
+        # create an Asubclass object for testing
+        path = self.ASubclass(d)
+        self.validate_object(path, d)
+
+        # verify __new__ and __init__ are called
+        # in the subclass for each created instance
+        # and the subclass value is correct
+        cases = [(path.glob, 'f*', join(d, filename)),    # _WildcardSelector
+                 (path.glob, 'fileA', join(d, filename)), # _PreciseSelector
+                 (path.glob, '**', d),                    # _RecursiveWildcardSelector
+                 (path.rglob, 'f*', join(d, filename)),
+                 (path.iterdir, None, join(d, filename))]
+
+        for func, param, value in cases:
+            n = 0
+            for name in func() if param is None else func(param):
+                self.validate_object(name, value)
+                n += 1
+            self.assertEqual(n, 1)
+
+    def test_resolve(self):
+        # create a file in a temp directory
+        d = tempfile.mkdtemp()
+        filename = 'fileA'
+        with open(join(d, filename), 'wb') as f:
+            f.write(b"this is file A\n")
+
+        self.validate_object(self.ASubclass(d, filename).resolve(strict=True),
+                             join(d, filename))
+
+    @os_helper.skip_unless_symlink
+    def test_readlink(self):
+        # create a file in a temp directory
+        d = tempfile.mkdtemp()
+        with open(join(d, 'fileA'), 'wb') as f:
+            f.write(b"this is file A\n")
+        # create a symlink to the file
+        os.symlink('fileA', join(d, 'linkA'))
+
+        path = self.ASubclass(d, 'linkA').readlink()
+        self.validate_object(path, 'fileA')
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2603,7 +2603,7 @@ class PurePosixPathSubclassNewAndInitTest(unittest.TestCase):
 
         def __init__(self, *args, **kwargs):
             self.init_called = True
-            super().__init__()
+            super().__init__(*args, **kwargs)
 
     def validate_object(self, path, value):
         self.assertIs(type(path), self.ASubclass)
@@ -2664,7 +2664,7 @@ class PureWindowsPathSubclassNewAndInitTest(unittest.TestCase):
 
         def __init__(self, *args, **kwargs):
             self.init_called = True
-            super().__init__()
+            super().__init__(*args, **kwargs)
 
     def validate_object(self, path, value):
         self.assertIs(type(path), self.ASubclass)
@@ -2726,7 +2726,7 @@ class PosixPathSubclassNewAndInitTest(unittest.TestCase):
 
         def __init__(self, *args, **kwargs):
             self.init_called = True
-            super().__init__()
+            super().__init__(*args, **kwargs)
 
     def validate_object(self, path, value):
         self.assertIs(type(path), self.ASubclass)
@@ -2816,7 +2816,7 @@ class WindowsPathSubclassNewAndInitTest(unittest.TestCase):
 
         def __init__(self, *args, **kwargs):
             self.init_called = True
-            super().__init__()
+            super().__init__(*args, **kwargs)
 
     def validate_object(self, path, value):
         self.assertIs(type(path), self.ASubclass)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2652,7 +2652,7 @@ class PureWindowsSubclassNewAndInitTest(unittest.TestCase):
     of PurePosixPath get called when PosixPath functions
     and properties instantiate new objects of the subclass.
     """
-    cls = pathlib.PurePosixPath
+    cls = pathlib.PureWindowsPath
 
     class ASubclass(cls):
         new_called = False
@@ -2673,38 +2673,38 @@ class PureWindowsSubclassNewAndInitTest(unittest.TestCase):
         self.assertEqual(str(path), value)
 
     def test_class_initialization(self):
-        self.validate_object(self.ASubclass('c:/a/b/c.foo'), 'c:/a/b/c.foo')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo'), 'c:\\a\\b\\c.foo')
 
     def test_joinpath(self):
-        self.validate_object(self.ASubclass('c:/a/b/c.foo').parent.joinpath('d/e'),
-                             'c:/a/b/d/e')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo').parent.joinpath('d\\e'),
+                             'c:\\a\\b\\d\\e')
 
     def test_parent(self):
-        self.validate_object(self.ASubclass('c:/a/b/c.foo').parent, 'c:/a/b')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo').parent, 'c:\\a\\b')
 
     def test_parents(self):
-        path = self.ASubclass('c:/a/b/c.foo')
-        self.validate_object(path.parents[0], 'c:/a/b')
-        self.validate_object(path.parents[1], 'c:/a')
+        path = self.ASubclass('c:\\a\\b\\c.foo')
+        self.validate_object(path.parents[0], 'c:\\a\\b')
+        self.validate_object(path.parents[1], 'c:\\a')
 
     def test_relative_to(self):
-        self.validate_object(self.ASubclass('c:/a/b/c.foo').relative_to('c:/a'),
-                             'b/c.foo')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo').relative_to('c:\\a'),
+                             'b\\c.foo')
 
     def test_rtruediv(self):
-        self.validate_object('c:/left' / self.ASubclass('test'), 'c:/left/test')
+        self.validate_object('c:\\left' / self.ASubclass('test'), 'c:\\left\\test')
 
     def test_truediv(self):
-        path = self.ASubclass('c:/a/b/c.foo')
-        self.validate_object(path.parent / 'd', 'c:/a/b/d')
+        path = self.ASubclass('c:\\a\\b\\c.foo')
+        self.validate_object(path.parent / 'd', 'c:\\a\\b\\d')
 
     def test_with_name(self):
-        self.validate_object(self.ASubclass('c:/a/b/c.foo').with_name('bar'),
-                             'c:/a/b/bar')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo').with_name('bar'),
+                             'c:\\a\\b\\bar')
 
     def test_with_suffix(self):
-        self.validate_object(self.ASubclass('c:/a/b/c.foo').with_suffix('.bar'),
-                             'c:/a/b/c.bar')
+        self.validate_object(self.ASubclass('c:\\a\\b\\c.foo').with_suffix('.bar'),
+                             'c:\\a\\b\\c.bar')
 
 
 @only_posix

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2732,13 +2732,13 @@ class _BasePathSubclassNewAndInitTest(object):
         filename = 'fileA'
         path = self.ASubclass(d)
         self.validate_object(path, d)
-        cases = [(path.glob, 'f*', join(d, filename)),    # _WildcardSelector
-                 (path.glob, 'fileA', join(d, filename)), # _PreciseSelector
-                 (path.glob, '**', d)]                    # _RecursiveWildcardSelector
+        cases = [('f*', join(d, filename)),    # _WildcardSelector
+                 ('fileA', join(d, filename)), # _PreciseSelector
+                 ('**', d)]                    # _RecursiveWildcardSelector
 
-        for func, param, value in cases:
+        for param, value in cases:
             n = 0
-            for name in func(param):
+            for name in path.glob(param):
                 self.validate_object(name, value)
                 n += 1
             self.assertEqual(n, 1)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2646,6 +2646,67 @@ class PurePosixSubclassNewAndInitTest(unittest.TestCase):
                              'a/b/c.bar')
 
 
+class PureWindowsSubclassNewAndInitTest(unittest.TestCase):
+    """
+    Test that the __init__() and __new__() functions of subclasses
+    of PurePosixPath get called when PosixPath functions
+    and properties instantiate new objects of the subclass.
+    """
+    cls = pathlib.PurePosixPath
+
+    class ASubclass(cls):
+        new_called = False
+        init_called = False
+
+        def __new__(cls, *args, **kwargs):
+            cls.new_called = True
+            return super().__new__(cls, *args, **kwargs)
+
+        def __init__(self, *args, **kwargs):
+            self.init_called = True
+            super().__init__()
+
+    def validate_object(self, path, value):
+        self.assertIs(type(path), self.ASubclass)
+        self.assertTrue(path.new_called)
+        self.assertTrue(path.init_called)
+        self.assertEqual(str(path), value)
+
+    def test_class_initialization(self):
+        self.validate_object(self.ASubclass('c:/a/b/c.foo'), 'c:/a/b/c.foo')
+
+    def test_joinpath(self):
+        self.validate_object(self.ASubclass('c:/a/b/c.foo').parent.joinpath('d/e'),
+                             'c:/a/b/d/e')
+
+    def test_parent(self):
+        self.validate_object(self.ASubclass('c:/a/b/c.foo').parent, 'c:/a/b')
+
+    def test_parents(self):
+        path = self.ASubclass('c:/a/b/c.foo')
+        self.validate_object(path.parents[0], 'c:/a/b')
+        self.validate_object(path.parents[1], 'c:/a')
+
+    def test_relative_to(self):
+        self.validate_object(self.ASubclass('c:/a/b/c.foo').relative_to('c:/a'),
+                             'b/c.foo')
+
+    def test_rtruediv(self):
+        self.validate_object('c:/left' / self.ASubclass('test'), 'c:/left/test')
+
+    def test_truediv(self):
+        path = self.ASubclass('c:/a/b/c.foo')
+        self.validate_object(path.parent / 'd', 'c:/a/b/d')
+
+    def test_with_name(self):
+        self.validate_object(self.ASubclass('c:/a/b/c.foo').with_name('bar'),
+                             'c:/a/b/bar')
+
+    def test_with_suffix(self):
+        self.validate_object(self.ASubclass('c:/a/b/c.foo').with_suffix('.bar'),
+                             'c:/a/b/c.bar')
+
+
 @only_posix
 class PosixPathSubclassNewAndInitTest(unittest.TestCase):
     """

--- a/Misc/NEWS.d/next/Library/2020-08-18-18-22-56.bpo-41109.QcFpg2.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-18-18-22-56.bpo-41109.QcFpg2.rst
@@ -1,4 +1,4 @@
-Subclasses of :class:`Path`: and :class:`PurePath`: now call the
-:func:`__new__`: and :func:`__init__`: functions of the subclasses when
-instantiating new subclass objects returned by various :class:`Path`: and
-:class:`PurePath`: functions and properties.  Patch by Jeffrey Kintscher.
+Subclasses of :class:`Path` and :class:`PurePath` now call the
+:func:`__new__` and :func:`__init__` functions of the subclasses when
+instantiating new subclass objects returned by various :class:`Path` and
+:class:`PurePath` functions and properties.  Patch by Jeffrey Kintscher.

--- a/Misc/NEWS.d/next/Library/2020-08-18-18-22-56.bpo-41109.QcFpg2.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-18-18-22-56.bpo-41109.QcFpg2.rst
@@ -1,0 +1,4 @@
+Subclasses of :class:`Path`: and :class:`PurePath`: now call the
+:func:`__new__`: and :func:`__init__`: functions of the subclasses when
+instantiating new subclass objects returned by various :class:`Path`: and
+:class:`PurePath`: functions and properties.  Patch by Jeffrey Kintscher.

--- a/Misc/NEWS.d/next/Library/2020-08-18-18-22-56.bpo-41109.QcFpg2.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-18-18-22-56.bpo-41109.QcFpg2.rst
@@ -1,4 +1,4 @@
-Subclasses of :class:`Path` and :class:`PurePath` now call the
+Subclasses of :class:`pathlib.Path` and :class:`pathlib.PurePath` now call the
 :func:`__new__` and :func:`__init__` functions of the subclasses when
-instantiating new subclass objects returned by various :class:`Path` and
-:class:`PurePath` functions and properties.  Patch by Jeffrey Kintscher.
+instantiating new subclass objects returned by various :class:`pathlib.Path` and
+:class:`pathlib.PurePath` functions and properties.  Patch by Jeffrey Kintscher.


### PR DESCRIPTION
Several pathlib.Path and pathlib.PurePath return new Path and PurePath objects.  A subclass of one of those classes returns objects that are instances of the subclass, but the subclass's __new__() and __init__() functions are not called.  A subclass has to override Path._init() or PurePath._init() to perform custom initialization for these returned objects in addition to its __init__() function.

This patch reworks the Path and PurePath object creation processes to ensure that the __new__() and __init__() functions in subclasses get called.  It moves the object creation process from PurePath._from_parts() and PurePath._from_parsed_parts() to PurePath.__init__() and Path.__init__(), and marks the two functions with deprecation warnings.

<!-- issue-number: [bpo-41109](https://bugs.python.org/issue41109) -->
https://bugs.python.org/issue41109
<!-- /issue-number -->
