### PR TITLE
bpo-38585: Remove references to defusedexpat

### DIFF
--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -20,7 +20,7 @@ Python's interfaces for processing XML are grouped in the ``xml`` package.
    The XML modules are not secure against erroneous or maliciously
    constructed data.  If you need to parse untrusted or
    unauthenticated data see the :ref:`xml-vulnerabilities` and
-   :ref:`defused-packages` sections.
+   :ref:`defusedxml-package` sections.
 
 It is important to note that modules in the :mod:`xml` package require that
 there be at least one SAX-compliant XML parser available. The Expat parser is
@@ -113,9 +113,9 @@ decompression bomb
 The documentation for `defusedxml`_ on PyPI has further information about
 all known attack vectors with examples and references.
 
-.. _defused-packages:
+.. _defusedxml-package:
 
-The :mod:`defusedxml` and :mod:`defusedexpat` Packages
+The :mod:`defusedxml` Package
 ------------------------------------------------------
 
 `defusedxml`_ is a pure Python package with modified subclasses of all stdlib
@@ -124,16 +124,8 @@ package is recommended for any server code that parses untrusted XML data. The
 package also ships with example exploits and extended documentation on more
 XML exploits such as XPath injection.
 
-`defusedexpat`_ provides a modified libexpat and a patched
-:mod:`pyexpat` module that have countermeasures against entity expansion
-DoS attacks. The :mod:`defusedexpat` module still allows a sane and configurable amount of entity
-expansions. The modifications may be included in some future release of Python,
-but will not be included in any bugfix releases of
-Python because they break backward compatibility.
-
 
 .. _defusedxml: https://pypi.org/project/defusedxml/
-.. _defusedexpat: https://pypi.org/project/defusedexpat/
 .. _Billion Laughs: https://en.wikipedia.org/wiki/Billion_laughs
 .. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb
 .. _DTD: https://en.wikipedia.org/wiki/Document_type_definition


### PR DESCRIPTION
defusedexpat is not maintained.


<!-- issue-number: [bpo-38585](https://bugs.python.org/issue38585) -->
https://bugs.python.org/issue38585
<!-- /issue-number -->


Automerge-Triggered-By: @Mariatta