### PR TITLE
bpo-41900: C14N 2.0 serialisation failed for unprefixed attributes when a default namespace was defined.

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -3899,6 +3899,14 @@ class C14NTest(unittest.TestCase):
         #self.assertEqual(c14n_roundtrip("<doc xmlns:x='http://example.com/x' xmlns='http://example.com/default'><b y:a1='1' xmlns='http://example.com/default' a3='3' xmlns:y='http://example.com/y' y:a2='2'/></doc>"),
         #'<doc xmlns:x="http://example.com/x"><b xmlns:y="http://example.com/y" a3="3" y:a1="1" y:a2="2"></b></doc>')
 
+        # Namespace issues
+        xml = '<X xmlns="http://nps/a"><Y targets="abc,xyz"></Y></X>'
+        self.assertEqual(c14n_roundtrip(xml), xml)
+        xml = '<X xmlns="http://nps/a"><Y xmlns="http://nsp/b" targets="abc,xyz"></Y></X>'
+        self.assertEqual(c14n_roundtrip(xml), xml)
+        xml = '<X xmlns="http://nps/a"><Y xmlns:b="http://nsp/b" b:targets="abc,xyz"></Y></X>'
+        self.assertEqual(c14n_roundtrip(xml), xml)
+
     def test_c14n_exclusion(self):
         xml = textwrap.dedent("""\
         <root xmlns:x="http://example.com/x">

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1876,6 +1876,11 @@ class C14NWriterTarget:
                 self._declared_ns_stack[-1].append((uri, prefix))
                 return f'{prefix}:{tag}' if prefix else tag, tag, uri
 
+        if not uri:
+            # As soon as a default namespace is defined,
+            # anything that has no namespace (and thus, no prefix) goes there.
+            return tag, tag, uri
+
         raise ValueError(f'Namespace "{uri}" is not declared in scope')
 
     def data(self, data):

--- a/Misc/NEWS.d/next/Library/2020-10-01-10-50-12.bpo-41900.Cho7oh.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-01-10-50-12.bpo-41900.Cho7oh.rst
@@ -1,0 +1,2 @@
+C14N 2.0 serialisation in xml.etree.ElementTree failed for unprefixed attributes
+when a default namespace was defined.


### PR DESCRIPTION


<!-- issue-number: [bpo-41900](https://bugs.python.org/issue41900) -->
https://bugs.python.org/issue41900
<!-- /issue-number -->
