### PR TITLE
bpo-41944: No longer call eval() on content received via HTTP in the UnicodeNames tests

### DIFF
--- a/Lib/test/test_ucn.py
+++ b/Lib/test/test_ucn.py
@@ -7,6 +7,7 @@ Modified for Python 2.0 by Fredrik Lundh (fredrik@pythonware.com)
 
 """#"
 
+import ast
 import unittest
 import unicodedata
 
@@ -24,7 +25,7 @@ class UnicodeNamesTest(unittest.TestCase):
         # Helper that put all \N escapes inside eval'd raw strings,
         # to make sure this script runs even if the compiler
         # chokes on \N escapes
-        res = eval(r'"\N{%s}"' % name)
+        res = ast.literal_eval(r'"\N{%s}"' % name)
         self.assertEqual(res, code)
         return res
 


### PR DESCRIPTION
Similarly to GH-22566, those tests called eval() on content received via
HTTP in test_named_sequences_full. This likely isn't exploitable because
unicodedata.lookup(seqname) is called before self.checkletter(seqname,
None) - thus any string which isn't a valid unicode character name
wouldn't ever reach the checkletter method.

Still, it's probably better to be safe than sorry.

<!-- issue-number: [bpo-41944](https://bugs.python.org/issue41944) -->
https://bugs.python.org/issue41944
<!-- /issue-number -->
