### PR TITLE
bpo-41654: Fix compiler warning in MemoryError_dealloc()

### DIFF
--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2321,7 +2321,8 @@ MemoryError_dealloc(PyBaseExceptionObject *self)
     /* If this is a subclass of MemoryError, we don't need to
      * do anything in the free-list*/
     if (!Py_IS_TYPE(self, (PyTypeObject *) PyExc_MemoryError)) {
-        return Py_TYPE(self)->tp_free((PyObject *)self);
+        Py_TYPE(self)->tp_free((PyObject *)self);
+        return;
     }
 
     _PyObject_GC_UNTRACK(self);


### PR DESCRIPTION
Fix warning:

Objects\exceptions.c(2324,56): warning C4098:
'MemoryError_dealloc': 'void' function returning a value

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41654](https://bugs.python.org/issue41654) -->
https://bugs.python.org/issue41654
<!-- /issue-number -->
