### PR TITLE
[3.9] closes bpo-41723: Fix an error in the py_compile documentation (GH-22110).

### DIFF
--- a/Doc/library/py_compile.rst
+++ b/Doc/library/py_compile.rst
@@ -35,7 +35,7 @@ byte-code cache files in the directory containing the source code.
    in ``.pyc``.
    For example, if *file* is ``/foo/bar/baz.py`` *cfile* will default to
    ``/foo/bar/__pycache__/baz.cpython-32.pyc`` for Python 3.2.  If *dfile* is
-   specified, it is used as the name of the source file in error messages when
+   specified, it is used as the name of the source file in error messages
    instead of *file*.  If *doraise* is true, a :exc:`PyCompileError` is raised
    when an error is encountered while compiling *file*. If *doraise* is false
    (the default), an error string is written to ``sys.stderr``, but no exception


### PR DESCRIPTION
(cherry picked from commit 5371a46)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41723](https://bugs.python.org/issue41723) -->
https://bugs.python.org/issue41723
<!-- /issue-number -->
