### PR TITLE
[doc] Fix padding in some typing definitions

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1195,7 +1195,7 @@ Corresponding to collections in :mod:`collections.abc`
 
 .. class:: AbstractSet(Sized, Collection[T_co])
 
-    A generic version of :class:`collections.abc.Set`.
+   A generic version of :class:`collections.abc.Set`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Set` now supports ``[]``. See :pep:`585`.
@@ -1224,7 +1224,7 @@ Corresponding to collections in :mod:`collections.abc`
 
 .. class:: Container(Generic[T_co])
 
-    A generic version of :class:`collections.abc.Container`.
+   A generic version of :class:`collections.abc.Container`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Container` now supports ``[]``. See :pep:`585`.
@@ -1245,11 +1245,11 @@ Corresponding to collections in :mod:`collections.abc`
 
 .. class:: Mapping(Sized, Collection[KT], Generic[VT_co])
 
-    A generic version of :class:`collections.abc.Mapping`.
-    This type can be used as follows::
+   A generic version of :class:`collections.abc.Mapping`.
+   This type can be used as follows::
 
-      def get_position_in_index(word_list: Mapping[str, int], word: str) -> int:
-          return word_list[word]
+     def get_position_in_index(word_list: Mapping[str, int], word: str) -> int:
+         return word_list[word]
 
    .. deprecated:: 3.9
       :class:`collections.abc.Mapping` now supports ``[]``. See :pep:`585`.
@@ -1263,7 +1263,7 @@ Corresponding to collections in :mod:`collections.abc`
 
 .. class:: MutableMapping(Mapping[KT, VT])
 
-    A generic version of :class:`collections.abc.MutableMapping`.
+   A generic version of :class:`collections.abc.MutableMapping`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.MutableMapping` now supports ``[]``. See :pep:`585`.
@@ -1277,14 +1277,14 @@ Corresponding to collections in :mod:`collections.abc`
 
 .. class:: MutableSet(AbstractSet[T])
 
-    A generic version of :class:`collections.abc.MutableSet`.
+   A generic version of :class:`collections.abc.MutableSet`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.MutableSet` now supports ``[]``. See :pep:`585`.
 
 .. class:: Sequence(Reversible[T_co], Collection[T_co])
 
-    A generic version of :class:`collections.abc.Sequence`.
+   A generic version of :class:`collections.abc.Sequence`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Sequence` now supports ``[]``. See :pep:`585`.
@@ -1301,14 +1301,14 @@ Corresponding to other types in :mod:`collections.abc`
 
 .. class:: Iterable(Generic[T_co])
 
-    A generic version of :class:`collections.abc.Iterable`.
+   A generic version of :class:`collections.abc.Iterable`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Iterable` now supports ``[]``. See :pep:`585`.
 
 .. class:: Iterator(Iterable[T_co])
 
-    A generic version of :class:`collections.abc.Iterator`.
+   A generic version of :class:`collections.abc.Iterator`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Iterator` now supports ``[]``. See :pep:`585`.
@@ -1353,7 +1353,7 @@ Corresponding to other types in :mod:`collections.abc`
 
 .. class:: Reversible(Iterable[T_co])
 
-    A generic version of :class:`collections.abc.Reversible`.
+   A generic version of :class:`collections.abc.Reversible`.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Reversible` now supports ``[]``. See :pep:`585`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


Automerge-Triggered-By: @gvanrossum