### PR TITLE
bpo-41887: omit leading whitespaces on ast.literal_eval

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1586,6 +1586,8 @@ and classes for traversing abstract syntax trees:
    .. versionchanged:: 3.9
       Now supports creating empty sets with ``'set()'``.
 
+   .. versionchanged:: 3.10
+      Now allows leading whitespaces
 
 .. function:: get_docstring(node, clean=True)
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1587,8 +1587,7 @@ and classes for traversing abstract syntax trees:
       Now supports creating empty sets with ``'set()'``.
 
    .. versionchanged:: 3.10
-      For string inputs, leading spaces and tabs is now stripped (as
-      the trailing ones already was).
+      For string inputs, leading spaces and tabs are now stripped.
 
 
 .. function:: get_docstring(node, clean=True)

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1587,7 +1587,8 @@ and classes for traversing abstract syntax trees:
       Now supports creating empty sets with ``'set()'``.
 
    .. versionchanged:: 3.10
-      Now allows leading whitespaces
+      For string inputs, leading whitespace is now stripped (as
+      trailing whitespace already was).
 
 
 .. function:: get_docstring(node, clean=True)

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1587,8 +1587,8 @@ and classes for traversing abstract syntax trees:
       Now supports creating empty sets with ``'set()'``.
 
    .. versionchanged:: 3.10
-      For string inputs, leading whitespace is now stripped (as
-      trailing whitespace already was).
+      For string inputs, leading spaces and tabs is now stripped (as
+      the trailing ones already was).
 
 
 .. function:: get_docstring(node, clean=True)

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1589,6 +1589,7 @@ and classes for traversing abstract syntax trees:
    .. versionchanged:: 3.10
       Now allows leading whitespaces
 
+
 .. function:: get_docstring(node, clean=True)
 
    Return the docstring of the given *node* (which must be a

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -506,7 +506,8 @@ are always available.  They are listed here in alphabetical order.
    returns the current global and local dictionary, respectively, which may be
    useful to pass around for use by :func:`eval` or :func:`exec`.
 
-   The leading whitespaces would be omitted.
+   If the given source is a string, then the leading whitespace will be
+   omitted.
 
    See :func:`ast.literal_eval` for a function that can safely evaluate strings
    with expressions containing only literals.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -506,8 +506,8 @@ are always available.  They are listed here in alphabetical order.
    returns the current global and local dictionary, respectively, which may be
    useful to pass around for use by :func:`eval` or :func:`exec`.
 
-   If the given source is a string, then then leading and trailing whitespace
-   is stripped.
+   If the given source is a string, then leading and trailing spaces and tabs
+   are stripped.
 
    See :func:`ast.literal_eval` for a function that can safely evaluate strings
    with expressions containing only literals.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -506,6 +506,8 @@ are always available.  They are listed here in alphabetical order.
    returns the current global and local dictionary, respectively, which may be
    useful to pass around for use by :func:`eval` or :func:`exec`.
 
+   The leading whitespaces would be omitted.
+
    See :func:`ast.literal_eval` for a function that can safely evaluate strings
    with expressions containing only literals.
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -506,8 +506,8 @@ are always available.  They are listed here in alphabetical order.
    returns the current global and local dictionary, respectively, which may be
    useful to pass around for use by :func:`eval` or :func:`exec`.
 
-   If the given source is a string, then the leading whitespace will be
-   omitted.
+   If the given source is a string, then then leading and trailing whitespace
+   is stripped.
 
    See :func:`ast.literal_eval` for a function that can safely evaluate strings
    with expressions containing only literals.

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -59,7 +59,8 @@ def literal_eval(node_or_string):
     sets, booleans, and None.
     """
     if isinstance(node_or_string, str):
-        node_or_string = parse(node_or_string, mode='eval')
+        # bpo-41887: Allow leading whitespace
+        node_or_string = parse(node_or_string.strip(" \t"), mode='eval')
     if isinstance(node_or_string, Expression):
         node_or_string = node_or_string.body
     def _raise_malformed_node(node):

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -59,8 +59,7 @@ def literal_eval(node_or_string):
     sets, booleans, and None.
     """
     if isinstance(node_or_string, str):
-        # bpo-41887: Allow leading whitespace
-        node_or_string = parse(node_or_string.strip(" \t"), mode='eval')
+        node_or_string = parse(node_or_string.lstrip(" \t"), mode='eval')
     if isinstance(node_or_string, Expression):
         node_or_string = node_or_string.body
     def _raise_malformed_node(node):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1008,6 +1008,7 @@ Module(
     def test_literal_eval_trailing_ws(self):
         self.assertEqual(ast.literal_eval("    -1"), -1)
         self.assertEqual(ast.literal_eval("\t\t-1"), -1)
+        self.assertEqual(ast.literal_eval(" \t -1"), -1)
         self.assertRaises(IndentationError, ast.literal_eval, "\n -1")
 
     def test_bad_integer(self):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1005,6 +1005,11 @@ Module(
         malformed = ast.Dict(keys=[ast.Constant(1)], values=[ast.Constant(2), ast.Constant(3)])
         self.assertRaises(ValueError, ast.literal_eval, malformed)
 
+    def test_literal_eval_trailing_ws(self):
+        self.assertEqual(ast.literal_eval("    -1"), -1)
+        self.assertEqual(ast.literal_eval("\t\t-1"), -1)
+        self.assertRaises(IndentationError, ast.literal_eval, "\n -1")
+
     def test_bad_integer(self):
         # issue13436: Bad error message with invalid numeric values
         body = [ast.ImportFrom(module='time',

--- a/Misc/NEWS.d/next/Library/2020-09-30-23-49-42.bpo-41887.-ee2S-.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-30-23-49-42.bpo-41887.-ee2S-.rst
@@ -1,2 +1,2 @@
-Strip leading whitespace on :func:`ast.literal_eval`. Also document
-stripping of whitespace for :func:`eval`.
+Strip leading spaces and tabs on :func:`ast.literal_eval`. Also document
+stripping of spaces and tabs for :func:`eval`.

--- a/Misc/NEWS.d/next/Library/2020-09-30-23-49-42.bpo-41887.-ee2S-.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-30-23-49-42.bpo-41887.-ee2S-.rst
@@ -1,1 +1,2 @@
-Omit leading whitespaces on :func:`ast.literal_eval`.
+Strip leading whitespace on :func:`ast.literal_eval`. Also document
+stripping of whitespace for :func:`eval`.

--- a/Misc/NEWS.d/next/Library/2020-09-30-23-49-42.bpo-41887.-ee2S-.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-30-23-49-42.bpo-41887.-ee2S-.rst
@@ -1,0 +1,1 @@
+Omit leading whitespaces on :func:`ast.literal_eval`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41887](https://bugs.python.org/issue41887) -->
https://bugs.python.org/issue41887
<!-- /issue-number -->
