### PR TITLE
bpo-41681 Fixed mistake in test for `f-string/str.format` error description (GH-22036)

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -514,7 +514,7 @@ class FormatTest(unittest.TestCase):
     def test_with_an_underscore_and_a_comma_in_format_specifier(self):
         error_msg = re.escape("Cannot specify both ',' and '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):
-            '{:,_}'.format(1)
+            '{:_,}'.format(1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1217,7 +1217,7 @@ non-important content
     def test_with_an_underscore_and_a_comma_in_format_specifier(self):
         error_msg = re.escape("Cannot specify both ',' and '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):
-            f'{1:,_}'
+            f'{1:_,}'
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@ericvsmith  Fixed mistake in two of the error description test for `f-string/str.format`.

```python
def test_with_an_underscore_and_a_comma_in_format_specifier(self):
    error_msg = re.escape("Cannot specify both ',' and '_'.")
    with self.assertRaisesRegex(ValueError, error_msg):
        '{:,_}'.format(1)
```

Should have been,
```python
def test_with_an_underscore_and_a_comma_in_format_specifier(self):
    error_msg = re.escape("Cannot specify both ',' and '_'.")
    with self.assertRaisesRegex(ValueError, error_msg):
        '{:_,}'.format(1)
```

And
```python
def test_with_an_underscore_and_a_comma_in_format_specifier(self):
    error_msg = re.escape("Cannot specify both ',' and '_'.")
    with self.assertRaisesRegex(ValueError, error_msg):
        f'{1:,_}'
```
Should have been,
```python
def test_with_an_underscore_and_a_comma_in_format_specifier(self):
    error_msg = re.escape("Cannot specify both ',' and '_'.")
    with self.assertRaisesRegex(ValueError, error_msg):
        f'{1:_,}'
```

<!-- issue-number: [bpo-41681](https://bugs.python.org/issue41681) -->
https://bugs.python.org/issue41681
<!-- /issue-number -->
