### PR TITLE
bpo-41739: Fix test_logging.test_race_between_set_target_and_flush()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2020-10-12-00-11-47.bpo-41739.wSCc4K.rst
+++ b/Misc/NEWS.d/next/Tests/2020-10-12-00-11-47.bpo-41739.wSCc4K.rst
@@ -1,0 +1,2 @@
+Fix test_logging.test_race_between_set_target_and_flush(): the test now
+waits until all threads complete to avoid leaking running threads.


### PR DESCRIPTION
The test now waits until all threads complete to avoid leaking
running threads.

Also, use regular threads rather than daemon threads.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41739](https://bugs.python.org/issue41739) -->
https://bugs.python.org/issue41739
<!-- /issue-number -->
