### PR TITLE
bpo-42014: shutil.rmtree: call onerror with correct function

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -708,7 +708,7 @@ def rmtree(path, ignore_errors=False, onerror=None):
         try:
             fd = os.open(path, os.O_RDONLY)
         except Exception:
-            onerror(os.lstat, path, sys.exc_info())
+            onerror(os.open, path, sys.exc_info())
             return
         try:
             if os.path.samestat(orig_st, os.fstat(fd)):

--- a/Misc/NEWS.d/next/Library/2020-11-10-15-40-56.bpo-42014.ShM37l.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-10-15-40-56.bpo-42014.ShM37l.rst
@@ -1,0 +1,1 @@
+The ``onerror`` callback from ``shutil.rmtree`` now receives correct function when ``os.open`` fails.


### PR DESCRIPTION
The onerror is supposed to be called with failed function, but in this case lstat is wrongly used instead of open.

Not sure if this needs bug or not...

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42014](https://bugs.python.org/issue42014) -->
https://bugs.python.org/issue42014
<!-- /issue-number -->

Automerge-Triggered-By: GH:hynek