### PR TITLE
Ease the debugging of internal pickle errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.profclang?
 *.profraw
 *.dyn
+*.ipynb
 .gdb_history
 .purify
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 *.profclang?
 *.profraw
 *.dyn
-*.ipynb
 .gdb_history
 .purify
 __pycache__

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4344,9 +4344,10 @@ _PyObject_GetState(PyObject *obj, int required)
 
         if (required && Py_TYPE(obj)->tp_itemsize) {
             PyErr_Format(PyExc_TypeError,
-                         "cannot pickle '%.200s' object: missing " \
-                         "`__getstate__()` on variable-length object",
+                         "cannot pickle '%.200s' object",
                          Py_TYPE(obj)->tp_name);
+            // for internal debugging
+            assert(! (required && Py_TYPE(obj)->tp_itemsize));
             return NULL;
         }
 
@@ -4386,9 +4387,10 @@ _PyObject_GetState(PyObject *obj, int required)
                 Py_DECREF(slotnames);
                 Py_DECREF(state);
                 PyErr_Format(PyExc_TypeError,
-                             "cannot pickle '%.200s' object: basic size " \
-                             "greater than expected",
+                             "cannot pickle '%.200s' object",
                              Py_TYPE(obj)->tp_name);
+                // for internal debugging
+                assert(! Py_TYPE(obj)->tp_basicsize > basicsize);
                 return NULL;
             }
         }
@@ -4624,8 +4626,10 @@ reduce_newobj(PyObject *obj)
 
     if (Py_TYPE(obj)->tp_new == NULL) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot pickle '%.200s' object: object has no `__new__()`",
+                     "cannot pickle '%.200s' object",
                      Py_TYPE(obj)->tp_name);
+        // for internal debugging
+        assert(Py_TYPE(obj)->tp_new != NULL);
         return NULL;
     }
     if (_PyObject_GetNewArguments(obj, &args, &kwargs) < 0)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4344,7 +4344,8 @@ _PyObject_GetState(PyObject *obj, int required)
 
         if (required && Py_TYPE(obj)->tp_itemsize) {
             PyErr_Format(PyExc_TypeError,
-                         "cannot pickle '%.200s' object",
+                         "cannot pickle '%.200s' object: expected " \
+                         "fixed-length instance (tp_itemsize != 0)",
                          Py_TYPE(obj)->tp_name);
             return NULL;
         }
@@ -4385,7 +4386,8 @@ _PyObject_GetState(PyObject *obj, int required)
                 Py_DECREF(slotnames);
                 Py_DECREF(state);
                 PyErr_Format(PyExc_TypeError,
-                             "cannot pickle '%.200s' object",
+                             "cannot pickle '%.200s' object: basic size " \
+                             "greater than expected",
                              Py_TYPE(obj)->tp_name);
                 return NULL;
             }
@@ -4622,7 +4624,7 @@ reduce_newobj(PyObject *obj)
 
     if (Py_TYPE(obj)->tp_new == NULL) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot pickle '%.200s' object",
+                     "cannot pickle '%.200s' object: object has no `__new__()`",
                      Py_TYPE(obj)->tp_name);
         return NULL;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4344,8 +4344,8 @@ _PyObject_GetState(PyObject *obj, int required)
 
         if (required && Py_TYPE(obj)->tp_itemsize) {
             PyErr_Format(PyExc_TypeError,
-                         "cannot pickle '%.200s' object: expected " \
-                         "fixed-length instance (tp_itemsize != 0)",
+                         "cannot pickle '%.200s' object: missing " \
+                         "`__getstate__()` on variable-length object",
                          Py_TYPE(obj)->tp_name);
             return NULL;
         }


### PR DESCRIPTION
All pickle error messages was a generic "cannot pickle 'type' object". Added <s>some explaining for every individual error.</s> `assert`s to individuate in debug mode the error.