### PR TITLE
bpo-41687: Fix error handling in Solaris sendfile implementation

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9521,14 +9521,13 @@ done:
 #if defined(__sun) && defined(__SVR4)
     // On Solaris, sendfile raises EINVAL rather than returning 0
     // when the offset is equal or bigger than the in_fd size.
-    int res;
     struct stat st;
 
     do {
         Py_BEGIN_ALLOW_THREADS
-        res = fstat(in_fd, &st);
+        ret = fstat(in_fd, &st);
         Py_END_ALLOW_THREADS
-    } while (res != 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
+    } while (ret != 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
     if (ret < 0)
         return (!async_err) ? posix_error() : NULL;
 


### PR DESCRIPTION
I just realized that my recent PR with sendfile on Solaris ([PR 22040](https://github.com/python/cpython/pull/22040)) has broken error handling.

Sorry for that, this simple followup fixes that.

<!-- issue-number: [bpo-41687](https://bugs.python.org/issue41687) -->
https://bugs.python.org/issue41687
<!-- /issue-number -->


Automerge-Triggered-By: @1st1