### PR TITLE
bpo-39101: Fixes BaseException hang in IsolatedAsyncioTestCase.

### DIFF
--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -102,9 +102,9 @@ class IsolatedAsyncioTestCase(TestCase):
                 ret = await awaitable
                 if not fut.cancelled():
                     fut.set_result(ret)
-            except asyncio.CancelledError:
+            except (SystemExit, KeyboardInterrupt):
                 raise
-            except BaseException as ex:
+            except (BaseException, asyncio.CancelledError) as ex:
                 if not fut.cancelled():
                     fut.set_exception(ex)
 

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -104,7 +104,7 @@ class IsolatedAsyncioTestCase(TestCase):
                     fut.set_result(ret)
             except asyncio.CancelledError:
                 raise
-            except Exception as ex:
+            except BaseException as ex:
                 if not fut.cancelled():
                     fut.set_exception(ex)
 

--- a/Lib/unittest/test/test_async_case.py
+++ b/Lib/unittest/test/test_async_case.py
@@ -193,21 +193,30 @@ class TestAsyncCase(unittest.TestCase):
     def test_base_exception_from_async_method(self):
         events = []
         class Test(unittest.IsolatedAsyncioTestCase):
-            async def test_a(self):
-                events.append("test_a")
+            async def test_base(self):
+                events.append("test_base")
                 raise BaseException()
                 events.append("not it")
 
-            async def test_b(self):
-                events.append("test_b")
+            async def test_no_err(self):
+                events.append("test_no_err")
 
-        test = Test("test_a")
+            async def test_cancel(self):
+                raise asyncio.CancelledError()
+
+        test = Test("test_base")
         output = test.run()
         self.assertFalse(output.wasSuccessful())
 
-        test = Test("test_b")
+        test = Test("test_no_err")
         test.run()
-        self.assertEqual(events, ['test_a', 'test_b'])
+        self.assertEqual(events, ['test_base', 'test_no_err'])
+
+        test = Test("test_cancel")
+        output = test.run()
+        self.assertFalse(output.wasSuccessful())
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/unittest/test/test_async_case.py
+++ b/Lib/unittest/test/test_async_case.py
@@ -190,6 +190,24 @@ class TestAsyncCase(unittest.TestCase):
                                   'async_cleanup 2',
                                   'sync_cleanup 1'])
 
+    def test_base_exception_from_async_method(self):
+        events = []
+        class Test(unittest.IsolatedAsyncioTestCase):
+            async def test_a(self):
+                events.append("test_a")
+                raise BaseException()
+                events.append("not it")
+
+            async def test_b(self):
+                events.append("test_b")
+
+        test = Test("test_a")
+        output = test.run()
+        self.assertFalse(output.wasSuccessful())
+
+        test = Test("test_b")
+        test.run()
+        self.assertEqual(events, ['test_a', 'test_b'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-10-11-21-43-03.bpo-39101.-I49Pm.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-11-21-43-03.bpo-39101.-I49Pm.rst
@@ -1,0 +1,1 @@
+Fixed tests using IsolatedAsyncioTestCase from hanging on BaseExceptions.


### PR DESCRIPTION
If a BaseException is raised in IsolatedAsyncioTestCase the test will hang forever. This should fix that, added a unit test that would hang forever without the fix. 

<!-- issue-number: [bpo-39101](https://bugs.python.org/issue39101) -->
https://bugs.python.org/issue39101
<!-- /issue-number -->
