### PR TITLE
bpo-25229: use gcc style runtime_library_dir_option in Linux

### DIFF
--- a/Lib/distutils/tests/test_unixccompiler.py
+++ b/Lib/distutils/tests/test_unixccompiler.py
@@ -83,7 +83,17 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sysconfig.get_config_var = gcv
         self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
 
-        # non-GCC GNULD
+        # non-GCC Linux GNULD
+        sys.platform = 'linux'
+        def gcv(v):
+            if v == 'CC':
+                return 'cc'
+            elif v == 'GNULD':
+                return 'yes'
+        sysconfig.get_config_var = gcv
+        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
+
+        # non-GCC non-Linux GNULD
         sys.platform = 'bar'
         def gcv(v):
             if v == 'CC':
@@ -93,7 +103,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sysconfig.get_config_var = gcv
         self.assertEqual(self.cc.rpath_foo(), '-R/foo')
 
-        # non-GCC non-GNULD
+        # non-GCC non-Linux non-GNULD
         sys.platform = 'bar'
         def gcv(v):
             if v == 'CC':

--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -242,11 +242,13 @@ class UnixCCompiler(CCompiler):
                 return ["-Wl,+s", "-L" + dir]
             return ["+s", "-L" + dir]
         else:
-            if self._is_gcc(compiler):
+            if sys.platform[:5] == "linux" or self._is_gcc(compiler):
                 # gcc on non-GNU systems does not need -Wl, but can
                 # use it anyway.  Since distutils has always passed in
                 # -Wl whenever gcc was used in the past it is probably
                 # safest to keep doing so.
+                # non-gcc compilers on Linux need gcc style linker
+                # option.
                 if sysconfig.get_config_var("GNULD") == "yes":
                     # GNU ld needs an extra option to get a RUNPATH
                     # instead of just an RPATH.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
https://bugs.python.org/issue25229
In much of proprietary compilers for Linux, gcc style runtime_library_dir_option is needed, not `-R`, current default value.

<!-- issue-number: [bpo-25229](https://bugs.python.org/issue25229) -->
https://bugs.python.org/issue25229
<!-- /issue-number -->
