### PR TITLE
bpo-41662: Fix bugs in binding parameters in sqlite3

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -133,6 +133,19 @@ class RegressionTests(unittest.TestCase):
         con.execute("insert into foo(bar) values (5)")
         con.execute(SELECT)
 
+    def CheckBindMutatingList(self):
+        # Issue41662: Crash when mutate a list of parameters during iteration.
+        class X:
+            def __conform__(self, protocol):
+                parameters.clear()
+                return "..."
+        parameters = [X(), 0]
+        con = sqlite.connect(":memory:",detect_types=sqlite.PARSE_DECLTYPES)
+        con.execute("create table foo(bar X, baz integer)")
+        # Should not crash
+        with self.assertRaises(IndexError):
+            con.execute("insert into foo(bar, baz) values (?, ?)", parameters)
+
     def CheckErrorMsgDecodeError(self):
         # When porting the module to Python 3.0, the error message about
         # decoding errors disappeared. This verifies they're back again.

--- a/Misc/NEWS.d/next/Library/2020-08-29-16-07-36.bpo-41662.Mn79zh.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-29-16-07-36.bpo-41662.Mn79zh.rst
@@ -1,1 +1,1 @@
-Fixed two rare bugs in binding parameters in the :mod:`sqlite3` module.
+Fixed crash when mutate list of parameters during iteration in :mod:`sqlite3`.

--- a/Misc/NEWS.d/next/Library/2020-08-29-16-07-36.bpo-41662.Mn79zh.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-29-16-07-36.bpo-41662.Mn79zh.rst
@@ -1,0 +1,1 @@
+Fixed two rare bugs in binding parameters in the :mod:`sqlite3` module.

--- a/Misc/NEWS.d/next/Library/2020-08-30-21-38-57.bpo-41662.6e9iZn.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-30-21-38-57.bpo-41662.6e9iZn.rst
@@ -1,0 +1,2 @@
+No longer override exceptions raised in ``__len__()`` of a sequence of
+parameters in :mod:`sqlite3` with :exc:`~sqlite3.ProgrammingError`.

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -227,6 +227,9 @@ void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* para
             num_params = PyList_GET_SIZE(parameters);
         } else {
             num_params = PySequence_Size(parameters);
+            if (num_params == -1) {
+                return;
+            }
         }
         if (num_params != num_params_needed) {
             PyErr_Format(pysqlite_ProgrammingError,
@@ -238,9 +241,9 @@ void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* para
         for (i = 0; i < num_params; i++) {
             if (PyTuple_CheckExact(parameters)) {
                 current_param = PyTuple_GET_ITEM(parameters, i);
-                Py_XINCREF(current_param);
+                Py_INCREF(current_param);
             } else if (PyList_CheckExact(parameters)) {
-                current_param = PyList_GET_ITEM(parameters, i);
+                current_param = PyList_GetItem(parameters, i);
                 Py_XINCREF(current_param);
             } else {
                 current_param = PySequence_GetItem(parameters, i);


### PR DESCRIPTION
* When the parameters argument is a list, correctly handle the case
  of changing it during iteration.
* When the parameters argument is a custom sequence, no longer
  override an exception raised in ``__len__()``.


<!-- issue-number: [bpo-41662](https://bugs.python.org/issue41662) -->
https://bugs.python.org/issue41662
<!-- /issue-number -->
