### PR TITLE
bpo-35765: Clarify references to "object x" in the JSON tutorial

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -475,7 +475,8 @@ If you have an object ``x``, you can view its JSON string representation with a
 simple line of code::
 
    >>> import json
-   >>> json.dumps([1, 'simple', 'list'])
+   >>> x = [1, 'simple', 'list']
+   >>> json.dumps(x)
    '[1, "simple", "list"]'
 
 Another variant of the :func:`~json.dumps` function, called :func:`~json.dump`,


### PR DESCRIPTION


<!-- issue-number: [bpo-35765](https://bugs.python.org/issue35765) -->
https://bugs.python.org/issue35765
<!-- /issue-number -->

Automerge-Triggered-By: GH:iritkatriel