### PR TITLE
[3.7] bpo-32751: Wait for task cancel in asyncio.wait_for() when timeout <= 0 (GH-21895)

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -836,6 +836,9 @@ class BaseTaskTests:
                 nonlocal task_done
                 try:
                     await asyncio.sleep(0.2, loop=loop)
+                except asyncio.CancelledError:
+                    await asyncio.sleep(0.1, loop=loop)
+                    raise
                 finally:
                     task_done = True
 
@@ -847,6 +850,34 @@ class BaseTaskTests:
             self.assertTrue(task_done)
 
         loop.run_until_complete(foo())
+
+    def test_wait_for_waits_for_task_cancellation_w_timeout_0(self):
+        loop = asyncio.new_event_loop()
+        self.addCleanup(loop.close)
+
+        task_done = False
+
+        async def foo():
+            async def inner():
+                nonlocal task_done
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    await asyncio.sleep(0.1)
+                    raise
+                finally:
+                    task_done = True
+
+            inner_task = self.new_task(loop, inner())
+            await asyncio.sleep(0.1)
+            await asyncio.wait_for(inner_task, timeout=0)
+
+        with self.assertRaises(asyncio.TimeoutError) as cm:
+            loop.run_until_complete(foo())
+
+        self.assertTrue(task_done)
+        chained = cm.exception.__context__
+        self.assertEqual(type(chained), asyncio.CancelledError)
 
     def test_wait_for_self_cancellation(self):
         loop = asyncio.new_event_loop()

--- a/Misc/NEWS.d/next/Library/2020-08-15-15-50-12.bpo-32751.85je5X.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-15-15-50-12.bpo-32751.85je5X.rst
@@ -1,0 +1,3 @@
+When cancelling the task due to a timeout, :meth:`asyncio.wait_for` will now
+wait until the cancellation is complete also in the case when *timeout* is
+<= 0, like it does with positive timeouts.


### PR DESCRIPTION
When I was fixing [bpo-32751](https://bugs.python.org/issue32751) back in GH-7216 I missed the case when
*timeout* is zero or negative.  This takes care of that.

Props to @aaliddell for noticing the inconsistency..
(cherry picked from commit c517fc712105c8e5930cb42baaebdbe37fc3e15f)

Co-authored-by: Elvis Pranskevichus <elvis@magic.io>

<!-- issue-number: [bpo-32751](https://bugs.python.org/issue32751) -->
https://bugs.python.org/issue32751
<!-- /issue-number -->


Automerge-Triggered-By: @1st1