### PR TITLE
bpo-41834: Remove _Py_CheckRecursionLimit variable

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -314,3 +314,7 @@ Removed
 * Removed ``PyUnicode_AsUnicodeCopy()``. Please use :c:func:`PyUnicode_AsUCS4Copy` or
   :c:func:`PyUnicode_AsWideCharString`
   (Contributed by Inada Naoki in :issue:`41103`.)
+
+* Removed ``_Py_CheckRecursionLimit`` variable: it has been replaced by
+  ``ceval.recursion_limit`` of the :c:type:`PyInterpreterState` structure.
+  (Contributed by Victor Stinner in :issue:`41834`.)

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -63,8 +63,6 @@ extern void _PyEval_ReleaseLock(PyThreadState *tstate);
 
 /* --- _Py_EnterRecursiveCall() ----------------------------------------- */
 
-PyAPI_DATA(int) _Py_CheckRecursionLimit;
-
 #ifdef USE_STACKCHECK
 /* With USE_STACKCHECK macro defined, trigger stack checks in
    _Py_CheckRecursiveCall() on every 64th call to Py_EnterRecursiveCall. */

--- a/Misc/NEWS.d/next/C API/2020-09-22-14-47-12.bpo-41834.nrOrDU.rst
+++ b/Misc/NEWS.d/next/C API/2020-09-22-14-47-12.bpo-41834.nrOrDU.rst
@@ -1,0 +1,3 @@
+Remove the ``_Py_CheckRecursionLimit`` variable: it has been replaced by
+``ceval.recursion_limit`` of the :c:type:`PyInterpreterState`
+structure. Patch by Victor Stinner.

--- a/PC/python3dll.c
+++ b/PC/python3dll.c
@@ -663,7 +663,6 @@ EXPORT_FUNC(PyWeakref_NewProxy)
 EXPORT_FUNC(PyWeakref_NewRef)
 EXPORT_FUNC(PyWrapper_New)
 
-EXPORT_DATA(_Py_CheckRecursionLimit)
 EXPORT_DATA(_Py_EllipsisObject)
 EXPORT_DATA(_Py_FalseStruct)
 EXPORT_DATA(_Py_NoneStruct)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -741,15 +741,12 @@ Py_MakePendingCalls(void)
 /* The interpreter's recursion limit */
 
 #ifndef Py_DEFAULT_RECURSION_LIMIT
-#define Py_DEFAULT_RECURSION_LIMIT 1000
+#  define Py_DEFAULT_RECURSION_LIMIT 1000
 #endif
-
-int _Py_CheckRecursionLimit = Py_DEFAULT_RECURSION_LIMIT;
 
 void
 _PyEval_InitRuntimeState(struct _ceval_runtime_state *ceval)
 {
-    _Py_CheckRecursionLimit = Py_DEFAULT_RECURSION_LIMIT;
 #ifndef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
     _gil_initialize(&ceval->gil);
 #endif
@@ -797,14 +794,11 @@ Py_SetRecursionLimit(int new_limit)
 {
     PyThreadState *tstate = _PyThreadState_GET();
     tstate->interp->ceval.recursion_limit = new_limit;
-    if (_Py_IsMainInterpreter(tstate)) {
-        _Py_CheckRecursionLimit = new_limit;
-    }
 }
 
 /* The function _Py_EnterRecursiveCall() only calls _Py_CheckRecursiveCall()
-   if the recursion_depth reaches _Py_CheckRecursionLimit.
-   If USE_STACKCHECK, the macro decrements _Py_CheckRecursionLimit
+   if the recursion_depth reaches recursion_limit.
+   If USE_STACKCHECK, the macro decrements recursion_limit
    to guarantee that _Py_CheckRecursiveCall() is regularly called.
    Without USE_STACKCHECK, there is no need for this. */
 int
@@ -818,10 +812,6 @@ _Py_CheckRecursiveCall(PyThreadState *tstate, const char *where)
         --tstate->recursion_depth;
         _PyErr_SetString(tstate, PyExc_MemoryError, "Stack overflow");
         return -1;
-    }
-    if (_Py_IsMainInterpreter(tstate)) {
-        /* Needed for ABI backwards-compatibility (see bpo-31857) */
-        _Py_CheckRecursionLimit = recursion_limit;
     }
 #endif
     if (tstate->recursion_critical)

--- a/Tools/c-analyzer/TODO
+++ b/Tools/c-analyzer/TODO
@@ -66,7 +66,6 @@ Objects/tupleobject.c:_Py_tuple_zero_allocs                      Py_ssize_t _Py_
 Objects/typeobject.c:next_version_tag                            static unsigned int next_version_tag
 Python/Python-ast.c:init_types():initialized                     static int initialized
 Python/bootstrap_hash.c:urandom_cache                            static struct { int fd; dev_t st_dev; ino_t st_ino; } urandom_cache
-Python/ceval.c:_Py_CheckRecursionLimit                           int _Py_CheckRecursionLimit
 Python/ceval.c:lltrace                                           static int lltrace
 Python/ceval.c:make_pending_calls():busy                         static int busy
 Python/dynload_shlib.c:handles                                   static struct { dev_t dev; ino_t ino; void *handle; } handles[128]

--- a/Tools/c-analyzer/known.tsv
+++ b/Tools/c-analyzer/known.tsv
@@ -805,7 +805,6 @@ Objects/iterobject.c	-	PyCallIter_Type	variable	PyTypeObject PyCallIter_Type
 Objects/capsule.c	-	PyCapsule_Type	variable	PyTypeObject PyCapsule_Type
 Objects/cellobject.c	-	PyCell_Type	variable	PyTypeObject PyCell_Type
 Objects/methodobject.c	-	PyCFunction_Type	variable	PyTypeObject PyCFunction_Type
-Python/ceval.c	-	_Py_CheckRecursionLimit	variable	int _Py_CheckRecursionLimit
 Objects/descrobject.c	-	PyClassMethodDescr_Type	variable	PyTypeObject PyClassMethodDescr_Type
 Objects/funcobject.c	-	PyClassMethod_Type	variable	PyTypeObject PyClassMethod_Type
 Objects/codeobject.c	-	PyCode_Type	variable	PyTypeObject PyCode_Type


### PR DESCRIPTION
Remove the global _Py_CheckRecursionLimit variable: it has been
replaced by ceval.recursion_critical of the PyInterpreterState
structure.

There is no need to keep the variable for the stable ABI, since
Py_EnterRecursiveCall() and Py_LeaveRecursiveCall() were not usable
in Python 3.8 and older: these macros accessed PyThreadState members,
whereas the PyThreadState structure is opaque in the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41834](https://bugs.python.org/issue41834) -->
https://bugs.python.org/issue41834
<!-- /issue-number -->
