### PR TITLE
bpo-41882: Clean up after CCompiler.has_function()

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -792,6 +792,8 @@ int main (int argc, char **argv) {
             objects = self.compile([fname], include_dirs=include_dirs)
         except CompileError:
             return False
+        finally:
+            os.remove(fname)
 
         try:
             self.link_executable(objects, "a.out",
@@ -799,6 +801,12 @@ int main (int argc, char **argv) {
                                  library_dirs=library_dirs)
         except (LinkError, TypeError):
             return False
+        else:
+            os.remove("a.out")
+        finally:
+            for fn in objects:
+                os.remove(fn)
+
         return True
 
     def find_library_file (self, dirs, lib, debug=0):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-09-28-19-21-41.bpo-41882.2v6wec.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-09-28-19-21-41.bpo-41882.2v6wec.rst
@@ -1,0 +1,1 @@
+Clean up after :func:`CCompiler.has_function`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
CCompiler.has_function() does not delete temporary files. Depending on the 
check result it leaves temporary C source, object and executable files. 
This PR fixes that.

<!-- issue-number: [bpo-41882](https://bugs.python.org/issue41882) -->
https://bugs.python.org/issue41882
<!-- /issue-number -->
