### PR TITLE
[doc] Update references to NumPy

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1191,7 +1191,7 @@ difference is that a Python list can contain objects of many different types.
 
 The ``array`` module also provides methods for creating arrays of fixed types
 with compact representations, but they are slower to index than lists.  Also
-note that the Numeric extensions and others define array-like structures with
+note that NumPy and other third party packages define array-like structures with
 various characteristics as well.
 
 To get Lisp-style linked lists, you can emulate cons cells using tuples::

--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -257,7 +257,6 @@ Examples::
       Packing and unpacking of External Data Representation (XDR) data as used in some
       remote procedure call systems.
 
-   `The Numerical Python Documentation <https://docs.scipy.org/doc/>`_
-      The Numeric Python extension (NumPy) defines another array type; see
-      http://www.numpy.org/ for further information about Numerical Python.
+   `NumPy <https://numpy.org/>`_
+      The NumPy package defines another array type.
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1512,14 +1512,12 @@ are always available.  They are listed here in alphabetical order.
 .. class:: slice(stop)
            slice(start, stop[, step])
 
-   .. index:: single: Numerical Python
-
    Return a :term:`slice` object representing the set of indices specified by
    ``range(start, stop, step)``.  The *start* and *step* arguments default to
    ``None``.  Slice objects have read-only data attributes :attr:`~slice.start`,
    :attr:`~slice.stop` and :attr:`~slice.step` which merely return the argument
    values (or their default).  They have no other explicit functionality;
-   however they are used by Numerical Python and other third party extensions.
+   however they are used by NumPy and other third party packages.
    Slice objects are also generated when extended indexing syntax is used.  For
    example: ``a[start:stop:step]`` or ``a[start:stop, i]``.  See
    :func:`itertools.islice` for an alternate version that returns an iterator.

--- a/Doc/tutorial/floatingpoint.rst
+++ b/Doc/tutorial/floatingpoint.rst
@@ -158,7 +158,7 @@ which implements arithmetic based on rational numbers (so the numbers like
 1/3 can be represented exactly).
 
 If you are a heavy user of floating point operations you should take a look
-at the Numerical Python package and many other packages for mathematical and
+at the NumPy package and many other packages for mathematical and
 statistical operations supplied by the SciPy project. See <https://scipy.org>.
 
 Python provides tools that may help on those rare occasions when you really


### PR DESCRIPTION
Numeric(al) Python to NumPy. It seems the old name hasn't been used for some time.

Automerge-Triggered-By: @lisroach