### PR TITLE
[3.7] bpo-41976: Fix the fallback to gcc of ctypes.util.find_library when using gcc>9 (GH-22598)

### DIFF
--- a/Lib/ctypes/test/test_find.py
+++ b/Lib/ctypes/test/test_find.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 import os.path
 import sys
 import test.support
@@ -72,7 +73,7 @@ class Test_OpenGL_libs(unittest.TestCase):
 
 @unittest.skipUnless(sys.platform.startswith('linux'),
                      'Test only valid for Linux')
-class LibPathFindTest(unittest.TestCase):
+class FindLibraryLinux(unittest.TestCase):
     def test_find_on_libpath(self):
         import subprocess
         import tempfile
@@ -110,6 +111,15 @@ class LibPathFindTest(unittest.TestCase):
                 # now check that the .so can be found (since in
                 # LD_LIBRARY_PATH)
                 self.assertEqual(find_library(libname), 'lib%s.so' % libname)
+
+    def test_find_library_with_gcc(self):
+        with unittest.mock.patch("ctypes.util._findSoname_ldconfig", lambda *args: None):
+            self.assertNotEqual(find_library('c'), None)
+
+    def test_find_library_with_ld(self):
+        with unittest.mock.patch("ctypes.util._findSoname_ldconfig", lambda *args: None), \
+             unittest.mock.patch("ctypes.util._findLib_gcc", lambda *args: None):
+            self.assertNotEqual(find_library('c'), None)
 
 
 if __name__ == "__main__":

--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -93,6 +93,12 @@ elif os.name == "posix":
     # Andreas Degert's find functions, using gcc, /sbin/ldconfig, objdump
     import re, tempfile
 
+    def _is_elf(filename):
+        "Return True if the given file is an ELF file"
+        elf_header = b'\x7fELF'
+        with open(filename, 'br') as thefile:
+            return thefile.read(4) == elf_header
+
     def _findLib_gcc(name):
         # Run GCC's linker with the -t (aka --trace) option and examine the
         # library name it prints out. The GCC command will fail because we
@@ -130,10 +136,17 @@ elif os.name == "posix":
                 # Raised if the file was already removed, which is the normal
                 # behaviour of GCC if linking fails
                 pass
-        res = re.search(expr, trace)
+        res = re.findall(expr, trace)
         if not res:
             return None
-        return os.fsdecode(res.group(0))
+
+        for file in res:
+            # Check if the given file is an elf file: gcc can report
+            # some files that are linker scripts and not actual
+            # shared objects. See bpo-41976 for more details
+            if not _is_elf(file):
+                continue
+            return os.fsdecode(file)
 
 
     if sys.platform == "sunos5":
@@ -299,17 +312,22 @@ elif os.name == "posix":
                                      stderr=subprocess.PIPE,
                                      universal_newlines=True)
                 out, _ = p.communicate()
-                res = re.search(expr, os.fsdecode(out))
-                if res:
-                    result = res.group(0)
-            except Exception as e:
+                res = re.findall(expr, os.fsdecode(out))
+                for file in res:
+                    # Check if the given file is an elf file: gcc can report
+                    # some files that are linker scripts and not actual
+                    # shared objects. See bpo-41976 for more details
+                    if not _is_elf(file):
+                        continue
+                    return os.fsdecode(file)
+            except Exception:
                 pass  # result will be None
             return result
 
         def find_library(name):
             # See issue #9998
             return _findSoname_ldconfig(name) or \
-                   _get_soname(_findLib_gcc(name) or _findLib_ld(name))
+                   _get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))
 
 ################################################################
 # test code

--- a/Misc/NEWS.d/next/Library/2020-10-08-18-22-28.bpo-41976.Svm0wb.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-08-18-22-28.bpo-41976.Svm0wb.rst
@@ -1,0 +1,3 @@
+Fixed a bug that was causing :func:`ctypes.util.find_library` to return
+``None`` when triying to locate a library in an environment when gcc>=9 is
+available and ``ldconfig`` is not. Patch by Pablo Galindo


### PR DESCRIPTION
…

(cherry picked from commit 27ac19cca2c639caaf6fedf3632fe6beb265f24f)

Co-authored-by: Pablo Galindo <Pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41976](https://bugs.python.org/issue41976) -->
https://bugs.python.org/issue41976
<!-- /issue-number -->
