### PR TITLE
Fix import of HTTPError

### DIFF
--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -9,7 +9,8 @@ import os
 import io
 import hashlib
 from base64 import standard_b64encode
-from urllib.request import urlopen, Request, HTTPError
+from urllib.error import HTTPError
+from urllib.request import urlopen, Request
 from urllib.parse import urlparse
 from distutils.errors import DistutilsError, DistutilsOptionError
 from distutils.core import PyPIRCCommand

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 import unittest.mock as mock
-from urllib.request import HTTPError
+from urllib.error import HTTPError
 
 from test.support import run_unittest
 


### PR DESCRIPTION
Import HTTPError from urllib.error instead of urllib.request.

This issue was flagged by python/typeshed#2149. It is a minor issue, but helps in the effort to check the standard lib with mypy.