### PR TITLE
gh-60207: Raise OSError instead of ThreadError if thread creation fails

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-09-02-10-51-13.bpo-16003.PWJjXq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-09-02-10-51-13.bpo-16003.PWJjXq.rst
@@ -1,0 +1,1 @@
+Raise :exc:`OSError` instead of :exc:`ThreadError` if thread creation fails.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1112,7 +1112,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
 
     ident = PyThread_start_new_thread(t_bootstrap, (void*) boot);
     if (ident == PYTHREAD_INVALID_THREAD_ID) {
-        PyErr_SetString(ThreadError, "can't start new thread");
+        PyErr_SetFromErrno(PyExc_OSError);
         Py_DECREF(func);
         Py_DECREF(args);
         Py_XDECREF(keyw);


### PR DESCRIPTION
If PyThread_start_new_thread() fails, use a more informative OSError
instead of a generic ThreadError.

<!-- issue-number: [bpo-16003](https://bugs.python.org/issue16003) -->
https://bugs.python.org/issue16003
<!-- /issue-number -->


<!-- gh-issue-number: gh-60207 -->
* Issue: gh-60207
<!-- /gh-issue-number -->
