### PR TITLE
[3.9] bpo-41617: Fix pycore_byteswap.h to support clang 3.0 (GH-22042)

### DIFF
--- a/Include/internal/pycore_byteswap.h
+++ b/Include/internal/pycore_byteswap.h
@@ -15,10 +15,12 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#if defined(__clang__) || \
-    (defined(__GNUC__) && \
-     ((__GNUC__ >= 5) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)))
-   /* __builtin_bswap16() is available since GCC 4.8,
+#if ((defined(__GNUC__) \
+      && ((__GNUC__ >= 5) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8))) \
+     || (defined(__clang__) \
+         && (__clang_major__ >= 4 \
+             || (__clang_major__ == 3 && __clang_minor__ >= 2))))
+   /* __builtin_bswap16() is available since GCC 4.8 and clang 3.2,
       __builtin_bswap32() is available since GCC 4.3,
       __builtin_bswap64() is available since GCC 4.3. */
 #  define _PY_HAVE_BUILTIN_BSWAP

--- a/Misc/NEWS.d/next/Build/2020-08-24-18-34-01.bpo-41617.sKKXz7.rst
+++ b/Misc/NEWS.d/next/Build/2020-08-24-18-34-01.bpo-41617.sKKXz7.rst
@@ -1,0 +1,2 @@
+Fix ``pycore_byteswap.h`` header file to support old clang versions:
+``__builtin_bswap16()`` is not available in LLVM clang 3.0.


### PR DESCRIPTION
__builtin_bswap16() is not available in LLVM clang 3.0.

(cherry picked from commit e6905e4c82cc05897dc1bf5ab2b5b94b2b043a7f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41617](https://bugs.python.org/issue41617) -->
https://bugs.python.org/issue41617
<!-- /issue-number -->
