### PR TITLE
bpo-41561: skip test_min_max_version_mismatch (GH-22308)

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3854,6 +3854,7 @@ class ThreadedTests(unittest.TestCase):
 
     @requires_minimum_version
     @requires_tls_version('TLSv1_2')
+    @requires_tls_version('TLSv1')
     def test_min_max_version_mismatch(self):
         client_context, server_context, hostname = testing_context()
         # client 1.0, server 1.2 (mismatch)

--- a/Misc/NEWS.d/next/Tests/2020-09-18-16-14-03.bpo-41561.uPnwrW.rst
+++ b/Misc/NEWS.d/next/Tests/2020-09-18-16-14-03.bpo-41561.uPnwrW.rst
@@ -1,0 +1,1 @@
+test_ssl: skip test_min_max_version_mismatch when TLS 1.0 is not available


### PR DESCRIPTION
skip test_min_max_version_mismatch when TLS 1.0 is not available

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41561](https://bugs.python.org/issue41561) -->
https://bugs.python.org/issue41561
<!-- /issue-number -->
