### PR TITLE
bpo-41670: Remove outdated predict macro invocation.

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -602,6 +602,23 @@ class TraceTestCase(unittest.TestCase):
         self.compare_events(doit_async.__code__.co_firstlineno,
                             tracer.events, events)
 
+    def test_loop_in_try_except(self):
+        # https://bugs.python.org/issue41670
+
+        def func():
+            try:
+                for i in []: pass
+                return 1
+            except:
+                return 2
+
+        self.run_and_compare(func,
+            [(0, 'call'),
+             (1, 'line'),
+             (2, 'line'),
+             (3, 'line'),
+             (3, 'return')])
+
 
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""

--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-31-11-37-59.bpo-41670.vmRJRx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-31-11-37-59.bpo-41670.vmRJRx.rst
@@ -1,0 +1,2 @@
+Prevent line trace being skipped on Windows and Mac when a for loop is
+nexted within a try-except block.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-31-11-37-59.bpo-41670.vmRJRx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-31-11-37-59.bpo-41670.vmRJRx.rst
@@ -1,2 +1,2 @@
 Prevent line trace being skipped on Windows and Mac when a for loop is
-nexted within a try-except block.
+nested within a try-except block.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-31-11-37-59.bpo-41670.vmRJRx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-31-11-37-59.bpo-41670.vmRJRx.rst
@@ -1,2 +1,4 @@
-Prevent line trace being skipped on Windows and Mac when a for loop is
-nested within a try-except block.
+Prevent line trace being skipped on platforms not compiled
+with ``USE_COMPUTED_GOTOS``.
+Fixes issue where some lines nested within a try-except block
+were not being traced on Windows.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2297,7 +2297,6 @@ main_loop:
         }
 
         case TARGET(POP_BLOCK): {
-            PREDICTED(POP_BLOCK);
             PyFrame_BlockPop(f);
             DISPATCH();
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3352,7 +3352,6 @@ main_loop:
             STACK_SHRINK(1);
             Py_DECREF(iter);
             JUMPBY(oparg);
-            PREDICT(POP_BLOCK);
             DISPATCH();
         }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-41670](https://bugs.python.org/issue41670) -->
https://bugs.python.org/issue41670
<!-- /issue-number -->
