### PR TITLE
Update heapq.py - Works with both python2 and python3.

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -209,7 +209,7 @@ def _siftdown(heap, startpos, pos):
     while pos > startpos:
         parentpos = (pos - 1) >> 1
         parent = heap[parentpos]
-        if newitem < parent:
+        if newitem[0] < parent[0]:
             heap[pos] = parent
             pos = parentpos
             continue
@@ -264,7 +264,7 @@ def _siftup(heap, pos):
     while childpos < endpos:
         # Set childpos to index of smaller child.
         rightpos = childpos + 1
-        if rightpos < endpos and not heap[childpos] < heap[rightpos]:
+        if rightpos < endpos and not heap[childpos][0] < heap[rightpos][0]:
             childpos = rightpos
         # Move the smaller child up.
         heap[pos] = heap[childpos]


### PR DESCRIPTION
Comparison between string and tuple is not supported in python3 but in python 2.  This change works in both cases.
I had faced the https://stackoverflow.com/questions/63570226/typeerror-on-heapq-heapop-on-python3-but-but-working-in-python2/63572303#63572303
issue and solved it using this technique.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
