### PR TITLE
bpo-41922: Use PEP 590 vectorcall to speed up reversed()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-04-01-02-58.bpo-41922.kHGT8I.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-04-01-02-58.bpo-41922.kHGT8I.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``reversed()`` by using the :pep:`590` ``vectorcall``
+calling convention. Patch by Dong-hee Na.

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -314,6 +314,24 @@ reversed_new_impl(PyTypeObject *type, PyObject *seq)
     return (PyObject *)ro;
 }
 
+static PyObject *
+reversed_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
+{
+    assert(PyType_Check(type));
+    
+    if (!_PyArg_NoKwnames("reversed", kwnames)) {
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("reversed", nargs, 1, 1)) {
+        return NULL;
+    }
+
+    return reversed_new_impl((PyTypeObject *)type, args[0]);
+}
+
 static void
 reversed_dealloc(reversedobject *ro)
 {
@@ -445,4 +463,5 @@ PyTypeObject PyReversed_Type = {
     PyType_GenericAlloc,            /* tp_alloc */
     reversed_new,                   /* tp_new */
     PyObject_GC_Del,                /* tp_free */
+    .tp_vectorcall = reversed_vectorcall,
 };

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -319,7 +319,7 @@ reversed_vectorcall(PyObject *type, PyObject * const*args,
                 size_t nargsf, PyObject *kwnames)
 {
     assert(PyType_Check(type));
-    
+
     if (!_PyArg_NoKwnames("reversed", kwnames)) {
         return NULL;
     }
@@ -463,5 +463,5 @@ PyTypeObject PyReversed_Type = {
     PyType_GenericAlloc,            /* tp_alloc */
     reversed_new,                   /* tp_new */
     PyObject_GC_Del,                /* tp_free */
-    .tp_vectorcall = reversed_vectorcall,
+    .tp_vectorcall = (vectorcallfunc)reversed_vectorcall,
 };


### PR DESCRIPTION
Signed-off-by: Dong-hee Na <donghee.na92@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41922](https://bugs.python.org/issue41922) -->
https://bugs.python.org/issue41922
<!-- /issue-number -->
