### PR TITLE
bpo-41713: _signal doesn't use multi-phase init

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-09-01-17-07-20.bpo-1635741.7wSuCc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-09-01-17-07-20.bpo-1635741.7wSuCc.rst
@@ -1,1 +1,0 @@
-Port the :mod:`_signal` extension module to multi-phase initialization (:pep:`489`).

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1649,25 +1649,31 @@ signal_exec(PyObject *m)
   return 0;
 }
 
-static PyModuleDef_Slot signal_slots[] = {
-    {Py_mod_exec, signal_exec},
-    {0, NULL}
-};
 
 static struct PyModuleDef signalmodule = {
     PyModuleDef_HEAD_INIT,
     "_signal",
     .m_doc = module_doc,
-    .m_size = 0,
+    .m_size = -1,
     .m_methods = signal_methods,
-    .m_slots = signal_slots
 };
+
 
 PyMODINIT_FUNC
 PyInit__signal(void)
 {
-    return PyModuleDef_Init(&signalmodule);
+    PyObject *mod = PyModule_Create(&signalmodule);
+    if (mod == NULL) {
+        return NULL;
+    }
+
+    if (signal_exec(mod) < 0) {
+        Py_DECREF(mod);
+        return NULL;
+    }
+    return mod;
 }
+
 
 static void
 finisignal(void)


### PR DESCRIPTION
Partially revert commit 71d1bd9569c8a497e279f2fea6fe47cd70a87ea3:
don't use multi-phase initialization (PEP 489) for the _signal
extension module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41713](https://bugs.python.org/issue41713) -->
https://bugs.python.org/issue41713
<!-- /issue-number -->
