### PR TITLE
[3.9] bpo-41688: Document bug in **= dispatching in the language data…

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2409,6 +2409,13 @@ left undefined.
    :ref:`faq-augmented-assignment-tuple-error`), but this behavior is in fact
    part of the data model.
 
+   .. note::
+
+      Due to a bug in the dispatching mechanism for ``**=``, a class that
+      defines :meth:`__ipow__` but returns ``NotImplemented`` would fail to
+      fall back to ``x.__pow__(y)`` and ``y.__rpow__(x)``. This bug is fixed
+      in Python 3.10.
+
 
 .. method:: object.__neg__(self)
             object.__pos__(self)


### PR DESCRIPTION
I tossed in a "This bug is fixed in Python 3.10" sentence but I'm not sure if that's appropriate to have here.

<!-- issue-number: [bpo-41688](https://bugs.python.org/issue41688) -->
https://bugs.python.org/issue41688
<!-- /issue-number -->


Automerge-Triggered-By: @brettcannon