### PR TITLE
bpo-41631: Check that importing _ast returns the right module 

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1945,6 +1945,22 @@ class NodeVisitorTests(unittest.TestCase):
         ])
 
 
+class ModuleReplacementTests(unittest.TestCase):
+    # bpo-41631
+    # Check that compile(..., ast.PyCF_ONLY_AST) fails if _ast is tampered with
+    def test_replaced_ast_module(self):
+        old_ast = sys.modules['_ast']
+        try:
+            for replacement in None, 'a string', ast:
+                with self.subTest(replacement=replacement):
+                    sys.modules['_ast'] = replacement
+                    with self.assertRaises(SystemError):
+                        compile('1+1', '<string>', 'eval',
+                                flags=ast.PyCF_ONLY_AST)
+        finally:
+            sys.modules['_ast'] = old_ast
+
+
 def main():
     if __name__ != '__main__':
         return

--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-26-22-25-25.bpo-41631.RTN8yW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-26-22-25-25.bpo-41631.RTN8yW.rst
@@ -1,2 +1,2 @@
 If the _ast module is unavailable or replaced with an unexpected object,
-compiling to AST now raises an exception rather than segfaults.
+compiling to AST now raises an exception.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-26-22-25-25.bpo-41631.RTN8yW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-26-22-25-25.bpo-41631.RTN8yW.rst
@@ -1,0 +1,2 @@
+If the _ast module is unavailable or replaced with an unexpected object,
+compiling to AST now raises an exception rather than segfaults.

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1408,7 +1408,14 @@ get_global_ast_state(void)
             "Non-module object imported as _ast");
         return NULL;
     }
-    if (PyModule_GetDef(module) != &_astmodule) {
+
+// testing "pegen" requires generating a C extension module, which contains
+// a copy of the symbols defined in Python-ast.c and needs to be treated
+// as the _ast module.
+#ifndef AST_SKIP_MODULE_CHECK
+
+    struct PyModuleDef *def = PyModule_GetDef(module);
+    if (def != &_astmodule) {
         if (!PyErr_Occurred()) {
             PyErr_SetString(
                 PyExc_SystemError,
@@ -1416,6 +1423,8 @@ get_global_ast_state(void)
         }
         return NULL;
     }
+#endif
+
     astmodulestate *state = get_ast_state(module);
     Py_DECREF(module);
     return state;

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1382,6 +1382,8 @@ get_ast_state(PyObject *module)
     return (astmodulestate*)state;
 }
 
+static struct PyModuleDef _astmodule;
+
 static astmodulestate*
 get_global_ast_state(void)
 {
@@ -1399,6 +1401,20 @@ get_global_ast_state(void)
         if (module == NULL) {
             return NULL;
         }
+    }
+    if (!PyModule_Check(module)) {
+        PyErr_SetString(
+            PyExc_SystemError,
+            "Non-module object imported as _ast");
+        return NULL;
+    }
+    if (PyModule_GetDef(module) != &_astmodule) {
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(
+                PyExc_SystemError,
+                "Unexpected module imported as _ast");
+        }
+        return NULL;
     }
     astmodulestate *state = get_ast_state(module);
     Py_DECREF(module);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -232,6 +232,8 @@ get_ast_state(PyObject *module)
     return (astmodulestate*)state;
 }
 
+static struct PyModuleDef _astmodule;
+
 static astmodulestate*
 get_global_ast_state(void)
 {
@@ -249,6 +251,20 @@ get_global_ast_state(void)
         if (module == NULL) {
             return NULL;
         }
+    }
+    if (!PyModule_Check(module)) {
+        PyErr_SetString(
+            PyExc_SystemError,
+            "Non-module object imported as _ast");
+        return NULL;
+    }
+    if (PyModule_GetDef(module) != &_astmodule) {
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(
+                PyExc_SystemError,
+                "Unexpected module imported as _ast");
+        }
+        return NULL;
     }
     astmodulestate *state = get_ast_state(module);
     Py_DECREF(module);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -258,7 +258,14 @@ get_global_ast_state(void)
             "Non-module object imported as _ast");
         return NULL;
     }
-    if (PyModule_GetDef(module) != &_astmodule) {
+
+// testing "pegen" requires generating a C extension module, which contains
+// a copy of the symbols defined in Python-ast.c and needs to be treated
+// as the _ast module.
+#ifndef AST_SKIP_MODULE_CHECK
+
+    struct PyModuleDef *def = PyModule_GetDef(module);
+    if (def != &_astmodule) {
         if (!PyErr_Occurred()) {
             PyErr_SetString(
                 PyExc_SystemError,
@@ -266,6 +273,8 @@ get_global_ast_state(void)
         }
         return NULL;
     }
+#endif
+
     astmodulestate *state = get_ast_state(module);
     Py_DECREF(module);
     return state;

--- a/Tools/peg_generator/pegen/ast_dump.py
+++ b/Tools/peg_generator/pegen/ast_dump.py
@@ -3,7 +3,8 @@ Copy-parse of ast.dump, removing the `isinstance` checks. This is needed,
 because testing pegen requires generating a C extension module, which contains
 a copy of the symbols defined in Python-ast.c. Thus, the isinstance check would
 always fail. We rely on string comparison of the base classes instead.
-TODO: Remove the above-described hack.
+TODO: Remove the above-described hack, along with AST_SKIP_MODULE_CHECK
+elsewhere.
 """
 
 

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -59,6 +59,12 @@ def compile_c_extension(
     extra_link_args = get_extra_flags("LDFLAGS", "PY_LDFLAGS_NODIST")
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
+
+    # testing pegen requires generating a C extension module, which contains
+    # a copy of the symbols defined in Python-ast.c and needs to be treated
+    # as the _ast module. See ast_dump.py.
+    extra_compile_args.append("-DAST_SKIP_MODULE_CHECK")
+
     extension = [
         Extension(
             extension_name,

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -60,7 +60,7 @@ def compile_c_extension(
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
 
-    # testing pegen requires generating a C extension module, which contains
+    # testing pegen requires generating C extension modules, which contains
     # a copy of the symbols defined in Python-ast.c and needs to be treated
     # as the _ast module. See ast_dump.py.
     extra_compile_args.append("-DAST_SKIP_MODULE_CHECK")


### PR DESCRIPTION
Hopefully #21961 will be OK, but if not: here is a relatively minimal fix for [bpo-41631](https://bugs.python.org/issue41631), which basically makes compiling to/from AST fail gracefully (with a proper exception rather than a NULL without exception) if the `_ast` module has been tampered with.
For example, it looks like Mercurial's lazy-loading scheme replaces `_ast`with a proxy object; this will make AST unusable.

The second commit deals with a hack in pegen's tests – please review the commits separately, and see comments.


<!-- issue-number: [bpo-41631](https://bugs.python.org/issue41631) -->
https://bugs.python.org/issue41631
<!-- /issue-number -->
