### PR TITLE
[3.8] bpo-39871: Fix an error in a news entry (GH-21749)

### DIFF
--- a/Misc/NEWS.d/3.8.3rc1.rst
+++ b/Misc/NEWS.d/3.8.3rc1.rst
@@ -83,7 +83,7 @@ Wozniski.
 
 Fix a possible :exc:`SystemError` in ``math.{atan2,copysign,remainder}()``
 when the first argument cannot be converted to a :class:`float`. Patch by
-Zachary Spytz.
+Zackery Spytz.
 
 ..
 


### PR DESCRIPTION
(cherry picked from commit 54636355805dd2877bb54fbad8d967e1ddd8b553)


<!-- issue-number: [bpo-39871](https://bugs.python.org/issue39871) -->
https://bugs.python.org/issue39871
<!-- /issue-number -->
