### PR TITLE
bpo-41655: New Node may not be visited in lib2to3.refactor.RefactoringTool.traverse_by

### DIFF
--- a/Lib/lib2to3/refactor.py
+++ b/Lib/lib2to3/refactor.py
@@ -88,7 +88,7 @@ def _get_accept_type_dict(fixer_list, fixer_accept_type):
                 for node_type in heads:
                     fixer_accept_type[fixer].add(node_type)
         else:
-            if fixer._accept_type is not none:
+            if fixer._accept_type is not None:
                 fixer_accept_type[fixer].add(fixer._accept_type)
             else:
                 every.append(fixer)

--- a/Lib/lib2to3/tests/test_refactor.py
+++ b/Lib/lib2to3/tests/test_refactor.py
@@ -115,6 +115,7 @@ from __future__ import print_function"""
 
     def test_get_accept_type_dict(self):
         import collections
+        from itertools import chain
         class NoneFix(fixer_base.BaseFix):
             pass
 

--- a/Lib/lib2to3/tests/test_refactor.py
+++ b/Lib/lib2to3/tests/test_refactor.py
@@ -113,7 +113,7 @@ from __future__ import print_function"""
         inp = "class x: pass\nfrom __future__ import print_function"
         self.assertEqual(run(inp), empty)
 
-    def test_get_headnode_dict(self):
+    def test_get_accept_type_dict(self):
         class NoneFix(fixer_base.BaseFix):
             pass
 
@@ -126,13 +126,16 @@ from __future__ import print_function"""
         no_head = NoneFix({}, [])
         with_head = FileInputFix({}, [])
         simple = SimpleFix({}, [])
-        d = refactor._get_headnode_dict([no_head, with_head, simple])
-        top_fixes = d.pop(pygram.python_symbols.file_input)
-        self.assertEqual(top_fixes, [with_head, no_head])
-        name_fixes = d.pop(token.NAME)
-        self.assertEqual(name_fixes, [simple, no_head])
-        for fixes in d.values():
-            self.assertEqual(fixes, [no_head])
+        accept_type_dict = collections.defaultdict(set)
+        refactor._get_accept_type_dict([no_head, with_head, simple],
+                accept_type_dict)
+        accept_types = accept_type_dict[with_head]
+        self.assertEqual(accept_types, {pygram.python_symbols.file_input})
+        accept_types = accept_type_dict[simple]
+        self.assertEqual(accept_types, {token.NAME})
+        for node_type in chain(pygram.python_grammar.symbol2number.values(),
+                           pygram.python_grammar.tokens):
+            self.assertTrue(node_type in accept_type_dict[no_head])
 
     def test_fixer_loading(self):
         from myfixes.fix_first import FixFirst

--- a/Lib/lib2to3/tests/test_refactor.py
+++ b/Lib/lib2to3/tests/test_refactor.py
@@ -114,6 +114,7 @@ from __future__ import print_function"""
         self.assertEqual(run(inp), empty)
 
     def test_get_accept_type_dict(self):
+        import collections
         class NoneFix(fixer_base.BaseFix):
             pass
 

--- a/Misc/NEWS.d/next/Library/2020-08-28-14-18-54.bpo-41655.RraOMs.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-28-14-18-54.bpo-41655.RraOMs.rst
@@ -1,0 +1,1 @@
+`lib2to3.refactor.RefactoringTool.traverse_by` do a pre-order or post-order traverse algorithm, and apply every candidate fixer to each node when traverse the tree. when a prior fixer add a new node that contains children, these children won't be visited by posterior fixers.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

`lib2to3.refactor.RefactoringTool.traverse_by` do a pre-order or post-order traverse algorithm, and apply every candidate fixer to each node when traverse the tree. when a prior fixer add a new node that contains children, these children won't be visited by posterior fixers. Check this [gist](https://gist.github.com/T8T9/a921877ca3a8c4b8f8686ced877dceca) to reproduce this bug.

<!-- issue-number: [bpo-41655](https://bugs.python.org/issue41655) -->
https://bugs.python.org/issue41655
<!-- /issue-number -->