### PR TITLE
[3.9] bpo-39728: Enum: fix duplicate `ValueError` (GH-22277)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -628,7 +628,7 @@ class Enum(metaclass=EnumMeta):
 
     @classmethod
     def _missing_(cls, value):
-        raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
+        return None
 
     def __repr__(self):
         return "<%s.%s: %r>" % (

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1821,6 +1821,18 @@ class TestEnum(unittest.TestCase):
             third = auto()
         self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
 
+    def test_default_missing(self):
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+        try:
+            Color(7)
+        except ValueError as exc:
+            self.assertTrue(exc.__context__ is None)
+        else:
+            raise Exception('Exception not raised.')
+
     def test_missing(self):
         class Color(Enum):
             red = 1
@@ -1839,7 +1851,12 @@ class TestEnum(unittest.TestCase):
                     # trigger not found
                     return None
         self.assertIs(Color('three'), Color.blue)
-        self.assertRaises(ValueError, Color, 7)
+        try:
+            Color(7)
+        except ValueError as exc:
+            self.assertTrue(exc.__context__ is None)
+        else:
+            raise Exception('Exception not raised.')
         try:
             Color('bad return')
         except TypeError as exc:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -432,6 +432,7 @@ Marcos Donolo
 Dima Dorfman
 Yves Dorfsman
 Michael Dorman
+Andrey Doroschenko
 Steve Dower
 Allen Downey
 Cesar Douady

--- a/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-24-10-58-34.bpo-39728.kOOaHn.rst
@@ -1,0 +1,1 @@
+fix default `_missing_` so a duplicate `ValueError` is not set as the `__context__` of the original `ValueError`


### PR DESCRIPTION
fix default `_missing_` to return `None` instead of raising a `ValueError`
Co-authored-by: Andrey Darascheka <andrei.daraschenka@leverx.com>
(cherry picked from commit c95ad7a91fbd7636f33a098d3b39964ab083bf49)

Co-authored-by: Ethan Furman <ethan@stoneleaf.us>

<!-- issue-number: [bpo-39728](https://bugs.python.org/issue39728) -->
https://bugs.python.org/issue39728
<!-- /issue-number -->


