### PR TITLE
bpo-36424: Add support for pickling frozen dataclasses with __slots__

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -569,6 +569,18 @@ def _frozen_get_del_attr(cls, fields, globals):
                        f'super(cls, self).__delattr__(name)'),
                        locals=locals,
                        globals=globals),
+            _create_fn('__getstate__',
+                       ('self',),
+                       ('fields = getattr(self, _fields)',
+                        'valid_fields = (f.name for f in fields.values() if f._field_type is _FIELD)',
+                        'return [(attr, getattr(self, attr, None)) for attr in valid_fields]',
+                       ),
+                       globals=dict(globals, _fields=_FIELDS, _FIELD=_FIELD)),
+            _create_fn('__setstate__',
+                       ('self', 'state'),
+                       ('for slot, value in state:',
+                        ' object.__setattr__(self, slot, value)'),
+                       globals=globals),
             )
 
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1934,6 +1934,22 @@ class TestCase(unittest.TestCase):
                     self.assertEqual(new_sample.x, another_new_sample.x)
                     self.assertEqual(sample.y, another_new_sample.y)
 
+    def test_frozen_dataclasses_pickleable(self):
+        global S
+        @dataclass(frozen=True)
+        class S:
+            __slots__ = ('x', 'y')
+            x: int
+            y: int
+
+        sample = S(42, 24)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(sample=sample, proto=proto):
+                new_sample = pickle.loads(pickle.dumps(sample, proto))
+                self.assertEqual(sample.x, new_sample.x)
+                self.assertEqual(sample.y, new_sample.y)
+                self.assertIsNot(sample, new_sample)
+
 
 class TestFieldNoAnnotation(unittest.TestCase):
     def test_field_without_annotation(self):

--- a/Misc/NEWS.d/next/Library/2020-09-29-19-19-39.bpo-36424.wENDWY.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-29-19-19-39.bpo-36424.wENDWY.rst
@@ -1,0 +1,2 @@
+Add support for pickling and unpickling frozen :mod:`dataclasses` that have
+``__slots__``.


### PR DESCRIPTION
Allow to pickle and unpickle frozen dataclasses that have
``__slots__``.

Co-Authored-By: Claudiu Popa <pcmanticore@gmail.com>



<!-- issue-number: [bpo-36424](https://bugs.python.org/issue36424) -->
https://bugs.python.org/issue36424
<!-- /issue-number -->
