### PR TITLE
bpo-38762: Fix edge case where logging records an incorrect processNa…

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -1091,8 +1091,8 @@ need:
 +-----------------------------------------------------+---------------------------------------------------+
 | Current process ID (:func:`os.getpid`)              | Set ``logging.logProcesses`` to ``False``.        |
 +-----------------------------------------------------+---------------------------------------------------+
-| Current process name when using ``multiprocessing`` | Set ``logging.logMultiprocessing`` to ``False``.  |
-| to manage multiple processes.                       |                                                   |
+| Current process name                                | Set ``logging.logMultiprocessing`` to ``False``.  |
+| (:class:`multiprocessing.Process`)                  |                                                   |
 +-----------------------------------------------------+---------------------------------------------------+
 
 Also note that the core logging module only includes the basic handlers. If

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -332,8 +332,9 @@ class LogRecord(object):
             self.processName = None
         else:
             self.processName = 'MainProcess'
-            mp = sys.modules.get('multiprocessing')
-            if mp is not None:
+            # import can fail, e.g. during shutdown. See issue 20037.
+            try:
+                import multiprocessing as mp
                 # Errors may occur if multiprocessing has not finished loading
                 # yet - e.g. if a custom import hook causes third-party code
                 # to run when multiprocessing calls import. See issue 8200
@@ -342,6 +343,8 @@ class LogRecord(object):
                     self.processName = mp.current_process().name
                 except Exception: #pragma: no cover
                     pass
+            except ImportError:
+                pass
         if logProcesses and hasattr(os, 'getpid'):
             self.process = os.getpid()
         else:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4354,15 +4354,40 @@ class LogRecordTest(BaseTest):
         r.removeHandler(h)
         h.close()
 
+    @classmethod
+    def _check_process_name(cls, conn=None):
+        import multiprocessing as mp
+        name = mp.current_process().name
+
+        r1 = logging.makeLogRecord({'msg': 'msg1'})
+        del sys.modules['multiprocessing']
+        r2 = logging.makeLogRecord({'msg': 'msg2'})
+
+        results = {'processName'  : name,
+                   'r1.processName': r1.processName,
+                   'r2.processName': r2.processName,
+                  }
+        if conn:
+            conn.send(results)
+        else:
+            return results
+
     def test_multiprocessing(self):
         r = logging.makeLogRecord({})
         self.assertEqual(r.processName, 'MainProcess')
-        try:
-            import multiprocessing as mp
-            r = logging.makeLogRecord({})
-            self.assertEqual(r.processName, mp.current_process().name)
-        except ImportError:
-            pass
+
+        results = self._check_process_name()
+        self.assertEqual(results['processName'], results['r1.processName'])
+        self.assertEqual(results['processName'], results['r2.processName'])
+
+        import multiprocessing
+        parent_conn, child_conn = multiprocessing.Pipe()
+        p = multiprocessing.Process(target=self._check_process_name, args=(child_conn,))
+        p.start()
+        results = parent_conn.recv()
+        self.assertEqual(results['processName'], results['r1.processName'])
+        self.assertEqual(results['processName'], results['r2.processName'])
+        p.join()
 
     def test_optional(self):
         r = logging.makeLogRecord({})

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4354,8 +4354,8 @@ class LogRecordTest(BaseTest):
         r.removeHandler(h)
         h.close()
 
-    @classmethod
-    def _check_process_name(cls, conn=None):
+    @staticmethod
+    def _extract_logrecord_process_name(conn=None):
         import multiprocessing as mp
         name = mp.current_process().name
 
@@ -4376,13 +4376,15 @@ class LogRecordTest(BaseTest):
         r = logging.makeLogRecord({})
         self.assertEqual(r.processName, 'MainProcess')
 
-        results = self._check_process_name()
+        results = self._extract_logrecord_process_name()
         self.assertEqual(results['processName'], results['r1.processName'])
         self.assertEqual(results['processName'], results['r2.processName'])
 
         import multiprocessing
         parent_conn, child_conn = multiprocessing.Pipe()
-        p = multiprocessing.Process(target=self._check_process_name, args=(child_conn,))
+        p = multiprocessing.Process(
+            target=self._extract_logrecord_process_name, args=(child_conn,)
+        )
         p.start()
         results = parent_conn.recv()
         self.assertEqual(results['processName'], results['r1.processName'])

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4354,7 +4354,7 @@ class LogRecordTest(BaseTest):
         r.removeHandler(h)
         h.close()
 
-    @staticmethod
+    @staticmethod # pickled as target of child process in the following test
     def _extract_logrecord_process_name(conn=None):
         import multiprocessing as mp
         name = mp.current_process().name
@@ -4383,7 +4383,8 @@ class LogRecordTest(BaseTest):
         import multiprocessing
         parent_conn, child_conn = multiprocessing.Pipe()
         p = multiprocessing.Process(
-            target=self._extract_logrecord_process_name, args=(child_conn,)
+            target=self._extract_logrecord_process_name,
+            args=(child_conn,)
         )
         p.start()
         results = parent_conn.recv()

--- a/Misc/NEWS.d/next/Library/2020-09-02-11-12-39.bpo-38762.rYpy97.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-02-11-12-39.bpo-38762.rYpy97.rst
@@ -1,0 +1,1 @@
+Fix edge case where logging records an incorrect processName on a log record.


### PR DESCRIPTION
…me by removing the flaky assumption that if multiprocessing is not in sys.modules then it must be the main process.

I rewrote the multiprocessing test because it was not checking processName at all off the main process. Now it checks with and without multiprocessing in sys.modules, and repeats that on and off the main process.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38762](https://bugs.python.org/issue38762) -->
https://bugs.python.org/issue38762
<!-- /issue-number -->


