### PR TITLE
bpo-23706: Add newline parameter to pathlib.Path.write_text (GH-22420)

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1158,7 +1158,7 @@ call fails (for example because the path doesn't exist).
    .. versionadded:: 3.5
 
 
-.. method:: Path.write_text(data, encoding=None, errors=None)
+.. method:: Path.write_text(data, encoding=None, errors=None, newline=None)
 
    Open the file pointed to in text mode, write *data* to it, and close the
    file::
@@ -1170,9 +1170,12 @@ call fails (for example because the path doesn't exist).
       'Text file contents'
 
    An existing file of the same name is overwritten. The optional parameters
-   have the same meaning as in :func:`open`.
-
+   *encoding* and *errors* have the same meaning as in :func:`open`.
+   If *newline* parameter is passed, all occurrences of default newline
+   characters (``\r``, ``\n`` and ``\r\n``) will be replaced with *newline*.
    .. versionadded:: 3.5
+   .. versionchanged:: 3.10
+      The *newline* parameter was added.
 
 Correspondence to tools in the :mod:`os` module
 -----------------------------------------------

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1174,6 +1174,7 @@ call fails (for example because the path doesn't exist).
    If *newline* parameter is passed, all occurrences of default newline
    characters (``\r``, ``\n`` and ``\r\n``) will be replaced with *newline*.
    .. versionadded:: 3.5
+
    .. versionchanged:: 3.10
       The *newline* parameter was added.
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1173,6 +1173,7 @@ call fails (for example because the path doesn't exist).
    *encoding* and *errors* have the same meaning as in :func:`open`.
    If *newline* parameter is passed, all occurrences of default newline
    characters (``\r``, ``\n`` and ``\r\n``) will be replaced with *newline*.
+
    .. versionadded:: 3.5
 
    .. versionchanged:: 3.10

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1170,9 +1170,7 @@ call fails (for example because the path doesn't exist).
       'Text file contents'
 
    An existing file of the same name is overwritten. The optional parameters
-   *encoding* and *errors* have the same meaning as in :func:`open`.
-   If *newline* parameter is passed, all occurrences of default newline
-   characters (``\r``, ``\n`` and ``\r\n``) will be replaced with *newline*.
+   have the same meaning as in :func:`open`.
 
    .. versionadded:: 3.5
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1264,13 +1264,15 @@ class Path(PurePath):
         with self.open(mode='wb') as f:
             return f.write(view)
 
-    def write_text(self, data, encoding=None, errors=None):
+    def write_text(self, data, encoding=None, errors=None, newline=None):
         """
         Open the file in text mode, write to it, and close the file.
         """
         if not isinstance(data, str):
             raise TypeError('data must be str, not %s' %
                             data.__class__.__name__)
+        if newline is not None:
+            data = re.sub('\r\n|\n|\r', newline, data)
         with self.open(mode='w', encoding=encoding, errors=errors) as f:
             return f.write(data)
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1271,9 +1271,7 @@ class Path(PurePath):
         if not isinstance(data, str):
             raise TypeError('data must be str, not %s' %
                             data.__class__.__name__)
-        if newline is not None:
-            data = re.sub('\r\n|\n|\r', newline, data)
-        with self.open(mode='w', encoding=encoding, errors=errors) as f:
+        with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
             return f.write(data)
 
     def readlink(self):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1510,6 +1510,25 @@ class _BasePathTest(object):
         self.assertRaises(TypeError, (p / 'fileA').write_text, b'somebytes')
         self.assertEqual((p / 'fileA').read_text(encoding='latin-1'), 'äbcdefg')
 
+    def test_write_text_with_newlines(self):
+        p = self.cls(BASE)
+        # Check that `\n` character is replaced
+        (p / 'fileA').write_text('abcde\nfghlk\n\nmnopq', newline='\1')
+        self.assertEqual((p / 'fileA').read_text(),
+                         'abcde\1fghlk\1\1mnopq')
+        # Check that `\r` character is replaced
+        (p / 'fileA').write_text('abcde\rfghlk\r\rmnopq', newline='\1')
+        self.assertEqual((p / 'fileA').read_text(),
+                         'abcde\1fghlk\1\1mnopq')
+        # Check that `\r\n` character is replaced
+        (p / 'fileA').write_text('abcde\r\nfghlk\r\n\r\nmnopq', newline='\1')
+        self.assertEqual((p / 'fileA').read_text(),
+                         'abcde\1fghlk\1\1mnopq')
+        # Check that None newline does not change anything
+        (p / 'fileA').write_text('abcde\nfghlk\n\nmnopq')
+        self.assertEqual((p / 'fileA').read_text(),
+                         'abcde\nfghlk\n\nmnopq')
+
     def test_iterdir(self):
         P = self.cls
         p = P(BASE)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1512,22 +1512,23 @@ class _BasePathTest(object):
 
     def test_write_text_with_newlines(self):
         p = self.cls(BASE)
-        # Check that `\n` character is replaced
-        (p / 'fileA').write_text('abcde\nfghlk\n\nmnopq', newline='\1')
-        self.assertEqual((p / 'fileA').read_text(),
-                         'abcde\1fghlk\1\1mnopq')
-        # Check that `\r` character is replaced
-        (p / 'fileA').write_text('abcde\rfghlk\r\rmnopq', newline='\1')
-        self.assertEqual((p / 'fileA').read_text(),
-                         'abcde\1fghlk\1\1mnopq')
-        # Check that `\r\n` character is replaced
-        (p / 'fileA').write_text('abcde\r\nfghlk\r\n\r\nmnopq', newline='\1')
-        self.assertEqual((p / 'fileA').read_text(),
-                         'abcde\1fghlk\1\1mnopq')
-        # Check that None newline does not change anything
-        (p / 'fileA').write_text('abcde\nfghlk\n\nmnopq')
-        self.assertEqual((p / 'fileA').read_text(),
-                         'abcde\nfghlk\n\nmnopq')
+        # Check that `\n` character change nothing
+        (p / 'fileA').write_text('abcde\r\nfghlk\n\rmnopq', newline='\n')
+        self.assertEqual((p / 'fileA').read_bytes(),
+                         b'abcde\r\nfghlk\n\rmnopq')
+        # Check that `\r` character replaces `\n`
+        (p / 'fileA').write_text('abcde\r\nfghlk\n\rmnopq', newline='\r')
+        self.assertEqual((p / 'fileA').read_bytes(),
+                         b'abcde\r\rfghlk\r\rmnopq')
+        # Check that `\r\n` character replaces `\n`
+        (p / 'fileA').write_text('abcde\r\nfghlk\n\rmnopq', newline='\r\n')
+        self.assertEqual((p / 'fileA').read_bytes(),
+                         b'abcde\r\r\nfghlk\r\n\rmnopq')
+        # Check that no argument passed will change `\n` to `os.linesep`
+        os_linesep_byte = bytes(os.linesep, encoding='ascii')
+        (p / 'fileA').write_text('abcde\nfghlk\n\rmnopq')
+        self.assertEqual((p / 'fileA').read_bytes(),
+                          b'abcde' + os_linesep_byte + b'fghlk' + os_linesep_byte + b'\rmnopq')
 
     def test_iterdir(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2020-09-30-11-05-11.bpo-23706.dHTGjF.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-30-11-05-11.bpo-23706.dHTGjF.rst
@@ -1,1 +1,1 @@
-Added *newline* parameter to *pathlib.Path.write_text()*.
+Added *newline* parameter to ``pathlib.Path.write_text()``.

--- a/Misc/NEWS.d/next/Library/2020-09-30-11-05-11.bpo-23706.dHTGjF.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-30-11-05-11.bpo-23706.dHTGjF.rst
@@ -1,0 +1,1 @@
+Added *newline* parameter to *pathlib.Path.write_text()*.


### PR DESCRIPTION
* Add _newline_ parameter to `pathlib.Path.write_text()`
* Update documentation of `pathlib.Path.write_text()`
* Add test case for `pathlib.Path.write_text()` calls with _newline_ parameter passed

<!-- issue-number: [bpo-23706](https://bugs.python.org/issue23706) -->
https://bugs.python.org/issue23706
<!-- /issue-number -->

Automerge-Triggered-By: GH:methane