### PR TITLE
subprocess: Add escape_wildcard parameter for program don't want the wildcard matched files

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1086,6 +1086,14 @@ class ProcessTestCase(BaseTestCase):
             shutil.rmtree(tmpdir)
 
     def test_list2cmdline(self):
+        self.assertEqual(subprocess.list2cmdline(['a b* c', 'd', 'e'], False),
+                         '"a b* c" d e')
+        self.assertEqual(subprocess.list2cmdline(['a b* c', 'd', 'e'], True),
+                         '"a b\\* c" d e')
+        self.assertEqual(subprocess.list2cmdline(['a b? c', 'd', 'e'], False),
+                         '"a b? c" d e')
+        self.assertEqual(subprocess.list2cmdline(['a b? c', 'd', 'e'], True),
+                         '"a b\\? c" d e')
         self.assertEqual(subprocess.list2cmdline(['a b c', 'd', 'e']),
                          '"a b c" d e')
         self.assertEqual(subprocess.list2cmdline(['ab"c', '\\', 'd']),


### PR DESCRIPTION

According to https://docs.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?redirectedfrom=MSDN#wildcard-expansion,
the default msvcrt will automatically using wildcard to matching files, and sometimes it's not the program wanted, so provide a
option to escape it.

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
