### PR TITLE
bpo-14916: use specified tokenizer fd for file input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,7 @@ matrix:
       env: TESTING=docs
       before_script:
         - cd Doc
-        # Sphinx is pinned so that new versions that introduce new warnings won't suddenly cause build failures.
-        # (Updating the version is fine as long as no warnings are raised by doing so.)
-        # The theme used by the docs is stored separately, so we need to install that as well.
-        - python -m pip install sphinx==2.2.0 blurb python-docs-theme
+        - make venv PYTHON=python
       script:
         - make check suspicious html SPHINXOPTS="-q -W -j4"
     - name: "Documentation tests"

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -143,7 +143,7 @@ clean:
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
 	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
-	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==3.2.1 blurb python-docs-theme
+	$(VENVDIR)/bin/python3 -m pip install -r requirements.txt
 	@echo "The venv has been created in the $(VENVDIR) directory"
 
 dist:

--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -15,6 +15,11 @@ than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
    The C structure used for generator objects.
 
 
+.. c:type:: PySendResult
+
+   The enum value used to represent different results of :c:func:`PyGen_Send`.
+
+
 .. c:var:: PyTypeObject PyGen_Type
 
    The type object corresponding to generator objects.
@@ -42,3 +47,13 @@ than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
    with ``__name__`` and ``__qualname__`` set to *name* and *qualname*.
    A reference to *frame* is stolen by this function.  The *frame* argument
    must not be ``NULL``.
+
+.. c:function:: PySendResult PyGen_Send(PyGenObject *gen, PyObject *arg, PyObject **presult)
+
+   Sends the *arg* value into the generator *gen*. Coroutine objects
+   are also allowed to be as the *gen* argument but they need to be
+   explicitly casted to PyGenObject*. Returns:
+
+   - ``PYGEN_RETURN`` if generator returns. Return value is returned via *presult*.
+   - ``PYGEN_NEXT`` if generator yields. Yielded value is returned via *presult*.
+   - ``PYGEN_ERROR`` if generator has raised and exception. *presult* is set to ``NULL``.

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -959,6 +959,11 @@ PyGen_NewWithQualName:PyFrameObject*:frame:0:
 PyGen_NewWithQualName:PyObject*:name:0:
 PyGen_NewWithQualName:PyObject*:qualname:0:
 
+PyGen_Send:int:::
+PyGen_Send:PyGenObject*:gen:0:
+PyGen_Send:PyObject*:arg:0:
+PyGen_Send:PyObject**:presult:+1:
+
 PyCoro_CheckExact:int:::
 PyCoro_CheckExact:PyObject*:ob:0:
 

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1504,20 +1504,19 @@ Most :meth:`__setattr__` implementations must modify ``self.__dict__`` to store
 local state for self without causing an infinite recursion.
 
 
-How do I call a method defined in a base class from a derived class that overrides it?
---------------------------------------------------------------------------------------
+How do I call a method defined in a base class from a derived class that extends it?
+------------------------------------------------------------------------------------
 
 Use the built-in :func:`super` function::
 
    class Derived(Base):
        def meth(self):
-           super(Derived, self).meth()
+           super().meth()  # calls Base.meth
 
-For version prior to 3.0, you may be using classic classes: For a class
-definition such as ``class Derived(Base): ...`` you can call method ``meth()``
-defined in ``Base`` (or one of ``Base``'s base classes) as ``Base.meth(self,
-arguments...)``.  Here, ``Base.meth`` is an unbound method, so you need to
-provide the ``self`` argument.
+In the example, :func:`super` will automatically determine the instance from
+which it was called (the ``self`` value), look up the :term:`method resolution
+order` (MRO) with ``type(self).__mro__``, and return the next in line after
+``Derived`` in the MRO: ``Base``.
 
 
 How can I organize my code to make it easier to change the base class?

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1141,7 +1141,7 @@ How do you remove duplicates from a list?
 
 See the Python Cookbook for a long discussion of many ways to do this:
 
-   https://code.activestate.com/recipes/52560/
+   https://github.com/ActiveState/code/tree/master/recipes/Python/52560_Remove_duplicates/recipe-52560.py
 
 If you don't mind reordering the list, sort it and then scan from the end of the
 list, deleting duplicates as you go::

--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -601,5 +601,5 @@ This document was reviewed and revised by John Lee.
        scripts with a localhost server, I have to prevent urllib from using
        the proxy.
 .. [#] urllib opener for SSL proxy (CONNECT method): `ASPN Cookbook Recipe
-       <https://code.activestate.com/recipes/456195/>`_.
+       <https://github.com/ActiveState/code/tree/master/recipes/Python/456195_urrlib2_opener_SSL_proxy_CONNECT/recipe-456195.py>`_.
 

--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -60,7 +60,7 @@ The following functions are provided:
 .. seealso::
 
    `SortedCollection recipe
-   <https://code.activestate.com/recipes/577197-sortedcollection/>`_ that uses
+   <https://github.com/ActiveState/code/tree/master/recipes/Python/577197_SortedCollection/recipe-577197.py>`_ that uses
    bisect to build a full-featured collection class with straight-forward search
    methods and support for a key-function.  The keys are precomputed to save
    unnecessary calls to the key function during searches.

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -308,7 +308,7 @@ Notes on using :class:`Set` and :class:`MutableSet` as a mixin:
 
 .. seealso::
 
-   * `OrderedSet recipe <https://code.activestate.com/recipes/576694/>`_ for an
+   * `OrderedSet recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/576694_OrderedSet/recipe-576694.py>`_ for an
      example built on :class:`MutableSet`.
 
    * For more about ABCs, see the :mod:`abc` module and :pep:`3119`.

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -135,12 +135,12 @@ The class can be used to simulate nested scopes and is useful in templating.
       :attr:`~collections.ChainMap.parents` property.
 
     * The `Nested Contexts recipe
-      <https://code.activestate.com/recipes/577434/>`_ has options to control
+      <https://github.com/ActiveState/code/tree/master/recipes/Python/577434_Nested_contexts__chamapping/recipe-577434.py>`_ has options to control
       whether writes and other mutations apply only to the first mapping or to
       any mapping in the chain.
 
     * A `greatly simplified read-only version of Chainmap
-      <https://code.activestate.com/recipes/305268/>`_.
+      <https://github.com/ActiveState/code/tree/master/recipes/Python/305268_Chained_map_lookups/recipe-305268.py>`_.
 
 
 :class:`ChainMap` Examples and Recipes

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -18,8 +18,8 @@
 --------------
 
 This module provides classes and functions for comparing sequences. It
-can be used for example, for comparing files, and can produce difference
-information in various formats, including HTML and context and unified
+can be used for example, for comparing files, and can produce information
+about file differences in various formats, including HTML and context and unified
 diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
 
 

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -633,7 +633,7 @@ If you want to know how to change the first sequence into the second, use
      work.
 
    * `Simple version control recipe
-     <https://code.activestate.com/recipes/576729/>`_ for a small application
+     <https://github.com/ActiveState/code/tree/master/recipes/Python/576729_Simple_Version_Control/recipe-576729.py>`_ for a small application
      built with :class:`SequenceMatcher`.
 
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -19,6 +19,12 @@ An enumeration is a set of symbolic names (members) bound to unique,
 constant values.  Within an enumeration, the members can be compared
 by identity, and the enumeration itself can be iterated over.
 
+.. note:: Case of Enum Members
+
+    Because Enums are used to represent constants we recommend using
+    UPPER_CASE names for enum members, and will be using that style
+    in our examples.
+
 
 Module Contents
 ---------------

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -656,6 +656,13 @@ be combined with them::
     >>> Perm.X | 8
     <Perm.8|X: 9>
 
+:class:`IntFlag` members can also be iterated over::
+
+    >>> list(RW)
+    [<Perm.R: 4>, <Perm.W: 2>]
+
+.. versionadded:: 3.10
+
 
 Flag
 ^^^^
@@ -708,6 +715,14 @@ value::
     <Color.BLACK: 0>
     >>> bool(Color.BLACK)
     False
+
+:class:`Flag` members can also be iterated over::
+
+    >>> purple = Color.RED | Color.BLUE
+    >>> list(purple)
+    [<Color.BLUE: 2>, <Color.RED: 1>]
+
+.. versionadded:: 3.10
 
 .. note::
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -44,6 +44,11 @@ helper, :class:`auto`.
     Base class for creating enumerated constants that are also
     subclasses of :class:`int`.
 
+.. class:: StrEnum
+
+    Base class for creating enumerated constants that are also
+    subclasses of :class:`str`.
+
 .. class:: IntFlag
 
     Base class for creating enumerated constants that can be combined using
@@ -601,6 +606,25 @@ However, they still can't be compared to standard :class:`Enum` enumerations::
     [0, 1]
 
 
+StrEnum
+^^^^^^^
+
+The second variation of :class:`Enum` that is provided is also a subclass of
+:class:`str`.  Members of a :class:`StrEnum` can be compared to strings;
+by extension, string enumerations of different types can also be compared
+to each other.  :class:`StrEnum` exists to help avoid the problem of getting
+an incorrect member::
+
+    >>> class Directions(StrEnum):
+    ...     NORTH = 'north',    # notice the trailing comma
+    ...     SOUTH = 'south'
+
+Before :class:`StrEnum`, ``Directions.NORTH`` would have been the :class:`tuple`
+``('north',)``.
+
+.. versionadded:: 3.10
+
+
 IntFlag
 ^^^^^^^
 
@@ -1130,6 +1154,20 @@ all-uppercase names for members)::
     2
 
 .. versionchanged:: 3.5
+
+
+Creating members that are mixed with other data types
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+When subclassing other data types, such as :class:`int` or :class:`str`, with
+an :class:`Enum`, all values after the `=` are passed to that data type's
+constructor.  For example::
+
+    >>> class MyEnum(IntEnum):
+    ...     example = '11', 16      # '11' will be interpreted as a hexadecimal
+    ...                             # number
+    >>> MyEnum.example
+    <MyEnum.example: 17>
 
 
 Boolean value of ``Enum`` classes and members

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -925,6 +925,32 @@ Using an auto-numbering :meth:`__new__` would look like::
     >>> Color.GREEN.value
     2
 
+To make a more general purpose ``AutoNumber``, add ``*args`` to the signature::
+
+    >>> class AutoNumber(NoValue):
+    ...     def __new__(cls, *args):      # this is the only change from above
+    ...         value = len(cls.__members__) + 1
+    ...         obj = object.__new__(cls)
+    ...         obj._value_ = value
+    ...         return obj
+    ...
+
+Then when you inherit from ``AutoNumber`` you can write your own ``__init__``
+to handle any extra arguments::
+
+    >>> class Swatch(AutoNumber):
+    ...     def __init__(self, pantone='unknown'):
+    ...         self.pantone = pantone
+    ...     AUBURN = '3497'
+    ...     SEA_GREEN = '1246'
+    ...     BLEACHED_CORAL = () # New color, no Pantone code yet!
+    ...
+    >>> Swatch.SEA_GREEN
+    <Swatch.SEA_GREEN: 2>
+    >>> Swatch.SEA_GREEN.pantone
+    '1246'
+    >>> Swatch.BLEACHED_CORAL.pantone
+    'unknown'
 
 .. note::
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -596,7 +596,7 @@ are always available.  They are listed here in alphabetical order.
    input must conform to the following grammar after leading and trailing
    whitespace characters are removed:
 
-   .. productionlist::
+   .. productionlist:: float
       sign: "+" | "-"
       infinity: "Infinity" | "inf"
       nan: "nan"

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -143,7 +143,7 @@ The following utility functions are defined:
 
 .. function:: Int2AP(num)
 
-   Converts an integer into a string representation using characters from the set
+   Converts an integer into a bytes representation using characters from the set
    [``A`` .. ``P``].
 
 
@@ -197,7 +197,7 @@ you want to avoid having an argument string quoted (eg: the *flags* argument to
 
 Each command returns a tuple: ``(type, [data, ...])`` where *type* is usually
 ``'OK'`` or ``'NO'``, and *data* is either the text from the command response,
-or mandated results from the command. Each *data* is either a string, or a
+or mandated results from the command. Each *data* is either a ``bytes``, or a
 tuple. If a tuple, then the first part is the header of the response, and the
 second part contains the data (ie: 'literal' value).
 

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -508,7 +508,7 @@ Background, details, hints, tips and caveats
 --------------------------------------------
 
 The C standard defines the locale as a program-wide property that may be
-relatively expensive to change.  On top of that, some implementation are broken
+relatively expensive to change.  On top of that, some implementations are broken
 in such a way that frequent locale changes may cause core dumps.  This makes the
 locale somewhat painful to use correctly.
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -481,6 +481,11 @@ Trigonometric functions
       Added support for n-dimensional points. Formerly, only the two
       dimensional case was supported.
 
+   .. versionchanged:: 3.10
+      Improved the algorithm's accuracy so that the maximum error is
+      under 1 ulp (unit in the last place).  More typically, the result
+      is almost always correctly rounded to within 1/2 ulp.
+
 
 .. function:: sin(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -123,7 +123,7 @@ Number-theoretic and representation functions
 
    For further discussion and two alternative approaches, see the `ASPN cookbook
    recipes for accurate floating point summation
-   <https://code.activestate.com/recipes/393090/>`_\.
+   <https://github.com/ActiveState/code/tree/master/recipes/Python/393090_Binary_floating_point_summatiaccurate_full/recipe-393090.py>`_\.
 
 
 .. function:: gcd(*integers)

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -57,7 +57,7 @@ from sources provided by the operating system.
 
 
    `Complementary-Multiply-with-Carry recipe
-   <https://code.activestate.com/recipes/576707/>`_ for a compatible alternative
+   <https://github.com/ActiveState/code/tree/master/recipes/Python/576707_Long_period_random_number/recipe-576707.py>`_ for a compatible alternative
    random number generator with a long period and comparatively simple update
    operations.
 

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -75,7 +75,7 @@ Two additional methods are supported:
 
 .. seealso::
 
-   `Persistent dictionary recipe <https://code.activestate.com/recipes/576642/>`_
+   `Persistent dictionary recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/576642_Persistent_dict_multiple_standard_file/recipe-576642.py>`_
    with widely supported storage formats and having the speed of native
    dictionaries.
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -158,9 +158,9 @@ Directory and files operations
 .. function:: copy(src, dst, *, follow_symlinks=True)
 
    Copies the file *src* to the file or directory *dst*.  *src* and *dst*
-   should be strings.  If *dst* specifies a directory, the file will be
-   copied into *dst* using the base filename from *src*.  Returns the
-   path to the newly created file.
+   should be :term:`path-like objects <path-like object>` or strings.  If
+   *dst* specifies a directory, the file will be copied into *dst* using the
+   base filename from *src*.  Returns the path to the newly created file.
 
    If *follow_symlinks* is false, and *src* is a symbolic link,
    *dst* will be created as a symbolic link.  If *follow_symlinks*

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -416,7 +416,7 @@ The :mod:`signal` module defines the following functions:
 
    :data:`SIGKILL` and :data:`SIGSTOP` cannot be blocked.
 
-   .. availability:: Unix.  See the man page :manpage:`sigprocmask(3)` and
+   .. availability:: Unix.  See the man page :manpage:`sigprocmask(2)` and
       :manpage:`pthread_sigmask(3)` for further information.
 
    See also :func:`pause`, :func:`sigpending` and :func:`sigwait`.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1568,33 +1568,6 @@ expression support in the :mod:`re` module).
    interpreted as in slice notation.
 
 
-.. method:: str.removeprefix(prefix, /)
-
-   If the string starts with the *prefix* string, return
-   ``string[len(prefix):]``. Otherwise, return a copy of the original
-   string::
-
-      >>> 'TestHook'.removeprefix('Test')
-      'Hook'
-      >>> 'BaseTestCase'.removeprefix('Test')
-      'BaseTestCase'
-
-   .. versionadded:: 3.9
-
-.. method:: str.removesuffix(suffix, /)
-
-   If the string ends with the *suffix* string and that *suffix* is not empty,
-   return ``string[:-len(suffix)]``. Otherwise, return a copy of the
-   original string::
-
-      >>> 'MiscTests'.removesuffix('Tests')
-      'Misc'
-      >>> 'TmpDirMixin'.removesuffix('Tests')
-      'TmpDirMixin'
-
-   .. versionadded:: 3.9
-
-
 .. method:: str.encode(encoding="utf-8", errors="strict")
 
    Return an encoded version of the string as a bytes object. Default encoding
@@ -1907,6 +1880,34 @@ expression support in the :mod:`re` module).
    containing the part before the separator, the separator itself, and the part
    after the separator.  If the separator is not found, return a 3-tuple containing
    the string itself, followed by two empty strings.
+
+
+.. method:: str.removeprefix(prefix, /)
+
+   If the string starts with the *prefix* string, return
+   ``string[len(prefix):]``. Otherwise, return a copy of the original
+   string::
+
+      >>> 'TestHook'.removeprefix('Test')
+      'Hook'
+      >>> 'BaseTestCase'.removeprefix('Test')
+      'BaseTestCase'
+
+   .. versionadded:: 3.9
+
+
+.. method:: str.removesuffix(suffix, /)
+
+   If the string ends with the *suffix* string and that *suffix* is not empty,
+   return ``string[:-len(suffix)]``. Otherwise, return a copy of the
+   original string::
+
+      >>> 'MiscTests'.removesuffix('Tests')
+      'Misc'
+      >>> 'TmpDirMixin'.removesuffix('Tests')
+      'TmpDirMixin'
+
+   .. versionadded:: 3.9
 
 
 .. method:: str.replace(old, new[, count])

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1404,7 +1404,7 @@ objects that compare equal might have different :attr:`~range.start`,
 
 .. seealso::
 
-   * The `linspace recipe <http://code.activestate.com/recipes/579000/>`_
+   * The `linspace recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/579000_Equallyspaced_numbers_linspace/recipe-579000.py>`_
      shows how to implement a lazy version of range suitable for floating
      point applications.
 

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -205,7 +205,7 @@ literal text, it can be escaped by doubling: ``{{`` and ``}}``.
 
 The grammar for a replacement field is as follows:
 
-   .. productionlist:: sf
+   .. productionlist:: format-string
       replacement_field: "{" [`field_name`] ["!" `conversion`] [":" `format_spec`] "}"
       field_name: arg_name ("." `attribute_name` | "[" `element_index` "]")*
       arg_name: [`identifier` | `digit`+]
@@ -308,7 +308,7 @@ non-empty format specification typically modifies the result.
 
 The general form of a *standard format specifier* is:
 
-.. productionlist::
+.. productionlist:: format-spec
    format_spec: [[`fill`]`align`][`sign`][#][0][`width`][`grouping_option`][.`precision`][`type`]
    fill: <any character>
    align: "<" | ">" | "=" | "^"

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -159,8 +159,8 @@ the :ref:`format-characters` section.
 Note the difference between ``'@'`` and ``'='``: both use native byte order, but
 the size and alignment of the latter is standardized.
 
-The form ``'!'`` is available for those poor souls who claim they can't remember
-whether network byte order is big-endian or little-endian.
+The form ``'!'`` represents the network byte order which is always big-endian
+as defined in `IETF RFC 1700 <IETF RFC 1700_>`_.
 
 There is no way to indicate non-native byte order (force byte-swapping); use the
 appropriate choice of ``'<'`` or ``'>'``.
@@ -467,3 +467,5 @@ The :mod:`struct` module also defines the following type:
 .. _half precision format: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 
 .. _ieee 754 standard: https://en.wikipedia.org/wiki/IEEE_floating_point#IEEE_754-2008
+
+.. _IETF RFC 1700: https://tools.ietf.org/html/rfc1700

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -679,7 +679,7 @@ always available.
    additional garbage collector overhead if the object is managed by the garbage
    collector.
 
-   See `recursive sizeof recipe <https://code.activestate.com/recipes/577504>`_
+   See `recursive sizeof recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/577504_Compute_Memory_footprint_object_its/recipe-577504.py>`_
    for an example of using :func:`getsizeof` recursively to find the size of
    containers and all their contents.
 

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -31,7 +31,7 @@ is recommended to use keyword arguments for clarity.
 
 The module defines the following user-callable items:
 
-.. function:: TemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
+.. function:: TemporaryFile(mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
 
    Return a :term:`file-like object` that can be used as a temporary storage area.
    The file is created securely, using the same rules as :func:`mkstemp`. It will be destroyed as soon
@@ -72,7 +72,7 @@ The module defines the following user-callable items:
       Added *errors* parameter.
 
 
-.. function:: NamedTemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True, *, errors=None)
+.. function:: NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True, *, errors=None)
 
    This function operates exactly as :func:`TemporaryFile` does, except that
    the file is guaranteed to have a visible name in the file system (on
@@ -93,7 +93,7 @@ The module defines the following user-callable items:
       Added *errors* parameter.
 
 
-.. function:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
+.. function:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=-1, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
 
    This function operates exactly as :func:`TemporaryFile` does, except that
    data is spooled in memory until the file size exceeds *max_size*, or

--- a/Doc/library/tkinter.font.rst
+++ b/Doc/library/tkinter.font.rst
@@ -38,8 +38,8 @@ The different font weights and slants are:
        | *family* - font family i.e. Courier, Times
        | *size* - font size
        |     If *size* is positive it is interpreted as size in points.
-       |     If *size* is a negative number its absolute value is treated as
-             as size in pixels.
+       |     If *size* is a negative number its absolute value is treated
+       |     as size in pixels.
        | *weight* - font emphasis (NORMAL, BOLD)
        | *slant* - ROMAN, ITALIC
        | *underline* - font underlining (0 - none, 1 - underline)

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -31,7 +31,7 @@ installed, so you can read the Tcl/Tk documentation specific to that version.
    `TKDocs <http://www.tkdocs.com/>`_
       Extensive tutorial plus friendlier widget pages for some of the widgets.
 
-   `Tkinter 8.5 reference: a GUI for Python <https://web.archive.org/web/20190524140835/https://infohost.nmt.edu/tcc/help/pubs/tkinter/web/index.html>`_
+   `Tkinter 8.5 reference: a GUI for Python <https://www.tkdocs.com/shipman/>`_
       On-line reference material.
 
    `Tkinter docs from effbot <http://effbot.org/tkinterbook/>`_

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1658,6 +1658,20 @@ Introspection helpers
 
    .. versionadded:: 3.8
 
+.. function:: is_typeddict(tp)
+
+   Check if an annotation is a TypedDict class.
+
+   For example::
+        class Film(TypedDict):
+            title: str
+            year: int
+
+        is_typeddict(Film)  # => True
+        is_typeddict(Union[list, str])  # => False
+
+   .. versionadded:: 3.10
+
 .. class:: ForwardRef
 
    A class used for internal typing representation of string forward references.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1660,7 +1660,7 @@ Introspection helpers
 
 .. function:: is_typeddict(tp)
 
-   Check if an annotation is a TypedDict class.
+   Check if a type is a :class:`TypedDict`.
 
    For example::
         class Film(TypedDict):

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -480,8 +480,8 @@ input, output, and error streams.
    rarely used and is not guaranteed by WSGI. On IIS<7, though, the
    setting can only be made on a vhost level, affecting all other script
    mappings, many of which break when exposed to the ``PATH_TRANSLATED`` bug.
-   For this reason IIS<7 is almost never deployed with the fix. (Even IIS7
-   rarely uses it because there is still no UI for it.)
+   For this reason IIS<7 is almost never deployed with the fix (Even IIS7
+   rarely uses it because there is still no UI for it.).
 
    There is no way for CGI code to tell whether the option was set, so a
    separate handler class is provided.  It is used in the same way as

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -44,7 +44,8 @@ executed::
 
 Summarizing:
 
-.. productionlist::
+
+.. productionlist:: python-grammar
    compound_stmt: `if_stmt`
                 : | `while_stmt`
                 : | `for_stmt`
@@ -89,7 +90,7 @@ The :keyword:`!if` statement
 
 The :keyword:`if` statement is used for conditional execution:
 
-.. productionlist::
+.. productionlist:: python-grammar
    if_stmt: "if" `assignment_expression` ":" `suite`
           : ("elif" `assignment_expression` ":" `suite`)*
           : ["else" ":" `suite`]
@@ -115,7 +116,7 @@ The :keyword:`!while` statement
 The :keyword:`while` statement is used for repeated execution as long as an
 expression is true:
 
-.. productionlist::
+.. productionlist:: python-grammar
    while_stmt: "while" `assignment_expression` ":" `suite`
              : ["else" ":" `suite`]
 
@@ -151,7 +152,7 @@ The :keyword:`!for` statement
 The :keyword:`for` statement is used to iterate over the elements of a sequence
 (such as a string, tuple or list) or other iterable object:
 
-.. productionlist::
+.. productionlist:: python-grammar
    for_stmt: "for" `target_list` "in" `expression_list` ":" `suite`
            : ["else" ":" `suite`]
 
@@ -234,7 +235,7 @@ The :keyword:`!try` statement
 The :keyword:`try` statement specifies exception handlers and/or cleanup code
 for a group of statements:
 
-.. productionlist::
+.. productionlist:: python-grammar
    try_stmt: `try1_stmt` | `try2_stmt`
    try1_stmt: "try" ":" `suite`
             : ("except" [`expression` ["as" `identifier`]] ":" `suite`)+
@@ -390,7 +391,7 @@ methods defined by a context manager (see section :ref:`context-managers`).
 This allows common :keyword:`try`...\ :keyword:`except`...\ :keyword:`finally`
 usage patterns to be encapsulated for convenient reuse.
 
-.. productionlist::
+.. productionlist:: python-grammar
    with_stmt: "with" `with_item` ("," `with_item`)* ":" `suite`
    with_item: `expression` ["as" `target`]
 
@@ -503,7 +504,7 @@ Function definitions
 A function definition defines a user-defined function object (see section
 :ref:`types`):
 
-.. productionlist::
+.. productionlist:: python-grammar
    funcdef: [`decorators`] "def" `funcname` "(" [`parameter_list`] ")"
           : ["->" `expression`] ":" `suite`
    decorators: `decorator`+
@@ -670,7 +671,7 @@ Class definitions
 
 A class definition defines a class object (see section :ref:`types`):
 
-.. productionlist::
+.. productionlist:: python-grammar
    classdef: [`decorators`] "class" `classname` [`inheritance`] ":" `suite`
    inheritance: "(" [`argument_list`] ")"
    classname: `identifier`
@@ -762,7 +763,7 @@ Coroutines
 Coroutine function definition
 -----------------------------
 
-.. productionlist::
+.. productionlist:: python-grammar
    async_funcdef: [`decorators`] "async" "def" `funcname` "(" [`parameter_list`] ")"
                 : ["->" `expression`] ":" `suite`
 
@@ -795,7 +796,7 @@ An example of a coroutine function::
 The :keyword:`!async for` statement
 -----------------------------------
 
-.. productionlist::
+.. productionlist:: python-grammar
    async_for_stmt: "async" `for_stmt`
 
 An :term:`asynchronous iterable` is able to call asynchronous code in its
@@ -840,7 +841,7 @@ body of a coroutine function.
 The :keyword:`!async with` statement
 ------------------------------------
 
-.. productionlist::
+.. productionlist:: python-grammar
    async_with_stmt: "async" `with_stmt`
 
 An :term:`asynchronous context manager` is a :term:`context manager` that is

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -13,7 +13,7 @@ This chapter explains the meaning of the elements of expressions in Python.
 be used to describe syntax, not lexical analysis.  When (one alternative of) a
 syntax rule has the form
 
-.. productionlist:: *
+.. productionlist:: python-grammar
    name: `othername`
 
 and no semantics are given, the semantics of this form of ``name`` are the same
@@ -54,7 +54,7 @@ Atoms are the most basic elements of expressions.  The simplest atoms are
 identifiers or literals.  Forms enclosed in parentheses, brackets or braces are
 also categorized syntactically as atoms.  The syntax for atoms is:
 
-.. productionlist::
+.. productionlist:: python-grammar
    atom: `identifier` | `literal` | `enclosure`
    enclosure: `parenth_form` | `list_display` | `dict_display` | `set_display`
             : | `generator_expression` | `yield_atom`
@@ -103,7 +103,7 @@ Literals
 
 Python supports string and bytes literals and various numeric literals:
 
-.. productionlist::
+.. productionlist:: python-grammar
    literal: `stringliteral` | `bytesliteral`
           : | `integer` | `floatnumber` | `imagnumber`
 
@@ -134,7 +134,7 @@ Parenthesized forms
 
 A parenthesized form is an optional expression list enclosed in parentheses:
 
-.. productionlist::
+.. productionlist:: python-grammar
    parenth_form: "(" [`starred_expression`] ")"
 
 A parenthesized expression list yields whatever that expression list yields: if
@@ -177,7 +177,7 @@ called "displays", each of them in two flavors:
 
 Common syntax elements for comprehensions are:
 
-.. productionlist::
+.. productionlist:: python-grammar
    comprehension: `assignment_expression` `comp_for`
    comp_for: ["async"] "for" `target_list` "in" `or_test` [`comp_iter`]
    comp_iter: `comp_for` | `comp_if`
@@ -243,7 +243,7 @@ List displays
 A list display is a possibly empty series of expressions enclosed in square
 brackets:
 
-.. productionlist::
+.. productionlist:: python-grammar
    list_display: "[" [`starred_list` | `comprehension`] "]"
 
 A list display yields a new list object, the contents being specified by either
@@ -267,7 +267,7 @@ Set displays
 A set display is denoted by curly braces and distinguishable from dictionary
 displays by the lack of colons separating keys and values:
 
-.. productionlist::
+.. productionlist:: python-grammar
    set_display: "{" (`starred_list` | `comprehension`) "}"
 
 A set display yields a new mutable set object, the contents being specified by
@@ -296,7 +296,7 @@ Dictionary displays
 A dictionary display is a possibly empty series of key/datum pairs enclosed in
 curly braces:
 
-.. productionlist::
+.. productionlist:: python-grammar
    dict_display: "{" [`key_datum_list` | `dict_comprehension`] "}"
    key_datum_list: `key_datum` ("," `key_datum`)* [","]
    key_datum: `expression` ":" `expression` | "**" `or_expr`
@@ -355,7 +355,7 @@ Generator expressions
 
 A generator expression is a compact generator notation in parentheses:
 
-.. productionlist::
+.. productionlist:: python-grammar
    generator_expression: "(" `expression` `comp_for` ")"
 
 A generator expression yields a new generator object.  Its syntax is the same as
@@ -409,7 +409,7 @@ Yield expressions
    pair: yield; expression
    pair: generator; function
 
-.. productionlist::
+.. productionlist:: python-grammar
    yield_atom: "(" `yield_expression` ")"
    yield_expression: "yield" [`expression_list` | "from" `expression`]
 
@@ -746,7 +746,7 @@ Primaries
 Primaries represent the most tightly bound operations of the language. Their
 syntax is:
 
-.. productionlist::
+.. productionlist:: python-grammar
    primary: `atom` | `attributeref` | `subscription` | `slicing` | `call`
 
 
@@ -761,7 +761,7 @@ Attribute references
 
 An attribute reference is a primary followed by a period and a name:
 
-.. productionlist::
+.. productionlist:: python-grammar
    attributeref: `primary` "." `identifier`
 
 .. index::
@@ -799,7 +799,7 @@ Subscriptions
 A subscription selects an item of a sequence (string, tuple or list) or mapping
 (dictionary) object:
 
-.. productionlist::
+.. productionlist:: python-grammar
    subscription: `primary` "[" `expression_list` "]"
 
 The primary must evaluate to an object that supports subscription (lists or
@@ -855,7 +855,7 @@ A slicing selects a range of items in a sequence object (e.g., a string, tuple
 or list).  Slicings may be used as expressions or as targets in assignment or
 :keyword:`del` statements.  The syntax for a slicing:
 
-.. productionlist::
+.. productionlist:: python-grammar
    slicing: `primary` "[" `slice_list` "]"
    slice_list: `slice_item` ("," `slice_item`)* [","]
    slice_item: `expression` | `proper_slice`
@@ -905,7 +905,7 @@ Calls
 A call calls a callable object (e.g., a :term:`function`) with a possibly empty
 series of :term:`arguments <argument>`:
 
-.. productionlist::
+.. productionlist:: python-grammar
    call: `primary` "(" [`argument_list` [","] | `comprehension`] ")"
    argument_list: `positional_arguments` ["," `starred_and_keywords`]
                 :   ["," `keywords_arguments`]
@@ -1088,7 +1088,7 @@ Await expression
 Suspend the execution of :term:`coroutine` on an :term:`awaitable` object.
 Can only be used inside a :term:`coroutine function`.
 
-.. productionlist::
+.. productionlist:: python-grammar
    await_expr: "await" `primary`
 
 .. versionadded:: 3.5
@@ -1106,7 +1106,7 @@ The power operator
 The power operator binds more tightly than unary operators on its left; it binds
 less tightly than unary operators on its right.  The syntax is:
 
-.. productionlist::
+.. productionlist:: python-grammar
    power: (`await_expr` | `primary`) ["**" `u_expr`]
 
 Thus, in an unparenthesized sequence of power and unary operators, the operators
@@ -1139,7 +1139,7 @@ Unary arithmetic and bitwise operations
 
 All unary arithmetic and bitwise operations have the same priority:
 
-.. productionlist::
+.. productionlist:: python-grammar
    u_expr: `power` | "-" `u_expr` | "+" `u_expr` | "~" `u_expr`
 
 .. index::
@@ -1183,7 +1183,7 @@ that some of these operations also apply to certain non-numeric types.  Apart
 from the power operator, there are only two levels, one for multiplicative
 operators and one for additive operators:
 
-.. productionlist::
+.. productionlist:: python-grammar
    m_expr: `u_expr` | `m_expr` "*" `u_expr` | `m_expr` "@" `m_expr` |
          : `m_expr` "//" `u_expr` | `m_expr` "/" `u_expr` |
          : `m_expr` "%" `u_expr`
@@ -1279,7 +1279,7 @@ Shifting operations
 
 The shifting operations have lower priority than the arithmetic operations:
 
-.. productionlist::
+.. productionlist:: python-grammar
    shift_expr: `a_expr` | `shift_expr` ("<<" | ">>") `a_expr`
 
 These operators accept integers as arguments.  They shift the first argument to
@@ -1300,7 +1300,7 @@ Binary bitwise operations
 
 Each of the three bitwise operations has a different priority level:
 
-.. productionlist::
+.. productionlist:: python-grammar
    and_expr: `shift_expr` | `and_expr` "&" `shift_expr`
    xor_expr: `and_expr` | `xor_expr` "^" `and_expr`
    or_expr: `xor_expr` | `or_expr` "|" `xor_expr`
@@ -1349,7 +1349,7 @@ lower than that of any arithmetic, shifting or bitwise operation.  Also unlike
 C, expressions like ``a < b < c`` have the interpretation that is conventional
 in mathematics:
 
-.. productionlist::
+.. productionlist:: python-grammar
    comparison: `or_expr` (`comp_operator` `or_expr`)*
    comp_operator: "<" | ">" | "==" | ">=" | "<=" | "!="
                 : | "is" ["not"] | ["not"] "in"
@@ -1608,7 +1608,7 @@ Boolean operations
    pair: Conditional; expression
    pair: Boolean; operation
 
-.. productionlist::
+.. productionlist:: python-grammar
    or_test: `and_test` | `or_test` "or" `and_test`
    and_test: `not_test` | `and_test` "and" `not_test`
    not_test: `comparison` | "not" `not_test`
@@ -1647,7 +1647,7 @@ returns a boolean value regardless of the type of its argument
 Assignment expressions
 ======================
 
-.. productionlist::
+.. productionlist:: python-grammar
    assignment_expression: [`identifier` ":="] `expression`
 
 An assignment expression (sometimes also called a "named expression" or
@@ -1683,7 +1683,7 @@ Conditional expressions
    single: if; conditional expression
    single: else; conditional expression
 
-.. productionlist::
+.. productionlist:: python-grammar
    conditional_expression: `or_test` ["if" `or_test` "else" `expression`]
    expression: `conditional_expression` | `lambda_expr`
    expression_nocond: `or_test` | `lambda_expr_nocond`
@@ -1710,7 +1710,7 @@ Lambdas
    pair: anonymous; function
    single: : (colon); lambda expression
 
-.. productionlist::
+.. productionlist:: python-grammar
    lambda_expr: "lambda" [`parameter_list`] ":" `expression`
    lambda_expr_nocond: "lambda" [`parameter_list`] ":" `expression_nocond`
 
@@ -1737,7 +1737,7 @@ Expression lists
    pair: expression; list
    single: , (comma); expression list
 
-.. productionlist::
+.. productionlist:: python-grammar
    expression_list: `expression` ("," `expression`)* [","]
    starred_list: `starred_item` ("," `starred_item`)* [","]
    starred_expression: `expression` | (`starred_item` ",")* [`starred_item`]

--- a/Doc/reference/introduction.rst
+++ b/Doc/reference/introduction.rst
@@ -93,7 +93,7 @@ Notation
 The descriptions of lexical analysis and syntax use a modified BNF grammar
 notation.  This uses the following style of definition:
 
-.. productionlist::
+.. productionlist:: notation
    name: `lc_letter` (`lc_letter` | "_")*
    lc_letter: "a"..."z"
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -296,7 +296,7 @@ Unicode Character Database as included in the :mod:`unicodedata` module.
 
 Identifiers are unlimited in length.  Case is significant.
 
-.. productionlist::
+.. productionlist:: python-grammar
    identifier: `xid_start` `xid_continue`*
    id_start: <all characters in general categories Lu, Ll, Lt, Lm, Lo, Nl, the underscore, and characters with the Other_ID_Start property>
    id_continue: <all characters in `id_start`, plus characters in the categories Mn, Mc, Nd, Pc and others with the Other_ID_Continue property>
@@ -412,7 +412,7 @@ String and Bytes literals
 
 String literals are described by the following lexical definitions:
 
-.. productionlist::
+.. productionlist:: python-grammar
    stringliteral: [`stringprefix`](`shortstring` | `longstring`)
    stringprefix: "r" | "u" | "R" | "U" | "f" | "F"
                : | "fr" | "Fr" | "fR" | "FR" | "rf" | "rF" | "Rf" | "RF"
@@ -424,7 +424,7 @@ String literals are described by the following lexical definitions:
    longstringchar: <any source character except "\">
    stringescapeseq: "\" <any source character>
 
-.. productionlist::
+.. productionlist:: python-grammar
    bytesliteral: `bytesprefix`(`shortbytes` | `longbytes`)
    bytesprefix: "b" | "B" | "br" | "Br" | "bR" | "BR" | "rb" | "rB" | "Rb" | "RB"
    shortbytes: "'" `shortbytesitem`* "'" | '"' `shortbytesitem`* '"'
@@ -659,7 +659,7 @@ Escape sequences are decoded like in ordinary string literals (except when
 a literal is also marked as a raw string).  After decoding, the grammar
 for the contents of the string is:
 
-.. productionlist::
+.. productionlist:: python-grammar
    f_string: (`literal_char` | "{{" | "}}" | `replacement_field`)*
    replacement_field: "{" `f_expression` ["="] ["!" `conversion`] [":" `format_spec`] "}"
    f_expression: (`conditional_expression` | "*" `or_expr`)
@@ -820,7 +820,7 @@ Integer literals
 
 Integer literals are described by the following lexical definitions:
 
-.. productionlist::
+.. productionlist:: python-grammar
    integer: `decinteger` | `bininteger` | `octinteger` | `hexinteger`
    decinteger: `nonzerodigit` (["_"] `digit`)* | "0"+ (["_"] "0")*
    bininteger: "0" ("b" | "B") (["_"] `bindigit`)+
@@ -864,7 +864,7 @@ Floating point literals
 
 Floating point literals are described by the following lexical definitions:
 
-.. productionlist::
+.. productionlist:: python-grammar
    floatnumber: `pointfloat` | `exponentfloat`
    pointfloat: [`digitpart`] `fraction` | `digitpart` "."
    exponentfloat: (`digitpart` | `pointfloat`) `exponent`
@@ -894,7 +894,7 @@ Imaginary literals
 
 Imaginary literals are described by the following lexical definitions:
 
-.. productionlist::
+.. productionlist:: python-grammar
    imagnumber: (`floatnumber` | `digitpart`) ("j" | "J")
 
 An imaginary literal yields a complex number with a real part of 0.0.  Complex

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -11,7 +11,7 @@ A simple statement is comprised within a single logical line. Several simple
 statements may occur on a single line separated by semicolons.  The syntax for
 simple statements is:
 
-.. productionlist::
+.. productionlist:: python-grammar
    simple_stmt: `expression_stmt`
               : | `assert_stmt`
               : | `assignment_stmt`
@@ -46,7 +46,7 @@ result; in Python, procedures return the value ``None``).  Other uses of
 expression statements are allowed and occasionally useful.  The syntax for an
 expression statement is:
 
-.. productionlist::
+.. productionlist:: python-grammar
    expression_stmt: `starred_expression`
 
 An expression statement evaluates the expression list (which may be a single
@@ -82,7 +82,7 @@ Assignment statements
 Assignment statements are used to (re)bind names to values and to modify
 attributes or items of mutable objects:
 
-.. productionlist::
+.. productionlist:: python-grammar
    assignment_stmt: (`target_list` "=")+ (`starred_expression` | `yield_expression`)
    target_list: `target` ("," `target`)* [","]
    target: `identifier`
@@ -280,7 +280,7 @@ Augmented assignment statements
 Augmented assignment is the combination, in a single statement, of a binary
 operation and an assignment statement:
 
-.. productionlist::
+.. productionlist:: python-grammar
    augmented_assignment_stmt: `augtarget` `augop` (`expression_list` | `yield_expression`)
    augtarget: `identifier` | `attributeref` | `subscription` | `slicing`
    augop: "+=" | "-=" | "*=" | "@=" | "/=" | "//=" | "%=" | "**="
@@ -328,7 +328,7 @@ Annotated assignment statements
 :term:`Annotation <variable annotation>` assignment is the combination, in a single
 statement, of a variable or attribute annotation and an optional assignment statement:
 
-.. productionlist::
+.. productionlist:: python-grammar
    annotated_assignment_stmt: `augtarget` ":" `expression`
                             : ["=" (`starred_expression` | `yield_expression`)]
 
@@ -385,7 +385,7 @@ The :keyword:`!assert` statement
 Assert statements are a convenient way to insert debugging assertions into a
 program:
 
-.. productionlist::
+.. productionlist:: python-grammar
    assert_stmt: "assert" `expression` ["," `expression`]
 
 The simple form, ``assert expression``, is equivalent to ::
@@ -425,7 +425,7 @@ The :keyword:`!pass` statement
    pair: null; operation
            pair: null; operation
 
-.. productionlist::
+.. productionlist:: python-grammar
    pass_stmt: "pass"
 
 :keyword:`pass` is a null operation --- when it is executed, nothing happens.
@@ -447,7 +447,7 @@ The :keyword:`!del` statement
    pair: deletion; target
    triple: deletion; target; list
 
-.. productionlist::
+.. productionlist:: python-grammar
    del_stmt: "del" `target_list`
 
 Deletion is recursively defined very similar to the way assignment is defined.
@@ -486,7 +486,7 @@ The :keyword:`!return` statement
    pair: function; definition
    pair: class; definition
 
-.. productionlist::
+.. productionlist:: python-grammar
    return_stmt: "return" [`expression_list`]
 
 :keyword:`return` may only occur syntactically nested in a function definition,
@@ -525,7 +525,7 @@ The :keyword:`!yield` statement
    single: function; generator
    exception: StopIteration
 
-.. productionlist::
+.. productionlist:: python-grammar
    yield_stmt: `yield_expression`
 
 A :keyword:`yield` statement is semantically equivalent to a :ref:`yield
@@ -560,7 +560,7 @@ The :keyword:`!raise` statement
    pair: raising; exception
    single: __traceback__ (exception attribute)
 
-.. productionlist::
+.. productionlist:: python-grammar
    raise_stmt: "raise" [`expression` ["from" `expression`]]
 
 If no expressions are present, :keyword:`raise` re-raises the last exception
@@ -663,7 +663,7 @@ The :keyword:`!break` statement
    statement: while
    pair: loop; statement
 
-.. productionlist::
+.. productionlist:: python-grammar
    break_stmt: "break"
 
 :keyword:`break` may only occur syntactically nested in a :keyword:`for` or
@@ -698,7 +698,7 @@ The :keyword:`!continue` statement
    pair: loop; statement
    keyword: finally
 
-.. productionlist::
+.. productionlist:: python-grammar
    continue_stmt: "continue"
 
 :keyword:`continue` may only occur syntactically nested in a :keyword:`for` or
@@ -725,7 +725,7 @@ The :keyword:`!import` statement
    exception: ImportError
    single: , (comma); import statement
 
-.. productionlist::
+.. productionlist:: python-grammar
    import_stmt: "import" `module` ["as" `identifier`] ("," `module` ["as" `identifier`])*
               : | "from" `relative_module` "import" `identifier` ["as" `identifier`]
               : ("," `identifier` ["as" `identifier`])*
@@ -859,7 +859,7 @@ that introduce incompatible changes to the language.  It allows use of the new
 features on a per-module basis before the release in which the feature becomes
 standard.
 
-.. productionlist:: *
+.. productionlist:: python-grammar
    future_stmt: "from" "__future__" "import" `feature` ["as" `identifier`]
               : ("," `feature` ["as" `identifier`])*
               : | "from" "__future__" "import" "(" `feature` ["as" `identifier`]
@@ -937,7 +937,7 @@ The :keyword:`!global` statement
    triple: global; name; binding
    single: , (comma); identifier list
 
-.. productionlist::
+.. productionlist:: python-grammar
    global_stmt: "global" `identifier` ("," `identifier`)*
 
 The :keyword:`global` statement is a declaration which holds for the entire
@@ -982,7 +982,7 @@ The :keyword:`!nonlocal` statement
 .. index:: statement: nonlocal
    single: , (comma); identifier list
 
-.. productionlist::
+.. productionlist:: python-grammar
    nonlocal_stmt: "nonlocal" `identifier` ("," `identifier`)*
 
 .. XXX add when implemented

--- a/Doc/reference/toplevel_components.rst
+++ b/Doc/reference/toplevel_components.rst
@@ -66,7 +66,7 @@ File input
 
 All input read from non-interactive files has the same form:
 
-.. productionlist::
+.. productionlist:: python-grammar
    file_input: (NEWLINE | `statement`)*
 
 This syntax is used in the following situations:
@@ -85,7 +85,7 @@ Interactive input
 
 Input in interactive mode is parsed using the following grammar:
 
-.. productionlist::
+.. productionlist:: python-grammar
    interactive_input: [`stmt_list`] NEWLINE | `compound_stmt` NEWLINE
 
 Note that a (top-level) compound statement must be followed by a blank line in
@@ -103,5 +103,5 @@ Expression input
 :func:`eval` is used for expression input.  It ignores leading whitespace. The
 string argument to :func:`eval` must have the following form:
 
-.. productionlist::
+.. productionlist:: python-grammar
    eval_input: `expression_list` NEWLINE*

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -1,5 +1,12 @@
-# Requirements for docs build on netlify
-# Pin sphinx to version specified in .travis.yml
-sphinx==2.2.0
+# Requirements to build the Python documentation
+
+# Sphinx version is pinned so that new versions that introduce new warnings
+# won't suddenly cause build failures. Updating the version is fine as long
+# as no warnings are raised by doing so.
+sphinx==3.2.1
+
 blurb
+
+# The theme used by the documentation is stored separately, so we need
+# to install that as well.
 python-docs-theme

--- a/Doc/tools/extensions/peg_highlight.py
+++ b/Doc/tools/extensions/peg_highlight.py
@@ -43,7 +43,7 @@ class PEGLexer(RegexLexer):
             (r"'\W+?'", Text),
             (r'"\W+?"', Text),
         ],
-        "variables": [(_name + _text_ws + "(=)", bygroups(None, None, None),),],
+        "variables": [(_name + _text_ws + r"(\[.*\])?" + _text_ws + "(=)", bygroups(None, None, None, None, None),),],
         "invalids": [
             (r"^(\s+\|\s+invalid_\w+\s*\n)", bygroups(None)),
             (r"^(\s+\|\s+incorrect_\w+\s*\n)", bygroups(None)),

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -31,7 +31,12 @@ from sphinx.util import status_iterator, logging
 from sphinx.util.nodes import split_explicit_title
 from sphinx.writers.text import TextWriter, TextTranslator
 from sphinx.writers.latex import LaTeXTranslator
-from sphinx.domains.python import PyModulelevel, PyClassmember
+
+try:
+    from sphinx.domains.python import PyFunction, PyMethod
+except ImportError:
+    from sphinx.domains.python import PyClassmember as PyMethod
+    from sphinx.domains.python import PyModulelevel as PyFunction
 
 # Support for checking for suspicious markup
 
@@ -271,17 +276,18 @@ class PyDecoratorMixin(object):
         return False
 
 
-class PyDecoratorFunction(PyDecoratorMixin, PyModulelevel):
+class PyDecoratorFunction(PyDecoratorMixin, PyFunction):
     def run(self):
         # a decorator function is a function after all
         self.name = 'py:function'
-        return PyModulelevel.run(self)
+        return PyFunction.run(self)
 
 
-class PyDecoratorMethod(PyDecoratorMixin, PyClassmember):
+# TODO: Use sphinx.domains.python.PyDecoratorMethod when possible
+class PyDecoratorMethod(PyDecoratorMixin, PyMethod):
     def run(self):
         self.name = 'py:method'
-        return PyClassmember.run(self)
+        return PyMethod.run(self)
 
 
 class PyCoroutineMixin(object):
@@ -298,31 +304,31 @@ class PyAwaitableMixin(object):
         return ret
 
 
-class PyCoroutineFunction(PyCoroutineMixin, PyModulelevel):
+class PyCoroutineFunction(PyCoroutineMixin, PyFunction):
     def run(self):
         self.name = 'py:function'
-        return PyModulelevel.run(self)
+        return PyFunction.run(self)
 
 
-class PyCoroutineMethod(PyCoroutineMixin, PyClassmember):
+class PyCoroutineMethod(PyCoroutineMixin, PyMethod):
     def run(self):
         self.name = 'py:method'
-        return PyClassmember.run(self)
+        return PyMethod.run(self)
 
 
-class PyAwaitableFunction(PyAwaitableMixin, PyClassmember):
+class PyAwaitableFunction(PyAwaitableMixin, PyFunction):
     def run(self):
         self.name = 'py:function'
-        return PyClassmember.run(self)
+        return PyFunction.run(self)
 
 
-class PyAwaitableMethod(PyAwaitableMixin, PyClassmember):
+class PyAwaitableMethod(PyAwaitableMixin, PyMethod):
     def run(self):
         self.name = 'py:method'
-        return PyClassmember.run(self)
+        return PyMethod.run(self)
 
 
-class PyAbstractMethod(PyClassmember):
+class PyAbstractMethod(PyMethod):
 
     def handle_signature(self, sig, signode):
         ret = super(PyAbstractMethod, self).handle_signature(sig, signode)
@@ -332,7 +338,7 @@ class PyAbstractMethod(PyClassmember):
 
     def run(self):
         self.name = 'py:method'
-        return PyClassmember.run(self)
+        return PyMethod.run(self)
 
 
 # Support for documenting version of removal in deprecations

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -210,15 +210,15 @@ iteration of the loop::
     ...     if num % 2 == 0:
     ...         print("Found an even number", num)
     ...         continue
-    ...     print("Found a number", num)
+    ...     print("Found an odd number", num)
     Found an even number 2
-    Found a number 3
+    Found an odd number 3
     Found an even number 4
-    Found a number 5
+    Found an odd number 5
     Found an even number 6
-    Found a number 7
+    Found an odd number 7
     Found an even number 8
-    Found a number 9
+    Found an odd number 9
 
 .. _tut-pass:
 

--- a/Doc/tutorial/whatnow.rst
+++ b/Doc/tutorial/whatnow.rst
@@ -43,7 +43,7 @@ More Python resources:
   for download.  Once you begin releasing code, you can register it here so that
   others can find it.
 
-* https://code.activestate.com/recipes/langs/python/: The Python Cookbook is a
+* https://github.com/ActiveState/code/tree/master/recipes/Python: The Python Cookbook is a
   sizable collection of code examples, larger modules, and useful scripts.
   Particularly notable contributions are collected in a book also titled Python
   Cookbook (O'Reilly & Associates, ISBN 0-596-00797-3.)

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -145,6 +145,13 @@ Add :data:`sys.orig_argv` attribute: the list of the original command line
 arguments passed to the Python executable.
 (Contributed by Victor Stinner in :issue:`23427`.)
 
+unittest
+--------
+
+Add new method :meth:`~unittest.TestCase.assertNoLogs` to complement the
+existing :meth:`~unittest.TestCase.assertLogs`. (Contributed by Kit Yan Choi
+in :issue:`39385`.)
+
 xml
 ---
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -781,8 +781,8 @@ functools
 
   (Contributed by Raymond Hettinger and incorporating design ideas from Jim
   Baker, Miki Tebeka, and Nick Coghlan; see `recipe 498245
-  <https://code.activestate.com/recipes/498245>`_\, `recipe 577479
-  <https://code.activestate.com/recipes/577479>`_\, :issue:`10586`, and
+  <https://github.com/ActiveState/code/tree/master/recipes/Python/498245_LRU_and_LFU_cache_decorators/recipe-498245.py>`_\, `recipe 577479
+  <https://github.com/ActiveState/code/tree/master/recipes/Python/577479_Simple_caching_decorator/recipe-577479.py>`_\, :issue:`10586`, and
   :issue:`10593`.)
 
 * The :func:`functools.wraps` decorator now adds a :attr:`__wrapped__` attribute

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -887,7 +887,7 @@ Removed
   deprecated since 2006, and only returning ``False`` when it's called.
   (Contributed by Batuhan Taskaya in :issue:`40208`)
 
-* The :meth:`asyncio.Task.current_task` and :meth:`asyncio.Task.all_tasks` have
+* The :meth:`asyncio.Task.current_task` and :meth:`asyncio.Task.all_tasks`
   have been removed. They were deprecated since Python 3.7 and you can use
   :func:`asyncio.current_task` and :func:`asyncio.all_tasks` instead.
   (Contributed by Rémi Lapeyre in :issue:`40967`)

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -708,6 +708,11 @@ Deprecated
   users can leverage the Abstract Syntax Tree (AST) generation and compilation
   stage, using the :mod:`ast` module.
 
+* The Public C API functions :c:func:`PyParser_SimpleParseStringFlags`,
+  :c:func:`PyParser_SimpleParseStringFlagsFilename`,
+  :c:func:`PyParser_SimpleParseFileFlags` and :c:func:`PyNode_Compile`
+  are deprecated and will be removed in Python 3.10 together with the old parser.
+
 * Using :data:`NotImplemented` in a boolean context has been deprecated,
   as it is almost exclusively the result of incorrect rich comparator
   implementations. It will be made a :exc:`TypeError` in a future version

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -887,6 +887,12 @@ Removed
   :func:`asyncio.current_task` and :func:`asyncio.all_tasks` instead.
   (Contributed by Rémi Lapeyre in :issue:`40967`)
 
+* The ``unescape()`` method in the :class:`html.parser.HTMLParser` class
+  has been removed (it was deprecated since Python 3.4).  :func:`html.unescape`
+  should be used for converting character references to the corresponding
+  unicode characters.
+
+
 Porting to Python 3.9
 =====================
 

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -34,27 +34,27 @@ func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression NEWLINE* ENDMA
 fstring[expr_ty]: star_expressions
 
 # type_expressions allow */** but ignore them
-type_expressions[asdl_seq*]:
+type_expressions[asdl_expr_seq*]:
     | a=','.expression+ ',' '*' b=expression ',' '**' c=expression {
-        _PyPegen_seq_append_to_end(p, CHECK(_PyPegen_seq_append_to_end(p, a, b)), c) }
-    | a=','.expression+ ',' '*' b=expression { _PyPegen_seq_append_to_end(p, a, b) }
-    | a=','.expression+ ',' '**' b=expression { _PyPegen_seq_append_to_end(p, a, b) }
+        (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, CHECK(_PyPegen_seq_append_to_end(p, a, b)), c) }
+    | a=','.expression+ ',' '*' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, a, b) }
+    | a=','.expression+ ',' '**' b=expression { (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, a, b) }
     | '*' a=expression ',' '**' b=expression {
-        _PyPegen_seq_append_to_end(p, CHECK(_PyPegen_singleton_seq(p, a)), b) }
-    | '*' a=expression { _PyPegen_singleton_seq(p, a) }
-    | '**' a=expression { _PyPegen_singleton_seq(p, a) }
-    | ','.expression+
+        (asdl_expr_seq*)_PyPegen_seq_append_to_end(p, CHECK(_PyPegen_singleton_seq(p, a)), b) }
+    | '*' a=expression { (asdl_expr_seq*)_PyPegen_singleton_seq(p, a) }
+    | '**' a=expression { (asdl_expr_seq*)_PyPegen_singleton_seq(p, a) }
+    | a[asdl_expr_seq*]=','.expression+ {a}
 
-statements[asdl_seq*]: a=statement+ { _PyPegen_seq_flatten(p, a) }
-statement[asdl_seq*]: a=compound_stmt { _PyPegen_singleton_seq(p, a) } | simple_stmt
-statement_newline[asdl_seq*]:
-    | a=compound_stmt NEWLINE { _PyPegen_singleton_seq(p, a) }
+statements[asdl_stmt_seq*]: a=statement+ { (asdl_stmt_seq*)_PyPegen_seq_flatten(p, a) }
+statement[asdl_stmt_seq*]: a=compound_stmt { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, a) } | a[asdl_stmt_seq*]=simple_stmt { a }
+statement_newline[asdl_stmt_seq*]:
+    | a=compound_stmt NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, a) }
     | simple_stmt
-    | NEWLINE { _PyPegen_singleton_seq(p, CHECK(_Py_Pass(EXTRA))) }
+    | NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, CHECK(_Py_Pass(EXTRA))) }
     | ENDMARKER { _PyPegen_interactive_exit(p) }
-simple_stmt[asdl_seq*]:
-    | a=small_stmt !';' NEWLINE { _PyPegen_singleton_seq(p, a) } # Not needed, there for speedup
-    | a=';'.small_stmt+ [';'] NEWLINE { a }
+simple_stmt[asdl_stmt_seq*]:
+    | a=small_stmt !';' NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, a) } # Not needed, there for speedup
+    | a[asdl_stmt_seq*]=';'.small_stmt+ [';'] NEWLINE { a }
 # NOTE: assignment MUST precede expression, else parsing a simple assignment
 # will throw a SyntaxError.
 small_stmt[stmt_ty] (memo):
@@ -91,7 +91,7 @@ assignment[stmt_ty]:
     | a=('(' b=single_target ')' { b }
          | single_subscript_attribute_target) ':' b=expression c=['=' d=annotated_rhs { d }] {
         CHECK_VERSION(6, "Variable annotations syntax is", _Py_AnnAssign(a, b, c, 0, EXTRA)) }
-    | a=(z=star_targets '=' { z })+ b=(yield_expr | star_expressions) !'=' tc=[TYPE_COMMENT] {
+    | a[asdl_expr_seq*]=(z=star_targets '=' { z })+ b=(yield_expr | star_expressions) !'=' tc=[TYPE_COMMENT] {
          _Py_Assign(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | a=single_target b=augassign ~ c=(yield_expr | star_expressions) {
          _Py_AugAssign(a, b->kind, c, EXTRA) }
@@ -112,9 +112,9 @@ augassign[AugOperator*]:
     | '**=' { _PyPegen_augoperator(p, Pow) }
     | '//=' { _PyPegen_augoperator(p, FloorDiv) }
 
-global_stmt[stmt_ty]: 'global' a=','.NAME+ {
+global_stmt[stmt_ty]: 'global' a[asdl_expr_seq*]=','.NAME+ {
     _Py_Global(CHECK(_PyPegen_map_names_to_ids(p, a)), EXTRA) }
-nonlocal_stmt[stmt_ty]: 'nonlocal' a=','.NAME+ {
+nonlocal_stmt[stmt_ty]: 'nonlocal' a[asdl_expr_seq*]=','.NAME+ {
     _Py_Nonlocal(CHECK(_PyPegen_map_names_to_ids(p, a)), EXTRA) }
 
 yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
@@ -133,19 +133,19 @@ import_from[stmt_ty]:
         _Py_ImportFrom(b->v.Name.id, c, _PyPegen_seq_count_dots(a), EXTRA) }
     | 'from' a=('.' | '...')+ 'import' b=import_from_targets {
         _Py_ImportFrom(NULL, b, _PyPegen_seq_count_dots(a), EXTRA) }
-import_from_targets[asdl_seq*]:
+import_from_targets[asdl_alias_seq*]:
     | '(' a=import_from_as_names [','] ')' { a }
     | import_from_as_names !','
-    | '*' { _PyPegen_singleton_seq(p, CHECK(_PyPegen_alias_for_star(p))) }
+    | '*' { (asdl_alias_seq*)_PyPegen_singleton_seq(p, CHECK(_PyPegen_alias_for_star(p))) }
     | invalid_import_from_targets
-import_from_as_names[asdl_seq*]:
-    | a=','.import_from_as_name+ { a }
+import_from_as_names[asdl_alias_seq*]:
+    | a[asdl_alias_seq*]=','.import_from_as_name+ { a }
 import_from_as_name[alias_ty]:
     | a=NAME b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
                                                (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                p->arena) }
-dotted_as_names[asdl_seq*]:
-    | a=','.dotted_as_name+ { a }
+dotted_as_names[asdl_alias_seq*]:
+    | a[asdl_alias_seq*]=','.dotted_as_name+ { a }
 dotted_as_name[alias_ty]:
     | a=dotted_name b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
                                                       (b) ? ((expr_ty) b)->v.Name.id : NULL,
@@ -155,12 +155,12 @@ dotted_name[expr_ty]:
     | NAME
 
 if_stmt[stmt_ty]:
-    | 'if' a=named_expression ':' b=block c=elif_stmt { _Py_If(a, b, CHECK(_PyPegen_singleton_seq(p, c)), EXTRA) }
+    | 'if' a=named_expression ':' b=block c=elif_stmt { _Py_If(a, b, CHECK((asdl_stmt_seq*)_PyPegen_singleton_seq(p, c)), EXTRA) }
     | 'if' a=named_expression ':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
 elif_stmt[stmt_ty]:
     | 'elif' a=named_expression ':' b=block c=elif_stmt { _Py_If(a, b, CHECK(_PyPegen_singleton_seq(p, c)), EXTRA) }
     | 'elif' a=named_expression ':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
-else_block[asdl_seq*]: 'else' ':' b=block { b }
+else_block[asdl_stmt_seq*]: 'else' ':' b=block { b }
 
 while_stmt[stmt_ty]:
     | 'while' a=named_expression ':' b=block c=[else_block] { _Py_While(a, b, c, EXTRA) }
@@ -173,13 +173,13 @@ for_stmt[stmt_ty]:
     | invalid_for_target
 
 with_stmt[stmt_ty]:
-    | 'with' '(' a=','.with_item+ ','? ')' ':' b=block {
+    | 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
         _Py_With(a, b, NULL, EXTRA) }
-    | 'with' a=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
+    | 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
         _Py_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
-    | ASYNC 'with' '(' a=','.with_item+ ','? ')' ':' b=block {
+    | ASYNC 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
        CHECK_VERSION(5, "Async with statements are", _Py_AsyncWith(a, b, NULL, EXTRA)) }
-    | ASYNC 'with' a=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
+    | ASYNC 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
        CHECK_VERSION(5, "Async with statements are", _Py_AsyncWith(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
 with_item[withitem_ty]:
     | e=expression 'as' t=target &(',' | ')' | ':') { _Py_withitem(e, t, p->arena) }
@@ -188,12 +188,12 @@ with_item[withitem_ty]:
 
 try_stmt[stmt_ty]:
     | 'try' ':' b=block f=finally_block { _Py_Try(b, NULL, NULL, f, EXTRA) }
-    | 'try' ':' b=block ex=except_block+ el=[else_block] f=[finally_block] { _Py_Try(b, ex, el, f, EXTRA) }
+    | 'try' ':' b=block ex[asdl_excepthandler_seq*]=except_block+ el=[else_block] f=[finally_block] { _Py_Try(b, ex, el, f, EXTRA) }
 except_block[excepthandler_ty]:
     | 'except' e=expression t=['as' z=NAME { z }] ':' b=block {
         _Py_ExceptHandler(e, (t) ? ((expr_ty) t)->v.Name.id : NULL, b, EXTRA) }
     | 'except' ':' b=block { _Py_ExceptHandler(NULL, NULL, b, EXTRA) }
-finally_block[asdl_seq*]: 'finally' ':' a=block { a }
+finally_block[asdl_stmt_seq*]: 'finally' ':' a=block { a }
 
 return_stmt[stmt_ty]:
     | 'return' a=[star_expressions] { _Py_Return(a, EXTRA) }
@@ -229,11 +229,11 @@ params[arguments_ty]:
     | parameters
 
 parameters[arguments_ty]:
-    | a=slash_no_default b=param_no_default* c=param_with_default* d=[star_etc] {
+    | a=slash_no_default b[asdl_arg_seq*]=param_no_default* c=param_with_default* d=[star_etc] {
         _PyPegen_make_arguments(p, a, NULL, b, c, d) }
     | a=slash_with_default b=param_with_default* c=[star_etc] {
         _PyPegen_make_arguments(p, NULL, a, NULL, b, c) }
-    | a=param_no_default+ b=param_with_default* c=[star_etc] {
+    | a[asdl_arg_seq*]=param_no_default+ b=param_with_default* c=[star_etc] {
         _PyPegen_make_arguments(p, NULL, NULL, a, b, c) }
     | a=param_with_default+ b=[star_etc] { _PyPegen_make_arguments(p, NULL, NULL, NULL, a, b)}
     | a=star_etc { _PyPegen_make_arguments(p, NULL, NULL, NULL, NULL, a) }
@@ -241,12 +241,12 @@ parameters[arguments_ty]:
 # Some duplication here because we can't write (',' | &')'),
 # which is because we don't support empty alternatives (yet).
 #
-slash_no_default[asdl_seq*]:
-    | a=param_no_default+ '/' ',' { a }
-    | a=param_no_default+ '/' &')' { a }
+slash_no_default[asdl_arg_seq*]:
+    | a[asdl_arg_seq*]=param_no_default+ '/' ',' { a }
+    | a[asdl_arg_seq*]=param_no_default+ '/' &')' { a }
 slash_with_default[SlashWithDefault*]:
-    | a=param_no_default* b=param_with_default+ '/' ',' { _PyPegen_slash_with_default(p, a, b) }
-    | a=param_no_default* b=param_with_default+ '/' &')' { _PyPegen_slash_with_default(p, a, b) }
+    | a=param_no_default* b=param_with_default+ '/' ',' { _PyPegen_slash_with_default(p, (asdl_arg_seq *)a, b) }
+    | a=param_no_default* b=param_with_default+ '/' &')' { _PyPegen_slash_with_default(p, (asdl_arg_seq *)a, b) }
 
 star_etc[StarEtc*]:
     | '*' a=param_no_default b=param_maybe_default* c=[kwds] {
@@ -284,7 +284,7 @@ param[arg_ty]: a=NAME b=annotation? { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
 annotation[expr_ty]: ':' a=expression { a }
 default[expr_ty]: '=' a=expression { a }
 
-decorators[asdl_seq*]: a=('@' f=named_expression NEWLINE { f })+ { a }
+decorators[asdl_expr_seq*]: a[asdl_expr_seq*]=('@' f=named_expression NEWLINE { f })+ { a }
 
 class_def[stmt_ty]:
     | a=decorators b=class_def_raw { _PyPegen_class_def_decorators(p, a, b) }
@@ -296,12 +296,12 @@ class_def_raw[stmt_ty]:
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
 
-block[asdl_seq*] (memo):
+block[asdl_stmt_seq*] (memo):
     | NEWLINE INDENT a=statements DEDENT { a }
     | simple_stmt
     | invalid_block
 
-expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
+expressions_list[asdl_expr_seq*]: a[asdl_expr_seq*]=','.star_expression+ [','] { a }
 star_expressions[expr_ty]:
     | a=star_expression b=(',' c=star_expression { c })+ [','] {
         _Py_Tuple(CHECK(_PyPegen_seq_insert_in_front(p, a, b)), Load, EXTRA) }
@@ -311,7 +311,7 @@ star_expression[expr_ty] (memo):
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | expression
 
-star_named_expressions[asdl_seq*]: a=','.star_named_expression+ [','] { a }
+star_named_expressions[asdl_expr_seq*]: a[asdl_expr_seq*]=','.star_named_expression+ [','] { a }
 star_named_expression[expr_ty]:
     | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
     | named_expression
@@ -344,21 +344,21 @@ lambda_params[arguments_ty]:
 # a colon, not a close parenthesis.  (For more, see parameters above.)
 #
 lambda_parameters[arguments_ty]:
-    | a=lambda_slash_no_default b=lambda_param_no_default* c=lambda_param_with_default* d=[lambda_star_etc] {
+    | a=lambda_slash_no_default b[asdl_arg_seq*]=lambda_param_no_default* c=lambda_param_with_default* d=[lambda_star_etc] {
         _PyPegen_make_arguments(p, a, NULL, b, c, d) }
     | a=lambda_slash_with_default b=lambda_param_with_default* c=[lambda_star_etc] {
         _PyPegen_make_arguments(p, NULL, a, NULL, b, c) }
-    | a=lambda_param_no_default+ b=lambda_param_with_default* c=[lambda_star_etc] {
+    | a[asdl_arg_seq*]=lambda_param_no_default+ b=lambda_param_with_default* c=[lambda_star_etc] {
         _PyPegen_make_arguments(p, NULL, NULL, a, b, c) }
     | a=lambda_param_with_default+ b=[lambda_star_etc] { _PyPegen_make_arguments(p, NULL, NULL, NULL, a, b)}
     | a=lambda_star_etc { _PyPegen_make_arguments(p, NULL, NULL, NULL, NULL, a) }
 
-lambda_slash_no_default[asdl_seq*]:
-    | a=lambda_param_no_default+ '/' ',' { a }
-    | a=lambda_param_no_default+ '/' &':' { a }
+lambda_slash_no_default[asdl_arg_seq*]:
+    | a[asdl_arg_seq*]=lambda_param_no_default+ '/' ',' { a }
+    | a[asdl_arg_seq*]=lambda_param_no_default+ '/' &':' { a }
 lambda_slash_with_default[SlashWithDefault*]:
-    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' ',' { _PyPegen_slash_with_default(p, a, b) }
-    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' &':' { _PyPegen_slash_with_default(p, a, b) }
+    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' ',' { _PyPegen_slash_with_default(p, (asdl_arg_seq *)a, b) }
+    | a=lambda_param_no_default* b=lambda_param_with_default+ '/' &':' { _PyPegen_slash_with_default(p, (asdl_arg_seq *)a, b) }
 
 lambda_star_etc[StarEtc*]:
     | '*' a=lambda_param_no_default b=lambda_param_maybe_default* c=[lambda_kwds] {
@@ -472,7 +472,7 @@ primary[expr_ty]:
 
 slices[expr_ty]:
     | a=slice !',' { a }
-    | a=','.slice+ [','] { _Py_Tuple(a, Load, EXTRA) }
+    | a[asdl_expr_seq*]=','.slice+ [','] { _Py_Tuple(a, Load, EXTRA) }
 slice[expr_ty]:
     | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _Py_Slice(a, b, c, EXTRA) }
     | a=expression { a }
@@ -518,12 +518,12 @@ double_starred_kvpair[KeyValuePair*]:
     | '**' a=bitwise_or { _PyPegen_key_value_pair(p, NULL, a) }
     | kvpair
 kvpair[KeyValuePair*]: a=expression ':' b=expression { _PyPegen_key_value_pair(p, a, b) }
-for_if_clauses[asdl_seq*]:
-    | for_if_clause+
+for_if_clauses[asdl_comprehension_seq*]:
+    | a[asdl_comprehension_seq*]=for_if_clause+ { a }
 for_if_clause[comprehension_ty]:
-    | ASYNC 'for' a=star_targets 'in' ~ b=disjunction c=('if' z=disjunction { z })* {
+    | ASYNC 'for' a=star_targets 'in' ~ b=disjunction c[asdl_expr_seq*]=('if' z=disjunction { z })* {
         CHECK_VERSION(6, "Async comprehensions are", _Py_comprehension(a, b, c, 1, p->arena)) }
-    | 'for' a=star_targets 'in' ~ b=disjunction c=('if' z=disjunction { z })* {
+    | 'for' a=star_targets 'in' ~ b=disjunction c[asdl_expr_seq*]=('if' z=disjunction { z })* {
         _Py_comprehension(a, b, c, 0, p->arena) }
     | invalid_for_target
 
@@ -535,7 +535,7 @@ arguments[expr_ty] (memo):
     | a=args [','] &')' { a }
     | incorrect_arguments
 args[expr_ty]:
-    | a=','.(starred_expression | named_expression !'=')+ b=[',' k=kwargs {k}] { _PyPegen_collect_call_seqs(p, a, b, EXTRA) }
+    | a[asdl_expr_seq*]=','.(starred_expression | named_expression !'=')+ b=[',' k=kwargs {k}] { _PyPegen_collect_call_seqs(p, a, b, EXTRA) }
     | a=kwargs { _Py_Call(_PyPegen_dummy_name(p),
                           CHECK_NULL_ALLOWED(_PyPegen_seq_extract_starred_exprs(p, a)),
                           CHECK_NULL_ALLOWED(_PyPegen_seq_delete_starred_exprs(p, a)),
@@ -562,7 +562,7 @@ star_targets[expr_ty]:
     | a=star_target !',' { a }
     | a=star_target b=(',' c=star_target { c })* [','] {
         _Py_Tuple(CHECK(_PyPegen_seq_insert_in_front(p, a, b)), Store, EXTRA) }
-star_targets_seq[asdl_seq*]: a=','.star_target+ [','] { a }
+star_targets_seq[asdl_expr_seq*]: a[asdl_expr_seq*]=','.star_target+ [','] { a }
 star_target[expr_ty] (memo):
     | '*' a=(!'*' star_target) {
         _Py_Starred(CHECK(_PyPegen_set_expr_context(p, a, Store)), Store, EXTRA) }
@@ -583,7 +583,7 @@ single_subscript_attribute_target[expr_ty]:
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary '[' b=slices ']' !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
 
-del_targets[asdl_seq*]: a=','.del_target+ [','] { a }
+del_targets[asdl_expr_seq*]: a[asdl_expr_seq*]=','.del_target+ [','] { a }
 del_target[expr_ty] (memo):
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Del, EXTRA) }
     | a=t_primary '[' b=slices ']' !t_lookahead { _Py_Subscript(a, b, Del, EXTRA) }
@@ -594,7 +594,7 @@ del_t_atom[expr_ty]:
     | '(' a=[del_targets] ')' { _Py_Tuple(a, Del, EXTRA) }
     | '[' a=[del_targets] ']' { _Py_List(a, Del, EXTRA) }
 
-targets[asdl_seq*]: a=','.target+ [','] { a }
+targets[asdl_expr_seq*]: a[asdl_expr_seq*]=','.target+ [','] { a }
 target[expr_ty] (memo):
     | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
     | a=t_primary '[' b=slices ']' !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }

--- a/Include/Python-ast.h
+++ b/Include/Python-ast.h
@@ -47,18 +47,99 @@ typedef struct _withitem *withitem_ty;
 typedef struct _type_ignore *type_ignore_ty;
 
 
+typedef struct {
+    _ASDL_SEQ_HEAD
+    mod_ty typed_elements[1];
+} asdl_mod_seq;
+
+asdl_mod_seq *_Py_asdl_mod_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    stmt_ty typed_elements[1];
+} asdl_stmt_seq;
+
+asdl_stmt_seq *_Py_asdl_stmt_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    expr_ty typed_elements[1];
+} asdl_expr_seq;
+
+asdl_expr_seq *_Py_asdl_expr_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    comprehension_ty typed_elements[1];
+} asdl_comprehension_seq;
+
+asdl_comprehension_seq *_Py_asdl_comprehension_seq_new(Py_ssize_t size, PyArena
+                                                       *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    excepthandler_ty typed_elements[1];
+} asdl_excepthandler_seq;
+
+asdl_excepthandler_seq *_Py_asdl_excepthandler_seq_new(Py_ssize_t size, PyArena
+                                                       *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    arguments_ty typed_elements[1];
+} asdl_arguments_seq;
+
+asdl_arguments_seq *_Py_asdl_arguments_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    arg_ty typed_elements[1];
+} asdl_arg_seq;
+
+asdl_arg_seq *_Py_asdl_arg_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    keyword_ty typed_elements[1];
+} asdl_keyword_seq;
+
+asdl_keyword_seq *_Py_asdl_keyword_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    alias_ty typed_elements[1];
+} asdl_alias_seq;
+
+asdl_alias_seq *_Py_asdl_alias_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    withitem_ty typed_elements[1];
+} asdl_withitem_seq;
+
+asdl_withitem_seq *_Py_asdl_withitem_seq_new(Py_ssize_t size, PyArena *arena);
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    type_ignore_ty typed_elements[1];
+} asdl_type_ignore_seq;
+
+asdl_type_ignore_seq *_Py_asdl_type_ignore_seq_new(Py_ssize_t size, PyArena
+                                                   *arena);
+
+
 enum _mod_kind {Module_kind=1, Interactive_kind=2, Expression_kind=3,
                  FunctionType_kind=4};
 struct _mod {
     enum _mod_kind kind;
     union {
         struct {
-            asdl_seq *body;
-            asdl_seq *type_ignores;
+            asdl_stmt_seq *body;
+            asdl_type_ignore_seq *type_ignores;
         } Module;
 
         struct {
-            asdl_seq *body;
+            asdl_stmt_seq *body;
         } Interactive;
 
         struct {
@@ -66,7 +147,7 @@ struct _mod {
         } Expression;
 
         struct {
-            asdl_seq *argtypes;
+            asdl_expr_seq *argtypes;
             expr_ty returns;
         } FunctionType;
 
@@ -87,8 +168,8 @@ struct _stmt {
         struct {
             identifier name;
             arguments_ty args;
-            asdl_seq *body;
-            asdl_seq *decorator_list;
+            asdl_stmt_seq *body;
+            asdl_expr_seq *decorator_list;
             expr_ty returns;
             string type_comment;
         } FunctionDef;
@@ -96,18 +177,18 @@ struct _stmt {
         struct {
             identifier name;
             arguments_ty args;
-            asdl_seq *body;
-            asdl_seq *decorator_list;
+            asdl_stmt_seq *body;
+            asdl_expr_seq *decorator_list;
             expr_ty returns;
             string type_comment;
         } AsyncFunctionDef;
 
         struct {
             identifier name;
-            asdl_seq *bases;
-            asdl_seq *keywords;
-            asdl_seq *body;
-            asdl_seq *decorator_list;
+            asdl_expr_seq *bases;
+            asdl_keyword_seq *keywords;
+            asdl_stmt_seq *body;
+            asdl_expr_seq *decorator_list;
         } ClassDef;
 
         struct {
@@ -115,11 +196,11 @@ struct _stmt {
         } Return;
 
         struct {
-            asdl_seq *targets;
+            asdl_expr_seq *targets;
         } Delete;
 
         struct {
-            asdl_seq *targets;
+            asdl_expr_seq *targets;
             expr_ty value;
             string type_comment;
         } Assign;
@@ -140,40 +221,40 @@ struct _stmt {
         struct {
             expr_ty target;
             expr_ty iter;
-            asdl_seq *body;
-            asdl_seq *orelse;
+            asdl_stmt_seq *body;
+            asdl_stmt_seq *orelse;
             string type_comment;
         } For;
 
         struct {
             expr_ty target;
             expr_ty iter;
-            asdl_seq *body;
-            asdl_seq *orelse;
+            asdl_stmt_seq *body;
+            asdl_stmt_seq *orelse;
             string type_comment;
         } AsyncFor;
 
         struct {
             expr_ty test;
-            asdl_seq *body;
-            asdl_seq *orelse;
+            asdl_stmt_seq *body;
+            asdl_stmt_seq *orelse;
         } While;
 
         struct {
             expr_ty test;
-            asdl_seq *body;
-            asdl_seq *orelse;
+            asdl_stmt_seq *body;
+            asdl_stmt_seq *orelse;
         } If;
 
         struct {
-            asdl_seq *items;
-            asdl_seq *body;
+            asdl_withitem_seq *items;
+            asdl_stmt_seq *body;
             string type_comment;
         } With;
 
         struct {
-            asdl_seq *items;
-            asdl_seq *body;
+            asdl_withitem_seq *items;
+            asdl_stmt_seq *body;
             string type_comment;
         } AsyncWith;
 
@@ -183,10 +264,10 @@ struct _stmt {
         } Raise;
 
         struct {
-            asdl_seq *body;
-            asdl_seq *handlers;
-            asdl_seq *orelse;
-            asdl_seq *finalbody;
+            asdl_stmt_seq *body;
+            asdl_excepthandler_seq *handlers;
+            asdl_stmt_seq *orelse;
+            asdl_stmt_seq *finalbody;
         } Try;
 
         struct {
@@ -195,21 +276,21 @@ struct _stmt {
         } Assert;
 
         struct {
-            asdl_seq *names;
+            asdl_alias_seq *names;
         } Import;
 
         struct {
             identifier module;
-            asdl_seq *names;
+            asdl_alias_seq *names;
             int level;
         } ImportFrom;
 
         struct {
-            asdl_seq *names;
+            asdl_identifier_seq *names;
         } Global;
 
         struct {
-            asdl_seq *names;
+            asdl_identifier_seq *names;
         } Nonlocal;
 
         struct {
@@ -236,7 +317,7 @@ struct _expr {
     union {
         struct {
             boolop_ty op;
-            asdl_seq *values;
+            asdl_expr_seq *values;
         } BoolOp;
 
         struct {
@@ -267,33 +348,33 @@ struct _expr {
         } IfExp;
 
         struct {
-            asdl_seq *keys;
-            asdl_seq *values;
+            asdl_expr_seq *keys;
+            asdl_expr_seq *values;
         } Dict;
 
         struct {
-            asdl_seq *elts;
+            asdl_expr_seq *elts;
         } Set;
 
         struct {
             expr_ty elt;
-            asdl_seq *generators;
+            asdl_comprehension_seq *generators;
         } ListComp;
 
         struct {
             expr_ty elt;
-            asdl_seq *generators;
+            asdl_comprehension_seq *generators;
         } SetComp;
 
         struct {
             expr_ty key;
             expr_ty value;
-            asdl_seq *generators;
+            asdl_comprehension_seq *generators;
         } DictComp;
 
         struct {
             expr_ty elt;
-            asdl_seq *generators;
+            asdl_comprehension_seq *generators;
         } GeneratorExp;
 
         struct {
@@ -311,13 +392,13 @@ struct _expr {
         struct {
             expr_ty left;
             asdl_int_seq *ops;
-            asdl_seq *comparators;
+            asdl_expr_seq *comparators;
         } Compare;
 
         struct {
             expr_ty func;
-            asdl_seq *args;
-            asdl_seq *keywords;
+            asdl_expr_seq *args;
+            asdl_keyword_seq *keywords;
         } Call;
 
         struct {
@@ -327,7 +408,7 @@ struct _expr {
         } FormattedValue;
 
         struct {
-            asdl_seq *values;
+            asdl_expr_seq *values;
         } JoinedStr;
 
         struct {
@@ -358,12 +439,12 @@ struct _expr {
         } Name;
 
         struct {
-            asdl_seq *elts;
+            asdl_expr_seq *elts;
             expr_context_ty ctx;
         } List;
 
         struct {
-            asdl_seq *elts;
+            asdl_expr_seq *elts;
             expr_context_ty ctx;
         } Tuple;
 
@@ -383,7 +464,7 @@ struct _expr {
 struct _comprehension {
     expr_ty target;
     expr_ty iter;
-    asdl_seq *ifs;
+    asdl_expr_seq *ifs;
     int is_async;
 };
 
@@ -394,7 +475,7 @@ struct _excepthandler {
         struct {
             expr_ty type;
             identifier name;
-            asdl_seq *body;
+            asdl_stmt_seq *body;
         } ExceptHandler;
 
     } v;
@@ -405,13 +486,13 @@ struct _excepthandler {
 };
 
 struct _arguments {
-    asdl_seq *posonlyargs;
-    asdl_seq *args;
+    asdl_arg_seq *posonlyargs;
+    asdl_arg_seq *args;
     arg_ty vararg;
-    asdl_seq *kwonlyargs;
-    asdl_seq *kw_defaults;
+    asdl_arg_seq *kwonlyargs;
+    asdl_expr_seq *kw_defaults;
     arg_ty kwarg;
-    asdl_seq *defaults;
+    asdl_expr_seq *defaults;
 };
 
 struct _arg {
@@ -458,39 +539,41 @@ struct _type_ignore {
 
 // Note: these macros affect function definitions, not only call sites.
 #define Module(a0, a1, a2) _Py_Module(a0, a1, a2)
-mod_ty _Py_Module(asdl_seq * body, asdl_seq * type_ignores, PyArena *arena);
+mod_ty _Py_Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores,
+                  PyArena *arena);
 #define Interactive(a0, a1) _Py_Interactive(a0, a1)
-mod_ty _Py_Interactive(asdl_seq * body, PyArena *arena);
+mod_ty _Py_Interactive(asdl_stmt_seq * body, PyArena *arena);
 #define Expression(a0, a1) _Py_Expression(a0, a1)
 mod_ty _Py_Expression(expr_ty body, PyArena *arena);
 #define FunctionType(a0, a1, a2) _Py_FunctionType(a0, a1, a2)
-mod_ty _Py_FunctionType(asdl_seq * argtypes, expr_ty returns, PyArena *arena);
+mod_ty _Py_FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena
+                        *arena);
 #define FunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) _Py_FunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-stmt_ty _Py_FunctionDef(identifier name, arguments_ty args, asdl_seq * body,
-                        asdl_seq * decorator_list, expr_ty returns, string
-                        type_comment, int lineno, int col_offset, int
+stmt_ty _Py_FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq *
+                        body, asdl_expr_seq * decorator_list, expr_ty returns,
+                        string type_comment, int lineno, int col_offset, int
                         end_lineno, int end_col_offset, PyArena *arena);
 #define AsyncFunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) _Py_AsyncFunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-stmt_ty _Py_AsyncFunctionDef(identifier name, arguments_ty args, asdl_seq *
-                             body, asdl_seq * decorator_list, expr_ty returns,
-                             string type_comment, int lineno, int col_offset,
-                             int end_lineno, int end_col_offset, PyArena
-                             *arena);
+stmt_ty _Py_AsyncFunctionDef(identifier name, arguments_ty args, asdl_stmt_seq
+                             * body, asdl_expr_seq * decorator_list, expr_ty
+                             returns, string type_comment, int lineno, int
+                             col_offset, int end_lineno, int end_col_offset,
+                             PyArena *arena);
 #define ClassDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_ClassDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
-stmt_ty _Py_ClassDef(identifier name, asdl_seq * bases, asdl_seq * keywords,
-                     asdl_seq * body, asdl_seq * decorator_list, int lineno,
-                     int col_offset, int end_lineno, int end_col_offset,
-                     PyArena *arena);
+stmt_ty _Py_ClassDef(identifier name, asdl_expr_seq * bases, asdl_keyword_seq *
+                     keywords, asdl_stmt_seq * body, asdl_expr_seq *
+                     decorator_list, int lineno, int col_offset, int
+                     end_lineno, int end_col_offset, PyArena *arena);
 #define Return(a0, a1, a2, a3, a4, a5) _Py_Return(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Return(expr_ty value, int lineno, int col_offset, int end_lineno,
                    int end_col_offset, PyArena *arena);
 #define Delete(a0, a1, a2, a3, a4, a5) _Py_Delete(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Delete(asdl_seq * targets, int lineno, int col_offset, int
+stmt_ty _Py_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
 #define Assign(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Assign(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_Assign(asdl_seq * targets, expr_ty value, string type_comment, int
-                   lineno, int col_offset, int end_lineno, int end_col_offset,
-                   PyArena *arena);
+stmt_ty _Py_Assign(asdl_expr_seq * targets, expr_ty value, string type_comment,
+                   int lineno, int col_offset, int end_lineno, int
+                   end_col_offset, PyArena *arena);
 #define AugAssign(a0, a1, a2, a3, a4, a5, a6, a7) _Py_AugAssign(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_AugAssign(expr_ty target, operator_ty op, expr_ty value, int
                       lineno, int col_offset, int end_lineno, int
@@ -500,52 +583,54 @@ stmt_ty _Py_AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int
                       simple, int lineno, int col_offset, int end_lineno, int
                       end_col_offset, PyArena *arena);
 #define For(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_For(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
-stmt_ty _Py_For(expr_ty target, expr_ty iter, asdl_seq * body, asdl_seq *
-                orelse, string type_comment, int lineno, int col_offset, int
-                end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _Py_For(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
+                asdl_stmt_seq * orelse, string type_comment, int lineno, int
+                col_offset, int end_lineno, int end_col_offset, PyArena *arena);
 #define AsyncFor(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_AsyncFor(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
-stmt_ty _Py_AsyncFor(expr_ty target, expr_ty iter, asdl_seq * body, asdl_seq *
-                     orelse, string type_comment, int lineno, int col_offset,
-                     int end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _Py_AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
+                     asdl_stmt_seq * orelse, string type_comment, int lineno,
+                     int col_offset, int end_lineno, int end_col_offset,
+                     PyArena *arena);
 #define While(a0, a1, a2, a3, a4, a5, a6, a7) _Py_While(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_While(expr_ty test, asdl_seq * body, asdl_seq * orelse, int lineno,
-                  int col_offset, int end_lineno, int end_col_offset, PyArena
-                  *arena);
+stmt_ty _Py_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse,
+                  int lineno, int col_offset, int end_lineno, int
+                  end_col_offset, PyArena *arena);
 #define If(a0, a1, a2, a3, a4, a5, a6, a7) _Py_If(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_If(expr_ty test, asdl_seq * body, asdl_seq * orelse, int lineno,
-               int col_offset, int end_lineno, int end_col_offset, PyArena
-               *arena);
+stmt_ty _Py_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int
+               lineno, int col_offset, int end_lineno, int end_col_offset,
+               PyArena *arena);
 #define With(a0, a1, a2, a3, a4, a5, a6, a7) _Py_With(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_With(asdl_seq * items, asdl_seq * body, string type_comment, int
-                 lineno, int col_offset, int end_lineno, int end_col_offset,
-                 PyArena *arena);
+stmt_ty _Py_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string
+                 type_comment, int lineno, int col_offset, int end_lineno, int
+                 end_col_offset, PyArena *arena);
 #define AsyncWith(a0, a1, a2, a3, a4, a5, a6, a7) _Py_AsyncWith(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_AsyncWith(asdl_seq * items, asdl_seq * body, string type_comment,
-                      int lineno, int col_offset, int end_lineno, int
-                      end_col_offset, PyArena *arena);
+stmt_ty _Py_AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body, string
+                      type_comment, int lineno, int col_offset, int end_lineno,
+                      int end_col_offset, PyArena *arena);
 #define Raise(a0, a1, a2, a3, a4, a5, a6) _Py_Raise(a0, a1, a2, a3, a4, a5, a6)
 stmt_ty _Py_Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset, int
                   end_lineno, int end_col_offset, PyArena *arena);
 #define Try(a0, a1, a2, a3, a4, a5, a6, a7, a8) _Py_Try(a0, a1, a2, a3, a4, a5, a6, a7, a8)
-stmt_ty _Py_Try(asdl_seq * body, asdl_seq * handlers, asdl_seq * orelse,
-                asdl_seq * finalbody, int lineno, int col_offset, int
-                end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _Py_Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers,
+                asdl_stmt_seq * orelse, asdl_stmt_seq * finalbody, int lineno,
+                int col_offset, int end_lineno, int end_col_offset, PyArena
+                *arena);
 #define Assert(a0, a1, a2, a3, a4, a5, a6) _Py_Assert(a0, a1, a2, a3, a4, a5, a6)
 stmt_ty _Py_Assert(expr_ty test, expr_ty msg, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
 #define Import(a0, a1, a2, a3, a4, a5) _Py_Import(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Import(asdl_seq * names, int lineno, int col_offset, int
+stmt_ty _Py_Import(asdl_alias_seq * names, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
 #define ImportFrom(a0, a1, a2, a3, a4, a5, a6, a7) _Py_ImportFrom(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_ImportFrom(identifier module, asdl_seq * names, int level, int
-                       lineno, int col_offset, int end_lineno, int
+stmt_ty _Py_ImportFrom(identifier module, asdl_alias_seq * names, int level,
+                       int lineno, int col_offset, int end_lineno, int
                        end_col_offset, PyArena *arena);
 #define Global(a0, a1, a2, a3, a4, a5) _Py_Global(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Global(asdl_seq * names, int lineno, int col_offset, int
+stmt_ty _Py_Global(asdl_identifier_seq * names, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
 #define Nonlocal(a0, a1, a2, a3, a4, a5) _Py_Nonlocal(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Nonlocal(asdl_seq * names, int lineno, int col_offset, int
-                     end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _Py_Nonlocal(asdl_identifier_seq * names, int lineno, int col_offset,
+                     int end_lineno, int end_col_offset, PyArena *arena);
 #define Expr(a0, a1, a2, a3, a4, a5) _Py_Expr(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Expr(expr_ty value, int lineno, int col_offset, int end_lineno, int
                  end_col_offset, PyArena *arena);
@@ -559,8 +644,9 @@ stmt_ty _Py_Break(int lineno, int col_offset, int end_lineno, int
 stmt_ty _Py_Continue(int lineno, int col_offset, int end_lineno, int
                      end_col_offset, PyArena *arena);
 #define BoolOp(a0, a1, a2, a3, a4, a5, a6) _Py_BoolOp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_BoolOp(boolop_ty op, asdl_seq * values, int lineno, int col_offset,
-                   int end_lineno, int end_col_offset, PyArena *arena);
+expr_ty _Py_BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int
+                   col_offset, int end_lineno, int end_col_offset, PyArena
+                   *arena);
 #define NamedExpr(a0, a1, a2, a3, a4, a5, a6) _Py_NamedExpr(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_NamedExpr(expr_ty target, expr_ty value, int lineno, int
                       col_offset, int end_lineno, int end_col_offset, PyArena
@@ -580,28 +666,28 @@ expr_ty _Py_IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
 #define Dict(a0, a1, a2, a3, a4, a5, a6) _Py_Dict(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Dict(asdl_seq * keys, asdl_seq * values, int lineno, int
+expr_ty _Py_Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno, int
                  col_offset, int end_lineno, int end_col_offset, PyArena
                  *arena);
 #define Set(a0, a1, a2, a3, a4, a5) _Py_Set(a0, a1, a2, a3, a4, a5)
-expr_ty _Py_Set(asdl_seq * elts, int lineno, int col_offset, int end_lineno,
-                int end_col_offset, PyArena *arena);
+expr_ty _Py_Set(asdl_expr_seq * elts, int lineno, int col_offset, int
+                end_lineno, int end_col_offset, PyArena *arena);
 #define ListComp(a0, a1, a2, a3, a4, a5, a6) _Py_ListComp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_ListComp(expr_ty elt, asdl_seq * generators, int lineno, int
-                     col_offset, int end_lineno, int end_col_offset, PyArena
-                     *arena);
-#define SetComp(a0, a1, a2, a3, a4, a5, a6) _Py_SetComp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_SetComp(expr_ty elt, asdl_seq * generators, int lineno, int
-                    col_offset, int end_lineno, int end_col_offset, PyArena
-                    *arena);
-#define DictComp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_DictComp(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_DictComp(expr_ty key, expr_ty value, asdl_seq * generators, int
+expr_ty _Py_ListComp(expr_ty elt, asdl_comprehension_seq * generators, int
                      lineno, int col_offset, int end_lineno, int
                      end_col_offset, PyArena *arena);
+#define SetComp(a0, a1, a2, a3, a4, a5, a6) _Py_SetComp(a0, a1, a2, a3, a4, a5, a6)
+expr_ty _Py_SetComp(expr_ty elt, asdl_comprehension_seq * generators, int
+                    lineno, int col_offset, int end_lineno, int end_col_offset,
+                    PyArena *arena);
+#define DictComp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_DictComp(a0, a1, a2, a3, a4, a5, a6, a7)
+expr_ty _Py_DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq *
+                     generators, int lineno, int col_offset, int end_lineno,
+                     int end_col_offset, PyArena *arena);
 #define GeneratorExp(a0, a1, a2, a3, a4, a5, a6) _Py_GeneratorExp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_GeneratorExp(expr_ty elt, asdl_seq * generators, int lineno, int
-                         col_offset, int end_lineno, int end_col_offset,
-                         PyArena *arena);
+expr_ty _Py_GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators, int
+                         lineno, int col_offset, int end_lineno, int
+                         end_col_offset, PyArena *arena);
 #define Await(a0, a1, a2, a3, a4, a5) _Py_Await(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_Await(expr_ty value, int lineno, int col_offset, int end_lineno,
                   int end_col_offset, PyArena *arena);
@@ -612,19 +698,19 @@ expr_ty _Py_Yield(expr_ty value, int lineno, int col_offset, int end_lineno,
 expr_ty _Py_YieldFrom(expr_ty value, int lineno, int col_offset, int
                       end_lineno, int end_col_offset, PyArena *arena);
 #define Compare(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Compare(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_Compare(expr_ty left, asdl_int_seq * ops, asdl_seq * comparators,
-                    int lineno, int col_offset, int end_lineno, int
-                    end_col_offset, PyArena *arena);
+expr_ty _Py_Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq *
+                    comparators, int lineno, int col_offset, int end_lineno,
+                    int end_col_offset, PyArena *arena);
 #define Call(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Call(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_Call(expr_ty func, asdl_seq * args, asdl_seq * keywords, int
-                 lineno, int col_offset, int end_lineno, int end_col_offset,
-                 PyArena *arena);
+expr_ty _Py_Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq *
+                 keywords, int lineno, int col_offset, int end_lineno, int
+                 end_col_offset, PyArena *arena);
 #define FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7) _Py_FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_FormattedValue(expr_ty value, int conversion, expr_ty format_spec,
                            int lineno, int col_offset, int end_lineno, int
                            end_col_offset, PyArena *arena);
 #define JoinedStr(a0, a1, a2, a3, a4, a5) _Py_JoinedStr(a0, a1, a2, a3, a4, a5)
-expr_ty _Py_JoinedStr(asdl_seq * values, int lineno, int col_offset, int
+expr_ty _Py_JoinedStr(asdl_expr_seq * values, int lineno, int col_offset, int
                       end_lineno, int end_col_offset, PyArena *arena);
 #define Constant(a0, a1, a2, a3, a4, a5, a6) _Py_Constant(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_Constant(constant value, string kind, int lineno, int col_offset,
@@ -646,11 +732,11 @@ expr_ty _Py_Name(identifier id, expr_context_ty ctx, int lineno, int
                  col_offset, int end_lineno, int end_col_offset, PyArena
                  *arena);
 #define List(a0, a1, a2, a3, a4, a5, a6) _Py_List(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_List(asdl_seq * elts, expr_context_ty ctx, int lineno, int
+expr_ty _Py_List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
                  col_offset, int end_lineno, int end_col_offset, PyArena
                  *arena);
 #define Tuple(a0, a1, a2, a3, a4, a5, a6) _Py_Tuple(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Tuple(asdl_seq * elts, expr_context_ty ctx, int lineno, int
+expr_ty _Py_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
 #define Slice(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Slice(a0, a1, a2, a3, a4, a5, a6, a7)
@@ -658,18 +744,18 @@ expr_ty _Py_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
 #define comprehension(a0, a1, a2, a3, a4) _Py_comprehension(a0, a1, a2, a3, a4)
-comprehension_ty _Py_comprehension(expr_ty target, expr_ty iter, asdl_seq *
-                                   ifs, int is_async, PyArena *arena);
+comprehension_ty _Py_comprehension(expr_ty target, expr_ty iter, asdl_expr_seq
+                                   * ifs, int is_async, PyArena *arena);
 #define ExceptHandler(a0, a1, a2, a3, a4, a5, a6, a7) _Py_ExceptHandler(a0, a1, a2, a3, a4, a5, a6, a7)
-excepthandler_ty _Py_ExceptHandler(expr_ty type, identifier name, asdl_seq *
-                                   body, int lineno, int col_offset, int
+excepthandler_ty _Py_ExceptHandler(expr_ty type, identifier name, asdl_stmt_seq
+                                   * body, int lineno, int col_offset, int
                                    end_lineno, int end_col_offset, PyArena
                                    *arena);
 #define arguments(a0, a1, a2, a3, a4, a5, a6, a7) _Py_arguments(a0, a1, a2, a3, a4, a5, a6, a7)
-arguments_ty _Py_arguments(asdl_seq * posonlyargs, asdl_seq * args, arg_ty
-                           vararg, asdl_seq * kwonlyargs, asdl_seq *
-                           kw_defaults, arg_ty kwarg, asdl_seq * defaults,
-                           PyArena *arena);
+arguments_ty _Py_arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args,
+                           arg_ty vararg, asdl_arg_seq * kwonlyargs,
+                           asdl_expr_seq * kw_defaults, arg_ty kwarg,
+                           asdl_expr_seq * defaults, PyArena *arena);
 #define arg(a0, a1, a2, a3, a4, a5, a6, a7) _Py_arg(a0, a1, a2, a3, a4, a5, a6, a7)
 arg_ty _Py_arg(identifier arg, expr_ty annotation, string type_comment, int
                lineno, int col_offset, int end_lineno, int end_col_offset,

--- a/Include/asdl.h
+++ b/Include/asdl.h
@@ -13,22 +13,65 @@ typedef PyObject * constant;
    interned Python strings.
 */
 
-/* XXX A sequence should be typed so that its use can be typechecked. */
+#define _ASDL_SEQ_HEAD \
+    Py_ssize_t size;   \
+    void **elements;
 
 typedef struct {
-    Py_ssize_t size;
-    void *elements[1];
+    _ASDL_SEQ_HEAD
 } asdl_seq;
 
 typedef struct {
-    Py_ssize_t size;
-    int elements[1];
+    _ASDL_SEQ_HEAD
+    void *typed_elements[1];
+} asdl_generic_seq;
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    PyObject *typed_elements[1];
+} asdl_identifier_seq;
+
+typedef struct {
+    _ASDL_SEQ_HEAD
+    int typed_elements[1];
 } asdl_int_seq;
 
-asdl_seq *_Py_asdl_seq_new(Py_ssize_t size, PyArena *arena);
+asdl_generic_seq *_Py_asdl_generic_seq_new(Py_ssize_t size, PyArena *arena);
+asdl_identifier_seq *_Py_asdl_identifier_seq_new(Py_ssize_t size, PyArena *arena);
 asdl_int_seq *_Py_asdl_int_seq_new(Py_ssize_t size, PyArena *arena);
 
-#define asdl_seq_GET(S, I) (S)->elements[(I)]
+
+#define GENERATE_ASDL_SEQ_CONSTRUCTOR(NAME, TYPE) \
+asdl_ ## NAME ## _seq *_Py_asdl_ ## NAME ## _seq_new(Py_ssize_t size, PyArena *arena) \
+{ \
+    asdl_ ## NAME ## _seq *seq = NULL; \
+    size_t n; \
+    /* check size is sane */ \
+    if (size < 0 || \
+        (size && (((size_t)size - 1) > (SIZE_MAX / sizeof(void *))))) { \
+        PyErr_NoMemory(); \
+        return NULL; \
+    } \
+    n = (size ? (sizeof(TYPE *) * (size - 1)) : 0); \
+    /* check if size can be added safely */ \
+    if (n > SIZE_MAX - sizeof(asdl_ ## NAME ## _seq)) { \
+        PyErr_NoMemory(); \
+        return NULL; \
+    } \
+    n += sizeof(asdl_ ## NAME ## _seq); \
+    seq = (asdl_ ## NAME ## _seq *)PyArena_Malloc(arena, n); \
+    if (!seq) { \
+        PyErr_NoMemory(); \
+        return NULL; \
+    } \
+    memset(seq, 0, n); \
+    seq->size = size; \
+    seq->elements = (void**)seq->typed_elements; \
+    return seq; \
+}
+
+#define asdl_seq_GET_UNTYPED(S, I) (S)->elements[(I)]
+#define asdl_seq_GET(S, I) (S)->typed_elements[(I)]
 #define asdl_seq_LEN(S) ((S) == NULL ? 0 : (S)->size)
 #ifdef Py_DEBUG
 #define asdl_seq_SET(S, I, V) \
@@ -36,10 +79,22 @@ asdl_int_seq *_Py_asdl_int_seq_new(Py_ssize_t size, PyArena *arena);
         Py_ssize_t _asdl_i = (I); \
         assert((S) != NULL); \
         assert(0 <= _asdl_i && _asdl_i < (S)->size); \
+        (S)->typed_elements[_asdl_i] = (V); \
+    } while (0)
+#else
+#define asdl_seq_SET(S, I, V) (S)->typed_elements[I] = (V)
+#endif
+
+#ifdef Py_DEBUG
+#define asdl_seq_SET_UNTYPED(S, I, V) \
+    do { \
+        Py_ssize_t _asdl_i = (I); \
+        assert((S) != NULL); \
+        assert(0 <= _asdl_i && _asdl_i < (S)->size); \
         (S)->elements[_asdl_i] = (V); \
     } while (0)
 #else
-#define asdl_seq_SET(S, I, V) (S)->elements[I] = (V)
+#define asdl_seq_SET_UNTYPED(S, I, V) (S)->elements[I] = (V)
 #endif
 
 #endif /* !Py_ASDL_H */

--- a/Include/ast.h
+++ b/Include/ast.h
@@ -15,7 +15,7 @@ PyAPI_FUNC(PyObject *) _PyAST_ExprAsUnicode(expr_ty);
 /* Return the borrowed reference to the first literal string in the
    sequence of statements or NULL if it doesn't start from a literal string.
    Doesn't set exception. */
-PyAPI_FUNC(PyObject *) _PyAST_GetDocString(asdl_seq *);
+PyAPI_FUNC(PyObject *) _PyAST_GetDocString(asdl_stmt_seq *);
 
 #ifdef __cplusplus
 }

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -45,6 +45,21 @@ PyAPI_FUNC(PyObject *) _PyGen_Send(PyGenObject *, PyObject *);
 PyObject *_PyGen_yf(PyGenObject *);
 PyAPI_FUNC(void) _PyGen_Finalize(PyObject *self);
 
+typedef enum {
+    PYGEN_RETURN = 0,
+    PYGEN_ERROR = -1,
+    PYGEN_NEXT = 1,
+} PySendResult;
+
+/* Sends the value into the generator or the coroutine. Returns:
+   - PYGEN_RETURN (0) if generator has returned.
+     'result' parameter is filled with return value
+   - PYGEN_ERROR (-1) if exception was raised.
+     'result' parameter is NULL
+   - PYGEN_NEXT (1) if generator has yielded.
+     'result' parameter is filled with yielded value. */
+PyAPI_FUNC(PySendResult) PyGen_Send(PyGenObject *, PyObject *, PyObject **);
+
 #ifndef Py_LIMITED_API
 typedef struct {
     _PyGenObject_HEAD(cr)

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -84,6 +84,7 @@ extern void _PyFaulthandler_Fini(void);
 extern void _PyHash_Fini(void);
 extern void _PyTraceMalloc_Fini(void);
 extern void _PyWarnings_Fini(PyInterpreterState *interp);
+extern void _PyAST_Fini(PyThreadState *tstate);
 
 extern PyStatus _PyGILState_Init(PyThreadState *tstate);
 extern void _PyGILState_Fini(PyThreadState *tstate);

--- a/Include/object.h
+++ b/Include/object.h
@@ -141,7 +141,7 @@ static inline PyTypeObject* _Py_TYPE(const PyObject *ob) {
 
 
 static inline int _Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
-    return ob->ob_type == type;
+    return Py_TYPE(ob) == type;
 }
 #define Py_IS_TYPE(ob, type) _Py_IS_TYPE(_PyObject_CAST_CONST(ob), type)
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -497,18 +497,20 @@ class NodeTransformer(NodeVisitor):
         return node
 
 
-# The following code is for backward compatibility.
-# It will be removed in future.
+# If the ast module is loaded more than once, only add deprecated methods once
+if not hasattr(Constant, 'n'):
+    # The following code is for backward compatibility.
+    # It will be removed in future.
 
-def _getter(self):
-    """Deprecated. Use value instead."""
-    return self.value
+    def _getter(self):
+        """Deprecated. Use value instead."""
+        return self.value
 
-def _setter(self, value):
-    self.value = value
+    def _setter(self, value):
+        self.value = value
 
-Constant.n = property(_getter, _setter)
-Constant.s = property(_getter, _setter)
+    Constant.n = property(_getter, _setter)
+    Constant.s = property(_getter, _setter)
 
 class _ABC(type):
 
@@ -600,14 +602,19 @@ class ExtSlice(slice):
     def __new__(cls, dims=(), **kwargs):
         return Tuple(list(dims), Load(), **kwargs)
 
-def _dims_getter(self):
-    """Deprecated. Use elts instead."""
-    return self.elts
+# If the ast module is loaded more than once, only add deprecated methods once
+if not hasattr(Tuple, 'dims'):
+    # The following code is for backward compatibility.
+    # It will be removed in future.
 
-def _dims_setter(self, value):
-    self.elts = value
+    def _dims_getter(self):
+        """Deprecated. Use elts instead."""
+        return self.elts
 
-Tuple.dims = property(_dims_getter, _dims_setter)
+    def _dims_setter(self, value):
+        self.elts = value
+
+    Tuple.dims = property(_dims_getter, _dims_setter)
 
 class Suite(mod):
     """Deprecated AST node class.  Unused in Python 3."""

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -133,14 +133,16 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         # a socket is closed, send() raises OSError (with errno set to
         # EBADF, but let's not rely on the exact error code).
         csock = self._csock
-        if csock is not None:
-            try:
-                csock.send(b'\0')
-            except OSError:
-                if self._debug:
-                    logger.debug("Fail to write a null byte into the "
-                                 "self-pipe socket",
-                                 exc_info=True)
+        if csock is None:
+            return
+
+        try:
+            csock.send(b'\0')
+        except OSError:
+            if self._debug:
+                logger.debug("Fail to write a null byte into the "
+                             "self-pipe socket",
+                             exc_info=True)
 
     def _start_serving(self, protocol_factory, sock,
                        sslcontext=None, server=None, backlog=100,

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -574,7 +574,7 @@ class Counter(dict):
     #   http://en.wikipedia.org/wiki/Multiset
     #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
     #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
-    #   http://code.activestate.com/recipes/259174/
+    #   https://github.com/ActiveState/code/tree/master/recipes/Python/259174_bag_collection_class/recipe-259174.py
     #   Knuth, TAOCP Vol. II section 4.6.3
 
     def __init__(self, iterable=None, /, **kwds):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -4,7 +4,7 @@ from types import MappingProxyType, DynamicClassAttribute
 
 __all__ = [
         'EnumMeta',
-        'Enum', 'IntEnum', 'Flag', 'IntFlag',
+        'Enum', 'IntEnum', 'StrEnum', 'Flag', 'IntFlag',
         'auto', 'unique',
         ]
 
@@ -688,7 +688,35 @@ class Enum(metaclass=EnumMeta):
 
 
 class IntEnum(int, Enum):
-    """Enum where members are also (and must be) ints"""
+    """
+    Enum where members are also (and must be) ints
+    """
+
+
+class StrEnum(str, Enum):
+    """
+    Enum where members are also (and must be) strings
+    """
+
+    def __new__(cls, *values):
+        if len(values) > 3:
+            raise TypeError('too many arguments for str(): %r' % (values, ))
+        if len(values) == 1:
+            # it must be a string
+            if not isinstance(values[0], str):
+                raise TypeError('%r is not a string' % (values[0], ))
+        if len(values) > 1:
+            # check that encoding argument is a string
+            if not isinstance(values[1], str):
+                raise TypeError('encoding must be a string, not %r' % (values[1], ))
+            if len(values) > 2:
+                # check that errors argument is a string
+                if not isinstance(values[2], str):
+                    raise TypeError('errors must be a string, not %r' % (values[2], ))
+        value = str(*values)
+        member = str.__new__(cls, value)
+        member._value_ = value
+        return member
 
 
 def _reduce_ex_by_name(self, proto):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -250,7 +250,11 @@ class EnumMeta(type):
 
         # double check that repr and friends are not the mixin's or various
         # things break (such as pickle)
+        # however, if the method is defined in the Enum itself, don't replace
+        # it
         for name in ('__repr__', '__str__', '__format__', '__reduce_ex__'):
+            if name in classdict:
+                continue
             class_method = getattr(enum_class, name)
             obj_method = getattr(member_type, name, None)
             enum_method = getattr(first_enum, name, None)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -482,14 +482,25 @@ class EnumMeta(type):
             return object, Enum
 
         def _find_data_type(bases):
+            data_types = []
             for chain in bases:
+                candidate = None
                 for base in chain.__mro__:
                     if base is object:
                         continue
                     elif '__new__' in base.__dict__:
                         if issubclass(base, Enum):
                             continue
-                        return base
+                        data_types.append(candidate or base)
+                        break
+                    elif not issubclass(base, Enum):
+                        candidate = base
+            if len(data_types) > 1:
+                raise TypeError('too many data types: %r' % data_types)
+            elif data_types:
+                return data_types[0]
+            else:
+                return None
 
         # ensure final parent class is an Enum derivative, find any concrete
         # data type, and check that Enum has no members

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -105,9 +105,9 @@ class _EnumDict(dict):
                 # enum overwriting a descriptor?
                 raise TypeError('%r already defined as: %r' % (key, self[key]))
             if isinstance(value, auto):
-                self._auto_called = True
                 if value.value == _auto_null:
                     value.value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])
+                    self._auto_called = True
                 value = value.value
             self._member_names.append(key)
             self._last_values.append(value)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -124,10 +124,12 @@ class EnumMeta(type):
     """Metaclass for Enum"""
     @classmethod
     def __prepare__(metacls, cls, bases):
+        # check that previous enum members do not exist
+        metacls._check_for_existing_members(cls, bases)
         # create the namespace dict
         enum_dict = _EnumDict()
         # inherit previous flags and _generate_next_value_ function
-        member_type, first_enum = metacls._get_mixins_(bases)
+        member_type, first_enum = metacls._get_mixins_(cls, bases)
         if first_enum is not None:
             enum_dict['_generate_next_value_'] = getattr(first_enum, '_generate_next_value_', None)
         return enum_dict
@@ -143,7 +145,7 @@ class EnumMeta(type):
         ignore = classdict['_ignore_']
         for key in ignore:
             classdict.pop(key, None)
-        member_type, first_enum = metacls._get_mixins_(bases)
+        member_type, first_enum = metacls._get_mixins_(cls, bases)
         __new__, save_new, use_args = metacls._find_new_(classdict, member_type,
                                                         first_enum)
 
@@ -402,7 +404,7 @@ class EnumMeta(type):
         """
         metacls = cls.__class__
         bases = (cls, ) if type is None else (type, cls)
-        _, first_enum = cls._get_mixins_(bases)
+        _, first_enum = cls._get_mixins_(cls, bases)
         classdict = metacls.__prepare__(class_name, bases)
 
         # special processing needed for names?
@@ -475,7 +477,14 @@ class EnumMeta(type):
         return cls
 
     @staticmethod
-    def _get_mixins_(bases):
+    def _check_for_existing_members(class_name, bases):
+        for chain in bases:
+            for base in chain.__mro__:
+                if issubclass(base, Enum) and base._member_names_:
+                    raise TypeError("%s: cannot extend enumeration %r" % (class_name, base.__name__))
+
+    @staticmethod
+    def _get_mixins_(class_name, bases):
         """Returns the type for creating enum members, and the first inherited
         enum class.
 
@@ -500,7 +509,7 @@ class EnumMeta(type):
                     elif not issubclass(base, Enum):
                         candidate = base
             if len(data_types) > 1:
-                raise TypeError('too many data types: %r' % data_types)
+                raise TypeError('%r: too many data types: %r' % (class_name, data_types))
             elif data_types:
                 return data_types[0]
             else:

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -644,7 +644,7 @@ class Enum(metaclass=EnumMeta):
                 for cls in self.__class__.mro()
                 for m in cls.__dict__
                 if m[0] != '_' and m not in self._member_map_
-                ]
+                ] + [m for m in self.__dict__ if m[0] != '_']
         return (['__class__', '__doc__', '__module__'] + added_behavior)
 
     def __format__(self, format_spec):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -753,6 +753,10 @@ class Flag(Enum):
                     type(other).__qualname__, self.__class__.__qualname__))
         return other._value_ & self._value_ == other._value_
 
+    def __iter__(self):
+        members, extra_flags = _decompose(self.__class__, self.value)
+        return (m for m in members if m._value_ != 0)
+
     def __repr__(self):
         cls = self.__class__
         if self._name_ is not None:

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -629,7 +629,7 @@ class Enum(metaclass=EnumMeta):
 
     @classmethod
     def _missing_(cls, value):
-        raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
+        return None
 
     def __repr__(self):
         return "<%s.%s: %r>" % (

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -76,7 +76,8 @@ class _EnumDict(dict):
                     '_order_', '_create_pseudo_member_',
                     '_generate_next_value_', '_missing_', '_ignore_',
                     ):
-                raise ValueError('_names_ are reserved for future Enum use')
+                raise ValueError(f'_sunder_ names, such as "{key}", are '
+                                  'reserved for future Enum use')
             if key == '_generate_next_value_':
                 # check if members already defined as auto()
                 if self._auto_called:

--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -456,7 +456,7 @@ def merge(*iterables, key=None, reverse=False):
 # 2) Made multiple passes over the data.
 # 3) Made more comparisons in common cases (small k, large n, semi-random input).
 # See the more detailed comparison of approach at:
-# http://code.activestate.com/recipes/577573-compare-algorithms-for-heapqsmallest
+# https://github.com/ActiveState/code/tree/master/recipes/Python/577573_Compare_algorithms/recipe-577573.py
 
 def nsmallest(n, iterable, key=None):
     """Find the n smallest elements in a dataset.

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2020-10-05?
 ======================================
 
 
+bpo-40181: In calltips, stop reminding that '/' marks the end of
+positional-only arguments.
+
 bpo-41468: Improve IDLE run crash error message (which users should
 never see).
 

--- a/Lib/idlelib/calltip.py
+++ b/Lib/idlelib/calltip.py
@@ -118,7 +118,6 @@ _INDENT = ' '*4  # for wrapped signatures
 _first_param = re.compile(r'(?<=\()\w*\,?\s*')
 _default_callable_argspec = "See source or doc"
 _invalid_method = "invalid method signature"
-_argument_positional = "  # '/' marks preceding args as positional-only."
 
 def get_argspec(ob):
     '''Return a string describing the signature of a callable object, or ''.
@@ -146,9 +145,6 @@ def get_argspec(ob):
         else:
             argspec = ''
 
-    if '/' in argspec and len(argspec) < _MAX_COLS - len(_argument_positional):
-        # Add explanation TODO remove after 3.7, before 3.9.
-        argspec += _argument_positional
     if isinstance(fob, type) and argspec == '()':
         # If fob has no argument, use default callable argspec.
         argspec = _default_callable_argspec

--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -61,18 +61,16 @@ class Get_argspecTest(unittest.TestCase):
 
         if List.__doc__ is not None:
             tiptest(List,
-                    f'(iterable=(), /){calltip._argument_positional}'
+                    f'(iterable=(), /)'
                     f'\n{List.__doc__}')
         tiptest(list.__new__,
               '(*args, **kwargs)\n'
               'Create and return a new object.  '
               'See help(type) for accurate signature.')
         tiptest(list.__init__,
-              '(self, /, *args, **kwargs)'
-              + calltip._argument_positional + '\n' +
+              '(self, /, *args, **kwargs)\n'
               'Initialize self.  See help(type(self)) for accurate signature.')
-        append_doc = (calltip._argument_positional
-                      + "\nAppend object to the end of the list.")
+        append_doc = "\nAppend object to the end of the list."
         tiptest(list.append, '(self, object, /)' + append_doc)
         tiptest(List.append, '(self, object, /)' + append_doc)
         tiptest([].append, '(object, /)' + append_doc)

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -45,9 +45,9 @@ class SortKey(str, Enum):
     TIME = 'time', 'tottime'
 
     def __new__(cls, *values):
-        obj = str.__new__(cls)
-
-        obj._value_ = values[0]
+        value = values[0]
+        obj = str.__new__(cls, value)
+        obj._value_ = value
         for other_value in values[1:]:
             cls._value2member_map_[other_value] = obj
         obj._all_values = values

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -170,6 +170,8 @@ def addpackage(sitedir, name, known_paths):
         for n, line in enumerate(f):
             if line.startswith("#"):
                 continue
+            if line.strip() == "":
+                continue
             try:
                 if line.startswith(("import ", "import\t")):
                     exec(line)

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -35,6 +35,13 @@ class BackupTests(unittest.TestCase):
         with self.assertRaises(sqlite.ProgrammingError):
             self.cx.backup(bck)
 
+    def test_bad_source_closed_connection(self):
+        bck = sqlite.connect(':memory:')
+        source = sqlite.connect(":memory:")
+        source.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            source.backup(bck)
+
     def test_bad_target_in_transaction(self):
         bck = sqlite.connect(':memory:')
         bck.execute('CREATE TABLE bar (key INTEGER)')

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -270,7 +270,7 @@ class CursorTests(unittest.TestCase):
         self.assertEqual(row[0], "foo")
 
     def CheckExecuteParamSequence(self):
-        class L(object):
+        class L:
             def __len__(self):
                 return 1
             def __getitem__(self, x):
@@ -281,6 +281,18 @@ class CursorTests(unittest.TestCase):
         self.cu.execute("select name from test where name=?", L())
         row = self.cu.fetchone()
         self.assertEqual(row[0], "foo")
+
+    def CheckExecuteParamSequenceBadLen(self):
+        # Issue41662: Error in __len__() was overridden with ProgrammingError.
+        class L:
+            def __len__(self):
+                1/0
+            def __getitem__(slf, x):
+                raise AssertionError
+
+        self.cu.execute("insert into test(name) values ('foo')")
+        with self.assertRaises(ZeroDivisionError):
+            self.cu.execute("select name from test where name=?", L())
 
     def CheckExecuteDictMapping(self):
         self.cu.execute("insert into test(name) values ('foo')")

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -132,6 +132,19 @@ class RegressionTests(unittest.TestCase):
         con.execute("insert into foo(bar) values (5)")
         con.execute(SELECT)
 
+    def CheckBindMutatingList(self):
+        # Issue41662: Crash when mutate a list of parameters during iteration.
+        class X:
+            def __conform__(self, protocol):
+                parameters.clear()
+                return "..."
+        parameters = [X(), 0]
+        con = sqlite.connect(":memory:",detect_types=sqlite.PARSE_DECLTYPES)
+        con.execute("create table foo(bar X, baz integer)")
+        # Should not crash
+        with self.assertRaises(IndexError):
+            con.execute("insert into foo(bar, baz) values (?, ?)", parameters)
+
     def CheckErrorMsgDecodeError(self):
         # When porting the module to Python 3.0, the error message about
         # decoding errors disappeared. This verifies they're back again.

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -145,7 +145,7 @@ class CmdLineTest(unittest.TestCase):
             *run_args, __isolated=False, __cwd=cwd, **env_vars
         )
         if verbose > 1:
-            print('Output from test script %r:' % script_exec_args)
+            print(f'Output from test script {script_exec_args!r:}')
             print(repr(err))
             print('Expected output: %r' % expected_msg)
         self.assertIn(expected_msg.encode('utf-8'), err)

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -202,6 +202,20 @@ class Test_Csv(unittest.TestCase):
                          escapechar='\\', quoting = csv.QUOTE_NONE)
         self._write_test(['a',1,'p,q'], 'a,1,p\\,q',
                          escapechar='\\', quoting = csv.QUOTE_NONE)
+        self._write_test(['\\', 'a'], '\\\\,a',
+                         escapechar='\\', quoting=csv.QUOTE_NONE)
+        self._write_test(['\\', 'a'], '\\\\,a',
+                         escapechar='\\', quoting=csv.QUOTE_MINIMAL)
+        self._write_test(['\\', 'a'], '"\\\\","a"',
+                         escapechar='\\', quoting=csv.QUOTE_ALL)
+        self._write_test(['\\ ', 'a'], '\\\\ ,a',
+                         escapechar='\\', quoting=csv.QUOTE_MINIMAL)
+        self._write_test(['\\,', 'a'], '\\\\\\,,a',
+                         escapechar='\\', quoting=csv.QUOTE_NONE)
+        self._write_test([',\\', 'a'], '",\\\\",a',
+                         escapechar='\\', quoting=csv.QUOTE_MINIMAL)
+        self._write_test(['C\\', '6', '7', 'X"'], 'C\\\\,6,7,"X"""',
+                         escapechar='\\', quoting=csv.QUOTE_MINIMAL)
 
     def test_write_iterable(self):
         self._write_test(iter(['a', 1, 'p,q']), 'a,1,"p,q"')

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -560,6 +560,49 @@ class TestEnum(unittest.TestCase):
         self.assertFormatIsValue('{:>20}', Directional.WEST)
         self.assertFormatIsValue('{:<20}', Directional.WEST)
 
+    def test_enum_str_override(self):
+        class MyStrEnum(Enum):
+            def __str__(self):
+                return 'MyStr'
+        class MyMethodEnum(Enum):
+            def hello(self):
+                return 'Hello!  My name is %s' % self.name
+        class Test1Enum(MyMethodEnum, int, MyStrEnum):
+            One = 1
+            Two = 2
+        self.assertEqual(str(Test1Enum.One), 'MyStr')
+        #
+        class Test2Enum(MyStrEnum, MyMethodEnum):
+            One = 1
+            Two = 2
+        self.assertEqual(str(Test2Enum.One), 'MyStr')
+
+    def test_inherited_data_type(self):
+        class HexInt(int):
+            def __repr__(self):
+                return hex(self)
+        class MyEnum(HexInt, enum.Enum):
+            A = 1
+            B = 2
+            C = 3
+        self.assertEqual(repr(MyEnum.A), '<MyEnum.A: 0x1>')
+
+    def test_too_many_data_types(self):
+        with self.assertRaisesRegex(TypeError, 'too many data types'):
+            class Huh(str, int, Enum):
+                One = 1
+
+        class MyStr(str):
+            def hello(self):
+                return 'hello, %s' % self
+        class MyInt(int):
+            def repr(self):
+                return hex(self)
+        with self.assertRaisesRegex(TypeError, 'too many data types'):
+            class Huh(MyStr, MyInt, Enum):
+                One = 1
+
+
     def test_hash(self):
         Season = self.Season
         dates = {}

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -419,6 +419,11 @@ class TestEnum(unittest.TestCase):
                 green = 2
                 blue = 3
 
+    def test_reserved__sunder_(self):
+        with self.assertRaisesRegex(ValueError, '_sunder_ names, such as '
+                                    '"_bad_", are reserved'):
+            class Bad(Enum):
+                _bad_ = 1
 
     def test_enum_with_value_name(self):
         class Huh(Enum):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -216,6 +216,18 @@ class TestEnum(unittest.TestCase):
                 set(['__class__', '__doc__', '__module__', 'name', 'value', 'invisible']),
                 )
 
+    def test_dir_on_sub_with_behavior_including_instance_dict_on_super(self):
+        # see issue40084
+        class SuperEnum(IntEnum):
+            def __new__(cls, value, description=""):
+                obj = int.__new__(cls, value)
+                obj._value_ = value
+                obj.description = description
+                return obj
+        class SubEnum(SuperEnum):
+            sample = 5
+        self.assertTrue({'description'} <= set(dir(SubEnum.sample)))
+
     def test_enum_in_enum_out(self):
         Season = self.Season
         self.assertIs(Season(Season.WINTER), Season.WINTER)

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2350,6 +2350,12 @@ class TestFlag(unittest.TestCase):
         self.assertFalse(W in RX)
         self.assertFalse(X in RW)
 
+    def test_member_iter(self):
+        Color = self.Color
+        self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
+        self.assertEqual(list(Color.BLUE), [Color.BLUE])
+        self.assertEqual(list(Color.GREEN), [Color.GREEN])
+
     def test_auto_number(self):
         class Color(Flag):
             red = auto()
@@ -2804,6 +2810,12 @@ class TestIntFlag(unittest.TestCase):
         self.assertFalse(X in RW)
         with self.assertRaises(TypeError):
             self.assertFalse('test' in RW)
+
+    def test_member_iter(self):
+        Color = self.Color
+        self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
+        self.assertEqual(list(Color.BLUE), [Color.BLUE])
+        self.assertEqual(list(Color.GREEN), [Color.GREEN])
 
     def test_bool(self):
         Perm = self.Perm

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1837,6 +1837,17 @@ class TestEnum(unittest.TestCase):
                 def _generate_next_value_(name, start, count, last):
                     return name
 
+    def test_auto_order_wierd(self):
+        weird_auto = auto()
+        weird_auto.value = 'pathological case'
+        class Color(Enum):
+            red = weird_auto
+            def _generate_next_value_(name, start, count, last):
+                return name
+            blue = auto()
+        self.assertEqual(list(Color), [Color.red, Color.blue])
+        self.assertEqual(Color.red.value, 'pathological case')
+        self.assertEqual(Color.blue.value, 'blue')
 
     def test_duplicate_auto(self):
         class Dupes(Enum):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -560,6 +560,14 @@ class TestEnum(unittest.TestCase):
         self.assertFormatIsValue('{:>20}', Directional.WEST)
         self.assertFormatIsValue('{:<20}', Directional.WEST)
 
+    def test_object_str_override(self):
+        class Colors(Enum):
+            RED, GREEN, BLUE = 1, 2, 3
+            def __repr__(self):
+                return "test.%s" % (self._name_, )
+            __str__ = object.__str__
+        self.assertEqual(str(Colors.RED), 'test.RED')
+
     def test_enum_str_override(self):
         class MyStrEnum(Enum):
             def __str__(self):
@@ -601,7 +609,6 @@ class TestEnum(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'too many data types'):
             class Huh(MyStr, MyInt, Enum):
                 One = 1
-
 
     def test_hash(self):
         Season = self.Season

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -420,8 +420,10 @@ class TestEnum(unittest.TestCase):
                 blue = 3
 
     def test_reserved__sunder_(self):
-        with self.assertRaisesRegex(ValueError, '_sunder_ names, such as '
-                                    '"_bad_", are reserved'):
+        with self.assertRaisesRegex(
+                ValueError,
+                '_sunder_ names, such as "_bad_", are reserved',
+            ):
             class Bad(Enum):
                 _bad_ = 1
 
@@ -1136,9 +1138,11 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "{}({!r}, {})".format(type(self).__name__,
-                                             self.__name__,
-                                             int.__repr__(self))
+                return "{}({!r}, {})".format(
+                        type(self).__name__,
+                        self.__name__,
+                        int.__repr__(self),
+                        )
             def __str__(self):
                 # str() is unchanged, even if it relies on the repr() fallback
                 base = int
@@ -1153,7 +1157,8 @@ class TestEnum(unittest.TestCase):
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
                         '({0} + {1})'.format(self.__name__, other.__name__),
-                        temp )
+                        temp,
+                        )
                 else:
                     return temp
 
@@ -1193,9 +1198,11 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "{}({!r}, {})".format(type(self).__name__,
-                                             self.__name__,
-                                             int.__repr__(self))
+                return "{}({!r}, {})".format(
+                        type(self).__name__,
+                        self.__name__,
+                        int.__repr__(self),
+                        )
             def __str__(self):
                 # str() is unchanged, even if it relies on the repr() fallback
                 base = int
@@ -1210,7 +1217,8 @@ class TestEnum(unittest.TestCase):
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
                         '({0} + {1})'.format(self.__name__, other.__name__),
-                        temp )
+                        temp,
+                        )
                 else:
                     return temp
 
@@ -1250,9 +1258,11 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "{}({!r}, {})".format(type(self).__name__,
-                                             self.__name__,
-                                             int.__repr__(self))
+                return "{}({!r}, {})".format(
+                        type(self).__name__,
+                        self.__name__,
+                        int.__repr__(self),
+                        )
             def __str__(self):
                 # str() is unchanged, even if it relies on the repr() fallback
                 base = int
@@ -1267,7 +1277,8 @@ class TestEnum(unittest.TestCase):
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
                         '({0} + {1})'.format(self.__name__, other.__name__),
-                        temp )
+                        temp,
+                        )
                 else:
                     return temp
 
@@ -1307,9 +1318,11 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "{}({!r}, {})".format(type(self).__name__,
-                                             self.__name__,
-                                             int.__repr__(self))
+                return "{}({!r}, {})".format(
+                        type(self).__name__,
+                        self.__name__,
+                        int.__repr__(self),
+                        )
             def __str__(self):
                 # str() is unchanged, even if it relies on the repr() fallback
                 base = int
@@ -1324,7 +1337,8 @@ class TestEnum(unittest.TestCase):
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
                         '({0} + {1})'.format(self.__name__, other.__name__),
-                        temp )
+                        temp,
+                        )
                 else:
                     return temp
 
@@ -1332,7 +1346,6 @@ class TestEnum(unittest.TestCase):
             __qualname__ = 'NEI'      # needed for pickle protocol 4
             x = ('the-x', 1)
             y = ('the-y', 2)
-
 
         self.assertIs(NEI.__new__, Enum.__new__)
         self.assertEqual(repr(NEI.x + NEI.y), "NamedInt('(the-x + the-y)', 3)")
@@ -1362,9 +1375,11 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "{}({!r}, {})".format(type(self).__name__,
-                                             self.__name__,
-                                             int.__repr__(self))
+                return "{}({!r}, {})".format(
+                        type(self).__name__,
+                        self.__name__,
+                        int.__repr__(self),
+                        )
             def __str__(self):
                 # str() is unchanged, even if it relies on the repr() fallback
                 base = int
@@ -1415,9 +1430,11 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "{}({!r}, {})".format(type(self).__name__,
-                                             self.__name__,
-                                             int.__repr__(self))
+                return "{}({!r}, {})".format(
+                        type(self).__name__,
+                        self.__name__,
+                        int.__repr__(self),
+                        )
             def __str__(self):
                 # str() is unchanged, even if it relies on the repr() fallback
                 base = int
@@ -1432,7 +1449,8 @@ class TestEnum(unittest.TestCase):
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
                         '({0} + {1})'.format(self.__name__, other.__name__),
-                        temp )
+                        temp,
+                        )
                 else:
                     return temp
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1009,6 +1009,9 @@ class TestEnum(unittest.TestCase):
                 cyan = 4
                 magenta = 5
                 yellow = 6
+        with self.assertRaisesRegex(TypeError, "EvenMoreColor: cannot extend enumeration 'Color'"):
+            class EvenMoreColor(Color, IntEnum):
+                chartruese = 7
 
     def test_exclude_methods(self):
         class whatever(Enum):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1845,6 +1845,18 @@ class TestEnum(unittest.TestCase):
             third = auto()
         self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
 
+    def test_default_missing(self):
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+        try:
+            Color(7)
+        except ValueError as exc:
+            self.assertTrue(exc.__context__ is None)
+        else:
+            raise Exception('Exception not raised.')
+
     def test_missing(self):
         class Color(Enum):
             red = 1
@@ -1863,7 +1875,12 @@ class TestEnum(unittest.TestCase):
                     # trigger not found
                     return None
         self.assertIs(Color('three'), Color.blue)
-        self.assertRaises(ValueError, Color, 7)
+        try:
+            Color(7)
+        except ValueError as exc:
+            self.assertTrue(exc.__context__ is None)
+        else:
+            raise Exception('Exception not raised.')
         try:
             Color('bad return')
         except TypeError as exc:

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -287,6 +287,11 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(a.__args__, (list[T], tuple[T, ...]))
         self.assertEqual(a.__parameters__, (T,))
 
+    def test_dir(self):
+        dir_of_gen_alias = set(dir(list[int]))
+        self.assertTrue(dir_of_gen_alias.issuperset(dir(list)))
+        for generic_alias_property in ("__origin__", "__args__", "__parameters__"):
+            self.assertIn(generic_alias_property, dir_of_gen_alias)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1,5 +1,5 @@
 import errno
-from http import client
+from http import client, HTTPStatus
 import io
 import itertools
 import os
@@ -519,6 +519,10 @@ class TransferEncodingTest(TestCase):
 
 
 class BasicTest(TestCase):
+    def test_dir_with_added_behavior_on_status(self):
+        # see issue40084
+        self.assertTrue({'description', 'name', 'phrase', 'value'} <= set(dir(HTTPStatus(404))))
+
     def test_status_lines(self):
         # Test HTTP status lines
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -611,7 +611,7 @@ class MathTests(unittest.TestCase):
         def msum(iterable):
             """Full precision summation.  Compute sum(iterable) without any
             intermediate accumulation of error.  Based on the 'lsum' function
-            at http://code.activestate.com/recipes/393090/
+            at https://github.com/ActiveState/code/tree/master/recipes/Python/393090_Binary_floating_point_summatiaccurate_full/recipe-393090.py
 
             """
             tmant, texp = 0, 0

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -803,6 +803,57 @@ class MathTests(unittest.TestCase):
             scale = FLOAT_MIN / 2.0 ** exp
             self.assertEqual(math.hypot(4*scale, 3*scale), 5*scale)
 
+    def testHypotAccuracy(self):
+        # Verify improved accuracy in cases that were known to be inaccurate.
+
+        hypot = math.hypot
+        Decimal = decimal.Decimal
+        high_precision = decimal.Context(prec=500)
+
+        for hx, hy in [
+            # Cases with a 1 ulp error in Python 3.7 compiled with Clang
+            ('0x1.10e89518dca48p+29', '0x1.1970f7565b7efp+30'),
+            ('0x1.10106eb4b44a2p+29', '0x1.ef0596cdc97f8p+29'),
+            ('0x1.459c058e20bb7p+30', '0x1.993ca009b9178p+29'),
+            ('0x1.378371ae67c0cp+30', '0x1.fbe6619854b4cp+29'),
+            ('0x1.f4cd0574fb97ap+29', '0x1.50fe31669340ep+30'),
+            ('0x1.494b2cdd3d446p+29', '0x1.212a5367b4c7cp+29'),
+            ('0x1.f84e649f1e46dp+29', '0x1.1fa56bef8eec4p+30'),
+            ('0x1.2e817edd3d6fap+30', '0x1.eb0814f1e9602p+29'),
+            ('0x1.0d3a6e3d04245p+29', '0x1.32a62fea52352p+30'),
+            ('0x1.888e19611bfc5p+29', '0x1.52b8e70b24353p+29'),
+
+            # Cases with 2 ulp error in Python 3.8
+            ('0x1.538816d48a13fp+29', '0x1.7967c5ca43e16p+29'),
+            ('0x1.57b47b7234530p+29', '0x1.74e2c7040e772p+29'),
+            ('0x1.821b685e9b168p+30', '0x1.677dc1c1e3dc6p+29'),
+            ('0x1.9e8247f67097bp+29', '0x1.24bd2dc4f4baep+29'),
+            ('0x1.b73b59e0cb5f9p+29', '0x1.da899ab784a97p+28'),
+            ('0x1.94a8d2842a7cfp+30', '0x1.326a51d4d8d8ap+30'),
+            ('0x1.e930b9cd99035p+29', '0x1.5a1030e18dff9p+30'),
+            ('0x1.1592bbb0e4690p+29', '0x1.a9c337b33fb9ap+29'),
+            ('0x1.1243a50751fd4p+29', '0x1.a5a10175622d9p+29'),
+            ('0x1.57a8596e74722p+30', '0x1.42d1af9d04da9p+30'),
+
+            # Cases with 1 ulp error in version fff3c28052e6b0750d6218e00acacd2fded4991a
+            ('0x1.ee7dbd9565899p+29', '0x1.7ab4d6fc6e4b4p+29'),
+            ('0x1.5c6bfbec5c4dcp+30', '0x1.02511184b4970p+30'),
+            ('0x1.59dcebba995cap+30', '0x1.50ca7e7c38854p+29'),
+            ('0x1.768cdd94cf5aap+29', '0x1.9cfdc5571d38ep+29'),
+            ('0x1.dcf137d60262ep+29', '0x1.1101621990b3ep+30'),
+            ('0x1.3a2d006e288b0p+30', '0x1.e9a240914326cp+29'),
+            ('0x1.62a32f7f53c61p+29', '0x1.47eb6cd72684fp+29'),
+            ('0x1.d3bcb60748ef2p+29', '0x1.3f13c4056312cp+30'),
+            ('0x1.282bdb82f17f3p+30', '0x1.640ba4c4eed3ap+30'),
+            ('0x1.89d8c423ea0c6p+29', '0x1.d35dcfe902bc3p+29'),
+        ]:
+            with self.subTest(hx=hx, hy=hy):
+                x = float.fromhex(hx)
+                y = float.fromhex(hy)
+                with decimal.localcontext(high_precision):
+                    z = float((Decimal(x)**2 + Decimal(y)**2).sqrt())
+                self.assertEqual(hypot(x, y), z)
+
     def testDist(self):
         from decimal import Decimal as D
         from fractions import Fraction as F

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -803,6 +803,69 @@ class MathTests(unittest.TestCase):
             scale = FLOAT_MIN / 2.0 ** exp
             self.assertEqual(math.hypot(4*scale, 3*scale), 5*scale)
 
+    @requires_IEEE_754
+    @unittest.skipIf(HAVE_DOUBLE_ROUNDING,
+                     "hypot() loses accuracy on machines with double rounding")
+    def testHypotAccuracy(self):
+        # Verify improved accuracy in cases that were known to be inaccurate.
+        #
+        # The new algorithm's accuracy depends on IEEE 754 arithmetic
+        # guarantees, on having the usual ROUND HALF EVEN rounding mode, on
+        # the system not having double rounding due to extended precision,
+        # and on the compiler maintaining the specified order of operations.
+        #
+        # This test is known to succeed on most of our builds.  If it fails
+        # some build, we either need to add another skipIf if the cause is
+        # identifiable; otherwise, we can remove this test entirely.
+
+        hypot = math.hypot
+        Decimal = decimal.Decimal
+        high_precision = decimal.Context(prec=500)
+
+        for hx, hy in [
+            # Cases with a 1 ulp error in Python 3.7 compiled with Clang
+            ('0x1.10e89518dca48p+29', '0x1.1970f7565b7efp+30'),
+            ('0x1.10106eb4b44a2p+29', '0x1.ef0596cdc97f8p+29'),
+            ('0x1.459c058e20bb7p+30', '0x1.993ca009b9178p+29'),
+            ('0x1.378371ae67c0cp+30', '0x1.fbe6619854b4cp+29'),
+            ('0x1.f4cd0574fb97ap+29', '0x1.50fe31669340ep+30'),
+            ('0x1.494b2cdd3d446p+29', '0x1.212a5367b4c7cp+29'),
+            ('0x1.f84e649f1e46dp+29', '0x1.1fa56bef8eec4p+30'),
+            ('0x1.2e817edd3d6fap+30', '0x1.eb0814f1e9602p+29'),
+            ('0x1.0d3a6e3d04245p+29', '0x1.32a62fea52352p+30'),
+            ('0x1.888e19611bfc5p+29', '0x1.52b8e70b24353p+29'),
+
+            # Cases with 2 ulp error in Python 3.8
+            ('0x1.538816d48a13fp+29', '0x1.7967c5ca43e16p+29'),
+            ('0x1.57b47b7234530p+29', '0x1.74e2c7040e772p+29'),
+            ('0x1.821b685e9b168p+30', '0x1.677dc1c1e3dc6p+29'),
+            ('0x1.9e8247f67097bp+29', '0x1.24bd2dc4f4baep+29'),
+            ('0x1.b73b59e0cb5f9p+29', '0x1.da899ab784a97p+28'),
+            ('0x1.94a8d2842a7cfp+30', '0x1.326a51d4d8d8ap+30'),
+            ('0x1.e930b9cd99035p+29', '0x1.5a1030e18dff9p+30'),
+            ('0x1.1592bbb0e4690p+29', '0x1.a9c337b33fb9ap+29'),
+            ('0x1.1243a50751fd4p+29', '0x1.a5a10175622d9p+29'),
+            ('0x1.57a8596e74722p+30', '0x1.42d1af9d04da9p+30'),
+
+            # Cases with 1 ulp error in version fff3c28052e6b0
+            ('0x1.ee7dbd9565899p+29', '0x1.7ab4d6fc6e4b4p+29'),
+            ('0x1.5c6bfbec5c4dcp+30', '0x1.02511184b4970p+30'),
+            ('0x1.59dcebba995cap+30', '0x1.50ca7e7c38854p+29'),
+            ('0x1.768cdd94cf5aap+29', '0x1.9cfdc5571d38ep+29'),
+            ('0x1.dcf137d60262ep+29', '0x1.1101621990b3ep+30'),
+            ('0x1.3a2d006e288b0p+30', '0x1.e9a240914326cp+29'),
+            ('0x1.62a32f7f53c61p+29', '0x1.47eb6cd72684fp+29'),
+            ('0x1.d3bcb60748ef2p+29', '0x1.3f13c4056312cp+30'),
+            ('0x1.282bdb82f17f3p+30', '0x1.640ba4c4eed3ap+30'),
+            ('0x1.89d8c423ea0c6p+29', '0x1.d35dcfe902bc3p+29'),
+        ]:
+            x = float.fromhex(hx)
+            y = float.fromhex(hy)
+            with self.subTest(hx=hx, hy=hy, x=x, y=y):
+                with decimal.localcontext(high_precision):
+                    z = float((Decimal(x)**2 + Decimal(y)**2).sqrt())
+                self.assertEqual(hypot(x, y), z)
+
     def testDist(self):
         from decimal import Decimal as D
         from fractions import Fraction as F

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -803,57 +803,6 @@ class MathTests(unittest.TestCase):
             scale = FLOAT_MIN / 2.0 ** exp
             self.assertEqual(math.hypot(4*scale, 3*scale), 5*scale)
 
-    def testHypotAccuracy(self):
-        # Verify improved accuracy in cases that were known to be inaccurate.
-
-        hypot = math.hypot
-        Decimal = decimal.Decimal
-        high_precision = decimal.Context(prec=500)
-
-        for hx, hy in [
-            # Cases with a 1 ulp error in Python 3.7 compiled with Clang
-            ('0x1.10e89518dca48p+29', '0x1.1970f7565b7efp+30'),
-            ('0x1.10106eb4b44a2p+29', '0x1.ef0596cdc97f8p+29'),
-            ('0x1.459c058e20bb7p+30', '0x1.993ca009b9178p+29'),
-            ('0x1.378371ae67c0cp+30', '0x1.fbe6619854b4cp+29'),
-            ('0x1.f4cd0574fb97ap+29', '0x1.50fe31669340ep+30'),
-            ('0x1.494b2cdd3d446p+29', '0x1.212a5367b4c7cp+29'),
-            ('0x1.f84e649f1e46dp+29', '0x1.1fa56bef8eec4p+30'),
-            ('0x1.2e817edd3d6fap+30', '0x1.eb0814f1e9602p+29'),
-            ('0x1.0d3a6e3d04245p+29', '0x1.32a62fea52352p+30'),
-            ('0x1.888e19611bfc5p+29', '0x1.52b8e70b24353p+29'),
-
-            # Cases with 2 ulp error in Python 3.8
-            ('0x1.538816d48a13fp+29', '0x1.7967c5ca43e16p+29'),
-            ('0x1.57b47b7234530p+29', '0x1.74e2c7040e772p+29'),
-            ('0x1.821b685e9b168p+30', '0x1.677dc1c1e3dc6p+29'),
-            ('0x1.9e8247f67097bp+29', '0x1.24bd2dc4f4baep+29'),
-            ('0x1.b73b59e0cb5f9p+29', '0x1.da899ab784a97p+28'),
-            ('0x1.94a8d2842a7cfp+30', '0x1.326a51d4d8d8ap+30'),
-            ('0x1.e930b9cd99035p+29', '0x1.5a1030e18dff9p+30'),
-            ('0x1.1592bbb0e4690p+29', '0x1.a9c337b33fb9ap+29'),
-            ('0x1.1243a50751fd4p+29', '0x1.a5a10175622d9p+29'),
-            ('0x1.57a8596e74722p+30', '0x1.42d1af9d04da9p+30'),
-
-            # Cases with 1 ulp error in version fff3c28052e6b0750d6218e00acacd2fded4991a
-            ('0x1.ee7dbd9565899p+29', '0x1.7ab4d6fc6e4b4p+29'),
-            ('0x1.5c6bfbec5c4dcp+30', '0x1.02511184b4970p+30'),
-            ('0x1.59dcebba995cap+30', '0x1.50ca7e7c38854p+29'),
-            ('0x1.768cdd94cf5aap+29', '0x1.9cfdc5571d38ep+29'),
-            ('0x1.dcf137d60262ep+29', '0x1.1101621990b3ep+30'),
-            ('0x1.3a2d006e288b0p+30', '0x1.e9a240914326cp+29'),
-            ('0x1.62a32f7f53c61p+29', '0x1.47eb6cd72684fp+29'),
-            ('0x1.d3bcb60748ef2p+29', '0x1.3f13c4056312cp+30'),
-            ('0x1.282bdb82f17f3p+30', '0x1.640ba4c4eed3ap+30'),
-            ('0x1.89d8c423ea0c6p+29', '0x1.d35dcfe902bc3p+29'),
-        ]:
-            with self.subTest(hx=hx, hy=hy):
-                x = float.fromhex(hx)
-                y = float.fromhex(hy)
-                with decimal.localcontext(high_precision):
-                    z = float((Decimal(x)**2 + Decimal(y)**2).sqrt())
-                self.assertEqual(hypot(x, y), z)
-
     def testDist(self):
         from decimal import Decimal as D
         from fractions import Fraction as F

--- a/Lib/test/test_pstats.py
+++ b/Lib/test/test_pstats.py
@@ -95,5 +95,9 @@ class StatsTestCase(unittest.TestCase):
         self.assertIn('pass2', funcs_called)
         self.assertIn('pass3', funcs_called)
 
+    def test_SortKey_enum(self):
+        self.assertEqual(SortKey.FILENAME, 'filename')
+        self.assertNotEqual(SortKey.FILENAME, SortKey.CALLS)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -161,6 +161,12 @@ class HelperFunctionsTests(unittest.TestCase):
         self.assertRegex(err_out.getvalue(), 'Traceback')
         self.assertRegex(err_out.getvalue(), 'ModuleNotFoundError')
 
+    def test_addpackage_empty_lines(self):
+        # Issue 33689
+        pth_dir, pth_fn = self.make_pth("\n\n  \n\n")
+        known_paths = site.addpackage(pth_dir, pth_fn, set())
+        self.assertEqual(known_paths, set())
+
     def test_addpackage_import_bad_pth_file(self):
         # Issue 5258
         pth_dir, pth_fn = self.make_pth("abc\x00def\n")
@@ -594,7 +600,6 @@ class StartupImportTests(unittest.TestCase):
         r = subprocess.Popen([sys.executable, '-I', '-c',
             'import site, sys; site.enablerlcompleter(); sys.exit(hasattr(sys, "__interactivehook__"))']).wait()
         self.assertTrue(r, "'__interactivehook__' not added by enablerlcompleter()")
-
 
 @unittest.skipUnless(sys.platform == 'win32', "only supported on Windows")
 class _pthFileTests(unittest.TestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -16,6 +16,7 @@ from typing import Generic, ClassVar, Final, final, Protocol
 from typing import cast, runtime_checkable
 from typing import get_type_hints
 from typing import get_origin, get_args
+from typing import is_typeddict
 from typing import no_type_check, no_type_check_decorator
 from typing import Type
 from typing import NewType
@@ -3899,6 +3900,12 @@ class TypedDictTests(BaseTestCase):
             'tail': bool,
             'voice': str,
         }
+
+    def test_is_typeddict(self):
+        assert is_typeddict(Point2D) is True
+        assert is_typeddict(Union[str, int]) is False
+        # classes, not instances
+        assert is_typeddict(Point2D()) is False
 
 
 class IOTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -103,6 +103,7 @@ __all__ = [
     'get_args',
     'get_origin',
     'get_type_hints',
+    'is_typeddict',
     'NewType',
     'no_type_check',
     'no_type_check_decorator',
@@ -1477,6 +1478,20 @@ def get_args(tp):
     if isinstance(tp, GenericAlias):
         return tp.__args__
     return ()
+
+
+def is_typeddict(tp):
+    """Check if an annotation is a TypedDict class
+
+    For example::
+        class Film(TypedDict):
+            title: str
+            year: int
+
+        is_typeddict(Film)  # => True
+        is_typeddict(Union[list, str])  # => False
+    """
+    return isinstance(tp, _TypedDictMeta)
 
 
 def no_type_check(arg):

--- a/Mac/BuildScript/resources/License.rtf
+++ b/Mac/BuildScript/resources/License.rtf
@@ -1,9 +1,9 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2511
+{\rtf1\ansi\ansicpg1252\cocoartf2513
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;\f2\fmodern\fcharset0 CourierNewPS-BoldMT;
 \f3\fmodern\fcharset0 CourierNewPSMT;}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
-\margl1440\margr1440\vieww14620\viewh13380\viewkind0
+\margl1440\margr1440\vieww18500\viewh13520\viewkind0
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \f0\b\fs36 \cf0 \ul \ulc0 HISTORY AND LICENSE\
@@ -47,8 +47,17 @@ Thanks to the many outside volunteers who have worked under Guido's direction to
 \
 
 \f0\b \ul TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON\
+\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f1\b0 \ulnone \
+\f1\b0 \cf0 \ulnone Python software and documentation are licensed under the Python Software Foundation License Version 2.\
+\
+Starting with Python 3.8.6, examples, recipes, and other code in the documentation are dual licensed under the PSF License Version 2 and the Zero-Clause BSD license.\
+\
+Some software incorporated into Python is under different licenses. The licenses are listed with code falling under that license.\
+\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 \
 
 \f0\b PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2\
 
@@ -124,6 +133,18 @@ Permission to use, copy, modify, and distribute this software and its documentat
 \
 STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.\
 \
+\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\b \cf0 ZERO-CLAUSE BSD LICENSE FOR CODE IN THE PYTHON DOCUMENTATION\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f1\b0 \cf0 \
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted.\
+\
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 \
 \
 
 \f0\b \ul LICENSES AND ACKNOWLEDGEMENTS FOR INCORPORATED SOFTWARE\

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1723,6 +1723,7 @@ Févry Thibault
 Lowe Thiderman
 Nicolas M. Thiéry
 James Thomas
+Reuben Thomas
 Robin Thomas
 Brian Thorne
 Christopher Thorne

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -736,6 +736,7 @@ Thomas Holmes
 Craig Holmquist
 Philip Homburg
 Naofumi Honda
+Weipeng Hong
 Jeffrey Honig
 Rob Hooft
 Michiel de Hoon

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -306,6 +306,7 @@ Albert Chin-A-Young
 Adal Chiriliuc
 Matt Chisholm
 Lita Cho
+Kit Yan Choi
 Sayan Chowdhury
 Yuan-Chao Chou
 Anders Chrigström

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -433,6 +433,7 @@ Marcos Donolo
 Dima Dorfman
 Yves Dorfsman
 Michael Dorman
+Andrey Doroschenko
 Steve Dower
 Allen Downey
 Cesar Douady

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -191,6 +191,7 @@ Gawain Bolton
 Carl Friedrich Bolz-Tereick
 Forest Bond
 Gregory Bond
+Angelin Booz
 Médéric Boquien
 Matias Bordese
 Jonas Borgström

--- a/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
+++ b/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
@@ -1,2 +1,2 @@
 fixed bug in "The Very High Level Layer" of c-api that prevented
-PyRun_InteractiveOne*() parsing from the provided FD.
+PyRun_InteractiveOne\*() parsing from the provided FD.

--- a/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
+++ b/Misc/NEWS.d/next/C API/2020-09-11-02-50-41.bpo-14916.QN1Y03.rst
@@ -1,0 +1,2 @@
+fixed bug in "The Very High Level Layer" of c-api that prevented
+PyRun_InteractiveOne*() parsing from the provided FD.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-08-26-11-23-31.bpo-41631.3jZcd9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-08-26-11-23-31.bpo-41631.3jZcd9.rst
@@ -1,0 +1,5 @@
+The ``_ast`` module uses again a global state. Using a module state per module
+instance is causing subtle practical problems. For example, the Mercurial
+project replaces the ``__import__()`` function to implement lazy import,
+whereas Python expected that ``import _ast`` always return a fully initialized
+``_ast`` module.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-09-12-12-55-45.bpo-41756.1h0tbV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-09-12-12-55-45.bpo-41756.1h0tbV.rst
@@ -1,0 +1,2 @@
+Add PyGen_Send function to allow sending value into generator/coroutine
+without raising StopIteration exception to signal return

--- a/Misc/NEWS.d/next/Core and Builtins/2020-09-15-23-29-49.bpo-41780.bOBUIH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-09-15-23-29-49.bpo-41780.bOBUIH.rst
@@ -1,0 +1,2 @@
+Fix :meth:`__dir__` of :class:`types.GenericAlias`. Patch by Batuhan
+Taskaya.

--- a/Misc/NEWS.d/next/Documentation/2020-09-10-07-48-02.bpo-37149.VD0rCv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-09-10-07-48-02.bpo-37149.VD0rCv.rst
@@ -1,0 +1,1 @@
+Change Shipman tkinter doc link from archive.org to TkDocs. (The doc has been removed from the NMT server.)  The new link responds much faster and includes a short explanatory note.

--- a/Misc/NEWS.d/next/Documentation/2020-09-12-17-37-13.bpo-35293._cOwPD.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-09-12-17-37-13.bpo-35293._cOwPD.rst
@@ -1,0 +1,1 @@
+Fix RemovedInSphinx40Warning when building the documentation. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/IDLE/2020-09-22-00-45-40.bpo-40181.hhQi3z.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-09-22-00-45-40.bpo-40181.hhQi3z.rst
@@ -1,0 +1,2 @@
+In calltips, stop reminding that '/' marks the end of positional-only
+arguments.

--- a/Misc/NEWS.d/next/Library/2019-05-31-23-54-28.bpo-12178.N6FLCZ.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-31-23-54-28.bpo-12178.N6FLCZ.rst
@@ -1,0 +1,3 @@
+:func:`csv.writer` now correctly escapes *escapechar* when input
+contains *escapechar*.  Patch by Catalin Iacob, Berker Peksag,
+and Itay Elbirt.

--- a/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
@@ -1,0 +1,1 @@
+fix default `_missing_` so a duplicate `ValueError` is not set as the `__context__` of the original `ValueError`

--- a/Misc/NEWS.d/next/Library/2020-03-29-21-32-00.bpo-40084.MCYwcv.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-29-21-32-00.bpo-40084.MCYwcv.rst
@@ -1,0 +1,1 @@
+Fix ``Enum.__dir__``: dir(Enum.member) now includes attributes as well as methods.

--- a/Misc/NEWS.d/next/Library/2020-06-02-23-49-07.bpo-32604.ZN4V4l.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-02-23-49-07.bpo-32604.ZN4V4l.rst
@@ -1,2 +1,2 @@
-Fix reference leak in the :mod:`select` module when the the module is
+Fix reference leak in the :mod:`select` module when the module is
 imported in a subinterpreter.

--- a/Misc/NEWS.d/next/Library/2020-06-04-16-25-15.bpo-40807.yYyLWx.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-04-16-25-15.bpo-40807.yYyLWx.rst
@@ -1,2 +1,2 @@
 Stop codeop._maybe_compile, used by code.InteractiveInterpreter (and IDLE).
-from from emitting each warning three times.
+from emitting each warning three times.

--- a/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-06-14-09-55.bpo-33689.EFUDH7.rst
@@ -1,0 +1,4 @@
+Ignore empty or whitespace-only lines in .pth files. This matches the
+documentated behavior. Before, empty lines caused the site-packages
+dir to appear multiple times in sys.path.
+By Ido Michael, contributors Malcolm Smith and Tal Einat.

--- a/Misc/NEWS.d/next/Library/2020-08-29-16-07-36.bpo-41662.Mn79zh.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-29-16-07-36.bpo-41662.Mn79zh.rst
@@ -1,0 +1,1 @@
+Fixed crash when mutate list of parameters during iteration in :mod:`sqlite3`.

--- a/Misc/NEWS.d/next/Library/2020-08-30-21-38-57.bpo-41662.6e9iZn.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-30-21-38-57.bpo-41662.6e9iZn.rst
@@ -1,0 +1,2 @@
+No longer override exceptions raised in ``__len__()`` of a sequence of
+parameters in :mod:`sqlite3` with :exc:`~sqlite3.ProgrammingError`.

--- a/Misc/NEWS.d/next/Library/2020-09-11-12-38-55.bpo-39651.JMp9l2.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-11-12-38-55.bpo-39651.JMp9l2.rst
@@ -1,0 +1,3 @@
+Fix a race condition in the ``call_soon_threadsafe()`` method of
+``asyncio.ProactorEventLoop``: do nothing if the self-pipe socket has been
+closed.

--- a/Misc/NEWS.d/next/Library/2020-09-12-16-18-42.bpo-32218.IpYkEe.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-12-16-18-42.bpo-32218.IpYkEe.rst
@@ -1,0 +1,1 @@
+`enum.Flag` and `enum.IntFlag` members are now iterable

--- a/Misc/NEWS.d/next/Library/2020-09-14-19-27-46.bpo-41789.pI_uZQ.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-14-19-27-46.bpo-41789.pI_uZQ.rst
@@ -1,0 +1,2 @@
+Honor `object` overrides in `Enum` class creation (specifically, `__str__`,
+`__repr__`, `__format__`, and `__reduce_ex__`).

--- a/Misc/NEWS.d/next/Library/2020-09-15-07-55-35.bpo-41792.qMpSlU.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-15-07-55-35.bpo-41792.qMpSlU.rst
@@ -1,0 +1,6 @@
+Add is_typeddict function to typing.py to check if a type is a TypedDict
+class
+
+Previously there was no way to check that without using private API. See the
+`relevant issue in python/typing
+<https://github.com/python/typing/issues/751>`

--- a/Misc/NEWS.d/next/Library/2020-09-15-14-56-13.bpo-39587.69xzuh.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-15-14-56-13.bpo-39587.69xzuh.rst
@@ -1,0 +1,1 @@
+use the correct mix-in data type when constructing Enums

--- a/Misc/NEWS.d/next/Library/2020-09-15-22-43-30.bpo-41517.sLBH7g.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-15-22-43-30.bpo-41517.sLBH7g.rst
@@ -1,0 +1,1 @@
+fix bug allowing Enums to be extended via multiple inheritance

--- a/Misc/NEWS.d/next/Library/2020-09-19-12-22-08.bpo-41816.ynynXJ.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-19-12-22-08.bpo-41816.ynynXJ.rst
@@ -1,0 +1,2 @@
+StrEnum added: it ensures that all members are already strings or string
+candidates

--- a/Misc/NEWS.d/next/Library/2020-09-19-23-14-54.bpo-41815.RNpuX3.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-19-23-14-54.bpo-41815.RNpuX3.rst
@@ -1,0 +1,2 @@
+Fix SQLite3 segfault when backing up closed database. Patch contributed by
+Peter David McCormick.

--- a/Misc/NEWS.d/next/Tests/2020-09-11-19-12-31.bpo-41731.Ivxh4U.rst
+++ b/Misc/NEWS.d/next/Tests/2020-09-11-19-12-31.bpo-41731.Ivxh4U.rst
@@ -1,0 +1,1 @@
+Make test_cmd_line_script pass with option '-vv'.

--- a/Misc/NEWS.d/next/Windows/2020-09-11-17-59-33.bpo-41744.e_ugDQ.rst
+++ b/Misc/NEWS.d/next/Windows/2020-09-11-17-59-33.bpo-41744.e_ugDQ.rst
@@ -1,0 +1,1 @@
+Fixes automatic import of props file when using the Nuget package.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2621,6 +2621,20 @@ task_set_error_soon(TaskObj *task, PyObject *et, const char *format, ...)
     Py_RETURN_NONE;
 }
 
+static inline int
+gen_status_from_result(PyObject **result)
+{
+    if (*result != NULL) {
+        return PYGEN_NEXT;
+    }
+    if (_PyGen_FetchStopIterationValue(result) == 0) {
+        return PYGEN_RETURN;
+    }
+
+    assert(PyErr_Occurred());
+    return PYGEN_ERROR;
+}
+
 static PyObject *
 task_step_impl(TaskObj *task, PyObject *exc)
 {
@@ -2679,26 +2693,29 @@ task_step_impl(TaskObj *task, PyObject *exc)
         return NULL;
     }
 
+    int gen_status = PYGEN_ERROR;
     if (exc == NULL) {
         if (PyGen_CheckExact(coro) || PyCoro_CheckExact(coro)) {
-            result = _PyGen_Send((PyGenObject*)coro, Py_None);
+            gen_status = PyGen_Send((PyGenObject*)coro, Py_None, &result);
         }
         else {
             result = _PyObject_CallMethodIdOneArg(coro, &PyId_send, Py_None);
+            gen_status = gen_status_from_result(&result);
         }
     }
     else {
         result = _PyObject_CallMethodIdOneArg(coro, &PyId_throw, exc);
+        gen_status = gen_status_from_result(&result);
         if (clear_exc) {
             /* We created 'exc' during this call */
             Py_DECREF(exc);
         }
     }
 
-    if (result == NULL) {
+    if (gen_status == PYGEN_RETURN || gen_status == PYGEN_ERROR) {
         PyObject *et, *ev, *tb;
 
-        if (_PyGen_FetchStopIterationValue(&o) == 0) {
+        if (result != NULL) {
             /* The error is StopIteration and that means that
                the underlying coroutine has resolved */
 
@@ -2709,10 +2726,10 @@ task_step_impl(TaskObj *task, PyObject *exc)
                 res = future_cancel((FutureObj*)task, task->task_cancel_msg);
             }
             else {
-                res = future_set_result((FutureObj*)task, o);
+                res = future_set_result((FutureObj*)task, result);
             }
 
-            Py_DECREF(o);
+            Py_DECREF(result);
 
             if (res == NULL) {
                 return NULL;

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1040,6 +1040,9 @@ join_append_data(WriterObj *self, unsigned int field_kind, const void *field_dat
                     else
                         want_escape = 1;
                 }
+                else if (c == dialect->escapechar) {
+                    want_escape = 1;
+                }
                 if (!want_escape)
                     *quoted = 1;
             }

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -50,7 +50,14 @@ typedef struct {
 #define POF_BUILTINS    0x004
 #define POF_NOMEMORY    0x100
 
+/*[clinic input]
+module _lsprof
+class _lsprof.Profiler "ProfilerObject *" "&ProfilerType"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=e349ac952152f336]*/
 static PyTypeObject PyProfiler_Type;
+
+#include "clinic/_lsprof.c.h"
 
 #define PyProfiler_Check(op) PyObject_TypeCheck(op, &PyProfiler_Type)
 #define PyProfiler_CheckExact(op) Py_IS_TYPE(op, &PyProfiler_Type)
@@ -556,49 +563,54 @@ static int statsForEntry(rotating_node_t *node, void *arg)
     return err;
 }
 
-PyDoc_STRVAR(getstats_doc, "\
-getstats() -> list of profiler_entry objects\n\
-\n\
-Return all information collected by the profiler.\n\
-Each profiler_entry is a tuple-like object with the\n\
-following attributes:\n\
-\n\
-    code          code object\n\
-    callcount     how many times this was called\n\
-    reccallcount  how many times called recursively\n\
-    totaltime     total time in this entry\n\
-    inlinetime    inline time in this entry (not in subcalls)\n\
-    calls         details of the calls\n\
-\n\
-The calls attribute is either None or a list of\n\
-profiler_subentry objects:\n\
-\n\
-    code          called code object\n\
-    callcount     how many times this is called\n\
-    reccallcount  how many times this is called recursively\n\
-    totaltime     total time spent in this call\n\
-    inlinetime    inline time (not in further subcalls)\n\
-");
+/*[clinic input]
+_lsprof.Profiler.getstats
 
-static PyObject*
-profiler_getstats(ProfilerObject *pObj, PyObject* noarg)
+list of profiler_entry objects.
+
+getstats() -> list of profiler_entry objects
+
+Return all information collected by the profiler.
+Each profiler_entry is a tuple-like object with the
+following attributes:
+
+    code          code object
+    callcount     how many times this was called
+    reccallcount  how many times called recursively
+    totaltime     total time in this entry
+    inlinetime    inline time in this entry (not in subcalls)
+    calls         details of the calls
+
+The calls attribute is either None or a list of
+profiler_subentry objects:
+
+    code          called code object
+    callcount     how many times this is called
+    reccallcount  how many times this is called recursively
+    totaltime     total time spent in this call
+    inlinetime    inline time (not in further subcalls)
+[clinic start generated code]*/
+
+static PyObject *
+_lsprof_Profiler_getstats_impl(ProfilerObject *self)
+/*[clinic end generated code: output=9461b451e9ef0f24 input=ade04fa384ce450a]*/
 {
     statscollector_t collect;
-    if (pending_exception(pObj)) {
+    if (pending_exception(self)) {
         return NULL;
     }
-    if (!pObj->externalTimer || pObj->externalTimerUnit == 0.0) {
+    if (!self->externalTimer || self->externalTimerUnit == 0.0) {
         _PyTime_t onesec = _PyTime_FromSeconds(1);
         collect.factor = (double)1 / onesec;
     }
     else {
-        collect.factor = pObj->externalTimerUnit;
+        collect.factor = self->externalTimerUnit;
     }
 
     collect.list = PyList_New(0);
     if (collect.list == NULL)
         return NULL;
-    if (RotatingTree_Enum(pObj->profilerEntries, statsForEntry, &collect)
+    if (RotatingTree_Enum(self->profilerEntries, statsForEntry, &collect)
         != 0) {
         Py_DECREF(collect.list);
         return NULL;
@@ -750,8 +762,7 @@ profiler_init(ProfilerObject *pObj, PyObject *args, PyObject *kw)
 }
 
 static PyMethodDef profiler_methods[] = {
-    {"getstats",    (PyCFunction)profiler_getstats,
-                    METH_NOARGS,                        getstats_doc},
+    _LSPROF_PROFILER_GETSTATS_METHODDEF
     {"enable",          (PyCFunction)(void(*)(void))profiler_enable,
                     METH_VARARGS | METH_KEYWORDS,       enable_doc},
     {"disable",         (PyCFunction)profiler_disable,

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1514,6 +1514,10 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
         sleep_ms = (int)ms;
     }
 
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
     if (!pysqlite_check_connection((pysqlite_Connection *)target)) {
         return NULL;
     }

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -227,6 +227,9 @@ void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* para
             num_params = PyList_GET_SIZE(parameters);
         } else {
             num_params = PySequence_Size(parameters);
+            if (num_params == -1) {
+                return;
+            }
         }
         if (num_params != num_params_needed) {
             PyErr_Format(pysqlite_ProgrammingError,
@@ -238,9 +241,9 @@ void pysqlite_statement_bind_parameters(pysqlite_Statement* self, PyObject* para
         for (i = 0; i < num_params; i++) {
             if (PyTuple_CheckExact(parameters)) {
                 current_param = PyTuple_GET_ITEM(parameters, i);
-                Py_XINCREF(current_param);
+                Py_INCREF(current_param);
             } else if (PyList_CheckExact(parameters)) {
-                current_param = PyList_GET_ITEM(parameters, i);
+                current_param = PyList_GetItem(parameters, i);
                 Py_XINCREF(current_param);
             } else {
                 current_param = PySequence_GetItem(parameters, i);

--- a/Modules/clinic/_lsprof.c.h
+++ b/Modules/clinic/_lsprof.c.h
@@ -1,0 +1,44 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(_lsprof_Profiler_getstats__doc__,
+"getstats($self, /)\n"
+"--\n"
+"\n"
+"list of profiler_entry objects.\n"
+"\n"
+"getstats() -> list of profiler_entry objects\n"
+"\n"
+"Return all information collected by the profiler.\n"
+"Each profiler_entry is a tuple-like object with the\n"
+"following attributes:\n"
+"\n"
+"    code          code object\n"
+"    callcount     how many times this was called\n"
+"    reccallcount  how many times called recursively\n"
+"    totaltime     total time in this entry\n"
+"    inlinetime    inline time in this entry (not in subcalls)\n"
+"    calls         details of the calls\n"
+"\n"
+"The calls attribute is either None or a list of\n"
+"profiler_subentry objects:\n"
+"\n"
+"    code          called code object\n"
+"    callcount     how many times this is called\n"
+"    reccallcount  how many times this is called recursively\n"
+"    totaltime     total time spent in this call\n"
+"    inlinetime    inline time (not in further subcalls)");
+
+#define _LSPROF_PROFILER_GETSTATS_METHODDEF    \
+    {"getstats", (PyCFunction)_lsprof_Profiler_getstats, METH_NOARGS, _lsprof_Profiler_getstats__doc__},
+
+static PyObject *
+_lsprof_Profiler_getstats_impl(ProfilerObject *self);
+
+static PyObject *
+_lsprof_Profiler_getstats(ProfilerObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return _lsprof_Profiler_getstats_impl(self);
+}
+/*[clinic end generated code: output=24c525812713e00f input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2550,8 +2550,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             assert(csum + lo * lo == csum);
             frac_lo += lo * lo;
         }
-        frac += frac_lo + frac_mid;
-        h = sqrt(csum - 1.0 + frac);
+        h = sqrt(csum - 1.0 + (frac_lo + frac_mid + frac));
 
         x = h;
         t = x * T27;
@@ -2569,15 +2568,15 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac += (oldcsum - csum) + x;
+        frac_mid += (oldcsum - csum) + x;
 
         x = -lo * lo;
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac += (oldcsum - csum) + x;
+        frac_lo += (oldcsum - csum) + x;
 
-        x = csum - 1.0 + frac;
+        x = csum - 1.0 + (frac_lo + frac_mid + frac);
         return (h + x / (2.0 * h)) / scale;
     }
     /* When max_e < -1023, ldexp(1.0, -max_e) overflows.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2429,7 +2429,7 @@ magnitude.  We avoid this cost by arranging the calculation so that
 fabs(csum) is always as large as fabs(x).
 
 To establish the invariant, *csum* is initialized to 1.0 which is
-always larger than x**2 after scaling or division by *max*.
+always larger than x**2 after scaling or after division by *max*.
 After the loop is finished, the initial 1.0 is subtracted out for a
 net zero effect on the final sum.  Since *csum* will be greater than
 1.0, the subtraction of 1.0 will not cause fractional digits to be
@@ -2458,7 +2458,7 @@ Since lo**2 is less than 1/2 ulp(csum), we have csum+lo*lo == csum.
 To minimize loss of information during the accumulation of fractional
 values, each term has a separate accumulator.  This also breaks up
 sequential dependencies in the inner loop so the CPU can maximize
-floating point throughput. [5] On a 2.6 GHz Haswell, adding one
+floating point throughput. [4]  On a 2.6 GHz Haswell, adding one
 dimension has an incremental cost of only 5ns -- for example when
 moving from hypot(x,y) to hypot(x,y,z).
 
@@ -2470,7 +2470,7 @@ The differential correction starts with a value *x* that is
 the difference between the square of *h*, the possibly inaccurately
 rounded square root, and the accurately computed sum of squares.
 The correction is the first order term of the Maclaurin series
-expansion of sqrt(h**2 + x) == h + x/(2*h) + O(x**2). [4]
+expansion of sqrt(h**2 + x) == h + x/(2*h) + O(x**2). [5]
 
 Essentially, this differential correction is equivalent to one
 refinement step in Newton's divide-and-average square root
@@ -2492,10 +2492,10 @@ References:
 1. Veltkamp-Dekker splitting: http://csclub.uwaterloo.ca/~pbarfuss/dekker1971.pdf
 2. Compensated summation:  http://www.ti3.tu-harburg.de/paper/rump/Ru08b.pdf
 3. Square root differential correction:  https://arxiv.org/pdf/1904.09481.pdf
-4. https://www.wolframalpha.com/input/?i=Maclaurin+series+sqrt%28h**2+%2B+x%29+at+x%3D0
-5. https://bugs.python.org/file49439/hypot.png
-6. https://bugs.python.org/file49435/best_frac.py
-7. https://bugs.python.org/file49448/test_hypot_commutativity.py
+4. Data dependency graph:  https://bugs.python.org/file49439/hypot.png
+5. https://www.wolframalpha.com/input/?i=Maclaurin+series+sqrt%28h**2+%2B+x%29+at+x%3D0
+6. Analysis of internal accuracy:  https://bugs.python.org/file49435/best_frac.py
+7. Commutativity test:  https://bugs.python.org/file49448/test_hypot_commutativity.py
 
 */
 

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -487,11 +487,50 @@ ga_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
                          alias->origin, alias->args);
 }
 
+static PyObject *
+ga_dir(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    gaobject *alias = (gaobject *)self;
+    PyObject *dir = PyObject_Dir(alias->origin);
+    if (dir == NULL) {
+        return NULL;
+    }
+
+    PyObject *dir_entry = NULL;
+    for (const char * const *p = attr_exceptions; ; p++) {
+        if (*p == NULL) {
+            break;
+        }
+        else {
+            dir_entry = PyUnicode_FromString(*p);
+            if (dir_entry == NULL) {
+                goto error;
+            }
+            int contains = PySequence_Contains(dir, dir_entry);
+            if (contains < 0) {
+                goto error;
+            }
+            if (contains == 0 && PyList_Append(dir, dir_entry) < 0) {
+                goto error;
+            }
+
+            Py_CLEAR(dir_entry);
+        }
+    }
+    return dir;
+
+error:
+    Py_DECREF(dir);
+    Py_XDECREF(dir_entry);
+    return NULL;
+}
+
 static PyMethodDef ga_methods[] = {
     {"__mro_entries__", ga_mro_entries, METH_O},
     {"__instancecheck__", ga_instancecheck, METH_O},
     {"__subclasscheck__", ga_subclasscheck, METH_O},
     {"__reduce__", ga_reduce, METH_NOARGS},
+    {"__dir__", ga_dir, METH_NOARGS},
     {0}
 };
 

--- a/PC/_testconsole.c
+++ b/PC/_testconsole.c
@@ -63,7 +63,7 @@ _testconsole_write_input_impl(PyObject *module, PyObject *file,
     for (DWORD i = 0; i < size; ++i, ++p, ++prec) {
         prec->EventType = KEY_EVENT;
         prec->Event.KeyEvent.bKeyDown = TRUE;
-        prec->Event.KeyEvent.wRepeatCount = 10;
+        prec->Event.KeyEvent.wRepeatCount = 1;
         prec->Event.KeyEvent.uChar.UnicodeChar = *p;
     }
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -163,6 +163,32 @@ class TypeDefVisitor(EmitVisitor):
         self.emit(s, depth)
         self.emit("", depth)
 
+class SequenceDefVisitor(EmitVisitor):
+    def visitModule(self, mod):
+        for dfn in mod.dfns:
+            self.visit(dfn)
+
+    def visitType(self, type, depth=0):
+        self.visit(type.value, type.name, depth)
+
+    def visitSum(self, sum, name, depth):
+        if is_simple(sum):
+            return
+        self.emit_sequence_constructor(name, depth)
+
+    def emit_sequence_constructor(self, name,depth):
+        ctype = get_c_type(name)
+        self.emit("""\
+typedef struct {
+    _ASDL_SEQ_HEAD
+    %(ctype)s typed_elements[1];
+} asdl_%(name)s_seq;""" % locals(), reflow=False, depth=depth)
+        self.emit("", depth)
+        self.emit("asdl_%(name)s_seq *_Py_asdl_%(name)s_seq_new(Py_ssize_t size, PyArena *arena);" % locals(), depth)
+        self.emit("", depth)
+
+    def visitProduct(self, product, name, depth):
+        self.emit_sequence_constructor(name, depth)
 
 class StructVisitor(EmitVisitor):
     """Visitor to generate typedefs for AST."""
@@ -219,7 +245,8 @@ class StructVisitor(EmitVisitor):
             if field.type == 'cmpop':
                 self.emit("asdl_int_seq *%(name)s;" % locals(), depth)
             else:
-                self.emit("asdl_seq *%(name)s;" % locals(), depth)
+                _type = field.type
+                self.emit("asdl_%(_type)s_seq *%(name)s;" % locals(), depth)
         else:
             self.emit("%(ctype)s %(name)s;" % locals(), depth)
 
@@ -274,7 +301,7 @@ class PrototypeVisitor(EmitVisitor):
                 if f.type == 'cmpop':
                     ctype = "asdl_int_seq *"
                 else:
-                    ctype = "asdl_seq *"
+                    ctype = f"asdl_{f.type}_seq *"
             else:
                 ctype = get_c_type(f.type)
             args.append((ctype, name, f.opt or f.seq))
@@ -507,7 +534,8 @@ class Obj2ModVisitor(PickleVisitor):
             if self.isSimpleType(field):
                 self.emit("asdl_int_seq* %s;" % field.name, depth)
             else:
-                self.emit("asdl_seq* %s;" % field.name, depth)
+                _type = field.type
+                self.emit(f"asdl_{field.type}_seq* {field.name};", depth)
         else:
             ctype = get_c_type(field.type)
             self.emit("%s %s;" % (ctype, field.name), depth)
@@ -562,7 +590,7 @@ class Obj2ModVisitor(PickleVisitor):
             if self.isSimpleType(field):
                 self.emit("%s = _Py_asdl_int_seq_new(len, arena);" % field.name, depth+1)
             else:
-                self.emit("%s = _Py_asdl_seq_new(len, arena);" % field.name, depth+1)
+                self.emit("%s = _Py_asdl_%s_seq_new(len, arena);" % (field.name, field.type), depth+1)
             self.emit("if (%s == NULL) goto failed;" % field.name, depth+1)
             self.emit("for (i = 0; i < len; i++) {", depth+1)
             self.emit("%s val;" % ctype, depth+2)
@@ -599,6 +627,24 @@ class MarshalPrototypeVisitor(PickleVisitor):
 
     visitProduct = visitSum = prototype
 
+
+class SequenceConstructorVisitor(EmitVisitor):
+    def visitModule(self, mod):
+        for dfn in mod.dfns:
+            self.visit(dfn)
+
+    def visitType(self, type):
+        self.visit(type.value, type.name)
+
+    def visitProduct(self, prod, name):
+        self.emit_sequence_constructor(name, get_c_type(name))
+
+    def visitSum(self, sum, name):
+        if not is_simple(sum):
+            self.emit_sequence_constructor(name, get_c_type(name))
+
+    def emit_sequence_constructor(self, name, type):
+        self.emit(f"GENERATE_ASDL_SEQ_CONSTRUCTOR({name}, {type})", depth=0)
 
 class PyTypesDeclareVisitor(PickleVisitor):
 
@@ -646,6 +692,7 @@ class PyTypesDeclareVisitor(PickleVisitor):
             for t in cons.fields:
                 self.emit('"%s",' % t.name, 1)
             self.emit("};",0)
+
 
 class PyTypesVisitor(PickleVisitor):
 
@@ -874,7 +921,7 @@ static PyObject* ast2obj_list(astmodulestate *state, asdl_seq *seq, PyObject* (*
     if (!result)
         return NULL;
     for (i = 0; i < n; i++) {
-        value = func(state, asdl_seq_GET(seq, i));
+        value = func(state, asdl_seq_GET_UNTYPED(seq, i));
         if (!value) {
             Py_DECREF(result);
             return NULL;
@@ -1264,7 +1311,7 @@ class ObjVisitor(PickleVisitor):
                           depth+2, reflow=False)
                 self.emit("}", depth)
             else:
-                self.emit("value = ast2obj_list(state, %s, ast2obj_%s);" % (value, field.type), depth)
+                self.emit("value = ast2obj_list(state, (asdl_seq*)%s, ast2obj_%s);" % (value, field.type), depth)
         else:
             ctype = get_c_type(field.type)
             self.emit("value = ast2obj_%s(state, %s);" % (field.type, value), depth, reflow=False)
@@ -1431,6 +1478,7 @@ def write_header(f, mod):
     f.write('#undef Yield   /* undefine macro conflicting with <winbase.h> */\n')
     f.write('\n')
     c = ChainOfVisitors(TypeDefVisitor(f),
+                        SequenceDefVisitor(f),
                         StructVisitor(f))
     c.visit(mod)
     f.write("// Note: these macros affect function definitions, not only call sites.\n")
@@ -1457,6 +1505,7 @@ def write_source(f, mod):
     generate_module_def(f, mod)
 
     v = ChainOfVisitors(
+        SequenceConstructorVisitor(f),
         PyTypesDeclareVisitor(f),
         PyTypesVisitor(f),
         Obj2ModPrototypeVisitor(f),

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -389,11 +389,11 @@ static mod_ty interactive_rule(Parser *p);
 static mod_ty eval_rule(Parser *p);
 static mod_ty func_type_rule(Parser *p);
 static expr_ty fstring_rule(Parser *p);
-static asdl_seq* type_expressions_rule(Parser *p);
-static asdl_seq* statements_rule(Parser *p);
-static asdl_seq* statement_rule(Parser *p);
-static asdl_seq* statement_newline_rule(Parser *p);
-static asdl_seq* simple_stmt_rule(Parser *p);
+static asdl_expr_seq* type_expressions_rule(Parser *p);
+static asdl_stmt_seq* statements_rule(Parser *p);
+static asdl_stmt_seq* statement_rule(Parser *p);
+static asdl_stmt_seq* statement_newline_rule(Parser *p);
+static asdl_stmt_seq* simple_stmt_rule(Parser *p);
 static stmt_ty small_stmt_rule(Parser *p);
 static stmt_ty compound_stmt_rule(Parser *p);
 static stmt_ty assignment_rule(Parser *p);
@@ -406,22 +406,22 @@ static stmt_ty del_stmt_rule(Parser *p);
 static stmt_ty import_stmt_rule(Parser *p);
 static stmt_ty import_name_rule(Parser *p);
 static stmt_ty import_from_rule(Parser *p);
-static asdl_seq* import_from_targets_rule(Parser *p);
-static asdl_seq* import_from_as_names_rule(Parser *p);
+static asdl_alias_seq* import_from_targets_rule(Parser *p);
+static asdl_alias_seq* import_from_as_names_rule(Parser *p);
 static alias_ty import_from_as_name_rule(Parser *p);
-static asdl_seq* dotted_as_names_rule(Parser *p);
+static asdl_alias_seq* dotted_as_names_rule(Parser *p);
 static alias_ty dotted_as_name_rule(Parser *p);
 static expr_ty dotted_name_rule(Parser *p);
 static stmt_ty if_stmt_rule(Parser *p);
 static stmt_ty elif_stmt_rule(Parser *p);
-static asdl_seq* else_block_rule(Parser *p);
+static asdl_stmt_seq* else_block_rule(Parser *p);
 static stmt_ty while_stmt_rule(Parser *p);
 static stmt_ty for_stmt_rule(Parser *p);
 static stmt_ty with_stmt_rule(Parser *p);
 static withitem_ty with_item_rule(Parser *p);
 static stmt_ty try_stmt_rule(Parser *p);
 static excepthandler_ty except_block_rule(Parser *p);
-static asdl_seq* finally_block_rule(Parser *p);
+static asdl_stmt_seq* finally_block_rule(Parser *p);
 static stmt_ty return_stmt_rule(Parser *p);
 static stmt_ty raise_stmt_rule(Parser *p);
 static stmt_ty function_def_rule(Parser *p);
@@ -429,7 +429,7 @@ static stmt_ty function_def_raw_rule(Parser *p);
 static Token* func_type_comment_rule(Parser *p);
 static arguments_ty params_rule(Parser *p);
 static arguments_ty parameters_rule(Parser *p);
-static asdl_seq* slash_no_default_rule(Parser *p);
+static asdl_arg_seq* slash_no_default_rule(Parser *p);
 static SlashWithDefault* slash_with_default_rule(Parser *p);
 static StarEtc* star_etc_rule(Parser *p);
 static arg_ty kwds_rule(Parser *p);
@@ -439,14 +439,14 @@ static NameDefaultPair* param_maybe_default_rule(Parser *p);
 static arg_ty param_rule(Parser *p);
 static expr_ty annotation_rule(Parser *p);
 static expr_ty default_rule(Parser *p);
-static asdl_seq* decorators_rule(Parser *p);
+static asdl_expr_seq* decorators_rule(Parser *p);
 static stmt_ty class_def_rule(Parser *p);
 static stmt_ty class_def_raw_rule(Parser *p);
-static asdl_seq* block_rule(Parser *p);
-static asdl_seq* expressions_list_rule(Parser *p);
+static asdl_stmt_seq* block_rule(Parser *p);
+static asdl_expr_seq* expressions_list_rule(Parser *p);
 static expr_ty star_expressions_rule(Parser *p);
 static expr_ty star_expression_rule(Parser *p);
-static asdl_seq* star_named_expressions_rule(Parser *p);
+static asdl_expr_seq* star_named_expressions_rule(Parser *p);
 static expr_ty star_named_expression_rule(Parser *p);
 static expr_ty named_expression_rule(Parser *p);
 static expr_ty annotated_rhs_rule(Parser *p);
@@ -455,7 +455,7 @@ static expr_ty expression_rule(Parser *p);
 static expr_ty lambdef_rule(Parser *p);
 static arguments_ty lambda_params_rule(Parser *p);
 static arguments_ty lambda_parameters_rule(Parser *p);
-static asdl_seq* lambda_slash_no_default_rule(Parser *p);
+static asdl_arg_seq* lambda_slash_no_default_rule(Parser *p);
 static SlashWithDefault* lambda_slash_with_default_rule(Parser *p);
 static StarEtc* lambda_star_etc_rule(Parser *p);
 static arg_ty lambda_kwds_rule(Parser *p);
@@ -504,7 +504,7 @@ static expr_ty dictcomp_rule(Parser *p);
 static asdl_seq* double_starred_kvpairs_rule(Parser *p);
 static KeyValuePair* double_starred_kvpair_rule(Parser *p);
 static KeyValuePair* kvpair_rule(Parser *p);
-static asdl_seq* for_if_clauses_rule(Parser *p);
+static asdl_comprehension_seq* for_if_clauses_rule(Parser *p);
 static comprehension_ty for_if_clause_rule(Parser *p);
 static expr_ty yield_expr_rule(Parser *p);
 static expr_ty arguments_rule(Parser *p);
@@ -514,15 +514,15 @@ static expr_ty starred_expression_rule(Parser *p);
 static KeywordOrStarred* kwarg_or_starred_rule(Parser *p);
 static KeywordOrStarred* kwarg_or_double_starred_rule(Parser *p);
 static expr_ty star_targets_rule(Parser *p);
-static asdl_seq* star_targets_seq_rule(Parser *p);
+static asdl_expr_seq* star_targets_seq_rule(Parser *p);
 static expr_ty star_target_rule(Parser *p);
 static expr_ty star_atom_rule(Parser *p);
 static expr_ty single_target_rule(Parser *p);
 static expr_ty single_subscript_attribute_target_rule(Parser *p);
-static asdl_seq* del_targets_rule(Parser *p);
+static asdl_expr_seq* del_targets_rule(Parser *p);
 static expr_ty del_target_rule(Parser *p);
 static expr_ty del_t_atom_rule(Parser *p);
-static asdl_seq* targets_rule(Parser *p);
+static asdl_expr_seq* targets_rule(Parser *p);
 static expr_ty target_rule(Parser *p);
 static expr_ty t_primary_rule(Parser *p);
 static void *t_lookahead_rule(Parser *p);
@@ -764,7 +764,7 @@ interactive_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> interactive[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "statement_newline"));
-        asdl_seq* a;
+        asdl_stmt_seq* a;
         if (
             (a = statement_newline_rule(p))  // statement_newline
         )
@@ -938,7 +938,7 @@ fstring_rule(Parser *p)
 //     | '*' expression
 //     | '**' expression
 //     | ','.expression+
-static asdl_seq*
+static asdl_expr_seq*
 type_expressions_rule(Parser *p)
 {
     D(p->level++);
@@ -946,7 +946,7 @@ type_expressions_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.expression+ ',' '*' expression ',' '**' expression
         if (p->error_indicator) {
@@ -978,7 +978,7 @@ type_expressions_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ type_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.expression+ ',' '*' expression ',' '**' expression"));
-            _res = _PyPegen_seq_append_to_end ( p , CHECK ( _PyPegen_seq_append_to_end ( p , a , b ) ) , c );
+            _res = ( asdl_expr_seq * ) _PyPegen_seq_append_to_end ( p , CHECK ( _PyPegen_seq_append_to_end ( p , a , b ) ) , c );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1011,7 +1011,7 @@ type_expressions_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ type_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.expression+ ',' '*' expression"));
-            _res = _PyPegen_seq_append_to_end ( p , a , b );
+            _res = ( asdl_expr_seq * ) _PyPegen_seq_append_to_end ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1044,7 +1044,7 @@ type_expressions_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ type_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.expression+ ',' '**' expression"));
-            _res = _PyPegen_seq_append_to_end ( p , a , b );
+            _res = ( asdl_expr_seq * ) _PyPegen_seq_append_to_end ( p , a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1080,7 +1080,7 @@ type_expressions_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ type_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' expression ',' '**' expression"));
-            _res = _PyPegen_seq_append_to_end ( p , CHECK ( _PyPegen_singleton_seq ( p , a ) ) , b );
+            _res = ( asdl_expr_seq * ) _PyPegen_seq_append_to_end ( p , CHECK ( _PyPegen_singleton_seq ( p , a ) ) , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1107,7 +1107,7 @@ type_expressions_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ type_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' expression"));
-            _res = _PyPegen_singleton_seq ( p , a );
+            _res = ( asdl_expr_seq * ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1134,7 +1134,7 @@ type_expressions_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ type_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'**' expression"));
-            _res = _PyPegen_singleton_seq ( p , a );
+            _res = ( asdl_expr_seq * ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1152,13 +1152,18 @@ type_expressions_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> type_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.expression+"));
-        asdl_seq * _gather_9_var;
+        asdl_expr_seq* a;
         if (
-            (_gather_9_var = _gather_9_rule(p))  // ','.expression+
+            (a = (asdl_expr_seq*)_gather_9_rule(p))  // ','.expression+
         )
         {
             D(fprintf(stderr, "%*c+ type_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.expression+"));
-            _res = _gather_9_var;
+            _res = a;
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
             goto done;
         }
         p->mark = _mark;
@@ -1172,7 +1177,7 @@ type_expressions_rule(Parser *p)
 }
 
 // statements: statement+
-static asdl_seq*
+static asdl_stmt_seq*
 statements_rule(Parser *p)
 {
     D(p->level++);
@@ -1180,7 +1185,7 @@ statements_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // statement+
         if (p->error_indicator) {
@@ -1194,7 +1199,7 @@ statements_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ statements[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "statement+"));
-            _res = _PyPegen_seq_flatten ( p , a );
+            _res = ( asdl_stmt_seq * ) _PyPegen_seq_flatten ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1213,7 +1218,7 @@ statements_rule(Parser *p)
 }
 
 // statement: compound_stmt | simple_stmt
-static asdl_seq*
+static asdl_stmt_seq*
 statement_rule(Parser *p)
 {
     D(p->level++);
@@ -1221,7 +1226,7 @@ statement_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // compound_stmt
         if (p->error_indicator) {
@@ -1235,7 +1240,7 @@ statement_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ statement[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "compound_stmt"));
-            _res = _PyPegen_singleton_seq ( p , a );
+            _res = ( asdl_stmt_seq * ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1253,13 +1258,18 @@ statement_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmt"));
-        asdl_seq* simple_stmt_var;
+        asdl_stmt_seq* a;
         if (
-            (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
+            (a = (asdl_stmt_seq*)simple_stmt_rule(p))  // simple_stmt
         )
         {
             D(fprintf(stderr, "%*c+ statement[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "simple_stmt"));
-            _res = simple_stmt_var;
+            _res = a;
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
             goto done;
         }
         p->mark = _mark;
@@ -1273,7 +1283,7 @@ statement_rule(Parser *p)
 }
 
 // statement_newline: compound_stmt NEWLINE | simple_stmt | NEWLINE | $
-static asdl_seq*
+static asdl_stmt_seq*
 statement_newline_rule(Parser *p)
 {
     D(p->level++);
@@ -1281,7 +1291,7 @@ statement_newline_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -1307,7 +1317,7 @@ statement_newline_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ statement_newline[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "compound_stmt NEWLINE"));
-            _res = _PyPegen_singleton_seq ( p , a );
+            _res = ( asdl_stmt_seq * ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1325,7 +1335,7 @@ statement_newline_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> statement_newline[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmt"));
-        asdl_seq* simple_stmt_var;
+        asdl_stmt_seq* simple_stmt_var;
         if (
             (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
         )
@@ -1359,7 +1369,7 @@ statement_newline_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyPegen_singleton_seq ( p , CHECK ( _Py_Pass ( EXTRA ) ) );
+            _res = ( asdl_stmt_seq * ) _PyPegen_singleton_seq ( p , CHECK ( _Py_Pass ( EXTRA ) ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1402,7 +1412,7 @@ statement_newline_rule(Parser *p)
 }
 
 // simple_stmt: small_stmt !';' NEWLINE | ';'.small_stmt+ ';'? NEWLINE
-static asdl_seq*
+static asdl_stmt_seq*
 simple_stmt_rule(Parser *p)
 {
     D(p->level++);
@@ -1410,7 +1420,7 @@ simple_stmt_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // small_stmt !';' NEWLINE
         if (p->error_indicator) {
@@ -1429,7 +1439,7 @@ simple_stmt_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ simple_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "small_stmt !';' NEWLINE"));
-            _res = _PyPegen_singleton_seq ( p , a );
+            _res = ( asdl_stmt_seq * ) _PyPegen_singleton_seq ( p , a );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1449,10 +1459,10 @@ simple_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "';'.small_stmt+ ';'? NEWLINE"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_stmt_seq* a;
         Token * newline_var;
         if (
-            (a = _gather_12_rule(p))  // ';'.small_stmt+
+            (a = (asdl_stmt_seq*)_gather_12_rule(p))  // ';'.small_stmt+
             &&
             (_opt_var = _PyPegen_expect_token(p, 13), 1)  // ';'?
             &&
@@ -2127,11 +2137,11 @@ assignment_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> assignment[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "((star_targets '='))+ (yield_expr | star_expressions) !'=' TYPE_COMMENT?"));
-        asdl_seq * a;
+        asdl_expr_seq* a;
         void *b;
         void *tc;
         if (
-            (a = _loop1_22_rule(p))  // ((star_targets '='))+
+            (a = (asdl_expr_seq*)_loop1_22_rule(p))  // ((star_targets '='))+
             &&
             (b = _tmp_23_rule(p))  // yield_expr | star_expressions
             &&
@@ -2602,11 +2612,11 @@ global_stmt_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> global_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'global' ','.NAME+"));
         Token * _keyword;
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
             (_keyword = _PyPegen_expect_token(p, 508))  // token='global'
             &&
-            (a = _gather_25_rule(p))  // ','.NAME+
+            (a = (asdl_expr_seq*)_gather_25_rule(p))  // ','.NAME+
         )
         {
             D(fprintf(stderr, "%*c+ global_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'global' ','.NAME+"));
@@ -2664,11 +2674,11 @@ nonlocal_stmt_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> nonlocal_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'nonlocal' ','.NAME+"));
         Token * _keyword;
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
             (_keyword = _PyPegen_expect_token(p, 509))  // token='nonlocal'
             &&
-            (a = _gather_27_rule(p))  // ','.NAME+
+            (a = (asdl_expr_seq*)_gather_27_rule(p))  // ','.NAME+
         )
         {
             D(fprintf(stderr, "%*c+ nonlocal_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'nonlocal' ','.NAME+"));
@@ -2850,7 +2860,7 @@ del_stmt_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> del_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'del' del_targets &(';' | NEWLINE)"));
         Token * _keyword;
-        asdl_seq* a;
+        asdl_expr_seq* a;
         if (
             (_keyword = _PyPegen_expect_token(p, 503))  // token='del'
             &&
@@ -2988,7 +2998,7 @@ import_name_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> import_name[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'import' dotted_as_names"));
         Token * _keyword;
-        asdl_seq* a;
+        asdl_alias_seq* a;
         if (
             (_keyword = _PyPegen_expect_token(p, 513))  // token='import'
             &&
@@ -3055,7 +3065,7 @@ import_from_rule(Parser *p)
         Token * _keyword_1;
         asdl_seq * a;
         expr_ty b;
-        asdl_seq* c;
+        asdl_alias_seq* c;
         if (
             (_keyword = _PyPegen_expect_token(p, 514))  // token='from'
             &&
@@ -3099,7 +3109,7 @@ import_from_rule(Parser *p)
         Token * _keyword;
         Token * _keyword_1;
         asdl_seq * a;
-        asdl_seq* b;
+        asdl_alias_seq* b;
         if (
             (_keyword = _PyPegen_expect_token(p, 514))  // token='from'
             &&
@@ -3143,7 +3153,7 @@ import_from_rule(Parser *p)
 //     | import_from_as_names !','
 //     | '*'
 //     | invalid_import_from_targets
-static asdl_seq*
+static asdl_alias_seq*
 import_from_targets_rule(Parser *p)
 {
     D(p->level++);
@@ -3151,7 +3161,7 @@ import_from_targets_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_alias_seq* _res = NULL;
     int _mark = p->mark;
     { // '(' import_from_as_names ','? ')'
         if (p->error_indicator) {
@@ -3163,7 +3173,7 @@ import_from_targets_rule(Parser *p)
         Token * _literal_1;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq* a;
+        asdl_alias_seq* a;
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -3193,7 +3203,7 @@ import_from_targets_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from_as_names !','"));
-        asdl_seq* import_from_as_names_var;
+        asdl_alias_seq* import_from_as_names_var;
         if (
             (import_from_as_names_var = import_from_as_names_rule(p))  // import_from_as_names
             &&
@@ -3220,7 +3230,7 @@ import_from_targets_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ import_from_targets[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*'"));
-            _res = _PyPegen_singleton_seq ( p , CHECK ( _PyPegen_alias_for_star ( p ) ) );
+            _res = ( asdl_alias_seq * ) _PyPegen_singleton_seq ( p , CHECK ( _PyPegen_alias_for_star ( p ) ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3258,7 +3268,7 @@ import_from_targets_rule(Parser *p)
 }
 
 // import_from_as_names: ','.import_from_as_name+
-static asdl_seq*
+static asdl_alias_seq*
 import_from_as_names_rule(Parser *p)
 {
     D(p->level++);
@@ -3266,7 +3276,7 @@ import_from_as_names_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_alias_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.import_from_as_name+
         if (p->error_indicator) {
@@ -3274,9 +3284,9 @@ import_from_as_names_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> import_from_as_names[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.import_from_as_name+"));
-        asdl_seq * a;
+        asdl_alias_seq* a;
         if (
-            (a = _gather_33_rule(p))  // ','.import_from_as_name+
+            (a = (asdl_alias_seq*)_gather_33_rule(p))  // ','.import_from_as_name+
         )
         {
             D(fprintf(stderr, "%*c+ import_from_as_names[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.import_from_as_name+"));
@@ -3343,7 +3353,7 @@ import_from_as_name_rule(Parser *p)
 }
 
 // dotted_as_names: ','.dotted_as_name+
-static asdl_seq*
+static asdl_alias_seq*
 dotted_as_names_rule(Parser *p)
 {
     D(p->level++);
@@ -3351,7 +3361,7 @@ dotted_as_names_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_alias_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.dotted_as_name+
         if (p->error_indicator) {
@@ -3359,9 +3369,9 @@ dotted_as_names_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> dotted_as_names[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.dotted_as_name+"));
-        asdl_seq * a;
+        asdl_alias_seq* a;
         if (
-            (a = _gather_36_rule(p))  // ','.dotted_as_name+
+            (a = (asdl_alias_seq*)_gather_36_rule(p))  // ','.dotted_as_name+
         )
         {
             D(fprintf(stderr, "%*c+ dotted_as_names[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.dotted_as_name+"));
@@ -3554,7 +3564,7 @@ if_stmt_rule(Parser *p)
         Token * _keyword;
         Token * _literal;
         expr_ty a;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         stmt_ty c;
         if (
             (_keyword = _PyPegen_expect_token(p, 510))  // token='if'
@@ -3578,7 +3588,7 @@ if_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_If ( a , b , CHECK ( _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
+            _res = _Py_If ( a , b , CHECK ( ( asdl_stmt_seq * ) _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3599,7 +3609,7 @@ if_stmt_rule(Parser *p)
         Token * _keyword;
         Token * _literal;
         expr_ty a;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         void *c;
         if (
             (_keyword = _PyPegen_expect_token(p, 510))  // token='if'
@@ -3672,7 +3682,7 @@ elif_stmt_rule(Parser *p)
         Token * _keyword;
         Token * _literal;
         expr_ty a;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         stmt_ty c;
         if (
             (_keyword = _PyPegen_expect_token(p, 515))  // token='elif'
@@ -3717,7 +3727,7 @@ elif_stmt_rule(Parser *p)
         Token * _keyword;
         Token * _literal;
         expr_ty a;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         void *c;
         if (
             (_keyword = _PyPegen_expect_token(p, 515))  // token='elif'
@@ -3760,7 +3770,7 @@ elif_stmt_rule(Parser *p)
 }
 
 // else_block: 'else' ':' block
-static asdl_seq*
+static asdl_stmt_seq*
 else_block_rule(Parser *p)
 {
     D(p->level++);
@@ -3768,7 +3778,7 @@ else_block_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // 'else' ':' block
         if (p->error_indicator) {
@@ -3778,7 +3788,7 @@ else_block_rule(Parser *p)
         D(fprintf(stderr, "%*c> else_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else' ':' block"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         if (
             (_keyword = _PyPegen_expect_token(p, 516))  // token='else'
             &&
@@ -3835,7 +3845,7 @@ while_stmt_rule(Parser *p)
         Token * _keyword;
         Token * _literal;
         expr_ty a;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         void *c;
         if (
             (_keyword = _PyPegen_expect_token(p, 512))  // token='while'
@@ -3910,7 +3920,7 @@ for_stmt_rule(Parser *p)
         Token * _keyword;
         Token * _keyword_1;
         Token * _literal;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         void *el;
         expr_ty ex;
         expr_ty t;
@@ -3972,7 +3982,7 @@ for_stmt_rule(Parser *p)
         Token * _keyword_1;
         Token * _literal;
         Token * async_var;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         void *el;
         expr_ty ex;
         expr_ty t;
@@ -4086,14 +4096,14 @@ with_stmt_rule(Parser *p)
         Token * _literal_2;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
-        asdl_seq* b;
+        asdl_withitem_seq* a;
+        asdl_stmt_seq* b;
         if (
             (_keyword = _PyPegen_expect_token(p, 519))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = _gather_39_rule(p))  // ','.with_item+
+            (a = (asdl_withitem_seq*)_gather_39_rule(p))  // ','.with_item+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
             &&
@@ -4134,13 +4144,13 @@ with_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with' ','.with_item+ ':' TYPE_COMMENT? block"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq * a;
-        asdl_seq* b;
+        asdl_withitem_seq* a;
+        asdl_stmt_seq* b;
         void *tc;
         if (
             (_keyword = _PyPegen_expect_token(p, 519))  // token='with'
             &&
-            (a = _gather_41_rule(p))  // ','.with_item+
+            (a = (asdl_withitem_seq*)_gather_41_rule(p))  // ','.with_item+
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -4183,9 +4193,9 @@ with_stmt_rule(Parser *p)
         Token * _literal_2;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_withitem_seq* a;
         Token * async_var;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
@@ -4193,7 +4203,7 @@ with_stmt_rule(Parser *p)
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = _gather_43_rule(p))  // ','.with_item+
+            (a = (asdl_withitem_seq*)_gather_43_rule(p))  // ','.with_item+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
             &&
@@ -4234,16 +4244,16 @@ with_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> with_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq * a;
+        asdl_withitem_seq* a;
         Token * async_var;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         void *tc;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
             (_keyword = _PyPegen_expect_token(p, 519))  // token='with'
             &&
-            (a = _gather_45_rule(p))  // ','.with_item+
+            (a = (asdl_withitem_seq*)_gather_45_rule(p))  // ','.with_item+
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -4402,8 +4412,8 @@ try_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' ':' block finally_block"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq* b;
-        asdl_seq* f;
+        asdl_stmt_seq* b;
+        asdl_stmt_seq* f;
         if (
             (_keyword = _PyPegen_expect_token(p, 511))  // token='try'
             &&
@@ -4444,9 +4454,9 @@ try_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> try_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'try' ':' block except_block+ else_block? finally_block?"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         void *el;
-        asdl_seq * ex;
+        asdl_excepthandler_seq* ex;
         void *f;
         if (
             (_keyword = _PyPegen_expect_token(p, 511))  // token='try'
@@ -4455,7 +4465,7 @@ try_stmt_rule(Parser *p)
             &&
             (b = block_rule(p))  // block
             &&
-            (ex = _loop1_48_rule(p))  // except_block+
+            (ex = (asdl_excepthandler_seq*)_loop1_48_rule(p))  // except_block+
             &&
             (el = else_block_rule(p), 1)  // else_block?
             &&
@@ -4518,7 +4528,7 @@ except_block_rule(Parser *p)
         D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' expression ['as' NAME] ':' block"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         expr_ty e;
         void *t;
         if (
@@ -4563,7 +4573,7 @@ except_block_rule(Parser *p)
         D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' ':' block"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         if (
             (_keyword = _PyPegen_expect_token(p, 521))  // token='except'
             &&
@@ -4601,7 +4611,7 @@ except_block_rule(Parser *p)
 }
 
 // finally_block: 'finally' ':' block
-static asdl_seq*
+static asdl_stmt_seq*
 finally_block_rule(Parser *p)
 {
     D(p->level++);
@@ -4609,7 +4619,7 @@ finally_block_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_stmt_seq* _res = NULL;
     int _mark = p->mark;
     { // 'finally' ':' block
         if (p->error_indicator) {
@@ -4619,7 +4629,7 @@ finally_block_rule(Parser *p)
         D(fprintf(stderr, "%*c> finally_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally' ':' block"));
         Token * _keyword;
         Token * _literal;
-        asdl_seq* a;
+        asdl_stmt_seq* a;
         if (
             (_keyword = _PyPegen_expect_token(p, 522))  // token='finally'
             &&
@@ -4824,7 +4834,7 @@ function_def_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> function_def[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "decorators function_def_raw"));
-        asdl_seq* d;
+        asdl_expr_seq* d;
         stmt_ty f;
         if (
             (d = decorators_rule(p))  // decorators
@@ -4903,7 +4913,7 @@ function_def_raw_rule(Parser *p)
         Token * _literal_1;
         Token * _literal_2;
         void *a;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         expr_ty n;
         void *params;
         void *tc;
@@ -4961,7 +4971,7 @@ function_def_raw_rule(Parser *p)
         Token * _literal_2;
         void *a;
         Token * async_var;
-        asdl_seq* b;
+        asdl_stmt_seq* b;
         expr_ty n;
         void *params;
         void *tc;
@@ -5179,14 +5189,14 @@ parameters_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "slash_no_default param_no_default* param_with_default* star_etc?"));
-        asdl_seq* a;
-        asdl_seq * b;
+        asdl_arg_seq* a;
+        asdl_arg_seq* b;
         asdl_seq * c;
         void *d;
         if (
             (a = slash_no_default_rule(p))  // slash_no_default
             &&
-            (b = _loop0_54_rule(p))  // param_no_default*
+            (b = (asdl_arg_seq*)_loop0_54_rule(p))  // param_no_default*
             &&
             (c = _loop0_55_rule(p))  // param_with_default*
             &&
@@ -5242,11 +5252,11 @@ parameters_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default+ param_with_default* star_etc?"));
-        asdl_seq * a;
+        asdl_arg_seq* a;
         asdl_seq * b;
         void *c;
         if (
-            (a = _loop1_57_rule(p))  // param_no_default+
+            (a = (asdl_arg_seq*)_loop1_57_rule(p))  // param_no_default+
             &&
             (b = _loop0_58_rule(p))  // param_with_default*
             &&
@@ -5324,7 +5334,7 @@ parameters_rule(Parser *p)
 }
 
 // slash_no_default: param_no_default+ '/' ',' | param_no_default+ '/' &')'
-static asdl_seq*
+static asdl_arg_seq*
 slash_no_default_rule(Parser *p)
 {
     D(p->level++);
@@ -5332,7 +5342,7 @@ slash_no_default_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_arg_seq* _res = NULL;
     int _mark = p->mark;
     { // param_no_default+ '/' ','
         if (p->error_indicator) {
@@ -5342,9 +5352,9 @@ slash_no_default_rule(Parser *p)
         D(fprintf(stderr, "%*c> slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default+ '/' ','"));
         Token * _literal;
         Token * _literal_1;
-        asdl_seq * a;
+        asdl_arg_seq* a;
         if (
-            (a = _loop1_60_rule(p))  // param_no_default+
+            (a = (asdl_arg_seq*)_loop1_60_rule(p))  // param_no_default+
             &&
             (_literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
@@ -5371,9 +5381,9 @@ slash_no_default_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "param_no_default+ '/' &')'"));
         Token * _literal;
-        asdl_seq * a;
+        asdl_arg_seq* a;
         if (
-            (a = _loop1_61_rule(p))  // param_no_default+
+            (a = (asdl_arg_seq*)_loop1_61_rule(p))  // param_no_default+
             &&
             (_literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
@@ -5433,7 +5443,7 @@ slash_with_default_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ slash_with_default[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "param_no_default* param_with_default+ '/' ','"));
-            _res = _PyPegen_slash_with_default ( p , a , b );
+            _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq * ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5465,7 +5475,7 @@ slash_with_default_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ slash_with_default[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "param_no_default* param_with_default+ '/' &')'"));
-            _res = _PyPegen_slash_with_default ( p , a , b );
+            _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq * ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6050,7 +6060,7 @@ default_rule(Parser *p)
 }
 
 // decorators: (('@' named_expression NEWLINE))+
-static asdl_seq*
+static asdl_expr_seq*
 decorators_rule(Parser *p)
 {
     D(p->level++);
@@ -6058,7 +6068,7 @@ decorators_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // (('@' named_expression NEWLINE))+
         if (p->error_indicator) {
@@ -6066,9 +6076,9 @@ decorators_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> decorators[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "(('@' named_expression NEWLINE))+"));
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
-            (a = _loop1_68_rule(p))  // (('@' named_expression NEWLINE))+
+            (a = (asdl_expr_seq*)_loop1_68_rule(p))  // (('@' named_expression NEWLINE))+
         )
         {
             D(fprintf(stderr, "%*c+ decorators[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "(('@' named_expression NEWLINE))+"));
@@ -6107,7 +6117,7 @@ class_def_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> class_def[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "decorators class_def_raw"));
-        asdl_seq* a;
+        asdl_expr_seq* a;
         stmt_ty b;
         if (
             (a = decorators_rule(p))  // decorators
@@ -6183,7 +6193,7 @@ class_def_raw_rule(Parser *p)
         Token * _literal;
         expr_ty a;
         void *b;
-        asdl_seq* c;
+        asdl_stmt_seq* c;
         if (
             (_keyword = _PyPegen_expect_token(p, 524))  // token='class'
             &&
@@ -6225,7 +6235,7 @@ class_def_raw_rule(Parser *p)
 }
 
 // block: NEWLINE INDENT statements DEDENT | simple_stmt | invalid_block
-static asdl_seq*
+static asdl_stmt_seq*
 block_rule(Parser *p)
 {
     D(p->level++);
@@ -6233,7 +6243,7 @@ block_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_stmt_seq* _res = NULL;
     if (_PyPegen_is_memoized(p, block_type, &_res)) {
         D(p->level--);
         return _res;
@@ -6245,7 +6255,7 @@ block_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NEWLINE INDENT statements DEDENT"));
-        asdl_seq* a;
+        asdl_stmt_seq* a;
         Token * dedent_var;
         Token * indent_var;
         Token * newline_var;
@@ -6278,7 +6288,7 @@ block_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "simple_stmt"));
-        asdl_seq* simple_stmt_var;
+        asdl_stmt_seq* simple_stmt_var;
         if (
             (simple_stmt_var = simple_stmt_rule(p))  // simple_stmt
         )
@@ -6318,7 +6328,7 @@ block_rule(Parser *p)
 }
 
 // expressions_list: ','.star_expression+ ','?
-static asdl_seq*
+static asdl_expr_seq*
 expressions_list_rule(Parser *p)
 {
     D(p->level++);
@@ -6326,7 +6336,7 @@ expressions_list_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_expression+ ','?
         if (p->error_indicator) {
@@ -6336,9 +6346,9 @@ expressions_list_rule(Parser *p)
         D(fprintf(stderr, "%*c> expressions_list[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.star_expression+ ','?"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
-            (a = _gather_70_rule(p))  // ','.star_expression+
+            (a = (asdl_expr_seq*)_gather_70_rule(p))  // ','.star_expression+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
@@ -6573,7 +6583,7 @@ star_expression_rule(Parser *p)
 }
 
 // star_named_expressions: ','.star_named_expression+ ','?
-static asdl_seq*
+static asdl_expr_seq*
 star_named_expressions_rule(Parser *p)
 {
     D(p->level++);
@@ -6581,7 +6591,7 @@ star_named_expressions_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_named_expression+ ','?
         if (p->error_indicator) {
@@ -6591,9 +6601,9 @@ star_named_expressions_rule(Parser *p)
         D(fprintf(stderr, "%*c> star_named_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.star_named_expression+ ','?"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
-            (a = _gather_73_rule(p))  // ','.star_named_expression+
+            (a = (asdl_expr_seq*)_gather_73_rule(p))  // ','.star_named_expression+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
@@ -7245,14 +7255,14 @@ lambda_parameters_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* lambda_star_etc?"));
-        asdl_seq* a;
-        asdl_seq * b;
+        asdl_arg_seq* a;
+        asdl_arg_seq* b;
         asdl_seq * c;
         void *d;
         if (
             (a = lambda_slash_no_default_rule(p))  // lambda_slash_no_default
             &&
-            (b = _loop0_76_rule(p))  // lambda_param_no_default*
+            (b = (asdl_arg_seq*)_loop0_76_rule(p))  // lambda_param_no_default*
             &&
             (c = _loop0_77_rule(p))  // lambda_param_with_default*
             &&
@@ -7308,11 +7318,11 @@ lambda_parameters_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> lambda_parameters[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default+ lambda_param_with_default* lambda_star_etc?"));
-        asdl_seq * a;
+        asdl_arg_seq* a;
         asdl_seq * b;
         void *c;
         if (
-            (a = _loop1_79_rule(p))  // lambda_param_no_default+
+            (a = (asdl_arg_seq*)_loop1_79_rule(p))  // lambda_param_no_default+
             &&
             (b = _loop0_80_rule(p))  // lambda_param_with_default*
             &&
@@ -7392,7 +7402,7 @@ lambda_parameters_rule(Parser *p)
 // lambda_slash_no_default:
 //     | lambda_param_no_default+ '/' ','
 //     | lambda_param_no_default+ '/' &':'
-static asdl_seq*
+static asdl_arg_seq*
 lambda_slash_no_default_rule(Parser *p)
 {
     D(p->level++);
@@ -7400,7 +7410,7 @@ lambda_slash_no_default_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_arg_seq* _res = NULL;
     int _mark = p->mark;
     { // lambda_param_no_default+ '/' ','
         if (p->error_indicator) {
@@ -7410,9 +7420,9 @@ lambda_slash_no_default_rule(Parser *p)
         D(fprintf(stderr, "%*c> lambda_slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default+ '/' ','"));
         Token * _literal;
         Token * _literal_1;
-        asdl_seq * a;
+        asdl_arg_seq* a;
         if (
-            (a = _loop1_82_rule(p))  // lambda_param_no_default+
+            (a = (asdl_arg_seq*)_loop1_82_rule(p))  // lambda_param_no_default+
             &&
             (_literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
@@ -7439,9 +7449,9 @@ lambda_slash_no_default_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> lambda_slash_no_default[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default+ '/' &':'"));
         Token * _literal;
-        asdl_seq * a;
+        asdl_arg_seq* a;
         if (
-            (a = _loop1_83_rule(p))  // lambda_param_no_default+
+            (a = (asdl_arg_seq*)_loop1_83_rule(p))  // lambda_param_no_default+
             &&
             (_literal = _PyPegen_expect_token(p, 17))  // token='/'
             &&
@@ -7501,7 +7511,7 @@ lambda_slash_with_default_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ lambda_slash_with_default[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default* lambda_param_with_default+ '/' ','"));
-            _res = _PyPegen_slash_with_default ( p , a , b );
+            _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq * ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7533,7 +7543,7 @@ lambda_slash_with_default_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ lambda_slash_with_default[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "lambda_param_no_default* lambda_param_with_default+ '/' &':'"));
-            _res = _PyPegen_slash_with_default ( p , a , b );
+            _res = _PyPegen_slash_with_default ( p , ( asdl_arg_seq * ) a , b );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -10553,9 +10563,9 @@ slices_rule(Parser *p)
         D(fprintf(stderr, "%*c> slices[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.slice+ ','?"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
-            (a = _gather_94_rule(p))  // ','.slice+
+            (a = (asdl_expr_seq*)_gather_94_rule(p))  // ','.slice+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
@@ -11111,7 +11121,7 @@ listcomp_rule(Parser *p)
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
-        asdl_seq* b;
+        asdl_comprehension_seq* b;
         if (
             (_literal = _PyPegen_expect_token(p, 9))  // token='['
             &&
@@ -11336,7 +11346,7 @@ genexp_rule(Parser *p)
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
-        asdl_seq* b;
+        asdl_comprehension_seq* b;
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -11428,7 +11438,7 @@ set_rule(Parser *p)
         D(fprintf(stderr, "%*c> set[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'{' expressions_list '}'"));
         Token * _literal;
         Token * _literal_1;
-        asdl_seq* a;
+        asdl_expr_seq* a;
         if (
             (_literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
@@ -11495,7 +11505,7 @@ setcomp_rule(Parser *p)
         Token * _literal;
         Token * _literal_1;
         expr_ty a;
-        asdl_seq* b;
+        asdl_comprehension_seq* b;
         if (
             (_literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
@@ -11653,7 +11663,7 @@ dictcomp_rule(Parser *p)
         Token * _literal;
         Token * _literal_1;
         KeyValuePair* a;
-        asdl_seq* b;
+        asdl_comprehension_seq* b;
         if (
             (_literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
@@ -11867,7 +11877,7 @@ kvpair_rule(Parser *p)
 }
 
 // for_if_clauses: for_if_clause+
-static asdl_seq*
+static asdl_comprehension_seq*
 for_if_clauses_rule(Parser *p)
 {
     D(p->level++);
@@ -11875,7 +11885,7 @@ for_if_clauses_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_comprehension_seq* _res = NULL;
     int _mark = p->mark;
     { // for_if_clause+
         if (p->error_indicator) {
@@ -11883,13 +11893,18 @@ for_if_clauses_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> for_if_clauses[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "for_if_clause+"));
-        asdl_seq * _loop1_105_var;
+        asdl_comprehension_seq* a;
         if (
-            (_loop1_105_var = _loop1_105_rule(p))  // for_if_clause+
+            (a = (asdl_comprehension_seq*)_loop1_105_rule(p))  // for_if_clause+
         )
         {
             D(fprintf(stderr, "%*c+ for_if_clauses[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "for_if_clause+"));
-            _res = _loop1_105_var;
+            _res = a;
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
             goto done;
         }
         p->mark = _mark;
@@ -11928,7 +11943,7 @@ for_if_clause_rule(Parser *p)
         expr_ty a;
         Token * async_var;
         expr_ty b;
-        asdl_seq * c;
+        asdl_expr_seq* c;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))  // token='ASYNC'
             &&
@@ -11942,7 +11957,7 @@ for_if_clause_rule(Parser *p)
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (c = _loop0_106_rule(p))  // (('if' disjunction))*
+            (c = (asdl_expr_seq*)_loop0_106_rule(p))  // (('if' disjunction))*
         )
         {
             D(fprintf(stderr, "%*c+ for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "ASYNC 'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
@@ -11973,7 +11988,7 @@ for_if_clause_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         expr_ty b;
-        asdl_seq * c;
+        asdl_expr_seq* c;
         if (
             (_keyword = _PyPegen_expect_token(p, 517))  // token='for'
             &&
@@ -11985,7 +12000,7 @@ for_if_clause_rule(Parser *p)
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (c = _loop0_107_rule(p))  // (('if' disjunction))*
+            (c = (asdl_expr_seq*)_loop0_107_rule(p))  // (('if' disjunction))*
         )
         {
             D(fprintf(stderr, "%*c+ for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
@@ -12228,10 +12243,10 @@ args_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> args[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.(starred_expression | named_expression !'=')+ [',' kwargs]"));
-        asdl_seq * a;
+        asdl_expr_seq* a;
         void *b;
         if (
-            (a = _gather_108_rule(p))  // ','.(starred_expression | named_expression !'=')+
+            (a = (asdl_expr_seq*)_gather_108_rule(p))  // ','.(starred_expression | named_expression !'=')+
             &&
             (b = _tmp_110_rule(p), 1)  // [',' kwargs]
         )
@@ -12768,7 +12783,7 @@ star_targets_rule(Parser *p)
 }
 
 // star_targets_seq: ','.star_target+ ','?
-static asdl_seq*
+static asdl_expr_seq*
 star_targets_seq_rule(Parser *p)
 {
     D(p->level++);
@@ -12776,7 +12791,7 @@ star_targets_seq_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.star_target+ ','?
         if (p->error_indicator) {
@@ -12786,9 +12801,9 @@ star_targets_seq_rule(Parser *p)
         D(fprintf(stderr, "%*c> star_targets_seq[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.star_target+ ','?"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
-            (a = _gather_120_rule(p))  // ','.star_target+
+            (a = (asdl_expr_seq*)_gather_120_rule(p))  // ','.star_target+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
@@ -13353,7 +13368,7 @@ single_subscript_attribute_target_rule(Parser *p)
 }
 
 // del_targets: ','.del_target+ ','?
-static asdl_seq*
+static asdl_expr_seq*
 del_targets_rule(Parser *p)
 {
     D(p->level++);
@@ -13361,7 +13376,7 @@ del_targets_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.del_target+ ','?
         if (p->error_indicator) {
@@ -13371,9 +13386,9 @@ del_targets_rule(Parser *p)
         D(fprintf(stderr, "%*c> del_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.del_target+ ','?"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
-            (a = _gather_123_rule(p))  // ','.del_target+
+            (a = (asdl_expr_seq*)_gather_123_rule(p))  // ','.del_target+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
@@ -13694,7 +13709,7 @@ del_t_atom_rule(Parser *p)
 }
 
 // targets: ','.target+ ','?
-static asdl_seq*
+static asdl_expr_seq*
 targets_rule(Parser *p)
 {
     D(p->level++);
@@ -13702,7 +13717,7 @@ targets_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq* _res = NULL;
+    asdl_expr_seq* _res = NULL;
     int _mark = p->mark;
     { // ','.target+ ','?
         if (p->error_indicator) {
@@ -13712,9 +13727,9 @@ targets_rule(Parser *p)
         D(fprintf(stderr, "%*c> targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.target+ ','?"));
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
-        asdl_seq * a;
+        asdl_expr_seq* a;
         if (
-            (a = _gather_125_rule(p))  // ','.target+
+            (a = (asdl_expr_seq*)_gather_125_rule(p))  // ','.target+
             &&
             (_opt_var = _PyPegen_expect_token(p, 12), 1)  // ','?
         )
@@ -14418,7 +14433,7 @@ incorrect_arguments_rule(Parser *p)
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
-        asdl_seq* for_if_clauses_var;
+        asdl_comprehension_seq* for_if_clauses_var;
         if (
             (a = expression_rule(p))  // expression
             &&
@@ -14449,7 +14464,7 @@ incorrect_arguments_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> incorrect_arguments[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "args for_if_clauses"));
         expr_ty a;
-        asdl_seq* for_if_clauses_var;
+        asdl_comprehension_seq* for_if_clauses_var;
         if (
             (a = args_rule(p))  // args
             &&
@@ -14478,7 +14493,7 @@ incorrect_arguments_rule(Parser *p)
         Token * _literal;
         expr_ty a;
         expr_ty args_var;
-        asdl_seq* for_if_clauses_var;
+        asdl_comprehension_seq* for_if_clauses_var;
         if (
             (args_var = args_rule(p))  // args
             &&
@@ -15029,7 +15044,7 @@ invalid_comprehension_rule(Parser *p)
         D(fprintf(stderr, "%*c> invalid_comprehension[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('[' | '(' | '{') starred_expression for_if_clauses"));
         void *_tmp_132_var;
         expr_ty a;
-        asdl_seq* for_if_clauses_var;
+        asdl_comprehension_seq* for_if_clauses_var;
         if (
             (_tmp_132_var = _tmp_132_rule(p))  // '[' | '(' | '{'
             &&
@@ -15078,7 +15093,7 @@ invalid_dict_comprehension_rule(Parser *p)
         Token * _literal_1;
         Token * a;
         expr_ty bitwise_or_var;
-        asdl_seq* for_if_clauses_var;
+        asdl_comprehension_seq* for_if_clauses_var;
         if (
             (_literal = _PyPegen_expect_token(p, 25))  // token='{'
             &&
@@ -15537,7 +15552,7 @@ invalid_import_from_targets_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> invalid_import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from_as_names ','"));
         Token * _literal;
-        asdl_seq* import_from_as_names_var;
+        asdl_alias_seq* import_from_as_names_var;
         if (
             (import_from_as_names_var = import_from_as_names_rule(p))  // import_from_as_names
             &&
@@ -15614,7 +15629,7 @@ _loop0_1_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_1[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NEWLINE"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -15622,7 +15637,7 @@ _loop0_1_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_1_type, _seq);
     D(p->level--);
@@ -15680,7 +15695,7 @@ _loop0_2_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_2[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NEWLINE"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -15688,7 +15703,7 @@ _loop0_2_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_2_type, _seq);
     D(p->level--);
@@ -15755,7 +15770,7 @@ _loop0_4_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_4[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' expression"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -15763,7 +15778,7 @@ _loop0_4_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_4_type, _seq);
     D(p->level--);
@@ -15869,7 +15884,7 @@ _loop0_6_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_6[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' expression"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -15877,7 +15892,7 @@ _loop0_6_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_6_type, _seq);
     D(p->level--);
@@ -15983,7 +15998,7 @@ _loop0_8_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_8[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' expression"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -15991,7 +16006,7 @@ _loop0_8_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_8_type, _seq);
     D(p->level--);
@@ -16097,7 +16112,7 @@ _loop0_10_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_10[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' expression"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -16105,7 +16120,7 @@ _loop0_10_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_10_type, _seq);
     D(p->level--);
@@ -16178,7 +16193,7 @@ _loop1_11_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop1_11[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "statement"));
-        asdl_seq* statement_var;
+        asdl_stmt_seq* statement_var;
         while (
             (statement_var = statement_rule(p))  // statement
         )
@@ -16207,7 +16222,7 @@ _loop1_11_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -16215,7 +16230,7 @@ _loop1_11_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_11_type, _seq);
     D(p->level--);
@@ -16282,7 +16297,7 @@ _loop0_13_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_13[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "';' small_stmt"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -16290,7 +16305,7 @@ _loop0_13_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_13_type, _seq);
     D(p->level--);
@@ -16840,7 +16855,7 @@ _loop1_22_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -16848,7 +16863,7 @@ _loop1_22_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_22_type, _seq);
     D(p->level--);
@@ -17025,7 +17040,7 @@ _loop0_26_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_26[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' NAME"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17033,7 +17048,7 @@ _loop0_26_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_26_type, _seq);
     D(p->level--);
@@ -17139,7 +17154,7 @@ _loop0_28_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_28[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' NAME"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17147,7 +17162,7 @@ _loop0_28_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_28_type, _seq);
     D(p->level--);
@@ -17343,7 +17358,7 @@ _loop0_31_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_31[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('.' | '...')"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17351,7 +17366,7 @@ _loop0_31_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_31_type, _seq);
     D(p->level--);
@@ -17414,7 +17429,7 @@ _loop1_32_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17422,7 +17437,7 @@ _loop1_32_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_32_type, _seq);
     D(p->level--);
@@ -17489,7 +17504,7 @@ _loop0_34_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_34[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' import_from_as_name"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17497,7 +17512,7 @@ _loop0_34_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_34_type, _seq);
     D(p->level--);
@@ -17647,7 +17662,7 @@ _loop0_37_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_37[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' dotted_as_name"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17655,7 +17670,7 @@ _loop0_37_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_37_type, _seq);
     D(p->level--);
@@ -17805,7 +17820,7 @@ _loop0_40_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_40[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' with_item"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17813,7 +17828,7 @@ _loop0_40_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_40_type, _seq);
     D(p->level--);
@@ -17919,7 +17934,7 @@ _loop0_42_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_42[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' with_item"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -17927,7 +17942,7 @@ _loop0_42_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_42_type, _seq);
     D(p->level--);
@@ -18033,7 +18048,7 @@ _loop0_44_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_44[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' with_item"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18041,7 +18056,7 @@ _loop0_44_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_44_type, _seq);
     D(p->level--);
@@ -18147,7 +18162,7 @@ _loop0_46_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_46[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' with_item"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18155,7 +18170,7 @@ _loop0_46_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_46_type, _seq);
     D(p->level--);
@@ -18331,7 +18346,7 @@ _loop1_48_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18339,7 +18354,7 @@ _loop1_48_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_48_type, _seq);
     D(p->level--);
@@ -18612,7 +18627,7 @@ _loop0_54_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_54[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18620,7 +18635,7 @@ _loop0_54_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_54_type, _seq);
     D(p->level--);
@@ -18678,7 +18693,7 @@ _loop0_55_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_55[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_with_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18686,7 +18701,7 @@ _loop0_55_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_55_type, _seq);
     D(p->level--);
@@ -18744,7 +18759,7 @@ _loop0_56_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_56[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_with_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18752,7 +18767,7 @@ _loop0_56_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_56_type, _seq);
     D(p->level--);
@@ -18815,7 +18830,7 @@ _loop1_57_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18823,7 +18838,7 @@ _loop1_57_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_57_type, _seq);
     D(p->level--);
@@ -18881,7 +18896,7 @@ _loop0_58_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_58[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_with_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18889,7 +18904,7 @@ _loop0_58_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_58_type, _seq);
     D(p->level--);
@@ -18952,7 +18967,7 @@ _loop1_59_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -18960,7 +18975,7 @@ _loop1_59_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_59_type, _seq);
     D(p->level--);
@@ -19023,7 +19038,7 @@ _loop1_60_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19031,7 +19046,7 @@ _loop1_60_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_60_type, _seq);
     D(p->level--);
@@ -19094,7 +19109,7 @@ _loop1_61_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19102,7 +19117,7 @@ _loop1_61_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_61_type, _seq);
     D(p->level--);
@@ -19160,7 +19175,7 @@ _loop0_62_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_62[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19168,7 +19183,7 @@ _loop0_62_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_62_type, _seq);
     D(p->level--);
@@ -19231,7 +19246,7 @@ _loop1_63_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19239,7 +19254,7 @@ _loop1_63_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_63_type, _seq);
     D(p->level--);
@@ -19297,7 +19312,7 @@ _loop0_64_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_64[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19305,7 +19320,7 @@ _loop0_64_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_64_type, _seq);
     D(p->level--);
@@ -19368,7 +19383,7 @@ _loop1_65_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19376,7 +19391,7 @@ _loop1_65_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_65_type, _seq);
     D(p->level--);
@@ -19434,7 +19449,7 @@ _loop0_66_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_66[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_maybe_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19442,7 +19457,7 @@ _loop0_66_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_66_type, _seq);
     D(p->level--);
@@ -19505,7 +19520,7 @@ _loop1_67_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19513,7 +19528,7 @@ _loop1_67_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_67_type, _seq);
     D(p->level--);
@@ -19576,7 +19591,7 @@ _loop1_68_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19584,7 +19599,7 @@ _loop1_68_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_68_type, _seq);
     D(p->level--);
@@ -19698,7 +19713,7 @@ _loop0_71_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_71[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_expression"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19706,7 +19721,7 @@ _loop0_71_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_71_type, _seq);
     D(p->level--);
@@ -19808,7 +19823,7 @@ _loop1_72_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19816,7 +19831,7 @@ _loop1_72_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_72_type, _seq);
     D(p->level--);
@@ -19883,7 +19898,7 @@ _loop0_74_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_74[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_named_expression"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -19891,7 +19906,7 @@ _loop0_74_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_74_type, _seq);
     D(p->level--);
@@ -19993,7 +20008,7 @@ _loop1_75_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20001,7 +20016,7 @@ _loop1_75_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_75_type, _seq);
     D(p->level--);
@@ -20059,7 +20074,7 @@ _loop0_76_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_76[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20067,7 +20082,7 @@ _loop0_76_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_76_type, _seq);
     D(p->level--);
@@ -20125,7 +20140,7 @@ _loop0_77_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_77[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_with_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20133,7 +20148,7 @@ _loop0_77_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_77_type, _seq);
     D(p->level--);
@@ -20191,7 +20206,7 @@ _loop0_78_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_78[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_with_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20199,7 +20214,7 @@ _loop0_78_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_78_type, _seq);
     D(p->level--);
@@ -20262,7 +20277,7 @@ _loop1_79_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20270,7 +20285,7 @@ _loop1_79_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_79_type, _seq);
     D(p->level--);
@@ -20328,7 +20343,7 @@ _loop0_80_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_80[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_with_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20336,7 +20351,7 @@ _loop0_80_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_80_type, _seq);
     D(p->level--);
@@ -20399,7 +20414,7 @@ _loop1_81_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20407,7 +20422,7 @@ _loop1_81_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_81_type, _seq);
     D(p->level--);
@@ -20470,7 +20485,7 @@ _loop1_82_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20478,7 +20493,7 @@ _loop1_82_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_82_type, _seq);
     D(p->level--);
@@ -20541,7 +20556,7 @@ _loop1_83_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20549,7 +20564,7 @@ _loop1_83_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_83_type, _seq);
     D(p->level--);
@@ -20607,7 +20622,7 @@ _loop0_84_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_84[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20615,7 +20630,7 @@ _loop0_84_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_84_type, _seq);
     D(p->level--);
@@ -20678,7 +20693,7 @@ _loop1_85_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20686,7 +20701,7 @@ _loop1_85_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_85_type, _seq);
     D(p->level--);
@@ -20744,7 +20759,7 @@ _loop0_86_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_86[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20752,7 +20767,7 @@ _loop0_86_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_86_type, _seq);
     D(p->level--);
@@ -20815,7 +20830,7 @@ _loop1_87_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20823,7 +20838,7 @@ _loop1_87_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_87_type, _seq);
     D(p->level--);
@@ -20881,7 +20896,7 @@ _loop0_88_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_88[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_maybe_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20889,7 +20904,7 @@ _loop0_88_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_88_type, _seq);
     D(p->level--);
@@ -20952,7 +20967,7 @@ _loop1_89_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -20960,7 +20975,7 @@ _loop1_89_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_89_type, _seq);
     D(p->level--);
@@ -21023,7 +21038,7 @@ _loop1_90_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -21031,7 +21046,7 @@ _loop1_90_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_90_type, _seq);
     D(p->level--);
@@ -21094,7 +21109,7 @@ _loop1_91_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -21102,7 +21117,7 @@ _loop1_91_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_91_type, _seq);
     D(p->level--);
@@ -21165,7 +21180,7 @@ _loop1_92_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -21173,7 +21188,7 @@ _loop1_92_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_92_type, _seq);
     D(p->level--);
@@ -21281,7 +21296,7 @@ _loop0_95_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_95[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' slice"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -21289,7 +21304,7 @@ _loop0_95_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_95_type, _seq);
     D(p->level--);
@@ -21657,7 +21672,7 @@ _loop1_100_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -21665,7 +21680,7 @@ _loop1_100_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_100_type, _seq);
     D(p->level--);
@@ -21834,7 +21849,7 @@ _loop0_104_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_104[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' double_starred_kvpair"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -21842,7 +21857,7 @@ _loop0_104_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_104_type, _seq);
     D(p->level--);
@@ -21944,7 +21959,7 @@ _loop1_105_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -21952,7 +21967,7 @@ _loop1_105_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_105_type, _seq);
     D(p->level--);
@@ -22010,7 +22025,7 @@ _loop0_106_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_106[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('if' disjunction)"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22018,7 +22033,7 @@ _loop0_106_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_106_type, _seq);
     D(p->level--);
@@ -22076,7 +22091,7 @@ _loop0_107_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_107[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('if' disjunction)"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22084,7 +22099,7 @@ _loop0_107_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_107_type, _seq);
     D(p->level--);
@@ -22151,7 +22166,7 @@ _loop0_109_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_109[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (starred_expression | named_expression !'=')"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22159,7 +22174,7 @@ _loop0_109_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_109_type, _seq);
     D(p->level--);
@@ -22309,7 +22324,7 @@ _loop0_112_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_112[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' kwarg_or_starred"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22317,7 +22332,7 @@ _loop0_112_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_112_type, _seq);
     D(p->level--);
@@ -22423,7 +22438,7 @@ _loop0_114_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_114[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' kwarg_or_double_starred"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22431,7 +22446,7 @@ _loop0_114_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_114_type, _seq);
     D(p->level--);
@@ -22537,7 +22552,7 @@ _loop0_116_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_116[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' kwarg_or_starred"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22545,7 +22560,7 @@ _loop0_116_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_116_type, _seq);
     D(p->level--);
@@ -22651,7 +22666,7 @@ _loop0_118_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_118[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' kwarg_or_double_starred"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22659,7 +22674,7 @@ _loop0_118_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_118_type, _seq);
     D(p->level--);
@@ -22756,7 +22771,7 @@ _loop0_119_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_119[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(',' star_target)"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22764,7 +22779,7 @@ _loop0_119_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_119_type, _seq);
     D(p->level--);
@@ -22831,7 +22846,7 @@ _loop0_121_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_121[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_target"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22839,7 +22854,7 @@ _loop0_121_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_121_type, _seq);
     D(p->level--);
@@ -22983,7 +22998,7 @@ _loop0_124_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_124[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' del_target"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -22991,7 +23006,7 @@ _loop0_124_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_124_type, _seq);
     D(p->level--);
@@ -23097,7 +23112,7 @@ _loop0_126_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_126[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' target"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -23105,7 +23120,7 @@ _loop0_126_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_126_type, _seq);
     D(p->level--);
@@ -23188,7 +23203,7 @@ _tmp_127_rule(Parser *p)
         }
         D(fprintf(stderr, "%*c> _tmp_127[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression for_if_clauses"));
         expr_ty expression_var;
-        asdl_seq* for_if_clauses_var;
+        asdl_comprehension_seq* for_if_clauses_var;
         if (
             (expression_var = expression_rule(p))  // expression
             &&
@@ -23236,7 +23251,7 @@ _loop0_128_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> _loop0_128[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_named_expressions"));
-        asdl_seq* star_named_expressions_var;
+        asdl_expr_seq* star_named_expressions_var;
         while (
             (star_named_expressions_var = star_named_expressions_rule(p))  // star_named_expressions
         )
@@ -23260,7 +23275,7 @@ _loop0_128_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_128[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "star_named_expressions"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -23268,7 +23283,7 @@ _loop0_128_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_128_type, _seq);
     D(p->level--);
@@ -23326,7 +23341,7 @@ _loop0_129_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_129[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(star_targets '=')"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -23334,7 +23349,7 @@ _loop0_129_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_129_type, _seq);
     D(p->level--);
@@ -23392,7 +23407,7 @@ _loop0_130_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_130[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(star_targets '=')"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -23400,7 +23415,7 @@ _loop0_130_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_130_type, _seq);
     D(p->level--);
@@ -23587,7 +23602,7 @@ _loop0_133_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_133[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -23595,7 +23610,7 @@ _loop0_133_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_133_type, _seq);
     D(p->level--);
@@ -23708,7 +23723,7 @@ _loop0_135_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_135[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_no_default"));
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -23716,7 +23731,7 @@ _loop0_135_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop0_135_type, _seq);
     D(p->level--);
@@ -24594,7 +24609,7 @@ _loop1_153_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -24602,7 +24617,7 @@ _loop1_153_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_153_type, _seq);
     D(p->level--);
@@ -24665,7 +24680,7 @@ _loop1_154_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    asdl_seq *_seq = _Py_asdl_seq_new(_n, p->arena);
+    asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
         p->error_indicator = 1;
@@ -24673,7 +24688,7 @@ _loop1_154_rule(Parser *p)
         D(p->level--);
         return NULL;
     }
-    for (int i = 0; i < _n; i++) asdl_seq_SET(_seq, i, _children[i]);
+    for (int i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);
     PyMem_Free(_children);
     _PyPegen_insert_memo(p, _start_mark, _loop1_154_type, _seq);
     D(p->level--);

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -91,7 +91,7 @@ typedef struct {
 } NameDefaultPair;
 
 typedef struct {
-    asdl_seq *plain_names;
+    asdl_arg_seq *plain_names;
     asdl_seq *names_with_defaults; // asdl_seq* of NameDefaultsPair's
 } SlashWithDefault;
 
@@ -229,7 +229,7 @@ mod_ty _PyPegen_run_parser_from_file_pointer(FILE *, int, PyObject *, const char
 void *_PyPegen_run_parser(Parser *);
 mod_ty _PyPegen_run_parser_from_file(const char *, int, PyObject *, PyCompilerFlags *, PyArena *);
 mod_ty _PyPegen_run_parser_from_string(const char *, int, PyObject *, PyCompilerFlags *, PyArena *);
-void *_PyPegen_interactive_exit(Parser *);
+asdl_stmt_seq *_PyPegen_interactive_exit(Parser *);
 asdl_seq *_PyPegen_singleton_seq(Parser *, void *);
 asdl_seq *_PyPegen_seq_insert_in_front(Parser *, void *, asdl_seq *);
 asdl_seq *_PyPegen_seq_append_to_end(Parser *, asdl_seq *, void *);
@@ -237,33 +237,33 @@ asdl_seq *_PyPegen_seq_flatten(Parser *, asdl_seq *);
 expr_ty _PyPegen_join_names_with_dot(Parser *, expr_ty, expr_ty);
 int _PyPegen_seq_count_dots(asdl_seq *);
 alias_ty _PyPegen_alias_for_star(Parser *);
-asdl_seq *_PyPegen_map_names_to_ids(Parser *, asdl_seq *);
+asdl_identifier_seq *_PyPegen_map_names_to_ids(Parser *, asdl_expr_seq *);
 CmpopExprPair *_PyPegen_cmpop_expr_pair(Parser *, cmpop_ty, expr_ty);
 asdl_int_seq *_PyPegen_get_cmpops(Parser *p, asdl_seq *);
-asdl_seq *_PyPegen_get_exprs(Parser *, asdl_seq *);
+asdl_expr_seq *_PyPegen_get_exprs(Parser *, asdl_seq *);
 expr_ty _PyPegen_set_expr_context(Parser *, expr_ty, expr_context_ty);
 KeyValuePair *_PyPegen_key_value_pair(Parser *, expr_ty, expr_ty);
-asdl_seq *_PyPegen_get_keys(Parser *, asdl_seq *);
-asdl_seq *_PyPegen_get_values(Parser *, asdl_seq *);
+asdl_expr_seq *_PyPegen_get_keys(Parser *, asdl_seq *);
+asdl_expr_seq *_PyPegen_get_values(Parser *, asdl_seq *);
 NameDefaultPair *_PyPegen_name_default_pair(Parser *, arg_ty, expr_ty, Token *);
-SlashWithDefault *_PyPegen_slash_with_default(Parser *, asdl_seq *, asdl_seq *);
+SlashWithDefault *_PyPegen_slash_with_default(Parser *, asdl_arg_seq *, asdl_seq *);
 StarEtc *_PyPegen_star_etc(Parser *, arg_ty, asdl_seq *, arg_ty);
-arguments_ty _PyPegen_make_arguments(Parser *, asdl_seq *, SlashWithDefault *,
-                            asdl_seq *, asdl_seq *, StarEtc *);
+arguments_ty _PyPegen_make_arguments(Parser *, asdl_arg_seq *, SlashWithDefault *,
+                                     asdl_arg_seq *, asdl_seq *, StarEtc *);
 arguments_ty _PyPegen_empty_arguments(Parser *);
 AugOperator *_PyPegen_augoperator(Parser*, operator_ty type);
-stmt_ty _PyPegen_function_def_decorators(Parser *, asdl_seq *, stmt_ty);
-stmt_ty _PyPegen_class_def_decorators(Parser *, asdl_seq *, stmt_ty);
+stmt_ty _PyPegen_function_def_decorators(Parser *, asdl_expr_seq *, stmt_ty);
+stmt_ty _PyPegen_class_def_decorators(Parser *, asdl_expr_seq *, stmt_ty);
 KeywordOrStarred *_PyPegen_keyword_or_starred(Parser *, void *, int);
-asdl_seq *_PyPegen_seq_extract_starred_exprs(Parser *, asdl_seq *);
-asdl_seq *_PyPegen_seq_delete_starred_exprs(Parser *, asdl_seq *);
-expr_ty _PyPegen_collect_call_seqs(Parser *, asdl_seq *, asdl_seq *,
+asdl_expr_seq *_PyPegen_seq_extract_starred_exprs(Parser *, asdl_seq *);
+asdl_keyword_seq *_PyPegen_seq_delete_starred_exprs(Parser *, asdl_seq *);
+expr_ty _PyPegen_collect_call_seqs(Parser *, asdl_expr_seq *, asdl_seq *,
                      int lineno, int col_offset, int end_lineno,
                      int end_col_offset, PyArena *arena);
 expr_ty _PyPegen_concatenate_strings(Parser *p, asdl_seq *);
 asdl_seq *_PyPegen_join_sequences(Parser *, asdl_seq *, asdl_seq *);
 int _PyPegen_check_barry_as_flufl(Parser *);
-mod_ty _PyPegen_make_module(Parser *, asdl_seq *);
+mod_ty _PyPegen_make_module(Parser *, asdl_stmt_seq *);
 
 // Error reporting helpers
 typedef enum {

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -970,15 +970,15 @@ ExprList_Dealloc(ExprList *l)
     l->size = -1;
 }
 
-static asdl_seq *
+static asdl_expr_seq *
 ExprList_Finish(ExprList *l, PyArena *arena)
 {
-    asdl_seq *seq;
+    asdl_expr_seq *seq;
 
     ExprList_check_invariants(l);
 
     /* Allocate the asdl_seq and copy the expressions in to it. */
-    seq = _Py_asdl_seq_new(l->size, arena);
+    seq = _Py_asdl_expr_seq_new(l->size, arena);
     if (seq) {
         Py_ssize_t i;
         for (i = 0; i < l->size; i++) {
@@ -1167,7 +1167,7 @@ expr_ty
 _PyPegen_FstringParser_Finish(Parser *p, FstringParser *state, Token* first_token,
                      Token *last_token)
 {
-    asdl_seq *seq;
+    asdl_expr_seq *seq;
 
     FstringParser_check_invariants(state);
 

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -3,6 +3,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_call.h"          // _PyObject_CallNoArgs()
 
 #include <ctype.h>
 #include <assert.h>
@@ -13,7 +14,6 @@
 #include "unicodeobject.h"
 #include "bytesobject.h"
 #include "fileobject.h"
-#include "codecs.h"
 #include "abstract.h"
 
 /* Alternate tab spacing */
@@ -51,11 +51,14 @@ static const char* type_comment_prefix = "# type: ";
 static struct tok_state *
 tok_new(void)
 {
-    struct tok_state *tok = (struct tok_state *)PyMem_MALLOC(
+    struct tok_state *tok = (struct tok_state *)PyMem_Malloc(
                                             sizeof(struct tok_state));
     if (tok == NULL)
         return NULL;
     tok->buf = tok->cur = tok->inp = NULL;
+    tok->fp_interactive = 0;
+    tok->interactive_src_start = NULL;
+    tok->interactive_src_end = NULL;
     tok->start = NULL;
     tok->end = NULL;
     tok->done = E_OK;
@@ -64,7 +67,6 @@ tok_new(void)
     tok->tabsize = TABSIZE;
     tok->indent = 0;
     tok->indstack[0] = 0;
-
     tok->atbol = 1;
     tok->pendin = 0;
     tok->prompt = tok->nextprompt = NULL;
@@ -73,7 +75,6 @@ tok_new(void)
     tok->altindstack[0] = 0;
     tok->decoding_state = STATE_INIT;
     tok->decoding_erred = 0;
-    tok->read_coding_spec = 0;
     tok->enc = NULL;
     tok->encoding = NULL;
     tok->cont_line = 0;
@@ -81,19 +82,19 @@ tok_new(void)
     tok->decoding_readline = NULL;
     tok->decoding_buffer = NULL;
     tok->type_comments = 0;
-
     tok->async_hacks = 0;
     tok->async_def = 0;
     tok->async_def_indent = 0;
     tok->async_def_nl = 0;
-
+    tok->interactive_underflow = IUNDERFLOW_NORMAL;
+    tok->str = NULL;
     return tok;
 }
 
 static char *
 new_string(const char *s, Py_ssize_t len, struct tok_state *tok)
 {
-    char* result = (char *)PyMem_MALLOC(len + 1);
+    char* result = (char *)PyMem_Malloc(len + 1);
     if (!result) {
         tok->done = E_NOMEM;
         return NULL;
@@ -107,8 +108,8 @@ static char *
 error_ret(struct tok_state *tok) /* XXX */
 {
     tok->decoding_erred = 1;
-    if (tok->fp != NULL && tok->buf != NULL) /* see PyTokenizer_Free */
-        PyMem_FREE(tok->buf);
+    if (tok->fp != NULL && tok->buf != NULL) /* see _PyTokenizer_Free */
+        PyMem_Free(tok->buf);
     tok->buf = tok->cur = tok->inp = NULL;
     tok->start = NULL;
     tok->end = NULL;
@@ -163,14 +164,14 @@ get_coding_spec(const char *s, char **spec, Py_ssize_t size, struct tok_state *t
     }
     for (; i < size - 6; i++) { /* XXX inefficient search */
         const char* t = s + i;
-        if (strncmp(t, "coding", 6) == 0) {
+        if (memcmp(t, "coding", 6) == 0) {
             const char* begin = NULL;
             t += 6;
             if (t[0] != ':' && t[0] != '=')
                 continue;
             do {
                 t++;
-            } while (t[0] == '\x20' || t[0] == '\t');
+            } while (t[0] == ' ' || t[0] == '\t');
 
             begin = t;
             while (Py_ISALNUM(t[0]) ||
@@ -184,7 +185,7 @@ get_coding_spec(const char *s, char **spec, Py_ssize_t size, struct tok_state *t
                     return 0;
                 q = get_normal_name(r);
                 if (r != q) {
-                    PyMem_FREE(r);
+                    PyMem_Free(r);
                     r = new_string(q, strlen(q), tok);
                     if (!r)
                         return 0;
@@ -207,15 +208,14 @@ check_coding_spec(const char* line, Py_ssize_t size, struct tok_state *tok,
                   int set_readline(struct tok_state *, const char *))
 {
     char *cs;
-    int r = 1;
-
     if (tok->cont_line) {
         /* It's a continuation line, so it can't be a coding spec. */
-        tok->read_coding_spec = 1;
+        tok->decoding_state = STATE_NORMAL;
         return 1;
     }
-    if (!get_coding_spec(line, &cs, size, tok))
+    if (!get_coding_spec(line, &cs, size, tok)) {
         return 0;
+    }
     if (!cs) {
         Py_ssize_t i;
         for (i = 0; i < size; i++) {
@@ -224,37 +224,33 @@ check_coding_spec(const char* line, Py_ssize_t size, struct tok_state *tok,
             if (line[i] != ' ' && line[i] != '\t' && line[i] != '\014') {
                 /* Stop checking coding spec after a line containing
                  * anything except a comment. */
-                tok->read_coding_spec = 1;
+                tok->decoding_state = STATE_NORMAL;
                 break;
             }
         }
         return 1;
     }
-    tok->read_coding_spec = 1;
+    tok->decoding_state = STATE_NORMAL;
     if (tok->encoding == NULL) {
-        assert(tok->decoding_state == STATE_RAW);
-        if (strcmp(cs, "utf-8") == 0) {
-            tok->encoding = cs;
-        } else {
-            r = set_readline(tok, cs);
-            if (r) {
-                tok->encoding = cs;
-                tok->decoding_state = STATE_NORMAL;
-            }
-            else {
-                PyErr_Format(PyExc_SyntaxError,
-                             "encoding problem: %s", cs);
-                PyMem_FREE(cs);
-            }
+        assert(tok->decoding_readline == NULL);
+        if (strcmp(cs, "utf-8") != 0 && !set_readline(tok, cs)) {
+            error_ret(tok);
+            PyErr_Format(PyExc_SyntaxError, "encoding problem: %s", cs);
+            PyMem_Free(cs);
+            return 0;
         }
+        tok->encoding = cs;
     } else {                /* then, compare cs with BOM */
-        r = (strcmp(tok->encoding, cs) == 0);
-        if (!r)
+        if (strcmp(tok->encoding, cs) != 0) {
+            error_ret(tok);
             PyErr_Format(PyExc_SyntaxError,
                          "encoding problem: %s with BOM", cs);
-        PyMem_FREE(cs);
+            PyMem_Free(cs);
+            return 0;
+        }
+        PyMem_Free(cs);
     }
-    return r;
+    return 1;
 }
 
 /* See whether the file starts with a BOM. If it does,
@@ -269,7 +265,7 @@ check_bom(int get_char(struct tok_state *),
 {
     int ch1, ch2, ch3;
     ch1 = get_char(tok);
-    tok->decoding_state = STATE_RAW;
+    tok->decoding_state = STATE_SEEK_CODING;
     if (ch1 == EOF) {
         return 1;
     } else if (ch1 == 0xEF) {
@@ -315,13 +311,43 @@ check_bom(int get_char(struct tok_state *),
         return 1;
     }
     if (tok->encoding != NULL)
-        PyMem_FREE(tok->encoding);
+        PyMem_Free(tok->encoding);
     tok->encoding = new_string("utf-8", 5, tok);
     if (!tok->encoding)
         return 0;
     /* No need to set_readline: input is already utf-8 */
     return 1;
 }
+
+static int
+tok_concatenate_interactive_new_line(struct tok_state *tok, const char *line) {
+    assert(tok->fp_interactive);
+
+    if (!line) {
+        return 0;
+    }
+
+    Py_ssize_t current_size = tok->interactive_src_end - tok->interactive_src_start;
+    Py_ssize_t line_size = strlen(line);
+    char* new_str = tok->interactive_src_start;
+
+    new_str = PyMem_Realloc(new_str, current_size + line_size + 1);
+    if (!new_str) {
+        if (tok->interactive_src_start) {
+            PyMem_Free(tok->interactive_src_start);
+        }
+        tok->interactive_src_start = NULL;
+        tok->interactive_src_end = NULL;
+        tok->done = E_NOMEM;
+        return -1;
+    }
+    strcpy(new_str + current_size, line);
+
+    tok->interactive_src_start = new_str;
+    tok->interactive_src_end = new_str + current_size + line_size;
+    return 0;
+}
+
 
 /* Read a line of text from TOK into S, using the stream in TOK.
    Return NULL on failure, else S.
@@ -330,73 +356,77 @@ check_bom(int get_char(struct tok_state *),
      1) NULL: need to call tok->decoding_readline to get a new line
      2) PyUnicodeObject *: decoding_feof has called tok->decoding_readline and
        stored the result in tok->decoding_buffer
-     3) PyByteArrayObject *: previous call to fp_readl did not have enough room
+     3) PyByteArrayObject *: previous call to tok_readline_recode did not have enough room
        (in the s buffer) to copy entire contents of the line read
        by tok->decoding_readline.  tok->decoding_buffer has the overflow.
-       In this case, fp_readl is called in a loop (with an expanded buffer)
+       In this case, tok_readline_recode is called in a loop (with an expanded buffer)
        until the buffer ends with a '\n' (or until the end of the file is
-       reached): see tok_nextc and its calls to decoding_fgets.
+       reached): see tok_nextc and its calls to tok_reserve_buf.
 */
 
-static char *
-fp_readl(char *s, int size, struct tok_state *tok)
+static int
+tok_reserve_buf(struct tok_state *tok, Py_ssize_t size)
 {
-    PyObject* bufobj;
-    const char *buf;
+    Py_ssize_t cur = tok->cur - tok->buf;
+    Py_ssize_t oldsize = tok->inp - tok->buf;
+    Py_ssize_t newsize = oldsize + Py_MAX(size, oldsize >> 1);
+    if (newsize > tok->end - tok->buf) {
+        char *newbuf = tok->buf;
+        Py_ssize_t start = tok->start == NULL ? -1 : tok->start - tok->buf;
+        Py_ssize_t line_start = tok->start == NULL ? -1 : tok->line_start - tok->buf;
+        Py_ssize_t multi_line_start = tok->multi_line_start - tok->buf;
+        newbuf = (char *)PyMem_Realloc(newbuf, newsize);
+        if (newbuf == NULL) {
+            tok->done = E_NOMEM;
+            return 0;
+        }
+        tok->buf = newbuf;
+        tok->cur = tok->buf + cur;
+        tok->inp = tok->buf + oldsize;
+        tok->end = tok->buf + newsize;
+        tok->start = start < 0 ? NULL : tok->buf + start;
+        tok->line_start = line_start < 0 ? NULL : tok->buf + line_start;
+        tok->multi_line_start = multi_line_start < 0 ? NULL : tok->buf + multi_line_start;
+    }
+    return 1;
+}
+
+static int
+tok_readline_recode(struct tok_state *tok) {
+    PyObject *line;
+    const  char *buf;
     Py_ssize_t buflen;
-
-    /* Ask for one less byte so we can terminate it */
-    assert(size > 0);
-    size--;
-
-    if (tok->decoding_buffer) {
-        bufobj = tok->decoding_buffer;
-        Py_INCREF(bufobj);
-    }
-    else
-    {
-        bufobj = _PyObject_CallNoArg(tok->decoding_readline);
-        if (bufobj == NULL)
-            goto error;
-    }
-    if (PyUnicode_CheckExact(bufobj))
-    {
-        buf = PyUnicode_AsUTF8AndSize(bufobj, &buflen);
-        if (buf == NULL) {
+    line = tok->decoding_buffer;
+    if (line == NULL) {
+        line = PyObject_CallNoArgs(tok->decoding_readline);
+        if (line == NULL) {
+            error_ret(tok);
             goto error;
         }
     }
-    else
-    {
-        buf = PyByteArray_AsString(bufobj);
-        if (buf == NULL) {
-            goto error;
-        }
-        buflen = PyByteArray_GET_SIZE(bufobj);
-    }
-
-    Py_XDECREF(tok->decoding_buffer);
-    if (buflen > size) {
-        /* Too many chars, the rest goes into tok->decoding_buffer */
-        tok->decoding_buffer = PyByteArray_FromStringAndSize(buf+size,
-                                                         buflen-size);
-        if (tok->decoding_buffer == NULL)
-            goto error;
-        buflen = size;
-    }
-    else
+    else {
         tok->decoding_buffer = NULL;
-
-    memcpy(s, buf, buflen);
-    s[buflen] = '\0';
-    if (buflen == 0) /* EOF */
-        s = NULL;
-    Py_DECREF(bufobj);
-    return s;
-
+    }
+    buf = PyUnicode_AsUTF8AndSize(line, &buflen);
+    if (buf == NULL) {
+        error_ret(tok);
+        goto error;
+    }
+    if (!tok_reserve_buf(tok, buflen + 1)) {
+        goto error;
+    }
+    memcpy(tok->inp, buf, buflen);
+    tok->inp += buflen;
+    *tok->inp = '\0';
+    if (tok->fp_interactive &&
+        tok_concatenate_interactive_new_line(tok, buf) == -1) {
+        goto error;
+    }
+    Py_DECREF(line);
+    return 1;
 error:
-    Py_XDECREF(bufobj);
-    return error_ret(tok);
+    Py_XDECREF(line);
+    return 0;
 }
 
 /* Set the readline function for TOK to a StreamReader's
@@ -431,7 +461,7 @@ fp_setreadl(struct tok_state *tok, const char* enc)
         return 0;
     }
 
-    io = PyImport_ImportModuleNoBlock("io");
+    io = PyImport_ImportModule("io");
     if (io == NULL)
         return 0;
 
@@ -448,7 +478,7 @@ fp_setreadl(struct tok_state *tok, const char* enc)
     Py_XSETREF(tok->decoding_readline, readline);
 
     if (pos > 0) {
-        PyObject *bufobj = _PyObject_CallNoArg(readline);
+        PyObject *bufobj = _PyObject_CallNoArgs(readline);
         if (bufobj == NULL)
             return 0;
         Py_DECREF(bufobj);
@@ -497,82 +527,30 @@ static int valid_utf8(const unsigned char* s)
     return length;
 }
 
-/* Read a line of input from TOK. Determine encoding
-   if necessary.  */
-
-static char *
-decoding_fgets(char *s, int size, struct tok_state *tok)
+static int
+ensure_utf8(char *line, struct tok_state *tok)
 {
-    char *line = NULL;
     int badchar = 0;
-    for (;;) {
-        if (tok->decoding_state == STATE_NORMAL) {
-            /* We already have a codec associated with
-               this input. */
-            line = fp_readl(s, size, tok);
+    unsigned char *c;
+    int length;
+    for (c = (unsigned char *)line; *c; c += length) {
+        if (!(length = valid_utf8(c))) {
+            badchar = *c;
             break;
-        } else if (tok->decoding_state == STATE_RAW) {
-            /* We want a 'raw' read. */
-            line = Py_UniversalNewlineFgets(s, size,
-                                            tok->fp, NULL);
-            break;
-        } else {
-            /* We have not yet determined the encoding.
-               If an encoding is found, use the file-pointer
-               reader functions from now on. */
-            if (!check_bom(fp_getc, fp_ungetc, fp_setreadl, tok))
-                return error_ret(tok);
-            assert(tok->decoding_state != STATE_INIT);
         }
-    }
-    if (line != NULL && tok->lineno < 2 && !tok->read_coding_spec) {
-        if (!check_coding_spec(line, strlen(line), tok, fp_setreadl)) {
-            return error_ret(tok);
-        }
-    }
-    /* The default encoding is UTF-8, so make sure we don't have any
-       non-UTF-8 sequences in it. */
-    if (line && !tok->encoding) {
-        unsigned char *c;
-        int length;
-        for (c = (unsigned char *)line; *c; c += length)
-            if (!(length = valid_utf8(c))) {
-                badchar = *c;
-                break;
-            }
     }
     if (badchar) {
         /* Need to add 1 to the line number, since this line
-           has not been counted, yet.  */
+       has not been counted, yet.  */
         PyErr_Format(PyExc_SyntaxError,
-                "Non-UTF-8 code starting with '\\x%.2x' "
-                "in file %U on line %i, "
-                "but no encoding declared; "
-                "see http://python.org/dev/peps/pep-0263/ for details",
-                badchar, tok->filename, tok->lineno + 1);
-        return error_ret(tok);
+                     "Non-UTF-8 code starting with '\\x%.2x' "
+                     "in file %U on line %i, "
+                     "but no encoding declared; "
+                     "see https://python.org/dev/peps/pep-0263/ for details",
+                     badchar, tok->filename, tok->lineno + 1);
+        return 0;
     }
-    return line;
-}
-
-static int
-decoding_feof(struct tok_state *tok)
-{
-    if (tok->decoding_state != STATE_NORMAL) {
-        return feof(tok->fp);
-    } else {
-        PyObject* buf = tok->decoding_buffer;
-        if (buf == NULL) {
-            buf = _PyObject_CallNoArg(tok->decoding_readline);
-            if (buf == NULL) {
-                error_ret(tok);
-                return 1;
-            } else {
-                tok->decoding_buffer = buf;
-            }
-        }
-        return PyObject_Length(buf) == 0;
-    }
+    return 1;
 }
 
 /* Fetch a byte from TOK, using the string buffer. */
@@ -620,7 +598,7 @@ translate_newlines(const char *s, int exec_input, struct tok_state *tok) {
     size_t needed_length = strlen(s) + 2, final_length;
     char *buf, *current;
     char c = '\0';
-    buf = PyMem_MALLOC(needed_length);
+    buf = PyMem_Malloc(needed_length);
     if (buf == NULL) {
         tok->done = E_NOMEM;
         return NULL;
@@ -651,9 +629,9 @@ translate_newlines(const char *s, int exec_input, struct tok_state *tok) {
     final_length = current - buf + 1;
     if (final_length < needed_length && final_length) {
         /* should never fail */
-        char* result = PyMem_REALLOC(buf, final_length);
+        char* result = PyMem_Realloc(buf, final_length);
         if (result == NULL) {
-            PyMem_FREE(buf);
+            PyMem_Free(buf);
         }
         buf = result;
     }
@@ -700,12 +678,13 @@ decode_str(const char *input, int single, struct tok_state *tok)
     /* need to check line 1 and 2 separately since check_coding_spec
        assumes a single line as input */
     if (newl[0]) {
-        if (!check_coding_spec(str, newl[0] - str, tok, buf_setreadl))
-            return error_ret(tok);
-        if (tok->enc == NULL && !tok->read_coding_spec && newl[1]) {
+        if (!check_coding_spec(str, newl[0] - str, tok, buf_setreadl)) {
+            return NULL;
+        }
+        if (tok->enc == NULL && tok->decoding_state != STATE_NORMAL && newl[1]) {
             if (!check_coding_spec(newl[0]+1, newl[1] - newl[0],
                                    tok, buf_setreadl))
-                return error_ret(tok);
+                return NULL;
         }
     }
     if (tok->enc != NULL) {
@@ -723,7 +702,7 @@ decode_str(const char *input, int single, struct tok_state *tok)
 /* Set up tokenizer for string */
 
 struct tok_state *
-PyTokenizer_FromString(const char *str, int exec_input)
+_PyTokenizer_FromString(const char *str, int exec_input)
 {
     struct tok_state *tok = tok_new();
     char *decoded;
@@ -732,7 +711,7 @@ PyTokenizer_FromString(const char *str, int exec_input)
         return NULL;
     decoded = decode_str(str, exec_input, tok);
     if (decoded == NULL) {
-        PyTokenizer_Free(tok);
+        _PyTokenizer_Free(tok);
         return NULL;
     }
 
@@ -741,8 +720,10 @@ PyTokenizer_FromString(const char *str, int exec_input)
     return tok;
 }
 
+/* Set up tokenizer for UTF-8 string */
+
 struct tok_state *
-PyTokenizer_FromUTF8(const char *str, int exec_input)
+_PyTokenizer_FromUTF8(const char *str, int exec_input)
 {
     struct tok_state *tok = tok_new();
     char *translated;
@@ -750,19 +731,17 @@ PyTokenizer_FromUTF8(const char *str, int exec_input)
         return NULL;
     tok->input = translated = translate_newlines(str, exec_input, tok);
     if (translated == NULL) {
-        PyTokenizer_Free(tok);
+        _PyTokenizer_Free(tok);
         return NULL;
     }
-    tok->decoding_state = STATE_RAW;
-    tok->read_coding_spec = 1;
+    tok->decoding_state = STATE_NORMAL;
     tok->enc = NULL;
     tok->str = translated;
-    tok->encoding = (char *)PyMem_MALLOC(6);
+    tok->encoding = new_string("utf-8", 5, tok);
     if (!tok->encoding) {
-        PyTokenizer_Free(tok);
+        _PyTokenizer_Free(tok);
         return NULL;
     }
-    strcpy(tok->encoding, "utf-8");
 
     tok->buf = tok->cur = tok->inp = translated;
     tok->end = translated;
@@ -772,14 +751,14 @@ PyTokenizer_FromUTF8(const char *str, int exec_input)
 /* Set up tokenizer for file */
 
 struct tok_state *
-PyTokenizer_FromFile(FILE *fp, const char* enc,
-                     const char *ps1, const char *ps2)
+_PyTokenizer_FromFile(FILE *fp, const char* enc,
+                      const char *ps1, const char *ps2)
 {
     struct tok_state *tok = tok_new();
     if (tok == NULL)
         return NULL;
-    if ((tok->buf = (char *)PyMem_MALLOC(BUFSIZ)) == NULL) {
-        PyTokenizer_Free(tok);
+    if ((tok->buf = (char *)PyMem_Malloc(BUFSIZ)) == NULL) {
+        _PyTokenizer_Free(tok);
         return NULL;
     }
     tok->cur = tok->inp = tok->buf;
@@ -790,40 +769,264 @@ PyTokenizer_FromFile(FILE *fp, const char* enc,
     if (enc != NULL) {
         /* Must copy encoding declaration since it
            gets copied into the parse tree. */
-        tok->encoding = PyMem_MALLOC(strlen(enc)+1);
+        tok->encoding = new_string(enc, strlen(enc), tok);
         if (!tok->encoding) {
-            PyTokenizer_Free(tok);
+            _PyTokenizer_Free(tok);
             return NULL;
         }
-        strcpy(tok->encoding, enc);
         tok->decoding_state = STATE_NORMAL;
     }
     return tok;
 }
 
-
 /* Free a tok_state structure */
 
 void
-PyTokenizer_Free(struct tok_state *tok)
+_PyTokenizer_Free(struct tok_state *tok)
 {
-    if (tok->encoding != NULL)
-        PyMem_FREE(tok->encoding);
+    if (tok->encoding != NULL) {
+        PyMem_Free(tok->encoding);
+    }
     Py_XDECREF(tok->decoding_readline);
     Py_XDECREF(tok->decoding_buffer);
     Py_XDECREF(tok->filename);
-    if (tok->fp != NULL && tok->buf != NULL)
-        PyMem_FREE(tok->buf);
-    if (tok->input)
-        PyMem_FREE(tok->input);
-    PyMem_FREE(tok);
+    if (tok->fp != NULL && tok->buf != NULL) {
+        PyMem_Free(tok->buf);
+    }
+    if (tok->input) {
+        PyMem_Free(tok->input);
+    }
+    if (tok->interactive_src_start != NULL) {
+        PyMem_Free(tok->interactive_src_start);
+    }
+    PyMem_Free(tok);
 }
+
+static int
+tok_readline_raw(struct tok_state *tok)
+{
+    do {
+        if (!tok_reserve_buf(tok, BUFSIZ)) {
+            return 0;
+        }
+        char *line = Py_UniversalNewlineFgets(tok->inp,
+                                              (int)(tok->end - tok->inp),
+                                              tok->fp, NULL);
+        if (line == NULL) {
+            return 1;
+        }
+        if (tok->fp_interactive &&
+            tok_concatenate_interactive_new_line(tok, line) == -1) {
+            return 0;
+        }
+        tok->inp = strchr(tok->inp, '\0');
+        if (tok->inp == tok->buf) {
+            return 0;
+        }
+    } while (tok->inp[-1] != '\n');
+    return 1;
+}
+
+static int
+tok_underflow_string(struct tok_state *tok) {
+    char *end = strchr(tok->inp, '\n');
+    if (end != NULL) {
+        end++;
+    }
+    else {
+        end = strchr(tok->inp, '\0');
+        if (end == tok->inp) {
+            tok->done = E_EOF;
+            return 0;
+        }
+    }
+    if (tok->start == NULL) {
+        tok->buf = tok->cur;
+    }
+    tok->line_start = tok->cur;
+    tok->lineno++;
+    tok->inp = end;
+    return 1;
+}
+
+static int
+tok_underflow_interactive(struct tok_state *tok) {
+    if (tok->interactive_underflow == IUNDERFLOW_STOP) {
+        tok->done = E_INTERACT_STOP;
+        return 1;
+    }
+    char *newtok = PyOS_Readline(tok->fp ? tok->fp : stdin, stdout, tok->prompt);
+    if (newtok != NULL) {
+        char *translated = translate_newlines(newtok, 0, tok);
+        PyMem_Free(newtok);
+        if (translated == NULL) {
+            return 0;
+        }
+        newtok = translated;
+    }
+    if (tok->encoding && newtok && *newtok) {
+        /* Recode to UTF-8 */
+        Py_ssize_t buflen;
+        const char* buf;
+        PyObject *u = translate_into_utf8(newtok, tok->encoding);
+        PyMem_Free(newtok);
+        if (u == NULL) {
+            tok->done = E_DECODE;
+            return 0;
+        }
+        buflen = PyBytes_GET_SIZE(u);
+        buf = PyBytes_AS_STRING(u);
+        newtok = PyMem_Malloc(buflen+1);
+        if (newtok == NULL) {
+            Py_DECREF(u);
+            tok->done = E_NOMEM;
+            return 0;
+        }
+        strcpy(newtok, buf);
+        Py_DECREF(u);
+    }
+    if (tok->fp_interactive &&
+        tok_concatenate_interactive_new_line(tok, newtok) == -1) {
+        PyMem_Free(newtok);
+        return 0;
+    }
+    if (tok->nextprompt != NULL) {
+        tok->prompt = tok->nextprompt;
+    }
+    if (newtok == NULL) {
+        tok->done = E_INTR;
+    }
+    else if (*newtok == '\0') {
+        PyMem_Free(newtok);
+        tok->done = E_EOF;
+    }
+    else if (tok->start != NULL) {
+        Py_ssize_t cur_multi_line_start = tok->multi_line_start - tok->buf;
+        size_t size = strlen(newtok);
+        tok->lineno++;
+        if (!tok_reserve_buf(tok, size + 1)) {
+            PyMem_Free(tok->buf);
+            tok->buf = NULL;
+            PyMem_Free(newtok);
+            return 0;
+        }
+        memcpy(tok->cur, newtok, size + 1);
+        PyMem_Free(newtok);
+        tok->inp += size;
+        tok->multi_line_start = tok->buf + cur_multi_line_start;
+    }
+    else {
+        tok->lineno++;
+        PyMem_Free(tok->buf);
+        tok->buf = newtok;
+        tok->cur = tok->buf;
+        tok->line_start = tok->buf;
+        tok->inp = strchr(tok->buf, '\0');
+        tok->end = tok->inp + 1;
+    }
+    if (tok->done != E_OK) {
+        if (tok->prompt != NULL) {
+            PySys_WriteStderr("\n");
+        }
+        return 0;
+    }
+    return 1;
+}
+
+static int
+tok_underflow_file(struct tok_state *tok) {
+    if (tok->start == NULL) {
+        tok->cur = tok->inp = tok->buf;
+    }
+    if (tok->decoding_state == STATE_INIT) {
+        /* We have not yet determined the encoding.
+           If an encoding is found, use the file-pointer
+           reader functions from now on. */
+        if (!check_bom(fp_getc, fp_ungetc, fp_setreadl, tok)) {
+            error_ret(tok);
+            return 0;
+        }
+        assert(tok->decoding_state != STATE_INIT);
+    }
+    /* Read until '\n' or EOF */
+    if (tok->decoding_readline != NULL) {
+        /* We already have a codec associated with this input. */
+        if (!tok_readline_recode(tok)) {
+            return 0;
+        }
+    }
+    else {
+        /* We want a 'raw' read. */
+        if (!tok_readline_raw(tok)) {
+            return 0;
+        }
+    }
+    if (tok->inp == tok->cur) {
+        tok->done = E_EOF;
+        return 0;
+    }
+    if (tok->inp[-1] != '\n') {
+        /* Last line does not end in \n, fake one */
+        *tok->inp++ = '\n';
+        *tok->inp = '\0';
+    }
+
+    tok->lineno++;
+    if (tok->decoding_state != STATE_NORMAL) {
+        if (tok->lineno > 2) {
+            tok->decoding_state = STATE_NORMAL;
+        }
+        else if (!check_coding_spec(tok->cur, strlen(tok->cur),
+                                    tok, fp_setreadl))
+        {
+            return 0;
+        }
+    }
+    /* The default encoding is UTF-8, so make sure we don't have any
+       non-UTF-8 sequences in it. */
+    if (!tok->encoding && !ensure_utf8(tok->cur, tok)) {
+        error_ret(tok);
+        return 0;
+    }
+    assert(tok->done == E_OK);
+    return tok->done == E_OK;
+}
+
+#if defined(Py_DEBUG)
+static void
+print_escape(FILE *f, const char *s, Py_ssize_t size)
+{
+    if (s == NULL) {
+        fputs("NULL", f);
+        return;
+    }
+    putc('"', f);
+    while (size-- > 0) {
+        unsigned char c = *s++;
+        switch (c) {
+            case '\n': fputs("\\n", f); break;
+            case '\r': fputs("\\r", f); break;
+            case '\t': fputs("\\t", f); break;
+            case '\f': fputs("\\f", f); break;
+            case '\'': fputs("\\'", f); break;
+            case '"': fputs("\\\"", f); break;
+            default:
+                if (0x20 <= c && c <= 0x7f)
+                    putc(c, f);
+                else
+                    fprintf(f, "\\x%02x", c);
+        }
+    }
+    putc('"', f);
+}
+#endif
 
 /* Get next char, updating state; error code goes into tok->done */
 
 static int
 tok_nextc(struct tok_state *tok)
 {
+    int rc;
     for (;;) {
         if (tok->cur != tok->inp) {
             return Py_CHARMASK(*tok->cur++); /* Fast path */
@@ -831,195 +1034,29 @@ tok_nextc(struct tok_state *tok)
         if (tok->done != E_OK)
             return EOF;
         if (tok->fp == NULL) {
-            char *end = strchr(tok->inp, '\n');
-            if (end != NULL)
-                end++;
-            else {
-                end = strchr(tok->inp, '\0');
-                if (end == tok->inp) {
-                    tok->done = E_EOF;
-                    return EOF;
-                }
-            }
-            if (tok->start == NULL)
-                tok->buf = tok->cur;
-            tok->line_start = tok->cur;
-            tok->lineno++;
-            tok->inp = end;
-            return Py_CHARMASK(*tok->cur++);
+            rc = tok_underflow_string(tok);
         }
-        if (tok->prompt != NULL) {
-            char *newtok = PyOS_Readline(tok->fp ? tok->fp : stdin, stdout, tok->prompt);
-            if (newtok != NULL) {
-                char *translated = translate_newlines(newtok, 0, tok);
-                PyMem_FREE(newtok);
-                if (translated == NULL)
-                    return EOF;
-                newtok = translated;
-            }
-            if (tok->encoding && newtok && *newtok) {
-                /* Recode to UTF-8 */
-                Py_ssize_t buflen;
-                const char* buf;
-                PyObject *u = translate_into_utf8(newtok, tok->encoding);
-                PyMem_FREE(newtok);
-                if (!u) {
-                    tok->done = E_DECODE;
-                    return EOF;
-                }
-                buflen = PyBytes_GET_SIZE(u);
-                buf = PyBytes_AS_STRING(u);
-                newtok = PyMem_MALLOC(buflen+1);
-                if (newtok == NULL) {
-                    Py_DECREF(u);
-                    tok->done = E_NOMEM;
-                    return EOF;
-                }
-                strcpy(newtok, buf);
-                Py_DECREF(u);
-            }
-            if (tok->nextprompt != NULL)
-                tok->prompt = tok->nextprompt;
-            if (newtok == NULL)
-                tok->done = E_INTR;
-            else if (*newtok == '\0') {
-                PyMem_FREE(newtok);
-                tok->done = E_EOF;
-            }
-            else if (tok->start != NULL) {
-                size_t start = tok->start - tok->buf;
-                size_t oldlen = tok->cur - tok->buf;
-                size_t newlen = oldlen + strlen(newtok);
-                Py_ssize_t cur_multi_line_start = tok->multi_line_start - tok->buf;
-                char *buf = tok->buf;
-                buf = (char *)PyMem_REALLOC(buf, newlen+1);
-                tok->lineno++;
-                if (buf == NULL) {
-                    PyMem_FREE(tok->buf);
-                    tok->buf = NULL;
-                    PyMem_FREE(newtok);
-                    tok->done = E_NOMEM;
-                    return EOF;
-                }
-                tok->buf = buf;
-                tok->cur = tok->buf + oldlen;
-                tok->multi_line_start = tok->buf + cur_multi_line_start;
-                tok->line_start = tok->cur;
-                strcpy(tok->buf + oldlen, newtok);
-                PyMem_FREE(newtok);
-                tok->inp = tok->buf + newlen;
-                tok->end = tok->inp + 1;
-                tok->start = tok->buf + start;
-            }
-            else {
-                tok->lineno++;
-                if (tok->buf != NULL)
-                    PyMem_FREE(tok->buf);
-                tok->buf = newtok;
-                tok->cur = tok->buf;
-                tok->line_start = tok->buf;
-                tok->inp = strchr(tok->buf, '\0');
-                tok->end = tok->inp + 1;
-            }
+        else if (tok->prompt != NULL) {
+            rc = tok_underflow_interactive(tok);
         }
         else {
-            int done = 0;
-            Py_ssize_t cur = 0;
-            char *pt;
-            if (tok->start == NULL) {
-                if (tok->buf == NULL) {
-                    tok->buf = (char *)
-                        PyMem_MALLOC(BUFSIZ);
-                    if (tok->buf == NULL) {
-                        tok->done = E_NOMEM;
-                        return EOF;
-                    }
-                    tok->end = tok->buf + BUFSIZ;
-                }
-                if (decoding_fgets(tok->buf, (int)(tok->end - tok->buf),
-                          tok) == NULL) {
-                    if (!tok->decoding_erred)
-                        tok->done = E_EOF;
-                    done = 1;
-                }
-                else {
-                    tok->done = E_OK;
-                    tok->inp = strchr(tok->buf, '\0');
-                    done = tok->inp == tok->buf || tok->inp[-1] == '\n';
-                }
-            }
-            else {
-                cur = tok->cur - tok->buf;
-                if (decoding_feof(tok)) {
-                    tok->done = E_EOF;
-                    done = 1;
-                }
-                else
-                    tok->done = E_OK;
-            }
-            tok->lineno++;
-            /* Read until '\n' or EOF */
-            while (!done) {
-                Py_ssize_t curstart = tok->start == NULL ? -1 :
-                          tok->start - tok->buf;
-                Py_ssize_t cur_multi_line_start = tok->multi_line_start - tok->buf;
-                Py_ssize_t curvalid = tok->inp - tok->buf;
-                Py_ssize_t newsize = curvalid + BUFSIZ;
-                char *newbuf = tok->buf;
-                newbuf = (char *)PyMem_REALLOC(newbuf,
-                                               newsize);
-                if (newbuf == NULL) {
-                    tok->done = E_NOMEM;
-                    tok->cur = tok->inp;
-                    return EOF;
-                }
-                tok->buf = newbuf;
-                tok->cur = tok->buf + cur;
-                tok->multi_line_start = tok->buf + cur_multi_line_start;
-                tok->line_start = tok->cur;
-                tok->inp = tok->buf + curvalid;
-                tok->end = tok->buf + newsize;
-                tok->start = curstart < 0 ? NULL :
-                         tok->buf + curstart;
-                if (decoding_fgets(tok->inp,
-                               (int)(tok->end - tok->inp),
-                               tok) == NULL) {
-                    /* Break out early on decoding
-                       errors, as tok->buf will be NULL
-                     */
-                    if (tok->decoding_erred)
-                        return EOF;
-                    /* Last line does not end in \n,
-                       fake one */
-                    if (tok->inp[-1] != '\n')
-                        strcpy(tok->inp, "\n");
-                }
-                tok->inp = strchr(tok->inp, '\0');
-                done = tok->inp[-1] == '\n';
-            }
-            if (tok->buf != NULL) {
-                tok->cur = tok->buf + cur;
-                tok->line_start = tok->cur;
-                /* replace "\r\n" with "\n" */
-                /* For Mac leave the \r, giving a syntax error */
-                pt = tok->inp - 2;
-                if (pt >= tok->buf && *pt == '\r') {
-                    *pt++ = '\n';
-                    *pt = '\0';
-                    tok->inp = pt;
-                }
-            }
+            rc = tok_underflow_file(tok);
         }
-        if (tok->done != E_OK) {
-            if (tok->prompt != NULL)
-                PySys_WriteStderr("\n");
+#if defined(Py_DEBUG)
+        if (Py_DebugFlag) {
+            fprintf(stderr, "line[%d] = ", tok->lineno);
+            print_escape(stderr, tok->cur, tok->inp - tok->cur);
+            fprintf(stderr, "  tok->done = %d\n", tok->done);
+        }
+#endif
+        if (!rc) {
             tok->cur = tok->inp;
             return EOF;
         }
+        tok->line_start = tok->cur;
     }
-    /*NOTREACHED*/
+    Py_UNREACHABLE();
 }
-
 
 /* Back-up one character */
 
@@ -1030,25 +1067,19 @@ tok_backup(struct tok_state *tok, int c)
         if (--tok->cur < tok->buf) {
             Py_FatalError("tokenizer beginning of buffer");
         }
-        if (*tok->cur != c) {
-            *tok->cur = c;
+        if ((int)(unsigned char)*tok->cur != c) {
+            Py_FatalError("tok_backup: wrong character");
         }
     }
 }
 
-
 static int
-syntaxerror(struct tok_state *tok, const char *format, ...)
+_syntaxerror_range(struct tok_state *tok, const char *format,
+                   int col_offset, int end_col_offset,
+                   va_list vargs)
 {
     PyObject *errmsg, *errtext, *args;
-    va_list vargs;
-#ifdef HAVE_STDARG_PROTOTYPES
-    va_start(vargs, format);
-#else
-    va_start(vargs);
-#endif
     errmsg = PyUnicode_FromFormatV(format, vargs);
-    va_end(vargs);
     if (!errmsg) {
         goto error;
     }
@@ -1058,7 +1089,14 @@ syntaxerror(struct tok_state *tok, const char *format, ...)
     if (!errtext) {
         goto error;
     }
-    int offset = (int)PyUnicode_GET_LENGTH(errtext);
+
+    if (col_offset == -1) {
+        col_offset = (int)PyUnicode_GET_LENGTH(errtext);
+    }
+    if (end_col_offset == -1) {
+        end_col_offset = col_offset;
+    }
+
     Py_ssize_t line_len = strcspn(tok->line_start, "\n");
     if (line_len != tok->cur - tok->line_start) {
         Py_DECREF(errtext);
@@ -1069,8 +1107,8 @@ syntaxerror(struct tok_state *tok, const char *format, ...)
         goto error;
     }
 
-    args = Py_BuildValue("(O(OiiN))", errmsg,
-                         tok->filename, tok->lineno, offset, errtext);
+    args = Py_BuildValue("(O(OiiNii))", errmsg, tok->filename, tok->lineno,
+                         col_offset, errtext, tok->lineno, end_col_offset);
     if (args) {
         PyErr_SetObject(PyExc_SyntaxError, args);
         Py_DECREF(args);
@@ -1083,11 +1121,150 @@ error:
 }
 
 static int
+syntaxerror(struct tok_state *tok, const char *format, ...)
+{
+    va_list vargs;
+#ifdef HAVE_STDARG_PROTOTYPES
+    va_start(vargs, format);
+#else
+    va_start(vargs);
+#endif
+    int ret = _syntaxerror_range(tok, format, -1, -1, vargs);
+    va_end(vargs);
+    return ret;
+}
+
+static int
+syntaxerror_known_range(struct tok_state *tok,
+                        int col_offset, int end_col_offset,
+                        const char *format, ...)
+{
+    va_list vargs;
+#ifdef HAVE_STDARG_PROTOTYPES
+    va_start(vargs, format);
+#else
+    va_start(vargs);
+#endif
+    int ret = _syntaxerror_range(tok, format, col_offset, end_col_offset, vargs);
+    va_end(vargs);
+    return ret;
+}
+
+
+
+static int
 indenterror(struct tok_state *tok)
 {
     tok->done = E_TABSPACE;
     tok->cur = tok->inp;
     return ERRORTOKEN;
+}
+
+static int
+parser_warn(struct tok_state *tok, const char *format, ...)
+{
+    PyObject *errmsg;
+    va_list vargs;
+#ifdef HAVE_STDARG_PROTOTYPES
+    va_start(vargs, format);
+#else
+    va_start(vargs);
+#endif
+    errmsg = PyUnicode_FromFormatV(format, vargs);
+    va_end(vargs);
+    if (!errmsg) {
+        goto error;
+    }
+
+    if (PyErr_WarnExplicitObject(PyExc_DeprecationWarning, errmsg, tok->filename,
+                                 tok->lineno, NULL, NULL) < 0) {
+        if (PyErr_ExceptionMatches(PyExc_DeprecationWarning)) {
+            /* Replace the DeprecationWarning exception with a SyntaxError
+               to get a more accurate error report */
+            PyErr_Clear();
+            syntaxerror(tok, "%U", errmsg);
+        }
+        goto error;
+    }
+    Py_DECREF(errmsg);
+    return 0;
+
+error:
+    Py_XDECREF(errmsg);
+    tok->done = E_ERROR;
+    return -1;
+}
+
+static int
+lookahead(struct tok_state *tok, const char *test)
+{
+    const char *s = test;
+    int res = 0;
+    while (1) {
+        int c = tok_nextc(tok);
+        if (*s == 0) {
+            res = !is_potential_identifier_char(c);
+        }
+        else if (c == *s) {
+            s++;
+            continue;
+        }
+
+        tok_backup(tok, c);
+        while (s != test) {
+            tok_backup(tok, *--s);
+        }
+        return res;
+    }
+}
+
+static int
+verify_end_of_number(struct tok_state *tok, int c, const char *kind)
+{
+    /* Emit a deprecation warning only if the numeric literal is immediately
+     * followed by one of keywords which can occur after a numeric literal
+     * in valid code: "and", "else", "for", "if", "in", "is" and "or".
+     * It allows to gradually deprecate existing valid code without adding
+     * warning before error in most cases of invalid numeric literal (which
+     * would be confusing and break existing tests).
+     * Raise a syntax error with slightly better message than plain
+     * "invalid syntax" if the numeric literal is immediately followed by
+     * other keyword or identifier.
+     */
+    int r = 0;
+    if (c == 'a') {
+        r = lookahead(tok, "nd");
+    }
+    else if (c == 'e') {
+        r = lookahead(tok, "lse");
+    }
+    else if (c == 'f') {
+        r = lookahead(tok, "or");
+    }
+    else if (c == 'i') {
+        int c2 = tok_nextc(tok);
+        if (c2 == 'f' || c2 == 'n' || c2 == 's') {
+            r = 1;
+        }
+        tok_backup(tok, c2);
+    }
+    else if (c == 'o') {
+        r = lookahead(tok, "r");
+    }
+    if (r) {
+        tok_backup(tok, c);
+        if (parser_warn(tok, "invalid %s literal", kind)) {
+            return 0;
+        }
+        tok_nextc(tok);
+    }
+    else /* In future releases, only error will remain. */
+    if (is_potential_identifier_char(c)) {
+        tok_backup(tok, c);
+        syntaxerror(tok, "invalid %s literal", kind);
+        return 0;
+    }
+    return 1;
 }
 
 /* Verify that the identifier follows PEP 3131.
@@ -1373,8 +1550,15 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
         }
     }
 
+    if (tok->done == E_INTERACT_STOP) {
+        return ENDMARKER;
+    }
+
     /* Check for EOF and errors now */
     if (c == EOF) {
+        if (tok->level) {
+            return ERRORTOKEN;
+        }
         return tok->done == E_EOF ? ENDMARKER : ERRORTOKEN;
     }
 
@@ -1531,6 +1715,9 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                         c = tok_nextc(tok);
                     } while (isxdigit(c));
                 } while (c == '_');
+                if (!verify_end_of_number(tok, c, "hexadecimal")) {
+                    return ERRORTOKEN;
+                }
             }
             else if (c == 'o' || c == 'O') {
                 /* Octal */
@@ -1540,12 +1727,12 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                         c = tok_nextc(tok);
                     }
                     if (c < '0' || c >= '8') {
-                        tok_backup(tok, c);
                         if (isdigit(c)) {
                             return syntaxerror(tok,
                                     "invalid digit '%c' in octal literal", c);
                         }
                         else {
+                            tok_backup(tok, c);
                             return syntaxerror(tok, "invalid octal literal");
                         }
                     }
@@ -1557,6 +1744,9 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                     return syntaxerror(tok,
                             "invalid digit '%c' in octal literal", c);
                 }
+                if (!verify_end_of_number(tok, c, "octal")) {
+                    return ERRORTOKEN;
+                }
             }
             else if (c == 'b' || c == 'B') {
                 /* Binary */
@@ -1566,12 +1756,12 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                         c = tok_nextc(tok);
                     }
                     if (c != '0' && c != '1') {
-                        tok_backup(tok, c);
                         if (isdigit(c)) {
                             return syntaxerror(tok,
                                     "invalid digit '%c' in binary literal", c);
                         }
                         else {
+                            tok_backup(tok, c);
                             return syntaxerror(tok, "invalid binary literal");
                         }
                     }
@@ -1582,6 +1772,9 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                 if (isdigit(c)) {
                     return syntaxerror(tok,
                             "invalid digit '%c' in binary literal", c);
+                }
+                if (!verify_end_of_number(tok, c, "binary")) {
+                    return ERRORTOKEN;
                 }
             }
             else {
@@ -1601,6 +1794,7 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                     }
                     c = tok_nextc(tok);
                 }
+                char* zeros_end = tok->cur;
                 if (isdigit(c)) {
                     nonzero = 1;
                     c = tok_decimal_tail(tok);
@@ -1621,10 +1815,15 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                 else if (nonzero) {
                     /* Old-style octal: now disallowed. */
                     tok_backup(tok, c);
-                    return syntaxerror(tok,
-                                       "leading zeros in decimal integer "
-                                       "literals are not permitted; "
-                                       "use an 0o prefix for octal integers");
+                    return syntaxerror_known_range(
+                            tok, (int)(tok->start + 1 - tok->line_start),
+                            (int)(zeros_end - tok->line_start),
+                            "leading zeros in decimal integer "
+                            "literals are not permitted; "
+                            "use an 0o prefix for octal integers");
+                }
+                if (!verify_end_of_number(tok, c, "decimal")) {
+                    return ERRORTOKEN;
                 }
             }
         }
@@ -1661,6 +1860,9 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                         }
                     } else if (!isdigit(c)) {
                         tok_backup(tok, c);
+                        if (!verify_end_of_number(tok, e, "decimal")) {
+                            return ERRORTOKEN;
+                        }
                         tok_backup(tok, e);
                         *p_start = tok->start;
                         *p_end = tok->cur;
@@ -1675,6 +1877,12 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
                     /* Imaginary part */
         imaginary:
                     c = tok_nextc(tok);
+                    if (!verify_end_of_number(tok, c, "imaginary")) {
+                        return ERRORTOKEN;
+                    }
+                }
+                else if (!verify_end_of_number(tok, c, "decimal")) {
+                    return ERRORTOKEN;
                 }
             }
         }
@@ -1716,20 +1924,27 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
         /* Get rest of string */
         while (end_quote_size != quote_size) {
             c = tok_nextc(tok);
-            if (c == EOF) {
+            if (c == EOF || (quote_size == 1 && c == '\n')) {
+                assert(tok->multi_line_start != NULL);
+                // shift the tok_state's location into
+                // the start of string, and report the error
+                // from the initial quote character
+                tok->cur = (char *)tok->start;
+                tok->cur++;
+                tok->line_start = tok->multi_line_start;
+                int start = tok->lineno;
+                tok->lineno = tok->first_lineno;
+
                 if (quote_size == 3) {
-                    tok->done = E_EOFS;
+                    return syntaxerror(tok,
+                                       "unterminated triple-quoted string literal"
+                                       " (detected at line %d)", start);
                 }
                 else {
-                    tok->done = E_EOLS;
+                    return syntaxerror(tok,
+                                       "unterminated string literal (detected at"
+                                       " line %d)", start);
                 }
-                tok->cur = tok->inp;
-                return ERRORTOKEN;
-            }
-            if (quote_size == 1 && c == '\n') {
-                tok->done = E_EOLS;
-                tok->cur = tok->inp;
-                return ERRORTOKEN;
             }
             if (c == quote) {
                 end_quote_size += 1;
@@ -1752,7 +1967,6 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
         c = tok_nextc(tok);
         if (c != '\n') {
             tok->done = E_LINECONT;
-            tok->cur = tok->inp;
             return ERRORTOKEN;
         }
         c = tok_nextc(tok);
@@ -1797,6 +2011,7 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
         }
         tok->parenstack[tok->level] = c;
         tok->parenlinenostack[tok->level] = tok->lineno;
+        tok->parencolstack[tok->level] = (int)(tok->start - tok->line_start);
         tok->level++;
         break;
     case ')':
@@ -1827,6 +2042,12 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
         break;
     }
 
+    if (!Py_UNICODE_ISPRINTABLE(c)) {
+        char hex[9];
+        (void)PyOS_snprintf(hex, sizeof(hex), "%04X", c);
+        return syntaxerror(tok, "invalid non-printable character U+%s", hex);
+    }
+
     /* Punctuation character */
     *p_start = tok->start;
     *p_end = tok->cur;
@@ -1834,7 +2055,8 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
 }
 
 int
-PyTokenizer_Get(struct tok_state *tok, const char **p_start, const char **p_end)
+_PyTokenizer_Get(struct tok_state *tok,
+                 const char **p_start, const char **p_end)
 {
     int result = tok_get(tok, p_start, p_end);
     if (tok->decoding_erred) {
@@ -1847,15 +2069,15 @@ PyTokenizer_Get(struct tok_state *tok, const char **p_start, const char **p_end)
 /* Get the encoding of a Python file. Check for the coding cookie and check if
    the file starts with a BOM.
 
-   PyTokenizer_FindEncodingFilename() returns NULL when it can't find the
+   _PyTokenizer_FindEncodingFilename() returns NULL when it can't find the
    encoding in the first or second line of the file (in which case the encoding
    should be assumed to be UTF-8).
 
-   The char* returned is malloc'ed via PyMem_MALLOC() and thus must be freed
+   The char* returned is malloc'ed via PyMem_Malloc() and thus must be freed
    by the caller. */
 
 char *
-PyTokenizer_FindEncodingFilename(int fd, PyObject *filename)
+_PyTokenizer_FindEncodingFilename(int fd, PyObject *filename)
 {
     struct tok_state *tok;
     FILE *fp;
@@ -1872,7 +2094,7 @@ PyTokenizer_FindEncodingFilename(int fd, PyObject *filename)
     if (fp == NULL) {
         return NULL;
     }
-    tok = PyTokenizer_FromFile(fp, NULL, NULL, NULL);
+    tok = _PyTokenizer_FromFile(fp, NULL, NULL, NULL);
     if (tok == NULL) {
         fclose(fp);
         return NULL;
@@ -1885,37 +2107,30 @@ PyTokenizer_FindEncodingFilename(int fd, PyObject *filename)
         tok->filename = PyUnicode_FromString("<string>");
         if (tok->filename == NULL) {
             fclose(fp);
-            PyTokenizer_Free(tok);
+            _PyTokenizer_Free(tok);
             return encoding;
         }
     }
     while (tok->lineno < 2 && tok->done == E_OK) {
-        PyTokenizer_Get(tok, &p_start, &p_end);
+        _PyTokenizer_Get(tok, &p_start, &p_end);
     }
     fclose(fp);
     if (tok->encoding) {
-        encoding = (char *)PyMem_MALLOC(strlen(tok->encoding) + 1);
-        if (encoding)
+        encoding = (char *)PyMem_Malloc(strlen(tok->encoding) + 1);
+        if (encoding) {
             strcpy(encoding, tok->encoding);
+        }
     }
-    PyTokenizer_Free(tok);
+    _PyTokenizer_Free(tok);
     return encoding;
 }
 
-char *
-PyTokenizer_FindEncoding(int fd)
-{
-    return PyTokenizer_FindEncodingFilename(fd, NULL);
-}
-
 #ifdef Py_DEBUG
-
 void
 tok_dump(int type, char *start, char *end)
 {
-    printf("%s", _PyParser_TokenNames[type]);
+    fprintf(stderr, "%s", _PyParser_TokenNames[type]);
     if (type == NAME || type == NUMBER || type == STRING || type == OP)
-        printf("(%.*s)", (int)(end - start), start);
+        fprintf(stderr, "(%.*s)", (int)(end - start), start);
 }
-
-#endif
+#endif  // Py_DEBUG

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -849,7 +849,7 @@ tok_nextc(struct tok_state *tok)
             return Py_CHARMASK(*tok->cur++);
         }
         if (tok->prompt != NULL) {
-            char *newtok = PyOS_Readline(tok->fp? tok->fp : stdin, stdout, tok->prompt);
+            char *newtok = PyOS_Readline(tok->fp ? tok->fp : stdin, stdout, tok->prompt);
             if (newtok != NULL) {
                 char *translated = translate_newlines(newtok, 0, tok);
                 PyMem_FREE(newtok);

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -849,7 +849,7 @@ tok_nextc(struct tok_state *tok)
             return Py_CHARMASK(*tok->cur++);
         }
         if (tok->prompt != NULL) {
-            char *newtok = PyOS_Readline(stdin, stdout, tok->prompt);
+            char *newtok = PyOS_Readline(tok->fp? tok->fp : stdin, stdout, tok->prompt);
             if (newtok != NULL) {
                 char *translated = translate_newlines(newtok, 0, tok);
                 PyMem_FREE(newtok);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -549,6 +549,18 @@ static int init_identifiers(astmodulestate *state)
     return 1;
 };
 
+GENERATE_ASDL_SEQ_CONSTRUCTOR(mod, mod_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(stmt, stmt_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(expr, expr_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(comprehension, comprehension_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(excepthandler, excepthandler_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(arguments, arguments_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(arg, arg_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(keyword, keyword_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(alias, alias_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(withitem, withitem_ty)
+GENERATE_ASDL_SEQ_CONSTRUCTOR(type_ignore, type_ignore_ty)
+
 static PyObject* ast2obj_mod(astmodulestate *state, void*);
 static const char * const Module_fields[]={
     "body",
@@ -1097,7 +1109,7 @@ static PyObject* ast2obj_list(astmodulestate *state, asdl_seq *seq, PyObject* (*
     if (!result)
         return NULL;
     for (i = 0; i < n; i++) {
-        value = func(state, asdl_seq_GET(seq, i));
+        value = func(state, asdl_seq_GET_UNTYPED(seq, i));
         if (!value) {
             Py_DECREF(result);
             return NULL;
@@ -1912,7 +1924,8 @@ static int obj2ast_type_ignore(astmodulestate *state, PyObject* obj,
                                type_ignore_ty* out, PyArena* arena);
 
 mod_ty
-Module(asdl_seq * body, asdl_seq * type_ignores, PyArena *arena)
+Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores, PyArena
+       *arena)
 {
     mod_ty p;
     p = (mod_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -1925,7 +1938,7 @@ Module(asdl_seq * body, asdl_seq * type_ignores, PyArena *arena)
 }
 
 mod_ty
-Interactive(asdl_seq * body, PyArena *arena)
+Interactive(asdl_stmt_seq * body, PyArena *arena)
 {
     mod_ty p;
     p = (mod_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -1954,7 +1967,7 @@ Expression(expr_ty body, PyArena *arena)
 }
 
 mod_ty
-FunctionType(asdl_seq * argtypes, expr_ty returns, PyArena *arena)
+FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena *arena)
 {
     mod_ty p;
     if (!returns) {
@@ -1972,9 +1985,10 @@ FunctionType(asdl_seq * argtypes, expr_ty returns, PyArena *arena)
 }
 
 stmt_ty
-FunctionDef(identifier name, arguments_ty args, asdl_seq * body, asdl_seq *
-            decorator_list, expr_ty returns, string type_comment, int lineno,
-            int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq * body,
+            asdl_expr_seq * decorator_list, expr_ty returns, string
+            type_comment, int lineno, int col_offset, int end_lineno, int
+            end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!name) {
@@ -2005,10 +2019,10 @@ FunctionDef(identifier name, arguments_ty args, asdl_seq * body, asdl_seq *
 }
 
 stmt_ty
-AsyncFunctionDef(identifier name, arguments_ty args, asdl_seq * body, asdl_seq
-                 * decorator_list, expr_ty returns, string type_comment, int
-                 lineno, int col_offset, int end_lineno, int end_col_offset,
-                 PyArena *arena)
+AsyncFunctionDef(identifier name, arguments_ty args, asdl_stmt_seq * body,
+                 asdl_expr_seq * decorator_list, expr_ty returns, string
+                 type_comment, int lineno, int col_offset, int end_lineno, int
+                 end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!name) {
@@ -2039,9 +2053,9 @@ AsyncFunctionDef(identifier name, arguments_ty args, asdl_seq * body, asdl_seq
 }
 
 stmt_ty
-ClassDef(identifier name, asdl_seq * bases, asdl_seq * keywords, asdl_seq *
-         body, asdl_seq * decorator_list, int lineno, int col_offset, int
-         end_lineno, int end_col_offset, PyArena *arena)
+ClassDef(identifier name, asdl_expr_seq * bases, asdl_keyword_seq * keywords,
+         asdl_stmt_seq * body, asdl_expr_seq * decorator_list, int lineno, int
+         col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!name) {
@@ -2083,7 +2097,7 @@ Return(expr_ty value, int lineno, int col_offset, int end_lineno, int
 }
 
 stmt_ty
-Delete(asdl_seq * targets, int lineno, int col_offset, int end_lineno, int
+Delete(asdl_expr_seq * targets, int lineno, int col_offset, int end_lineno, int
        end_col_offset, PyArena *arena)
 {
     stmt_ty p;
@@ -2100,8 +2114,8 @@ Delete(asdl_seq * targets, int lineno, int col_offset, int end_lineno, int
 }
 
 stmt_ty
-Assign(asdl_seq * targets, expr_ty value, string type_comment, int lineno, int
-       col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+Assign(asdl_expr_seq * targets, expr_ty value, string type_comment, int lineno,
+       int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!value) {
@@ -2189,8 +2203,8 @@ AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int simple, int
 }
 
 stmt_ty
-For(expr_ty target, expr_ty iter, asdl_seq * body, asdl_seq * orelse, string
-    type_comment, int lineno, int col_offset, int end_lineno, int
+For(expr_ty target, expr_ty iter, asdl_stmt_seq * body, asdl_stmt_seq * orelse,
+    string type_comment, int lineno, int col_offset, int end_lineno, int
     end_col_offset, PyArena *arena)
 {
     stmt_ty p;
@@ -2221,9 +2235,9 @@ For(expr_ty target, expr_ty iter, asdl_seq * body, asdl_seq * orelse, string
 }
 
 stmt_ty
-AsyncFor(expr_ty target, expr_ty iter, asdl_seq * body, asdl_seq * orelse,
-         string type_comment, int lineno, int col_offset, int end_lineno, int
-         end_col_offset, PyArena *arena)
+AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body, asdl_stmt_seq *
+         orelse, string type_comment, int lineno, int col_offset, int
+         end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!target) {
@@ -2253,8 +2267,8 @@ AsyncFor(expr_ty target, expr_ty iter, asdl_seq * body, asdl_seq * orelse,
 }
 
 stmt_ty
-While(expr_ty test, asdl_seq * body, asdl_seq * orelse, int lineno, int
-      col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int lineno,
+      int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!test) {
@@ -2277,7 +2291,7 @@ While(expr_ty test, asdl_seq * body, asdl_seq * orelse, int lineno, int
 }
 
 stmt_ty
-If(expr_ty test, asdl_seq * body, asdl_seq * orelse, int lineno, int
+If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int lineno, int
    col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
@@ -2301,8 +2315,8 @@ If(expr_ty test, asdl_seq * body, asdl_seq * orelse, int lineno, int
 }
 
 stmt_ty
-With(asdl_seq * items, asdl_seq * body, string type_comment, int lineno, int
-     col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+With(asdl_withitem_seq * items, asdl_stmt_seq * body, string type_comment, int
+     lineno, int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -2320,8 +2334,9 @@ With(asdl_seq * items, asdl_seq * body, string type_comment, int lineno, int
 }
 
 stmt_ty
-AsyncWith(asdl_seq * items, asdl_seq * body, string type_comment, int lineno,
-          int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body, string type_comment,
+          int lineno, int col_offset, int end_lineno, int end_col_offset,
+          PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -2357,9 +2372,9 @@ Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset, int end_lineno,
 }
 
 stmt_ty
-Try(asdl_seq * body, asdl_seq * handlers, asdl_seq * orelse, asdl_seq *
-    finalbody, int lineno, int col_offset, int end_lineno, int end_col_offset,
-    PyArena *arena)
+Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers, asdl_stmt_seq *
+    orelse, asdl_stmt_seq * finalbody, int lineno, int col_offset, int
+    end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -2401,7 +2416,7 @@ Assert(expr_ty test, expr_ty msg, int lineno, int col_offset, int end_lineno,
 }
 
 stmt_ty
-Import(asdl_seq * names, int lineno, int col_offset, int end_lineno, int
+Import(asdl_alias_seq * names, int lineno, int col_offset, int end_lineno, int
        end_col_offset, PyArena *arena)
 {
     stmt_ty p;
@@ -2418,8 +2433,8 @@ Import(asdl_seq * names, int lineno, int col_offset, int end_lineno, int
 }
 
 stmt_ty
-ImportFrom(identifier module, asdl_seq * names, int level, int lineno, int
-           col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+ImportFrom(identifier module, asdl_alias_seq * names, int level, int lineno,
+           int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -2437,8 +2452,8 @@ ImportFrom(identifier module, asdl_seq * names, int level, int lineno, int
 }
 
 stmt_ty
-Global(asdl_seq * names, int lineno, int col_offset, int end_lineno, int
-       end_col_offset, PyArena *arena)
+Global(asdl_identifier_seq * names, int lineno, int col_offset, int end_lineno,
+       int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -2454,8 +2469,8 @@ Global(asdl_seq * names, int lineno, int col_offset, int end_lineno, int
 }
 
 stmt_ty
-Nonlocal(asdl_seq * names, int lineno, int col_offset, int end_lineno, int
-         end_col_offset, PyArena *arena)
+Nonlocal(asdl_identifier_seq * names, int lineno, int col_offset, int
+         end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -2541,7 +2556,7 @@ Continue(int lineno, int col_offset, int end_lineno, int end_col_offset,
 }
 
 expr_ty
-BoolOp(boolop_ty op, asdl_seq * values, int lineno, int col_offset, int
+BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int col_offset, int
        end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
@@ -2716,8 +2731,8 @@ IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno, int col_offset,
 }
 
 expr_ty
-Dict(asdl_seq * keys, asdl_seq * values, int lineno, int col_offset, int
-     end_lineno, int end_col_offset, PyArena *arena)
+Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno, int col_offset,
+     int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -2734,7 +2749,7 @@ Dict(asdl_seq * keys, asdl_seq * values, int lineno, int col_offset, int
 }
 
 expr_ty
-Set(asdl_seq * elts, int lineno, int col_offset, int end_lineno, int
+Set(asdl_expr_seq * elts, int lineno, int col_offset, int end_lineno, int
     end_col_offset, PyArena *arena)
 {
     expr_ty p;
@@ -2751,8 +2766,8 @@ Set(asdl_seq * elts, int lineno, int col_offset, int end_lineno, int
 }
 
 expr_ty
-ListComp(expr_ty elt, asdl_seq * generators, int lineno, int col_offset, int
-         end_lineno, int end_col_offset, PyArena *arena)
+ListComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno, int
+         col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!elt) {
@@ -2774,8 +2789,8 @@ ListComp(expr_ty elt, asdl_seq * generators, int lineno, int col_offset, int
 }
 
 expr_ty
-SetComp(expr_ty elt, asdl_seq * generators, int lineno, int col_offset, int
-        end_lineno, int end_col_offset, PyArena *arena)
+SetComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno, int
+        col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!elt) {
@@ -2797,8 +2812,9 @@ SetComp(expr_ty elt, asdl_seq * generators, int lineno, int col_offset, int
 }
 
 expr_ty
-DictComp(expr_ty key, expr_ty value, asdl_seq * generators, int lineno, int
-         col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq * generators, int
+         lineno, int col_offset, int end_lineno, int end_col_offset, PyArena
+         *arena)
 {
     expr_ty p;
     if (!key) {
@@ -2826,8 +2842,8 @@ DictComp(expr_ty key, expr_ty value, asdl_seq * generators, int lineno, int
 }
 
 expr_ty
-GeneratorExp(expr_ty elt, asdl_seq * generators, int lineno, int col_offset,
-             int end_lineno, int end_col_offset, PyArena *arena)
+GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators, int lineno, int
+             col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!elt) {
@@ -2910,8 +2926,9 @@ YieldFrom(expr_ty value, int lineno, int col_offset, int end_lineno, int
 }
 
 expr_ty
-Compare(expr_ty left, asdl_int_seq * ops, asdl_seq * comparators, int lineno,
-        int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq * comparators, int
+        lineno, int col_offset, int end_lineno, int end_col_offset, PyArena
+        *arena)
 {
     expr_ty p;
     if (!left) {
@@ -2934,8 +2951,8 @@ Compare(expr_ty left, asdl_int_seq * ops, asdl_seq * comparators, int lineno,
 }
 
 expr_ty
-Call(expr_ty func, asdl_seq * args, asdl_seq * keywords, int lineno, int
-     col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq * keywords, int
+     lineno, int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!func) {
@@ -2983,8 +3000,8 @@ FormattedValue(expr_ty value, int conversion, expr_ty format_spec, int lineno,
 }
 
 expr_ty
-JoinedStr(asdl_seq * values, int lineno, int col_offset, int end_lineno, int
-          end_col_offset, PyArena *arena)
+JoinedStr(asdl_expr_seq * values, int lineno, int col_offset, int end_lineno,
+          int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -3147,7 +3164,7 @@ Name(identifier id, expr_context_ty ctx, int lineno, int col_offset, int
 }
 
 expr_ty
-List(asdl_seq * elts, expr_context_ty ctx, int lineno, int col_offset, int
+List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int col_offset, int
      end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
@@ -3170,8 +3187,8 @@ List(asdl_seq * elts, expr_context_ty ctx, int lineno, int col_offset, int
 }
 
 expr_ty
-Tuple(asdl_seq * elts, expr_context_ty ctx, int lineno, int col_offset, int
-      end_lineno, int end_col_offset, PyArena *arena)
+Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int col_offset,
+      int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!ctx) {
@@ -3212,7 +3229,7 @@ Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int col_offset,
 }
 
 comprehension_ty
-comprehension(expr_ty target, expr_ty iter, asdl_seq * ifs, int is_async,
+comprehension(expr_ty target, expr_ty iter, asdl_expr_seq * ifs, int is_async,
               PyArena *arena)
 {
     comprehension_ty p;
@@ -3237,8 +3254,9 @@ comprehension(expr_ty target, expr_ty iter, asdl_seq * ifs, int is_async,
 }
 
 excepthandler_ty
-ExceptHandler(expr_ty type, identifier name, asdl_seq * body, int lineno, int
-              col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+ExceptHandler(expr_ty type, identifier name, asdl_stmt_seq * body, int lineno,
+              int col_offset, int end_lineno, int end_col_offset, PyArena
+              *arena)
 {
     excepthandler_ty p;
     p = (excepthandler_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -3256,9 +3274,9 @@ ExceptHandler(expr_ty type, identifier name, asdl_seq * body, int lineno, int
 }
 
 arguments_ty
-arguments(asdl_seq * posonlyargs, asdl_seq * args, arg_ty vararg, asdl_seq *
-          kwonlyargs, asdl_seq * kw_defaults, arg_ty kwarg, asdl_seq *
-          defaults, PyArena *arena)
+arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args, arg_ty vararg,
+          asdl_arg_seq * kwonlyargs, asdl_expr_seq * kw_defaults, arg_ty kwarg,
+          asdl_expr_seq * defaults, PyArena *arena)
 {
     arguments_ty p;
     p = (arguments_ty)PyArena_Malloc(arena, sizeof(*p));
@@ -3386,12 +3404,12 @@ ast2obj_mod(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Module_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Module.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Module.body, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Module.type_ignores,
+        value = ast2obj_list(state, (asdl_seq*)o->v.Module.type_ignores,
                              ast2obj_type_ignore);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_ignores, value) == -1)
@@ -3402,7 +3420,8 @@ ast2obj_mod(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Interactive_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Interactive.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Interactive.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
@@ -3422,7 +3441,8 @@ ast2obj_mod(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->FunctionType_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.FunctionType.argtypes, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.FunctionType.argtypes,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->argtypes, value) == -1)
             goto failed;
@@ -3465,12 +3485,13 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.FunctionDef.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.FunctionDef.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.FunctionDef.decorator_list,
+        value = ast2obj_list(state, (asdl_seq*)o->v.FunctionDef.decorator_list,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
@@ -3501,12 +3522,14 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.AsyncFunctionDef.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncFunctionDef.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.AsyncFunctionDef.decorator_list,
+        value = ast2obj_list(state,
+                             (asdl_seq*)o->v.AsyncFunctionDef.decorator_list,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
@@ -3532,22 +3555,26 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.ClassDef.bases, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.bases,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->bases, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.ClassDef.keywords, ast2obj_keyword);
+        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.keywords,
+                             ast2obj_keyword);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->keywords, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.ClassDef.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.ClassDef.decorator_list, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.decorator_list,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
             goto failed;
@@ -3567,7 +3594,8 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Delete_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Delete.targets, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Delete.targets,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->targets, value) == -1)
             goto failed;
@@ -3577,7 +3605,8 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Assign_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Assign.targets, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Assign.targets,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->targets, value) == -1)
             goto failed;
@@ -3652,12 +3681,12 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.For.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.For.body, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.For.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.For.orelse, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
@@ -3682,12 +3711,14 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.AsyncFor.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncFor.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.AsyncFor.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncFor.orelse,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
@@ -3707,12 +3738,12 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.While.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.While.body, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.While.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.While.orelse, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
@@ -3727,12 +3758,12 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.If.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.If.body, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.If.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.If.orelse, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
@@ -3742,12 +3773,13 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->With_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.With.items, ast2obj_withitem);
+        value = ast2obj_list(state, (asdl_seq*)o->v.With.items,
+                             ast2obj_withitem);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->items, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.With.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.With.body, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
@@ -3762,12 +3794,14 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->AsyncWith_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.AsyncWith.items, ast2obj_withitem);
+        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncWith.items,
+                             ast2obj_withitem);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->items, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.AsyncWith.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncWith.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
@@ -3797,22 +3831,24 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Try_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Try.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Try.body, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Try.handlers, ast2obj_excepthandler);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Try.handlers,
+                             ast2obj_excepthandler);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->handlers, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Try.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Try.orelse, ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Try.finalbody, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Try.finalbody,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->finalbody, value) == -1)
             goto failed;
@@ -3837,7 +3873,8 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Import_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Import.names, ast2obj_alias);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Import.names,
+                             ast2obj_alias);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
@@ -3852,7 +3889,8 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->module, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.ImportFrom.names, ast2obj_alias);
+        value = ast2obj_list(state, (asdl_seq*)o->v.ImportFrom.names,
+                             ast2obj_alias);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
@@ -3867,7 +3905,8 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Global_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Global.names, ast2obj_identifier);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Global.names,
+                             ast2obj_identifier);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
@@ -3877,7 +3916,8 @@ ast2obj_stmt(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Nonlocal_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Nonlocal.names, ast2obj_identifier);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Nonlocal.names,
+                             ast2obj_identifier);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
@@ -3955,7 +3995,8 @@ ast2obj_expr(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.BoolOp.values, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.BoolOp.values,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->values, value) == -1)
             goto failed;
@@ -4050,12 +4091,12 @@ ast2obj_expr(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Dict_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Dict.keys, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Dict.keys, ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->keys, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Dict.values, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Dict.values, ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->values, value) == -1)
             goto failed;
@@ -4065,7 +4106,7 @@ ast2obj_expr(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Set_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Set.elts, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Set.elts, ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
@@ -4080,7 +4121,7 @@ ast2obj_expr(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.ListComp.generators,
+        value = ast2obj_list(state, (asdl_seq*)o->v.ListComp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -4096,7 +4137,7 @@ ast2obj_expr(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.SetComp.generators,
+        value = ast2obj_list(state, (asdl_seq*)o->v.SetComp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -4117,7 +4158,7 @@ ast2obj_expr(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.DictComp.generators,
+        value = ast2obj_list(state, (asdl_seq*)o->v.DictComp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -4133,7 +4174,7 @@ ast2obj_expr(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.GeneratorExp.generators,
+        value = ast2obj_list(state, (asdl_seq*)o->v.GeneratorExp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -4190,7 +4231,8 @@ ast2obj_expr(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->ops, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Compare.comparators, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Compare.comparators,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->comparators, value) == -1)
             goto failed;
@@ -4205,12 +4247,13 @@ ast2obj_expr(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->func, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Call.args, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Call.args, ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.Call.keywords, ast2obj_keyword);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Call.keywords,
+                             ast2obj_keyword);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->keywords, value) == -1)
             goto failed;
@@ -4240,7 +4283,8 @@ ast2obj_expr(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->JoinedStr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.JoinedStr.values, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.JoinedStr.values,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->values, value) == -1)
             goto failed;
@@ -4335,7 +4379,7 @@ ast2obj_expr(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->List_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.List.elts, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.List.elts, ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
@@ -4350,7 +4394,7 @@ ast2obj_expr(astmodulestate *state, void* _o)
         tp = (PyTypeObject *)state->Tuple_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, o->v.Tuple.elts, ast2obj_expr);
+        value = ast2obj_list(state, (asdl_seq*)o->v.Tuple.elts, ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
@@ -4557,7 +4601,7 @@ ast2obj_comprehension(astmodulestate *state, void* _o)
     if (PyObject_SetAttr(result, state->iter, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, o->ifs, ast2obj_expr);
+    value = ast2obj_list(state, (asdl_seq*)o->ifs, ast2obj_expr);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->ifs, value) == -1)
         goto failed;
@@ -4598,7 +4642,8 @@ ast2obj_excepthandler(astmodulestate *state, void* _o)
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, o->v.ExceptHandler.body, ast2obj_stmt);
+        value = ast2obj_list(state, (asdl_seq*)o->v.ExceptHandler.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
@@ -4644,12 +4689,12 @@ ast2obj_arguments(astmodulestate *state, void* _o)
     tp = (PyTypeObject *)state->arguments_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_list(state, o->posonlyargs, ast2obj_arg);
+    value = ast2obj_list(state, (asdl_seq*)o->posonlyargs, ast2obj_arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->posonlyargs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, o->args, ast2obj_arg);
+    value = ast2obj_list(state, (asdl_seq*)o->args, ast2obj_arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->args, value) == -1)
         goto failed;
@@ -4659,12 +4704,12 @@ ast2obj_arguments(astmodulestate *state, void* _o)
     if (PyObject_SetAttr(result, state->vararg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, o->kwonlyargs, ast2obj_arg);
+    value = ast2obj_list(state, (asdl_seq*)o->kwonlyargs, ast2obj_arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->kwonlyargs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, o->kw_defaults, ast2obj_expr);
+    value = ast2obj_list(state, (asdl_seq*)o->kw_defaults, ast2obj_expr);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->kw_defaults, value) == -1)
         goto failed;
@@ -4674,7 +4719,7 @@ ast2obj_arguments(astmodulestate *state, void* _o)
     if (PyObject_SetAttr(result, state->kwarg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, o->defaults, ast2obj_expr);
+    value = ast2obj_list(state, (asdl_seq*)o->defaults, ast2obj_expr);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->defaults, value) == -1)
         goto failed;
@@ -4899,8 +4944,8 @@ obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* body;
-        asdl_seq* type_ignores;
+        asdl_stmt_seq* body;
+        asdl_type_ignore_seq* type_ignores;
 
         if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
@@ -4918,7 +4963,7 @@ obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -4951,7 +4996,7 @@ obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            type_ignores = _Py_asdl_seq_new(len, arena);
+            type_ignores = _Py_asdl_type_ignore_seq_new(len, arena);
             if (type_ignores == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 type_ignore_ty val;
@@ -4978,7 +5023,7 @@ obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* body;
+        asdl_stmt_seq* body;
 
         if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
@@ -4996,7 +5041,7 @@ obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -5048,7 +5093,7 @@ obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* argtypes;
+        asdl_expr_seq* argtypes;
         expr_ty returns;
 
         if (_PyObject_LookupAttr(obj, state->argtypes, &tmp) < 0) {
@@ -5067,7 +5112,7 @@ obj2ast_mod(astmodulestate *state, PyObject* obj, mod_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            argtypes = _Py_asdl_seq_new(len, arena);
+            argtypes = _Py_asdl_expr_seq_new(len, arena);
             if (argtypes == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -5184,8 +5229,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         identifier name;
         arguments_ty args;
-        asdl_seq* body;
-        asdl_seq* decorator_list;
+        asdl_stmt_seq* body;
+        asdl_expr_seq* decorator_list;
         expr_ty returns;
         string type_comment;
 
@@ -5231,7 +5276,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -5264,7 +5309,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            decorator_list = _Py_asdl_seq_new(len, arena);
+            decorator_list = _Py_asdl_expr_seq_new(len, arena);
             if (decorator_list == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -5321,8 +5366,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         identifier name;
         arguments_ty args;
-        asdl_seq* body;
-        asdl_seq* decorator_list;
+        asdl_stmt_seq* body;
+        asdl_expr_seq* decorator_list;
         expr_ty returns;
         string type_comment;
 
@@ -5368,7 +5413,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -5401,7 +5446,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            decorator_list = _Py_asdl_seq_new(len, arena);
+            decorator_list = _Py_asdl_expr_seq_new(len, arena);
             if (decorator_list == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -5457,10 +5502,10 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     if (isinstance) {
         identifier name;
-        asdl_seq* bases;
-        asdl_seq* keywords;
-        asdl_seq* body;
-        asdl_seq* decorator_list;
+        asdl_expr_seq* bases;
+        asdl_keyword_seq* keywords;
+        asdl_stmt_seq* body;
+        asdl_expr_seq* decorator_list;
 
         if (_PyObject_LookupAttr(obj, state->name, &tmp) < 0) {
             return 1;
@@ -5491,7 +5536,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            bases = _Py_asdl_seq_new(len, arena);
+            bases = _Py_asdl_expr_seq_new(len, arena);
             if (bases == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -5524,7 +5569,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            keywords = _Py_asdl_seq_new(len, arena);
+            keywords = _Py_asdl_keyword_seq_new(len, arena);
             if (keywords == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 keyword_ty val;
@@ -5557,7 +5602,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -5590,7 +5635,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            decorator_list = _Py_asdl_seq_new(len, arena);
+            decorator_list = _Py_asdl_expr_seq_new(len, arena);
             if (decorator_list == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -5644,7 +5689,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* targets;
+        asdl_expr_seq* targets;
 
         if (_PyObject_LookupAttr(obj, state->targets, &tmp) < 0) {
             return 1;
@@ -5662,7 +5707,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            targets = _Py_asdl_seq_new(len, arena);
+            targets = _Py_asdl_expr_seq_new(len, arena);
             if (targets == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -5690,7 +5735,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* targets;
+        asdl_expr_seq* targets;
         expr_ty value;
         string type_comment;
 
@@ -5710,7 +5755,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            targets = _Py_asdl_seq_new(len, arena);
+            targets = _Py_asdl_expr_seq_new(len, arena);
             if (targets == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -5888,8 +5933,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty target;
         expr_ty iter;
-        asdl_seq* body;
-        asdl_seq* orelse;
+        asdl_stmt_seq* body;
+        asdl_stmt_seq* orelse;
         string type_comment;
 
         if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
@@ -5934,7 +5979,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -5967,7 +6012,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            orelse = _Py_asdl_seq_new(len, arena);
+            orelse = _Py_asdl_stmt_seq_new(len, arena);
             if (orelse == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6010,8 +6055,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty target;
         expr_ty iter;
-        asdl_seq* body;
-        asdl_seq* orelse;
+        asdl_stmt_seq* body;
+        asdl_stmt_seq* orelse;
         string type_comment;
 
         if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
@@ -6056,7 +6101,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6089,7 +6134,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            orelse = _Py_asdl_seq_new(len, arena);
+            orelse = _Py_asdl_stmt_seq_new(len, arena);
             if (orelse == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6131,8 +6176,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     if (isinstance) {
         expr_ty test;
-        asdl_seq* body;
-        asdl_seq* orelse;
+        asdl_stmt_seq* body;
+        asdl_stmt_seq* orelse;
 
         if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
             return 1;
@@ -6163,7 +6208,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6196,7 +6241,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            orelse = _Py_asdl_seq_new(len, arena);
+            orelse = _Py_asdl_stmt_seq_new(len, arena);
             if (orelse == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6225,8 +6270,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     if (isinstance) {
         expr_ty test;
-        asdl_seq* body;
-        asdl_seq* orelse;
+        asdl_stmt_seq* body;
+        asdl_stmt_seq* orelse;
 
         if (_PyObject_LookupAttr(obj, state->test, &tmp) < 0) {
             return 1;
@@ -6257,7 +6302,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6290,7 +6335,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            orelse = _Py_asdl_seq_new(len, arena);
+            orelse = _Py_asdl_stmt_seq_new(len, arena);
             if (orelse == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6318,8 +6363,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* items;
-        asdl_seq* body;
+        asdl_withitem_seq* items;
+        asdl_stmt_seq* body;
         string type_comment;
 
         if (_PyObject_LookupAttr(obj, state->items, &tmp) < 0) {
@@ -6338,7 +6383,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            items = _Py_asdl_seq_new(len, arena);
+            items = _Py_asdl_withitem_seq_new(len, arena);
             if (items == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 withitem_ty val;
@@ -6371,7 +6416,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6412,8 +6457,8 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* items;
-        asdl_seq* body;
+        asdl_withitem_seq* items;
+        asdl_stmt_seq* body;
         string type_comment;
 
         if (_PyObject_LookupAttr(obj, state->items, &tmp) < 0) {
@@ -6432,7 +6477,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            items = _Py_asdl_seq_new(len, arena);
+            items = _Py_asdl_withitem_seq_new(len, arena);
             if (items == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 withitem_ty val;
@@ -6465,7 +6510,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6546,10 +6591,10 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* body;
-        asdl_seq* handlers;
-        asdl_seq* orelse;
-        asdl_seq* finalbody;
+        asdl_stmt_seq* body;
+        asdl_excepthandler_seq* handlers;
+        asdl_stmt_seq* orelse;
+        asdl_stmt_seq* finalbody;
 
         if (_PyObject_LookupAttr(obj, state->body, &tmp) < 0) {
             return 1;
@@ -6567,7 +6612,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6600,7 +6645,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            handlers = _Py_asdl_seq_new(len, arena);
+            handlers = _Py_asdl_excepthandler_seq_new(len, arena);
             if (handlers == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 excepthandler_ty val;
@@ -6633,7 +6678,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            orelse = _Py_asdl_seq_new(len, arena);
+            orelse = _Py_asdl_stmt_seq_new(len, arena);
             if (orelse == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6666,7 +6711,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            finalbody = _Py_asdl_seq_new(len, arena);
+            finalbody = _Py_asdl_stmt_seq_new(len, arena);
             if (finalbody == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -6734,7 +6779,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* names;
+        asdl_alias_seq* names;
 
         if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
             return 1;
@@ -6752,7 +6797,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            names = _Py_asdl_seq_new(len, arena);
+            names = _Py_asdl_alias_seq_new(len, arena);
             if (names == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 alias_ty val;
@@ -6781,7 +6826,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
     }
     if (isinstance) {
         identifier module;
-        asdl_seq* names;
+        asdl_alias_seq* names;
         int level;
 
         if (_PyObject_LookupAttr(obj, state->module, &tmp) < 0) {
@@ -6813,7 +6858,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            names = _Py_asdl_seq_new(len, arena);
+            names = _Py_asdl_alias_seq_new(len, arena);
             if (names == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 alias_ty val;
@@ -6854,7 +6899,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* names;
+        asdl_identifier_seq* names;
 
         if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
             return 1;
@@ -6872,7 +6917,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            names = _Py_asdl_seq_new(len, arena);
+            names = _Py_asdl_identifier_seq_new(len, arena);
             if (names == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 identifier val;
@@ -6900,7 +6945,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* names;
+        asdl_identifier_seq* names;
 
         if (_PyObject_LookupAttr(obj, state->names, &tmp) < 0) {
             return 1;
@@ -6918,7 +6963,7 @@ obj2ast_stmt(astmodulestate *state, PyObject* obj, stmt_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            names = _Py_asdl_seq_new(len, arena);
+            names = _Py_asdl_identifier_seq_new(len, arena);
             if (names == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 identifier val;
@@ -7081,7 +7126,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
     }
     if (isinstance) {
         boolop_ty op;
-        asdl_seq* values;
+        asdl_expr_seq* values;
 
         if (_PyObject_LookupAttr(obj, state->op, &tmp) < 0) {
             return 1;
@@ -7112,7 +7157,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            values = _Py_asdl_seq_new(len, arena);
+            values = _Py_asdl_expr_seq_new(len, arena);
             if (values == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -7368,8 +7413,8 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* keys;
-        asdl_seq* values;
+        asdl_expr_seq* keys;
+        asdl_expr_seq* values;
 
         if (_PyObject_LookupAttr(obj, state->keys, &tmp) < 0) {
             return 1;
@@ -7387,7 +7432,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            keys = _Py_asdl_seq_new(len, arena);
+            keys = _Py_asdl_expr_seq_new(len, arena);
             if (keys == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -7420,7 +7465,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            values = _Py_asdl_seq_new(len, arena);
+            values = _Py_asdl_expr_seq_new(len, arena);
             if (values == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -7448,7 +7493,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* elts;
+        asdl_expr_seq* elts;
 
         if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
             return 1;
@@ -7466,7 +7511,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            elts = _Py_asdl_seq_new(len, arena);
+            elts = _Py_asdl_expr_seq_new(len, arena);
             if (elts == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -7494,7 +7539,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
     }
     if (isinstance) {
         expr_ty elt;
-        asdl_seq* generators;
+        asdl_comprehension_seq* generators;
 
         if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
             return 1;
@@ -7525,7 +7570,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            generators = _Py_asdl_seq_new(len, arena);
+            generators = _Py_asdl_comprehension_seq_new(len, arena);
             if (generators == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 comprehension_ty val;
@@ -7554,7 +7599,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
     }
     if (isinstance) {
         expr_ty elt;
-        asdl_seq* generators;
+        asdl_comprehension_seq* generators;
 
         if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
             return 1;
@@ -7585,7 +7630,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            generators = _Py_asdl_seq_new(len, arena);
+            generators = _Py_asdl_comprehension_seq_new(len, arena);
             if (generators == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 comprehension_ty val;
@@ -7615,7 +7660,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty key;
         expr_ty value;
-        asdl_seq* generators;
+        asdl_comprehension_seq* generators;
 
         if (_PyObject_LookupAttr(obj, state->key, &tmp) < 0) {
             return 1;
@@ -7659,7 +7704,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            generators = _Py_asdl_seq_new(len, arena);
+            generators = _Py_asdl_comprehension_seq_new(len, arena);
             if (generators == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 comprehension_ty val;
@@ -7688,7 +7733,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
     }
     if (isinstance) {
         expr_ty elt;
-        asdl_seq* generators;
+        asdl_comprehension_seq* generators;
 
         if (_PyObject_LookupAttr(obj, state->elt, &tmp) < 0) {
             return 1;
@@ -7719,7 +7764,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            generators = _Py_asdl_seq_new(len, arena);
+            generators = _Py_asdl_comprehension_seq_new(len, arena);
             if (generators == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 comprehension_ty val;
@@ -7827,7 +7872,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty left;
         asdl_int_seq* ops;
-        asdl_seq* comparators;
+        asdl_expr_seq* comparators;
 
         if (_PyObject_LookupAttr(obj, state->left, &tmp) < 0) {
             return 1;
@@ -7891,7 +7936,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            comparators = _Py_asdl_seq_new(len, arena);
+            comparators = _Py_asdl_expr_seq_new(len, arena);
             if (comparators == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -7920,8 +7965,8 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
     }
     if (isinstance) {
         expr_ty func;
-        asdl_seq* args;
-        asdl_seq* keywords;
+        asdl_expr_seq* args;
+        asdl_keyword_seq* keywords;
 
         if (_PyObject_LookupAttr(obj, state->func, &tmp) < 0) {
             return 1;
@@ -7952,7 +7997,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            args = _Py_asdl_seq_new(len, arena);
+            args = _Py_asdl_expr_seq_new(len, arena);
             if (args == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -7985,7 +8030,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            keywords = _Py_asdl_seq_new(len, arena);
+            keywords = _Py_asdl_keyword_seq_new(len, arena);
             if (keywords == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 keyword_ty val;
@@ -8067,7 +8112,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* values;
+        asdl_expr_seq* values;
 
         if (_PyObject_LookupAttr(obj, state->values, &tmp) < 0) {
             return 1;
@@ -8085,7 +8130,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            values = _Py_asdl_seq_new(len, arena);
+            values = _Py_asdl_expr_seq_new(len, arena);
             if (values == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -8341,7 +8386,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* elts;
+        asdl_expr_seq* elts;
         expr_context_ty ctx;
 
         if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
@@ -8360,7 +8405,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            elts = _Py_asdl_seq_new(len, arena);
+            elts = _Py_asdl_expr_seq_new(len, arena);
             if (elts == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -8401,7 +8446,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
         return 1;
     }
     if (isinstance) {
-        asdl_seq* elts;
+        asdl_expr_seq* elts;
         expr_context_ty ctx;
 
         if (_PyObject_LookupAttr(obj, state->elts, &tmp) < 0) {
@@ -8420,7 +8465,7 @@ obj2ast_expr(astmodulestate *state, PyObject* obj, expr_ty* out, PyArena* arena)
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            elts = _Py_asdl_seq_new(len, arena);
+            elts = _Py_asdl_expr_seq_new(len, arena);
             if (elts == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 expr_ty val;
@@ -8834,7 +8879,7 @@ obj2ast_comprehension(astmodulestate *state, PyObject* obj, comprehension_ty*
     PyObject* tmp = NULL;
     expr_ty target;
     expr_ty iter;
-    asdl_seq* ifs;
+    asdl_expr_seq* ifs;
     int is_async;
 
     if (_PyObject_LookupAttr(obj, state->target, &tmp) < 0) {
@@ -8879,7 +8924,7 @@ obj2ast_comprehension(astmodulestate *state, PyObject* obj, comprehension_ty*
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
-        ifs = _Py_asdl_seq_new(len, arena);
+        ifs = _Py_asdl_expr_seq_new(len, arena);
         if (ifs == NULL) goto failed;
         for (i = 0; i < len; i++) {
             expr_ty val;
@@ -8993,7 +9038,7 @@ obj2ast_excepthandler(astmodulestate *state, PyObject* obj, excepthandler_ty*
     if (isinstance) {
         expr_ty type;
         identifier name;
-        asdl_seq* body;
+        asdl_stmt_seq* body;
 
         if (_PyObject_LookupAttr(obj, state->type, &tmp) < 0) {
             return 1;
@@ -9037,7 +9082,7 @@ obj2ast_excepthandler(astmodulestate *state, PyObject* obj, excepthandler_ty*
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
-            body = _Py_asdl_seq_new(len, arena);
+            body = _Py_asdl_stmt_seq_new(len, arena);
             if (body == NULL) goto failed;
             for (i = 0; i < len; i++) {
                 stmt_ty val;
@@ -9071,13 +9116,13 @@ obj2ast_arguments(astmodulestate *state, PyObject* obj, arguments_ty* out,
                   PyArena* arena)
 {
     PyObject* tmp = NULL;
-    asdl_seq* posonlyargs;
-    asdl_seq* args;
+    asdl_arg_seq* posonlyargs;
+    asdl_arg_seq* args;
     arg_ty vararg;
-    asdl_seq* kwonlyargs;
-    asdl_seq* kw_defaults;
+    asdl_arg_seq* kwonlyargs;
+    asdl_expr_seq* kw_defaults;
     arg_ty kwarg;
-    asdl_seq* defaults;
+    asdl_expr_seq* defaults;
 
     if (_PyObject_LookupAttr(obj, state->posonlyargs, &tmp) < 0) {
         return 1;
@@ -9095,7 +9140,7 @@ obj2ast_arguments(astmodulestate *state, PyObject* obj, arguments_ty* out,
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
-        posonlyargs = _Py_asdl_seq_new(len, arena);
+        posonlyargs = _Py_asdl_arg_seq_new(len, arena);
         if (posonlyargs == NULL) goto failed;
         for (i = 0; i < len; i++) {
             arg_ty val;
@@ -9128,7 +9173,7 @@ obj2ast_arguments(astmodulestate *state, PyObject* obj, arguments_ty* out,
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
-        args = _Py_asdl_seq_new(len, arena);
+        args = _Py_asdl_arg_seq_new(len, arena);
         if (args == NULL) goto failed;
         for (i = 0; i < len; i++) {
             arg_ty val;
@@ -9174,7 +9219,7 @@ obj2ast_arguments(astmodulestate *state, PyObject* obj, arguments_ty* out,
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
-        kwonlyargs = _Py_asdl_seq_new(len, arena);
+        kwonlyargs = _Py_asdl_arg_seq_new(len, arena);
         if (kwonlyargs == NULL) goto failed;
         for (i = 0; i < len; i++) {
             arg_ty val;
@@ -9207,7 +9252,7 @@ obj2ast_arguments(astmodulestate *state, PyObject* obj, arguments_ty* out,
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
-        kw_defaults = _Py_asdl_seq_new(len, arena);
+        kw_defaults = _Py_asdl_expr_seq_new(len, arena);
         if (kw_defaults == NULL) goto failed;
         for (i = 0; i < len; i++) {
             expr_ty val;
@@ -9253,7 +9298,7 @@ obj2ast_arguments(astmodulestate *state, PyObject* obj, arguments_ty* out,
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
-        defaults = _Py_asdl_seq_new(len, arena);
+        defaults = _Py_asdl_expr_seq_new(len, arena);
         if (defaults == NULL) goto failed;
         for (i = 0; i < len; i++) {
             expr_ty val;

--- a/Python/asdl.c
+++ b/Python/asdl.c
@@ -1,64 +1,6 @@
 #include "Python.h"
 #include "asdl.h"
 
-asdl_seq *
-_Py_asdl_seq_new(Py_ssize_t size, PyArena *arena)
-{
-    asdl_seq *seq = NULL;
-    size_t n;
-
-    /* check size is sane */
-    if (size < 0 ||
-        (size && (((size_t)size - 1) > (SIZE_MAX / sizeof(void *))))) {
-        PyErr_NoMemory();
-        return NULL;
-    }
-    n = (size ? (sizeof(void *) * (size - 1)) : 0);
-
-    /* check if size can be added safely */
-    if (n > SIZE_MAX - sizeof(asdl_seq)) {
-        PyErr_NoMemory();
-        return NULL;
-    }
-    n += sizeof(asdl_seq);
-
-    seq = (asdl_seq *)PyArena_Malloc(arena, n);
-    if (!seq) {
-        PyErr_NoMemory();
-        return NULL;
-    }
-    memset(seq, 0, n);
-    seq->size = size;
-    return seq;
-}
-
-asdl_int_seq *
-_Py_asdl_int_seq_new(Py_ssize_t size, PyArena *arena)
-{
-    asdl_int_seq *seq = NULL;
-    size_t n;
-
-    /* check size is sane */
-    if (size < 0 ||
-        (size && (((size_t)size - 1) > (SIZE_MAX / sizeof(void *))))) {
-            PyErr_NoMemory();
-            return NULL;
-    }
-    n = (size ? (sizeof(void *) * (size - 1)) : 0);
-
-    /* check if size can be added safely */
-    if (n > SIZE_MAX - sizeof(asdl_seq)) {
-        PyErr_NoMemory();
-        return NULL;
-    }
-    n += sizeof(asdl_seq);
-
-    seq = (asdl_int_seq *)PyArena_Malloc(arena, n);
-    if (!seq) {
-        PyErr_NoMemory();
-        return NULL;
-    }
-    memset(seq, 0, n);
-    seq->size = size;
-    return seq;
-}
+GENERATE_ASDL_SEQ_CONSTRUCTOR(generic, void*);
+GENERATE_ASDL_SEQ_CONSTRUCTOR(identifier, PyObject*);
+GENERATE_ASDL_SEQ_CONSTRUCTOR(int, int);

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -14,9 +14,9 @@
 
 #define MAXLEVEL 200    /* Max parentheses level */
 
-static int validate_stmts(asdl_seq *);
-static int validate_exprs(asdl_seq *, expr_context_ty, int);
-static int validate_nonempty_seq(asdl_seq *, const char *, const char *);
+static int validate_stmts(asdl_stmt_seq *);
+static int validate_exprs(asdl_expr_seq*, expr_context_ty, int);
+static int _validate_nonempty_seq(asdl_seq *, const char *, const char *);
 static int validate_stmt(stmt_ty);
 static int validate_expr(expr_ty, expr_context_ty);
 
@@ -40,7 +40,7 @@ validate_name(PyObject *name)
 }
 
 static int
-validate_comprehension(asdl_seq *gens)
+validate_comprehension(asdl_comprehension_seq *gens)
 {
     Py_ssize_t i;
     if (!asdl_seq_LEN(gens)) {
@@ -58,7 +58,7 @@ validate_comprehension(asdl_seq *gens)
 }
 
 static int
-validate_keywords(asdl_seq *keywords)
+validate_keywords(asdl_keyword_seq *keywords)
 {
     Py_ssize_t i;
     for (i = 0; i < asdl_seq_LEN(keywords); i++)
@@ -68,7 +68,7 @@ validate_keywords(asdl_seq *keywords)
 }
 
 static int
-validate_args(asdl_seq *args)
+validate_args(asdl_arg_seq *args)
 {
     Py_ssize_t i;
     for (i = 0; i < asdl_seq_LEN(args); i++) {
@@ -324,23 +324,24 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
 }
 
 static int
-validate_nonempty_seq(asdl_seq *seq, const char *what, const char *owner)
+_validate_nonempty_seq(asdl_seq *seq, const char *what, const char *owner)
 {
     if (asdl_seq_LEN(seq))
         return 1;
     PyErr_Format(PyExc_ValueError, "empty %s on %s", what, owner);
     return 0;
 }
+#define validate_nonempty_seq(seq, what, owner) _validate_nonempty_seq((asdl_seq*)seq, what, owner)
 
 static int
-validate_assignlist(asdl_seq *targets, expr_context_ty ctx)
+validate_assignlist(asdl_expr_seq *targets, expr_context_ty ctx)
 {
     return validate_nonempty_seq(targets, "targets", ctx == Del ? "Delete" : "Assign") &&
         validate_exprs(targets, ctx, 0);
 }
 
 static int
-validate_body(asdl_seq *body, const char *owner)
+validate_body(asdl_stmt_seq *body, const char *owner)
 {
     return validate_nonempty_seq(body, "body", owner) && validate_stmts(body);
 }
@@ -488,7 +489,7 @@ validate_stmt(stmt_ty stmt)
 }
 
 static int
-validate_stmts(asdl_seq *seq)
+validate_stmts(asdl_stmt_seq *seq)
 {
     Py_ssize_t i;
     for (i = 0; i < asdl_seq_LEN(seq); i++) {
@@ -507,7 +508,7 @@ validate_stmts(asdl_seq *seq)
 }
 
 static int
-validate_exprs(asdl_seq *exprs, expr_context_ty ctx, int null_ok)
+validate_exprs(asdl_expr_seq *exprs, expr_context_ty ctx, int null_ok)
 {
     Py_ssize_t i;
     for (i = 0; i < asdl_seq_LEN(exprs); i++) {
@@ -550,7 +551,7 @@ PyAST_Validate(mod_ty mod)
 }
 
 PyObject *
-_PyAST_GetDocString(asdl_seq *body)
+_PyAST_GetDocString(asdl_stmt_seq *body)
 {
     if (!asdl_seq_LEN(body)) {
         return NULL;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -271,7 +271,7 @@ fold_binop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
 }
 
 static PyObject*
-make_const_tuple(asdl_seq *elts)
+make_const_tuple(asdl_expr_seq *elts)
 {
     for (int i = 0; i < asdl_seq_LEN(elts); i++) {
         expr_ty e = (expr_ty)asdl_seq_GET(elts, i);
@@ -337,7 +337,7 @@ fold_iter(expr_ty arg, PyArena *arena, _PyASTOptimizeState *state)
     PyObject *newval;
     if (arg->kind == List_kind) {
         /* First change a list into tuple. */
-        asdl_seq *elts = arg->v.List.elts;
+        asdl_expr_seq *elts = arg->v.List.elts;
         Py_ssize_t n = asdl_seq_LEN(elts);
         for (Py_ssize_t i = 0; i < n; i++) {
             expr_ty e = (expr_ty)asdl_seq_GET(elts, i);
@@ -368,7 +368,7 @@ static int
 fold_compare(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
 {
     asdl_int_seq *ops;
-    asdl_seq *args;
+    asdl_expr_seq *args;
     Py_ssize_t i;
 
     ops = node->v.Compare.ops;
@@ -405,9 +405,9 @@ static int astfold_excepthandler(excepthandler_ty node_, PyArena *ctx_, _PyASTOp
 
 #define CALL_SEQ(FUNC, TYPE, ARG) { \
     int i; \
-    asdl_seq *seq = (ARG); /* avoid variable capture */ \
+    asdl_ ## TYPE ## _seq *seq = (ARG); /* avoid variable capture */ \
     for (i = 0; i < asdl_seq_LEN(seq); i++) { \
-        TYPE elt = (TYPE)asdl_seq_GET(seq, i); \
+        TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
         if (elt != NULL && !FUNC(elt, ctx_, state)) \
             return 0; \
     } \
@@ -424,13 +424,13 @@ static int astfold_excepthandler(excepthandler_ty node_, PyArena *ctx_, _PyASTOp
 }
 
 static int
-astfold_body(asdl_seq *stmts, PyArena *ctx_, _PyASTOptimizeState *state)
+astfold_body(asdl_stmt_seq *stmts, PyArena *ctx_, _PyASTOptimizeState *state)
 {
     int docstring = _PyAST_GetDocString(stmts) != NULL;
-    CALL_SEQ(astfold_stmt, stmt_ty, stmts);
+    CALL_SEQ(astfold_stmt, stmt, stmts);
     if (!docstring && _PyAST_GetDocString(stmts) != NULL) {
         stmt_ty st = (stmt_ty)asdl_seq_GET(stmts, 0);
-        asdl_seq *values = _Py_asdl_seq_new(1, ctx_);
+        asdl_expr_seq *values = _Py_asdl_expr_seq_new(1, ctx_);
         if (!values) {
             return 0;
         }
@@ -453,7 +453,7 @@ astfold_mod(mod_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         CALL(astfold_body, asdl_seq, node_->v.Module.body);
         break;
     case Interactive_kind:
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.Interactive.body);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.Interactive.body);
         break;
     case Expression_kind:
         CALL(astfold_expr, expr_ty, node_->v.Expression.body);
@@ -469,7 +469,7 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
     switch (node_->kind) {
     case BoolOp_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.BoolOp.values);
+        CALL_SEQ(astfold_expr, expr, node_->v.BoolOp.values);
         break;
     case BinOp_kind:
         CALL(astfold_expr, expr_ty, node_->v.BinOp.left);
@@ -490,28 +490,28 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         CALL(astfold_expr, expr_ty, node_->v.IfExp.orelse);
         break;
     case Dict_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Dict.keys);
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Dict.values);
+        CALL_SEQ(astfold_expr, expr, node_->v.Dict.keys);
+        CALL_SEQ(astfold_expr, expr, node_->v.Dict.values);
         break;
     case Set_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Set.elts);
+        CALL_SEQ(astfold_expr, expr, node_->v.Set.elts);
         break;
     case ListComp_kind:
         CALL(astfold_expr, expr_ty, node_->v.ListComp.elt);
-        CALL_SEQ(astfold_comprehension, comprehension_ty, node_->v.ListComp.generators);
+        CALL_SEQ(astfold_comprehension, comprehension, node_->v.ListComp.generators);
         break;
     case SetComp_kind:
         CALL(astfold_expr, expr_ty, node_->v.SetComp.elt);
-        CALL_SEQ(astfold_comprehension, comprehension_ty, node_->v.SetComp.generators);
+        CALL_SEQ(astfold_comprehension, comprehension, node_->v.SetComp.generators);
         break;
     case DictComp_kind:
         CALL(astfold_expr, expr_ty, node_->v.DictComp.key);
         CALL(astfold_expr, expr_ty, node_->v.DictComp.value);
-        CALL_SEQ(astfold_comprehension, comprehension_ty, node_->v.DictComp.generators);
+        CALL_SEQ(astfold_comprehension, comprehension, node_->v.DictComp.generators);
         break;
     case GeneratorExp_kind:
         CALL(astfold_expr, expr_ty, node_->v.GeneratorExp.elt);
-        CALL_SEQ(astfold_comprehension, comprehension_ty, node_->v.GeneratorExp.generators);
+        CALL_SEQ(astfold_comprehension, comprehension, node_->v.GeneratorExp.generators);
         break;
     case Await_kind:
         CALL(astfold_expr, expr_ty, node_->v.Await.value);
@@ -524,20 +524,20 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         break;
     case Compare_kind:
         CALL(astfold_expr, expr_ty, node_->v.Compare.left);
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Compare.comparators);
+        CALL_SEQ(astfold_expr, expr, node_->v.Compare.comparators);
         CALL(fold_compare, expr_ty, node_);
         break;
     case Call_kind:
         CALL(astfold_expr, expr_ty, node_->v.Call.func);
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Call.args);
-        CALL_SEQ(astfold_keyword, keyword_ty, node_->v.Call.keywords);
+        CALL_SEQ(astfold_expr, expr, node_->v.Call.args);
+        CALL_SEQ(astfold_keyword, keyword, node_->v.Call.keywords);
         break;
     case FormattedValue_kind:
         CALL(astfold_expr, expr_ty, node_->v.FormattedValue.value);
         CALL_OPT(astfold_expr, expr_ty, node_->v.FormattedValue.format_spec);
         break;
     case JoinedStr_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.JoinedStr.values);
+        CALL_SEQ(astfold_expr, expr, node_->v.JoinedStr.values);
         break;
     case Attribute_kind:
         CALL(astfold_expr, expr_ty, node_->v.Attribute.value);
@@ -556,10 +556,10 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         CALL_OPT(astfold_expr, expr_ty, node_->v.Slice.step);
         break;
     case List_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.List.elts);
+        CALL_SEQ(astfold_expr, expr, node_->v.List.elts);
         break;
     case Tuple_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Tuple.elts);
+        CALL_SEQ(astfold_expr, expr, node_->v.Tuple.elts);
         CALL(fold_tuple, expr_ty, node_);
         break;
     case Name_kind:
@@ -586,7 +586,7 @@ astfold_comprehension(comprehension_ty node_, PyArena *ctx_, _PyASTOptimizeState
 {
     CALL(astfold_expr, expr_ty, node_->target);
     CALL(astfold_expr, expr_ty, node_->iter);
-    CALL_SEQ(astfold_expr, expr_ty, node_->ifs);
+    CALL_SEQ(astfold_expr, expr, node_->ifs);
 
     CALL(fold_iter, expr_ty, node_->iter);
     return 1;
@@ -595,13 +595,13 @@ astfold_comprehension(comprehension_ty node_, PyArena *ctx_, _PyASTOptimizeState
 static int
 astfold_arguments(arguments_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
-    CALL_SEQ(astfold_arg, arg_ty, node_->posonlyargs);
-    CALL_SEQ(astfold_arg, arg_ty, node_->args);
+    CALL_SEQ(astfold_arg, arg, node_->posonlyargs);
+    CALL_SEQ(astfold_arg, arg, node_->args);
     CALL_OPT(astfold_arg, arg_ty, node_->vararg);
-    CALL_SEQ(astfold_arg, arg_ty, node_->kwonlyargs);
-    CALL_SEQ(astfold_expr, expr_ty, node_->kw_defaults);
+    CALL_SEQ(astfold_arg, arg, node_->kwonlyargs);
+    CALL_SEQ(astfold_expr, expr, node_->kw_defaults);
     CALL_OPT(astfold_arg, arg_ty, node_->kwarg);
-    CALL_SEQ(astfold_expr, expr_ty, node_->defaults);
+    CALL_SEQ(astfold_expr, expr, node_->defaults);
     return 1;
 }
 
@@ -621,7 +621,7 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     case FunctionDef_kind:
         CALL(astfold_arguments, arguments_ty, node_->v.FunctionDef.args);
         CALL(astfold_body, asdl_seq, node_->v.FunctionDef.body);
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.FunctionDef.decorator_list);
+        CALL_SEQ(astfold_expr, expr, node_->v.FunctionDef.decorator_list);
         if (!(state->ff_features & CO_FUTURE_ANNOTATIONS)) {
             CALL_OPT(astfold_expr, expr_ty, node_->v.FunctionDef.returns);
         }
@@ -629,25 +629,25 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     case AsyncFunctionDef_kind:
         CALL(astfold_arguments, arguments_ty, node_->v.AsyncFunctionDef.args);
         CALL(astfold_body, asdl_seq, node_->v.AsyncFunctionDef.body);
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.AsyncFunctionDef.decorator_list);
+        CALL_SEQ(astfold_expr, expr, node_->v.AsyncFunctionDef.decorator_list);
         if (!(state->ff_features & CO_FUTURE_ANNOTATIONS)) {
             CALL_OPT(astfold_expr, expr_ty, node_->v.AsyncFunctionDef.returns);
         }
         break;
     case ClassDef_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.ClassDef.bases);
-        CALL_SEQ(astfold_keyword, keyword_ty, node_->v.ClassDef.keywords);
+        CALL_SEQ(astfold_expr, expr, node_->v.ClassDef.bases);
+        CALL_SEQ(astfold_keyword, keyword, node_->v.ClassDef.keywords);
         CALL(astfold_body, asdl_seq, node_->v.ClassDef.body);
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.ClassDef.decorator_list);
+        CALL_SEQ(astfold_expr, expr, node_->v.ClassDef.decorator_list);
         break;
     case Return_kind:
         CALL_OPT(astfold_expr, expr_ty, node_->v.Return.value);
         break;
     case Delete_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Delete.targets);
+        CALL_SEQ(astfold_expr, expr, node_->v.Delete.targets);
         break;
     case Assign_kind:
-        CALL_SEQ(astfold_expr, expr_ty, node_->v.Assign.targets);
+        CALL_SEQ(astfold_expr, expr, node_->v.Assign.targets);
         CALL(astfold_expr, expr_ty, node_->v.Assign.value);
         break;
     case AugAssign_kind:
@@ -664,44 +664,44 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     case For_kind:
         CALL(astfold_expr, expr_ty, node_->v.For.target);
         CALL(astfold_expr, expr_ty, node_->v.For.iter);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.For.body);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.For.orelse);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.For.body);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.For.orelse);
 
         CALL(fold_iter, expr_ty, node_->v.For.iter);
         break;
     case AsyncFor_kind:
         CALL(astfold_expr, expr_ty, node_->v.AsyncFor.target);
         CALL(astfold_expr, expr_ty, node_->v.AsyncFor.iter);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.AsyncFor.body);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.AsyncFor.orelse);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.AsyncFor.body);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.AsyncFor.orelse);
         break;
     case While_kind:
         CALL(astfold_expr, expr_ty, node_->v.While.test);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.While.body);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.While.orelse);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.While.body);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.While.orelse);
         break;
     case If_kind:
         CALL(astfold_expr, expr_ty, node_->v.If.test);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.If.body);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.If.orelse);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.If.body);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.If.orelse);
         break;
     case With_kind:
-        CALL_SEQ(astfold_withitem, withitem_ty, node_->v.With.items);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.With.body);
+        CALL_SEQ(astfold_withitem, withitem, node_->v.With.items);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.With.body);
         break;
     case AsyncWith_kind:
-        CALL_SEQ(astfold_withitem, withitem_ty, node_->v.AsyncWith.items);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.AsyncWith.body);
+        CALL_SEQ(astfold_withitem, withitem, node_->v.AsyncWith.items);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.AsyncWith.body);
         break;
     case Raise_kind:
         CALL_OPT(astfold_expr, expr_ty, node_->v.Raise.exc);
         CALL_OPT(astfold_expr, expr_ty, node_->v.Raise.cause);
         break;
     case Try_kind:
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.Try.body);
-        CALL_SEQ(astfold_excepthandler, excepthandler_ty, node_->v.Try.handlers);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.Try.orelse);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.Try.finalbody);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.Try.body);
+        CALL_SEQ(astfold_excepthandler, excepthandler, node_->v.Try.handlers);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.Try.orelse);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.Try.finalbody);
         break;
     case Assert_kind:
         CALL(astfold_expr, expr_ty, node_->v.Assert.test);
@@ -722,7 +722,7 @@ astfold_excepthandler(excepthandler_ty node_, PyArena *ctx_, _PyASTOptimizeState
     switch (node_->kind) {
     case ExceptHandler_kind:
         CALL_OPT(astfold_expr, expr_ty, node_->v.ExceptHandler.type);
-        CALL_SEQ(astfold_stmt, stmt_ty, node_->v.ExceptHandler.body);
+        CALL_SEQ(astfold_stmt, stmt, node_->v.ExceptHandler.body);
         break;
     default:
         break;

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -117,7 +117,7 @@ static int
 append_ast_boolop(_PyUnicodeWriter *writer, expr_ty e, int level)
 {
     Py_ssize_t i, value_count;
-    asdl_seq *values;
+    asdl_expr_seq *values;
     const char *op = (e->v.BoolOp.op == And) ? " and " : " or ";
     int pr = (e->v.BoolOp.op == And) ? PR_AND : PR_OR;
 
@@ -398,7 +398,7 @@ append_ast_comprehension(_PyUnicodeWriter *writer, comprehension_ty gen)
 }
 
 static int
-append_ast_comprehensions(_PyUnicodeWriter *writer, asdl_seq *comprehensions)
+append_ast_comprehensions(_PyUnicodeWriter *writer, asdl_comprehension_seq *comprehensions)
 {
     Py_ssize_t i, gen_count;
     gen_count = asdl_seq_LEN(comprehensions);
@@ -453,7 +453,7 @@ append_ast_compare(_PyUnicodeWriter *writer, expr_ty e, int level)
 {
     const char *op;
     Py_ssize_t i, comparator_count;
-    asdl_seq *comparators;
+    asdl_expr_seq *comparators;
     asdl_int_seq *ops;
 
     APPEND_STR_IF(level > PR_CMP, "(");
@@ -612,7 +612,7 @@ append_fstring_element(_PyUnicodeWriter *writer, expr_ty e, bool is_format_spec)
 /* Build body separately to enable wrapping the entire stream of Strs,
    Constants and FormattedValues in one opening and one closing quote. */
 static PyObject *
-build_fstring_body(asdl_seq *values, bool is_format_spec)
+build_fstring_body(asdl_expr_seq *values, bool is_format_spec)
 {
     Py_ssize_t i, value_count;
     _PyUnicodeWriter body_writer;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -222,27 +222,27 @@ static int compiler_subscript(struct compiler *, expr_ty);
 static int compiler_slice(struct compiler *, expr_ty);
 
 static int inplace_binop(operator_ty);
-static int are_all_items_const(asdl_seq *, Py_ssize_t, Py_ssize_t);
+static int are_all_items_const(asdl_expr_seq *, Py_ssize_t, Py_ssize_t);
 static int expr_constant(expr_ty);
 
 static int compiler_with(struct compiler *, stmt_ty, int);
 static int compiler_async_with(struct compiler *, stmt_ty, int);
 static int compiler_async_for(struct compiler *, stmt_ty);
 static int compiler_call_helper(struct compiler *c, int n,
-                                asdl_seq *args,
-                                asdl_seq *keywords);
+                                asdl_expr_seq *args,
+                                asdl_keyword_seq *keywords);
 static int compiler_try_except(struct compiler *, stmt_ty);
 static int compiler_set_qualname(struct compiler *);
 
 static int compiler_sync_comprehension_generator(
                                       struct compiler *c,
-                                      asdl_seq *generators, int gen_index,
+                                      asdl_comprehension_seq *generators, int gen_index,
                                       int depth,
                                       expr_ty elt, expr_ty val, int type);
 
 static int compiler_async_comprehension_generator(
                                       struct compiler *c,
-                                      asdl_seq *generators, int gen_index,
+                                      asdl_comprehension_seq *generators, int gen_index,
                                       int depth,
                                       expr_ty elt, expr_ty val, int type);
 
@@ -1525,7 +1525,7 @@ compiler_addop_j(struct compiler *c, int opcode, basicblock *b)
 
 #define VISIT_SEQ(C, TYPE, SEQ) { \
     int _i; \
-    asdl_seq *seq = (SEQ); /* avoid variable capture */ \
+    asdl_ ## TYPE ## _seq *seq = (SEQ); /* avoid variable capture */ \
     for (_i = 0; _i < asdl_seq_LEN(seq); _i++) { \
         TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, _i); \
         if (!compiler_visit_ ## TYPE((C), elt)) \
@@ -1535,7 +1535,7 @@ compiler_addop_j(struct compiler *c, int opcode, basicblock *b)
 
 #define VISIT_SEQ_IN_SCOPE(C, TYPE, SEQ) { \
     int _i; \
-    asdl_seq *seq = (SEQ); /* avoid variable capture */ \
+    asdl_ ## TYPE ## _seq *seq = (SEQ); /* avoid variable capture */ \
     for (_i = 0; _i < asdl_seq_LEN(seq); _i++) { \
         TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, _i); \
         if (!compiler_visit_ ## TYPE((C), elt)) { \
@@ -1559,7 +1559,7 @@ compiler_addop_j(struct compiler *c, int opcode, basicblock *b)
 /* Search if variable annotations are present statically in a block. */
 
 static int
-find_ann(asdl_seq *stmts)
+find_ann(asdl_stmt_seq *stmts)
 {
     int i, j, res = 0;
     stmt_ty st;
@@ -1778,7 +1778,7 @@ compiler_unwind_fblock_stack(struct compiler *c, int preserve_tos, struct fblock
    and for annotations. */
 
 static int
-compiler_body(struct compiler *c, asdl_seq *stmts)
+compiler_body(struct compiler *c, asdl_stmt_seq *stmts)
 {
     int i = 0;
     stmt_ty st;
@@ -1841,8 +1841,7 @@ compiler_mod(struct compiler *c, mod_ty mod)
             ADDOP(c, SETUP_ANNOTATIONS);
         }
         c->c_interactive = 1;
-        VISIT_SEQ_IN_SCOPE(c, stmt,
-                                mod->v.Interactive.body);
+        VISIT_SEQ_IN_SCOPE(c, stmt, mod->v.Interactive.body);
         break;
     case Expression_kind:
         VISIT_IN_SCOPE(c, expr, mod->v.Expression.body);
@@ -1945,7 +1944,7 @@ compiler_make_closure(struct compiler *c, PyCodeObject *co, Py_ssize_t flags, Py
 }
 
 static int
-compiler_decorators(struct compiler *c, asdl_seq* decos)
+compiler_decorators(struct compiler *c, asdl_expr_seq* decos)
 {
     int i;
 
@@ -1959,8 +1958,8 @@ compiler_decorators(struct compiler *c, asdl_seq* decos)
 }
 
 static int
-compiler_visit_kwonlydefaults(struct compiler *c, asdl_seq *kwonlyargs,
-                              asdl_seq *kw_defaults)
+compiler_visit_kwonlydefaults(struct compiler *c, asdl_arg_seq *kwonlyargs,
+                              asdl_expr_seq *kw_defaults)
 {
     /* Push a dict of keyword-only default values.
 
@@ -2047,7 +2046,7 @@ compiler_visit_argannotation(struct compiler *c, identifier id,
 }
 
 static int
-compiler_visit_argannotations(struct compiler *c, asdl_seq* args,
+compiler_visit_argannotations(struct compiler *c, asdl_arg_seq* args,
                               PyObject *names)
 {
     int i;
@@ -2173,7 +2172,7 @@ compiler_check_debug_one_arg(struct compiler *c, arg_ty arg)
 }
 
 static int
-compiler_check_debug_args_seq(struct compiler *c, asdl_seq *args)
+compiler_check_debug_args_seq(struct compiler *c, asdl_arg_seq *args)
 {
     if (args != NULL) {
         for (Py_ssize_t i = 0, n = asdl_seq_LEN(args); i < n; i++) {
@@ -2208,8 +2207,8 @@ compiler_function(struct compiler *c, stmt_ty s, int is_async)
     arguments_ty args;
     expr_ty returns;
     identifier name;
-    asdl_seq* decos;
-    asdl_seq *body;
+    asdl_expr_seq* decos;
+    asdl_stmt_seq *body;
     Py_ssize_t i, funcflags;
     int annotations;
     int scope_type;
@@ -2306,7 +2305,7 @@ compiler_class(struct compiler *c, stmt_ty s)
     PyCodeObject *co;
     PyObject *str;
     int i, firstlineno;
-    asdl_seq* decos = s->v.ClassDef.decorator_list;
+    asdl_expr_seq *decos = s->v.ClassDef.decorator_list;
 
     if (!compiler_decorators(c, decos))
         return 0;
@@ -2418,9 +2417,7 @@ compiler_class(struct compiler *c, stmt_ty s)
     ADDOP_LOAD_CONST(c, s->v.ClassDef.name);
 
     /* 5. generate the rest of the code for the call */
-    if (!compiler_call_helper(c, 2,
-                              s->v.ClassDef.bases,
-                              s->v.ClassDef.keywords))
+    if (!compiler_call_helper(c, 2, s->v.ClassDef.bases, s->v.ClassDef.keywords))
         return 0;
 
     /* 6. apply decorators */
@@ -2528,7 +2525,7 @@ compiler_jump_if(struct compiler *c, expr_ty e, basicblock *next, int cond)
         /* fallback to general implementation */
         break;
     case BoolOp_kind: {
-        asdl_seq *s = e->v.BoolOp.values;
+        asdl_expr_seq *s = e->v.BoolOp.values;
         Py_ssize_t i, n = asdl_seq_LEN(s) - 1;
         assert(n >= 0);
         int cond2 = e->v.BoolOp.op == Or;
@@ -3645,7 +3642,7 @@ compiler_boolop(struct compiler *c, expr_ty e)
     basicblock *end;
     int jumpi;
     Py_ssize_t i, n;
-    asdl_seq *s;
+    asdl_expr_seq *s;
 
     assert(e->kind == BoolOp_kind);
     if (e->v.BoolOp.op == And)
@@ -3673,7 +3670,7 @@ compiler_boolop(struct compiler *c, expr_ty e)
 }
 
 static int
-starunpack_helper(struct compiler *c, asdl_seq *elts, int pushed,
+starunpack_helper(struct compiler *c, asdl_expr_seq *elts, int pushed,
                   int build, int add, int extend, int tuple)
 {
     Py_ssize_t n = asdl_seq_LEN(elts);
@@ -3750,7 +3747,7 @@ starunpack_helper(struct compiler *c, asdl_seq *elts, int pushed,
 }
 
 static int
-assignment_helper(struct compiler *c, asdl_seq *elts)
+assignment_helper(struct compiler *c, asdl_expr_seq *elts)
 {
     Py_ssize_t n = asdl_seq_LEN(elts);
     Py_ssize_t i;
@@ -3784,7 +3781,7 @@ assignment_helper(struct compiler *c, asdl_seq *elts)
 static int
 compiler_list(struct compiler *c, expr_ty e)
 {
-    asdl_seq *elts = e->v.List.elts;
+    asdl_expr_seq *elts = e->v.List.elts;
     if (e->v.List.ctx == Store) {
         return assignment_helper(c, elts);
     }
@@ -3800,7 +3797,7 @@ compiler_list(struct compiler *c, expr_ty e)
 static int
 compiler_tuple(struct compiler *c, expr_ty e)
 {
-    asdl_seq *elts = e->v.Tuple.elts;
+    asdl_expr_seq *elts = e->v.Tuple.elts;
     if (e->v.Tuple.ctx == Store) {
         return assignment_helper(c, elts);
     }
@@ -3821,7 +3818,7 @@ compiler_set(struct compiler *c, expr_ty e)
 }
 
 static int
-are_all_items_const(asdl_seq *seq, Py_ssize_t begin, Py_ssize_t end)
+are_all_items_const(asdl_expr_seq *seq, Py_ssize_t begin, Py_ssize_t end)
 {
     Py_ssize_t i;
     for (i = begin; i < end; i++) {
@@ -4084,7 +4081,7 @@ maybe_optimize_method_call(struct compiler *c, expr_ty e)
 {
     Py_ssize_t argsl, i;
     expr_ty meth = e->v.Call.func;
-    asdl_seq *args = e->v.Call.args;
+    asdl_expr_seq *args = e->v.Call.args;
 
     /* Check that the call node is an attribute access, and that
        the call doesn't have keyword parameters. */
@@ -4110,7 +4107,7 @@ maybe_optimize_method_call(struct compiler *c, expr_ty e)
 }
 
 static int
-validate_keywords(struct compiler *c, asdl_seq *keywords)
+validate_keywords(struct compiler *c, asdl_keyword_seq *keywords)
 {
     Py_ssize_t nkeywords = asdl_seq_LEN(keywords);
     for (Py_ssize_t i = 0; i < nkeywords; i++) {
@@ -4210,7 +4207,7 @@ compiler_formatted_value(struct compiler *c, expr_ty e)
 }
 
 static int
-compiler_subkwargs(struct compiler *c, asdl_seq *keywords, Py_ssize_t begin, Py_ssize_t end)
+compiler_subkwargs(struct compiler *c, asdl_keyword_seq *keywords, Py_ssize_t begin, Py_ssize_t end)
 {
     Py_ssize_t i, n = end - begin;
     keyword_ty kw;
@@ -4249,8 +4246,8 @@ compiler_subkwargs(struct compiler *c, asdl_seq *keywords, Py_ssize_t begin, Py_
 static int
 compiler_call_helper(struct compiler *c,
                      int n, /* Args already pushed */
-                     asdl_seq *args,
-                     asdl_seq *keywords)
+                     asdl_expr_seq *args,
+                     asdl_keyword_seq *keywords)
 {
     Py_ssize_t i, nseen, nelts, nkwelts;
 
@@ -4375,7 +4372,7 @@ ex_call:
 
 static int
 compiler_comprehension_generator(struct compiler *c,
-                                 asdl_seq *generators, int gen_index,
+                                 asdl_comprehension_seq *generators, int gen_index,
                                  int depth,
                                  expr_ty elt, expr_ty val, int type)
 {
@@ -4392,7 +4389,7 @@ compiler_comprehension_generator(struct compiler *c,
 
 static int
 compiler_sync_comprehension_generator(struct compiler *c,
-                                      asdl_seq *generators, int gen_index,
+                                      asdl_comprehension_seq *generators, int gen_index,
                                       int depth,
                                       expr_ty elt, expr_ty val, int type)
 {
@@ -4424,7 +4421,7 @@ compiler_sync_comprehension_generator(struct compiler *c,
         /* Fast path for the temporary variable assignment idiom:
              for y in [f(x)]
          */
-        asdl_seq *elts;
+        asdl_expr_seq *elts;
         switch (gen->iter->kind) {
             case List_kind:
                 elts = gen->iter->v.List.elts;
@@ -4511,7 +4508,7 @@ compiler_sync_comprehension_generator(struct compiler *c,
 
 static int
 compiler_async_comprehension_generator(struct compiler *c,
-                                      asdl_seq *generators, int gen_index,
+                                      asdl_comprehension_seq *generators, int gen_index,
                                       int depth,
                                       expr_ty elt, expr_ty val, int type)
 {
@@ -4602,7 +4599,7 @@ compiler_async_comprehension_generator(struct compiler *c,
 
 static int
 compiler_comprehension(struct compiler *c, expr_ty e, int type,
-                       identifier name, asdl_seq *generators, expr_ty elt,
+                       identifier name, asdl_comprehension_seq *generators, expr_ty elt,
                        expr_ty val)
 {
     PyCodeObject *co = NULL;
@@ -5226,7 +5223,7 @@ check_ann_subscr(struct compiler *c, expr_ty e)
         return 1;
     case Tuple_kind: {
         /* extended slice */
-        asdl_seq *elts = e->v.Tuple.elts;
+        asdl_expr_seq *elts = e->v.Tuple.elts;
         Py_ssize_t i, n = asdl_seq_LEN(elts);
         for (i = 0; i < n; i++) {
             if (!check_ann_subscr(c, asdl_seq_GET(elts, i))) {

--- a/Python/future.c
+++ b/Python/future.c
@@ -13,11 +13,10 @@ static int
 future_check_features(PyFutureFeatures *ff, stmt_ty s, PyObject *filename)
 {
     int i;
-    asdl_seq *names;
 
     assert(s->kind == ImportFrom_kind);
 
-    names = s->v.ImportFrom.names;
+    asdl_alias_seq *names = s->v.ImportFrom.names;
     for (i = 0; i < asdl_seq_LEN(names); i++) {
         alias_ty name = (alias_ty)asdl_seq_GET(names, i);
         const char *feature = PyUnicode_AsUTF8(name->name);

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2674,7 +2674,7 @@ init_dump_ascii_wstr(const wchar_t *str)
         if (ch == L'\'') {
             PySys_WriteStderr("\\'");
         } else if (0x20 <= ch && ch < 0x7f) {
-            PySys_WriteStderr("%lc", ch);
+            PySys_WriteStderr("%c", ch);
         }
         else if (ch <= 0xff) {
             PySys_WriteStderr("\\x%02x", ch);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1259,6 +1259,12 @@ flush_std_files(void)
 static void
 finalize_interp_types(PyThreadState *tstate)
 {
+    // The _ast module state is shared by all interpreters.
+    // The state must only be cleared by the main interpreter.
+    if (_Py_IsMainInterpreter(tstate)) {
+        _PyAST_Fini(tstate);
+    }
+
     _PyExc_Fini(tstate);
     _PyFrame_Fini(tstate);
     _PyAsyncGen_Fini(tstate);

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -202,8 +202,8 @@ static int symtable_visit_excepthandler(struct symtable *st, excepthandler_ty);
 static int symtable_visit_alias(struct symtable *st, alias_ty);
 static int symtable_visit_comprehension(struct symtable *st, comprehension_ty);
 static int symtable_visit_keyword(struct symtable *st, keyword_ty);
-static int symtable_visit_params(struct symtable *st, asdl_seq *args);
-static int symtable_visit_argannotations(struct symtable *st, asdl_seq *args);
+static int symtable_visit_params(struct symtable *st, asdl_arg_seq *args);
+static int symtable_visit_argannotations(struct symtable *st, asdl_arg_seq *args);
 static int symtable_implicit_arg(struct symtable *st, int pos);
 static int symtable_visit_annotations(struct symtable *st, arguments_ty, expr_ty);
 static int symtable_visit_withitem(struct symtable *st, withitem_ty item);
@@ -261,7 +261,7 @@ struct symtable *
 PySymtable_BuildObject(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
 {
     struct symtable *st = symtable_new();
-    asdl_seq *seq;
+    asdl_stmt_seq *seq;
     int i;
     PyThreadState *tstate;
     int recursion_limit = Py_GetRecursionLimit();
@@ -1116,7 +1116,7 @@ symtable_add_def(struct symtable *st, PyObject *name, int flag) {
 
 #define VISIT_SEQ(ST, TYPE, SEQ) { \
     int i; \
-    asdl_seq *seq = (SEQ); /* avoid variable capture */ \
+    asdl_ ## TYPE ## _seq *seq = (SEQ); /* avoid variable capture */ \
     for (i = 0; i < asdl_seq_LEN(seq); i++) { \
         TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
         if (!symtable_visit_ ## TYPE((ST), elt)) \
@@ -1126,7 +1126,7 @@ symtable_add_def(struct symtable *st, PyObject *name, int flag) {
 
 #define VISIT_SEQ_TAIL(ST, TYPE, SEQ, START) { \
     int i; \
-    asdl_seq *seq = (SEQ); /* avoid variable capture */ \
+    asdl_ ## TYPE ## _seq *seq = (SEQ); /* avoid variable capture */ \
     for (i = (START); i < asdl_seq_LEN(seq); i++) { \
         TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
         if (!symtable_visit_ ## TYPE((ST), elt)) \
@@ -1136,7 +1136,7 @@ symtable_add_def(struct symtable *st, PyObject *name, int flag) {
 
 #define VISIT_SEQ_WITH_NULL(ST, TYPE, SEQ) {     \
     int i = 0; \
-    asdl_seq *seq = (SEQ); /* avoid variable capture */ \
+    asdl_ ## TYPE ## _seq *seq = (SEQ); /* avoid variable capture */ \
     for (i = 0; i < asdl_seq_LEN(seq); i++) { \
         TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
         if (!elt) continue; /* can be NULL */ \
@@ -1318,7 +1318,7 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
         break;
     case Global_kind: {
         int i;
-        asdl_seq *seq = s->v.Global.names;
+        asdl_identifier_seq *seq = s->v.Global.names;
         for (i = 0; i < asdl_seq_LEN(seq); i++) {
             identifier name = (identifier)asdl_seq_GET(seq, i);
             long cur = symtable_lookup(st, name);
@@ -1351,7 +1351,7 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
     }
     case Nonlocal_kind: {
         int i;
-        asdl_seq *seq = s->v.Nonlocal.names;
+        asdl_identifier_seq *seq = s->v.Nonlocal.names;
         for (i = 0; i < asdl_seq_LEN(seq); i++) {
             identifier name = (identifier)asdl_seq_GET(seq, i);
             long cur = symtable_lookup(st, name);
@@ -1683,7 +1683,7 @@ symtable_implicit_arg(struct symtable *st, int pos)
 }
 
 static int
-symtable_visit_params(struct symtable *st, asdl_seq *args)
+symtable_visit_params(struct symtable *st, asdl_arg_seq *args)
 {
     int i;
 
@@ -1700,7 +1700,7 @@ symtable_visit_params(struct symtable *st, asdl_seq *args)
 }
 
 static int
-symtable_visit_argannotations(struct symtable *st, asdl_seq *args)
+symtable_visit_argannotations(struct symtable *st, asdl_arg_seq *args)
 {
     int i;
 
@@ -1850,7 +1850,7 @@ symtable_visit_keyword(struct symtable *st, keyword_ty k)
 
 static int
 symtable_handle_comprehension(struct symtable *st, expr_ty e,
-                              identifier scope_name, asdl_seq *generators,
+                              identifier scope_name, asdl_comprehension_seq *generators,
                               expr_ty elt, expr_ty value)
 {
     int is_generator = (e->kind == GeneratorExp_kind);

--- a/Tools/c-analyzer/c_analyzer/common/info.py
+++ b/Tools/c-analyzer/c_analyzer/common/info.py
@@ -9,7 +9,8 @@ from .util import classonly, _NTBase
 
 UNKNOWN = '???'
 
-NAME_RE = re.compile(r'^([a-zA-Z]|_\w*[a-zA-Z]\w*|[a-zA-Z]\w*)$')
+# Does not start with digit and contains at least one letter.
+NAME_RE = re.compile(r'(?!\d)(?=.*?[A-Za-z])\w+', re.ASCII)
 
 
 class ID(_NTBase, namedtuple('ID', 'filename funcname name')):
@@ -50,17 +51,16 @@ class ID(_NTBase, namedtuple('ID', 'filename funcname name')):
         """Fail if the object is invalid (i.e. init with bad data)."""
         if not self.name:
             raise TypeError('missing name')
-        else:
-            if not NAME_RE.match(self.name):
-                raise ValueError(
-                        f'name must be an identifier, got {self.name!r}')
+        if not NAME_RE.fullmatch(self.name):
+            raise ValueError(
+                    f'name must be an identifier, got {self.name!r}')
 
         # Symbols from a binary might not have filename/funcname info.
 
         if self.funcname:
             if not self.filename:
                 raise TypeError('missing filename')
-            if not NAME_RE.match(self.funcname) and self.funcname != UNKNOWN:
+            if not NAME_RE.fullmatch(self.funcname) and self.funcname != UNKNOWN:
                 raise ValueError(
                         f'name must be an identifier, got {self.funcname!r}')
 

--- a/Tools/nuget/python.nuspec
+++ b/Tools/nuget/python.nuspec
@@ -13,6 +13,6 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
   </files>
 </package>

--- a/Tools/nuget/pythonarm32.nuspec
+++ b/Tools/nuget/pythonarm32.nuspec
@@ -14,6 +14,7 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
+    <file src="python.props" target="build\native\pythonarm32.props" />
   </files>
 </package>

--- a/Tools/nuget/pythondaily.nuspec
+++ b/Tools/nuget/pythondaily.nuspec
@@ -13,6 +13,7 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
+    <file src="python.props" target="build\native\pythondaily.props" />
   </files>
 </package>

--- a/Tools/nuget/pythonx86.nuspec
+++ b/Tools/nuget/pythonx86.nuspec
@@ -13,6 +13,7 @@
   </metadata>
   <files>
     <file src="**\*" exclude="python.props" target="tools" />
-    <file src="python.props" target="build\native" />
+    <file src="python.props" target="build\native\python.props" />
+    <file src="python.props" target="build\native\pythonx86.props" />
   </files>
 </package>

--- a/Tools/peg_generator/pegen/grammar.py
+++ b/Tools/peg_generator/pegen/grammar.py
@@ -259,9 +259,10 @@ class Alt:
 
 
 class NamedItem:
-    def __init__(self, name: Optional[str], item: Item):
+    def __init__(self, name: Optional[str], item: Item, type: Optional[str] = None):
         self.name = name
         self.item = item
+        self.type = type
         self.nullable = False
 
     def __str__(self) -> str:

--- a/Tools/peg_generator/pegen/grammar_parser.py
+++ b/Tools/peg_generator/pegen/grammar_parser.py
@@ -402,8 +402,48 @@ class GeneratedParser(Parser):
 
     @memoize
     def named_item(self) -> Optional[NamedItem]:
-        # named_item: NAME '=' ~ item | item | lookahead
+        # named_item: NAME '[' NAME '*' ']' '=' ~ item | NAME '[' NAME ']' '=' ~ item | NAME '=' ~ item | item | lookahead
         mark = self.mark()
+        cut = False
+        if (
+            (name := self.name())
+            and
+            (literal := self.expect('['))
+            and
+            (type := self.name())
+            and
+            (literal_1 := self.expect('*'))
+            and
+            (literal_2 := self.expect(']'))
+            and
+            (literal_3 := self.expect('='))
+            and
+            (cut := True)
+            and
+            (item := self.item())
+        ):
+            return NamedItem ( name . string , item , f"{type.string}*" )
+        self.reset(mark)
+        if cut: return None
+        cut = False
+        if (
+            (name := self.name())
+            and
+            (literal := self.expect('['))
+            and
+            (type := self.name())
+            and
+            (literal_1 := self.expect(']'))
+            and
+            (literal_2 := self.expect('='))
+            and
+            (cut := True)
+            and
+            (item := self.item())
+        ):
+            return NamedItem ( name . string , item , type . string )
+        self.reset(mark)
+        if cut: return None
         cut = False
         if (
             (name := self.name())

--- a/Tools/peg_generator/pegen/metagrammar.gram
+++ b/Tools/peg_generator/pegen/metagrammar.gram
@@ -83,6 +83,8 @@ items[NamedItemList]:
     | named_item { [named_item] }
 
 named_item[NamedItem]:
+    | NAME '[' type=NAME '*' ']' '=' ~ item {NamedItem(name.string, item, f"{type.string}*")}
+    | NAME '[' type=NAME ']' '=' ~ item {NamedItem(name.string, item, type.string)}
     | NAME '=' ~ item {NamedItem(name.string, item)}
     | item {NamedItem(None, item)}
     | it=lookahead {NamedItem(None, it)}

--- a/Tools/peg_generator/pegen/sccutils.py
+++ b/Tools/peg_generator/pegen/sccutils.py
@@ -18,7 +18,7 @@ def strongly_connected_components(
       exactly once; vertices not part of a SCC are returned as
       singleton sets.
 
-    From http://code.activestate.com/recipes/578507/.
+    From https://github.com/ActiveState/code/tree/master/recipes/Python/578507_Strongly_connected_components_directed/recipe-578507.py.
     """
     identified: Set[str] = set()
     stack: List[str] = []
@@ -81,7 +81,7 @@ def topsort(
         {B, C}
         {A}
 
-    From http://code.activestate.com/recipes/577413/.
+    From https://github.com/ActiveState/code/tree/master/recipes/Python/577413_Topological_Sort/recipe-577413.py.
     """
     # TODO: Use a faster algorithm?
     for k, v in data.items():


### PR DESCRIPTION
PyRun_InteractiveOne*() functions allow to explicitily set fd instead of stdin.
but stdin was hardcoded in readline call.

This patch does not fix target file for prompt unlike original bpo one : prompt fd is unrelated to tokenizer source which could be read only.

Also actual  documentation say "prompt the user" so one would expect prompt to go on stdout not a file for both  PyRun_InteractiveOne*()  and PyRun_InteractiveLoop*().


EDIT/ to be clear this is a &#x1F534;type-bugfix&#x1F534;


<!-- issue-number: [bpo-14916](https://bugs.python.org/issue14916) -->
https://bugs.python.org/issue14916
<!-- /issue-number -->
