### PR TITLE
bpo-32218: make `Flag` and `IntFlag` members iterable

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -650,6 +650,13 @@ be combined with them::
     >>> Perm.X | 8
     <Perm.8|X: 9>
 
+:class:`IntFlag` members can also be iterated over::
+
+    >>> list(RW)
+    [<Perm.R: 4>, <Perm.W: 2>]
+
+.. versionadded:: 3.10
+
 
 Flag
 ^^^^
@@ -702,6 +709,14 @@ value::
     <Color.BLACK: 0>
     >>> bool(Color.BLACK)
     False
+
+:class:`Flag` members can also be iterated over::
+
+    >>> purple = Color.RED | Color.BLUE
+    >>> list(purple)
+    [<Color.BLUE: 2>, <Color.RED: 1>]
+
+.. versionadded:: 3.10
 
 .. note::
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -728,6 +728,10 @@ class Flag(Enum):
                     type(other).__qualname__, self.__class__.__qualname__))
         return other._value_ & self._value_ == other._value_
 
+    def __iter__(self):
+        members, extra_flags = _decompose(self.__class__, self.value)
+        return (m for m in members if m._value_ != 0)
+
     def __repr__(self):
         cls = self.__class__
         if self._name_ is not None:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2246,6 +2246,12 @@ class TestFlag(unittest.TestCase):
         self.assertFalse(W in RX)
         self.assertFalse(X in RW)
 
+    def test_member_iter(self):
+        Color = self.Color
+        self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
+        self.assertEqual(list(Color.BLUE), [Color.BLUE])
+        self.assertEqual(list(Color.GREEN), [Color.GREEN])
+
     def test_auto_number(self):
         class Color(Flag):
             red = auto()
@@ -2700,6 +2706,12 @@ class TestIntFlag(unittest.TestCase):
         self.assertFalse(X in RW)
         with self.assertRaises(TypeError):
             self.assertFalse('test' in RW)
+
+    def test_member_iter(self):
+        Color = self.Color
+        self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
+        self.assertEqual(list(Color.BLUE), [Color.BLUE])
+        self.assertEqual(list(Color.GREEN), [Color.GREEN])
 
     def test_bool(self):
         Perm = self.Perm

--- a/Misc/NEWS.d/next/Library/2020-09-12-16-18-42.bpo-32218.IpYkEe.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-12-16-18-42.bpo-32218.IpYkEe.rst
@@ -1,0 +1,1 @@
+`enum.Flag` and `enum.IntFlag` members are now iterable


### PR DESCRIPTION
Member and member combinations can now be iterated over:

    class Color(Flag):
        RED = 1
        BLUE = 2
        GREEN = 4

    purple = Color.RED | Color.BLUE
    list(purple)
    # [<Color.BLUE: 2>, <Color.RED: 1>]

<!-- issue-number: [bpo-32218](https://bugs.python.org/issue32218) -->
https://bugs.python.org/issue32218
<!-- /issue-number -->
