### PR TITLE
bpo-37449: ensurepip uses importlib.resources.files() traversable APIs

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -8,7 +8,6 @@ import tempfile
 from importlib import resources
 
 
-
 __all__ = ["version", "bootstrap"]
 _PACKAGE_NAMES = ('setuptools', 'pip')
 _SETUPTOOLS_VERSION = "56.0.0"
@@ -79,8 +78,8 @@ _PACKAGES = None
 
 
 def _run_pip(args, additional_paths=None):
-    # Run the bootstraping in a subprocess to avoid leaking any state that happens
-    # after pip has executed. Particulary, this avoids the case when pip holds onto
+    # Run the bootstrapping in a subprocess to avoid leaking any state that happens
+    # after pip has executed. Particularly, this avoids the case when pip holds onto
     # the files in *additional_paths*, preventing us to remove them at the end of the
     # invocation.
     code = f"""
@@ -164,9 +163,10 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         for name, package in _get_packages().items():
             if package.wheel_name:
                 # Use bundled wheel package
-                from ensurepip import _bundled
                 wheel_name = package.wheel_name
-                whl = resources.read_binary(_bundled, wheel_name)
+                wheel_path = resources.files("ensurepip") / "_bundled" / wheel_name
+                with wheel_path.open("rb") as fp:
+                    whl = fp.read()
             else:
                 # Use the wheel package directory
                 with open(package.wheel_path, "rb") as fp:

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -165,8 +165,7 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
                 # Use bundled wheel package
                 wheel_name = package.wheel_name
                 wheel_path = resources.files("ensurepip") / "_bundled" / wheel_name
-                with wheel_path.open("rb") as fp:
-                    whl = fp.read()
+                whl = wheel_path.read_bytes()
             else:
                 # Use the wheel package directory
                 with open(package.wheel_path, "rb") as fp:

--- a/Misc/NEWS.d/next/Library/2020-10-11-20-23-48.bpo-37449.f-t3V6.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-11-20-23-48.bpo-37449.f-t3V6.rst
@@ -1,0 +1,1 @@
+`ensurepip` now uses `importlib.resources.files()` traversable APIs

--- a/Misc/NEWS.d/next/Library/2020-10-11-20-23-48.bpo-37449.f-t3V6.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-11-20-23-48.bpo-37449.f-t3V6.rst
@@ -1,1 +1,1 @@
-`ensurepip` now uses `importlib.resources.files()` traversable APIs
+``ensurepip`` now uses ``importlib.resources.files()`` traversable APIs


### PR DESCRIPTION
follow-up to https://github.com/python/cpython/pull/15109

If I understand https://gitlab.com/python-devs/importlib_resources/-/issues/80 correctly, the traversable APIs are preferred - and https://docs.python.org/3/library/importlib.html#importlib.resources.files is avail since 3.9

<!-- issue-number: [bpo-37449](https://bugs.python.org/issue37449) -->
https://bugs.python.org/issue37449
<!-- /issue-number -->
