### PR TITLE
bpo-1635741 - port unicodedata to multi-phase init

### DIFF
--- a/Include/ucnhash.h
+++ b/Include/ucnhash.h
@@ -27,6 +27,8 @@ typedef struct {
     int (*getcode)(PyObject *self, const char* name, int namelen, Py_UCS4* code,
                    int with_named_seq);
 
+    PyObject *module;
+
 } _PyUnicode_Name_CAPI;
 
 #ifdef __cplusplus

--- a/Misc/NEWS.d/next/Core and Builtins/2020-09-07-20-44-12.bpo-1635741.iYVVTS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-09-07-20-44-12.bpo-1635741.iYVVTS.rst
@@ -1,0 +1,2 @@
+Port the :mod:`unicodedata` extension module to multi-phase initialization
+(:pep:`489`).

--- a/Modules/clinic/unicodedata.c.h
+++ b/Modules/clinic/unicodedata.c.h
@@ -13,14 +13,49 @@ PyDoc_STRVAR(unicodedata_UCD_decimal__doc__,
 "ValueError is raised.");
 
 #define UNICODEDATA_UCD_DECIMAL_METHODDEF    \
-    {"decimal", (PyCFunction)(void(*)(void))unicodedata_UCD_decimal, METH_FASTCALL, unicodedata_UCD_decimal__doc__},
+    {"decimal", (PyCFunction)(void(*)(void))unicodedata_UCD_decimal, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_decimal__doc__},
 
 static PyObject *
-unicodedata_UCD_decimal_impl(PyObject *self, int chr,
+unicodedata_UCD_decimal_impl(PyObject *self, PyTypeObject *cls, int chr,
                              PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_decimal(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+unicodedata_UCD_decimal(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "", NULL};
+    static _PyArg_Parser _parser = {"C|O:decimal", _keywords, 0};
+    int chr;
+    PyObject *default_value = NULL;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr, &default_value)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_decimal_impl(self, cls, chr, default_value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_decimal__doc__,
+"decimal($module, chr, default=<unrepresentable>, /)\n"
+"--\n"
+"\n"
+"Converts a Unicode character into its equivalent decimal value.\n"
+"\n"
+"Returns the decimal value assigned to the character chr as integer.\n"
+"If no such value is defined, default is returned, or, if not given,\n"
+"ValueError is raised.");
+
+#define UNICODEDATA_DECIMAL_METHODDEF    \
+    {"decimal", (PyCFunction)(void(*)(void))unicodedata_decimal, METH_FASTCALL, unicodedata_decimal__doc__},
+
+static PyObject *
+unicodedata_decimal_impl(PyObject *module, int chr, PyObject *default_value);
+
+static PyObject *
+unicodedata_decimal(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -46,7 +81,7 @@ unicodedata_UCD_decimal(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
     default_value = args[1];
 skip_optional:
-    return_value = unicodedata_UCD_decimal_impl(self, chr, default_value);
+    return_value = unicodedata_decimal_impl(module, chr, default_value);
 
 exit:
     return return_value;
@@ -112,14 +147,49 @@ PyDoc_STRVAR(unicodedata_UCD_numeric__doc__,
 "ValueError is raised.");
 
 #define UNICODEDATA_UCD_NUMERIC_METHODDEF    \
-    {"numeric", (PyCFunction)(void(*)(void))unicodedata_UCD_numeric, METH_FASTCALL, unicodedata_UCD_numeric__doc__},
+    {"numeric", (PyCFunction)(void(*)(void))unicodedata_UCD_numeric, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_numeric__doc__},
 
 static PyObject *
-unicodedata_UCD_numeric_impl(PyObject *self, int chr,
+unicodedata_UCD_numeric_impl(PyObject *self, PyTypeObject *cls, int chr,
                              PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_numeric(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+unicodedata_UCD_numeric(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "", NULL};
+    static _PyArg_Parser _parser = {"C|O:numeric", _keywords, 0};
+    int chr;
+    PyObject *default_value = NULL;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr, &default_value)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_numeric_impl(self, cls, chr, default_value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_numeric__doc__,
+"numeric($module, chr, default=<unrepresentable>, /)\n"
+"--\n"
+"\n"
+"Converts a Unicode character into its equivalent numeric value.\n"
+"\n"
+"Returns the numeric value assigned to the character chr as float.\n"
+"If no such value is defined, default is returned, or, if not given,\n"
+"ValueError is raised.");
+
+#define UNICODEDATA_NUMERIC_METHODDEF    \
+    {"numeric", (PyCFunction)(void(*)(void))unicodedata_numeric, METH_FASTCALL, unicodedata_numeric__doc__},
+
+static PyObject *
+unicodedata_numeric_impl(PyObject *module, int chr, PyObject *default_value);
+
+static PyObject *
+unicodedata_numeric(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -145,7 +215,7 @@ unicodedata_UCD_numeric(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
     default_value = args[1];
 skip_optional:
-    return_value = unicodedata_UCD_numeric_impl(self, chr, default_value);
+    return_value = unicodedata_numeric_impl(module, chr, default_value);
 
 exit:
     return return_value;
@@ -158,13 +228,43 @@ PyDoc_STRVAR(unicodedata_UCD_category__doc__,
 "Returns the general category assigned to the character chr as string.");
 
 #define UNICODEDATA_UCD_CATEGORY_METHODDEF    \
-    {"category", (PyCFunction)unicodedata_UCD_category, METH_O, unicodedata_UCD_category__doc__},
+    {"category", (PyCFunction)(void(*)(void))unicodedata_UCD_category, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_category__doc__},
 
 static PyObject *
-unicodedata_UCD_category_impl(PyObject *self, int chr);
+unicodedata_UCD_category_impl(PyObject *self, PyTypeObject *cls, int chr);
 
 static PyObject *
-unicodedata_UCD_category(PyObject *self, PyObject *arg)
+unicodedata_UCD_category(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", NULL};
+    static _PyArg_Parser _parser = {"C:category", _keywords, 0};
+    int chr;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_category_impl(self, cls, chr);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_category__doc__,
+"category($module, chr, /)\n"
+"--\n"
+"\n"
+"Returns the general category assigned to the character chr as string.");
+
+#define UNICODEDATA_CATEGORY_METHODDEF    \
+    {"category", (PyCFunction)unicodedata_category, METH_O, unicodedata_category__doc__},
+
+static PyObject *
+unicodedata_category_impl(PyObject *module, int chr);
+
+static PyObject *
+unicodedata_category(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -181,7 +281,7 @@ unicodedata_UCD_category(PyObject *self, PyObject *arg)
         goto exit;
     }
     chr = PyUnicode_READ_CHAR(arg, 0);
-    return_value = unicodedata_UCD_category_impl(self, chr);
+    return_value = unicodedata_category_impl(module, chr);
 
 exit:
     return return_value;
@@ -196,13 +296,46 @@ PyDoc_STRVAR(unicodedata_UCD_bidirectional__doc__,
 "If no such value is defined, an empty string is returned.");
 
 #define UNICODEDATA_UCD_BIDIRECTIONAL_METHODDEF    \
-    {"bidirectional", (PyCFunction)unicodedata_UCD_bidirectional, METH_O, unicodedata_UCD_bidirectional__doc__},
+    {"bidirectional", (PyCFunction)(void(*)(void))unicodedata_UCD_bidirectional, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_bidirectional__doc__},
 
 static PyObject *
-unicodedata_UCD_bidirectional_impl(PyObject *self, int chr);
+unicodedata_UCD_bidirectional_impl(PyObject *self, PyTypeObject *cls,
+                                   int chr);
 
 static PyObject *
-unicodedata_UCD_bidirectional(PyObject *self, PyObject *arg)
+unicodedata_UCD_bidirectional(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", NULL};
+    static _PyArg_Parser _parser = {"C:bidirectional", _keywords, 0};
+    int chr;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_bidirectional_impl(self, cls, chr);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_bidirectional__doc__,
+"bidirectional($module, chr, /)\n"
+"--\n"
+"\n"
+"Returns the bidirectional class assigned to the character chr as string.\n"
+"\n"
+"If no such value is defined, an empty string is returned.");
+
+#define UNICODEDATA_BIDIRECTIONAL_METHODDEF    \
+    {"bidirectional", (PyCFunction)unicodedata_bidirectional, METH_O, unicodedata_bidirectional__doc__},
+
+static PyObject *
+unicodedata_bidirectional_impl(PyObject *module, int chr);
+
+static PyObject *
+unicodedata_bidirectional(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -219,7 +352,7 @@ unicodedata_UCD_bidirectional(PyObject *self, PyObject *arg)
         goto exit;
     }
     chr = PyUnicode_READ_CHAR(arg, 0);
-    return_value = unicodedata_UCD_bidirectional_impl(self, chr);
+    return_value = unicodedata_bidirectional_impl(module, chr);
 
 exit:
     return return_value;
@@ -234,13 +367,50 @@ PyDoc_STRVAR(unicodedata_UCD_combining__doc__,
 "Returns 0 if no combining class is defined.");
 
 #define UNICODEDATA_UCD_COMBINING_METHODDEF    \
-    {"combining", (PyCFunction)unicodedata_UCD_combining, METH_O, unicodedata_UCD_combining__doc__},
+    {"combining", (PyCFunction)(void(*)(void))unicodedata_UCD_combining, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_combining__doc__},
 
 static int
-unicodedata_UCD_combining_impl(PyObject *self, int chr);
+unicodedata_UCD_combining_impl(PyObject *self, PyTypeObject *cls, int chr);
 
 static PyObject *
-unicodedata_UCD_combining(PyObject *self, PyObject *arg)
+unicodedata_UCD_combining(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", NULL};
+    static _PyArg_Parser _parser = {"C:combining", _keywords, 0};
+    int chr;
+    int _return_value;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr)) {
+        goto exit;
+    }
+    _return_value = unicodedata_UCD_combining_impl(self, cls, chr);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_combining__doc__,
+"combining($module, chr, /)\n"
+"--\n"
+"\n"
+"Returns the canonical combining class assigned to the character chr as integer.\n"
+"\n"
+"Returns 0 if no combining class is defined.");
+
+#define UNICODEDATA_COMBINING_METHODDEF    \
+    {"combining", (PyCFunction)unicodedata_combining, METH_O, unicodedata_combining__doc__},
+
+static int
+unicodedata_combining_impl(PyObject *module, int chr);
+
+static PyObject *
+unicodedata_combining(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -258,7 +428,7 @@ unicodedata_UCD_combining(PyObject *self, PyObject *arg)
         goto exit;
     }
     chr = PyUnicode_READ_CHAR(arg, 0);
-    _return_value = unicodedata_UCD_combining_impl(self, chr);
+    _return_value = unicodedata_combining_impl(module, chr);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -278,13 +448,51 @@ PyDoc_STRVAR(unicodedata_UCD_mirrored__doc__,
 "character in bidirectional text, 0 otherwise.");
 
 #define UNICODEDATA_UCD_MIRRORED_METHODDEF    \
-    {"mirrored", (PyCFunction)unicodedata_UCD_mirrored, METH_O, unicodedata_UCD_mirrored__doc__},
+    {"mirrored", (PyCFunction)(void(*)(void))unicodedata_UCD_mirrored, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_mirrored__doc__},
 
 static int
-unicodedata_UCD_mirrored_impl(PyObject *self, int chr);
+unicodedata_UCD_mirrored_impl(PyObject *self, PyTypeObject *cls, int chr);
 
 static PyObject *
-unicodedata_UCD_mirrored(PyObject *self, PyObject *arg)
+unicodedata_UCD_mirrored(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", NULL};
+    static _PyArg_Parser _parser = {"C:mirrored", _keywords, 0};
+    int chr;
+    int _return_value;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr)) {
+        goto exit;
+    }
+    _return_value = unicodedata_UCD_mirrored_impl(self, cls, chr);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_mirrored__doc__,
+"mirrored($module, chr, /)\n"
+"--\n"
+"\n"
+"Returns the mirrored property assigned to the character chr as integer.\n"
+"\n"
+"Returns 1 if the character has been identified as a \"mirrored\"\n"
+"character in bidirectional text, 0 otherwise.");
+
+#define UNICODEDATA_MIRRORED_METHODDEF    \
+    {"mirrored", (PyCFunction)unicodedata_mirrored, METH_O, unicodedata_mirrored__doc__},
+
+static int
+unicodedata_mirrored_impl(PyObject *module, int chr);
+
+static PyObject *
+unicodedata_mirrored(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -302,7 +510,7 @@ unicodedata_UCD_mirrored(PyObject *self, PyObject *arg)
         goto exit;
     }
     chr = PyUnicode_READ_CHAR(arg, 0);
-    _return_value = unicodedata_UCD_mirrored_impl(self, chr);
+    _return_value = unicodedata_mirrored_impl(module, chr);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -319,13 +527,44 @@ PyDoc_STRVAR(unicodedata_UCD_east_asian_width__doc__,
 "Returns the east asian width assigned to the character chr as string.");
 
 #define UNICODEDATA_UCD_EAST_ASIAN_WIDTH_METHODDEF    \
-    {"east_asian_width", (PyCFunction)unicodedata_UCD_east_asian_width, METH_O, unicodedata_UCD_east_asian_width__doc__},
+    {"east_asian_width", (PyCFunction)(void(*)(void))unicodedata_UCD_east_asian_width, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_east_asian_width__doc__},
 
 static PyObject *
-unicodedata_UCD_east_asian_width_impl(PyObject *self, int chr);
+unicodedata_UCD_east_asian_width_impl(PyObject *self, PyTypeObject *cls,
+                                      int chr);
 
 static PyObject *
-unicodedata_UCD_east_asian_width(PyObject *self, PyObject *arg)
+unicodedata_UCD_east_asian_width(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", NULL};
+    static _PyArg_Parser _parser = {"C:east_asian_width", _keywords, 0};
+    int chr;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_east_asian_width_impl(self, cls, chr);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_east_asian_width__doc__,
+"east_asian_width($module, chr, /)\n"
+"--\n"
+"\n"
+"Returns the east asian width assigned to the character chr as string.");
+
+#define UNICODEDATA_EAST_ASIAN_WIDTH_METHODDEF    \
+    {"east_asian_width", (PyCFunction)unicodedata_east_asian_width, METH_O, unicodedata_east_asian_width__doc__},
+
+static PyObject *
+unicodedata_east_asian_width_impl(PyObject *module, int chr);
+
+static PyObject *
+unicodedata_east_asian_width(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -342,7 +581,7 @@ unicodedata_UCD_east_asian_width(PyObject *self, PyObject *arg)
         goto exit;
     }
     chr = PyUnicode_READ_CHAR(arg, 0);
-    return_value = unicodedata_UCD_east_asian_width_impl(self, chr);
+    return_value = unicodedata_east_asian_width_impl(module, chr);
 
 exit:
     return return_value;
@@ -357,13 +596,46 @@ PyDoc_STRVAR(unicodedata_UCD_decomposition__doc__,
 "An empty string is returned in case no such mapping is defined.");
 
 #define UNICODEDATA_UCD_DECOMPOSITION_METHODDEF    \
-    {"decomposition", (PyCFunction)unicodedata_UCD_decomposition, METH_O, unicodedata_UCD_decomposition__doc__},
+    {"decomposition", (PyCFunction)(void(*)(void))unicodedata_UCD_decomposition, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_decomposition__doc__},
 
 static PyObject *
-unicodedata_UCD_decomposition_impl(PyObject *self, int chr);
+unicodedata_UCD_decomposition_impl(PyObject *self, PyTypeObject *cls,
+                                   int chr);
 
 static PyObject *
-unicodedata_UCD_decomposition(PyObject *self, PyObject *arg)
+unicodedata_UCD_decomposition(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", NULL};
+    static _PyArg_Parser _parser = {"C:decomposition", _keywords, 0};
+    int chr;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_decomposition_impl(self, cls, chr);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_decomposition__doc__,
+"decomposition($module, chr, /)\n"
+"--\n"
+"\n"
+"Returns the character decomposition mapping assigned to the character chr as string.\n"
+"\n"
+"An empty string is returned in case no such mapping is defined.");
+
+#define UNICODEDATA_DECOMPOSITION_METHODDEF    \
+    {"decomposition", (PyCFunction)unicodedata_decomposition, METH_O, unicodedata_decomposition__doc__},
+
+static PyObject *
+unicodedata_decomposition_impl(PyObject *module, int chr);
+
+static PyObject *
+unicodedata_decomposition(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -380,7 +652,7 @@ unicodedata_UCD_decomposition(PyObject *self, PyObject *arg)
         goto exit;
     }
     chr = PyUnicode_READ_CHAR(arg, 0);
-    return_value = unicodedata_UCD_decomposition_impl(self, chr);
+    return_value = unicodedata_decomposition_impl(module, chr);
 
 exit:
     return return_value;
@@ -395,14 +667,48 @@ PyDoc_STRVAR(unicodedata_UCD_is_normalized__doc__,
 "Valid values for form are \'NFC\', \'NFKC\', \'NFD\', and \'NFKD\'.");
 
 #define UNICODEDATA_UCD_IS_NORMALIZED_METHODDEF    \
-    {"is_normalized", (PyCFunction)(void(*)(void))unicodedata_UCD_is_normalized, METH_FASTCALL, unicodedata_UCD_is_normalized__doc__},
+    {"is_normalized", (PyCFunction)(void(*)(void))unicodedata_UCD_is_normalized, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_is_normalized__doc__},
 
 static PyObject *
-unicodedata_UCD_is_normalized_impl(PyObject *self, PyObject *form,
-                                   PyObject *input);
+unicodedata_UCD_is_normalized_impl(PyObject *self, PyTypeObject *cls,
+                                   PyObject *form, PyObject *input);
 
 static PyObject *
-unicodedata_UCD_is_normalized(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+unicodedata_UCD_is_normalized(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "", NULL};
+    static _PyArg_Parser _parser = {"UU:is_normalized", _keywords, 0};
+    PyObject *form;
+    PyObject *input;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &form, &input)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_is_normalized_impl(self, cls, form, input);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_is_normalized__doc__,
+"is_normalized($module, form, unistr, /)\n"
+"--\n"
+"\n"
+"Return whether the Unicode string unistr is in the normal form \'form\'.\n"
+"\n"
+"Valid values for form are \'NFC\', \'NFKC\', \'NFD\', and \'NFKD\'.");
+
+#define UNICODEDATA_IS_NORMALIZED_METHODDEF    \
+    {"is_normalized", (PyCFunction)(void(*)(void))unicodedata_is_normalized, METH_FASTCALL, unicodedata_is_normalized__doc__},
+
+static PyObject *
+unicodedata_is_normalized_impl(PyObject *module, PyObject *form,
+                               PyObject *input);
+
+static PyObject *
+unicodedata_is_normalized(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *form;
@@ -427,7 +733,7 @@ unicodedata_UCD_is_normalized(PyObject *self, PyObject *const *args, Py_ssize_t 
         goto exit;
     }
     input = args[1];
-    return_value = unicodedata_UCD_is_normalized_impl(self, form, input);
+    return_value = unicodedata_is_normalized_impl(module, form, input);
 
 exit:
     return return_value;
@@ -442,14 +748,47 @@ PyDoc_STRVAR(unicodedata_UCD_normalize__doc__,
 "Valid values for form are \'NFC\', \'NFKC\', \'NFD\', and \'NFKD\'.");
 
 #define UNICODEDATA_UCD_NORMALIZE_METHODDEF    \
-    {"normalize", (PyCFunction)(void(*)(void))unicodedata_UCD_normalize, METH_FASTCALL, unicodedata_UCD_normalize__doc__},
+    {"normalize", (PyCFunction)(void(*)(void))unicodedata_UCD_normalize, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_normalize__doc__},
 
 static PyObject *
-unicodedata_UCD_normalize_impl(PyObject *self, PyObject *form,
-                               PyObject *input);
+unicodedata_UCD_normalize_impl(PyObject *self, PyTypeObject *cls,
+                               PyObject *form, PyObject *input);
 
 static PyObject *
-unicodedata_UCD_normalize(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+unicodedata_UCD_normalize(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "", NULL};
+    static _PyArg_Parser _parser = {"UU:normalize", _keywords, 0};
+    PyObject *form;
+    PyObject *input;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &form, &input)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_normalize_impl(self, cls, form, input);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_normalize__doc__,
+"normalize($module, form, unistr, /)\n"
+"--\n"
+"\n"
+"Return the normal form \'form\' for the Unicode string unistr.\n"
+"\n"
+"Valid values for form are \'NFC\', \'NFKC\', \'NFD\', and \'NFKD\'.");
+
+#define UNICODEDATA_NORMALIZE_METHODDEF    \
+    {"normalize", (PyCFunction)(void(*)(void))unicodedata_normalize, METH_FASTCALL, unicodedata_normalize__doc__},
+
+static PyObject *
+unicodedata_normalize_impl(PyObject *module, PyObject *form, PyObject *input);
+
+static PyObject *
+unicodedata_normalize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *form;
@@ -474,7 +813,7 @@ unicodedata_UCD_normalize(PyObject *self, PyObject *const *args, Py_ssize_t narg
         goto exit;
     }
     input = args[1];
-    return_value = unicodedata_UCD_normalize_impl(self, form, input);
+    return_value = unicodedata_normalize_impl(module, form, input);
 
 exit:
     return return_value;
@@ -490,13 +829,48 @@ PyDoc_STRVAR(unicodedata_UCD_name__doc__,
 "ValueError is raised.");
 
 #define UNICODEDATA_UCD_NAME_METHODDEF    \
-    {"name", (PyCFunction)(void(*)(void))unicodedata_UCD_name, METH_FASTCALL, unicodedata_UCD_name__doc__},
+    {"name", (PyCFunction)(void(*)(void))unicodedata_UCD_name, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_name__doc__},
 
 static PyObject *
-unicodedata_UCD_name_impl(PyObject *self, int chr, PyObject *default_value);
+unicodedata_UCD_name_impl(PyObject *self, PyTypeObject *cls, int chr,
+                          PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_name(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+unicodedata_UCD_name(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "", NULL};
+    static _PyArg_Parser _parser = {"C|O:name", _keywords, 0};
+    int chr;
+    PyObject *default_value = NULL;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &chr, &default_value)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_name_impl(self, cls, chr, default_value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_name__doc__,
+"name($module, chr, default=<unrepresentable>, /)\n"
+"--\n"
+"\n"
+"Returns the name assigned to the character chr as a string.\n"
+"\n"
+"If no name is defined, default is returned, or, if not given,\n"
+"ValueError is raised.");
+
+#define UNICODEDATA_NAME_METHODDEF    \
+    {"name", (PyCFunction)(void(*)(void))unicodedata_name, METH_FASTCALL, unicodedata_name__doc__},
+
+static PyObject *
+unicodedata_name_impl(PyObject *module, int chr, PyObject *default_value);
+
+static PyObject *
+unicodedata_name(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int chr;
@@ -522,7 +896,7 @@ unicodedata_UCD_name(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
     default_value = args[1];
 skip_optional:
-    return_value = unicodedata_UCD_name_impl(self, chr, default_value);
+    return_value = unicodedata_name_impl(module, chr, default_value);
 
 exit:
     return return_value;
@@ -538,14 +912,49 @@ PyDoc_STRVAR(unicodedata_UCD_lookup__doc__,
 "corresponding character.  If not found, KeyError is raised.");
 
 #define UNICODEDATA_UCD_LOOKUP_METHODDEF    \
-    {"lookup", (PyCFunction)unicodedata_UCD_lookup, METH_O, unicodedata_UCD_lookup__doc__},
+    {"lookup", (PyCFunction)(void(*)(void))unicodedata_UCD_lookup, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, unicodedata_UCD_lookup__doc__},
 
 static PyObject *
-unicodedata_UCD_lookup_impl(PyObject *self, const char *name,
-                            Py_ssize_clean_t name_length);
+unicodedata_UCD_lookup_impl(PyObject *self, PyTypeObject *cls,
+                            const char *name, Py_ssize_clean_t name_length);
 
 static PyObject *
-unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
+unicodedata_UCD_lookup(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", NULL};
+    static _PyArg_Parser _parser = {"s#:lookup", _keywords, 0};
+    const char *name;
+    Py_ssize_clean_t name_length;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &name, &name_length)) {
+        goto exit;
+    }
+    return_value = unicodedata_UCD_lookup_impl(self, cls, name, name_length);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(unicodedata_lookup__doc__,
+"lookup($module, name, /)\n"
+"--\n"
+"\n"
+"Look up character by name.\n"
+"\n"
+"If a character with the given name is found, return the\n"
+"corresponding character.  If not found, KeyError is raised.");
+
+#define UNICODEDATA_LOOKUP_METHODDEF    \
+    {"lookup", (PyCFunction)unicodedata_lookup, METH_O, unicodedata_lookup__doc__},
+
+static PyObject *
+unicodedata_lookup_impl(PyObject *module, const char *name,
+                        Py_ssize_clean_t name_length);
+
+static PyObject *
+unicodedata_lookup(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     const char *name;
@@ -554,9 +963,9 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
     if (!PyArg_Parse(arg, "s#:lookup", &name, &name_length)) {
         goto exit;
     }
-    return_value = unicodedata_UCD_lookup_impl(self, name, name_length);
+    return_value = unicodedata_lookup_impl(module, name, name_length);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=10c23477dbe8a202 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=33a45f2827e2d12f input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6523,8 +6523,8 @@ _PyUnicode_DecodeUnicodeEscape(const char *s,
                     s++;
                     ch = 0xffffffff; /* in case 'getcode' messes up */
                     if (namelen <= INT_MAX &&
-                        ucnhash_CAPI->getcode(NULL, start, (int)namelen,
-                                              &ch, 0)) {
+                        ucnhash_CAPI->getcode(ucnhash_CAPI->module, start,
+                                              (int)namelen, &ch, 0)) {
                         assert(ch <= MAX_UNICODE);
                         WRITE_CHAR(ch);
                         continue;

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -986,7 +986,8 @@ PyObject *PyCodec_NameReplaceErrors(PyObject *exc)
         for (i = start, ressize = 0; i < end; ++i) {
             /* object is guaranteed to be "ready" */
             c = PyUnicode_READ_CHAR(object, i);
-            if (ucnhash_CAPI->getname(NULL, c, buffer, sizeof(buffer), 1)) {
+            if (ucnhash_CAPI->getname(ucnhash_CAPI->module, c,
+                                      buffer, sizeof(buffer), 1)) {
                 replsize = 1+1+1+(int)strlen(buffer)+1;
             }
             else if (c >= 0x10000) {
@@ -1009,7 +1010,8 @@ PyObject *PyCodec_NameReplaceErrors(PyObject *exc)
             i < end; ++i) {
             c = PyUnicode_READ_CHAR(object, i);
             *outp++ = '\\';
-            if (ucnhash_CAPI->getname(NULL, c, buffer, sizeof(buffer), 1)) {
+            if (ucnhash_CAPI->getname(ucnhash_CAPI->module, c,
+                                      buffer, sizeof(buffer), 1)) {
                 *outp++ = 'N';
                 *outp++ = '{';
                 strcpy((char *)outp, buffer);


### PR DESCRIPTION
Second attempt, this time I'm slightly less ignorant about CPython core and argument clinic.

"Every problem in software engineering can be solved by adding a layer of indirection".  I hope this is true about porting unicodedata to multi-phase init.

The challenge with this module is that the methods are shared between the module, class and in some cases a capsule API.  Each of those cases will have its own way to get the module state (which is optional in the case of the capsule API).

I created internal functions like `unicodedata_UCD_normalize_internal` which is passed in the module state.  The class methods pass it in by getting it from the defining class, the module methods get it their own way.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
