### PR TITLE
bpo-28724: Move socket.send_fds and socket.recv_fds documentation to the "Other functions" section

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1143,6 +1143,32 @@ The :mod:`socket` module also offers various network-related services:
       "Interface name" is a name as documented in :func:`if_nameindex`.
 
 
+.. function:: socket.send_fds(sock, buffers, fds[, flags[, address]])
+
+   Send the list of file descriptors *fds* over an :const:`AF_UNIX` socket *sock*.
+   The *fds* parameter is a sequence of file descriptors.
+   Consult :meth:`sendmsg` for the documentation of these parameters.
+
+   .. availability:: Unix supporting :meth:`~socket.sendmsg` and :const:`SCM_RIGHTS` mechanism.
+
+   .. versionadded:: 3.9
+
+
+.. function:: socket.recv_fds(sock, bufsize, maxfds[, flags])
+
+   Receive up to *maxfds* file descriptors from an :const:`AF_UNIX` socket *sock*.
+   Return ``(msg, list(fds), flags, addr)``.
+   Consult :meth:`recvmsg` for the documentation of these parameters.
+
+   .. availability:: Unix supporting :meth:`~socket.recvmsg` and :const:`SCM_RIGHTS` mechanism.
+
+   .. versionadded:: 3.9
+
+   .. note::
+
+      Any truncated integers at the end of the list of file descriptors.
+
+
 .. _socket-objects:
 
 Socket Objects
@@ -1636,29 +1662,6 @@ to sockets.
    .. availability:: Linux >= 2.6.38.
 
    .. versionadded:: 3.6
-
-.. method:: socket.send_fds(sock, buffers, fds[, flags[, address]])
-
-   Send the list of file descriptors *fds* over an :const:`AF_UNIX` socket.
-   The *fds* parameter is a sequence of file descriptors.
-   Consult :meth:`sendmsg` for the documentation of these parameters.
-
-   .. availability:: Unix supporting :meth:`~socket.sendmsg` and :const:`SCM_RIGHTS` mechanism.
-
-   .. versionadded:: 3.9
-
-.. method:: socket.recv_fds(sock, bufsize, maxfds[, flags])
-
-   Receive up to *maxfds* file descriptors. Return ``(msg, list(fds), flags, addr)``. Consult
-   :meth:`recvmsg` for the documentation of these parameters.
-
-   .. availability:: Unix supporting :meth:`~socket.recvmsg` and :const:`SCM_RIGHTS` mechanism.
-
-   .. versionadded:: 3.9
-
-   .. note::
-
-      Any truncated integers at the end of the list of file descriptors.
 
 .. method:: socket.sendfile(file, offset=0, count=None)
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1143,7 +1143,7 @@ The :mod:`socket` module also offers various network-related services:
       "Interface name" is a name as documented in :func:`if_nameindex`.
 
 
-.. function:: socket.send_fds(sock, buffers, fds[, flags[, address]])
+.. function:: send_fds(sock, buffers, fds[, flags[, address]])
 
    Send the list of file descriptors *fds* over an :const:`AF_UNIX` socket *sock*.
    The *fds* parameter is a sequence of file descriptors.
@@ -1154,7 +1154,7 @@ The :mod:`socket` module also offers various network-related services:
    .. versionadded:: 3.9
 
 
-.. function:: socket.recv_fds(sock, bufsize, maxfds[, flags])
+.. function:: recv_fds(sock, bufsize, maxfds[, flags])
 
    Receive up to *maxfds* file descriptors from an :const:`AF_UNIX` socket *sock*.
    Return ``(msg, list(fds), flags, addr)``.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -658,7 +658,7 @@ The socket module now supports the :data:`~socket.CAN_J1939` protocol on
 platforms that support it.  (Contributed by Karl Ding in :issue:`40291`.)
 
 The socket module now has the :func:`socket.send_fds` and
-:func:`socket.recv.fds` methods. (Contributed by Joannah Nanjekye, Shinya
+:func:`socket.recv_fds` functions. (Contributed by Joannah Nanjekye, Shinya
 Okano and Victor Stinner in :issue:`28724`.)
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Move `socket.send_fds` and `socket.recv_fds` documentation to the "Other functions" section, since they are module-level functions rather than methods of socket objects. Putting them in the "Socket Objects" section would make people incorrectly think that they are methods of socket objects, which is confusing.

<!-- issue-number: [bpo-28724](https://bugs.python.org/issue28724) -->
https://bugs.python.org/issue28724
<!-- /issue-number -->
