### PR TITLE
bpo-41880: fix finding headers when cross compiling

### DIFF
--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -95,8 +95,6 @@ def get_python_inc(plat_specific=0, prefix=None):
     If 'prefix' is supplied, use it instead of sys.base_prefix or
     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
     """
-    if prefix is None:
-        prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
     if os.name == "posix":
         if python_build:
             # Assume the executable is in the build directory.  The
@@ -109,9 +107,17 @@ def get_python_inc(plat_specific=0, prefix=None):
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
                 return os.path.normpath(incdir)
-        python_dir = 'python' + get_python_version() + build_flags
-        return os.path.join(prefix, "include", python_dir)
+        if prefix is None:
+            if plat_specific:
+                return get_config_var('CONFINCLUDEPY')
+            else:
+                return get_config_var('INCLUDEPY')
+        else:
+            python_dir = 'python' + get_python_version() + build_flags
+            return os.path.join(prefix, "include", python_dir)
     elif os.name == "nt":
+        if prefix is None:
+            prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
         if python_build:
             # Include both the include and PC dir to ensure we can find
             # pyconfig.h


### PR DESCRIPTION
When cross-compiling third-party extensions, `get_python_inc()` may be called to
return the path to Python's headers. However, it uses the `sys.prefix` or
`sys.exec_prefix` of the build Python, which returns incorrect paths when
cross-compiling (paths pointing to build system headers).

To fix this, we use the `INCLUDEPY` and `CONFINCLUDEPY` conf variables, which can
be configured to point at host Python by setting `_PYTHON_SYSCONFIGDATA_NAME`.
The existing behavior is maintained on non-POSIX platforms or if a prefix is
manually specified.

<!-- issue-number: [bpo-41880](https://bugs.python.org/issue41880) -->
https://bugs.python.org/issue41880
<!-- /issue-number -->
