### PR TITLE
bpo-41517: do not allow Enums to be extended

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -124,10 +124,12 @@ class EnumMeta(type):
     """Metaclass for Enum"""
     @classmethod
     def __prepare__(metacls, cls, bases):
+        # check that previous enum members do not exist
+        metacls._check_for_existing_members(cls, bases)
         # create the namespace dict
         enum_dict = _EnumDict()
         # inherit previous flags and _generate_next_value_ function
-        member_type, first_enum = metacls._get_mixins_(bases)
+        member_type, first_enum = metacls._get_mixins_(cls, bases)
         if first_enum is not None:
             enum_dict['_generate_next_value_'] = getattr(first_enum, '_generate_next_value_', None)
         return enum_dict
@@ -143,7 +145,7 @@ class EnumMeta(type):
         ignore = classdict['_ignore_']
         for key in ignore:
             classdict.pop(key, None)
-        member_type, first_enum = metacls._get_mixins_(bases)
+        member_type, first_enum = metacls._get_mixins_(cls, bases)
         __new__, save_new, use_args = metacls._find_new_(classdict, member_type,
                                                         first_enum)
 
@@ -398,7 +400,7 @@ class EnumMeta(type):
         """
         metacls = cls.__class__
         bases = (cls, ) if type is None else (type, cls)
-        _, first_enum = cls._get_mixins_(bases)
+        _, first_enum = cls._get_mixins_(cls, bases)
         classdict = metacls.__prepare__(class_name, bases)
 
         # special processing needed for names?
@@ -471,7 +473,14 @@ class EnumMeta(type):
         return cls
 
     @staticmethod
-    def _get_mixins_(bases):
+    def _check_for_existing_members(class_name, bases):
+        for chain in bases:
+            for base in chain.__mro__:
+                    if issubclass(base, Enum) and base._member_names_:
+                        raise TypeError("%s: cannot extend enumeration %r" % (class_name, base.__name__))
+
+    @staticmethod
+    def _get_mixins_(class_name, bases):
         """Returns the type for creating enum members, and the first inherited
         enum class.
 
@@ -496,7 +505,7 @@ class EnumMeta(type):
                     elif not issubclass(base, Enum):
                         candidate = base
             if len(data_types) > 1:
-                raise TypeError('too many data types: %r' % data_types)
+                raise TypeError('%r: too many data types: %r' % (class_name, data_types))
             elif data_types:
                 return data_types[0]
             else:

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -476,8 +476,8 @@ class EnumMeta(type):
     def _check_for_existing_members(class_name, bases):
         for chain in bases:
             for base in chain.__mro__:
-                    if issubclass(base, Enum) and base._member_names_:
-                        raise TypeError("%s: cannot extend enumeration %r" % (class_name, base.__name__))
+                if issubclass(base, Enum) and base._member_names_:
+                    raise TypeError("%s: cannot extend enumeration %r" % (class_name, base.__name__))
 
     @staticmethod
     def _get_mixins_(class_name, bases):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1002,6 +1002,9 @@ class TestEnum(unittest.TestCase):
                 cyan = 4
                 magenta = 5
                 yellow = 6
+        with self.assertRaisesRegex(TypeError, "EvenMoreColor: cannot extend enumeration 'Color'"):
+            class EvenMoreColor(Color, IntEnum):
+                chartruese = 7
 
     def test_exclude_methods(self):
         class whatever(Enum):

--- a/Misc/NEWS.d/next/Library/2020-09-15-22-43-30.bpo-41517.sLBH7g.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-15-22-43-30.bpo-41517.sLBH7g.rst
@@ -1,0 +1,1 @@
+fix bug allowing Enums to be extended via multiple inheritance


### PR DESCRIPTION
fix bug that let Enums be extended via multiple inheritance

<!-- issue-number: [bpo-41517](https://bugs.python.org/issue41517) -->
https://bugs.python.org/issue41517
<!-- /issue-number -->
