### PR TITLE
bpo-39385: Add missing what's new entry for TestCase.assertNoLogs

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -145,6 +145,13 @@ Add :data:`sys.orig_argv` attribute: the list of the original command line
 arguments passed to the Python executable.
 (Contributed by Victor Stinner in :issue:`23427`.)
 
+unittest
+--------
+
+Add new method :meth:`~unittest.TestCase.assertNoLogs` to complement the
+existing :meth:`~unittest.TestCase.assertLogs`. (Contributed by Kit Yan Choi
+in :issue:`39385`.)
+
 xml
 ---
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -306,6 +306,7 @@ Albert Chin-A-Young
 Adal Chiriliuc
 Matt Chisholm
 Lita Cho
+Kit Yan Choi
 Sayan Chowdhury
 Yuan-Chao Chou
 Anders Chrigström


### PR DESCRIPTION
This PR adds a what's new entry and an author acknowledgement for #18067.

<!-- issue-number: [bpo-39385](https://bugs.python.org/issue39385) -->
https://bugs.python.org/issue39385
<!-- /issue-number -->
