### PR TITLE
bpo-41720: Add "return NotImplemented" in turtle.Vec2D.__rmul__().

### DIFF
--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -130,6 +130,14 @@ class VectorComparisonMixin:
             self.assertAlmostEqual(
                 i, j, msg='values at index {} do not match'.format(idx))
 
+class Multiplier:
+
+    def __mul__(self, other):
+        return f'M*{other}'
+
+    def __rmul__(self, other):
+        return f'{other}*M'
+
 
 class TestVec2D(VectorComparisonMixin, unittest.TestCase):
 
@@ -211,9 +219,15 @@ class TestVec2D(VectorComparisonMixin, unittest.TestCase):
         self.assertAlmostEqual(answer, expected)
 
         vec = Vec2D(0.5, 3)
-        answer = vec * 10
         expected = Vec2D(5, 30)
-        self.assertVectorsAlmostEqual(answer, expected)
+        self.assertVectorsAlmostEqual(vec * 10, expected)
+        self.assertVectorsAlmostEqual(10 * vec, expected)
+        self.assertVectorsAlmostEqual(vec * 10.0, expected)
+        self.assertVectorsAlmostEqual(10.0 * vec, expected)
+
+        M = Multiplier()
+        self.assertEqual(vec * M, Vec2D(f"{vec[0]}*M", f"{vec[1]}*M"))
+        self.assertEqual(M * vec, f'M*{vec}')
 
     def test_vector_negative(self):
         vec = Vec2D(10, -10)

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -258,6 +258,7 @@ class Vec2D(tuple):
     def __rmul__(self, other):
         if isinstance(other, int) or isinstance(other, float):
             return Vec2D(self[0]*other, self[1]*other)
+        return NotImplemented
     def __sub__(self, other):
         return Vec2D(self[0]-other[0], self[1]-other[1])
     def __neg__(self):

--- a/Misc/NEWS.d/next/Library/2020-09-04-20-45-38.bpo-41720.PW9MzZ.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-04-20-45-38.bpo-41720.PW9MzZ.rst
@@ -1,0 +1,2 @@
+Fixed :meth:`turtle.Vec2D.__rmul__` for arguments which are not int or
+float.


### PR DESCRIPTION


<!-- issue-number: [bpo-41720](https://bugs.python.org/issue41720) -->
https://bugs.python.org/issue41720
<!-- /issue-number -->
