### PR TITLE
bpo-41815: SQLite: segfault if backup called on closed database

### DIFF
--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -35,6 +35,13 @@ class BackupTests(unittest.TestCase):
         with self.assertRaises(sqlite.ProgrammingError):
             self.cx.backup(bck)
 
+    def test_bad_source_closed_connection(self):
+        bck = sqlite.connect(':memory:')
+        source = sqlite.connect(":memory:")
+        source.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            source.backup(bck)
+
     def test_bad_target_in_transaction(self):
         bck = sqlite.connect(':memory:')
         bck.execute('CREATE TABLE bar (key INTEGER)')

--- a/Misc/NEWS.d/next/Library/2020-09-19-23-14-54.bpo-41815.RNpuX3.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-19-23-14-54.bpo-41815.RNpuX3.rst
@@ -1,0 +1,2 @@
+Fix SQLite3 segfault when backing up closed database. Patch contributed by
+Peter David McCormick.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1514,6 +1514,10 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
         sleep_ms = (int)ms;
     }
 
+    if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+
     if (!pysqlite_check_connection((pysqlite_Connection *)target)) {
         return NULL;
     }


### PR DESCRIPTION
# [bpo-41815](https://bugs.python.org/issue41815): SQLite: fix segfault if backup called on closed database

Attempting to backup a closed database will trigger segfault:

```python
import sqlite3
target = sqlite3.connect(':memory:')
source = sqlite3.connect(':memory:')
source.close()
source.backup(target)
```

<!-- issue-number: [bpo-41815](https://bugs.python.org/issue41815) -->
https://bugs.python.org/issue41815
<!-- /issue-number -->


Automerge-Triggered-By: @aeros