### PR TITLE
Update import.rst

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -982,9 +982,9 @@ __main__.__spec__
 Depending on how :mod:`__main__` is initialized, ``__main__.__spec__``
 gets set appropriately or to ``None``.
 
-When Python is started with the :option:`-m` option, ``__spec__`` is set
-to the module spec of the corresponding module or package. ``__spec__`` is
-also populated when the ``__main__`` module is loaded as part of executing a
+When Python is started with the :option:`-m` option, ``__main__.__spec__`` is set
+to the module spec of the corresponding module or package. ``__main__.__spec__`` is
+also populated when the :mod:`__main__` module is loaded as part of executing a
 directory, zipfile or other :data:`sys.path` entry.
 
 In :ref:`the remaining cases <using-on-interface-options>`
@@ -1001,11 +1001,11 @@ Note that ``__main__.__spec__`` is always ``None`` in the last case,
 instead. Use the :option:`-m` switch if valid module metadata is desired
 in :mod:`__main__`.
 
-Note also that even when ``__main__`` corresponds with an importable module
-and ``__main__.__spec__`` is set accordingly, they're still considered
+Note also that even when :mod:`__main__` corresponds with an importable module
+and ``__main__.__spec__`` is set accordingly, they are still considered
 *distinct* modules. This is due to the fact that blocks guarded by
-``if __name__ == "__main__":`` checks only execute when the module is used
-to populate the ``__main__`` namespace, and not during normal import.
+``if __name__ == '__main__':`` checks only execute when the module is used
+to populate the :mod:`__main__` namespace, and not during normal import.
 
 
 Open issues


### PR DESCRIPTION
This minor PR adds missing prefixes `__main__.` and formatting tags `:mod:` in the section [5.8. Special considerations for \_\_main__](https://docs.python.org/3/reference/import.html#special-considerations-for-main) of the import system documentation.