### PR TITLE
[3.8] bpo-41401: Fix test_fspath_support in test_io. (GH-21640) (GH-22133)

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -922,7 +922,7 @@ class IOTest(unittest.TestCase):
                 self.assertEqual(f.read(), "egg\n")
 
         check_path_succeeds(FakePath(support.TESTFN))
-        check_path_succeeds(FakePath(support.TESTFN.encode('utf-8')))
+        check_path_succeeds(FakePath(os.fsencode(support.TESTFN)))
 
         with self.open(support.TESTFN, "w") as f:
             bad_path = FakePath(f.fileno())


### PR DESCRIPTION
The error is exposed on non-UTF-8 locales.

(cherry picked from commit 67987acd5dc9776f55f4e139e2b3d9e7a6434d9f)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>
(cherry picked from commit c73ee5acc96b4bbd6885156883b224b8cc3e470c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41401](https://bugs.python.org/issue41401) -->
https://bugs.python.org/issue41401
<!-- /issue-number -->
