### PR TITLE
gh-79509: Always set VIRTUAL_ENV_PROMPT at venv activation

### DIFF
--- a/Lib/venv/scripts/common/Activate.ps1
+++ b/Lib/venv/scripts/common/Activate.ps1
@@ -218,6 +218,7 @@ deactivate -nondestructive
 # Now set the environment variable VIRTUAL_ENV, used by many tools to determine
 # that there is an activated venv.
 $env:VIRTUAL_ENV = $VenvDir
+$env:VIRTUAL_ENV_PROMPT = $Prompt
 
 if (-not $Env:VIRTUAL_ENV_DISABLE_PROMPT) {
 
@@ -233,7 +234,6 @@ if (-not $Env:VIRTUAL_ENV_DISABLE_PROMPT) {
         Write-Host -NoNewline -ForegroundColor Green "($_PYTHON_VENV_PROMPT_PREFIX) "
         _OLD_VIRTUAL_PROMPT
     }
-    $env:VIRTUAL_ENV_PROMPT = $Prompt
 }
 
 # Clear PYTHONHOME

--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -40,6 +40,8 @@ deactivate nondestructive
 
 VIRTUAL_ENV="__VENV_DIR__"
 export VIRTUAL_ENV
+VIRTUAL_ENV_PROMPT="__VENV_PROMPT__"
+export VIRTUAL_ENV_PROMPT
 
 _OLD_VIRTUAL_PATH="$PATH"
 PATH="$VIRTUAL_ENV/__VENV_BIN_NAME__:$PATH"
@@ -57,8 +59,6 @@ if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1:-}"
     PS1="__VENV_PROMPT__${PS1:-}"
     export PS1
-    VIRTUAL_ENV_PROMPT="__VENV_PROMPT__"
-    export VIRTUAL_ENV_PROMPT
 fi
 
 # This should detect bash and zsh, which have a hash command that must

--- a/Lib/venv/scripts/posix/activate.csh
+++ b/Lib/venv/scripts/posix/activate.csh
@@ -9,6 +9,7 @@ alias deactivate 'test $?_OLD_VIRTUAL_PATH != 0 && setenv PATH "$_OLD_VIRTUAL_PA
 deactivate nondestructive
 
 setenv VIRTUAL_ENV "__VENV_DIR__"
+setenv VIRTUAL_ENV_PROMPT "__VENV_PROMPT__"
 
 set _OLD_VIRTUAL_PATH="$PATH"
 setenv PATH "$VIRTUAL_ENV/__VENV_BIN_NAME__:$PATH"
@@ -18,7 +19,6 @@ set _OLD_VIRTUAL_PROMPT="$prompt"
 
 if (! "$?VIRTUAL_ENV_DISABLE_PROMPT") then
     set prompt = "__VENV_PROMPT__$prompt"
-    setenv VIRTUAL_ENV_PROMPT "__VENV_PROMPT__"
 endif
 
 alias pydoc python -m pydoc

--- a/Lib/venv/scripts/posix/activate.fish
+++ b/Lib/venv/scripts/posix/activate.fish
@@ -31,6 +31,7 @@ end
 deactivate nondestructive
 
 set -gx VIRTUAL_ENV "__VENV_DIR__"
+set -gx VIRTUAL_ENV_PROMPT "__VENV_PROMPT__"
 
 set -gx _OLD_VIRTUAL_PATH $PATH
 set -gx PATH "$VIRTUAL_ENV/__VENV_BIN_NAME__" $PATH
@@ -62,5 +63,4 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
     end
 
     set -gx _OLD_FISH_PROMPT_OVERRIDE "$VIRTUAL_ENV"
-    set -gx VIRTUAL_ENV_PROMPT "__VENV_PROMPT__"
 end


### PR DESCRIPTION
This is a follow-up to [GH-21587](https://github.com/python/cpython/pull/21587) and modifies the behavior so that `VIRTUAL_ENV_PROMPT` is always set.

The change is needed because `VIRTUAL_ENV_PROMPT` is being conditionally set only if `VIRTUAL_ENV_DISABLE_PROMPT` is unset. Shell prompts must set `VIRTUAL_ENV_DISABLE_PROMPT` to non-empty to prevent venv from hijacking PS1. I'm one of the maintainers of the Pure prompt for zsh, and for us it would be great if `VIRTUAL_ENV_PROMPT` could always be set, just as `VIRTUAL_ENV` is too.

No news added since this PR is true to the news written in [GH-21587](https://github.com/python/cpython/pull/21587).

<!-- issue-number: [bpo-35328](https://bugs.python.org/issue35328) -->
https://bugs.python.org/issue35328
<!-- /issue-number -->

<!-- gh-issue-number: gh-79509 -->
* Issue: gh-79509
<!-- /gh-issue-number -->
