### PR TITLE
bpo-41428: Fix compiler warnings in unionobject.c

### DIFF
--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -179,8 +179,8 @@ exit:
 static PyObject*
 flatten_args(PyObject* args)
 {
-    int arg_length = PyTuple_GET_SIZE(args);
-    int total_args = 0;
+    Py_ssize_t arg_length = PyTuple_GET_SIZE(args);
+    Py_ssize_t total_args = 0;
     // Get number of total args once it's flattened.
     for (Py_ssize_t i = 0; i < arg_length; i++) {
         PyObject *arg = PyTuple_GET_ITEM(args, i);
@@ -434,7 +434,7 @@ _Py_Union(PyObject *args)
     unionobject* result = NULL;
 
     // Check arguments are unionable.
-    int nargs = PyTuple_GET_SIZE(args);
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     for (Py_ssize_t iarg = 0; iarg < nargs; iarg++) {
         PyObject *arg = PyTuple_GET_ITEM(args, iarg);
         if (arg == NULL) {


### PR DESCRIPTION
Use Py_ssize_t type rather than int, to store lengths in
unionobject.c. Fix warnings:

Objects\unionobject.c(189,71): warning C4244: '+=':
conversion from 'Py_ssize_t' to 'int', possible loss of data

Objects\unionobject.c(182,1): warning C4244: 'initializing':
conversion from 'Py_ssize_t' to 'int', possible loss of data

Objects\unionobject.c(205,1): warning C4244: 'initializing':
conversion from 'Py_ssize_t' to 'int', possible loss of data

Objects\unionobject.c(437,1): warning C4244: 'initializing':
conversion from 'Py_ssize_t' to 'int', possible loss of data

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41428](https://bugs.python.org/issue41428) -->
https://bugs.python.org/issue41428
<!-- /issue-number -->
