### PR TITLE
bpo-41833: threading.Thread now uses the target name

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -264,8 +264,10 @@ since it is impossible to detect the termination of alien threads.
    *target* is the callable object to be invoked by the :meth:`run` method.
    Defaults to ``None``, meaning nothing is called.
 
-   *name* is the thread name.  By default, a unique name is constructed of the
-   form "Thread-*N*" where *N* is a small decimal number.
+   *name* is the thread name. By default, a unique name is constructed
+   of the form "Thread-*N*" where *N* is a small decimal number,
+   or "Thread-*N* (target)" where "target" is ``target.__name__`` if the
+   *target* argument is specified.
 
    *args* is the argument tuple for the target invocation.  Defaults to ``()``.
 
@@ -279,6 +281,9 @@ since it is impossible to detect the termination of alien threads.
    If the subclass overrides the constructor, it must make sure to invoke the
    base class constructor (``Thread.__init__()``) before doing anything else to
    the thread.
+
+   .. versionchanged:: 3.10
+      Use the *target* name if *name* argument is omitted.
 
    .. versionchanged:: 3.3
       Added the *daemon* argument.

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -801,7 +801,7 @@ class Thread:
             kwargs = {}
         if name:
             name = str(name)
-        if not name:
+        else:
             name = _newname("Thread-%d")
             if target is not None:
                 try:

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -802,14 +802,13 @@ class Thread:
         if name:
             name = str(name)
         if not name:
-            name_template = "Thread-%d"
+            name = _newname("Thread-%d")
             if target is not None:
                 try:
                     target_name = target.__name__
-                    name_template = f"{name_template} ({target_name})"
+                    name += f" ({target_name})"
                 except AttributeError:
                     pass
-            name = _newname(name_template)
 
         self._target = target
         self._name = name

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -745,10 +745,9 @@ class BrokenBarrierError(RuntimeError):
 
 
 # Helper to generate new thread names
-_counter = _count().__next__
-_counter() # Consume 0 so first non-main thread has id 1.
-def _newname(template="Thread-%d"):
-    return template % _counter()
+_counter = _count(1).__next__
+def _newname(name_template):
+    return name_template % _counter()
 
 # Active thread administration
 _active_limbo_lock = _allocate_lock()
@@ -800,8 +799,20 @@ class Thread:
         assert group is None, "group argument must be None for now"
         if kwargs is None:
             kwargs = {}
+        if name:
+            name = str(name)
+        if not name:
+            name_template = "Thread-%d"
+            if target is not None:
+                try:
+                    target_name = target.__name__
+                    name_template = f"{name_template} ({target_name})"
+                except AttributeError:
+                    pass
+            name = _newname(name_template)
+
         self._target = target
-        self._name = str(name or _newname())
+        self._name = name
         self._args = args
         self._kwargs = kwargs
         if daemon is not None:

--- a/Misc/NEWS.d/next/Library/2020-09-22-13-51-14.bpo-41833.6HVDjT.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-22-13-51-14.bpo-41833.6HVDjT.rst
@@ -1,0 +1,2 @@
+The :class:`threading.Thread` constructor now uses the target name if the
+*target* argument is specified but the *name* argument is omitted.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41833](https://bugs.python.org/issue41833) -->
https://bugs.python.org/issue41833
<!-- /issue-number -->
