### PR TITLE
bpo-41654: Fix deallocator of MemoryError to account for subclasses

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1,6 +1,7 @@
 # Python test set -- part 5, built-in exceptions
 
 import copy
+import gc
 import os
 import sys
 import unittest
@@ -1329,6 +1330,38 @@ class ExceptionTests(unittest.TestCase):
         else:
             del AssertionError
             self.fail('Expected exception')
+
+    def test_memory_error_subclasses(self):
+        # MemoryError instances use a freelist of objects that are
+        # linked using the 'dict' attribute when they are
+        # inactive/dead. Subclasses of MemoryError should not
+        # participate in the freelist schema. This test creates a
+        # MemoryError object and keeps it alive (therefore
+        # advancing the freelist) and then it creates and destroys
+        # a subclass object. Finally, it checks that creating a
+        # new MemoryError succeeds, proving that the freelist is
+        # not corrupted. See bpo-41654 for more information.
+
+        class TestException(MemoryError):
+            pass
+
+        try:
+            raise MemoryError
+        except MemoryError as exc:
+            inst = exc
+
+        try:
+            raise TestException
+        except Exception:
+            pass
+
+        for _ in range(10):
+            try:
+                raise MemoryError
+            except MemoryError as exc:
+                pass
+
+            gc.collect()
 
 
 class ImportErrorTests(unittest.TestCase):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1332,15 +1332,13 @@ class ExceptionTests(unittest.TestCase):
             self.fail('Expected exception')
 
     def test_memory_error_subclasses(self):
-        # MemoryError instances use a freelist of objects that are
-        # linked using the 'dict' attribute when they are
-        # inactive/dead. Subclasses of MemoryError should not
-        # participate in the freelist schema. This test creates a
-        # MemoryError object and keeps it alive (therefore
-        # advancing the freelist) and then it creates and destroys
-        # a subclass object. Finally, it checks that creating a
-        # new MemoryError succeeds, proving that the freelist is
-        # not corrupted. See bpo-41654 for more information.
+        # bpo-41654: MemoryError instances use a freelist of objects that are
+        # linked using the 'dict' attribute when they are inactive/dead.
+        # Subclasses of MemoryError should not participate in the freelist
+        # schema. This test creates a MemoryError object and keeps it alive
+        # (therefore advancing the freelist) and then it creates and destroys a
+        # subclass object. Finally, it checks that creating a new MemoryError
+        # succeeds, proving that the freelist is not corrupted.
 
         class TestException(MemoryError):
             pass
@@ -1361,7 +1359,7 @@ class ExceptionTests(unittest.TestCase):
             except MemoryError as exc:
                 pass
 
-            gc.collect()
+            gc_collect()
 
 
 class ImportErrorTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-30-20-38-33.bpo-41654.HtnhAM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-30-20-38-33.bpo-41654.HtnhAM.rst
@@ -1,0 +1,2 @@
+Fix a crash that occurred when destroying subclasses of
+:class:`MemoryError`. Patch by Pablo Galindo.


### PR DESCRIPTION
When allocating MemoryError classes, there is some logic to use
pre-allocated instances in a freelist only if the type that is being
allocated is not a subclass of MemoryError. Unfortunately in the
destructor this logic is not present so the freelist is altered even
with subclasses of MemoryError.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41654](https://bugs.python.org/issue41654) -->
https://bugs.python.org/issue41654
<!-- /issue-number -->
