### PR TITLE
bpo-39010: Improve test shutdown

### DIFF
--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -225,10 +225,18 @@ class ProactorTests(test_utils.TestCase):
         self.loop.run_forever()
         self.loop.stop()
         self.loop.run_forever()
-        # If we don't wait for f to complete here, we may get another
-        # warning logged about a thread that didn't shut down cleanly.
+
+        # Shut everything down cleanly. This is an important part of the
+        # test - in issue 39010, the error occurred during loop.close(),
+        # so we want to close the loop during the test instead of leaving
+        # it for tearDown.
+        #
+        # First wait for f to complete to avoid a "future's result was never
+        # retrieved" error.
         self.loop.run_until_complete(f)
-        self.loop.close()
+        # Now shut down the loop itself (self.close_loop also shuts down the
+        # loop's default executor).
+        self.close_loop(self.loop)
         self.assertFalse(self.loop.call_exception_handler.called)
 
 


### PR DESCRIPTION
Simply closing the event loop isn't enough to avoid warnings. If we
don't also shut down the event loop's default executor, it sometimes
logs a "dangling thread" warning.

Follow-up to GH-22017

Since GH-22017 is being backported to the 3.8 and 3.9 branches, this one should be too. 


<!-- issue-number: [bpo-39010](https://bugs.python.org/issue39010) -->
https://bugs.python.org/issue39010
<!-- /issue-number -->
