### PR TITLE
Add versionchanged directives to glob.iglob documentation

### DIFF
--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -84,6 +84,16 @@ For example, ``'[?]'`` matches the character ``'?'``.
 
    .. audit-event:: glob.glob pathname,recursive glob.iglob
 
+   .. note::
+      Using the "``**``" pattern in large directory trees may consume
+      an inordinate amount of time.
+
+   .. versionchanged:: 3.5
+      Support for recursive globs using "``**``".
+
+   .. versionchanged:: 3.10
+      Added the *root_dir* and *dir_fd* parameters.
+
 
 .. function:: escape(pathname)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Add `versionchanged` directives to `glob.iglob` documentation. Previously these directives were only added to `glob.glob`. Although the documentation says that the only difference between `glob.glob` and `glob.iglob` is that the latter is a lazy iterator, I still feel it better to add `versionchanged` directives also to `glob.iglob`, because people may not be aware that the `recursive` argument is 3.5+ and `root_dir`/`dir_fd` are 3.10+ for `glob.iglob`, especially when they come from [a link with anchor](https://docs.python.org/3.10/library/glob.html#glob.iglob). This change would make things more noticeable.
