### PR TITLE
bpo-42005: Fix CLI of cProfile and profile to catch BrokenPipeError

### DIFF
--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -175,7 +175,12 @@ def main():
                 '__package__': None,
                 '__cached__': None,
             }
-        runctx(code, globs, None, options.outfile, options.sort)
+        try:
+            runctx(code, globs, None, options.outfile, options.sort)
+        except BrokenPipeError as exc:
+            # Prevent "Exception ignored" during interpreter shutdown.
+            sys.stdout = None
+            sys.exit(exc.errno)
     else:
         parser.print_usage()
     return parser

--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -595,7 +595,12 @@ def main():
                 '__package__': None,
                 '__cached__': None,
             }
-        runctx(code, globs, None, options.outfile, options.sort)
+        try:
+            runctx(code, globs, None, options.outfile, options.sort)
+        except BrokenPipeError as exc:
+            # Prevent "Exception ignored" during interpreter shutdown.
+            sys.stdout = None
+            sys.exit(exc.errno)
     else:
         parser.print_usage()
     return parser

--- a/Misc/NEWS.d/next/Library/2020-10-11-13-48-03.bpo-42005.Jq6Az-.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-11-13-48-03.bpo-42005.Jq6Az-.rst
@@ -1,0 +1,2 @@
+Fix CLI of :mod:`cProfile` and :mod:`profile` to catch
+:exc:`BrokenPipeError`.


### PR DESCRIPTION
Catch `BrokenPipeError` in the CLI of `cProfile` and `profile` to reduce noise when piping through `head`.

Prior art of catching `BrokenPipeError` in a PSL CLI: [bpo-39828](https://bugs.python.org/issue39828) #18779 targeting `json.tool`.

A test can be added but I've held off for now since it would be rather unwieldy and of pretty limited value.

<!-- issue-number: [bpo-42005](https://bugs.python.org/issue42005) -->
https://bugs.python.org/issue42005
<!-- /issue-number -->
