### PR TITLE
bpo-41858: Fix incomplete line on optparse documentation

### DIFF
--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -55,7 +55,7 @@ equivalent to the above example::
    <yourscript> -q -foutfile
    <yourscript> -qfoutfile
 
-Additionally, users can run one of the next lines::
+Additionally, users can run one of the following ::
 
    <yourscript> -h
    <yourscript> --help

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -55,7 +55,7 @@ equivalent to the above example::
    <yourscript> -q -foutfile
    <yourscript> -qfoutfile
 
-Additionally, users can run one of  ::
+Additionally, users can run one of the next lines::
 
    <yourscript> -h
    <yourscript> --help


### PR DESCRIPTION
This line seems to be incomplete. This fix come from the translation
to spanish of @fjsevilla-dev on https://github.com/python/python-docs-es/pull/758/file.
reading the proposal for the translate has sense add `the next lines`.

I thinks that NEWS could be ignore here.

<!-- issue-number: [bpo-41858](https://bugs.python.org/issue41858) -->
https://bugs.python.org/issue41858
<!-- /issue-number -->
