### PR TITLE
bpo-41646: Mention path-like objects support in the docs for shutil.copy()

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -158,9 +158,9 @@ Directory and files operations
 .. function:: copy(src, dst, *, follow_symlinks=True)
 
    Copies the file *src* to the file or directory *dst*.  *src* and *dst*
-   should be strings.  If *dst* specifies a directory, the file will be
-   copied into *dst* using the base filename from *src*.  Returns the
-   path to the newly created file.
+   should be :term:`path-like objects <path-like object>` or strings.  If
+   *dst* specifies a directory, the file will be copied into *dst* using the
+   base filename from *src*.  Returns the path to the newly created file.
 
    If *follow_symlinks* is false, and *src* is a symbolic link,
    *dst* will be created as a symbolic link.  If *follow_symlinks*


### PR DESCRIPTION


<!-- issue-number: [bpo-41646](https://bugs.python.org/issue41646) -->
https://bugs.python.org/issue41646
<!-- /issue-number -->
