### PR TITLE
bpo-41959: Fix grammar around class asyncio.MultiLoopChildWatcher text

### DIFF
--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -219,7 +219,7 @@ implementation used by the asyncio event loop:
 
    This implementation registers a :py:data:`SIGCHLD` signal handler on
    instantiation. That can break third-party code that installs a custom handler for
-   `SIGCHLD`.  signal).
+   :py:data:`SIGCHLD` signal.
 
    The watcher avoids disrupting other code spawning processes
    by polling every process explicitly on a :py:data:`SIGCHLD` signal.


### PR DESCRIPTION
While translating the following document to Spanish we found there is a grammar issue on the original documentation.

https://bugs.python.org/issue41959


<!-- issue-number: [bpo-41959](https://bugs.python.org/issue41959) -->
https://bugs.python.org/issue41959
<!-- /issue-number -->

Automerge-Triggered-By: GH:asvetlov