### PR TITLE
bpo-41585 When max-line-length is None default to 0

### DIFF
--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -46,7 +46,12 @@ class _PolicyBase:
         """
         for name, value in kw.items():
             if hasattr(self, name):
-                super(_PolicyBase,self).__setattr__(name, value)
+                # Behaviour for max-line-length == None is the same
+                # as it is for when it is 0.
+                if name == "max_line_length":
+                    super(_PolicyBase, self).__setattr__(name, value or 0)
+                else:
+                    super(_PolicyBase, self).__setattr__(name, value)
             else:
                 raise TypeError(
                     "{!r} is an invalid keyword argument for {}".format(
@@ -72,7 +77,10 @@ class _PolicyBase:
                 raise TypeError(
                     "{!r} is an invalid keyword argument for {}".format(
                         attr, self.__class__.__name__))
-            object.__setattr__(newpolicy, attr, value)
+            if attr == "max_line_length":
+                object.__setattr__(newpolicy, attr, value or 0)
+            else:
+                object.__setattr__(newpolicy, attr, value)
         return newpolicy
 
     def __setattr__(self, name, value):

--- a/Lib/email/contentmanager.py
+++ b/Lib/email/contentmanager.py
@@ -153,17 +153,19 @@ def _encode_text(string, charset, cte, policy):
                 pass
             if policy.cte_type == '8bit':
                 return '8bit', normal_body(lines).decode('ascii', 'surrogateescape')
-        sniff = embedded_body(lines[:10])
-        sniff_qp = quoprimime.body_encode(sniff.decode('latin-1'),
-                                          policy.max_line_length)
-        sniff_base64 = binascii.b2a_base64(sniff)
-        # This is a little unfair to qp; it includes lineseps, base64 doesn't.
-        if len(sniff_qp) > len(sniff_base64):
-            cte = 'base64'
-        else:
-            cte = 'quoted-printable'
-            if len(lines) <= 10:
-                return cte, sniff_qp
+        # quoprimime requires at least 4 max_line_length
+        if 4 <= policy.max_line_length:
+            sniff = embedded_body(lines[:10])
+            sniff_qp = quoprimime.body_encode(sniff.decode('latin-1'),
+                                            policy.max_line_length)
+            sniff_base64 = binascii.b2a_base64(sniff)
+            # This is a little unfair to qp; it includes lineseps, base64 doesn't.
+            if len(sniff_qp) > len(sniff_base64):
+                cte = 'base64'
+            else:
+                cte = 'quoted-printable'
+                if len(lines) <= 10:
+                    return cte, sniff_qp
     if cte == '7bit':
         data = normal_body(lines).decode('ascii')
     elif cte == '8bit':

--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -303,6 +303,16 @@ class TestRawDataManager(TestEmailBase):
         self.assertEqual(m.get_payload(decode=True).decode('utf-8'), content)
         self.assertEqual(m.get_content(), content)
 
+    def test_set_text_plain_max_line_length(self):
+        self.policy = policy.default.clone(max_line_length=None,
+                                           content_manager=raw_data_manager)
+        m = self._make_message()
+        content = "Simple message.\n"
+        with self.assertRaises(ValueError) as ar:
+            raw_data_manager.set_content(m, content)
+            exc = str(ar.exception)
+            self.assertIn("Unknown content transfer encoding None", exc)
+
     def test_set_text_plain_null(self):
         m = self._make_message()
         content = ''


### PR DESCRIPTION
The docs indicate:
>**max_line_length**
The maximum length of any line in the serialized output, not counting the end of line character(s). Default is 78, per RFC 5322. _A value of 0 or None indicates that no line wrapping should be done at all._

https://docs.python.org/3/library/email.policy.html#email.policy.Policy.max_line_length

Since the behaviour for both `0` and `None` should be the same, I've defaulted to using `0` when `None` is passed, this will fix errors caused by comparisons with `None`. Like we see in the issue:

```python
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
``` 

<!-- issue-number: [bpo-41585](https://bugs.python.org/issue41585) -->
https://bugs.python.org/issue41585
<!-- /issue-number -->
