### PR TITLE
bpo-41679: Fix invalid escape sequences in the peg_highlight Sphinx extension

### DIFF
--- a/Doc/tools/extensions/peg_highlight.py
+++ b/Doc/tools/extensions/peg_highlight.py
@@ -59,7 +59,7 @@ class PEGLexer(RegexLexer):
             include("variables"),
             (r"\b(?!(NULL|EXTRA))([A-Z_]+)\b\s*(?!\()", Text,),
             (
-                r"^\s*" + _name + "\s*" + "(\[.*\])?" + "\s*" + "(\(.+\))?" + "\s*(:)",
+                r"^\s*" + _name + r"\s*" + r"(\[.*\])?" + r"\s*" + r"(\(.+\))?" + r"\s*(:)",
                 bygroups(Name.Function, None, None, Punctuation),
             ),
             (_name, Name.Function),


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41679](https://bugs.python.org/issue41679) -->
https://bugs.python.org/issue41679
<!-- /issue-number -->
