### PR TITLE
Doc: Fix the array.fromfile method doc

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -160,8 +160,7 @@ The following data items and methods are also supported:
    Read *n* items (as machine values) from the :term:`file object` *f* and append
    them to the end of the array.  If less than *n* items are available,
    :exc:`EOFError` is raised, but the items that were available are still
-   inserted into the array. *f* must be a real built-in file object; something
-   else with a :meth:`read` method won't do.
+   inserted into the array.
 
 
 .. method:: array.fromlist(list)


### PR DESCRIPTION
The check about the f argument type was removed in this commit:
https://github.com/python/cpython/commit/2c94aa567e525c82041ad68a3174d8c3acbf37e2

Thanks for Pedro Arthur Duarte (pedroarthur.jedi at gmail.com) by the help with
this bug.
