### PR TITLE
bpo-1635741: Port _string module to multi-phase init

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-09-08-13-51-16.bpo-1635741.wkPeoT.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-08-13-51-16.bpo-1635741.wkPeoT.rst
@@ -1,0 +1,2 @@
+Port the ``_string`` extension module to the multi-phase initialization API
+(:pep:`489`).

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -16243,20 +16243,16 @@ static PyMethodDef _string_methods[] = {
 
 static struct PyModuleDef _string_module = {
     PyModuleDef_HEAD_INIT,
-    "_string",
-    PyDoc_STR("string helper module"),
-    0,
-    _string_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
+    .m_name = "_string",
+    .m_doc = PyDoc_STR("string helper module"),
+    .m_size = 0,
+    .m_methods = _string_methods,
 };
 
 PyMODINIT_FUNC
 PyInit__string(void)
 {
-    return PyModule_Create(&_string_module);
+    return PyModuleDef_Init(&_string_module);
 }
 
 


### PR DESCRIPTION
Port the _string extension module to the multi-phase initialization
API (PEP 489).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
