### PR TITLE
bpo-41939: Fix test_site.test_license_exists_at_url()

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -525,6 +525,8 @@ class ImportSideEffectTests(unittest.TestCase):
         # string displayed by license in the absence of a LICENSE file.
         url = license._Printer__data.split()[1]
         req = urllib.request.Request(url, method='HEAD')
+        # Reset global urllib.request._opener
+        self.addCleanup(urllib.request.urlcleanup)
         try:
             with socket_helper.transient_internet(url):
                 with urllib.request.urlopen(req) as data:

--- a/Misc/NEWS.d/next/Tests/2020-10-05-09-37-43.bpo-41939.P4OlbA.rst
+++ b/Misc/NEWS.d/next/Tests/2020-10-05-09-37-43.bpo-41939.P4OlbA.rst
@@ -1,0 +1,3 @@
+Fix test_site.test_license_exists_at_url(): call
+``urllib.request.urlcleanup()`` to reset the global
+``urllib.request._opener``. Patch by Victor Stinner.


### PR DESCRIPTION
Call urllib.request.urlcleanup() to reset the global
urllib.request._opener.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41939](https://bugs.python.org/issue41939) -->
https://bugs.python.org/issue41939
<!-- /issue-number -->
