### PR TITLE
[3.9] bpo-41631: Fix a compiler warning in pycore_pylifecycle.h

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -82,7 +82,7 @@ extern void _PyFaulthandler_Fini(void);
 extern void _PyHash_Fini(void);
 extern void _PyTraceMalloc_Fini(void);
 extern void _PyWarnings_Fini(PyInterpreterState *interp);
-extern void _PyAST_Fini();
+extern void _PyAST_Fini(void);
 
 extern PyStatus _PyGILState_Init(PyThreadState *tstate);
 extern void _PyGILState_Fini(PyThreadState *tstate);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41631](https://bugs.python.org/issue41631) -->
https://bugs.python.org/issue41631
<!-- /issue-number -->

This PR suppress this warning introduced in 55e0836849c14fb474e1ba7f37851e07660eea3c:

```
./Include/internal/pycore_pylifecycle.h:85:24: warning: this function declaration is not 1 warning generated.
a prototype [-Wstrict-prototypes]
extern void _PyAST_Fini();
                       ^
                        void
```