### PR TITLE
bpo-42000: Cleanup the AST related C-code

### DIFF
--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1897,7 +1897,7 @@ _PyPegen_empty_arguments(Parser *p)
         return NULL;
     }
 
-    return _Py_arguments(posonlyargs, posargs, NULL, kwonlyargs, kwdefaults, NULL, kwdefaults,
+    return _Py_arguments(posonlyargs, posargs, NULL, kwonlyargs, kwdefaults, NULL, posdefaults,
                          p->arena);
 }
 

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -1,18 +1,12 @@
 /*
- * This file includes functions to transform a concrete syntax tree (CST) to
- * an abstract syntax tree (AST). The main function is PyAST_FromNode().
- *
+ * This file exposes PyAST_Validate interface to check the integrity
+ * of the given abstract syntax tree (potentially constructed manually).
  */
 #include "Python.h"
 #include "Python-ast.h"
 #include "ast.h"
-#include "token.h"
-#include "pythonrun.h"
 
 #include <assert.h>
-#include <stdbool.h>
-
-#define MAXLEVEL 200    /* Max parentheses level */
 
 static int validate_stmts(asdl_stmt_seq *);
 static int validate_exprs(asdl_expr_seq*, expr_context_ty, int);
@@ -62,7 +56,7 @@ validate_keywords(asdl_keyword_seq *keywords)
 {
     Py_ssize_t i;
     for (i = 0; i < asdl_seq_LEN(keywords); i++)
-        if (!validate_expr(((keyword_ty)asdl_seq_GET(keywords, i))->value, Load))
+        if (!validate_expr((asdl_seq_GET(keywords, i))->value, Load))
             return 0;
     return 1;
 }
@@ -556,7 +550,7 @@ _PyAST_GetDocString(asdl_stmt_seq *body)
     if (!asdl_seq_LEN(body)) {
         return NULL;
     }
-    stmt_ty st = (stmt_ty)asdl_seq_GET(body, 0);
+    stmt_ty st = asdl_seq_GET(body, 0);
     if (st->kind != Expr_kind) {
         return NULL;
     }


### PR DESCRIPTION
- Use the proper asdl sequence when creating empty arguments
- Remove reduntant casts (thanks to new typed asdl_sequences)
- Remove MarshalPrototypeVisitor and some utilities from asdl generator
- Fix the header of `Python/ast.c` (kept from pgen times)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42000](https://bugs.python.org/issue42000) -->
https://bugs.python.org/issue42000
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal