### PR TITLE
[3.8] bpo-41624: fix documentation of typing.Coroutine (GH-21952).

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -733,7 +733,7 @@ The module defines the following classes, functions and decorators:
 
    .. versionadded:: 3.5.2
 
-.. class:: Coroutine(Awaitable[V_co], Generic[T_co T_contra, V_co])
+.. class:: Coroutine(Awaitable[V_co], Generic[T_co, T_contra, V_co])
 
    A generic version of :class:`collections.abc.Coroutine`.
    The variance and order of type variables

--- a/Misc/NEWS.d/next/Documentation/2020-08-25-15-11-23.bpo-41624.ddjJlN.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-08-25-15-11-23.bpo-41624.ddjJlN.rst
@@ -1,0 +1,1 @@
+Fix the signature of :class:`typing.Coroutine`.


### PR DESCRIPTION
(cherry picked from commit 8c58d2a216ca2b5965361df9b8d8944bc7d4854d)

Co-authored-by: MingZhe Hu <humingzhework@163.com>


<!-- issue-number: [bpo-41624](https://bugs.python.org/issue41624) -->
https://bugs.python.org/issue41624
<!-- /issue-number -->
