### PR TITLE
[doc] description in threading

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -455,7 +455,7 @@ All methods are executed atomically.
       block until the lock is unlocked, then set it to locked and return ``True``.
 
       When invoked with the *blocking* argument set to ``False``, do not block.
-      If a call with *blocking* set to ``True`` would block, return ``False``
+      If a call with *blocking* set to ``False`` would block, return ``False``
       immediately; otherwise, set the lock to locked and return ``True``.
 
       When invoked with the floating-point *timeout* argument set to a positive


### PR DESCRIPTION
If blocking is **False** and another thread holds the lock, the method will return False immediately.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
