### PR TITLE
bpo-41428: Fix compiler warning in unionobject.c

### DIFF
--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -202,8 +202,8 @@ flatten_args(PyObject* args)
         PyTypeObject* arg_type = Py_TYPE(arg);
         if (arg_type == &_Py_UnionType) {
             PyObject* nested_args = ((unionobject*)arg)->args;
-            int nested_arg_length = PyTuple_GET_SIZE(nested_args);
-            for (int j = 0; j < nested_arg_length; j++) {
+            Py_ssize_t nested_arg_length = PyTuple_GET_SIZE(nested_args);
+            for (Py_ssize_t j = 0; j < nested_arg_length; j++) {
                 PyObject* nested_arg = PyTuple_GET_ITEM(nested_args, j);
                 Py_INCREF(nested_arg);
                 PyTuple_SET_ITEM(flattened_args, pos, nested_arg);
@@ -231,7 +231,7 @@ dedup_and_flatten_args(PyObject* args)
         return NULL;
     }
     // Add unique elements to an array.
-    int added_items = 0;
+    Py_ssize_t added_items = 0;
     for (Py_ssize_t i = 0; i < arg_length; i++) {
         int is_duplicate = 0;
         PyObject* i_element = PyTuple_GET_ITEM(args, i);


### PR DESCRIPTION
Use Py_ssize_t type rather than int, to store lengths in
unionobject.c. Fix the warning:

Objects\unionobject.c(205,1): warning C4244: 'initializing':
conversion from 'Py_ssize_t' to 'int', possible loss of data

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41428](https://bugs.python.org/issue41428) -->
https://bugs.python.org/issue41428
<!-- /issue-number -->
