### PR TITLE
bpo-41936. Remove macros Py_ALLOW_RECURSION/Py_END_ALLOW_RECURSION

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -342,3 +342,8 @@ Removed
 * Removed ``_Py_CheckRecursionLimit`` variable: it has been replaced by
   ``ceval.recursion_limit`` of the :c:type:`PyInterpreterState` structure.
   (Contributed by Victor Stinner in :issue:`41834`.)
+
+* Removed undocumented macros ``Py_ALLOW_RECURSION`` and
+  ``Py_END_ALLOW_RECURSION`` and the ``recursion_critical`` field of the
+  :c:type:`PyInterpreterState` structure.
+  (Contributed by Serhiy Storchaka in :issue:`41936`.)

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -67,14 +67,6 @@ PyAPI_FUNC(int) Py_GetRecursionLimit(void);
 PyAPI_FUNC(int) Py_EnterRecursiveCall(const char *where);
 PyAPI_FUNC(void) Py_LeaveRecursiveCall(void);
 
-#define Py_ALLOW_RECURSION \
-  do { unsigned char _old = PyThreadState_GET()->recursion_critical;\
-    PyThreadState_GET()->recursion_critical = 1;
-
-#define Py_END_ALLOW_RECURSION \
-    PyThreadState_GET()->recursion_critical = _old; \
-  } while(0);
-
 PyAPI_FUNC(const char *) PyEval_GetFuncName(PyObject *);
 PyAPI_FUNC(const char *) PyEval_GetFuncDesc(PyObject *);
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -56,8 +56,6 @@ struct _ts {
     int recursion_depth;
     char overflowed; /* The stack has overflowed. Allow 50 more calls
                         to handle the runtime error. */
-    char recursion_critical; /* The current calls must not cause
-                                a stack overflow. */
     int stackcheck_counter;
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.

--- a/Misc/NEWS.d/next/C API/2020-10-05-01-25-23.bpo-41936.1gb5ra.rst
+++ b/Misc/NEWS.d/next/C API/2020-10-05-01-25-23.bpo-41936.1gb5ra.rst
@@ -1,0 +1,3 @@
+Removed undocumented macros ``Py_ALLOW_RECURSION`` and
+``Py_END_ALLOW_RECURSION`` and the ``recursion_critical`` field of the
+:c:type:`PyInterpreterState` structure.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -814,9 +814,6 @@ _Py_CheckRecursiveCall(PyThreadState *tstate, const char *where)
         return -1;
     }
 #endif
-    if (tstate->recursion_critical)
-        /* Somebody asked that we don't check for recursion. */
-        return 0;
     if (tstate->overflowed) {
         if (tstate->recursion_depth > recursion_limit + 50) {
             /* Overflowing while handling an overflow. Give up. */

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -581,7 +581,6 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->frame = NULL;
     tstate->recursion_depth = 0;
     tstate->overflowed = 0;
-    tstate->recursion_critical = 0;
     tstate->stackcheck_counter = 0;
     tstate->tracing = 0;
     tstate->use_tracing = 0;


### PR DESCRIPTION


<!-- issue-number: [bpo-41936](https://bugs.python.org/issue41936) -->
https://bugs.python.org/issue41936
<!-- /issue-number -->
