### PR TITLE
[doc] Link __setattr__ and __delattr__ in functions

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -361,8 +361,9 @@ are always available.  They are listed here in alphabetical order.
 
    This is a relative of :func:`setattr`.  The arguments are an object and a
    string.  The string must be the name of one of the object's attributes.  The
-   function deletes the named attribute, provided the object allows it.  For
-   example, ``delattr(x, 'foobar')`` is equivalent to ``del x.foobar``.
+   function deletes the named attribute, provided the object allows it (see
+   :meth:`__delattr__` for details).  For example, ``delattr(x, 'foobar')`` is
+   equivalent to ``del x.foobar``.
 
 
 .. _func-dict:
@@ -1505,8 +1506,8 @@ are always available.  They are listed here in alphabetical order.
    This is the counterpart of :func:`getattr`.  The arguments are an object, a
    string and an arbitrary value.  The string may name an existing attribute or a
    new attribute.  The function assigns the value to the attribute, provided the
-   object allows it.  For example, ``setattr(x, 'foobar', 123)`` is equivalent to
-   ``x.foobar = 123``.
+   object allows it (see :meth:`__setattr__` for details).  For example,
+   ``setattr(x, 'foobar', 123)`` is equivalent to ``x.foobar = 123``.
 
 
 .. class:: slice(stop)


### PR DESCRIPTION
This is useful to understand how a class can disallow deleting/setting instance attributes.