### PR TITLE
bpo-39825: fix sysconfig.get_config_var('EXT_SUFFIX') on windows

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -424,10 +424,11 @@ def _init_posix(vars):
 def _init_non_posix(vars):
     """Initialize the module as appropriate for NT"""
     # set basic install directories
+    import _imp
     vars['LIBDEST'] = get_path('stdlib')
     vars['BINLIBDEST'] = get_path('platstdlib')
     vars['INCLUDEPY'] = get_path('include')
-    vars['EXT_SUFFIX'] = '.pyd'
+    vars['EXT_SUFFIX'] = _imp.extension_suffixes()[0]
     vars['EXE'] = '.exe'
     vars['VERSION'] = _PY_VERSION_SHORT_NO_DOT
     vars['BINDIR'] = os.path.dirname(_safe_realpath(sys.executable))

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -360,10 +360,12 @@ class TestSysConfig(unittest.TestCase):
 
     @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
                      'EXT_SUFFIX required for this test')
-    def test_SO_in_vars(self):
+    def test_EXT_SUFFIX_in_vars(self):
+        import _imp
         vars = sysconfig.get_config_vars()
         self.assertIsNotNone(vars['SO'])
         self.assertEqual(vars['SO'], vars['EXT_SUFFIX'])
+        self.assertEqual(vars['EXT_SUFFIX'], _imp.extension_suffixes()[0])
 
     @unittest.skipUnless(sys.platform == 'linux' and
                          hasattr(sys.implementation, '_multiarch'),

--- a/Misc/NEWS.d/next/Library/2020-10-20-08-28-26.bpo-39825.n6KnG0.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-20-08-28-26.bpo-39825.n6KnG0.rst
@@ -1,0 +1,5 @@
+Windows: Change ``sysconfig.get_config_var('EXT_SUFFIX')`` to the expected
+full ``platform_tag.extension`` format. Previously it was hard-coded to
+``.pyd``, now it is compatible with ``distutils.sysconfig`` and will result
+in something like ``.cp38-win_amd64.pyd``. This brings windows into
+conformance with the other platforms.


### PR DESCRIPTION
Fixes `sysconfig.get_config_var('EXT_SUFFIX')` to the expected full platform_tag.extension format.

May influence downstream packages like wheel (@agronholm) which use this value, 

<!-- issue-number: [bpo-39825](https://bugs.python.org/issue39825) -->
https://bugs.python.org/issue39825
<!-- /issue-number -->
