### PR TITLE
bpo-40941: Fix fold_tuple_on_constants() compiler warnings

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6100,13 +6100,11 @@ fold_tuple_on_constants(struct instr *inst,
         PyTuple_SET_ITEM(newconst, i, constant);
     }
     Py_ssize_t index = PyList_GET_SIZE(consts);
-#if SIZEOF_SIZE_T > SIZEOF_INT
-    if ((size_t)index >= UINT_MAX - 1) {
+    if ((size_t)index >= (size_t)INT_MAX - 1) {
         Py_DECREF(newconst);
         PyErr_SetString(PyExc_OverflowError, "too many constants");
         return -1;
     }
-#endif
     if (PyList_Append(consts, newconst)) {
         Py_DECREF(newconst);
         return -1;
@@ -6116,7 +6114,7 @@ fold_tuple_on_constants(struct instr *inst,
         inst[i].i_opcode = NOP;
     }
     inst[n].i_opcode = LOAD_CONST;
-    inst[n].i_oparg = index;
+    inst[n].i_oparg = (int)index;
     return 0;
 }
 


### PR DESCRIPTION
Add explicit casts to fix compiler warnings in
fold_tuple_on_constants().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40941](https://bugs.python.org/issue40941) -->
https://bugs.python.org/issue40941
<!-- /issue-number -->
