### PR TITLE
bpo-41624: fix documentation of typing.Coroutine

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1365,7 +1365,7 @@ Corresponding to other types in :mod:`collections.abc`
 Asynchronous programming
 """"""""""""""""""""""""
 
-.. class:: Coroutine(Awaitable[V_co], Generic[T_co T_contra, V_co])
+.. class:: Coroutine(Awaitable[V_co], Generic[T_co, T_contra, V_co])
 
    A generic version of :class:`collections.abc.Coroutine`.
    The variance and order of type variables

--- a/Misc/NEWS.d/next/Documentation/2020-08-25-15-11-23.bpo-41624.ddjJlN.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-08-25-15-11-23.bpo-41624.ddjJlN.rst
@@ -1,0 +1,1 @@
+Fix the signature of :class:`typing.Coroutine`.


### PR DESCRIPTION
The documentation [1] for Coroutine in typing library writes:

class typing.Coroutine(Awaitable[V_co], Generic[T_co T_contra, V_co])

which should be:

class typing.Coroutine(Awaitable[V_co], Generic[T_co, T_contra, V_co])

a comma is missed between the first type variable T_co and the second one T_contr.

[1] https://docs.python.org/3/library/typing.html#typing.Coroutine

<!-- issue-number: [bpo-41624](https://bugs.python.org/issue41624) -->
https://bugs.python.org/issue41624
<!-- /issue-number -->
