### PR TITLE
bpo-41916: allow cross-compiled python to have -pthread set for CXX

### DIFF
--- a/Misc/NEWS.d/next/Build/2022-03-04-10-47-23.bpo-41916.1d2GLU.rst
+++ b/Misc/NEWS.d/next/Build/2022-03-04-10-47-23.bpo-41916.1d2GLU.rst
@@ -1,0 +1,2 @@
+Allow override of ac_cv_cxx_thread so that cross compiled python can set
+-pthread for CXX.

--- a/configure
+++ b/configure
@@ -9509,12 +9509,14 @@ fi
 
 # If we have set a CC compiler flag for thread support then
 # check if it works for CXX, too.
-ac_cv_cxx_thread=no
 if test ! -z "$CXX"
 then
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX also accepts flags for thread support" >&5
 $as_echo_n "checking whether $CXX also accepts flags for thread support... " >&6; }
-ac_save_cxx="$CXX"
+if ${ac_cv_cxx_thread+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_save_cxx="$CXX"
 
 if test "$ac_cv_kpthread" = "yes"
 then
@@ -9528,6 +9530,8 @@ elif test "$ac_cv_pthread" = "yes"
 then
   CXX="$CXX -pthread"
   ac_cv_cxx_thread=yes
+else
+  ac_cv_cxx_thread=no
 fi
 
 if test $ac_cv_cxx_thread = yes
@@ -9543,10 +9547,13 @@ then
   fi
   rm -fr conftest*
 fi
+CXX="$ac_save_cxx"
+fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_thread" >&5
 $as_echo "$ac_cv_cxx_thread" >&6; }
+else
+  ac_cv_cxx_thread=no
 fi
-CXX="$ac_save_cxx"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2664,11 +2664,10 @@ fi
 
 # If we have set a CC compiler flag for thread support then
 # check if it works for CXX, too.
-ac_cv_cxx_thread=no
 if test ! -z "$CXX"
 then
-AC_MSG_CHECKING(whether $CXX also accepts flags for thread support)
-ac_save_cxx="$CXX"
+AC_CACHE_CHECK([whether $CXX also accepts flags for thread support], [ac_cv_cxx_thread],
+[ac_save_cxx="$CXX"
 
 if test "$ac_cv_kpthread" = "yes"
 then
@@ -2682,6 +2681,8 @@ elif test "$ac_cv_pthread" = "yes"
 then
   CXX="$CXX -pthread"
   ac_cv_cxx_thread=yes
+else
+  ac_cv_cxx_thread=no
 fi
 
 if test $ac_cv_cxx_thread = yes
@@ -2697,9 +2698,10 @@ then
   fi
   rm -fr conftest*
 fi
-AC_MSG_RESULT($ac_cv_cxx_thread)
+CXX="$ac_save_cxx"])
+else
+  ac_cv_cxx_thread=no
 fi
-CXX="$ac_save_cxx"
 
 dnl # check for ANSI or K&R ("traditional") preprocessor
 dnl AC_MSG_CHECKING(for C preprocessor type)


### PR DESCRIPTION
When cross-compiling, the compile/run test for -pthread always fails so -pthread will never be automatically set without an override from the cache. ac_cv_pthread can already be overridden, so do the same thing for ac_cv_cxx_thread.

I've validated that my cross-compiled python has the variables set now when configured via:

```
   ./configure --host=$TARGET_HOST --build=$BUILD_HOST --prefix=$PREFIX \
        --disable-ipv6 --enable-unicode=ucs4 \
        ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no \
        ac_cv_have_long_long_format=yes \
        ac_cv_pthread_is_default=no ac_cv_pthread=yes ac_cv_cxx_thread=yes; \
```

I now get as expected:

```
>>> import pprint, distutils.sysconfig
>>> pprint.pprint({i: distutils.sysconfig.get_config_vars(i)[0] for i in ('CC', 'CXX', 'LDSHARED')})
{'CC': 'arm-frc2020-linux-gnueabi-gcc -pthread',
 'CXX': 'arm-frc2020-linux-gnueabi-c++ -pthread',
 'LDSHARED': 'arm-frc2020-linux-gnueabi-gcc -pthread -shared'}
```

I haven't yet checked to see if it all works quite yet, will do later today. 


<!-- issue-number: [bpo-41916](https://bugs.python.org/issue41916) -->
https://bugs.python.org/issue41916
<!-- /issue-number -->
