### PR TITLE
bpo-41756: Delete PyGen_Send function

### DIFF
--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -42,13 +42,3 @@ than explicitly calling :c:func:`PyGen_New` or :c:func:`PyGen_NewWithQualName`.
    with ``__name__`` and ``__qualname__`` set to *name* and *qualname*.
    A reference to *frame* is stolen by this function.  The *frame* argument
    must not be ``NULL``.
-
-.. c:function:: PySendResult PyGen_Send(PyGenObject *gen, PyObject *arg, PyObject **presult)
-
-   Sends the *arg* value into the generator *gen*. Coroutine objects
-   are also allowed to be as the *gen* argument but they need to be
-   explicitly casted to PyGenObject*. Returns:
-
-   - ``PYGEN_RETURN`` if generator returns. Return value is returned via *presult*.
-   - ``PYGEN_NEXT`` if generator yields. Yielded value is returned via *presult*.
-   - ``PYGEN_ERROR`` if generator has raised and exception. *presult* is set to ``NULL``.

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -959,11 +959,6 @@ PyGen_NewWithQualName:PyFrameObject*:frame:0:
 PyGen_NewWithQualName:PyObject*:name:0:
 PyGen_NewWithQualName:PyObject*:qualname:0:
 
-PyGen_Send:int:::
-PyGen_Send:PyGenObject*:gen:0:
-PyGen_Send:PyObject*:arg:0:
-PyGen_Send:PyObject**:presult:+1:
-
 PyCoro_CheckExact:int:::
 PyCoro_CheckExact:PyObject*:ob:0:
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -314,7 +314,7 @@ New Features
   search function.
   (Contributed by Hai Shi in :issue:`41842`.)
 
-* The :c:func:`PyIter_Send` and :c:func:`PyGen_Send` functions were added to allow
+* The :c:func:`PyIter_Send` function was added to allow
   sending value into iterator without raising ``StopIteration`` exception.
   (Contributed by Vladimir Matveev in :issue:`41756`.)
 

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -45,15 +45,6 @@ PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
 PyObject *_PyGen_yf(PyGenObject *);
 PyAPI_FUNC(void) _PyGen_Finalize(PyObject *self);
 
-/* Sends the value into the generator or the coroutine. Returns:
-   - PYGEN_RETURN (0) if generator has returned.
-     'result' parameter is filled with return value
-   - PYGEN_ERROR (-1) if exception was raised.
-     'result' parameter is NULL
-   - PYGEN_NEXT (1) if generator has yielded.
-     'result' parameter is filled with yielded value. */
-PyAPI_FUNC(PySendResult) PyGen_Send(PyGenObject *, PyObject *, PyObject **);
-
 #ifndef Py_LIMITED_API
 typedef struct {
     _PyGenObject_HEAD(cr)

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -133,16 +133,6 @@ Port the :mod:`_lsprof` extension module to multi-phase initialization
 
 ..
 
-.. bpo: 41756
-.. date: 2020-09-12-12-55-45
-.. nonce: 1h0tbV
-.. section: Core and Builtins
-
-Add PyGen_Send function to allow sending value into generator/coroutine
-without raising StopIteration exception to signal return
-
-..
-
 .. bpo: 1635741
 .. date: 2020-09-08-21-58-47
 .. nonce: vdjSLH

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2669,31 +2669,6 @@ PyIter_Next(PyObject *iter)
     return result;
 }
 
-PySendResult
-PyIter_Send(PyObject *iter, PyObject *arg, PyObject **result)
-{
-    _Py_IDENTIFIER(send);
-    assert(result != NULL);
-
-    if (PyGen_CheckExact(iter) || PyCoro_CheckExact(iter)) {
-        return PyGen_Send((PyGenObject *)iter, arg, result);
-    }
-
-    if (arg == Py_None && PyIter_Check(iter)) {
-        *result = Py_TYPE(iter)->tp_iternext(iter);
-    }
-    else {
-        *result = _PyObject_CallMethodIdOneArg(iter, &PyId_send, arg);
-    }
-    if (*result != NULL) {
-        return PYGEN_NEXT;
-    }
-    if (_PyGen_FetchStopIterationValue(result) == 0) {
-        return PYGEN_RETURN;
-    }
-    return PYGEN_ERROR;
-}
-
 /*
  * Flatten a sequence of bytes() objects into a C array of
  * NULL terminated string pointers with a NULL char* terminating the array.


### PR DESCRIPTION
Delete `PyGen_Send` function and  inline its body into `PyIter_Send`.  This PR does not introduce new functionality so there is  nothing to report in news.

<!-- issue-number: [bpo-41756](https://bugs.python.org/issue41756) -->
https://bugs.python.org/issue41756
<!-- /issue-number -->
