### PR TITLE
bpo-40170: Use inline _PyType_HasFeature() function

### DIFF
--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -349,8 +349,9 @@ iobase_dealloc(iobase *self)
     if (_PyIOBase_finalize((PyObject *) self) < 0) {
         /* When called from a heap type's dealloc, the type will be
            decref'ed on return (see e.g. subtype_dealloc in typeobject.c). */
-        if (PyType_HasFeature(Py_TYPE(self), Py_TPFLAGS_HEAPTYPE))
+        if (_PyType_HasFeature(Py_TYPE(self), Py_TPFLAGS_HEAPTYPE)) {
             Py_INCREF(Py_TYPE(self));
+        }
         return;
     }
     _PyObject_GC_UNTRACK(self);

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -94,7 +94,7 @@ structseq_dealloc(PyStructSequence *obj)
         Py_XDECREF(obj->ob_item[i]);
     }
     PyObject_GC_Del(obj);
-    if (PyType_GetFlags(tp) & Py_TPFLAGS_HEAPTYPE) {
+    if (_PyType_HasFeature(tp, Py_TPFLAGS_HEAPTYPE)) {
         Py_DECREF(tp);
     }
 }


### PR DESCRIPTION
Use _PyType_HasFeature() in the _io module and in structseq
implementation. Replace PyType_HasFeature() opaque function call with
_PyType_HasFeature() inlined function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
