### PR TITLE
gh-85894: Debug logging when adding TarInfo object

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2009,7 +2009,9 @@ class TarFile(object):
                 blocks += 1
             self.offset += blocks * BLOCKSIZE
 
-        self._dbg(3, "%s, size: %i, mtime: %.0f, mode: %i, uname: %s, gname: %s" % (tarinfo.name, tarinfo.size, tarinfo.mtime, tarinfo.mode, tarinfo.uname, tarinfo.gname))
+        self._dbg(3, "%s, size: %i, mtime: %.0f, mode: %i, uname: %s, gname: %s" \
+            % (tarinfo.name, tarinfo.size, tarinfo.mtime, tarinfo.mode, \
+            tarinfo.uname, tarinfo.gname))
 
         self.members.append(tarinfo)
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2008,7 +2008,7 @@ class TarFile(object):
                 self.fileobj.write(NUL * (BLOCKSIZE - remainder))
                 blocks += 1
             self.offset += blocks * BLOCKSIZE
-        
+
         self._dbg(3, "%s, size: %i, mtime: %.0f, mode: %i, uname: %s, gname: %s" % (tarinfo.name, tarinfo.size, tarinfo.mtime, tarinfo.mode, tarinfo.uname, tarinfo.gname))
 
         self.members.append(tarinfo)

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2008,6 +2008,8 @@ class TarFile(object):
                 self.fileobj.write(NUL * (BLOCKSIZE - remainder))
                 blocks += 1
             self.offset += blocks * BLOCKSIZE
+        
+        self._dbg(3, "%s, size: %i, mtime: %.0f, mode: %i, uname: %s, gname: %s" % (tarinfo.name, tarinfo.size, tarinfo.mtime, tarinfo.mode, tarinfo.uname, tarinfo.gname))
 
         self.members.append(tarinfo)
 

--- a/Misc/NEWS.d/next/Library/2020-09-06-00-22-17.bpo-41728.Lx8Z_N.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-06-00-22-17.bpo-41728.Lx8Z_N.rst
@@ -1,1 +1,2 @@
-Log detailed attributes of the TarInfo object in `tarfile.addfile()` when debug=3
+Log detailed attributes of the :class:`tarfile.TarInfo` object in
+:meth:`tarfile.TarFile.addfile` when ``debug==3``.

--- a/Misc/NEWS.d/next/Library/2020-09-06-00-22-17.bpo-41728.Lx8Z_N.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-06-00-22-17.bpo-41728.Lx8Z_N.rst
@@ -1,0 +1,1 @@
+Log detailed attributes of the TarInfo object in `tarfile.addfile()` when debug=3


### PR DESCRIPTION
# [bpo-41728](https://bugs.python.org/issue41728): Debug logging when adding TarInfo

Log attributes of the TarInfo object including name, size mtime, mode, uname, and gname when using `addfile()`
Only when debug=3.  This level appears to be unused although it is already documented.
The `add()` method already logs the name, but this logs the arcname instead so it's not redundant.

<!-- issue-number: [bpo-41728](https://bugs.python.org/issue41728) -->
https://bugs.python.org/issue41728
<!-- /issue-number -->

<!-- gh-issue-number: gh-85894 -->
* Issue: gh-85894
<!-- /gh-issue-number -->
