### PR TITLE
bpo-41778: Change a punctuation on documentation.

### DIFF
--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -480,8 +480,8 @@ input, output, and error streams.
    rarely used and is not guaranteed by WSGI. On IIS<7, though, the
    setting can only be made on a vhost level, affecting all other script
    mappings, many of which break when exposed to the ``PATH_TRANSLATED`` bug.
-   For this reason IIS<7 is almost never deployed with the fix. (Even IIS7
-   rarely uses it because there is still no UI for it.)
+   For this reason IIS<7 is almost never deployed with the fix (Even IIS7
+   rarely uses it because there is still no UI for it.).
 
    There is no way for CGI code to tell whether the option was set, so a
    separate handler class is provided.  It is used in the same way as


### PR DESCRIPTION
On this paragrapah the clarification about IIS7 seems there's not
connection beacuase is in other sentence. Move the punctuation
to connect both the last sentence with the information in the
parenthesis.

I think the NEWS is not necessary here.

<!-- issue-number: [bpo-41778](https://bugs.python.org/issue41778) -->
https://bugs.python.org/issue41778
<!-- /issue-number -->


Automerge-Triggered-By: @ericvsmith