### PR TITLE
bpo-41696: Fix handling of debug mode in asyncio.run

### DIFF
--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -5,7 +5,7 @@ from . import events
 from . import tasks
 
 
-def run(main, *, debug=False):
+def run(main, *, debug=None):
     """Execute the coroutine and return the result.
 
     This function runs the passed coroutine, taking care of
@@ -39,7 +39,8 @@ def run(main, *, debug=False):
     loop = events.new_event_loop()
     try:
         events.set_event_loop(loop)
-        loop.set_debug(debug)
+        if debug is not None:
+            loop.set_debug(debug)
         return loop.run_until_complete(main)
     finally:
         try:

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -87,6 +87,9 @@ class RunTests(BaseTest):
 
         asyncio.run(main(False))
         asyncio.run(main(True), debug=True)
+        with mock.patch('asyncio.coroutines._is_debug_mode', lambda: True):
+            asyncio.run(main(True))
+            asyncio.run(main(False), debug=False)
 
     def test_asyncio_run_from_running_loop(self):
         async def main():

--- a/Misc/NEWS.d/next/Library/2020-09-03-01-35-32.bpo-41696.zkYGre.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-03-01-35-32.bpo-41696.zkYGre.rst
@@ -1,0 +1,1 @@
+Fix handling of debug mode in :func:`asyncio.run`. This allows setting ``PYTHONASYNCIODEBUG`` or ``-X dev`` to enable asyncio debug mode when using :func:`asyncio.run`.


### PR DESCRIPTION
This allows PYTHONASYNCIODEBUG or -X dev to enable asyncio debug mode
when using asyncio.run

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41696](https://bugs.python.org/issue41696) -->
https://bugs.python.org/issue41696
<!-- /issue-number -->
