### PR TITLE
bpo-33660: Fix corner-case in PosixPath.resolve resulting in `"//path"`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -329,7 +329,13 @@ class _PosixFlavour(_Flavour):
                     # parent dir
                     path, _, _ = path.rpartition(sep)
                     continue
-                newpath = path + sep + name
+
+                if path.endswith(sep):
+                    # special case for "/" root directory
+                    newpath = path + name
+                else:
+                    newpath = path + sep + name
+
                 if newpath in seen:
                     # Already seen this path
                     path = seen[newpath]

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2385,6 +2385,19 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         # Non-strict
         self._check_symlink_loop(BASE, 'linkW', 'foo', strict=False)
 
+    def test_resolve_pwd_root(self):
+        P = self.cls
+
+        # Resolve relative path in root directory.
+        old_path = os.getcwd()
+        os.chdir("/")
+        try:
+            given = P("var").resolve()
+            expect = P("/var")
+            self.assertEqual(given, expect)
+        finally:
+            os.chdir(old_path)
+
     def test_glob(self):
         P = self.cls
         p = P(BASE)


### PR DESCRIPTION
This PR is provisional, a bpo doesn't exist yet.

On POSIX, when `Path.cwd() == Path("/")`, then `Path("path").resolve() == Path("//var")`

This is because the normal case is that `sep` must be added between the base path and the relative path, as the prefix/base does not usually end with `sep` itself. In this respect, the root directory `Path("/")` is a corner-case that I believe was previously missed.

A consequence of this can be that the `relative_to` method raises an error, even though the intent was to just normalize different both absolute and relative paths to relative paths:

```
In [9]: Path.cwd()
Out[9]: PosixPath('/')

In [10]: Path("path").resolve().relative_to(Path("/"))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-10-02608bb55fa0> in <module>
----> 1 Path("path").resolve().relative_to(Path("/"))

~/miniconda3/envs/py38/lib/python3.8/pathlib.py in relative_to(self, *other)
    897         if (root or drv) if n == 0 else cf(abs_parts[:n]) != cf(to_abs_parts):
    898             formatted = self._format_parsed_parts(to_drv, to_root, to_parts)
--> 899             raise ValueError("{!r} does not start with {!r}"
    900                              .format(str(self), str(formatted)))
    901         return self._from_parsed_parts('', root if n == 1 else '',

ValueError: '//path' does not start with '/'
```

<!-- issue-number: [bpo-33660](https://bugs.python.org/issue33660) -->
https://bugs.python.org/issue33660
<!-- /issue-number -->
