### PR TITLE
bpo-41902: Add fast path for long_div if the divisor is one

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -204,7 +204,10 @@ class LongTest(unittest.TestCase):
         self.check_division(710031681576388032, 26769404391308)
         self.check_division(1933622614268221, 30212853348836)
 
-
+    @support.cpython_only
+    def test_division_with_one(self):
+        for n in range(10000000):
+            self.assertEqual(n, n // 1)
 
     def test_karatsuba(self):
         digits = list(range(1, 5)) + list(range(KARATSUBA_CUTOFF,

--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-02-00-53-08.bpo-41902.owZSPO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-02-00-53-08.bpo-41902.owZSPO.rst
@@ -1,0 +1,1 @@
+Add fast path for long_div if the divisor is one. Patch by Dong-hee Na.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3697,6 +3697,10 @@ long_div(PyObject *a, PyObject *b)
     PyLongObject *div;
 
     CHECK_BINOP(a, b);
+    if (b == _PyLong_One) {
+        Py_INCREF(a);
+        return a;
+    }
 
     if (Py_ABS(Py_SIZE(a)) == 1 && Py_ABS(Py_SIZE(b)) == 1) {
         return fast_floor_div((PyLongObject*)a, (PyLongObject*)b);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3695,12 +3695,12 @@ static PyObject *
 long_div(PyObject *a, PyObject *b)
 {
     PyLongObject *div;
-
-    CHECK_BINOP(a, b);
-    if (b == _PyLong_One) {
+    if (b == _PyLong_One && PyLong_CheckExact(a)) {
         Py_INCREF(a);
         return a;
     }
+
+    CHECK_BINOP(a, b);
 
     if (Py_ABS(Py_SIZE(a)) == 1 && Py_ABS(Py_SIZE(b)) == 1) {
         return fast_floor_div((PyLongObject*)a, (PyLongObject*)b);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41902](https://bugs.python.org/issue41902) -->
https://bugs.python.org/issue41902
<!-- /issue-number -->
