### PR TITLE
Fix documented Python version for venv --upgrade-deps

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -67,7 +67,7 @@ The command, if run with ``-h``, will show the available options::
     Once an environment has been created, you may wish to activate it, e.g. by
     sourcing an activate script in its bin directory.
 
-.. versionchanged:: 3.8
+.. versionchanged:: 3.9
    Add ``--upgrade-deps`` option to upgrade pip + setuptools to the latest on PyPI
 
 .. versionchanged:: 3.4


### PR DESCRIPTION
Fixes incorrect Python version added for `venv` `--upgrade-deps` in #13100. This feature was added in Python 3.9 not 3.8.

Relates to:

- https://bugs.python.org/issue34556
- https://github.com/python/cpython/commit/1cba1c9abadf76f458ecf883a48515aa3b534dbd



Automerge-Triggered-By: @vsajip