### PR TITLE
bpo-41638: Improve ProgrammingError message for absent parameter.

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-08-29-16-45-12.bpo-41638.iZfW5N.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-29-16-45-12.bpo-41638.iZfW5N.rst
@@ -1,3 +1,3 @@
-ProgrammingError message for absent parameter in :mod:`sqlite3`
+:exc:`~sqlite3.ProgrammingError` message for absent parameter in :mod:`sqlite3`
 contains now the name of the parameter instead of its index when parameters
 are supplied as a dict.

--- a/Misc/NEWS.d/next/Library/2020-08-29-16-45-12.bpo-41638.iZfW5N.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-29-16-45-12.bpo-41638.iZfW5N.rst
@@ -1,0 +1,3 @@
+ProgrammingError message for absent parameter in :mod:`sqlite3`
+contains now the name of the parameter instead of its index when parameters
+are supplied as a dict.

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -295,7 +295,7 @@ void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* para
             Py_DECREF(binding_name_obj);
             if (!current_param) {
                 if (!PyErr_Occurred() || PyErr_ExceptionMatches(PyExc_LookupError)) {
-                    PyErr_Format(pysqlite_ProgrammingError, "You did not supply a value for binding %d.", i);
+                    PyErr_Format(pysqlite_ProgrammingError, "You did not supply a value for binding parameter :%s.", binding_name);
                 }
                 return;
             }


### PR DESCRIPTION
It contains now the name of the parameter instead of its index when parameters
are supplied as a dict.


<!-- issue-number: [bpo-41638](https://bugs.python.org/issue41638) -->
https://bugs.python.org/issue41638
<!-- /issue-number -->
