### PR TITLE
bpo-41718: Reduce test.libregrtest imports

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -520,7 +520,7 @@ class BaseTestCase(unittest.TestCase):
         if 'stderr' not in kw:
             kw['stderr'] = subprocess.STDOUT
         proc = subprocess.run(args,
-                              universal_newlines=True,
+                              text=True,
                               input=input,
                               stdout=subprocess.PIPE,
                               **kw)
@@ -1305,6 +1305,22 @@ class TestUtils(unittest.TestCase):
                          '3 hour 2 min')
         self.assertEqual(utils.format_duration(3 * 3600 + 1),
                          '3 hour 1 sec')
+
+
+class MiscTestCase(BaseTestCase):
+    def test_num_imports(self):
+        # bpo-41718: "import test.libregrtest" must not import too many
+        # modules.
+        code = textwrap.dedent("""
+            import sys
+            import test.libregrtest
+            print(len(sys.modules))
+        """)
+        proc = self.run_command([sys.executable, '-I', '-c', code])
+        out = proc.stdout.strip()
+        nmodules = int(out)
+        # Python 3.10 on Linux imports 149 modules
+        self.assertLess(nmodules, 155)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -468,7 +468,7 @@ class TestSupport(unittest.TestCase):
         proc = subprocess.run(cmd,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.DEVNULL,
-                              universal_newlines=True,
+                              text=True,
                               env=env)
         if expected is None:
             expected = args
@@ -655,6 +655,20 @@ class TestSupport(unittest.TestCase):
                                  "Warning -- msg\n")
         self.check_print_warning("a\nb",
                                  'Warning -- a\nWarning -- b\n')
+
+    def test_num_imports(self):
+        # bpo-41718: "import test.support" must not import too many modules.
+        code = textwrap.dedent("""
+            import sys
+            import test.support
+            print(len(sys.modules))
+        """)
+        cmd = [sys.executable, '-I', '-c', code]
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, text=True, check=True)
+        out = proc.stdout.strip()
+        nmodules = int(out)
+        # Python 3.10 on Linux imports 96 modules
+        self.assertLess(nmodules, 100)
 
     # XXX -follows a list of untested API
     # make_legacy_pyc

--- a/Misc/NEWS.d/next/Tests/2020-09-04-17-50-28.bpo-41718.MBxAOC.rst
+++ b/Misc/NEWS.d/next/Tests/2020-09-04-17-50-28.bpo-41718.MBxAOC.rst
@@ -1,0 +1,2 @@
+test.libregrtest.save_env no longer imports asyncio, multiprocessing nor
+urllib to reduce the number of imports, to better isolate unit tests.


### PR DESCRIPTION
test.libregrtest.save_env no longer imports asyncio, multiprocessing
nor urllib to reduce the number of imports, to better isolate unit
tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
