### PR TITLE
[3.9] bpo-41371: Handle lzma lib import error in test_zoneinfo.py (GH-21734)

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -6,7 +6,6 @@ import dataclasses
 import importlib.metadata
 import io
 import json
-import lzma
 import os
 import pathlib
 import pickle
@@ -20,7 +19,9 @@ from functools import cached_property
 
 from . import _support as test_support
 from ._support import OS_ENV_LOCK, TZPATH_TEST_LOCK, ZoneInfoTestBase
+from test.support import import_module
 
+lzma = import_module('lzma')
 py_zoneinfo, c_zoneinfo = test_support.get_modules()
 
 try:


### PR DESCRIPTION

(cherry picked from commit 5f0769a)

Co-authored-by: Nathan M <nathanmaynes@gmail.com>


<!-- issue-number: [bpo-41371](https://bugs.python.org/issue41371) -->
https://bugs.python.org/issue41371
<!-- /issue-number -->
