### PR TITLE
bpo-41513: Save unnecessary steps in the hypot() calculation

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2519,6 +2519,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             csum += x;
             frac += (oldcsum - csum) + x;
 
+            assert(csum + lo * lo == csum);
             frac += lo * lo;
         }
         h = sqrt(csum - 1.0 + frac);
@@ -2541,7 +2542,11 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         csum += x;
         frac += (oldcsum - csum) + x;
 
-        frac -= lo * lo;
+        x = -2.0 * hi * lo;
+        assert(fabs(csum) >= fabs(x));
+        oldcsum = csum;
+        csum += x;
+        frac += (oldcsum - csum) + x;
 
         x = csum - 1.0 + frac;
         return (h + x / (2.0 * h)) / scale;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2519,11 +2519,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             csum += x;
             frac += (oldcsum - csum) + x;
 
-            x = lo * lo;
-            assert(fabs(csum) >= fabs(x));
-            oldcsum = csum;
-            csum += x;
-            frac += (oldcsum - csum) + x;
+            frac += lo * lo;
         }
         h = sqrt(csum - 1.0 + frac);
 
@@ -2545,11 +2541,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         csum += x;
         frac += (oldcsum - csum) + x;
 
-        x = -lo * lo;
-        assert(fabs(csum) >= fabs(x));
-        oldcsum = csum;
-        csum += x;
-        frac += (oldcsum - csum) + x;
+        frac -= lo * lo;
 
         x = csum - 1.0 + frac;
         return (h + x / (2.0 * h)) / scale;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2447,6 +2447,14 @@ precision.  When a value at or below 1.0 is correctly rounded, it
 never goes above 1.0.  And when values at or below 1.0 are squared,
 they remain at or below 1.0, thus preserving the summation invariant.
 
+Another interesting assertion is that csum+lo*lo == csum. In the loop,
+each scaled vector element has a magnitude less than 1.0.  After the
+Veltkamp split, *lo* has a maximum value of 2**-27.  So the maximum
+value of *lo* squared is 2**-54.  The value of ulp(1.0)/2.0 is 2**-53.
+Given that csum >= 1.0, we have:
+    lo**2 <= 2**-54 < 2**-53 == 1/2*ulp(1.0) <= ulp(csum)/2
+Since lo**2 is less than 1/2 ulp(csum), we have csum+lo*lo == csum.
+
 The square root differential correction is needed because a
 correctly rounded square root of a correctly rounded sum of
 squares can still be off by as much as one ulp.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2542,7 +2542,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         csum += x;
         frac += (oldcsum - csum) + x;
 
-        x = -2.0 * hi * lo;
+        x = -lo * lo;
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;


### PR DESCRIPTION
Reasoning for the assertion:

* In the loop, each scaled vector element has a magnitude less than `1.0`.
* After the Veltkamp split, *lo* has a maximum magnitude of `2**-27`.
* The maximum magnitude of lo squared is `2**-54`.
* `2**-54 < float_info.epsilon`
* Since `csum >= 1.0` and `lo ** 2 < float_info.epsilon`, we have `csum + lo*lo == csum`

Note that outside of the loop, that chain of reasoning fails. Unlike scaled vector elements, *h* can be greater than 1.0, so after ``hi, lo = split(h)``, the ``lo * lo`` term can be greater than epsilon.

<!-- issue-number: [bpo-41513](https://bugs.python.org/issue41513) -->
https://bugs.python.org/issue41513
<!-- /issue-number -->
