### PR TITLE
bpo-41876: Overload __repr__ for tkinter Font objects

### DIFF
--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -101,7 +101,7 @@ class Font:
         return self.name
 
     def __repr__(self):
-        return f"{self.__class__.__module__}.{self.__class__.__name__} object '{self.name}'"
+        return f"<{self.__class__.__module__}.{self.__class__.__qualname__} object '{self.name}'>"
 
     def __eq__(self, other):
         if not isinstance(other, Font):

--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -100,6 +100,9 @@ class Font:
     def __str__(self):
         return self.name
 
+    def __repr__(self):
+        return f"{self.__class__.__module__}.{self.__class__.__name__} object '{self.name}'"
+
     def __eq__(self, other):
         if not isinstance(other, Font):
             return NotImplemented

--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -101,7 +101,8 @@ class Font:
         return self.name
 
     def __repr__(self):
-        return f"<{self.__class__.__module__}.{self.__class__.__qualname__} object {self.name!r}>"
+        return f"<{self.__class__.__module__}.{self.__class__.__qualname__}" \
+               f" object {self.name!r}>"
 
     def __eq__(self, other):
         if not isinstance(other, Font):

--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -101,7 +101,7 @@ class Font:
         return self.name
 
     def __repr__(self):
-        return f"<{self.__class__.__module__}.{self.__class__.__qualname__} object '{self.name}'>"
+        return f"<{self.__class__.__module__}.{self.__class__.__qualname__} object {self.name!r}>"
 
     def __eq__(self, other):
         if not isinstance(other, Font):

--- a/Lib/tkinter/test/test_tkinter/test_font.py
+++ b/Lib/tkinter/test/test_tkinter/test_font.py
@@ -100,10 +100,10 @@ class FontTest(AbstractTkTest, unittest.TestCase):
             self.assertIsInstance(name, str)
             self.assertTrue(name)
         self.assertIn(fontname, names)
-    
+
     def test_repr(self):
         self.assertEqual(repr(self.font), f'<{self.font.__class__.__module__}.{self.font.__class__.__qualname__} object {fontname!r}>')
-        
+
 
 tests_gui = (FontTest, )
 

--- a/Lib/tkinter/test/test_tkinter/test_font.py
+++ b/Lib/tkinter/test/test_tkinter/test_font.py
@@ -102,7 +102,7 @@ class FontTest(AbstractTkTest, unittest.TestCase):
         self.assertIn(fontname, names)
     
     def test_repr(self):
-        assert repr(self.font) == f'<{self.font.__class__.__module__}.{self.__class__.__qualname__} object {fontname!r}>'
+        self.assertEqual(repr(self.font), f'<{self.font.__class__.__module__}.{self.font.__class__.__qualname__} object {fontname!r}>')
         
 
 tests_gui = (FontTest, )

--- a/Lib/tkinter/test/test_tkinter/test_font.py
+++ b/Lib/tkinter/test/test_tkinter/test_font.py
@@ -102,7 +102,9 @@ class FontTest(AbstractTkTest, unittest.TestCase):
         self.assertIn(fontname, names)
 
     def test_repr(self):
-        self.assertEqual(repr(self.font), f'<{self.font.__class__.__module__}.{self.font.__class__.__qualname__} object {fontname!r}>')
+        self.assertEqual(
+            repr(self.font), f'<tkinter.font.Font object {fontname!r}>'
+        )
 
 
 tests_gui = (FontTest, )

--- a/Lib/tkinter/test/test_tkinter/test_font.py
+++ b/Lib/tkinter/test/test_tkinter/test_font.py
@@ -100,6 +100,10 @@ class FontTest(AbstractTkTest, unittest.TestCase):
             self.assertIsInstance(name, str)
             self.assertTrue(name)
         self.assertIn(fontname, names)
+    
+    def test_repr(self):
+        assert repr(self.font) == f'<{self.font.__class__.__module__}.{self.__class__.__qualname__} object {fontname!r}>'
+        
 
 tests_gui = (FontTest, )
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1351,6 +1351,7 @@ Zero Piraeus
 Antoine Pitrou
 Jean-François Piéronne
 Oleg Plakhotnyuk
+Anatoliy Platonov
 Marcel Plch
 Remi Pointel
 Jon Poler

--- a/Misc/NEWS.d/next/Library/2020-09-29-16-23-54.bpo-41876.QicdDU.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-29-16-23-54.bpo-41876.QicdDU.rst
@@ -1,2 +1,1 @@
-Change in :class:`tkinter.font.Font`, now representation of font object contains
-font name instead of object address.
+Tkinter font class repr uses font name

--- a/Misc/NEWS.d/next/Library/2020-09-29-16-23-54.bpo-41876.QicdDU.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-29-16-23-54.bpo-41876.QicdDU.rst
@@ -1,0 +1,2 @@
+Change in :class:`tkinter.font.Font`, now representation of font object contains
+font name instead of object address.


### PR DESCRIPTION
Put name of font instead of object address

<!-- issue-number: [bpo-41876](https://bugs.python.org/issue41876) -->
https://bugs.python.org/issue41876
<!-- /issue-number -->
