### PR TITLE
[3.9] bpo-41970: Avoid test failure in test_lib2to3 if the module is already imported (GH-22595)

### DIFF
--- a/Lib/test/test_lib2to3.py
+++ b/Lib/test/test_lib2to3.py
@@ -1,8 +1,8 @@
 import unittest
-from test.support import check_warnings
+from test.support import check_warnings, import_fresh_module
 
 with check_warnings(("", PendingDeprecationWarning)):
-    from lib2to3.tests import load_tests
+    load_tests = import_fresh_module('lib2to3.tests', fresh=['lib2to3']).load_tests
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Tests/2020-10-08-14-00-17.bpo-41970.aZ8QFf.rst
+++ b/Misc/NEWS.d/next/Tests/2020-10-08-14-00-17.bpo-41970.aZ8QFf.rst
@@ -1,0 +1,2 @@
+Avoid a test failure in ``test_lib2to3`` if the module has already imported
+at the time the test executes. Patch by Pablo Galindo.


### PR DESCRIPTION
Automerge-Triggered-By: @pablogsal.
(cherry picked from commit 4a9f82f50d957b6cf3fd207de8b583d9137316b8)

Co-authored-by: Pablo Galindo <Pablogsal@gmail.com>

<!-- issue-number: [bpo-41970](https://bugs.python.org/issue41970) -->
https://bugs.python.org/issue41970
<!-- /issue-number -->
