### PR TITLE
bpo-41894: Fix UTF-8 errors loading native module

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-02-11-35-33.bpo-41894.ffmtOt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-02-11-35-33.bpo-41894.ffmtOt.rst
@@ -1,0 +1,3 @@
+When loading a native module and a load failure occurs, prevent a possible
+UnicodeDecodeError when not running in a UTF-8 locale by decoding the load
+error message using the current locale's encoding.

--- a/Python/dynload_aix.c
+++ b/Python/dynload_aix.c
@@ -144,10 +144,16 @@ aix_loaderror(const char *pathname)
         ERRBUF_APPEND(message[i]);
         ERRBUF_APPEND("\n");
     }
-    errbuf[strlen(errbuf)-1] = '\0';            /* trim off last newline */
+    /* Subtract 1 from the length to trim off trailing newline */
+    errbuf_ob = PyUnicode_DecodeLocaleAndSize(errbuf, strlen(errbuf)-1, "surrogateescape");
+    if (errbuf_ob == NULL)
+        return;
     pathname_ob = PyUnicode_DecodeFSDefault(pathname);
-    errbuf_ob = PyUnicode_DecodeLocale(errbuf, "surrogateescape");
-    PyErr_SetImportError(errbuf_ob, NULL, pathname);
+    if (pathname_ob == NULL) {
+        Py_DECREF(errbuf_ob);
+        return;
+    }
+    PyErr_SetImportError(errbuf_ob, NULL, pathname_ob);
     Py_DECREF(pathname_ob);
     Py_DECREF(errbuf_ob);
     return;

--- a/Python/dynload_aix.c
+++ b/Python/dynload_aix.c
@@ -145,8 +145,8 @@ aix_loaderror(const char *pathname)
         ERRBUF_APPEND("\n");
     }
     errbuf[strlen(errbuf)-1] = '\0';            /* trim off last newline */
-    pathname_ob = PyUnicode_FromString(pathname);
-    errbuf_ob = PyUnicode_FromString(errbuf);
+    pathname_ob = PyUnicode_DecodeFSDefault(pathname);
+    errbuf_ob = PyUnicode_DecodeLocale(errbuf, "surrogateescape");
     PyErr_SetImportError(errbuf_ob, NULL, pathname);
     Py_DECREF(pathname_ob);
     Py_DECREF(errbuf_ob);

--- a/Python/dynload_hpux.c
+++ b/Python/dynload_hpux.c
@@ -37,8 +37,19 @@ dl_funcptr _PyImport_FindSharedFuncptr(const char *prefix,
         PyOS_snprintf(buf, sizeof(buf), "Failed to load %.200s",
                       pathname);
         PyObject *buf_ob = PyUnicode_DecodeFSDefault(buf);
+        if (buf_ob == NULL)
+            return NULL;
         PyObject *shortname_ob = PyUnicode_FromString(shortname);
+        if (shortname_ob == NULL) {
+            Py_DECREF(buf_ob);
+            return NULL;
+        }
         PyObject *pathname_ob = PyUnicode_DecodeFSDefault(pathname);
+        if (pathname_ob == NULL) {
+            Py_DECREF(buf_ob);
+            Py_DECREF(shortname_ob);
+            return NULL;
+        }
         PyErr_SetImportError(buf_ob, shortname_ob, pathname_ob);
         Py_DECREF(buf_ob);
         Py_DECREF(shortname_ob);

--- a/Python/dynload_hpux.c
+++ b/Python/dynload_hpux.c
@@ -36,9 +36,9 @@ dl_funcptr _PyImport_FindSharedFuncptr(const char *prefix,
         char buf[256];
         PyOS_snprintf(buf, sizeof(buf), "Failed to load %.200s",
                       pathname);
-        PyObject *buf_ob = PyUnicode_FromString(buf);
+        PyObject *buf_ob = PyUnicode_DecodeFSDefault(buf);
         PyObject *shortname_ob = PyUnicode_FromString(shortname);
-        PyObject *pathname_ob = PyUnicode_FromString(pathname);
+        PyObject *pathname_ob = PyUnicode_DecodeFSDefault(pathname);
         PyErr_SetImportError(buf_ob, shortname_ob, pathname_ob);
         Py_DECREF(buf_ob);
         Py_DECREF(shortname_ob);

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -106,7 +106,7 @@ _PyImport_FindSharedFuncptr(const char *prefix,
         const char *error = dlerror();
         if (error == NULL)
             error = "unknown dlopen() error";
-        error_ob = PyUnicode_FromString(error);
+        error_ob = PyUnicode_DecodeLocale(error, "surrogateescape");
         if (error_ob == NULL)
             return NULL;
         mod_name = PyUnicode_FromString(shortname);
@@ -114,7 +114,7 @@ _PyImport_FindSharedFuncptr(const char *prefix,
             Py_DECREF(error_ob);
             return NULL;
         }
-        path = PyUnicode_FromString(pathname);
+        path = PyUnicode_DecodeFSDefault(pathname);
         if (path == NULL) {
             Py_DECREF(error_ob);
             Py_DECREF(mod_name);


### PR DESCRIPTION
When running in a non-UTF-8 locale, if an error occurs while importing a
native Python module (say because a dependent share library is missing),
the error message string returned may contain non-ASCII code points
causing a UnicodeDecodeError.

While this is most likely to occur on AIX, which still uses non-UTF-8
locales by default, it could occur on any Unix-like system.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41894](https://bugs.python.org/issue41894) -->
https://bugs.python.org/issue41894
<!-- /issue-number -->
