### PR TITLE
[3.9] bpo-35293: Travis CI uses "make venv" for the doc (GH-22307)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,7 @@ matrix:
       env: TESTING=docs
       before_script:
         - cd Doc
-        # Sphinx is pinned so that new versions that introduce new warnings won't suddenly cause build failures.
-        # (Updating the version is fine as long as no warnings are raised by doing so.)
-        # The theme used by the docs is stored separately, so we need to install that as well.
-        - python -m pip install sphinx==2.2.0 blurb python-docs-theme
+        - make venv PYTHON=python
       script:
         - make check suspicious html SPHINXOPTS="-q -W -j4"
     - name: "Documentation tests"

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -143,7 +143,7 @@ clean:
 venv:
 	$(PYTHON) -m venv $(VENVDIR)
 	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
-	$(VENVDIR)/bin/python3 -m pip install -U Sphinx==2.3.1 blurb python-docs-theme
+	$(VENVDIR)/bin/python3 -m pip install -r requirements.txt
 	@echo "The venv has been created in the $(VENVDIR) directory"
 
 dist:

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -1,5 +1,12 @@
-# Requirements for docs build on netlify
-# Pin sphinx to version specified in .travis.yml
-sphinx==2.2.0
+# Requirements to build the Python documentation
+
+# Sphinx version is pinned so that new versions that introduce new warnings
+# won't suddenly cause build failures. Updating the version is fine as long
+# as no warnings are raised by doing so.
+sphinx==2.4.4
+
 blurb
+
+# The theme used by the documentation is stored separately, so we need
+# to install that as well.
 python-docs-theme


### PR DESCRIPTION
Doc/requirements.txt becomes the reference for packages and package
versions needed to build the Python documentation.

* Doc/Makefile now uses Doc/requirements.txt
* .travis.yml now uses "make env" of Doc/Makefile
* Update Sphinx to version 2.4.4

(cherry picked from commit 8394500cca56490cc347604d39ca40abcdce46c3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35293](https://bugs.python.org/issue35293) -->
https://bugs.python.org/issue35293
<!-- /issue-number -->
