### PR TITLE
bpo-41819: Fix "warning: format specifies type `wint_t` (aka `int`)"

### DIFF
--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2674,7 +2674,7 @@ init_dump_ascii_wstr(const wchar_t *str)
         if (ch == L'\'') {
             PySys_WriteStderr("\\'");
         } else if (0x20 <= ch && ch < 0x7f) {
-            PySys_WriteStderr("%lc", ch);
+            PySys_WriteStderr("%c", ch);
         }
         else if (ch <= 0xff) {
             PySys_WriteStderr("\\x%02x", ch);


### PR DESCRIPTION


<!-- issue-number: [bpo-41819](https://bugs.python.org/issue41819) -->
https://bugs.python.org/issue41819
<!-- /issue-number -->
