### PR TITLE
bpo-41687: Fix sendfile implementation to work with Solaris

### DIFF
--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -446,6 +446,8 @@ class SendfileMixin(SendfileBase):
         self.assertEqual(srv_proto.data, self.DATA)
         self.assertEqual(self.file.tell(), len(self.DATA))
 
+    @unittest.skipIf(sys.platform.startswith('sunos'),
+                     "Doesn't work on Solaris")
     def test_sendfile_close_peer_in_the_middle_of_receiving(self):
         srv_proto, cli_proto = self.prepare_sendfile(close_after=1024)
         with self.assertRaises(ConnectionError):

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -446,6 +446,10 @@ class SendfileMixin(SendfileBase):
         self.assertEqual(srv_proto.data, self.DATA)
         self.assertEqual(self.file.tell(), len(self.DATA))
 
+    # On Solaris, lowering SO_RCVBUF on a TCP connection after it has been
+    # established has no effect. Due to its age, this bug affects both Oracle
+    # Solaris as well as all other OpenSolaris forks (unless they fixed it
+    # themselves).
     @unittest.skipIf(sys.platform.startswith('sunos'),
                      "Doesn't work on Solaris")
     def test_sendfile_close_peer_in_the_middle_of_receiving(self):

--- a/Misc/NEWS.d/next/Library/2020-09-01-15-57-51.bpo-41687.m1b1KA.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-01-15-57-51.bpo-41687.m1b1KA.rst
@@ -1,0 +1,1 @@
+Fix implementation of sendfile to be compatible with Solaris.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9519,6 +9519,8 @@ done:
         return NULL;
 
 #if defined(__sun) && defined(__SVR4)
+    // On Solaris, sendfile raises EINVAL rather than returning 0
+    // when the offset is equal or bigger than the in_fd size.
     int res;
     struct stat st;
 


### PR DESCRIPTION
Sendfile on Solaris raises EINVAL if offset is equal or bigger than the size of the file. This is different from Linux, where similar sendfile call returns 0, which is used in an ad-hoc fashion to indicate EOF. This patches in additional offset check to make the implementation Solaris compatible.

<!-- issue-number: [bpo-41687](https://bugs.python.org/issue41687) -->
https://bugs.python.org/issue41687
<!-- /issue-number -->
