### PR TITLE
bpo-41634: Fix a typo in the curses documentation

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -717,7 +717,7 @@ the following methods and attributes:
             window.addch(y, x, ch[, attr])
 
    Paint character *ch* at ``(y, x)`` with attributes *attr*, overwriting any
-   character previously painter at that location.  By default, the character
+   character previously painted at that location.  By default, the character
    position and attributes are the current settings for the window object.
 
    .. note::


### PR DESCRIPTION


<!-- issue-number: [bpo-41634](https://bugs.python.org/issue41634) -->
https://bugs.python.org/issue41634
<!-- /issue-number -->
