### PR TITLE
[3.7] bpo-37658: Fix asyncio.wait_for() to respect waited task status (GH-21894)

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -434,9 +434,12 @@ async def wait_for(fut, timeout, *, loop=None):
         try:
             await waiter
         except futures.CancelledError:
-            fut.remove_done_callback(cb)
-            fut.cancel()
-            raise
+            if fut.done():
+                return fut.result()
+            else:
+                fut.remove_done_callback(cb)
+                fut.cancel()
+                raise
 
         if fut.done():
             return fut.result()

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -825,6 +825,22 @@ class BaseTaskTests:
         res = loop.run_until_complete(task)
         self.assertEqual(res, "ok")
 
+    def test_wait_for_cancellation_race_condition(self):
+        def gen():
+            yield 0.1
+            yield 0.1
+            yield 0.1
+            yield 0.1
+
+        loop = self.new_test_loop(gen)
+
+        fut = self.new_future(loop)
+        loop.call_later(0.1, fut.set_result, "ok")
+        task = loop.create_task(asyncio.wait_for(fut, timeout=1))
+        loop.call_later(0.1, task.cancel)
+        res = loop.run_until_complete(task)
+        self.assertEqual(res, "ok")
+
     def test_wait_for_waits_for_task_cancellation(self):
         loop = asyncio.new_event_loop()
         self.addCleanup(loop.close)

--- a/Misc/NEWS.d/next/Library/2020-08-15-15-21-40.bpo-37658.f9nivB.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-15-15-21-40.bpo-37658.f9nivB.rst
@@ -1,0 +1,2 @@
+:meth:`asyncio.wait_for` now properly handles races between cancellation of
+itself and the completion of the wrapped awaitable.


### PR DESCRIPTION
Currently, if `asyncio.wait_for()` itself is cancelled it will always
raise `CancelledError` regardless if the underlying task is still
running.  This is similar to a race with the timeout, which is handled
already..
(cherry picked from commit a2118a14627256197bddcf4fcecad4c264c1e39d)


<!-- issue-number: [bpo-37658](https://bugs.python.org/issue37658) -->
https://bugs.python.org/issue37658
<!-- /issue-number -->
