### PR TITLE
bpo-38572: Raise UnsupportedOperation when fileno() is not supported

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -878,7 +878,9 @@ class _BufferedIOMixin(BufferedIOBase):
     ### Lower-level APIs ###
 
     def fileno(self):
-        return self.raw.fileno()
+        if hasattr(self.raw, 'fileno'):
+            return self.raw.fileno()
+        self._unsupported('fileno')
 
     def isatty(self):
         return self.raw.isatty()

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -164,6 +164,28 @@ class PyMockRawIO(MockRawIO, pyio.RawIOBase):
     pass
 
 
+class MockRawIOWithoutFileno:
+
+    def readable(self):
+        return True
+
+    def read(self, n=None):
+        return b''
+
+    def seekable(self):
+        return True
+
+    def seek(self, pos, whence):
+        return 0
+
+    def writable(self):
+        return True
+
+
+class CMockRawIOWithoutFileno(MockRawIOWithoutFileno, io.RawIOBase):
+    pass
+
+
 class MisbehavedRawIO(MockRawIO):
     def write(self, b):
         return super().write(b) * 2
@@ -1606,9 +1628,17 @@ class CBufferedReaderTest(BufferedReaderTest, SizeofTest):
             bufio.readline()
         self.assertIsInstance(cm.exception.__cause__, TypeError)
 
+    def test_unsupported_underlying_fileno(self):
+        with self.assertRaises(self.UnsupportedOperation):
+            self.tp(CMockRawIOWithoutFileno()).fileno()
+
 
 class PyBufferedReaderTest(BufferedReaderTest):
     tp = pyio.BufferedReader
+
+    def test_unsupported_underlying_fileno(self):
+        with self.assertRaises(self.UnsupportedOperation):
+            self.tp(CMockRawIOWithoutFileno()).fileno()
 
 
 class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
@@ -1952,9 +1982,18 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
         with self.assertRaisesRegex(TypeError, "BufferedWriter"):
             self.tp(io.BytesIO(), 1024, 1024, 1024)
 
+    def test_unsupported_underlying_fileno(self):
+        with self.assertRaises(self.UnsupportedOperation):
+            self.tp(CMockRawIOWithoutFileno()).fileno()
+
 
 class PyBufferedWriterTest(BufferedWriterTest):
     tp = pyio.BufferedWriter
+
+    def test_unsupported_underlying_fileno(self):
+        with self.assertRaises(self.UnsupportedOperation):
+            self.tp(CMockRawIOWithoutFileno()).fileno()
+
 
 class BufferedRWPairTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2020-09-09-14-21-46.bpo-38572.Zi7ZSC.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-09-14-21-46.bpo-38572.Zi7ZSC.rst
@@ -1,0 +1,3 @@
+The ``fileno()`` methods of :class:`io.BufferedReader` and
+:class:`io.BufferedWriter` now raise :exc:`io.UnsupportedOperation` if the
+underlying stream does not have a ``fileno`` attribute.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -596,6 +596,14 @@ static PyObject *
 buffered_fileno(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
+    PyObject *attr = PyObject_GetAttr(self->raw, _PyIO_str_fileno);
+    if (attr == NULL) {
+        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            return bufferediobase_unsupported("fileno");
+        }
+        return NULL;
+    }
+    Py_DECREF(attr);
     return PyObject_CallMethodNoArgs(self->raw, _PyIO_str_fileno);
 }
 


### PR DESCRIPTION
Co-Authored-By: Claudiu Popa <pcmanticore@gmail.com>

<!-- issue-number: [bpo-38572](https://bugs.python.org/issue38572) -->
https://bugs.python.org/issue38572
<!-- /issue-number -->
