### PR TITLE
bpo-41805: Documentation for PEP 585

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -476,6 +476,13 @@ Glossary
       See also the :term:`single dispatch` glossary entry, the
       :func:`functools.singledispatch` decorator, and :pep:`443`.
 
+   generic type
+      A :term:`type` that can be parameterized; typically a container like
+      :class:`list`. Used for :term:`type hints <type hint>` and
+      :term:`annotations <annotation>`.
+
+      See :pep:`483` for more details, and :mod:`typing` or
+      :ref:`generic alias type <types-genericalias>` for its uses.
 
    GIL
       See :term:`global interpreter lock`.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4759,6 +4759,12 @@ Generic Alias Type
    object: GenericAlias
    pair: Generic; Alias
 
+Most of the time, the :ref:`subscription expression <subscriptions>` calls the
+:term:`method` :meth:`__getitem__` of an :term:`object`. However, the
+subscription of a :term:`class` itself calls the :func:`classmethod
+<classmethod>` :meth:`__class_getitem__` of the class instead. The classmethod
+:meth:`__class_getitem__` returns a ``GenericAlias`` object.
+
 The ``GenericAlias`` object acts as a proxy for :term:`generic types
 <generic type>`, implementing *parameterized generics* - a specific instance
 of a generic with the types for container elements provided. It is intended
@@ -4766,6 +4772,13 @@ primarily for type :term:`annotations <annotation>`.  ``GenericAlias`` objects
 are created by expressions like ``list[int]``.
 
 The type for the ``GenericAlias`` object is :data:`types.GenericAlias`.
+
+.. impl-detail::
+
+   The C equivalent of :meth:`__getitem__` - :c:func:`PyObject_GetItem` - is
+   called first for builtin classes and types. When :c:func:`PyObject_GetItem`
+   detects that it was called on a type, it then calls :meth:`__class_getitem__`
+   and returns the ``GenericAlias`` object.
 
 .. describe:: generic[X, Y, ...]
 
@@ -4885,12 +4898,12 @@ their type parameters can be found in the :mod:`typing` module:
 * :ref:`re.Match <match-objects>`
 
 
-Special Attributes of Generics
-------------------------------
+Special Attributes of Generic Alias
+-----------------------------------
 
 All parameterized generics implement special read-only attributes.
 
-.. attribute:: generic.__origin__
+.. attribute:: genericalias.__origin__
 
    This attribute points at the non-parameterized generic class::
 
@@ -4898,7 +4911,7 @@ All parameterized generics implement special read-only attributes.
       <class 'list'>
 
 
-.. attribute:: generic.__args__
+.. attribute:: genericalias.__args__
 
    This attribute is a :class:`tuple` (possibly of length 1) of generic
    types passed to the original :meth:`__class_getitem__`
@@ -4908,7 +4921,7 @@ All parameterized generics implement special read-only attributes.
       (<class 'str'>, list[int])
 
 
-.. attribute:: generic.__parameters__
+.. attribute:: genericalias.__parameters__
 
    This attribute is a lazily computed tuple (possibly empty) of unique type
    variables found in ``__args__``::

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4772,19 +4772,7 @@ class instead. The classmethod :meth:`__class_getitem__` should return a
 .. note::
    If the :meth:`__getitem__` of the class' metaclass is present, it will take
    precedence over the :meth:`__class_getitem__` defined in the class (see
-   :pep:`560` for more details)::
-
-      >>> class M(type):
-      ...     def __getitem__(self, key):
-      ...         print('__getitem__ was called')
-
-      >>> class T(metaclass=M):
-      ...     def __class_getitem__(cls, key):
-      ...         print('__class_getitem__ was called')
-
-      >>> T[int]
-      '__getitem__ was called'
-
+   :pep:`560` for more details).
 
 The ``GenericAlias`` object acts as a proxy for :term:`generic types
 <generic type>`, implementing *parameterized generics* - a specific instance
@@ -4805,9 +4793,8 @@ The user-exposed type for the ``GenericAlias`` object can be accessed from
 
    Another example for :term:`mapping` objects, using a :class:`dict`, which
    is a generic type expecting two type parameters representing the key type
-   and the value type.  In this case, the function expects a ``dict`` for its
-   ``body`` argument.  The ``body`` has keys of type :class:`str` and their
-   corresponding values are of type :class:`int`::
+   and the value type.  In this example, the function expects a ``dict`` with
+   keys of type :class:`str` and values of type :class:`int`::
 
       def send_post_request(url: str, body: dict[str, int]) -> None:
           ...
@@ -4819,11 +4806,6 @@ The builtin functions :func:`isinstance` and :func:`issubclass` do not accept
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: isinstance() argument 2 cannot be a parameterized generic
-
-   >>> issubclass(list, list[str])
-   Traceback (most recent call last):
-     File "<stdin>", line 1, in <module>
-   TypeError: issubclass() argument 2 cannot be a parameterized generic
 
 The Python runtime does not enforce :term:`type annotations <annotation>`.
 This extends to generic types and their type parameters. When creating

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4772,7 +4772,7 @@ class instead. The classmethod :meth:`__class_getitem__` should return a
 .. note::
    If the :meth:`__getitem__` of the class' metaclass is present, it will take
    precedence over the :meth:`__class_getitem__` defined in the class (see
-   :pep:`560` for more details) ::
+   :pep:`560` for more details)::
 
       >>> class M(type):
       ...     def __getitem__(self, key):
@@ -4946,7 +4946,7 @@ All parameterized generics implement special read-only attributes.
    variables found in ``__args__``::
 
       >>> from typing import TypeVar
-      >>>
+
       >>> T = TypeVar('T')
       >>> list[T].__parameters__
       (~T,)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4763,7 +4763,7 @@ The ``GenericAlias`` object acts as a proxy for :term:`generic types
 <generic type>`, implementing *parameterized generics* - a specific instance
 of a generic with the types for container elements provided. It is intended
 primarily for type :term:`annotations <annotation>`.  ``GenericAlias`` objects
-are returned by expressions like ``list[int]``.
+are created by expressions like ``list[int]``.
 
 The type for the ``GenericAlias`` object is :data:`types.GenericAlias`.
 
@@ -4923,8 +4923,7 @@ All parameterized generics implement special read-only attributes.
 .. seealso::
 
    * :pep:`585` -- "Type Hinting Generics In Standard Collections"
-   * :meth:`__class_getitem__` -- Method used to parameterize contained types.
-     in generics
+   * :meth:`__class_getitem__` -- Used to implement parameterized generics.
 
 .. versionadded:: 3.9
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4749,6 +4749,112 @@ define these methods must provide them as a normal Python accessible method.
 Compared to the overhead of setting up the runtime context, the overhead of a
 single class dictionary lookup is negligible.
 
+
+.. _types-genericalias:
+
+Generic Alias Type
+==================
+
+.. index::
+   object: GenericAlias
+   pair: Generic; Alias
+
+The ``GenericAlias`` object acts as a proxy for :term:`generic types
+<generic type>`, implementing *parameterized generics* - a specific instance
+of a generic with the types for container elements provided. It is intended
+primarily for type :term:`annotations <annotation>`.  ``GenericAlias`` objects
+are returned by expressions like ``list[int]``.
+
+.. describe:: generic[X, Y, ...]
+
+   Defines a generic containing elements of types *X*, *Y*, and more depending
+   on the *generic* used.  For example, for a function expecting a :class:`list`
+   containing :class:`float` elements::
+
+      def average(values: list[float]) -> float:
+          return sum(values) / len(values)
+
+   Another example for :term:`mapping` objects, using a :class:`dict`.  In this
+   case, the expected ``dict`` has keys of type :class:`str` and their
+   corresponding values are lists which hold :class:`int` elements::
+
+      def send_request(message_body: dict[str, list[int]]) -> None:
+          ...
+
+The builtin functions :func:`isinstance` and :func:`issubclass` do not accept
+parameterized generic types for their second argument::
+
+   >>> isinstance([1, 2], list[str])
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+   TypeError: isinstance() argument 2 cannot be a parameterized generic
+   >>> issubclass(list, list[str])
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+   TypeError: issubclass() argument 2 cannot be a parameterized generic
+
+Generic types erase type parameters during object creation::
+
+   list[int]() == []
+
+Furthermore, type parameters are not checked by the Python interpreter during
+object creation when using a generic type::
+
+   list[str]([1, 2, 3]) == list[int]([1, 2, 3])
+
+The following collections are generics.  Most of their type parameters
+can be found in the :mod:`typing` module:
+
+* :class:`tuple`
+* :class:`list`
+* :class:`dict`
+* :class:`set`
+* :class:`frozenset`
+* :class:`type`
+* :class:`collections.deque`
+* :class:`collections.defaultdict`
+* :class:`collections.OrderedDict`
+* :class:`collections.Counter`
+* :class:`collections.ChainMap`
+* :class:`collections.abc.Awaitable`
+* :class:`collections.abc.Coroutine`
+* :class:`collections.abc.AsyncIterable`
+* :class:`collections.abc.AsyncIterator`
+* :class:`collections.abc.AsyncGenerator`
+* :class:`collections.abc.Iterable`
+* :class:`collections.abc.Iterator`
+* :class:`collections.abc.Generator`
+* :class:`collections.abc.Reversible`
+* :class:`collections.abc.Container`
+* :class:`collections.abc.Collection`
+* :class:`collections.abc.Callable`
+* :class:`collections.abc.Set`
+* :class:`collections.abc.MutableSet`
+* :class:`collections.abc.Mapping`
+* :class:`collections.abc.MutableMapping`
+* :class:`collections.abc.Sequence`
+* :class:`collections.abc.MutableSequence`
+* :class:`collections.abc.ByteString`
+* :class:`collections.abc.MappingView`
+* :class:`collections.abc.KeysView`
+* :class:`collections.abc.ItemsView`
+* :class:`collections.abc.ValuesView`
+* :class:`contextlib.AbstractContextManager`
+* :class:`contextlib.AbstractAsyncContextManager`
+* :ref:`re.Pattern <re-objects>`
+* :ref:`re.Match <match-objects>`
+
+The type for the ``GenericAlias`` object is :data:`types.GenericAlias`.
+
+.. seealso::
+
+   * :pep:`585` -- "Type Hinting Generics In Standard Collections"
+   * :meth:`__class_getitem__` -- Method used to parameterize contained types.
+     in generics
+
+.. versionadded:: 3.9
+
+
 .. _types-union:
 
 Union Type

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -261,6 +261,8 @@ Standard names are defined for the following types:
    The type of :ref:`parameterized generics <types-genericalias>` such as
    ``list[int]``.
 
+   .. versionadded:: 3.9
+
 .. data:: Union
 
    The type of :ref:`union type expressions<types-union>`.

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -256,6 +256,11 @@ Standard names are defined for the following types:
 
    .. versionadded:: 3.10
 
+.. data:: GenericAlias
+
+   The type of :ref:`parameterized generics <types-genericalias>` such as
+   ``list[int]``.
+
 .. data:: Union
 
    The type of :ref:`union type expressions<types-union>`.

--- a/Misc/NEWS.d/next/Documentation/2020-10-10-01-36-37.bpo-41805.l-CGv5.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-10-10-01-36-37.bpo-41805.l-CGv5.rst
@@ -1,0 +1,3 @@
+Documented :ref:`generic alias type <types-genericalias>` and
+:data:`types.GenericAlias`. Also added an entry in glossary for
+:term:`generic types <generic type>`.


### PR DESCRIPTION
This PR (if accepted) probably needs a backport to 3.9. It also partly addresses https://bugs.python.org/issue40814.

Also, I'll need to update the links in stdtypes Union Type to point to GenericAlias now. However, I'm not sure if doing that in this PR would make backporting harder/go against the 1 issue per PR recommendation.

Lastly, I have a feeling that we should create a section in stdtypes called "Types for Type Annotations" and place GenericAlias and Union under that since it's becoming a moderate chunk of the documentation for that page. I'll open a bpo if that makes sense.

<!-- issue-number: [bpo-41805](https://bugs.python.org/issue41805) -->
https://bugs.python.org/issue41805
<!-- /issue-number -->
