### PR TITLE
bpo-41986: Add Py_FileSystemDefaultEncodeErrors and Py_UTF8Mode back to limited API

### DIFF
--- a/Include/cpython/fileobject.h
+++ b/Include/cpython/fileobject.h
@@ -4,14 +4,6 @@
 
 PyAPI_FUNC(char *) Py_UniversalNewlineFgets(char *, int, FILE*, PyObject *);
 
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03060000
-PyAPI_DATA(const char *) Py_FileSystemDefaultEncodeErrors;
-#endif
-
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
-PyAPI_DATA(int) Py_UTF8Mode;
-#endif
-
 /* The std printer acts as a preliminary sys.stderr until the new io
    infrastructure is in place. */
 PyAPI_FUNC(PyObject *) PyFile_NewStdPrinter(int);

--- a/Include/fileobject.h
+++ b/Include/fileobject.h
@@ -20,7 +20,14 @@ PyAPI_FUNC(int) PyObject_AsFileDescriptor(PyObject *);
    If non-NULL, this is different than the default encoding for strings
 */
 PyAPI_DATA(const char *) Py_FileSystemDefaultEncoding;
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03060000
+PyAPI_DATA(const char *) Py_FileSystemDefaultEncodeErrors;
+#endif
 PyAPI_DATA(int) Py_HasFileSystemDefaultEncoding;
+
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
+PyAPI_DATA(int) Py_UTF8Mode;
+#endif
 
 /* A routine to check if a file descriptor can be select()-ed. */
 #ifdef _MSC_VER

--- a/Misc/NEWS.d/next/C API/2020-10-09-22-50-46.bpo-41986.JUPE59.rst
+++ b/Misc/NEWS.d/next/C API/2020-10-09-22-50-46.bpo-41986.JUPE59.rst
@@ -1,0 +1,2 @@
+:c:data:`Py_FileSystemDefaultEncodeErrors` and :c:data:`Py_UTF8Mode` are
+available again in limited API.


### PR DESCRIPTION


<!-- issue-number: [bpo-41986](https://bugs.python.org/issue41986) -->
https://bugs.python.org/issue41986
<!-- /issue-number -->
