### PR TITLE
bpo-41621: More accurate signature for defaultdict

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -698,7 +698,7 @@ stack manipulations such as ``dup``, ``drop``, ``swap``, ``over``, ``pick``,
 :class:`defaultdict` objects
 ----------------------------
 
-.. class:: defaultdict([default_factory[, ...]])
+.. class:: defaultdict(default_factory=None, /, [...])
 
     Returns a new dictionary-like object.  :class:`defaultdict` is a subclass of the
     built-in :class:`dict` class.  It overrides one method and adds one writable

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -700,7 +700,7 @@ stack manipulations such as ``dup``, ``drop``, ``swap``, ``over``, ``pick``,
 
 .. class:: defaultdict(default_factory=None, /, [...])
 
-    Returns a new dictionary-like object.  :class:`defaultdict` is a subclass of the
+    Return a new dictionary-like object.  :class:`defaultdict` is a subclass of the
     built-in :class:`dict` class.  It overrides one method and adds one writable
     instance variable.  The remaining functionality is the same as for the
     :class:`dict` class and is not documented here.

--- a/Misc/NEWS.d/next/Documentation/2020-08-24-13-35-04.bpo-41621.nqaw9G.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-08-24-13-35-04.bpo-41621.nqaw9G.rst
@@ -1,1 +1,1 @@
-The signature of :class:`collections.defaultdict` now shows that the ``default_factory`` parameter is position-only.
+Document that :class:`collections.defaultdict` parameter ``default_factory`` defaults to None and is positional-only.

--- a/Misc/NEWS.d/next/Documentation/2020-08-24-13-35-04.bpo-41621.nqaw9G.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-08-24-13-35-04.bpo-41621.nqaw9G.rst
@@ -1,0 +1,1 @@
+The signature of :class:`collections.defaultdict` now shows that the ``default_factory`` parameter is position-only.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2194,7 +2194,7 @@ defdict_init(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 PyDoc_STRVAR(defdict_doc,
-"defaultdict(default_factory[, ...]) --> dict with default factory\n\
+"defaultdict(default_factory=None, /, [...]) --> dict with default factory\n\
 \n\
 The default factory is called without arguments to produce\n\
 a new value when a key is not present, in __getitem__ only.\n\


### PR DESCRIPTION
`default_factory` cannot be passed as a keyword argument.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41621](https://bugs.python.org/issue41621) -->
https://bugs.python.org/issue41621
<!-- /issue-number -->
