### PR TITLE
bpo-41907: fix format() behavior for IntFlag

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -653,7 +653,7 @@ class Enum(metaclass=EnumMeta):
         # the value
 
         # pure Enum branch, or branch with __str__ explicitly overridden
-        str_overridden = type(self).__str__ != Enum.__str__
+        str_overridden = type(self).__str__ not in (Enum.__str__, Flag.__str__)
         if self._member_type_ is object or str_overridden:
             cls = str
             val = str(self)

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -585,12 +585,15 @@ class TestEnum(unittest.TestCase):
         class Test1Enum(MyMethodEnum, int, MyStrEnum):
             One = 1
             Two = 2
+        self.assertTrue(Test1Enum._member_type_ is int)
         self.assertEqual(str(Test1Enum.One), 'MyStr')
+        self.assertEqual(format(Test1Enum.One, ''), 'MyStr')
         #
         class Test2Enum(MyStrEnum, MyMethodEnum):
             One = 1
             Two = 2
         self.assertEqual(str(Test2Enum.One), 'MyStr')
+        self.assertEqual(format(Test1Enum.One, ''), 'MyStr')
 
     def test_inherited_data_type(self):
         class HexInt(int):
@@ -2225,6 +2228,11 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(repr(~(Open.RO | Open.CE)), '<Open.AC: 3>')
         self.assertEqual(repr(~(Open.WO | Open.CE)), '<Open.RW: 2>')
 
+    def test_format(self):
+        Perm = self.Perm
+        self.assertEqual(format(Perm.R, ''), 'Perm.R')
+        self.assertEqual(format(Perm.R | Perm.X, ''), 'Perm.R|X')
+
     def test_or(self):
         Perm = self.Perm
         for i in Perm:
@@ -2564,6 +2572,7 @@ class TestIntFlag(unittest.TestCase):
 
     def test_type(self):
         Perm = self.Perm
+        self.assertTrue(Perm._member_type_ is int)
         Open = self.Open
         for f in Perm:
             self.assertTrue(isinstance(f, Perm))
@@ -2642,6 +2651,11 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(repr(~(Open.RO | Open.CE)), '<Open.AC|RW|WO: -524289>')
         self.assertEqual(repr(~(Open.WO | Open.CE)), '<Open.RW: -524290>')
         self.assertEqual(repr(Open(~4)), '<Open.CE|AC|RW|WO: -5>')
+
+    def test_format(self):
+        Perm = self.Perm
+        self.assertEqual(format(Perm.R, ''), '4')
+        self.assertEqual(format(Perm.R | Perm.X, ''), '5')
 
     def test_or(self):
         Perm = self.Perm

--- a/Misc/NEWS.d/next/Library/2020-10-02-10-19-49.bpo-41907.wiIEsz.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-02-10-19-49.bpo-41907.wiIEsz.rst
@@ -1,0 +1,1 @@
+fix `format()` behavior for `IntFlag`


### PR DESCRIPTION
A regression was introduced with GH-14545 (Use overridden `__str__` if present);  the fix did not account for `Flag` having its own `__str__`.

<!-- issue-number: [bpo-41907](https://bugs.python.org/issue41907) -->
https://bugs.python.org/issue41907
<!-- /issue-number -->
