### PR TITLE
bpo-1635741: replace UCD_Check with Py_IS_TYPE

### DIFF
--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -92,7 +92,12 @@ static PyMemberDef DB_members[] = {
 
 /* forward declaration */
 static PyTypeObject UCD_Type;
-#define UCD_Check(o) Py_IS_TYPE(o, &UCD_Type)
+
+//check if self is of given type (which will be UCD_Type)
+//UCD_Type is not in the macro because this will become a heap
+//type and will need to be passed in.  self is NULL when
+//the PyCapsule API is used.
+#define UCD_Check(self, type) self && Py_IS_TYPE(self, type)
 
 static PyObject*
 new_previous_version(const char*name, const change_record* (*getrecord)(Py_UCS4),
@@ -135,7 +140,7 @@ unicodedata_UCD_decimal_impl(PyObject *self, int chr,
     long rc;
     Py_UCS4 c = (Py_UCS4)chr;
 
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0) {
             /* unassigned */
@@ -223,7 +228,7 @@ unicodedata_UCD_numeric_impl(PyObject *self, int chr,
     double rc;
     Py_UCS4 c = (Py_UCS4)chr;
 
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0) {
             /* unassigned */
@@ -268,7 +273,7 @@ unicodedata_UCD_category_impl(PyObject *self, int chr)
     int index;
     Py_UCS4 c = (Py_UCS4)chr;
     index = (int) _getrecord_ex(c)->category;
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed != 0xFF)
             index = old->category_changed;
@@ -295,7 +300,7 @@ unicodedata_UCD_bidirectional_impl(PyObject *self, int chr)
     int index;
     Py_UCS4 c = (Py_UCS4)chr;
     index = (int) _getrecord_ex(c)->bidirectional;
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0)
             index = 0; /* unassigned */
@@ -324,7 +329,7 @@ unicodedata_UCD_combining_impl(PyObject *self, int chr)
     int index;
     Py_UCS4 c = (Py_UCS4)chr;
     index = (int) _getrecord_ex(c)->combining;
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0)
             index = 0; /* unassigned */
@@ -352,7 +357,7 @@ unicodedata_UCD_mirrored_impl(PyObject *self, int chr)
     int index;
     Py_UCS4 c = (Py_UCS4)chr;
     index = (int) _getrecord_ex(c)->mirrored;
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0)
             index = 0; /* unassigned */
@@ -379,7 +384,7 @@ unicodedata_UCD_east_asian_width_impl(PyObject *self, int chr)
     int index;
     Py_UCS4 c = (Py_UCS4)chr;
     index = (int) _getrecord_ex(c)->east_asian_width;
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0)
             index = 0; /* unassigned */
@@ -413,7 +418,7 @@ unicodedata_UCD_decomposition_impl(PyObject *self, int chr)
 
     code = (int)c;
 
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0)
             return PyUnicode_FromString(""); /* unassigned */
@@ -460,7 +465,7 @@ get_decomp_record(PyObject *self, Py_UCS4 code, int *index, int *prefix, int *co
 {
     if (code >= 0x110000) {
         *index = 0;
-    } else if (self && UCD_Check(self) &&
+    } else if (UCD_Check(self, &UCD_Type) &&
                get_old_record(self, code)->category_changed==0) {
         /* unassigned in old version */
         *index = 0;
@@ -558,7 +563,7 @@ nfd_nfkd(PyObject *self, PyObject *input, int k)
                 continue;
             }
             /* normalization changes */
-            if (self && UCD_Check(self)) {
+            if (UCD_Check(self, &UCD_Type)) {
                 Py_UCS4 value = ((PreviousDBVersion*)self)->normalization(code);
                 if (value != 0) {
                     stack[stackptr++] = value;
@@ -799,7 +804,7 @@ is_normalized_quickcheck(PyObject *self, PyObject *input,
 {
     /* An older version of the database is requested, quickchecks must be
        disabled. */
-    if (self && UCD_Check(self))
+    if (UCD_Check(self, &UCD_Type))
         return NO;
 
     Py_ssize_t i, len;
@@ -1066,7 +1071,7 @@ _getucname(PyObject *self, Py_UCS4 code, char* buffer, int buflen,
     if (!with_alias_and_seq && (IS_ALIAS(code) || IS_NAMED_SEQ(code)))
         return 0;
 
-    if (self && UCD_Check(self)) {
+    if (UCD_Check(self, &UCD_Type)) {
         /* in 3.2.0 there are no aliases and named sequences */
         const change_record *old;
         if (IS_ALIAS(code) || IS_NAMED_SEQ(code))

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -93,11 +93,9 @@ static PyMemberDef DB_members[] = {
 /* forward declaration */
 static PyTypeObject UCD_Type;
 
-//check if self is of given type (which will be UCD_Type)
-//UCD_Type is not in the macro because this will become a heap
-//type and will need to be passed in.  self is NULL when
-//the PyCapsule API is used.
-#define UCD_Check(self, type) self && Py_IS_TYPE(self, type)
+// Check if self is an instance of UCD_Type.
+// Return 0 if self is NULL (when the PyCapsule C API is used).
+#define UCD_Check(self, ucd_type) (self != NULL && Py_IS_TYPE(self, ucd_type))
 
 static PyObject*
 new_previous_version(const char*name, const change_record* (*getrecord)(Py_UCS4),


### PR DESCRIPTION
First stage requested by @vstinner from #22145 - "Add a ucd_type parameter to UCD_Check() macro".  Since this would make UCD_Check equivalent to Py_IS_TYPE, I instead converted to Py_IS_TYPE everywhere.


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
