### PR TITLE
bpo-41513: Make steps after the loop consistent with the loop body

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2550,8 +2550,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             assert(csum + lo * lo == csum);
             frac_lo += lo * lo;
         }
-        frac += frac_lo + frac_mid;
-        h = sqrt(csum - 1.0 + frac);
+        h = sqrt(csum - 1.0 + (frac_lo + frac_mid + frac));
 
         x = h;
         t = x * T27;
@@ -2569,15 +2568,15 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac += (oldcsum - csum) + x;
+        frac_mid += (oldcsum - csum) + x;
 
         x = -lo * lo;
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac += (oldcsum - csum) + x;
+        frac_lo += (oldcsum - csum) + x;
 
-        x = csum - 1.0 + frac;
+        x = csum - 1.0 + (frac_lo + frac_mid + frac);
         return (h + x / (2.0 * h)) / scale;
     }
     /* When max_e < -1023, ldexp(1.0, -max_e) overflows.


### PR DESCRIPTION
Make the post-loop code more consistent with the loop body.  Improves internal accuracy by not prematurely combining the separate accumulators.

Accuracy measurements. "hypot3" is current baseline.  "hypot12" includes this PR.  Column 1 is the number of dimensions. Column 2 is the weighted average number of bits of accuracy (higher is better). Column 3 is the algorithm.  Column 4 has counts for number of bits of accuracy, `(104, 111)` means 111 cases where the accuracy was 104 bits:

```
$ python3.9 best_frac.py
n=2	108.69	hypot3	[(104, 111), (105, 1924), (106, 10415), ...
n=2	108.93	hypot12	[(104, 43), (105, 926), (106, 7569), ...

n=3	108.22	hypot3	[(103, 1), (104, 170), (105, 3060), (106, 13216), ...
n=3	108.47	hypot12	[(104, 55), (105, 1355), (106, 9510), ...

n=5	107.96	hypot3	[(103, 4), (104, 300), (105, 4188), (106, 15269), ...
n=5	108.17	hypot12	[(104, 133), (105, 1772), (106, 12429), ...

n=10	107.77	hypot3	[(103, 20), (104, 920), (105, 6295), (106, 17161), ...
n=10	107.97	hypot12	[(103, 2), (104, 357), (105, 3351), (106, 15103), ...

n=20	107.74	hypot3	[(103, 56), (104, 895), (105, 6319), (106, 17725), ...
n=20	107.91	hypot12	[(103, 13), (104, 390), (105, 3898), (106, 15418), ...

n=50	107.54	hypot3	[(103, 35), (104, 1068), (105, 8344), (106, 20028), ...
n=50	107.70	hypot12	[(103, 8), (104, 484), (105, 5360), (106, 18953), ...

n=100	107.17	hypot3	[(102, 1), (103, 138), (104, 2516), (105, 11646), (106, 24699), ...
n=100	107.30	hypot12	[(102, 1), (103, 37), (104, 1513), (105, 9966), (106, 23976), ...

n=1000	104.64	hypot3	[(100, 12), (101, 661), (102, 6047), (103, 19302), (104, 27590), (105, 21319), (106, 12119), ...
n=1000	104.70	hypot12	[(100, 11), (101, 595), (102, 5524), (103, 18350), (104, 27514), (105, 21928), (106, 12718), ...
```

<!-- issue-number: [bpo-41513](https://bugs.python.org/issue41513) -->
https://bugs.python.org/issue41513
<!-- /issue-number -->
