### PR TITLE
bpo-41749: Little improve on imghdr

### DIFF
--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -13,7 +13,7 @@ def what(file='', h=None):
     try:
         if h is None:
             if file == '':
-                raise ValueError("You need specify a str or PathLike for file, "
+                raise TypeError("You need specify a str or PathLike for file, "
                                  "or pass a byte stream as h parameter")
             if isinstance(file, (str, PathLike)):
                 f = open(file, 'rb')

--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -8,10 +8,13 @@ __all__ = ["what"]
 # Recognize image headers #
 #-------------------------#
 
-def what(file, h=None):
+def what(file='', h=None):
     f = None
     try:
         if h is None:
+            if file == '':
+                raise ValueError("You need specify a str or PathLike for file, "
+                                 "or pass a byte stream as h parameter")
             if isinstance(file, (str, PathLike)):
                 f = open(file, 'rb')
                 h = f.read(32)

--- a/Lib/test/test_imghdr.py
+++ b/Lib/test/test_imghdr.py
@@ -83,7 +83,7 @@ class TestImghdr(unittest.TestCase):
             imghdr.what(None)
         with self.assertRaises(TypeError):
             imghdr.what(self.testfile, 1)
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(BytesWarning):
             imghdr.what(os.fsencode(self.testfile))
         with open(self.testfile, 'rb') as f:
             with self.assertRaises(AttributeError):

--- a/Lib/test/test_imghdr.py
+++ b/Lib/test/test_imghdr.py
@@ -77,7 +77,7 @@ class TestImghdr(unittest.TestCase):
             self.assertEqual(stream.tell(), pos)
 
     def test_bad_args(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             imghdr.what()
         with self.assertRaises(AttributeError):
             imghdr.what(None)

--- a/Lib/test/test_imghdr.py
+++ b/Lib/test/test_imghdr.py
@@ -49,8 +49,8 @@ class TestImghdr(unittest.TestCase):
                 self.assertEqual(imghdr.what(stream), expected)
             with open(filename, 'rb') as stream:
                 data = stream.read()
-            self.assertEqual(imghdr.what(None, data), expected)
-            self.assertEqual(imghdr.what(None, bytearray(data)), expected)
+            self.assertEqual(imghdr.what(h=data), expected)
+            self.assertEqual(imghdr.what(h=bytearray(data)), expected)
 
     def test_pathlike_filename(self):
         for filename, expected in TEST_FILES:
@@ -64,7 +64,7 @@ class TestImghdr(unittest.TestCase):
                 return 'ham'
         imghdr.tests.append(test_jumbo)
         self.addCleanup(imghdr.tests.pop)
-        self.assertEqual(imghdr.what(None, b'eggs'), 'ham')
+        self.assertEqual(imghdr.what(h=b'eggs'), 'ham')
 
     def test_file_pos(self):
         with open(TESTFN, 'wb') as stream:
@@ -77,7 +77,7 @@ class TestImghdr(unittest.TestCase):
             self.assertEqual(stream.tell(), pos)
 
     def test_bad_args(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             imghdr.what()
         with self.assertRaises(AttributeError):
             imghdr.what(None)
@@ -108,7 +108,7 @@ class TestImghdr(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     imghdr.what(io.StringIO(data))
                 with self.assertRaises(TypeError):
-                    imghdr.what(None, data)
+                    imghdr.what(h=data)
 
     def test_missing_file(self):
         with self.assertRaises(FileNotFoundError):

--- a/Misc/NEWS.d/next/Library/2020-09-09-04-04-46.bpo-41749.xqeeeI.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-09-04-04-46.bpo-41749.xqeeeI.rst
@@ -1,0 +1,1 @@
+Allow to programmer to don't use `file` parameter on `what` on imghdr library.


### PR DESCRIPTION
For the `what()` function, the `file` parameter is always needed.
In despite of that users can use `h` for send a bytes stream to
detect the kind of the image, the `file` parameter is need.

Don't have sense ask for `file` parameter when this parameter will
not any effect on the result of the `what` function.

[bpo-41749](https://bugs.python.org/issue41749): Little improve on imghdr

<!-- issue-number: [bpo-41749](https://bugs.python.org/issue41749) -->
https://bugs.python.org/issue41749
<!-- /issue-number -->
