### PR TITLE
bpo-41773: random.choices doesn't support non-finite weights

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -180,8 +180,8 @@ Functions for sequences
 
    The *weights* or *cum_weights* can use any numeric type that interoperates
    with the :class:`float` values returned by :func:`random` (that includes
-   integers, floats, and fractions but excludes decimals).  Behavior is
-   undefined if any weight is negative.  A :exc:`ValueError` is raised if all
+   integers, floats, and fractions but excludes decimals).  Weights are assumed
+   to be non-negative and finite.  A :exc:`ValueError` is raised if all
    weights are zero.
 
    For a given seed, the :func:`choices` function with equal weighting

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -48,7 +48,7 @@ General notes on the underlying Mersenne Twister core generator:
 from warnings import warn as _warn
 from math import log as _log, exp as _exp, pi as _pi, e as _e, ceil as _ceil
 from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
-from math import tau as TWOPI, floor as _floor
+from math import tau as TWOPI, floor as _floor, isfinite as _isfinite
 from os import urandom as _urandom
 from _collections_abc import Set as _Set, Sequence as _Sequence
 from itertools import accumulate as _accumulate, repeat as _repeat
@@ -492,6 +492,8 @@ class Random(_random.Random):
         total = cum_weights[-1] + 0.0   # convert to float
         if total <= 0.0:
             raise ValueError('Total of weights must be greater than zero')
+        if not _isfinite(total):
+            raise ValueError('Total of weights must be finite')
         bisect = _bisect
         hi = n - 1
         return [population[bisect(cum_weights, random() * total, 0, hi)]

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -324,6 +324,22 @@ class TestBasicOps:
         with self.assertRaises(ValueError):
             self.gen.choices('AB', [0.0, 0.0])
 
+    def test_choices_negative_total(self):
+        with self.assertRaises(ValueError):
+            self.gen.choices('ABC', [3, -5, 1])
+
+    def test_choices_infinite_total(self):
+        with self.assertRaises(ValueError):
+            self.gen.choices('A', [float('inf')])
+        with self.assertRaises(ValueError):
+            self.gen.choices('AB', [0.0, float('inf')])
+        with self.assertRaises(ValueError):
+            self.gen.choices('AB', [-float('inf'), 123])
+        with self.assertRaises(ValueError):
+            self.gen.choices('AB', [0.0, float('nan')])
+        with self.assertRaises(ValueError):
+            self.gen.choices('AB', [float('-inf'), float('inf')])
+
     def test_gauss(self):
         # Ensure that the seed() method initializes all the hidden state.  In
         # particular, through 2.2.1 it failed to reset a piece of state used

--- a/Misc/NEWS.d/next/Library/2020-09-28-23-22-25.bpo-41773.oKkus0.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-28-23-22-25.bpo-41773.oKkus0.rst
@@ -1,0 +1,2 @@
+Note in documentation that :func:`random.choices` doesn't support non-finite
+weights, raise :exc:`ValueError` when given non-finite weights.


### PR DESCRIPTION


<!-- issue-number: [bpo-41773](https://bugs.python.org/issue41773) -->
https://bugs.python.org/issue41773
<!-- /issue-number -->
