### PR TITLE
[doc] Fix broken links and improve stand-alone tools list in FAQ

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -90,11 +90,12 @@ then compiles the generated C code and links it with the rest of the Python
 interpreter to form a self-contained binary which acts exactly like your script.
 
 Obviously, freeze requires a C compiler.  There are several other utilities
-which don't. One is Thomas Heller's py2exe (Windows only) at
+which don't:
 
-    http://www.py2exe.org/
-
-Another tool is Anthony Tuininga's `cx_Freeze <https://anthony-tuininga.github.io/cx_Freeze/>`_.
+* `py2exe <http://www.py2exe.org/>`_ for Windows binaries
+* `py2app <https://github.com/ronaldoussoren/py2app>`_ for Mac OS X binaries
+* `cx_Freeze <https://cx-freeze.readthedocs.io/en/latest/>`_ for cross-platform
+  binaries
 
 
 Are there coding standards or a style guide for Python programs?

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -140,11 +140,9 @@ offender.
 How do I make an executable from a Python script?
 -------------------------------------------------
 
-See `cx_Freeze <https://cx-freeze.readthedocs.io/en/latest/>`_ for a distutils extension
-that allows you to create console and GUI executables from Python code.
-`py2exe <http://www.py2exe.org/>`_, the most popular extension for building
-Python 2.x-based executables, does not yet support Python 3 but a version that
-does is in development.
+See `cx_Freeze <https://cx-freeze.readthedocs.io/en/latest/>`_ and
+`py2exe <http://www.py2exe.org/>`_, both are distutils extensions
+that allow you to create console and GUI executables from Python code.
 
 
 Is a ``*.pyd`` file the same as a DLL?

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1101,7 +1101,7 @@ shipped with PyWin32.  It is an embeddable IDE with a built-in debugger.
 cx_Freeze
 ---------
 
-`cx_Freeze <https://anthony-tuininga.github.io/cx_Freeze/>`_ is a :mod:`distutils`
+`cx_Freeze <https://cx-freeze.readthedocs.io/en/latest/>`_ is a :mod:`distutils`
 extension (see :ref:`extending-distutils`) which wraps Python scripts into
 executable Windows programs (:file:`{*}.exe` files).  When you have done this,
 you can distribute your application without requiring your users to install


### PR DESCRIPTION
This fixes the obsolete URL for cx_Freeze, adds a mention to py2app, and shows the applications as a list.