### PR TITLE
Add option to omit build time

### DIFF
--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -5,7 +5,7 @@
 #endif
 
 #ifndef DATE
-#ifdef __DATE__
+#if defined(__DATE__) && !defined(OMIT_BUILD_TIMESTAMP)
 #define DATE __DATE__
 #else
 #define DATE "xx/xx/xx"
@@ -13,7 +13,7 @@
 #endif
 
 #ifndef TIME
-#ifdef __TIME__
+#if defined(__TIME__) && !defined(OMIT_BUILD_TIMESTAMP)
 #define TIME __TIME__
 #else
 #define TIME "xx:xx:xx"


### PR DESCRIPTION
This patch adds an option, `OMIT_BUILD_TIMESTAMP`, to `getbuildinfo.c`.
If this option is set, the compilation date will always be `xx/xx/xx xx:xx:xx`
This makes it easier to do reproducible builds.

This change is trivial and doesn't break any existing workflows; the option is opt-in.