### PR TITLE
bpo-41889: enum: fix multiple-inheritance regression

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -146,8 +146,9 @@ class EnumMeta(type):
         for key in ignore:
             classdict.pop(key, None)
         member_type, first_enum = metacls._get_mixins_(cls, bases)
-        __new__, save_new, use_args = metacls._find_new_(classdict, member_type,
-                                                        first_enum)
+        __new__, save_new, use_args = metacls._find_new_(
+                classdict, member_type, first_enum,
+                )
 
         # save enum items into separate mapping so they don't get baked into
         # the new class
@@ -501,12 +502,16 @@ class EnumMeta(type):
                 for base in chain.__mro__:
                     if base is object:
                         continue
+                    elif issubclass(base, Enum):
+                        if base._member_type_ is not object:
+                            data_types.append(base._member_type_)
+                            break
                     elif '__new__' in base.__dict__:
                         if issubclass(base, Enum):
                             continue
                         data_types.append(candidate or base)
                         break
-                    elif not issubclass(base, Enum):
+                    else:
                         candidate = base
             if len(data_types) > 1:
                 raise TypeError('%r: too many data types: %r' % (class_name, data_types))

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2021,6 +2021,32 @@ class TestEnum(unittest.TestCase):
             REVERT_ALL = "REVERT_ALL"
             RETRY = "RETRY"
 
+    def test_multiple_mixin_inherited(self):
+        class MyInt(int):
+            def __new__(cls, value):
+                return super().__new__(cls, value)
+
+        class HexMixin:
+            def __repr__(self):
+                return hex(self)
+
+        class MyIntEnum(HexMixin, MyInt, enum.Enum):
+            pass
+
+        class Foo(MyIntEnum):
+            TEST = 1
+        self.assertTrue(isinstance(Foo.TEST, MyInt))
+        self.assertEqual(repr(Foo.TEST), "0x1")
+
+        class Fee(MyIntEnum):
+            TEST = 1
+            def __new__(cls, value):
+                value += 1
+                member = int.__new__(cls, value)
+                member._value_ = value
+                return member
+        self.assertEqual(Fee.TEST, 2)
+
     def test_empty_globals(self):
         # bpo-35717: sys._getframe(2).f_globals['__name__'] fails with KeyError
         # when using compile and exec because f_globals is empty

--- a/Misc/NEWS.d/next/Library/2020-10-01-16-17-11.bpo-41889.qLkNh8.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-01-16-17-11.bpo-41889.qLkNh8.rst
@@ -1,0 +1,1 @@
+Enum: fix regression involving inheriting a multiply-inherited enum


### PR DESCRIPTION
When an Enum class is created from another multi-inherited Enum class, the member type is not being found.

<!-- issue-number: [bpo-41889](https://bugs.python.org/issue41889) -->
https://bugs.python.org/issue41889
<!-- /issue-number -->
