### PR TITLE
bpo-34215: Clarify IncompleteReadError message when "expected" is None

### DIFF
--- a/Lib/asyncio/exceptions.py
+++ b/Lib/asyncio/exceptions.py
@@ -34,8 +34,9 @@ class IncompleteReadError(EOFError):
     - expected: total number of expected bytes (or None if unknown)
     """
     def __init__(self, partial, expected):
+        r_expected = 'undefined' if expected is None else repr(expected)
         super().__init__(f'{len(partial)} bytes read on a total of '
-                         f'{expected!r} expected bytes')
+                         f'{r_expected} expected bytes')
         self.partial = partial
         self.expected = expected
 

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -452,12 +452,14 @@ class StreamTests(test_utils.TestCase):
 
     def test_readuntil_eof(self):
         stream = asyncio.StreamReader(loop=self.loop)
-        stream.feed_data(b'some dataAA')
+        data = b'some dataAA'
+        stream.feed_data(data)
         stream.feed_eof()
 
-        with self.assertRaises(asyncio.IncompleteReadError) as cm:
+        with self.assertRaisesRegex(asyncio.IncompleteReadError,
+                                    'undefined expected bytes') as cm:
             self.loop.run_until_complete(stream.readuntil(b'AAA'))
-        self.assertEqual(cm.exception.partial, b'some dataAA')
+        self.assertEqual(cm.exception.partial, data)
         self.assertIsNone(cm.exception.expected)
         self.assertEqual(b'', stream._buffer)
 

--- a/Misc/NEWS.d/next/Library/2020-08-19-20-17-51.bpo-34215._Cv8c-.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-19-20-17-51.bpo-34215._Cv8c-.rst
@@ -1,0 +1,2 @@
+Clarify the error message for :exc:`asyncio.IncompleteReadError` when
+``expected`` is ``None``.


### PR DESCRIPTION
Co-Authored-By: Tyler Bell <mrbell321@gmail.com>



<!-- issue-number: [bpo-34215](https://bugs.python.org/issue34215) -->
https://bugs.python.org/issue34215
<!-- /issue-number -->
