### PR TITLE
bpo-41513: Improve order of adding fractional values. Improve variable names.

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2502,8 +2502,8 @@ References:
 static inline double
 vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 {
-    const double T27 = 134217729.0;     /* ldexp(1.0, 27)+1.0) */
-    double x, csum = 1.0, oldcsum, scale, frac=0.0, frac_mid=0.0, frac_lo=0.0;
+    const double T27 = 134217729.0;     /* ldexp(1.0, 27) + 1.0) */
+    double x, scale, oldcsum, csum = 1.0, frac1 = 0.0, frac2 = 0.0, frac3 = 0.0;
     double t, hi, lo, h;
     int max_e;
     Py_ssize_t i;
@@ -2539,18 +2539,18 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             assert(fabs(csum) >= fabs(x));
             oldcsum = csum;
             csum += x;
-            frac += (oldcsum - csum) + x;
+            frac1 += (oldcsum - csum) + x;
 
             x = 2.0 * hi * lo;
             assert(fabs(csum) >= fabs(x));
             oldcsum = csum;
             csum += x;
-            frac_mid += (oldcsum - csum) + x;
+            frac2 += (oldcsum - csum) + x;
 
             assert(csum + lo * lo == csum);
-            frac_lo += lo * lo;
+            frac3 += lo * lo;
         }
-        h = sqrt(csum - 1.0 + (frac_lo + frac_mid + frac));
+        h = sqrt(csum - 1.0 + (frac1 + frac2 + frac3));
 
         x = h;
         t = x * T27;
@@ -2562,21 +2562,21 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac += (oldcsum - csum) + x;
+        frac1 += (oldcsum - csum) + x;
 
         x = -2.0 * hi * lo;
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac_mid += (oldcsum - csum) + x;
+        frac2 += (oldcsum - csum) + x;
 
         x = -lo * lo;
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac_lo += (oldcsum - csum) + x;
+        frac3 += (oldcsum - csum) + x;
 
-        x = csum - 1.0 + (frac_lo + frac_mid + frac);
+        x = csum - 1.0 + (frac1 + frac2 + frac3);
         return (h + x / (2.0 * h)) / scale;
     }
     /* When max_e < -1023, ldexp(1.0, -max_e) overflows.
@@ -2591,9 +2591,9 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert(fabs(csum) >= fabs(x));
         oldcsum = csum;
         csum += x;
-        frac += (oldcsum - csum) + x;
+        frac1 += (oldcsum - csum) + x;
     }
-    return max * sqrt(csum - 1.0 + frac);
+    return max * sqrt(csum - 1.0 + frac1);
 }
 
 #define NUM_STACK_ELEMS 16


### PR DESCRIPTION
Improve the variable names and optimize the order that the fractional components are added together.  Gives a slight improvement in speed and a minor improvement in accuracy.

Baseline timing:
```
$ pytime -s 'from math import pi, hypot, e, tau' 'hypot(pi, e)'
5000000 loops, best of 11: 83.6 nsec per loop
$ pytime -s 'from math import pi, hypot, e, tau' 'hypot(pi, e, tau)'
5000000 loops, best of 11: 89.1 nsec per loop
$ pytime -s 'from math import pi, hypot, e, tau' 'hypot(pi, e, tau, e)'
5000000 loops, best of 11: 98.4 nsec per loop
```

Timing with PR:
```
$ pytime -s 'from math import pi, hypot, e, tau' 'hypot(pi, e)'
5000000 loops, best of 11: 83.1 nsec per loop
$ pytime -s 'from math import pi, hypot, e, tau' 'hypot(pi, e, tau)'
5000000 loops, best of 11: 89.1 nsec per loop
$ pytime -s 'from math import pi, hypot, e, tau' 'hypot(pi, e, tau, e)'
5000000 loops, best of 11: 96 nsec per loop
```

Accuracy tests.  *n* is the number of dimensions followed by the weighted average number of correct bits (higher is better). The list contains counts for number of bits of error (lower counts are better). *hypot12* is the baseline and *hypot15* is the new code:
```
n=2 108.94  hypot12 [(104, 465), (105, 9650), (106, 74210), (107, 177328), (108, 220778)
n=2 109.12  hypot15 [(104, 76), (105, 6170), (106, 65987), (107, 163375), (108, 206841)

n=3 108.48  hypot12 [(103, 8), (104, 486), (105, 13420), (106, 93712), (107, 229769), (108, 243386)
n=3 108.72  hypot15 [(104, 102), (105, 7086), (106, 82426), (107, 208486), (108, 230416)

n=5 108.17  hypot12 [(103, 11), (104, 1353), (105, 18261), (106, 123382), (107, 253589), (108, 250362)
n=5 108.40  hypot15 [(104, 174), (105, 10427), (106, 108216), (107, 232246), (108, 243693)

n=10    107.97  hypot12 [(103, 33), (104, 3417), (105, 33754), (106, 150365), (107, 261133), (108, 237118)
n=10    108.18  hypot15 [(103, 5), (104, 653), (105, 24797), (106, 132075), (107, 243443), (108, 238205)

n=20    107.92  hypot12 [(102, 1), (103, 193), (104, 3811), (105, 39405), (106, 153847), (107, 263381), (108, 234462)
n=20    108.10  hypot15 [(103, 59), (104, 2030), (105, 29794), (106, 136819), (107, 247027), (108, 238805)

n=50    107.69  hypot12 [(103, 57), (104, 4987), (105, 53502), (106, 188830), (107, 275831), (108, 217911)
n=50    107.80  hypot15 [(103, 97), (104, 4406), (105, 47363), (106, 175900), (107, 265514), (108, 223802)

n=100   107.29  hypot12 [(103, 397), (104, 14872), (105, 101681), (106, 240449), (107, 264715), (108, 178790)
n=100   107.33  hypot15 [(103, 615), (104, 18598), (105, 100409), (106, 228175), (107, 258464), (108, 183213)

n=200   106.62  hypot12 [(102, 19), (103, 4065), (104, 55179), (105, 204706), (106, 282193), (107, 210798), (108, 119011)
n=200   106.60  hypot15 [(102, 31), (103, 5541), (104, 59552), (105, 205935), (106, 278179), (107, 208483), (108, 118478)

n=1000  104.68  hypot12 [(100, 102), (101, 5593), (102, 57169), (103, 184363), (104, 276279), (105, 218668), (106, 126077)
n=1000  104.64  hypot15 [(100, 119), (101, 5805), (102, 60339), (103, 193004), (104, 276688), (105, 213714), (106, 122384)

# Case for very large n but with fewer trials:

n=10000 100.49  hypot12 [(96, 62), (97, 1261), (98, 8502), (99, 20909), (100, 25938), (101, 19875), (102, 11594)
n=10000 100.48  hypot15 [(96, 61), (97, 1271), (98, 8530), (99, 20922), (100, 26032), (101, 19856), (102, 11562)

n=50000 97.72   hypot12 [(93, 5), (94, 521), (95, 5593), (96, 18338), (97, 26766), (98, 22070), (99, 12926)
n=50000 97.72   hypot15 [(93, 5), (94, 531), (95, 5582), (96, 18319), (97, 26805), (98, 22049), (99, 12970)
```

<!-- issue-number: [bpo-41513](https://bugs.python.org/issue41513) -->
https://bugs.python.org/issue41513
<!-- /issue-number -->
