### PR TITLE
bpo-39728: Enum: fix duplicate `ValueError`

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -606,7 +606,7 @@ class Enum(metaclass=EnumMeta):
                         'error in %s._missing_: returned %r instead of None or a valid member'
                         % (cls.__name__, result)
                         )
-                exc.__context__ = ve_exc
+            exc.__context__ = ve_exc
             raise exc
 
     def _generate_next_value_(name, start, count, last_values):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -606,6 +606,7 @@ class Enum(metaclass=EnumMeta):
                         'error in %s._missing_: returned %r instead of None or a valid member'
                         % (cls.__name__, result)
                         )
+                exc.__context__ = ve_exc
             raise exc
 
     def _generate_next_value_(name, start, count, last_values):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -620,7 +620,7 @@ class Enum(metaclass=EnumMeta):
 
     @classmethod
     def _missing_(cls, value):
-        raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
+        return None
 
     def __repr__(self):
         return "<%s.%s: %r>" % (

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -606,7 +606,6 @@ class Enum(metaclass=EnumMeta):
                         'error in %s._missing_: returned %r instead of None or a valid member'
                         % (cls.__name__, result)
                         )
-            exc.__context__ = ve_exc
             raise exc
 
     def _generate_next_value_(name, start, count, last_values):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1862,10 +1862,18 @@ class TestEnum(unittest.TestCase):
         self.assertIs(Color('three'), Color.blue)
         with self.assertRaises(ValueError):
             Color(7)
-        with self.assertRaises(TypeError):
+        try:
             Color('bad return')
-        with self.assertRaises(ZeroDivisionError):
+        except TypeError as exc:
+            self.assertTrue(isinstance(exc.__context__, ValueError))
+        else:
+            raise Exception('Exception not raised.')
+        try:
             Color('error out')
+        except ZeroDivisionError as exc:
+            self.assertTrue(not exc.__context__)
+        else:
+            raise Exception('Exception not raised.')
 
     def test_multiple_mixin(self):
         class MaxMixin:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1871,7 +1871,7 @@ class TestEnum(unittest.TestCase):
         try:
             Color('error out')
         except ZeroDivisionError as exc:
-            self.assertTrue(not exc.__context__)
+            self.assertTrue(isinstance(exc.__context__, ValueError))
         else:
             raise Exception('Exception not raised.')
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1860,19 +1860,12 @@ class TestEnum(unittest.TestCase):
                     # trigger not found
                     return None
         self.assertIs(Color('three'), Color.blue)
-        self.assertRaises(ValueError, Color, 7)
-        try:
+        with self.assertRaises(ValueError):
+            Color(7)
+        with self.assertRaises(TypeError):
             Color('bad return')
-        except TypeError as exc:
-            self.assertTrue(isinstance(exc.__context__, ValueError))
-        else:
-            raise Exception('Exception not raised.')
-        try:
+        with self.assertRaises(ZeroDivisionError):
             Color('error out')
-        except ZeroDivisionError as exc:
-            self.assertTrue(isinstance(exc.__context__, ValueError))
-        else:
-            raise Exception('Exception not raised.')
 
     def test_multiple_mixin(self):
         class MaxMixin:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1842,6 +1842,18 @@ class TestEnum(unittest.TestCase):
             third = auto()
         self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
 
+    def test_default_missing(self):
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+        try:
+            Color(7)
+        except ValueError as exc:
+            self.assertTrue(exc.__context__ is None)
+        else:
+            raise Exception('Exception not raised.')
+
     def test_missing(self):
         class Color(Enum):
             red = 1
@@ -1860,8 +1872,12 @@ class TestEnum(unittest.TestCase):
                     # trigger not found
                     return None
         self.assertIs(Color('three'), Color.blue)
-        with self.assertRaises(ValueError):
+        try:
             Color(7)
+        except ValueError as exc:
+            self.assertTrue(exc.__context__ is None)
+        else:
+            raise Exception('Exception not raised.')
         try:
             Color('bad return')
         except TypeError as exc:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -433,6 +433,7 @@ Marcos Donolo
 Dima Dorfman
 Yves Dorfsman
 Michael Dorman
+Andrey Doroschenko
 Steve Dower
 Allen Downey
 Cesar Douady

--- a/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
@@ -1,0 +1,1 @@
+Instantiating enum with invalid value results in ValueError twice

--- a/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
@@ -1,1 +1,1 @@
-Instantiating enum with invalid value results in ValueError twice
+fix default `_missing_` so a duplicate `ValueError` is not set as the `__context__` of the original `ValueError`


### PR DESCRIPTION
`_missing_` should not raise a `ValueError` when it fails to match, it should return `None`

<!-- issue-number: [bpo-39728](https://bugs.python.org/issue39728) -->
https://bugs.python.org/issue39728
<!-- /issue-number -->
