### PR TITLE
bpo-41730: Show deprecation warnings for tkinter.tix

### DIFF
--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -10,8 +10,9 @@ _tkinter = import_helper.import_module('_tkinter')
 # Skip test if tk cannot be initialized.
 support.requires('gui')
 
-with warnings.catch_warnings():
-    from tkinter import tix
+warnings.simplefilter('ignore', DeprecationWarning)
+from tkinter import tix
+warnings.simplefilter('always', DeprecationWarning)
 from tkinter import TclError
 
 

--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -10,7 +10,7 @@ _tkinter = import_helper.import_module('_tkinter')
 # Skip test if tk cannot be initialized.
 support.requires('gui')
 
-tix = support.import_module('tkinter.tix', deprecated=True)
+tix = import_helper.import_module('tkinter.tix', deprecated=True)
 from tkinter import TclError
 
 

--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 
 # Skip this test if the _tkinter module wasn't built.
-_tkinter = import_helper.import_module('_tkinter')
+_tkinter = support.import_module('_tkinter')
 
 # Skip test if tk cannot be initialized.
 support.requires('gui')
@@ -27,10 +27,9 @@ class TestTix(unittest.TestCase):
             self.addCleanup(self.root.destroy)
 
     def test_tix_warning(self):
-        support.import_fresh_module('tkinter.tix', fresh=('tkinter.tix',))
         # Refresh module to issue warning
         with self.assertWarns(DeprecationWarning):
-            from tkinter import tix
+            tix = support.import_fresh_module('tkinter.tix', fresh=('tkinter.tix',))
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -10,9 +10,7 @@ _tkinter = import_helper.import_module('_tkinter')
 # Skip test if tk cannot be initialized.
 support.requires('gui')
 
-warnings.simplefilter('ignore', DeprecationWarning)
-from tkinter import tix
-warnings.simplefilter('always', DeprecationWarning)
+tix = support.import_module('tkinter.tix', deprecated=True)
 from tkinter import TclError
 
 
@@ -29,6 +27,8 @@ class TestTix(unittest.TestCase):
             self.addCleanup(self.root.destroy)
 
     def test_tix_warning(self):
+        support.import_fresh_module('tkinter.tix', fresh=('tkinter.tix',))
+        # Refresh module to issue warning
         with self.assertWarns(DeprecationWarning):
             from tkinter import tix
 

--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -1,8 +1,7 @@
+import sys
 import unittest
 from test import support
 from test.support import import_helper
-import sys
-import warnings
 
 # Skip this test if the _tkinter module wasn't built.
 _tkinter = import_helper.import_module('_tkinter')
@@ -10,6 +9,7 @@ _tkinter = import_helper.import_module('_tkinter')
 # Skip test if tk cannot be initialized.
 support.requires('gui')
 
+# Suppress the deprecation warning
 tix = import_helper.import_module('tkinter.tix', deprecated=True)
 from tkinter import TclError
 
@@ -26,10 +26,12 @@ class TestTix(unittest.TestCase):
         else:
             self.addCleanup(self.root.destroy)
 
-    def test_tix_warning(self):
-        # Refresh module to issue warning
+    def test_tix_deprecation(self):
         with self.assertWarns(DeprecationWarning):
-            tix = support.import_fresh_module('tkinter.tix', fresh=('tkinter.tix',))
+            import_helper.import_fresh_module(
+                'tkinter.tix',
+                fresh=('tkinter.tix',),
+                )
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -2,6 +2,7 @@ import unittest
 from test import support
 from test.support import import_helper
 import sys
+import warnings
 
 # Skip this test if the _tkinter module wasn't built.
 _tkinter = import_helper.import_module('_tkinter')
@@ -9,7 +10,9 @@ _tkinter = import_helper.import_module('_tkinter')
 # Skip test if tk cannot be initialized.
 support.requires('gui')
 
-from tkinter import tix, TclError
+with warnings.catch_warnings():
+    from tkinter import tix
+from tkinter import TclError
 
 
 class TestTix(unittest.TestCase):
@@ -24,9 +27,9 @@ class TestTix(unittest.TestCase):
         else:
             self.addCleanup(self.root.destroy)
 
-    def test_tix_available(self):
-        # this test is just here to make setUp run
-        pass
+    def test_tix_warning(self):
+        with self.assertWarns(DeprecationWarning):
+            from tkinter import tix
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 
 # Skip this test if the _tkinter module wasn't built.
-_tkinter = support.import_module('_tkinter')
+_tkinter = import_helper.import_module('_tkinter')
 
 # Skip test if tk cannot be initialized.
 support.requires('gui')

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -65,7 +65,6 @@ TCL_TIMER_EVENTS  = 1 << 4
 TCL_IDLE_EVENTS   = 1 << 5
 TCL_ALL_EVENTS    = 0
 
-# Deprecation warning
 warnings.warn('the tkinter.tix module is deprecated in favour of tkinter.ttk and is set '
               'to be removed in the near-future', DeprecationWarning, stacklevel=2)
 

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -65,7 +65,8 @@ TCL_TIMER_EVENTS  = 1 << 4
 TCL_IDLE_EVENTS   = 1 << 5
 TCL_ALL_EVENTS    = 0
 
-warnings.warn('The Tix Tk extension is unmaintained, and the tkinter.tix wrapper is deprecated in '
+warnings.warn('The Tix Tk extension is unmaintained, '
+              'and the tkinter.tix wrapper is deprecated in '
               'favor of tkinter.ttk', DeprecationWarning, stacklevel=2)
 
 # BEWARE - this is implemented by copying some code from the Widget class

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -29,7 +29,12 @@ import tkinter
 from tkinter import *
 from tkinter import _cnfmerge
 
-import _tkinter # If this fails your Python may not be configured for Tk
+warnings.warn(
+    'The Tix Tk extension is unmaintained, and the tkinter.tix wrapper module'
+    ' is deprecated in favor of tkinter.ttk',
+    DeprecationWarning,
+    stacklevel=2,
+    )
 
 # Some more constants (for consistency with Tkinter)
 WINDOW = 'window'
@@ -64,10 +69,6 @@ TCL_FILE_EVENTS   = 1 << 3
 TCL_TIMER_EVENTS  = 1 << 4
 TCL_IDLE_EVENTS   = 1 << 5
 TCL_ALL_EVENTS    = 0
-
-warnings.warn('The Tix Tk extension is unmaintained, '
-              'and the tkinter.tix wrapper is deprecated in '
-              'favor of tkinter.ttk', DeprecationWarning, stacklevel=2)
 
 # BEWARE - this is implemented by copying some code from the Widget class
 #          in Tkinter (to override Widget initialization) and is therefore

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -65,8 +65,8 @@ TCL_TIMER_EVENTS  = 1 << 4
 TCL_IDLE_EVENTS   = 1 << 5
 TCL_ALL_EVENTS    = 0
 
-warnings.warn('the tkinter.tix module is deprecated in favour of tkinter.ttk and is set '
-              'to be removed in the near-future', DeprecationWarning, stacklevel=2)
+warnings.warn('The Tix Tk extension is unmaintained, and the tkinter.tix wrapper is deprecated in '
+              'favour of tkinter.ttk', DeprecationWarning, stacklevel=2)
 
 # BEWARE - this is implemented by copying some code from the Widget class
 #          in Tkinter (to override Widget initialization) and is therefore

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -66,7 +66,7 @@ TCL_IDLE_EVENTS   = 1 << 5
 TCL_ALL_EVENTS    = 0
 
 warnings.warn('The Tix Tk extension is unmaintained, and the tkinter.tix wrapper is deprecated in '
-              'favour of tkinter.ttk', DeprecationWarning, stacklevel=2)
+              'favor of tkinter.ttk', DeprecationWarning, stacklevel=2)
 
 # BEWARE - this is implemented by copying some code from the Widget class
 #          in Tkinter (to override Widget initialization) and is therefore

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -13,8 +13,8 @@
 # inheritance of base classes.
 #
 # As a result after creating a 'w = StdButtonBox', I can write
-#               w.ok['text'] = 'Who Cares'
-# or            w.ok['bg'] = w['bg']
+#              w.ok['text'] = 'Who Cares'
+#    or              w.ok['bg'] = w['bg']
 # or even       w.ok.invoke()
 # etc.
 #

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -67,7 +67,7 @@ TCL_ALL_EVENTS    = 0
 
 # Deprecation warning
 warnings.warn('the tkinter.tix module is deprecated in favour of tkinter.ttk and is set \
-to be removed in the near-future.', DeprecationWarning, stacklevel=2)
+to be removed in the near-future', DeprecationWarning, stacklevel=2)
 
 # BEWARE - this is implemented by copying some code from the Widget class
 #          in Tkinter (to override Widget initialization) and is therefore

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -66,8 +66,8 @@ TCL_IDLE_EVENTS   = 1 << 5
 TCL_ALL_EVENTS    = 0
 
 # Deprecation warning
-warnings.warn('the tkinter.tix module is deprecated in favour of tkinter.ttk and is set \
-to be removed in the near-future', DeprecationWarning, stacklevel=2)
+warnings.warn('the tkinter.tix module is deprecated in favour of tkinter.ttk and is set '
+              'to be removed in the near-future', DeprecationWarning, stacklevel=2)
 
 # BEWARE - this is implemented by copying some code from the Widget class
 #          in Tkinter (to override Widget initialization) and is therefore

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -13,16 +13,18 @@
 # inheritance of base classes.
 #
 # As a result after creating a 'w = StdButtonBox', I can write
-#              w.ok['text'] = 'Who Cares'
-#    or              w.ok['bg'] = w['bg']
+#               w.ok['text'] = 'Who Cares'
+# or            w.ok['bg'] = w['bg']
 # or even       w.ok.invoke()
 # etc.
 #
 # Compare the demo tixwidgets.py to the original Tcl program and you will
 # appreciate the advantages.
 #
+# NOTE: This module is deprecated since Python 3.6.
 
 import os
+import warnings
 import tkinter
 from tkinter import *
 from tkinter import _cnfmerge
@@ -62,6 +64,10 @@ TCL_FILE_EVENTS   = 1 << 3
 TCL_TIMER_EVENTS  = 1 << 4
 TCL_IDLE_EVENTS   = 1 << 5
 TCL_ALL_EVENTS    = 0
+
+# Deprecation warning
+warnings.warn('the tkinter.tix module is deprecated in favour of tkinter.ttk and is set \
+to be removed in the near-future.', DeprecationWarning, stacklevel=2)
 
 # BEWARE - this is implemented by copying some code from the Widget class
 #          in Tkinter (to override Widget initialization) and is therefore

--- a/Misc/NEWS.d/next/Library/2020-09-10-07-16-27.bpo-41370.DyKFi9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-10-07-16-27.bpo-41370.DyKFi9.rst
@@ -1,0 +1,1 @@
+The ``tkinter.ttk`` module has been deprecated since Python 3.6. Warn a ``DeprecationWarning`` when importing it.

--- a/Misc/NEWS.d/next/Library/2020-09-10-07-16-27.bpo-41370.DyKFi9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-10-07-16-27.bpo-41370.DyKFi9.rst
@@ -1,1 +1,0 @@
-The ``tkinter.ttk`` module has been deprecated since Python 3.6. Warn a ``DeprecationWarning`` when importing it.

--- a/Misc/NEWS.d/next/Library/2020-09-10-07-23-24.bpo-41730.DyKFi9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-10-07-23-24.bpo-41730.DyKFi9.rst
@@ -1,1 +1,1 @@
-The ``tkinter.tix`` module has been deprecated since Python 3.6. Warn a ``DeprecationWarning`` when importing it.
+``DeprecationWarning`` is now raised when importing :mod:`tkinter.tix`, which has been deprecated in documentation since Python 3.6.

--- a/Misc/NEWS.d/next/Library/2020-09-10-07-23-24.bpo-41730.DyKFi9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-10-07-23-24.bpo-41730.DyKFi9.rst
@@ -1,0 +1,1 @@
+The ``tkinter.tix`` module has been deprecated since Python 3.6. Warn a ``DeprecationWarning`` when importing it.


### PR DESCRIPTION
The ``tkinter.tix`` module has been deprecated since Python 3.6. Warn a ``DeprecationWarning`` when importing it.

<!-- issue-number: [bpo-41730](https://bugs.python.org/issue41730) -->
https://bugs.python.org/issue41730
<!-- /issue-number -->
