### PR TITLE
[3.9] bpo-41778: Change a punctuation on documentation. (GH-22229)

### DIFF
--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -480,8 +480,8 @@ input, output, and error streams.
    rarely used and is not guaranteed by WSGI. On IIS<7, though, the
    setting can only be made on a vhost level, affecting all other script
    mappings, many of which break when exposed to the ``PATH_TRANSLATED`` bug.
-   For this reason IIS<7 is almost never deployed with the fix. (Even IIS7
-   rarely uses it because there is still no UI for it.)
+   For this reason IIS<7 is almost never deployed with the fix (Even IIS7
+   rarely uses it because there is still no UI for it.).
 
    There is no way for CGI code to tell whether the option was set, so a
    separate handler class is provided.  It is used in the same way as


### PR DESCRIPTION
On this paragrapah the clarification about IIS7 seems there's not
connection beacuase is in other sentence. Move the punctuation
to connect both the last sentence with the information in the
parenthesis.

I think the NEWS is not necessary here.

Automerge-Triggered-By: @ericvsmith
(cherry picked from commit 94bfdee25db31941b187591ae5ae9bf3ed431090)

Co-authored-by: Emmanuel Arias <eamanu@yaerobi.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41778](https://bugs.python.org/issue41778) -->
https://bugs.python.org/issue41778
<!-- /issue-number -->
