### PR TITLE
bpo-39481: Fix duplicate SimpleQueue type in test_genericalias.py

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     # multiprocessing.shared_memory is not available on e.g. Android
     ShareableList = None
-from multiprocessing.queues import SimpleQueue
+from multiprocessing.queues import SimpleQueue as MPSimpleQueue
 from os import DirEntry
 from re import Pattern, Match
 from types import GenericAlias, MappingProxyType, AsyncGeneratorType
@@ -81,7 +81,7 @@ class BaseTest(unittest.TestCase):
                  SplitResult, ParseResult,
                  ValueProxy, ApplyResult,
                  WeakSet, ReferenceType, ref,
-                 ShareableList, SimpleQueue,
+                 ShareableList, MPSimpleQueue,
                  Future, _WorkItem,
                  Morsel]
         if ctypes is not None:


### PR DESCRIPTION
There are two different `SimpleQueue` types imported (from `multiprocessing.queues` and `queue`) in `Lib/test/test_genericalias.py`, the second one shadowing the first one, making the first one not actually tested. Fix by using different names.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum