### PR TITLE
[doc] Revert "Fix all Python Cookbook links (#22205)"

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1141,7 +1141,7 @@ How do you remove duplicates from a list?
 
 See the Python Cookbook for a long discussion of many ways to do this:
 
-   https://github.com/ActiveState/code/tree/master/recipes/Python/52560_Remove_duplicates/recipe-52560.py
+   https://code.activestate.com/recipes/52560/
 
 If you don't mind reordering the list, sort it and then scan from the end of the
 list, deleting duplicates as you go::

--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -601,5 +601,5 @@ This document was reviewed and revised by John Lee.
        scripts with a localhost server, I have to prevent urllib from using
        the proxy.
 .. [#] urllib opener for SSL proxy (CONNECT method): `ASPN Cookbook Recipe
-       <https://github.com/ActiveState/code/tree/master/recipes/Python/456195_urrlib2_opener_SSL_proxy_CONNECT/recipe-456195.py>`_.
+       <https://code.activestate.com/recipes/456195/>`_.
 

--- a/Doc/library/bisect.rst
+++ b/Doc/library/bisect.rst
@@ -60,7 +60,7 @@ The following functions are provided:
 .. seealso::
 
    `SortedCollection recipe
-   <https://github.com/ActiveState/code/tree/master/recipes/Python/577197_SortedCollection/recipe-577197.py>`_ that uses
+   <https://code.activestate.com/recipes/577197-sortedcollection/>`_ that uses
    bisect to build a full-featured collection class with straight-forward search
    methods and support for a key-function.  The keys are precomputed to save
    unnecessary calls to the key function during searches.

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -308,7 +308,7 @@ Notes on using :class:`Set` and :class:`MutableSet` as a mixin:
 
 .. seealso::
 
-   * `OrderedSet recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/576694_OrderedSet/recipe-576694.py>`_ for an
+   * `OrderedSet recipe <https://code.activestate.com/recipes/576694/>`_ for an
      example built on :class:`MutableSet`.
 
    * For more about ABCs, see the :mod:`abc` module and :pep:`3119`.

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -135,12 +135,12 @@ The class can be used to simulate nested scopes and is useful in templating.
       :attr:`~collections.ChainMap.parents` property.
 
     * The `Nested Contexts recipe
-      <https://github.com/ActiveState/code/tree/master/recipes/Python/577434_Nested_contexts__chamapping/recipe-577434.py>`_ has options to control
+      <https://code.activestate.com/recipes/577434/>`_ has options to control
       whether writes and other mutations apply only to the first mapping or to
       any mapping in the chain.
 
     * A `greatly simplified read-only version of Chainmap
-      <https://github.com/ActiveState/code/tree/master/recipes/Python/305268_Chained_map_lookups/recipe-305268.py>`_.
+      <https://code.activestate.com/recipes/305268/>`_.
 
 
 :class:`ChainMap` Examples and Recipes

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -633,7 +633,7 @@ If you want to know how to change the first sequence into the second, use
      work.
 
    * `Simple version control recipe
-     <https://github.com/ActiveState/code/tree/master/recipes/Python/576729_Simple_Version_Control/recipe-576729.py>`_ for a small application
+     <https://code.activestate.com/recipes/576729/>`_ for a small application
      built with :class:`SequenceMatcher`.
 
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -123,7 +123,7 @@ Number-theoretic and representation functions
 
    For further discussion and two alternative approaches, see the `ASPN cookbook
    recipes for accurate floating point summation
-   <https://github.com/ActiveState/code/tree/master/recipes/Python/393090_Binary_floating_point_summatiaccurate_full/recipe-393090.py>`_\.
+   <https://code.activestate.com/recipes/393090/>`_\.
 
 
 .. function:: gcd(*integers)

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -57,7 +57,7 @@ from sources provided by the operating system.
 
 
    `Complementary-Multiply-with-Carry recipe
-   <https://github.com/ActiveState/code/tree/master/recipes/Python/576707_Long_period_random_number/recipe-576707.py>`_ for a compatible alternative
+   <https://code.activestate.com/recipes/576707/>`_ for a compatible alternative
    random number generator with a long period and comparatively simple update
    operations.
 

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -75,7 +75,7 @@ Two additional methods are supported:
 
 .. seealso::
 
-   `Persistent dictionary recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/576642_Persistent_dict_multiple_standard_file/recipe-576642.py>`_
+   `Persistent dictionary recipe <https://code.activestate.com/recipes/576642/>`_
    with widely supported storage formats and having the speed of native
    dictionaries.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1404,7 +1404,7 @@ objects that compare equal might have different :attr:`~range.start`,
 
 .. seealso::
 
-   * The `linspace recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/579000_Equallyspaced_numbers_linspace/recipe-579000.py>`_
+   * The `linspace recipe <http://code.activestate.com/recipes/579000/>`_
      shows how to implement a lazy version of range suitable for floating
      point applications.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -679,7 +679,7 @@ always available.
    additional garbage collector overhead if the object is managed by the garbage
    collector.
 
-   See `recursive sizeof recipe <https://github.com/ActiveState/code/tree/master/recipes/Python/577504_Compute_Memory_footprint_object_its/recipe-577504.py>`_
+   See `recursive sizeof recipe <https://code.activestate.com/recipes/577504>`_
    for an example of using :func:`getsizeof` recursively to find the size of
    containers and all their contents.
 

--- a/Doc/tutorial/whatnow.rst
+++ b/Doc/tutorial/whatnow.rst
@@ -43,7 +43,7 @@ More Python resources:
   for download.  Once you begin releasing code, you can register it here so that
   others can find it.
 
-* https://github.com/ActiveState/code/tree/master/recipes/Python: The Python Cookbook is a
+* https://code.activestate.com/recipes/langs/python/: The Python Cookbook is a
   sizable collection of code examples, larger modules, and useful scripts.
   Particularly notable contributions are collected in a book also titled Python
   Cookbook (O'Reilly & Associates, ISBN 0-596-00797-3.)

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -781,8 +781,8 @@ functools
 
   (Contributed by Raymond Hettinger and incorporating design ideas from Jim
   Baker, Miki Tebeka, and Nick Coghlan; see `recipe 498245
-  <https://github.com/ActiveState/code/tree/master/recipes/Python/498245_LRU_and_LFU_cache_decorators/recipe-498245.py>`_\, `recipe 577479
-  <https://github.com/ActiveState/code/tree/master/recipes/Python/577479_Simple_caching_decorator/recipe-577479.py>`_\, :issue:`10586`, and
+  <https://code.activestate.com/recipes/498245>`_\, `recipe 577479
+  <https://code.activestate.com/recipes/577479>`_\, :issue:`10586`, and
   :issue:`10593`.)
 
 * The :func:`functools.wraps` decorator now adds a :attr:`__wrapped__` attribute

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -574,7 +574,7 @@ class Counter(dict):
     #   http://en.wikipedia.org/wiki/Multiset
     #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
     #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
-    #   https://github.com/ActiveState/code/tree/master/recipes/Python/259174_bag_collection_class/recipe-259174.py
+    #   http://code.activestate.com/recipes/259174/
     #   Knuth, TAOCP Vol. II section 4.6.3
 
     def __init__(self, iterable=None, /, **kwds):

--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -456,7 +456,7 @@ def merge(*iterables, key=None, reverse=False):
 # 2) Made multiple passes over the data.
 # 3) Made more comparisons in common cases (small k, large n, semi-random input).
 # See the more detailed comparison of approach at:
-# https://github.com/ActiveState/code/tree/master/recipes/Python/577573_Compare_algorithms/recipe-577573.py
+# http://code.activestate.com/recipes/577573-compare-algorithms-for-heapqsmallest
 
 def nsmallest(n, iterable, key=None):
     """Find the n smallest elements in a dataset.

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -611,7 +611,7 @@ class MathTests(unittest.TestCase):
         def msum(iterable):
             """Full precision summation.  Compute sum(iterable) without any
             intermediate accumulation of error.  Based on the 'lsum' function
-            at https://github.com/ActiveState/code/tree/master/recipes/Python/393090_Binary_floating_point_summatiaccurate_full/recipe-393090.py
+            at http://code.activestate.com/recipes/393090/
 
             """
             tmant, texp = 0, 0

--- a/Tools/peg_generator/pegen/sccutils.py
+++ b/Tools/peg_generator/pegen/sccutils.py
@@ -18,7 +18,7 @@ def strongly_connected_components(
       exactly once; vertices not part of a SCC are returned as
       singleton sets.
 
-    From https://github.com/ActiveState/code/tree/master/recipes/Python/578507_Strongly_connected_components_directed/recipe-578507.py.
+    From http://code.activestate.com/recipes/578507/.
     """
     identified: Set[str] = set()
     stack: List[str] = []
@@ -81,7 +81,7 @@ def topsort(
         {B, C}
         {A}
 
-    From https://github.com/ActiveState/code/tree/master/recipes/Python/577413_Topological_Sort/recipe-577413.py.
+    From http://code.activestate.com/recipes/577413/.
     """
     # TODO: Use a faster algorithm?
     for k, v in data.items():


### PR DESCRIPTION
This reverts commit ac0333e1e117b7f61ed7ef1dbcdb6e515ada603b.

It seems there was a problem in the Web site when I tested it and opened the original PR:

Aug 21, working: https://web.archive.org/web/20200821104214/https://code.activestate.com/
Sep 13, not working: https://web.archive.org/web/20200913175415/https://code.activestate.com/

Opening per @pablogsal request.