### PR TITLE
[doc] Replace super(XXX, self) with super() in code examples

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1188,7 +1188,7 @@ to the above, as in the following example::
 
     class StyleAdapter(logging.LoggerAdapter):
         def __init__(self, logger, extra=None):
-            super(StyleAdapter, self).__init__(logger, extra or {})
+            super().__init__(logger, extra or {})
 
         def log(self, level, msg, /, *args, **kwargs):
             if self.isEnabledFor(level):
@@ -1783,7 +1783,7 @@ as in the following complete example::
                 return tuple(o)
             elif isinstance(o, unicode):
                 return o.encode('unicode_escape').decode('ascii')
-            return super(Encoder, self).default(o)
+            return super().default(o)
 
     class StructuredMessage:
         def __init__(self, message, /, **kwargs):
@@ -2175,11 +2175,11 @@ class, as shown in the following example::
             """
             Format an exception so that it prints on a single line.
             """
-            result = super(OneLineExceptionFormatter, self).formatException(exc_info)
+            result = super().formatException(exc_info)
             return repr(result)  # or format into one line however you want to
 
         def format(self, record):
-            s = super(OneLineExceptionFormatter, self).format(record)
+            s = super().format(record)
             if record.exc_text:
                 s = s.replace('\n', '') + '|'
             return s
@@ -2813,7 +2813,7 @@ refer to the comments in the code snippet for more detailed information.
     #
     class QtHandler(logging.Handler):
         def __init__(self, slotfunc, *args, **kwargs):
-            super(QtHandler, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             self.signaller = Signaller()
             self.signaller.signal.connect(slotfunc)
 
@@ -2883,7 +2883,7 @@ refer to the comments in the code snippet for more detailed information.
         }
 
         def __init__(self, app):
-            super(Window, self).__init__()
+            super().__init__()
             self.app = app
             self.textedit = te = QtWidgets.QPlainTextEdit(self)
             # Set whatever the default monospace font is for the platform

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -863,7 +863,7 @@ An example of a custom action::
    ...     def __init__(self, option_strings, dest, nargs=None, **kwargs):
    ...         if nargs is not None:
    ...             raise ValueError("nargs not allowed")
-   ...         super(FooAction, self).__init__(option_strings, dest, **kwargs)
+   ...         super().__init__(option_strings, dest, **kwargs)
    ...     def __call__(self, parser, namespace, values, option_string=None):
    ...         print('%r %r %r' % (namespace, values, option_string))
    ...         setattr(namespace, self.dest, values)

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -638,7 +638,7 @@ even further by means of a small helper class::
 
    class Callback(ExitStack):
        def __init__(self, callback, /, *args, **kwds):
-           super(Callback, self).__init__()
+           super().__init__()
            self.callback(callback, *args, **kwds)
 
        def cancel(self):

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1926,7 +1926,7 @@ client to access it remotely::
     >>> class Worker(Process):
     ...     def __init__(self, q):
     ...         self.q = q
-    ...         super(Worker, self).__init__()
+    ...         super().__init__()
     ...     def run(self):
     ...         self.q.put('local hello')
     ...

--- a/Doc/library/unittest.mock-examples.rst
+++ b/Doc/library/unittest.mock-examples.rst
@@ -893,7 +893,7 @@ Here's an example implementation:
     ...     def __call__(self, /, *args, **kwargs):
     ...         args = deepcopy(args)
     ...         kwargs = deepcopy(kwargs)
-    ...         return super(CopyingMock, self).__call__(*args, **kwargs)
+    ...         return super().__call__(*args, **kwargs)
     ...
     >>> c = CopyingMock(return_value=None)
     >>> arg = set()

--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -382,7 +382,7 @@ the referent is accessed::
 
    class ExtendedRef(weakref.ref):
        def __init__(self, ob, callback=None, /, **annotations):
-           super(ExtendedRef, self).__init__(ob, callback)
+           super().__init__(ob, callback)
            self.__counter = 0
            for k, v in annotations.items():
                setattr(self, k, v)
@@ -391,7 +391,7 @@ the referent is accessed::
            """Return a pair containing the referent and the number of
            times the reference has been called.
            """
-           ob = super(ExtendedRef, self).__call__()
+           ob = super().__call__()
            if ob is not None:
                self.__counter += 1
                ob = (ob, self.__counter)


### PR DESCRIPTION
As it is documented, it can make one think passing args to super() in these cases is needed, which is misleading.