### PR TITLE
bpo-41685: Temporarily pin setuptools to 49.2.1 in Docs venv.

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -142,7 +142,8 @@ clean:
 
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
-	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
+#	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
+	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools==49.2.1
 	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb python-docs-theme
 	@echo "The venv has been created in the $(VENVDIR) directory"
 


### PR DESCRIPTION
See https://github.com/pypa/setuptools/pull/2361


<!-- issue-number: [bpo-41685](https://bugs.python.org/issue41685) -->
https://bugs.python.org/issue41685
<!-- /issue-number -->
