### PR TITLE
bpo-41747: Ensure all dataclass methods uses their parents' qualname

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -7,7 +7,7 @@ import keyword
 import builtins
 import functools
 import _thread
-from types import GenericAlias
+from types import FunctionType, GenericAlias
 
 
 __all__ = ['dataclass',
@@ -753,6 +753,8 @@ def _get_field(cls, a_name, a_type):
 def _set_new_attribute(cls, name, value):
     # Never overwrites an existing attribute.  Returns True if the
     # attribute already exists.
+    if isinstance(value, FunctionType):
+        value.__qualname__ = f"{cls.__qualname__}.{value.__name__}"
     if name in cls.__dict__:
         return True
     setattr(cls, name, value)

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -751,7 +751,7 @@ def _get_field(cls, a_name, a_type):
 
 def _set_qualname(cls, value):
     # Ensure that the functions returned from _create_fn uses the proper
-    # __qualname__ (the class they belong)
+    # __qualname__ (the class they belong to).
     if isinstance(value, FunctionType):
         value.__qualname__ = f"{cls.__qualname__}.{value.__name__}"
     return value

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -749,14 +749,19 @@ def _get_field(cls, a_name, a_type):
 
     return f
 
+def _set_qualname(cls, value):
+    # Ensure that the functions returned from _create_fn uses the proper
+    # __qualname__ (the class they belong)
+    if isinstance(value, FunctionType):
+        value.__qualname__ = f"{cls.__qualname__}.{value.__name__}"
+    return value
 
 def _set_new_attribute(cls, name, value):
     # Never overwrites an existing attribute.  Returns True if the
     # attribute already exists.
-    if isinstance(value, FunctionType):
-        value.__qualname__ = f"{cls.__qualname__}.{value.__name__}"
     if name in cls.__dict__:
         return True
+    _set_qualname(cls, value)
     setattr(cls, name, value)
     return False
 
@@ -771,7 +776,7 @@ def _hash_set_none(cls, fields, globals):
 
 def _hash_add(cls, fields, globals):
     flds = [f for f in fields if (f.compare if f.hash is None else f.hash)]
-    return _hash_fn(flds, globals)
+    return _set_qualname(cls, _hash_fn(flds, globals))
 
 def _hash_exception(cls, fields, globals):
     # Raise an exception.

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1935,13 +1935,25 @@ class TestCase(unittest.TestCase):
                     self.assertEqual(sample.y, another_new_sample.y)
 
     def test_dataclasses_qualnames(self):
-        @dataclass
+        @dataclass(order=True, unsafe_hash=True, frozen=True)
         class A:
             x: int
             y: int
 
         self.assertEqual(A.__init__.__name__, "__init__")
-        self.assertEqual(A.__init__.__qualname__, "TestCase.test_dataclasses_qualnames.<locals>.A.__init__")
+        for function in (
+            '__eq__',
+            '__lt__',
+            '__le__',
+            '__gt__',
+            '__ge__',
+            '__hash__',
+            '__init__',
+            '__repr__',
+            '__setattr__',
+            '__delattr__',
+        ):
+            self.assertEqual(getattr(A, function).__qualname__, f"TestCase.test_dataclasses_qualnames.<locals>.A.{function}")
 
         with self.assertRaisesRegex(TypeError, r"A.__init__\(\) missing"):
             A()

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1934,6 +1934,18 @@ class TestCase(unittest.TestCase):
                     self.assertEqual(new_sample.x, another_new_sample.x)
                     self.assertEqual(sample.y, another_new_sample.y)
 
+    def test_dataclasses_qualnames(self):
+        @dataclass
+        class A:
+            x: int
+            y: int
+
+        self.assertEqual(A.__init__.__name__, "__init__")
+        self.assertEqual(A.__init__.__qualname__, "TestCase.test_dataclasses_qualnames.<locals>.A.__init__")
+
+        with self.assertRaisesRegex(TypeError, r"A.__init__\(\) missing"):
+            A()
+
 
 class TestFieldNoAnnotation(unittest.TestCase):
     def test_field_without_annotation(self):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1955,7 +1955,7 @@ class TestCase(unittest.TestCase):
         ):
             self.assertEqual(getattr(A, function).__qualname__, f"TestCase.test_dataclasses_qualnames.<locals>.A.{function}")
 
-        with self.assertRaisesRegex(TypeError, r"A.__init__\(\) missing"):
+        with self.assertRaisesRegex(TypeError, r"A\.__init__\(\) missing"):
             A()
 
 

--- a/Misc/NEWS.d/next/Library/2020-09-08-23-41-29.bpo-41747.M6wLKv.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-08-23-41-29.bpo-41747.M6wLKv.rst
@@ -1,3 +1,3 @@
-Ensure all methods belonging to :func:`dataclasses.dataclass` objects
-now have the proper ``__qualname__`` attribute referring to the class
-they belong. Patch by Batuhan Taskaya.
+Ensure all methods that generated from :func:`dataclasses.dataclass`
+objects now have the proper ``__qualname__`` attribute referring to
+the class they belong to. Patch by Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Library/2020-09-08-23-41-29.bpo-41747.M6wLKv.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-08-23-41-29.bpo-41747.M6wLKv.rst
@@ -1,0 +1,2 @@
+Ensure all methods from a :func:`dataclasses.dataclass` uses the
+``__qualname__`` of the class they belong. Patch by Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Library/2020-09-08-23-41-29.bpo-41747.M6wLKv.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-08-23-41-29.bpo-41747.M6wLKv.rst
@@ -1,2 +1,3 @@
-Ensure all methods from a :func:`dataclasses.dataclass` uses the
-``__qualname__`` of the class they belong. Patch by Batuhan Taskaya.
+Ensure all methods belonging to :func:`dataclasses.dataclass` objects
+now have the proper ``__qualname__`` attribute referring to the class
+they belong. Patch by Batuhan Taskaya.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41747](https://bugs.python.org/issue41747) -->
https://bugs.python.org/issue41747
<!-- /issue-number -->
