### PR TITLE
Fix typo in typing.py

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -245,7 +245,7 @@ def _tp_cache(func):
 
 
 def _eval_type(t, globalns, localns, recursive_guard=frozenset()):
-    """Evaluate all forward reverences in the given type t.
+    """Evaluate all forward references in the given type t.
     For use of globalns and localns see the docstring for get_type_hints().
     recursive_guard is used to prevent prevent infinite recursion
     with recursive ForwardRef.


### PR DESCRIPTION
This is a trivial PR to fix a typo in a docstring in `typing.py`. From reverences -> references

Automerge-Triggered-By: @Mariatta