### PR TITLE
bpo-41802: Document 'PyDict_DelItem' can raise a 'KeyError'

### DIFF
--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -81,14 +81,15 @@ Dictionary Objects
 .. c:function:: int PyDict_DelItem(PyObject *p, PyObject *key)
 
    Remove the entry in dictionary *p* with key *key*. *key* must be hashable;
-   if it isn't, :exc:`TypeError` is raised, if key is not in the dictionary,
+   if it isn't, :exc:`TypeError` is raised, if *key* is not in the dictionary,
    :exc:`KeyError` is raised. Return ``0`` on success or ``-1`` on failure.
 
 
 .. c:function:: int PyDict_DelItemString(PyObject *p, const char *key)
 
    Remove the entry in dictionary *p* which has a key specified by the string
-   *key*.  Return ``0`` on success or ``-1`` on failure.
+   *key*.  If *key* is not in the dictionary, :exc:`KeyError` is raised.
+   Return ``0`` on success or ``-1`` on failure.
 
 
 .. c:function:: PyObject* PyDict_GetItem(PyObject *p, PyObject *key)

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -81,8 +81,8 @@ Dictionary Objects
 .. c:function:: int PyDict_DelItem(PyObject *p, PyObject *key)
 
    Remove the entry in dictionary *p* with key *key*. *key* must be hashable;
-   if it isn't, :exc:`TypeError` is raised.  Return ``0`` on success or ``-1``
-   on failure.
+   if it isn't, :exc:`TypeError` is raised, if key is not in the dictionary,
+   :exc:`KeyError` is raised. Return ``0`` on success or ``-1`` on failure.
 
 
 .. c:function:: int PyDict_DelItemString(PyObject *p, const char *key)

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -81,14 +81,15 @@ Dictionary Objects
 .. c:function:: int PyDict_DelItem(PyObject *p, PyObject *key)
 
    Remove the entry in dictionary *p* with key *key*. *key* must be hashable;
-   if it isn't, :exc:`TypeError` is raised, if *key* is not in the dictionary,
-   :exc:`KeyError` is raised. Return ``0`` on success or ``-1`` on failure.
+   if it isn't, :exc:`TypeError` is raised.
+   If *key* is not in the dictionary, :exc:`KeyError` is raised.
+   Return ``0`` on success or ``-1`` on failure.
 
 
 .. c:function:: int PyDict_DelItemString(PyObject *p, const char *key)
 
-   Remove the entry in dictionary *p* which has a key specified by the string
-   *key*.  If *key* is not in the dictionary, :exc:`KeyError` is raised.
+   Remove the entry in dictionary *p* which has a key specified by the string *key*.
+   If *key* is not in the dictionary, :exc:`KeyError` is raised.
    Return ``0`` on success or ``-1`` on failure.
 
 


### PR DESCRIPTION
Correct Documentation, as it's not documented that deleting a key `PyDict_DelItem` will raise a `KeyError` if it's not in the dictionary.

This caused me to accidentally misuse the API recently.

https://developer.blender.org/rBef4877fde311f0638617cc6ff29cf64aedb4dab3

issue #41802

<!-- issue-number: [bpo-41802](https://bugs.python.org/issue41802) -->
https://bugs.python.org/issue41802
<!-- /issue-number -->
