### PR TITLE
bpo-41620: Return the result when the test is being skipped

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -574,7 +574,7 @@ class TestCase(object):
                 self._addSkip(result, self, skip_why)
             finally:
                 result.stopTest(self)
-            return
+            return result
         expecting_failure_method = getattr(testMethod,
                                            "__unittest_expecting_failure__", False)
         expecting_failure_class = getattr(self,


### PR DESCRIPTION
Currently unittest does not return `TestResult` object when the test is skipped.

<!-- issue-number: [bpo-41620](https://bugs.python.org/issue41620) -->
https://bugs.python.org/issue41620
<!-- /issue-number -->
