### PR TITLE
[3.8] bpo-41993: Fix possible issues in remove_module() (GH-22631)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-10-13-53-52.bpo-41993.YMzixQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-10-13-53-52.bpo-41993.YMzixQ.rst
@@ -1,0 +1,2 @@
+Fixed potential issues with removing not completely initialized module from
+``sys.modules`` when import fails.


### PR DESCRIPTION
* PyMapping_HasKey() is not safe because it silences all exceptions and can return incorrect result.
* Informative exceptions from PyMapping_DelItem() are overridden with RuntimeError and
  the original exception raised before calling remove_module() is lost.
* There is a race condition between PyMapping_HasKey() and PyMapping_DelItem().
(cherry picked from commit 8287aadb75f6bd0154996424819334cd3839707c)


<!-- issue-number: [bpo-41993](https://bugs.python.org/issue41993) -->
https://bugs.python.org/issue41993
<!-- /issue-number -->
