### PR TITLE
bpo-41816: `StrEnum.__str__` is `str.__str__`

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -622,6 +622,11 @@ an incorrect member::
 Before :class:`StrEnum`, ``Directions.NORTH`` would have been the :class:`tuple`
 ``('north',)``.
 
+.. note::
+
+    Unlike other Enum's, ``str(StrEnum.member)`` will return the value of the
+    member instead of the usual ``"EnumClass.member"``.
+
 .. versionadded:: 3.10
 
 
@@ -1216,4 +1221,14 @@ all named flags and all named combinations of flags that are in the value::
     <Color.YELLOW: 3>
     >>> Color(7)      # not named combination
     <Color.CYAN|MAGENTA|BLUE|YELLOW|GREEN|RED: 7>
+
+``StrEnum`` and :meth:`str.__str__`
+"""""""""""""""""""""""""""""""""""
+
+An important difference between :class:`StrEnum` and other Enums is the
+:meth:`__str__` method; because :class:`StrEnum` members are strings, some
+parts of Python will read the string data directly, while others will call
+:meth:`str()`. To make those two operations have the same result,
+:meth:`StrEnum.__str__` will be the same as :meth:`str.__str__` so that
+``str(StrEnum.member) == StrEnum.member`` is true.
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -718,6 +718,8 @@ class StrEnum(str, Enum):
         member._value_ = value
         return member
 
+    __str__ = str.__str__
+
 
 def _reduce_ex_by_name(self, proto):
     return self.name

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2036,6 +2036,35 @@ class TestEnum(unittest.TestCase):
             two = '2'
             three = b'3', 'ascii'
             four = b'4', 'latin1', 'strict'
+        self.assertEqual(GoodStrEnum.one, '1')
+        self.assertEqual(GoodStrEnum.one, str(GoodStrEnum.one))
+        #
+        class DumbMixin:
+            def __str__(self):
+                return "don't do this"
+        class DumbStrEnum(DumbMixin, StrEnum):
+            five = '5'
+            six = '6'
+            seven = '7'
+        self.assertEqual(DumbStrEnum.seven, '7')
+        self.assertEqual(str(DumbStrEnum.seven), "don't do this")
+        #
+        class EnumMixin(Enum):
+            def hello(self):
+                print('hello from %s' % (self, ))
+        class HelloEnum(EnumMixin, StrEnum):
+            eight = '8'
+        self.assertEqual(HelloEnum.eight, '8')
+        self.assertEqual(HelloEnum.eight, str(HelloEnum.eight))
+        #
+        class GoodbyeMixin:
+            def goodbye(self):
+                print('%s wishes you a fond farewell')
+        class GoodbyeEnum(GoodbyeMixin, EnumMixin, StrEnum):
+            nine = '9'
+        self.assertEqual(GoodbyeEnum.nine, '9')
+        self.assertEqual(GoodbyeEnum.nine, str(GoodbyeEnum.nine))
+        #
         with self.assertRaisesRegex(TypeError, '1 is not a string'):
             class FirstFailedStrEnum(StrEnum):
                 one = 1

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2037,6 +2037,7 @@ class TestEnum(unittest.TestCase):
             three = b'3', 'ascii'
             four = b'4', 'latin1', 'strict'
         self.assertEqual(GoodStrEnum.one, '1')
+        self.assertEqual(str(GoodStrEnum.one), '1')
         self.assertEqual(GoodStrEnum.one, str(GoodStrEnum.one))
         self.assertEqual(GoodStrEnum.one, '{}'.format(GoodStrEnum.one))
         #

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2038,6 +2038,7 @@ class TestEnum(unittest.TestCase):
             four = b'4', 'latin1', 'strict'
         self.assertEqual(GoodStrEnum.one, '1')
         self.assertEqual(GoodStrEnum.one, str(GoodStrEnum.one))
+        self.assertEqual(GoodStrEnum.one, '{}'.format(GoodStrEnum.one))
         #
         class DumbMixin:
             def __str__(self):


### PR DESCRIPTION
use `str.__str__` for StrEnum` so that `str(StrEnum)` is the same as directly accessing the string value of a `StrEnum` member.

<!-- issue-number: [bpo-41816](https://bugs.python.org/issue41816) -->
https://bugs.python.org/issue41816
<!-- /issue-number -->
