### PR TITLE
gh-84256: Fix _tkinter resuming null thread state

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-09-29-17-13-58.bpo-40075.pQAxXp.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-29-17-13-58.bpo-40075.pQAxXp.rst
@@ -1,1 +1,1 @@
-_tkinter correctly handles a null thread state when trying to restore the state.
+Fix a crash in ``_tkinter`` on Windows where ``ENTER_PYTHON`` may try to restore a NULL state.

--- a/Misc/NEWS.d/next/Library/2020-09-29-17-13-58.bpo-40075.pQAxXp.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-29-17-13-58.bpo-40075.pQAxXp.rst
@@ -1,0 +1,1 @@
+_tkinter correctly handles a null thread state when trying to restore the state.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -261,6 +261,10 @@ static PyThreadState *tcl_tstate = NULL;
 
 #define ENTER_PYTHON \
     { PyThreadState *tstate = tcl_tstate; tcl_tstate = NULL; \
+        if(tstate == NULL) { \
+          PyGILState_STATE gstate = PyGILState_Ensure(); \
+          tstate = PyThreadState_Get(); \
+          PyGILState_Release(gstate); } \
         if(tcl_lock) \
           PyThread_release_lock(tcl_lock); PyEval_RestoreThread((tstate)); }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-40075](https://bugs.python.org/issue40075) -->
https://bugs.python.org/issue40075
<!-- /issue-number -->

<!-- gh-issue-number: gh-84256 -->
* Issue: gh-84256
<!-- /gh-issue-number -->
