### PR TITLE
bpo-29940: Add follow_wrapped option to help()

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1772,9 +1772,11 @@ def render_doc(thing, title='Python Library Documentation: %s', forceload=0,
     return title % desc + '\n\n' + renderer.document(object, name)
 
 def doc(thing, title='Python Library Documentation: %s', forceload=0,
-        output=None):
+        output=None, follow_wrapped=False):
     """Display text documentation, given an object or a path to an object."""
     try:
+        if follow_wrapped:
+            thing = inspect.unwrap(thing)
         if output is None:
             pager(render_doc(thing, title, forceload))
         else:
@@ -1995,9 +1997,9 @@ class Helper:
                                      self.__class__.__qualname__)
 
     _GoInteractive = object()
-    def __call__(self, request=_GoInteractive):
+    def __call__(self, request=_GoInteractive, follow_wrapped=False):
         if request is not self._GoInteractive:
-            self.help(request)
+            self.help(request, follow_wrapped=follow_wrapped)
         else:
             self.intro()
             self.interact()
@@ -2038,7 +2040,7 @@ has the same effect as typing a particular string at the help> prompt.
             self.output.flush()
             return self.input.readline()
 
-    def help(self, request):
+    def help(self, request, follow_wrapped=False):
         if type(request) is type(''):
             request = request.strip()
             if request == 'keywords': self.listkeywords()
@@ -2050,13 +2052,16 @@ has the same effect as typing a particular string at the help> prompt.
             elif request in self.symbols: self.showsymbol(request)
             elif request in ['True', 'False', 'None']:
                 # special case these keywords since they are objects too
-                doc(eval(request), 'Help on %s:')
+                doc(eval(request), 'Help on %s:', follow_wrapped=follow_wrapped)
             elif request in self.keywords: self.showtopic(request)
             elif request in self.topics: self.showtopic(request)
-            elif request: doc(request, 'Help on %s:', output=self._output)
-            else: doc(str, 'Help on %s:', output=self._output)
+            elif request: doc(request, 'Help on %s:', output=self._output, 
+                              follow_wrapped=follow_wrapped)
+            else: doc(str, 'Help on %s:', output=self._output,
+                      follow_wrapped=follow_wrapped)
         elif isinstance(request, Helper): self()
-        else: doc(request, 'Help on %s:', output=self._output)
+        else: doc(request, 'Help on %s:', output=self._output,
+                  follow_wrapped=follow_wrapped)
         self.output.write('\n')
 
     def intro(self):

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1775,9 +1775,8 @@ def doc(thing, title='Python Library Documentation: %s', forceload=0,
         output=None, follow_wrapped=True):
     """Display text documentation, given an object or a path to an object."""
     try:
-        if follow_wrapped:
-            thing = inspect.unwrap(thing,
-                                   stop=(lambda func: not getattr(func, '__doc__', True)))
+        if not follow_wrapped:
+            thing = type(thing)
         if output is None:
             pager(render_doc(thing, title, forceload))
         else:

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1772,10 +1772,10 @@ def render_doc(thing, title='Python Library Documentation: %s', forceload=0,
     return title % desc + '\n\n' + renderer.document(object, name)
 
 def doc(thing, title='Python Library Documentation: %s', forceload=0,
-        output=None, follow_wrapped=False):
+        output=None, follow_wrapped=True):
     """Display text documentation, given an object or a path to an object."""
     try:
-        if follow_wrapped:
+        if not follow_wrapped:
             thing = inspect.unwrap(thing)
         if output is None:
             pager(render_doc(thing, title, forceload))
@@ -2040,7 +2040,7 @@ has the same effect as typing a particular string at the help> prompt.
             self.output.flush()
             return self.input.readline()
 
-    def help(self, request, follow_wrapped=False):
+    def help(self, request, follow_wrapped=True):
         if type(request) is type(''):
             request = request.strip()
             if request == 'keywords': self.listkeywords()

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1777,7 +1777,7 @@ def doc(thing, title='Python Library Documentation: %s', forceload=0,
     try:
         if follow_wrapped:
             thing = inspect.unwrap(thing,
-                                   stop=(lambda func: not hasattr(func, '__doc__')))
+                                   stop=(lambda func: not getattr(func, '__doc__', True)))
         if output is None:
             pager(render_doc(thing, title, forceload))
         else:

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1776,7 +1776,7 @@ def doc(thing, title='Python Library Documentation: %s', forceload=0,
     """Display text documentation, given an object or a path to an object."""
     try:
         if not follow_wrapped:
-            thing = inspect.unwrap(thing)
+            thing = inspect.unwrap(thing, stop=lambda func: getattr(func, '__doc__', None)
         if output is None:
             pager(render_doc(thing, title, forceload))
         else:

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2055,7 +2055,7 @@ has the same effect as typing a particular string at the help> prompt.
                 doc(eval(request), 'Help on %s:', follow_wrapped=follow_wrapped)
             elif request in self.keywords: self.showtopic(request)
             elif request in self.topics: self.showtopic(request)
-            elif request: doc(request, 'Help on %s:', output=self._output, 
+            elif request: doc(request, 'Help on %s:', output=self._output,
                               follow_wrapped=follow_wrapped)
             else: doc(str, 'Help on %s:', output=self._output,
                       follow_wrapped=follow_wrapped)

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1775,13 +1775,14 @@ def doc(thing, title='Python Library Documentation: %s', forceload=0,
         output=None, follow_wrapped=True):
     """Display text documentation, given an object or a path to an object."""
     try:
-        if not follow_wrapped:
-            thing = inspect.unwrap(thing, stop=lambda func: getattr(func, '__doc__', None)
+        if follow_wrapped:
+            thing = inspect.unwrap(thing,
+                                   stop=(lambda func: not hasattr(func, '__doc__')))
         if output is None:
             pager(render_doc(thing, title, forceload))
         else:
             output.write(render_doc(thing, title, forceload, plaintext))
-    except (ImportError, ErrorDuringImport) as value:
+    except (ImportError, ErrorDuringImport, ValueError) as value:
         print(value)
 
 def writedoc(thing, forceload=0):
@@ -1997,7 +1998,7 @@ class Helper:
                                      self.__class__.__qualname__)
 
     _GoInteractive = object()
-    def __call__(self, request=_GoInteractive, follow_wrapped=False):
+    def __call__(self, request=_GoInteractive, follow_wrapped=True):
         if request is not self._GoInteractive:
             self.help(request, follow_wrapped=follow_wrapped)
         else:

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -647,7 +647,7 @@ class PydocDocTest(unittest.TestCase):
         # Testing that the subclasses section does not appear
         self.assertNotIn('Built-in subclasses', text)
 
-    def test_builtin_with_wrapper(self):
+    def test_help_with_wrapper(self):
         """Test help on function wrapped.
 
         When running help() on a function that is wrapped,
@@ -659,7 +659,7 @@ class PydocDocTest(unittest.TestCase):
         class TestWrapper:
             """This is the docstring of Wrapper"""
             def __init__(self, func):
-                functools.update_wrapper(func)
+                functools.update_wrapper(self, func)
             def __call__(self):
                 pass
 
@@ -668,19 +668,22 @@ class PydocDocTest(unittest.TestCase):
             """Test func1"""
             pass
 
-        doc = pydoc.TextDoc()
-        text = doc.docclass(test_func1)
-        self.assertIn('Test func1', text)
+        buff = StringIO()
 
-        text = doc.docclass(test_func1, follow_wrapped=False)
-        self.assertIn("This is the docstring for Wrapper", text)
+        helper = pydoc.Helper(output=buff)
+
+        helper.help(test_func1)
+        self.assertIn('Test func1', buff.getvalue().strip())
+
+        helper.help(test_func1, follow_wrapped=False)
+        self.assertIn("This is the docstring of Wrapper", buff.getvalue().strip())
 
         @TestWrapper
         def test_func2():
             pass
 
-        text = doc.docclass(test_func1)
-        self.assertIn("This is the docstring for wrapper", text)
+        helper.help(test_func2)
+        self.assertIn("This is the docstring of Wrapper", buff.getvalue().strip())
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      'Docstrings are omitted with -O2 and above')

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -647,6 +647,41 @@ class PydocDocTest(unittest.TestCase):
         # Testing that the subclasses section does not appear
         self.assertNotIn('Built-in subclasses', text)
 
+    def test_builtin_with_wrapper(self):
+        """Test help on function wrapped.
+
+        When running help() on a function that is wrapped,
+        should be show the docstring of the last object in the chain
+        with __doc__ method.
+        """
+
+        import functools
+        class TestWrapper:
+            """This is the docstring of Wrapper"""
+            def __init__(self, func):
+                functools.update_wrapper(func)
+            def __call__(self):
+                pass
+
+        @TestWrapper
+        def test_func1():
+            """Test func1"""
+            pass
+
+        doc = pydoc.TextDoc()
+        text = doc.docclass(test_func1)
+        self.assertIn('Test func1', text)
+
+        text = doc.docclass(test_func1, follow_wrapped=False)
+        self.assertIn("This is the docstring for Wrapper", text)
+
+        @TestWrapper
+        def test_func2():
+            pass
+
+        text = doc.docclass(test_func1)
+        self.assertIn("This is the docstring for wrapper", text)
+
     @unittest.skipIf(sys.flags.optimize >= 2,
                      'Docstrings are omitted with -O2 and above')
     @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),

--- a/Misc/NEWS.d/next/Library/2019-04-22-17-25-46.bpo-29940.fslqG1.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-22-17-25-46.bpo-29940.fslqG1.rst
@@ -1,0 +1,2 @@
+Add follow_wrapped to help function to print the docstring of a wrapped
+function.


### PR DESCRIPTION
When print the docstring using help builtin for an wrapper function
it doesn't correspond to the function wrapped. For avoid this
this PR add the follow_wrapped option to help() function.

This is the continuation of the wrong https://github.com/python/cpython/pull/12915

cc: @chrahunt @taleinat 

<!-- issue-number: [bpo-29940](https://bugs.python.org/issue29940) -->
https://bugs.python.org/issue29940
<!-- /issue-number -->
