### PR TITLE
bpo-40521: Fix PyUnicode_InternInPlace()

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15754,6 +15754,10 @@ PyUnicode_InternInPlace(PyObject **p)
        this. */
     Py_SET_REFCNT(s, Py_REFCNT(s) - 2);
     _PyUnicode_STATE(s).interned = SSTATE_INTERNED_MORTAL;
+#else
+    // PyDict expects that interned strings have their hash
+    // (PyASCIIObject.hash) already computed.
+    (void)unicode_hash(s);
 #endif
 }
 


### PR DESCRIPTION
Fix PyUnicode_InternInPlace() when the INTERNED_STRINGS macro is not
defined (when the EXPERIMENTAL_ISOLATED_SUBINTERPRETERS macro is
defined).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
