### PR TITLE
[3.8] Fix typo in typing.py (GH-22121)

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -263,7 +263,7 @@ def _tp_cache(func):
 
 
 def _eval_type(t, globalns, localns):
-    """Evaluate all forward reverences in the given type t.
+    """Evaluate all forward references in the given type t.
     For use of globalns and localns see the docstring for get_type_hints().
     """
     if isinstance(t, ForwardRef):


### PR DESCRIPTION
This is a trivial PR to fix a typo in a docstring in typing.py. From reverences -> references.
(cherry picked from commit 84ef33c5117acd9867781135a9aeb62052432e8a)

Co-authored-by: Graham Bleaney <gbleaney@gmail.com>


Automerge-Triggered-By: @Mariatta