### PR TITLE
bpo-41870: Use PEP 590 vectorcall to speed up bool() 

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-09-27-22-23-14.bpo-41870.2v6_v4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-09-27-22-23-14.bpo-41870.2v6_v4.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``bool()`` by using the :pep:`590` ``vectorcall`` calling
+convention. Patch by Dong-hee Na.

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -55,6 +55,30 @@ bool_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return PyBool_FromLong(ok);
 }
 
+static PyObject *
+bool_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
+{
+    long ok = 0;
+    if (!_PyArg_NoKwnames("bool", kwnames)) {
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("bool", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    assert(PyType_Check(type));
+    if (nargs) {
+        ok = PyObject_IsTrue(args[0]);
+    }
+    if (ok < 0) {
+        return NULL;
+    }
+    return PyBool_FromLong(ok);
+}
+
 /* Arithmetic operations redefined to return bool if both args are bool. */
 
 static PyObject *
@@ -170,6 +194,7 @@ PyTypeObject PyBool_Type = {
     0,                                          /* tp_init */
     0,                                          /* tp_alloc */
     bool_new,                                   /* tp_new */
+    .tp_vectorcall = bool_vectorcall,
 };
 
 /* The objects representing bool values False and True */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41870](https://bugs.python.org/issue41870) -->
https://bugs.python.org/issue41870
<!-- /issue-number -->
