### PR TITLE
bpo-40670: More reliable validation of statements in timeit.Timer.

### DIFF
--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -77,6 +77,9 @@ class TestTimeit(unittest.TestCase):
         self.assertRaises(SyntaxError, timeit.Timer, stmt='break')
         self.assertRaises(SyntaxError, timeit.Timer, stmt='continue')
         self.assertRaises(SyntaxError, timeit.Timer, stmt='from timeit import *')
+        self.assertRaises(SyntaxError, timeit.Timer, stmt='  pass')
+        self.assertRaises(SyntaxError, timeit.Timer,
+                          setup='while False:\n  pass', stmt='  break')
 
     def test_timer_invalid_setup(self):
         self.assertRaises(ValueError, timeit.Timer, setup=None)
@@ -86,6 +89,12 @@ class TestTimeit(unittest.TestCase):
         self.assertRaises(SyntaxError, timeit.Timer, setup='break')
         self.assertRaises(SyntaxError, timeit.Timer, setup='continue')
         self.assertRaises(SyntaxError, timeit.Timer, setup='from timeit import *')
+        self.assertRaises(SyntaxError, timeit.Timer, setup='  pass')
+
+    def test_timer_empty_stmt(self):
+        timeit.Timer(stmt='')
+        timeit.Timer(stmt=' \n\t\f')
+        timeit.Timer(stmt='# comment')
 
     fake_setup = "import timeit\ntimeit._fake_timer.setup()"
     fake_stmt = "import timeit\ntimeit._fake_timer.inc()"

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -72,6 +72,7 @@ def inner(_it, _timer{init}):
     _t0 = _timer()
     for _i in _it:
         {stmt}
+        pass
     _t1 = _timer()
     return _t1 - _t0
 """

--- a/Misc/NEWS.d/next/Library/2020-09-22-14-55-34.bpo-40670.R5sm68.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-22-14-55-34.bpo-40670.R5sm68.rst
@@ -1,3 +1,3 @@
-More reliable validation of statements in :class:`timit.Timer`. It now
+More reliable validation of statements in :class:`timeit.Timer`. It now
 accepts "empty" statements (only whitespaces and comments) and rejects
 misindentent statements.

--- a/Misc/NEWS.d/next/Library/2020-09-22-14-55-34.bpo-40670.R5sm68.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-22-14-55-34.bpo-40670.R5sm68.rst
@@ -1,0 +1,3 @@
+More reliable validation of statements in :class:`timit.Timer`. It now
+accepts "empty" statements (only whitespaces and comments) and rejects
+misindentent statements.


### PR DESCRIPTION
It now accepts "empty" statements (only whitespaces and comments)
and rejects misindentent statements.


<!-- issue-number: [bpo-40670](https://bugs.python.org/issue40670) -->
https://bugs.python.org/issue40670
<!-- /issue-number -->
