### PR TITLE
bpo-41744: Package NuGet python.props with correct name to be used

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-09-11-17-59-33.bpo-41744.e_ugDQ.rst
+++ b/Misc/NEWS.d/next/Windows/2020-09-11-17-59-33.bpo-41744.e_ugDQ.rst
@@ -1,0 +1,1 @@
+Fixes automatic import of props file when using the Nuget package.

--- a/Tools/nuget/python.nuspec
+++ b/Tools/nuget/python.nuspec
@@ -13,6 +13,6 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
   </files>
 </package>

--- a/Tools/nuget/pythonarm32.nuspec
+++ b/Tools/nuget/pythonarm32.nuspec
@@ -14,6 +14,7 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
+    <file src="python.props" target="build\native\pythonarm32.props" />
   </files>
 </package>

--- a/Tools/nuget/pythondaily.nuspec
+++ b/Tools/nuget/pythondaily.nuspec
@@ -13,6 +13,7 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
+    <file src="python.props" target="build\native\pythondaily.props" />
   </files>
 </package>

--- a/Tools/nuget/pythonx86.nuspec
+++ b/Tools/nuget/pythonx86.nuspec
@@ -13,6 +13,7 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
+    <file src="python.props" target="build\native\pythonx86.props" />
   </files>
 </package>


### PR DESCRIPTION
NuGet automatically includes `.props` file from the build directory in the target using the package, but only if the file has the correct name: it must be `$(id).props`. This means that Python's support for this only works correctly in the `python` nuget packages, but not in `pythonx86` and others, because the file is copied as python.props there too.

This PR fixes the problem by renaming the props file appropriately.



<!-- issue-number: [bpo-41744](https://bugs.python.org/issue41744) -->
https://bugs.python.org/issue41744
<!-- /issue-number -->
