### PR TITLE
bpo-25292: asyncio ssl fail hard when writing to closed transport

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -381,8 +381,13 @@ class _SSLProtocolTransport(transports._FlowControlMixin,
         if not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError(f"data: expecting a bytes-like instance, "
                             f"got {type(data).__name__}")
+        if self._ssl_protocol._sslpipe is None:
+            # The SSL pipe has been destroyed. Writing should fail.
+            # See bpo-25292.
+            raise BrokenPipeError("SSL pipe is broken")
         if not data:
             return
+
         self._ssl_protocol._write_appdata(data)
 
     def can_write_eof(self):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -151,8 +151,8 @@ class SslProtoHandshakeTests(test_utils.TestCase):
         transp = ssl_proto._app_transport
         transp.close()
 
-        # should not raise
-        self.assertIsNone(transp.write(b'data'))
+        with self.assertRaises(BrokenPipeError):
+            self.assertIsNone(transp.write(b'data'))
 
 
 ##############################################################################


### PR DESCRIPTION
Here is my attempt at [bpo-25292](https://bugs.python.org/issue25292) 🤗 I hope this is the desired behaviour. Should I add a note to [asyncio.StreamWriter.write](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.write), mentioning that it can fail with `BrokenPipeError`?

<!-- issue-number: [bpo-25292](https://bugs.python.org/issue25292) -->
https://bugs.python.org/issue25292
<!-- /issue-number -->
