### PR TITLE
bpo-28850: Fix PrettyPrinter.format overrides being ignored for contents of small containers

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -544,8 +544,10 @@ class PrettyPrinter:
             else:
                 items = object.items()
             for k, v in items:
-                krepr, kreadable, krecur = self.format(k, context, maxlevels, level)
-                vrepr, vreadable, vrecur = self.format(v, context, maxlevels, level)
+                krepr, kreadable, krecur = self.format(
+                    k, context, maxlevels, level)
+                vrepr, vreadable, vrecur = self.format(
+                    v, context, maxlevels, level)
                 append("%s: %s" % (krepr, vrepr))
                 readable = readable and kreadable and vreadable
                 if krecur or vrecur:
@@ -577,7 +579,8 @@ class PrettyPrinter:
             append = components.append
             level += 1
             for o in object:
-                orepr, oreadable, orecur = self.format(o, context, maxlevels, level)
+                orepr, oreadable, orecur = self.format(
+                    o, context, maxlevels, level)
                 append(orepr)
                 if not oreadable:
                     readable = False

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -518,77 +518,78 @@ class PrettyPrinter:
 
     _dispatch[_collections.UserString.__repr__] = _pprint_user_string
 
-# Return triple (repr_string, isreadable, isrecursive).
+if True:
+    # Return triple (repr_string, isreadable, isrecursive).
 
-def _safe_repr(object, context, maxlevels, level, sort_dicts):
-    typ = type(object)
-    if typ in _builtin_scalars:
-        return repr(object), True, False
+    def _safe_repr(object, context, maxlevels, level, sort_dicts):
+        typ = type(object)
+        if typ in _builtin_scalars:
+            return repr(object), True, False
 
-    r = getattr(typ, "__repr__", None)
-    if issubclass(typ, dict) and r is dict.__repr__:
-        if not object:
-            return "{}", True, False
-        objid = id(object)
-        if maxlevels and level >= maxlevels:
-            return "{...}", False, objid in context
-        if objid in context:
-            return _recursion(object), False, True
-        context[objid] = 1
-        readable = True
-        recursive = False
-        components = []
-        append = components.append
-        level += 1
-        if sort_dicts:
-            items = sorted(object.items(), key=_safe_tuple)
-        else:
-            items = object.items()
-        for k, v in items:
-            krepr, kreadable, krecur = _safe_repr(k, context, maxlevels, level, sort_dicts)
-            vrepr, vreadable, vrecur = _safe_repr(v, context, maxlevels, level, sort_dicts)
-            append("%s: %s" % (krepr, vrepr))
-            readable = readable and kreadable and vreadable
-            if krecur or vrecur:
-                recursive = True
-        del context[objid]
-        return "{%s}" % ", ".join(components), readable, recursive
-
-    if (issubclass(typ, list) and r is list.__repr__) or \
-       (issubclass(typ, tuple) and r is tuple.__repr__):
-        if issubclass(typ, list):
+        r = getattr(typ, "__repr__", None)
+        if issubclass(typ, dict) and r is dict.__repr__:
             if not object:
-                return "[]", True, False
-            format = "[%s]"
-        elif len(object) == 1:
-            format = "(%s,)"
-        else:
-            if not object:
-                return "()", True, False
-            format = "(%s)"
-        objid = id(object)
-        if maxlevels and level >= maxlevels:
-            return format % "...", False, objid in context
-        if objid in context:
-            return _recursion(object), False, True
-        context[objid] = 1
-        readable = True
-        recursive = False
-        components = []
-        append = components.append
-        level += 1
-        for o in object:
-            orepr, oreadable, orecur = _safe_repr(o, context, maxlevels, level, sort_dicts)
-            append(orepr)
-            if not oreadable:
-                readable = False
-            if orecur:
-                recursive = True
-        del context[objid]
-        return format % ", ".join(components), readable, recursive
+                return "{}", True, False
+            objid = id(object)
+            if maxlevels and level >= maxlevels:
+                return "{...}", False, objid in context
+            if objid in context:
+                return _recursion(object), False, True
+            context[objid] = 1
+            readable = True
+            recursive = False
+            components = []
+            append = components.append
+            level += 1
+            if sort_dicts:
+                items = sorted(object.items(), key=_safe_tuple)
+            else:
+                items = object.items()
+            for k, v in items:
+                krepr, kreadable, krecur = _safe_repr(k, context, maxlevels, level, sort_dicts)
+                vrepr, vreadable, vrecur = _safe_repr(v, context, maxlevels, level, sort_dicts)
+                append("%s: %s" % (krepr, vrepr))
+                readable = readable and kreadable and vreadable
+                if krecur or vrecur:
+                    recursive = True
+            del context[objid]
+            return "{%s}" % ", ".join(components), readable, recursive
 
-    rep = repr(object)
-    return rep, (rep and not rep.startswith('<')), False
+        if (issubclass(typ, list) and r is list.__repr__) or \
+           (issubclass(typ, tuple) and r is tuple.__repr__):
+            if issubclass(typ, list):
+                if not object:
+                    return "[]", True, False
+                format = "[%s]"
+            elif len(object) == 1:
+                format = "(%s,)"
+            else:
+                if not object:
+                    return "()", True, False
+                format = "(%s)"
+            objid = id(object)
+            if maxlevels and level >= maxlevels:
+                return format % "...", False, objid in context
+            if objid in context:
+                return _recursion(object), False, True
+            context[objid] = 1
+            readable = True
+            recursive = False
+            components = []
+            append = components.append
+            level += 1
+            for o in object:
+                orepr, oreadable, orecur = _safe_repr(o, context, maxlevels, level, sort_dicts)
+                append(orepr)
+                if not oreadable:
+                    readable = False
+                if orecur:
+                    recursive = True
+            del context[objid]
+            return format % ", ".join(components), readable, recursive
+
+        rep = repr(object)
+        return rep, (rep and not rep.startswith('<')), False
 
 _builtin_scalars = frozenset({str, bytes, bytearray, int, float, complex,
                               bool, type(None)})

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -544,8 +544,8 @@ class PrettyPrinter:
             else:
                 items = object.items()
             for k, v in items:
-                krepr, kreadable, krecur = self._safe_repr(k, context, maxlevels, level)
-                vrepr, vreadable, vrecur = self._safe_repr(v, context, maxlevels, level)
+                krepr, kreadable, krecur = self.format(k, context, maxlevels, level)
+                vrepr, vreadable, vrecur = self.format(v, context, maxlevels, level)
                 append("%s: %s" % (krepr, vrepr))
                 readable = readable and kreadable and vreadable
                 if krecur or vrecur:
@@ -577,7 +577,7 @@ class PrettyPrinter:
             append = components.append
             level += 1
             for o in object:
-                orepr, oreadable, orecur = self._safe_repr(o, context, maxlevels, level)
+                orepr, oreadable, orecur = self.format(o, context, maxlevels, level)
                 append(orepr)
                 if not oreadable:
                     readable = False

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -459,15 +459,17 @@ AdvancedNamespace(the=0,
         exp = """\
 {'names with spaces': 'should be presented using repr()',
  others.should.not.be: like.this}"""
-        self.assertEqual(DottedPrettyPrinter().pformat(o), exp)
+
+        dotted_printer = DottedPrettyPrinter()
+        self.assertEqual(dotted_printer.pformat(o), exp)
 
         # length(repr(obj)) < width
         o1 = ['with space']
         exp1 = "['with space']"
-        self.assertEqual(DottedPrettyPrinter().pformat(o1), exp1)
+        self.assertEqual(dotted_printer.pformat(o1), exp1)
         o2 = ['without.space']
         exp2 = "[without.space]"
-        self.assertEqual(DottedPrettyPrinter().pformat(o2), exp2)
+        self.assertEqual(dotted_printer.pformat(o2), exp2)
 
     def test_set_reprs(self):
         self.assertEqual(pprint.pformat(set()), 'set()')

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -466,7 +466,7 @@ AdvancedNamespace(the=0,
         exp1 = "['with space']"
         self.assertEqual(DottedPrettyPrinter().pformat(o1), exp1)
         o2 = ['without.space']
-        exp2 = "['without.space']"  # this is bug bpo-28850
+        exp2 = "[without.space]"
         self.assertEqual(DottedPrettyPrinter().pformat(o2), exp2)
 
     def test_set_reprs(self):

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -453,12 +453,21 @@ AdvancedNamespace(the=0,
                   dog=8)""")
 
     def test_subclassing(self):
+        # length(repr(obj)) > width
         o = {'names with spaces': 'should be presented using repr()',
              'others.should.not.be': 'like.this'}
         exp = """\
 {'names with spaces': 'should be presented using repr()',
  others.should.not.be: like.this}"""
         self.assertEqual(DottedPrettyPrinter().pformat(o), exp)
+
+        # length(repr(obj)) < width
+        o1 = ['with space']
+        exp1 = "['with space']"
+        self.assertEqual(DottedPrettyPrinter().pformat(o1), exp1)
+        o2 = ['without.space']
+        exp2 = "['without.space']"  # this is bug bpo-28850
+        self.assertEqual(DottedPrettyPrinter().pformat(o2), exp2)
 
     def test_set_reprs(self):
         self.assertEqual(pprint.pformat(set()), 'set()')

--- a/Misc/NEWS.d/next/Library/2020-09-06-16-37-54.bpo-issue28850.HJNggD.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-06-16-37-54.bpo-issue28850.HJNggD.rst
@@ -1,0 +1,1 @@
+Fix PrettyPrinter.format overrides being ignored for contents of small containers.

--- a/Misc/NEWS.d/next/Library/2020-09-06-16-37-54.bpo-issue28850.HJNggD.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-06-16-37-54.bpo-issue28850.HJNggD.rst
@@ -1,1 +1,0 @@
-Fix PrettyPrinter.format overrides being ignored for contents of small containers.

--- a/Misc/NEWS.d/next/Library/2020-09-06-21-55-44.bpo-28850.HJNggD.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-06-21-55-44.bpo-28850.HJNggD.rst
@@ -1,1 +1,1 @@
-Fix :meth:`pprint.PrettyPrinter.format` overrides being ignored for contents of small containers.
+Fix :meth:`pprint.PrettyPrinter.format` overrides being ignored for contents of small containers. The :func:`pprint._safe_repr` function was removed.

--- a/Misc/NEWS.d/next/Library/2020-09-06-21-55-44.bpo-28850.HJNggD.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-06-21-55-44.bpo-28850.HJNggD.rst
@@ -1,1 +1,1 @@
-Fix PrettyPrinter.format overrides being ignored for contents of small containers.
+Fix :meth:`pprint.PrettyPrinter.format` overrides being ignored for contents of small containers.

--- a/Misc/NEWS.d/next/Library/2020-09-06-21-55-44.bpo-28850.HJNggD.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-06-21-55-44.bpo-28850.HJNggD.rst
@@ -1,0 +1,1 @@
+Fix PrettyPrinter.format overrides being ignored for contents of small containers.


### PR DESCRIPTION
This PR fixes a bug where subclassing PrettyPrinter and overriding format doesn't work for container contents (see issue 28850 for details).

The solution suggested here is to make _safe_repr a method of PrettyPrinter, and make it call self.format() when it needs to recurse on container contents. 

The diff looks substantial, but that's mostly due to the indentation of _safe_repr code. To make it easier to review, I split it into several commits, where the indentation is done in one commit as a noop change. The other commits have much smaller diffs.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28850](https://bugs.python.org/issue28850) -->
https://bugs.python.org/issue28850
<!-- /issue-number -->
