### PR TITLE
Docs: improve equivalence expression for chained comparison

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1359,12 +1359,12 @@ Comparisons yield boolean values: ``True`` or ``False``.
 .. index:: pair: chaining; comparisons
 
 Comparisons can be chained arbitrarily, e.g., ``x < y <= z`` is equivalent to
-``x < y and y <= z``, except that ``y`` is evaluated only once (but in both
+``( x < y and y <= z )``, except that ``y`` is evaluated only once (but in both
 cases ``z`` is not evaluated at all when ``x < y`` is found to be false).
 
 Formally, if *a*, *b*, *c*, ..., *y*, *z* are expressions and *op1*, *op2*, ...,
 *opN* are comparison operators, then ``a op1 b op2 c ... y opN z`` is equivalent
-to ``a op1 b and b op2 c and ... y opN z``, except that each expression is
+to a single expression ``( a op1 b and b op2 c and ... y opN z )``, except that each expression is
 evaluated at most once.
 
 Note that ``a op1 b op2 c`` doesn't imply any kind of comparison between *a* and


### PR DESCRIPTION
Add grouping parenthesis around the informal equivalence expression to make it clear that it is evaluated as a single expression.

`x < y < z` parses as a single expression, so while it is equivalent to x < y and y < z in isolation, it is different when used in an expression with `not`.  
`not` has a higher precedence than `and`.  We don't see this with `or` as it has a lower precedence than `and`.  (See the next section on Boolean Expressions)

+ `not x < y < z` == `not (x < y < z)`
+ `not x < y and y < z` != `not (x < y and y < z)`

```
>>> import ast
>>> ast.dump(ast.parse('not x<y<z')) == ast.dump(ast.parse('not(x < y <z)'))
True

>>> ast.dump(ast.parse('not x < y and y < z')) == ast.dump(ast.parse('(not x < y) and y < z'))
True

>>> ast.dump(ast.parse('not x < y and y < z')) == ast.dump(ast.parse('not (x < y and y < z)'))
False
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
