### PR TITLE
bpo-41657: Refactor for variable OBJECT_OBJS variable in Makefile

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -385,50 +385,7 @@ PYTHON_OBJS=	\
 
 ##########################################################################
 # Objects
-OBJECT_OBJS=	\
-		Objects/abstract.o \
-		Objects/accu.o \
-		Objects/boolobject.o \
-		Objects/bytes_methods.o \
-		Objects/bytearrayobject.o \
-		Objects/bytesobject.o \
-		Objects/call.o \
-		Objects/capsule.o \
-		Objects/cellobject.o \
-		Objects/classobject.o \
-		Objects/codeobject.o \
-		Objects/complexobject.o \
-		Objects/descrobject.o \
-		Objects/enumobject.o \
-		Objects/exceptions.o \
-		Objects/genericaliasobject.o \
-		Objects/genobject.o \
-		Objects/fileobject.o \
-		Objects/floatobject.o \
-		Objects/frameobject.o \
-		Objects/funcobject.o \
-		Objects/interpreteridobject.o \
-		Objects/iterobject.o \
-		Objects/listobject.o \
-		Objects/longobject.o \
-		Objects/dictobject.o \
-		Objects/odictobject.o \
-		Objects/memoryobject.o \
-		Objects/methodobject.o \
-		Objects/moduleobject.o \
-		Objects/namespaceobject.o \
-		Objects/object.o \
-		Objects/obmalloc.o \
-		Objects/picklebufobject.o \
-		Objects/rangeobject.o \
-		Objects/setobject.o \
-		Objects/sliceobject.o \
-		Objects/structseq.o \
-		Objects/tupleobject.o \
-		Objects/typeobject.o \
-		Objects/unicodeobject.o \
-		Objects/unicodectype.o \
-		Objects/weakrefobject.o
+OBJECT_OBJS=$(patsubst %.c, %.o, $(wildcard Objects/*.c))
 
 ##########################################################################
 # objects that get linked into the Python library

--- a/Misc/NEWS.d/next/Build/2020-08-28-23-39-04.bpo-41657.4t3CEO.rst
+++ b/Misc/NEWS.d/next/Build/2020-08-28-23-39-04.bpo-41657.4t3CEO.rst
@@ -1,0 +1,3 @@
+Done a refactor in the variable OBJECT_OBJS inside Makefile.pre.in.
+
+This change was done because a redundancy found in this variable. And it will benefit the next builds if a source file is created inside the Object folder, because this variable will seek this file automatically.


### PR DESCRIPTION
Done a refactor in the variable _OBJECT_OBJS_ inside Makefile.pre.in.

This change was done because a redundancy found in this variable. And it will benefit the next builds if a source file is created inside the Object folder, because this variable will seek this file automatically.

PS: This is my first PR, please give some feedback if something wrong was found in it.

<!-- issue-number: [bpo-41657](https://bugs.python.org/issue41657) -->
https://bugs.python.org/issue41657
<!-- /issue-number -->
