### PR TITLE
[3.8] bpo-30826: improve example for iteration considerations (GH-22078)

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -70,17 +70,26 @@ Code that modifies a collection while iterating over that same collection can
 be tricky to get right.  Instead, it is usually more straight-forward to loop
 over a copy of the collection or to create a new collection::
 
-    # Strategy:  Iterate over a copy
-    for user, status in users.copy().items():
-        if status == 'inactive':
-            del users[user]
+    >>> # Strategy:  Iterate over a copy
+    >>> cheeses = ['Cheshire', 'Brie', 'Roquefort']
+    >>> for c in cheeses[:]:
+    ...     if c == 'Brie':
+    ...         cheeses.append(c)
+    ...
+    >>> print(cheeses)
+    ['Cheshire', 'Brie', 'Roquefort', 'Brie']
 
-    # Strategy:  Create a new collection
-    active_users = {}
-    for user, status in users.items():
-        if status == 'active':
-            active_users[user] = status
-
+    >>> # Strategy:  Create a new collection
+    >>> cheeses = ['Cheshire', 'Brie', 'Roquefort']
+    >>> switched = []
+    >>> for c in cheeses:
+    ...     if c == 'Brie':
+    ...         switched.append("Stilton")
+    ...     else:
+    ...         switched.append(c)
+    ...
+    >>> print(switched)
+    ['Cheshire', 'Stilton', 'Roquefort']
 
 .. _tut-range:
 

--- a/Misc/NEWS.d/next/Documentation/2020-09-04-12-35-07.bpo-30826.TO4e7S.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-09-04-12-35-07.bpo-30826.TO4e7S.rst
@@ -1,0 +1,5 @@
+Up to this point in the tutorial the reader has not been introduced to
+the `dict` data type but the example is using it to demonstrate a point.
+Since the reader has been introduced to the `list` data type and some of
+its basic functionalities like shallow copy and `append`, the example has
+been leveraging those to demonstrate the same point.


### PR DESCRIPTION
The issue 30826 has been wrongly closed.
Because of the way it's been handled, it raises the following problem:

Up to this point in the tutorial the reader has not been introduced to
the `dict` data type but the example is using it to demonstrate a point.

Proposition:

Since the reader has been introduced to the `list` data type and some of
its basic functionalities like shallow copy and `append`, the example has
been leveraging those to demonstrate the same point.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30826](https://bugs.python.org/issue30826) -->
https://bugs.python.org/issue30826
<!-- /issue-number -->
