### PR TITLE
bpo-41944: No longer call eval() on content received via HTTP in the CJK codec tests

### DIFF
--- a/Lib/test/multibytecodec_support.py
+++ b/Lib/test/multibytecodec_support.py
@@ -305,29 +305,22 @@ class TestBase_Mapping(unittest.TestCase):
             self._test_mapping_file_plain()
 
     def _test_mapping_file_plain(self):
-        unichrs = lambda s: ''.join(map(chr, map(eval, s.split('+'))))
+        def unichrs(s):
+            return ''.join(chr(int(x, 16)) for x in s.split('+'))
+
         urt_wa = {}
 
         with self.open_mapping_file() as f:
             for line in f:
                 if not line:
                     break
-                data = line.split('#')[0].strip().split()
+                data = line.split('#')[0].split()
                 if len(data) != 2:
                     continue
 
-                csetval = eval(data[0])
-                if csetval <= 0x7F:
-                    csetch = bytes([csetval & 0xff])
-                elif csetval >= 0x1000000:
-                    csetch = bytes([(csetval >> 24), ((csetval >> 16) & 0xff),
-                                    ((csetval >> 8) & 0xff), (csetval & 0xff)])
-                elif csetval >= 0x10000:
-                    csetch = bytes([(csetval >> 16), ((csetval >> 8) & 0xff),
-                                    (csetval & 0xff)])
-                elif csetval >= 0x100:
-                    csetch = bytes([(csetval >> 8), (csetval & 0xff)])
-                else:
+                assert data[0][:2] == '0x'
+                csetch = bytes.fromhex(data[0][2:])
+                if len(csetch) == 1 and 0x80 <= csetch[0]:
                     continue
 
                 unich = unichrs(data[1])

--- a/Lib/test/multibytecodec_support.py
+++ b/Lib/test/multibytecodec_support.py
@@ -318,7 +318,8 @@ class TestBase_Mapping(unittest.TestCase):
                 if len(data) != 2:
                     continue
 
-                assert data[0][:2] == '0x'
+                if data[0][:2] != '0x':
+                    self.fail(f"Invalid line: {line!r}")
                 csetch = bytes.fromhex(data[0][2:])
                 if len(csetch) == 1 and 0x80 <= csetch[0]:
                     continue

--- a/Misc/NEWS.d/next/Tests/2020-10-05-17-43-46.bpo-41944.rf1dYb.rst
+++ b/Misc/NEWS.d/next/Tests/2020-10-05-17-43-46.bpo-41944.rf1dYb.rst
@@ -1,0 +1,1 @@
+Tests for CJK codecs no longer call ``eval()`` on content received via HTTP.


### PR DESCRIPTION


<!-- issue-number: [bpo-41944](https://bugs.python.org/issue41944) -->
https://bugs.python.org/issue41944
<!-- /issue-number -->
