### PR TITLE
[3.9] bpo-41789: honor object overrides in Enum classes (GH-22250)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -249,7 +249,11 @@ class EnumMeta(type):
 
         # double check that repr and friends are not the mixin's or various
         # things break (such as pickle)
+        # however, if the method is defined in the Enum itself, don't replace
+        # it
         for name in ('__repr__', '__str__', '__format__', '__reduce_ex__'):
+            if name in classdict:
+                continue
             class_method = getattr(enum_class, name)
             obj_method = getattr(member_type, name, None)
             enum_method = getattr(first_enum, name, None)

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -552,6 +552,14 @@ class TestEnum(unittest.TestCase):
         self.assertFormatIsValue('{:>20}', Directional.WEST)
         self.assertFormatIsValue('{:<20}', Directional.WEST)
 
+    def test_object_str_override(self):
+        class Colors(Enum):
+            RED, GREEN, BLUE = 1, 2, 3
+            def __repr__(self):
+                return "test.%s" % (self._name_, )
+            __str__ = object.__str__
+        self.assertEqual(str(Colors.RED), 'test.RED')
+
     def test_enum_str_override(self):
         class MyStrEnum(Enum):
             def __str__(self):
@@ -593,7 +601,6 @@ class TestEnum(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'too many data types'):
             class Huh(MyStr, MyInt, Enum):
                 One = 1
-
 
     def test_hash(self):
         Season = self.Season

--- a/Misc/NEWS.d/next/Library/2020-09-14-19-27-46.bpo-41789.pI_uZQ.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-14-19-27-46.bpo-41789.pI_uZQ.rst
@@ -1,0 +1,2 @@
+Honor `object` overrides in `Enum` class creation (specifically, `__str__`,
+`__repr__`, `__format__`, and `__reduce_ex__`).


### PR DESCRIPTION
EnumMeta double-checks that `__repr__`, `__str__`, `__format__`, and `__reduce_ex__` are not the same as `object`'s, and replaces them if they are -- even if that replacement was intentionally done in the Enum being constructed.  This patch fixes that.

<!-- issue-number: [bpo-41789](https://bugs.python.org/issue41789) -->
https://bugs.python.org/issue41789
<!-- /issue-number -->


