### PR TITLE
bpo-41685: Don't pin setuptools version in Doc/Makefile

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -142,8 +142,7 @@ clean:
 
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
-#	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
-	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools==49.2.1
+	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
 	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==3.2.1 blurb python-docs-theme
 	@echo "The venv has been created in the $(VENVDIR) directory"
 


### PR DESCRIPTION
setuptools 50.0.2 is now compatible with Python 3.10:
https://github.com/pypa/setuptools/pull/2361

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41685](https://bugs.python.org/issue41685) -->
https://bugs.python.org/issue41685
<!-- /issue-number -->
