### PR TITLE
bpo-41627: Distinguish 32 and 64-bit user site packages on Windows

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -274,7 +274,8 @@ def _get_path(userbase):
     version = sys.version_info
 
     if os.name == 'nt':
-        return f'{userbase}\\Python{version[0]}{version[1]}\\site-packages'
+        ver_nodot = sys.winver.replace('.', '')
+        return f'{userbase}\\Python{ver_nodot}\\site-packages'
 
     if sys.platform == 'darwin' and sys._framework:
         return f'{userbase}/lib/python/site-packages'

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -432,7 +432,6 @@ def _init_non_posix(vars):
     vars['VERSION'] = _PY_VERSION_SHORT_NO_DOT
     vars['BINDIR'] = os.path.dirname(_safe_realpath(sys.executable))
     vars['TZPATH'] = ''
-    vars['py_version_nodot_plat'] = sys.winver.replace('.', '')
 
 #
 # public APIs
@@ -545,6 +544,10 @@ def get_config_vars(*args):
         except AttributeError:
             # sys.abiflags may not be defined on all platforms.
             _CONFIG_VARS['abiflags'] = ''
+        try:
+            _CONFIG_VARS['py_version_nodot_plat'] = sys.winver.replace('.', '')
+        except AttributeError:
+            _CONFIG_VARS['py_version_nodot_plat'] = ''
 
         if os.name == 'nt':
             _init_non_posix(_CONFIG_VARS)

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -149,10 +149,10 @@ if _PYTHON_BUILD:
 def _subst_vars(s, local_vars):
     try:
         return s.format(**local_vars)
-    except KeyError:
+    except KeyError as var:
         try:
             return s.format(**os.environ)
-        except KeyError as var:
+        except KeyError:
             raise AttributeError('{%s}' % var) from None
 
 def _extend_dict(target_dict, other_dict):

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -53,12 +53,12 @@ _INSTALL_SCHEMES = {
         },
     # NOTE: When modifying "purelib" scheme, update site._get_path() too.
     'nt_user': {
-        'stdlib': '{userbase}/Python{py_version_nodot}',
-        'platstdlib': '{userbase}/Python{py_version_nodot}',
-        'purelib': '{userbase}/Python{py_version_nodot}/site-packages',
-        'platlib': '{userbase}/Python{py_version_nodot}/site-packages',
-        'include': '{userbase}/Python{py_version_nodot}/Include',
-        'scripts': '{userbase}/Python{py_version_nodot}/Scripts',
+        'stdlib': '{userbase}/Python{py_version_nodot_plat}',
+        'platstdlib': '{userbase}/Python{py_version_nodot_plat}',
+        'purelib': '{userbase}/Python{py_version_nodot_plat}/site-packages',
+        'platlib': '{userbase}/Python{py_version_nodot_plat}/site-packages',
+        'include': '{userbase}/Python{py_version_nodot_plat}/Include',
+        'scripts': '{userbase}/Python{py_version_nodot_plat}/Scripts',
         'data': '{userbase}',
         },
     'posix_user': {
@@ -431,6 +431,8 @@ def _init_non_posix(vars):
     vars['EXE'] = '.exe'
     vars['VERSION'] = _PY_VERSION_SHORT_NO_DOT
     vars['BINDIR'] = os.path.dirname(_safe_realpath(sys.executable))
+    vars['TZPATH'] = ''
+    vars['py_version_nodot_plat'] = sys.winver.replace('.', '')
 
 #
 # public APIs
@@ -546,7 +548,6 @@ def get_config_vars(*args):
 
         if os.name == 'nt':
             _init_non_posix(_CONFIG_VARS)
-            _CONFIG_VARS['TZPATH'] = ''
         if os.name == 'posix':
             _init_posix(_CONFIG_VARS)
         # For backward compatibility, see issue19555

--- a/Misc/NEWS.d/next/Windows/2020-09-04-21-35-28.bpo-41627.sx2KN1.rst
+++ b/Misc/NEWS.d/next/Windows/2020-09-04-21-35-28.bpo-41627.sx2KN1.rst
@@ -1,0 +1,2 @@
+The user site directory for 32-bit now includes a ``-32`` suffix to
+distinguish it from the 64-bit interpreter's directory.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41627](https://bugs.python.org/issue41627) -->
https://bugs.python.org/issue41627
<!-- /issue-number -->
