### PR TITLE
bpo-41792 / typing#751 - Add is_typeddict function to typing.py

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1658,6 +1658,20 @@ Introspection helpers
 
    .. versionadded:: 3.8
 
+.. function:: is_typeddict(tp)
+
+   Check if an annotation is a TypedDict class.
+
+   For example::
+        class Film(TypedDict):
+            title: str
+            year: int
+
+        is_typeddict(Film)  # => True
+        is_typeddict(Union[list, str])  # => False
+
+   .. versionadded:: 3.10
+
 .. class:: ForwardRef
 
    A class used for internal typing representation of string forward references.

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -16,6 +16,7 @@ from typing import Generic, ClassVar, Final, final, Protocol
 from typing import cast, runtime_checkable
 from typing import get_type_hints
 from typing import get_origin, get_args
+from typing import is_typeddict
 from typing import no_type_check, no_type_check_decorator
 from typing import Type
 from typing import NewType
@@ -3899,6 +3900,12 @@ class TypedDictTests(BaseTestCase):
             'tail': bool,
             'voice': str,
         }
+
+    def test_is_typeddict(self):
+        assert is_typeddict(Point2D) is True
+        assert is_typeddict(Union[str, int]) is False
+        # classes, not instances
+        assert is_typeddict(Point2D()) is False
 
 
 class IOTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -103,6 +103,7 @@ __all__ = [
     'get_args',
     'get_origin',
     'get_type_hints',
+    'is_typeddict',
     'NewType',
     'no_type_check',
     'no_type_check_decorator',
@@ -1477,6 +1478,20 @@ def get_args(tp):
     if isinstance(tp, GenericAlias):
         return tp.__args__
     return ()
+
+
+def is_typeddict(tp):
+    """Check if an annotation is a TypedDict class
+
+    For example::
+        class Film(TypedDict):
+            title: str
+            year: int
+
+        is_typeddict(Film)  # => True
+        is_typeddict(Union[list, str])  # => False
+    """
+    return isinstance(tp, _TypedDictMeta)
 
 
 def no_type_check(arg):

--- a/Misc/NEWS.d/next/Library/2020-09-15-07-55-35.bpo-41792.qMpSlU.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-15-07-55-35.bpo-41792.qMpSlU.rst
@@ -1,0 +1,6 @@
+Add is_typeddict function to typing.py to check if a type is a TypedDict
+class
+
+Previously there was no way to check that without using private API. See the
+`relevant issue in python/typing
+<https://github.com/python/typing/issues/751>`


### PR DESCRIPTION
Not a BPO issue, see https://github.com/python/typing/issues/751

<!-- issue-number: [bpo-41792](https://bugs.python.org/issue41792) -->
https://bugs.python.org/issue41792
<!-- /issue-number -->
