### PR TITLE
bpo-41842: Add a unregister function in _codecs module

### DIFF
--- a/Doc/c-api/codec.rst
+++ b/Doc/c-api/codec.rst
@@ -10,6 +10,16 @@ Codec registry and support functions
    As side effect, this tries to load the :mod:`encodings` package, if not yet
    done, to make sure that it is always first in the list of search functions.
 
+.. c:function:: int PyCodec_Unregister(PyObject *search_function)
+
+   Unregister a codec search function.
+
+   Unregister a codec search function and clear the registry's cache.
+   If the search function is not registered, do nothing.
+   Return 0 on success. Raise an exception and return -1 on success.
+
+   .. versionadded:: 3.10
+
 .. c:function:: int PyCodec_KnownEncoding(const char *encoding)
 
    Return ``1`` or ``0`` depending on whether there is a registered codec for

--- a/Doc/c-api/codec.rst
+++ b/Doc/c-api/codec.rst
@@ -12,8 +12,6 @@ Codec registry and support functions
 
 .. c:function:: int PyCodec_Unregister(PyObject *search_function)
 
-   Unregister a codec search function.
-
    Unregister a codec search function and clear the registry's cache.
    If the search function is not registered, do nothing.
    Return 0 on success. Raise an exception and return -1 on success.

--- a/Doc/c-api/codec.rst
+++ b/Doc/c-api/codec.rst
@@ -14,7 +14,7 @@ Codec registry and support functions
 
    Unregister a codec search function and clear the registry's cache.
    If the search function is not registered, do nothing.
-   Return 0 on success. Raise an exception and return -1 on success.
+   Return 0 on success. Raise an exception and return -1 on error.
 
    .. versionadded:: 3.10
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -165,9 +165,16 @@ function:
 
    .. note::
 
-      Search function registration is not currently reversible,
-      which may cause problems in some cases, such as unit testing or
-      module reloading.
+      Search function registration is reversible since Python 3.10.
+      You can use `codecs.unregister()` to unregister the search function.
+
+.. function:: unregister(search_function)
+
+   Unregister a codec search function from the codecs registry. If
+   the search function haven't registered, this function dose nothing.
+
+   .. versionadded:: 3.10
+
 
 While the builtin :func:`open` and the associated :mod:`io` module are the
 recommended approach for working with encoded text files, this module

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -166,9 +166,8 @@ function:
 
 .. function:: unregister(search_function)
 
-   Unregister a codec search function from the codecs registry.
+   Unregister a codec search function and clear the registry's cache.
    If the search function is not registered, do nothing.
-   Clear the registry's cache if the codec search function is removed.
 
    .. versionadded:: 3.10
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -163,15 +163,12 @@ function:
    :class:`CodecInfo` object. In case a search function cannot find
    a given encoding, it should return ``None``.
 
-   .. note::
-
-      Search function registration is reversible since Python 3.10.
-      You can use `codecs.unregister()` to unregister the search function.
 
 .. function:: unregister(search_function)
 
-   Unregister a codec search function from the codecs registry. If
-   the search function haven't registered, this function dose nothing.
+   Unregister a codec search function from the codecs registry.
+   If the search function is not registered, do nothing.
+   Clear the registry's cache if the codec search function is removed.
 
    .. versionadded:: 3.10
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -112,7 +112,7 @@ Base32 Encoding with Extended Hex Alphabet.
 codecs
 ------
 
-Add :func:`_codecs.unregister` to unregister a codec search function.
+Add :func:`codecs.unregister` to unregister a codec search function.
 
 curses
 ------

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -112,8 +112,7 @@ Base32 Encoding with Extended Hex Alphabet.
 codecs
 ------
 
-Add :func:`codecs.unregister` and :c:func:`PyCodec_Unregister` to unregister
-a codec search function.
+Add a :func:`codecs.unregister` to unregister a codec search function.
 
 curses
 ------
@@ -228,6 +227,9 @@ New Features
   structure: the list of the original command line arguments passed to the
   Python executable.
   (Contributed by Victor Stinner in :issue:`23427`.)
+
+* Add a c:func:`PyCodec_Unregister` to unregister a codec search function.
+  (Contributed by Hai Shi in :issue:`41842`.)
 
 Porting to Python 3.10
 ----------------------

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -112,7 +112,7 @@ Base32 Encoding with Extended Hex Alphabet.
 codecs
 ------
 
-Add a :func:`codecs.unregister` to unregister a codec search function.
+Add a :func:`codecs.unregister` function to unregister a codec search function.
 (Contributed by Hai Shi in :issue:`41842`.)
 
 curses
@@ -243,7 +243,8 @@ New Features
   :class:`datetime.time` objects.
   (Contributed by Zackery Spytz in :issue:`30155`.)
 
-* Add a :c:func:`PyCodec_Unregister` to unregister a codec search function.
+* Add a :c:func:`PyCodec_Unregister` function to unregister a codec
+  search function.
   (Contributed by Hai Shi in :issue:`41842`.)
 
 Porting to Python 3.10

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -112,7 +112,8 @@ Base32 Encoding with Extended Hex Alphabet.
 codecs
 ------
 
-Add :func:`codecs.unregister` to unregister a codec search function.
+Add :func:`codecs.unregister` and :c:func:`PyCodec_Unregister` to unregister
+a codec search function.
 
 curses
 ------

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -113,6 +113,7 @@ codecs
 ------
 
 Add a :func:`codecs.unregister` to unregister a codec search function.
+(Contributed by Hai Shi in :issue:`41842`.)
 
 curses
 ------
@@ -244,8 +245,6 @@ New Features
 
 * Add a :c:func:`PyCodec_Unregister` to unregister a codec search function.
   (Contributed by Hai Shi in :issue:`41842`.)
-
-=======
 
 Porting to Python 3.10
 ----------------------

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -109,6 +109,11 @@ base64
 Add :func:`base64.b32hexencode` and :func:`base64.b32hexdecode` to support the
 Base32 Encoding with Extended Hex Alphabet.
 
+codecs
+------
+
+Add :func:`_codecs.unregister` to unregister a codec search function.
+
 curses
 ------
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -242,7 +242,7 @@ New Features
   :class:`datetime.time` objects.
   (Contributed by Zackery Spytz in :issue:`30155`.)
 
-* Add a c:func:`PyCodec_Unregister` to unregister a codec search function.
+* Add a :c:func:`PyCodec_Unregister` to unregister a codec search function.
   (Contributed by Hai Shi in :issue:`41842`.)
 
 =======

--- a/Include/codecs.h
+++ b/Include/codecs.h
@@ -27,6 +27,16 @@ PyAPI_FUNC(int) PyCodec_Register(
        PyObject *search_function
        );
 
+/* Unregister a codec search function.
+
+   Unregister a codec search function and clear the registry's cache.
+   If the search function is not registered, do nothing.
+   */
+
+PyAPI_FUNC(int) PyCodec_Unregister(
+       PyObject *search_function
+       );
+
 /* Codec registry lookup API.
 
    Looks up the given encoding and returns a CodecInfo object with
@@ -52,10 +62,6 @@ PyAPI_FUNC(PyObject *) _PyCodec_Lookup(
 
 PyAPI_FUNC(int) _PyCodec_Forget(
        const char *encoding
-       );
-
-PyAPI_FUNC(int) _PyCodec_Unregister(
-       PyObject *search_function
        );
 #endif
 

--- a/Include/codecs.h
+++ b/Include/codecs.h
@@ -31,7 +31,7 @@ PyAPI_FUNC(int) PyCodec_Register(
 
    Unregister a codec search function and clear the registry's cache.
    If the search function is not registered, do nothing.
-   Return 0 on success. Raise an exception and return -1 on success. */
+   Return 0 on success. Raise an exception and return -1 on error. */
 
 PyAPI_FUNC(int) PyCodec_Unregister(
        PyObject *search_function

--- a/Include/codecs.h
+++ b/Include/codecs.h
@@ -27,9 +27,7 @@ PyAPI_FUNC(int) PyCodec_Register(
        PyObject *search_function
        );
 
-/* Unregister a codec search function.
-
-   Unregister a codec search function and clear the registry's cache.
+/* Unregister a codec search function and clear the registry's cache.
    If the search function is not registered, do nothing.
    Return 0 on success. Raise an exception and return -1 on error. */
 

--- a/Include/codecs.h
+++ b/Include/codecs.h
@@ -53,6 +53,10 @@ PyAPI_FUNC(PyObject *) _PyCodec_Lookup(
 PyAPI_FUNC(int) _PyCodec_Forget(
        const char *encoding
        );
+
+PyAPI_FUNC(PyObject *) _PyCodec_Unregister(
+       PyObject *search_function
+       );
 #endif
 
 /* Codec registry encoding check API.

--- a/Include/codecs.h
+++ b/Include/codecs.h
@@ -31,7 +31,7 @@ PyAPI_FUNC(int) PyCodec_Register(
 
    Unregister a codec search function and clear the registry's cache.
    If the search function is not registered, do nothing.
-   */
+   Return 0 on success. Raise an exception and return -1 on success. */
 
 PyAPI_FUNC(int) PyCodec_Unregister(
        PyObject *search_function

--- a/Include/codecs.h
+++ b/Include/codecs.h
@@ -54,7 +54,7 @@ PyAPI_FUNC(int) _PyCodec_Forget(
        const char *encoding
        );
 
-PyAPI_FUNC(PyObject *) _PyCodec_Unregister(
+PyAPI_FUNC(int) _PyCodec_Unregister(
        PyObject *search_function
        );
 #endif

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1642,10 +1642,14 @@ class CodecsModuleTest(unittest.TestCase):
         self.assertRaises(TypeError, codecs.register, 42)
 
     def test_unregister(self):
-        search_function = mock.Mock(return_value=(1, 2, 3, 4))
+        name = "nonexistent_codec_name"
+        search_function = mock.Mock()
         codecs.register(search_function)
+        self.assertRaises(TypeError, codecs.lookup, name)
+        search_function.assert_called_with(name)
+        search_function.reset_mock()
         codecs.unregister(search_function)
-        self.assertRaises(LookupError, codecs.lookup, "nonexistent_codec_name")
+        self.assertRaises(LookupError, codecs.lookup, name)
         search_function.assert_not_called()
 
     def test_lookup(self):

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1642,10 +1642,11 @@ class CodecsModuleTest(unittest.TestCase):
         self.assertRaises(TypeError, codecs.register, 42)
 
     def test_unregister(self):
-        def test_encoding(encoding):
-            return None
-        codecs.register(test_encoding)
-        self.assertEqual(codecs.unregister(test_encoding), None)
+        search_function = mock.Mock(return_value=(1, 2, 3, 4))
+        codecs.register(search_function)
+        codecs.unregister(search_function)
+        self.assertRaises(LookupError, codecs.lookup, "test")
+        search_function.assert_not_called()
 
     def test_lookup(self):
         self.assertRaises(TypeError, codecs.lookup)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1648,6 +1648,7 @@ class CodecsModuleTest(unittest.TestCase):
         self.assertRaises(TypeError, codecs.lookup, name)
         search_function.assert_called_with(name)
         search_function.reset_mock()
+
         codecs.unregister(search_function)
         self.assertRaises(LookupError, codecs.lookup, name)
         search_function.assert_not_called()

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1645,7 +1645,7 @@ class CodecsModuleTest(unittest.TestCase):
         search_function = mock.Mock(return_value=(1, 2, 3, 4))
         codecs.register(search_function)
         codecs.unregister(search_function)
-        self.assertRaises(LookupError, codecs.lookup, "test")
+        self.assertRaises(LookupError, codecs.lookup, "nonexistent_codec_name")
         search_function.assert_not_called()
 
     def test_lookup(self):

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1641,6 +1641,12 @@ class CodecsModuleTest(unittest.TestCase):
         self.assertRaises(TypeError, codecs.register)
         self.assertRaises(TypeError, codecs.register, 42)
 
+    def test_unregister(self):
+        def test_encoding(encoding):
+            return None
+        codecs.register(test_encoding)
+        self.assertEqual(codecs.unregister(test_encoding), None)
+
     def test_lookup(self):
         self.assertRaises(TypeError, codecs.lookup)
         self.assertRaises(LookupError, codecs.lookup, "__spam__")

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1574,6 +1574,7 @@ Akash Shende
 Charlie Shepherd
 Bruce Sherwood
 Gregory Shevchenko
+Hai Shi
 Alexander Shigin
 Pete Shinners
 Michael Shiplett

--- a/Misc/NEWS.d/next/C API/2020-09-27-20-43-16.bpo-41842.bCakAj.rst
+++ b/Misc/NEWS.d/next/C API/2020-09-27-20-43-16.bpo-41842.bCakAj.rst
@@ -1,0 +1,2 @@
+Add :c:func:`PyCodec_Unregister` function to unregister a codec search
+function.

--- a/Misc/NEWS.d/next/Library/2020-09-22-20-54-18.bpo-39337.zX2e5M.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-22-20-54-18.bpo-39337.zX2e5M.rst
@@ -1,2 +1,0 @@
-Add a :func:`_codecs.unregister` which could unregister a codec search
-function from the codec registry.

--- a/Misc/NEWS.d/next/Library/2020-09-22-20-54-18.bpo-39337.zX2e5M.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-22-20-54-18.bpo-39337.zX2e5M.rst
@@ -1,0 +1,2 @@
+Add a :func:`_codecs.unregister` which could unregister a codec search
+function from the codec registry.

--- a/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
@@ -1,2 +1,1 @@
-Add :func:`codecs.unregister` and :c:func:`PyCodec_Unregister` to unregister
-a codec search function.
+Add :func:`codecs.unregister` function to unregister a codec search function.

--- a/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
@@ -1,1 +1,2 @@
-Add a :func:`codecs.unregister` to unregister a codec search function.
+Add :func:`codecs.unregister` and :c:func:`PyCodec_Unregister` to unregister
+a codec search function.

--- a/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
@@ -1,0 +1,1 @@
+Add a :func:`_codecs.unregister` to unregister a codec search function.

--- a/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-23-22-52-24.bpo-41842.lIuhC9.rst
@@ -1,1 +1,1 @@
-Add a :func:`_codecs.unregister` to unregister a codec search function.
+Add a :func:`codecs.unregister` to unregister a codec search function.

--- a/Modules/_codecsmodule.c
+++ b/Modules/_codecsmodule.c
@@ -73,16 +73,16 @@ _codecs.unregister
     search_function: object
     /
 
-Unregister a codec search function.
+Unregister a codec search function and clear the registry's cache.
 
 If the search function is not registered, do nothing.
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_unregister(PyObject *module, PyObject *search_function)
-/*[clinic end generated code: output=1f0edee9cf246399 input=8bfb99685e00d653]*/
+/*[clinic end generated code: output=1f0edee9cf246399 input=dd7c004c652d345e]*/
 {
-    if (_PyCodec_Unregister(search_function)) {
+    if (PyCodec_Unregister(search_function) < 0) {
         return NULL;
     }
 

--- a/Modules/_codecsmodule.c
+++ b/Modules/_codecsmodule.c
@@ -75,15 +75,18 @@ _codecs.unregister
 
 Unregister a codec search function.
 
-Unregister a codec search function from codec registry. If the search
-function haven't registered, this function does nothing.
+If the search function is not registered, do nothing.
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_unregister(PyObject *module, PyObject *search_function)
-/*[clinic end generated code: output=1f0edee9cf246399 input=ecb26613941e6a47]*/
+/*[clinic end generated code: output=1f0edee9cf246399 input=8bfb99685e00d653]*/
 {
-    return _PyCodec_Unregister(search_function);
+    if (_PyCodec_Unregister(search_function)) {
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
 }
 
 /*[clinic input]

--- a/Modules/_codecsmodule.c
+++ b/Modules/_codecsmodule.c
@@ -69,6 +69,24 @@ _codecs_register(PyObject *module, PyObject *search_function)
 }
 
 /*[clinic input]
+_codecs.unregister
+    search_function: object
+    /
+
+Unregister a codec search function.
+
+Unregister a codec search function from codec registry. If the search
+function haven't registered, this function does nothing.
+[clinic start generated code]*/
+
+static PyObject *
+_codecs_unregister(PyObject *module, PyObject *search_function)
+/*[clinic end generated code: output=1f0edee9cf246399 input=ecb26613941e6a47]*/
+{
+    return _PyCodec_Unregister(search_function);
+}
+
+/*[clinic input]
 _codecs.lookup
     encoding: str
     /
@@ -992,6 +1010,7 @@ _codecs_lookup_error_impl(PyObject *module, const char *name)
 
 static PyMethodDef _codecs_functions[] = {
     _CODECS_REGISTER_METHODDEF
+    _CODECS_UNREGISTER_METHODDEF
     _CODECS_LOOKUP_METHODDEF
     _CODECS_ENCODE_METHODDEF
     _CODECS_DECODE_METHODDEF

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -21,8 +21,7 @@ PyDoc_STRVAR(_codecs_unregister__doc__,
 "\n"
 "Unregister a codec search function.\n"
 "\n"
-"Unregister a codec search function from codec registry. If the search\n"
-"function haven\'t registered, this function does nothing.");
+"If the search function is not registered, do nothing.");
 
 #define _CODECS_UNREGISTER_METHODDEF    \
     {"unregister", (PyCFunction)_codecs_unregister, METH_O, _codecs_unregister__doc__},
@@ -2839,4 +2838,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=b2d6d8e9caa87da7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=47d275cbfe79eea2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -19,7 +19,7 @@ PyDoc_STRVAR(_codecs_unregister__doc__,
 "unregister($module, search_function, /)\n"
 "--\n"
 "\n"
-"Unregister a codec search function.\n"
+"Unregister a codec search function and clear the registry\'s cache.\n"
 "\n"
 "If the search function is not registered, do nothing.");
 
@@ -2838,4 +2838,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=47d275cbfe79eea2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9a97e2ddf3e69072 input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -15,6 +15,18 @@ PyDoc_STRVAR(_codecs_register__doc__,
 #define _CODECS_REGISTER_METHODDEF    \
     {"register", (PyCFunction)_codecs_register, METH_O, _codecs_register__doc__},
 
+PyDoc_STRVAR(_codecs_unregister__doc__,
+"unregister($module, search_function, /)\n"
+"--\n"
+"\n"
+"Unregister a codec search function.\n"
+"\n"
+"Unregister a codec search function from codec registry. If the search\n"
+"function haven\'t registered, this function does nothing.");
+
+#define _CODECS_UNREGISTER_METHODDEF    \
+    {"unregister", (PyCFunction)_codecs_unregister, METH_O, _codecs_unregister__doc__},
+
 PyDoc_STRVAR(_codecs_lookup__doc__,
 "lookup($module, encoding, /)\n"
 "--\n"
@@ -2827,4 +2839,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=eeead01414be6e42 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b2d6d8e9caa87da7 input=a9049054013a1b77]*/

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -60,11 +60,15 @@ PyCodec_Unregister(PyObject *search_function)
         return 0;
     }
 
-    Py_ssize_t n = PyList_Size(codec_search_path);
+    assert(PyList_CheckExact(codec_search_path));
+    Py_ssize_t n = PyList_GET_SIZE(codec_search_path);
     for (Py_ssize_t i = 0; i < n; i++) {
-        PyObject *item = PyList_GetItem(codec_search_path, i);
+        PyObject *item = PyList_GET_ITEM(codec_search_path, i);
         if (item == search_function) {
-            PyDict_Clear(interp->codec_search_cache);
+            if (interp->codec_search_cache != NULL) {
+                assert(PyDict_Check(interp->codec_search_cache));
+                PyDict_Clear(interp->codec_search_cache);
+            }
             return PyList_SetSlice(codec_search_path, i, i+1, NULL);
         }
     }

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -54,17 +54,18 @@ int
 PyCodec_Unregister(PyObject *search_function)
 {
     PyInterpreterState *interp = PyInterpreterState_Get();
+    PyObject *codec_search_path = interp->codec_search_path;
     /* Do nothing if codec_search_path is not created yet or was cleared. */
-    if (interp->codec_search_path == NULL) {
+    if (codec_search_path == NULL) {
         return 0;
     }
 
-    Py_ssize_t n = PyList_Size(interp->codec_search_path);
+    Py_ssize_t n = PyList_Size(codec_search_path);
     for (Py_ssize_t i = 0; i < n; i++) {
-        PyObject *item = PyList_GetItem(interp->codec_search_path, i);
+        PyObject *item = PyList_GetItem(codec_search_path, i);
         if (item == search_function) {
             PyDict_Clear(interp->codec_search_cache);
-            return PyList_SetSlice(interp->codec_search_path, i, i+1, NULL);
+            return PyList_SetSlice(codec_search_path, i, i+1, NULL);
         }
     }
     return 0;

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -51,7 +51,7 @@ int PyCodec_Register(PyObject *search_function)
 }
 
 int
-_PyCodec_Unregister(PyObject *search_function)
+PyCodec_Unregister(PyObject *search_function)
 {
     PyInterpreterState *interp = PyInterpreterState_Get();
     /* Do nothing if codec_search_path is not created yet or was created. */
@@ -63,10 +63,10 @@ _PyCodec_Unregister(PyObject *search_function)
     for (Py_ssize_t i = 0; i < n; i++) {
         PyObject *item = PyList_GetItem(interp->codec_search_path, i);
         if (item == search_function) {
+            PyDict_Clear(interp->codec_search_cache);
             return PyList_SetSlice(interp->codec_search_path, i, i+1, NULL);
         }
     }
-    PyDict_Clear(interp->codec_search_cache);
     return 0;
 }
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -50,6 +50,26 @@ int PyCodec_Register(PyObject *search_function)
     return -1;
 }
 
+PyObject *
+_PyCodec_Unregister(PyObject *search_function)
+{
+    PyInterpreterState *interp = PyInterpreterState_Get();
+    if (interp->codec_search_path == NULL) {
+        Py_RETURN_NONE;
+    }
+
+    Py_ssize_t n = PyList_Size(interp->codec_search_path);
+    PyObject *list = PyList_New(0);
+    for (Py_ssize_t i = 0; i < n; i++) {
+        PyObject *item = PyList_GetItem(interp->codec_search_path, i);
+        if (item != search_function) {
+            PyList_Append(list, item);
+        }
+    }
+    Py_SETREF(interp->codec_search_path, list);
+    Py_RETURN_NONE;
+}
+
 extern int _Py_normalize_encoding(const char *, char *, size_t);
 
 /* Convert a string to a normalized Python string(decoded from UTF-8): all characters are

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -54,7 +54,7 @@ int
 PyCodec_Unregister(PyObject *search_function)
 {
     PyInterpreterState *interp = PyInterpreterState_Get();
-    /* Do nothing if codec_search_path is not created yet or was created. */
+    /* Do nothing if codec_search_path is not created yet or was cleared. */
     if (interp->codec_search_path == NULL) {
         return 0;
     }

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -66,7 +66,7 @@ PyCodec_Unregister(PyObject *search_function)
         PyObject *item = PyList_GET_ITEM(codec_search_path, i);
         if (item == search_function) {
             if (interp->codec_search_cache != NULL) {
-                assert(PyDict_Check(interp->codec_search_cache));
+                assert(PyDict_CheckExact(interp->codec_search_cache));
                 PyDict_Clear(interp->codec_search_cache);
             }
             return PyList_SetSlice(codec_search_path, i, i+1, NULL);

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -50,24 +50,24 @@ int PyCodec_Register(PyObject *search_function)
     return -1;
 }
 
-PyObject *
+int
 _PyCodec_Unregister(PyObject *search_function)
 {
     PyInterpreterState *interp = PyInterpreterState_Get();
+    /* Do nothing if codec_search_path is not created yet or was created. */
     if (interp->codec_search_path == NULL) {
-        Py_RETURN_NONE;
+        return 0;
     }
 
     Py_ssize_t n = PyList_Size(interp->codec_search_path);
-    PyObject *list = PyList_New(0);
     for (Py_ssize_t i = 0; i < n; i++) {
         PyObject *item = PyList_GetItem(interp->codec_search_path, i);
-        if (item != search_function) {
-            PyList_Append(list, item);
+        if (item == search_function) {
+            return PyList_SetSlice(interp->codec_search_path, i, i+1, NULL);
         }
     }
-    Py_SETREF(interp->codec_search_path, list);
-    Py_RETURN_NONE;
+    PyDict_Clear(interp->codec_search_cache);
+    return 0;
 }
 
 extern int _Py_normalize_encoding(const char *, char *, size_t);


### PR DESCRIPTION
Add a _codecs.unregister() in _codecs module to unregister search function. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41842](https://bugs.python.org/issue41842) -->
https://bugs.python.org/issue41842
<!-- /issue-number -->
