### PR TITLE
bpo-41586: Add pipesize parameter to subprocess. Add F_GETPIPE_SZ and F_SETPIPE_SZ to fcntl.

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -39,6 +39,11 @@ descriptor.
    On Linux(>=3.15), the fcntl module exposes the ``F_OFD_GETLK``, ``F_OFD_SETLK``
    and ``F_OFD_SETLKW`` constants, which working with open file description locks.
 
+.. versionchanged:: 3.10
+   On Linux >= 2.6.11, the fcntl module exposes the ``F_GETPIPE_SZ`` and
+   ``F_SETPIPE_SZ`` constants, which allow to check and modify a pipe's size
+   respectively.
+
 The module defines the following functions:
 
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -627,7 +627,8 @@ functions.
 
    *pipesize* can be used to change the size of the pipe when
    :data:`PIPE` is used for *stdin*, *stdout* or *stderr*. The size of the pipe
-   is only changed on platforms that support this.
+   is only changed on platforms that support this (only Linux at this time of
+   writing). Other platforms will ignore this parameter.
 
    .. versionadded:: 3.10
       The ``pipesize`` parameter was added.

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -625,8 +625,9 @@ functions.
       * :data:`CREATE_DEFAULT_ERROR_MODE`
       * :data:`CREATE_BREAKAWAY_FROM_JOB`
 
-   ``pipesize`` can be used to change the size of the pipe when
-   ``subprocess.PIPE`` is used for ``stdin``,``stdout`` or ``stderr`` on Linux.
+   *pipesize* can be used to change the size of the pipe when
+   :data:`PIPE` is used for *stdin*, *stdout* or *stderr*. The size of the pipe
+   is only changed on platforms that support this.
 
    .. versionadded:: 3.10
       The ``pipesize`` parameter was added.

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -341,7 +341,7 @@ functions.
                  startupinfo=None, creationflags=0, restore_signals=True, \
                  start_new_session=False, pass_fds=(), \*, group=None, \
                  extra_groups=None, user=None, umask=-1, \
-                 encoding=None, errors=None, text=None)
+                 encoding=None, errors=None, text=None, pipesize=-1)
 
    Execute a child program in a new process.  On POSIX, the class uses
    :meth:`os.execvp`-like behavior to execute the child program.  On Windows,
@@ -624,6 +624,12 @@ functions.
       * :data:`DETACHED_PROCESS`
       * :data:`CREATE_DEFAULT_ERROR_MODE`
       * :data:`CREATE_BREAKAWAY_FROM_JOB`
+
+   ``pipesize`` can be used to change the size of the pipe when
+   ``subprocess.PIPE`` is used for ``stdin``,``stdout`` or ``stderr`` on Linux.
+
+   .. versionadded:: 3.10
+      The ``pipesize`` parameter was added.
 
    Popen objects are supported as context managers via the :keyword:`with` statement:
    on exit, standard file descriptors are closed, and the process is waited for.

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -775,12 +775,14 @@ class Popen(object):
         self._communication_started = False
         if bufsize is None:
             bufsize = -1  # Restore default
-        if pipesize is None:
-            pipesize = -1  # Restore default
         if not isinstance(bufsize, int):
             raise TypeError("bufsize must be an integer")
+
+        if pipesize is None:
+            pipesize = -1  # Restore default
         if not isinstance(pipesize, int):
             raise TypeError("pipesize must be an integer")
+
         if _mswindows:
             if preexec_fn is not None:
                 raise ValueError("preexec_fn is not supported on Windows "
@@ -1256,11 +1258,11 @@ class Popen(object):
             if stdin is None:
                 p2cread = _winapi.GetStdHandle(_winapi.STD_INPUT_HANDLE)
                 if p2cread is None:
-                    p2cread, _ = _winapi.CreatePipe(None, self.pipesize)
+                    p2cread, _ = _winapi.CreatePipe(None, 0)
                     p2cread = Handle(p2cread)
                     _winapi.CloseHandle(_)
             elif stdin == PIPE:
-                p2cread, p2cwrite = _winapi.CreatePipe(None, self.pipesize)
+                p2cread, p2cwrite = _winapi.CreatePipe(None, 0)
                 p2cread, p2cwrite = Handle(p2cread), Handle(p2cwrite)
             elif stdin == DEVNULL:
                 p2cread = msvcrt.get_osfhandle(self._get_devnull())
@@ -1274,11 +1276,11 @@ class Popen(object):
             if stdout is None:
                 c2pwrite = _winapi.GetStdHandle(_winapi.STD_OUTPUT_HANDLE)
                 if c2pwrite is None:
-                    _, c2pwrite = _winapi.CreatePipe(None, self.pipesize)
+                    _, c2pwrite = _winapi.CreatePipe(None, 0)
                     c2pwrite = Handle(c2pwrite)
                     _winapi.CloseHandle(_)
             elif stdout == PIPE:
-                c2pread, c2pwrite = _winapi.CreatePipe(None, self.pipesize)
+                c2pread, c2pwrite = _winapi.CreatePipe(None, 0)
                 c2pread, c2pwrite = Handle(c2pread), Handle(c2pwrite)
             elif stdout == DEVNULL:
                 c2pwrite = msvcrt.get_osfhandle(self._get_devnull())
@@ -1292,11 +1294,11 @@ class Popen(object):
             if stderr is None:
                 errwrite = _winapi.GetStdHandle(_winapi.STD_ERROR_HANDLE)
                 if errwrite is None:
-                    _, errwrite = _winapi.CreatePipe(None, self.pipesize)
+                    _, errwrite = _winapi.CreatePipe(None, 0)
                     errwrite = Handle(errwrite)
                     _winapi.CloseHandle(_)
             elif stderr == PIPE:
-                errread, errwrite = _winapi.CreatePipe(None, self.pipesize)
+                errread, errwrite = _winapi.CreatePipe(None, 0)
                 errread, errwrite = Handle(errread), Handle(errwrite)
             elif stderr == STDOUT:
                 errwrite = c2pwrite

--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -72,14 +72,11 @@ class TestFcntl(unittest.TestCase):
 
     def setUp(self):
         self.f = None
-        self.testpipe_path = "testpipe"
 
     def tearDown(self):
         if self.f and not self.f.closed:
             self.f.close()
         unlink(TESTFN)
-        if os.path.exists(self.testpipe_path):
-            unlink(self.testpipe_path)
 
     def test_fcntl_fileno(self):
         # the example from the library docs
@@ -195,12 +192,13 @@ class TestFcntl(unittest.TestCase):
 
     @unittest.skipIf(sys.platform != 'linux', "F_SETPIPE_SZ and F_GETPIPE_SZ are only available on linux")
     def test_fcntl_f_pipesize(self):
-        os.mkfifo(self.testpipe_path)
-        test_pipe_fd = os.open(self.testpipe_path, os.O_RDWR)
+        test_pipe_r, test_pipe_w = os.pipe()
         pipesize = 16 * 1024  # 64K is linux default.
-        self.assertNotEqual(fcntl.fcntl(test_pipe_fd, fcntl.F_GETPIPE_SZ), pipesize)
-        fcntl.fcntl(test_pipe_fd, fcntl.F_SETPIPE_SZ, pipesize)
-        self.assertEqual(fcntl.fcntl(test_pipe_fd, fcntl.F_GETPIPE_SZ), pipesize)
+        self.assertNotEqual(fcntl.fcntl(test_pipe_w, fcntl.F_GETPIPE_SZ), pipesize)
+        fcntl.fcntl(test_pipe_w, fcntl.F_SETPIPE_SZ, pipesize)
+        self.assertEqual(fcntl.fcntl(test_pipe_w, fcntl.F_GETPIPE_SZ), pipesize)
+        os.close(test_pipe_r)
+        os.close(test_pipe_w)
 
 
 def test_main():

--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -194,10 +194,11 @@ class TestFcntl(unittest.TestCase):
                      "F_SETPIPE_SZ and F_GETPIPE_SZ are not available on all unix platforms.")
     def test_fcntl_f_pipesize(self):
         test_pipe_r, test_pipe_w = os.pipe()
-        pipesize = 16 * 1024  # 64K is linux default.
-        self.assertNotEqual(fcntl.fcntl(test_pipe_w, fcntl.F_GETPIPE_SZ), pipesize)
-        fcntl.fcntl(test_pipe_w, fcntl.F_SETPIPE_SZ, pipesize)
-        self.assertEqual(fcntl.fcntl(test_pipe_w, fcntl.F_GETPIPE_SZ), pipesize)
+        # Get the default pipesize with F_GETPIPE_SZ
+        pipesize_default = fcntl.fcntl(test_pipe_w, fcntl.F_GETPIPE_SZ)
+        # Multiply the default with 2 to get a new value.
+        fcntl.fcntl(test_pipe_w, fcntl.F_SETPIPE_SZ, pipesize_default * 2)
+        self.assertEqual(fcntl.fcntl(test_pipe_w, fcntl.F_GETPIPE_SZ), pipesize_default * 2)
         os.close(test_pipe_r)
         os.close(test_pipe_w)
 

--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -190,7 +190,8 @@ class TestFcntl(unittest.TestCase):
         res = fcntl.fcntl(self.f.fileno(), fcntl.F_GETPATH, bytes(len(expected)))
         self.assertEqual(expected, res)
 
-    @unittest.skipIf(sys.platform != 'linux', "F_SETPIPE_SZ and F_GETPIPE_SZ are only available on linux")
+    @unittest.skipIf(not (hasattr(fcntl, "F_SETPIPE_SZ") and hasattr(fcntl, "F_GETPIPE_SZ")),
+                     "F_SETPIPE_SZ and F_GETPIPE_SZ are not available on all unix platforms.")
     def test_fcntl_f_pipesize(self):
         test_pipe_r, test_pipe_w = os.pipe()
         pipesize = 16 * 1024  # 64K is linux default.

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3528,7 +3528,7 @@ class MiscTests(unittest.TestCase):
 
     def test__all__(self):
         """Ensure that __all__ is populated properly."""
-        intentionally_excluded = {"list2cmdline", "Handle", "pwd", "grp"}
+        intentionally_excluded = {"list2cmdline", "Handle", "pwd", "grp", "fcntl"}
         exported = set(subprocess.__all__)
         possible_exports = set()
         import types

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1805,6 +1805,7 @@ Johannes Vogel
 Michael Vogt
 Radu Voicilas
 Alex Volkov
+Ruben Vorderman
 Guido Vranken
 Martijn Vries
 Sjoerd de Vries

--- a/Misc/NEWS.d/next/Library/2020-08-19-08-32-13.bpo-41586.IYjmjK.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-19-08-32-13.bpo-41586.IYjmjK.rst
@@ -1,0 +1,2 @@
+Add F_SETPIPE_SZ and F_GETPIPE_SZ to fcntl module. Allow setting pipesize on
+subprocess.Popen.

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -577,6 +577,14 @@ all_ins(PyObject* m)
     if (PyModule_AddIntMacro(m, F_SHLCK)) return -1;
 #endif
 
+/* Linux specifics */
+#ifdef F_SETPIPE_SZ
+    if (PyModule_AddIntMacro(m, F_SETPIPE_SZ)) return -1;
+#endif
+#ifdef F_GETPIPE_SZ
+    if (PyModule_AddIntMacro(m, F_GETPIPE_SZ)) return -1;
+#endif
+
 /* OS X specifics */
 #ifdef F_FULLFSYNC
     if (PyModule_AddIntMacro(m, F_FULLFSYNC)) return -1;


### PR DESCRIPTION
A detailed performance comparison using subprocess and altering the pipesize can be found here: https://github.com/marcelm/xopen/issues/35. 

This PR adds a `pipesize` parameter to subprocess.Popen (and therefore also to `subprocess.run` etc. which pass arguments.) This will make it easier for users to control the size of the pipe as the default of 64K can be too small in HPC applications.

In order to enable this functionality. F_SETPIPE_SZ and F_GETPIPE_SZ were added to the fcntl module.

Platform compatibility has been taken care of:
- Pipesize is only changed on systems that have the fcntl module, and where this module has the `F_SETPIPE_SZ` constant. As far as I know, this is only on Linux platforms.
- On other platforms the pipesize will not be changed. No errors will be raised.

`_winapi.CreatePipe` can set the pipesize. This was not done however, because testing if the pipesize has changed requires [GetNamedPipeInfo](https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-getnamedpipeinfo) from the windows api, and this has not been incorporated in the _winapi. Since I never have worked with _winapi before and never have developed software on Windows, I am a bit hesitant to add this.



<!-- issue-number: [bpo-41586](https://bugs.python.org/issue41586) -->
https://bugs.python.org/issue41586
<!-- /issue-number -->
