### PR TITLE
bpo-25655: Improve Win DLL loading failures doc

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1338,7 +1338,7 @@ way is to instantiate one of the following classes:
 
 .. seealso::
 
-    `MS DUMPBIN tool <https://docs.microsoft.com/cpp/build/reference/dependents>`_
+    `Microsoft DUMPBIN tool <https://docs.microsoft.com/cpp/build/reference/dependents>`_
     -- A tool to find DLL dependents.
 
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1328,7 +1328,7 @@ way is to instantiate one of the following classes:
 
    On Windows creating a :class:`CDLL` instance may fail even if the DLL name
    exists. When a dependent DLL of the loaded DLL is not found, a
-   :class:`OSError` error is raised with the message *"[WinError 126] The
+   :exc:`OSError` error is raised with the message *"[WinError 126] The
    specified module could not be found".* This error message does not contains
    the name of the missing DLL because the Windows API does not return this
    information making this error hard to diagnose. To resolve this error and
@@ -2559,4 +2559,3 @@ Arrays and pointers
 
         Returns the object to which to pointer points.  Assigning to this
         attribute changes the pointer to point to the assigned object.
-

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1337,7 +1337,7 @@ way is to instantiate one of the following classes:
 
 .. seealso::
 
-    `MS DUMPBIN tool https://docs.microsoft.com/cpp/build/reference/dependents`_
+    `MS DUMPBIN tool <https://docs.microsoft.com/cpp/build/reference/dependents>`_
     -- A tool to find DLL dependents.
 
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1326,6 +1326,20 @@ way is to instantiate one of the following classes:
    libraries use the standard C calling convention, and are assumed to return
    :c:type:`int`.
 
+   On Windows creating a :class:`CDLL` instance may fail even if the DLL name
+   exists. When a dependent DLL of the loaded DLL is not found, a
+   :class:`OSError` error is raised with the message *"[WinError 126] The
+   specified module could not be found".* This error message does not contains
+   the name of the missing DLL because the Windows API does not return this
+   information making this error hard to diagnose. To resolve this error and
+   determine which DLL is missing, you need to find the list of missing
+   dependent DLLs using Windows debugging and tracing tools.
+
+.. seealso::
+
+    `MS DUMPBIN tool https://docs.microsoft.com/cpp/build/reference/dependents`_
+    -- A tool to find DLL dependents.
+
 
 .. class:: OleDLL(name, mode=DEFAULT_MODE, handle=None, use_errno=False, use_last_error=False, winmode=0)
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1329,11 +1329,12 @@ way is to instantiate one of the following classes:
    On Windows creating a :class:`CDLL` instance may fail even if the DLL name
    exists. When a dependent DLL of the loaded DLL is not found, a
    :exc:`OSError` error is raised with the message *"[WinError 126] The
-   specified module could not be found".* This error message does not contains
+   specified module could not be found".* This error message does not contain
    the name of the missing DLL because the Windows API does not return this
    information making this error hard to diagnose. To resolve this error and
-   determine which DLL is missing, you need to find the list of missing
-   dependent DLLs using Windows debugging and tracing tools.
+   determine which DLL is not found, you need to find the list of dependent
+   DLLs and determine which one is not found using Windows debugging and
+   tracing tools.
 
 .. seealso::
 


### PR DESCRIPTION
Add documentation to help diagnose CDLL dependent DLL loading errors
on Windows for OSError with message:
"[WinError 126] The specified module could not be found"
This error is otherwise difficult to diagnose.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-25655](https://bugs.python.org/issue25655) -->
https://bugs.python.org/issue25655
<!-- /issue-number -->
