### PR TITLE
bpo-41817: use new StrEnum to ensure all members are strings

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -144,12 +144,12 @@ def _splitdict(tk, v, cut_minus=True, conv=None):
     return dict
 
 
-class EventType(str, enum.Enum):
+class EventType(enum.StrEnum):
     KeyPress = '2'
-    Key = KeyPress,
+    Key = KeyPress
     KeyRelease = '3'
     ButtonPress = '4'
-    Button = ButtonPress,
+    Button = ButtonPress
     ButtonRelease = '5'
     Motion = '6'
     Enter = '7'
@@ -180,10 +180,10 @@ class EventType(str, enum.Enum):
     Colormap = '32'
     ClientMessage = '33'    # undocumented
     Mapping = '34'          # undocumented
-    VirtualEvent = '35',    # undocumented
-    Activate = '36',
-    Deactivate = '37',
-    MouseWheel = '38',
+    VirtualEvent = '35'     # undocumented
+    Activate = '36'
+    Deactivate = '37'
+    MouseWheel = '38'
 
     def __str__(self):
         return self.name

--- a/Misc/NEWS.d/next/Library/2020-09-22-00-23-30.bpo-41817.bnh-VG.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-22-00-23-30.bpo-41817.bnh-VG.rst
@@ -1,0 +1,1 @@
+fix `tkinter.EventType` Enum so all members are strings, and none are tuples


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41817](https://bugs.python.org/issue41817) -->
https://bugs.python.org/issue41817
<!-- /issue-number -->
