### PR TITLE
bpo-40721: add note about enum member name case

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -21,8 +21,9 @@ by identity, and the enumeration itself can be iterated over.
 
 .. note:: Case of Enum Members
 
-    Because Enums are used to represent constants we will be using
-    UPPER_CASE names in our examples.
+    Because Enums are used to represent constants we recommend using
+    UPPER_CASE names for enum members, and will be using that style
+    in our examples.
 
 
 Module Contents

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -19,6 +19,11 @@ An enumeration is a set of symbolic names (members) bound to unique,
 constant values.  Within an enumeration, the members can be compared
 by identity, and the enumeration itself can be iterated over.
 
+.. note:: Case of Enum Members
+
+    Because Enums are used to represent constants we will be using
+    UPPER_CASE names in our examples.
+
 
 Module Contents
 ---------------


### PR DESCRIPTION
Which is that UPPER_CASE is preferred as enums are constants.

<!-- issue-number: [bpo-40721](https://bugs.python.org/issue40721) -->
https://bugs.python.org/issue40721
<!-- /issue-number -->


