### PR TITLE
bpo-42010: Prevent generic types from being indexed

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -294,11 +294,11 @@ class BaseTest(unittest.TestCase):
             self.assertIn(generic_alias_property, dir_of_gen_alias)
 
     def test_indexing(self):
-        with self.assertRaises(TypeError):
-            list[0]
-            list[0.8]
-            list[True]
-            list[1 + 3j]
+        stmts = ['list[0]', 'list[0.0]', 'list[True]', 'list[1 + 3j]']
+        for stmt in stmts:
+            with self.subTest(stmt=stmt):
+                with self.assertRaises(TypeError):
+                    eval(stmt)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -293,5 +293,13 @@ class BaseTest(unittest.TestCase):
         for generic_alias_property in ("__origin__", "__args__", "__parameters__"):
             self.assertIn(generic_alias_property, dir_of_gen_alias)
 
+    def test_indexing(self):
+        with self.assertRaises(TypeError):
+            list[0]
+            list[0.8]
+            list[True]
+            list[1 + 3j]
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-12-15-58-48.bpo-42010.1anqDP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-12-15-58-48.bpo-42010.1anqDP.rst
@@ -1,0 +1,2 @@
+Throw :exc:`TypeError` when attempting to index a generic type. For example,
+``list[1]``.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -187,6 +187,12 @@ PyObject_GetItem(PyObject *o, PyObject *key)
         if ((PyTypeObject*)o == &PyType_Type) {
             return Py_GenericAlias(o, key);
         }
+        // To deny things like list[1], list[0.8], list[True], list[3 + 3j]
+        if (PyLong_CheckExact(key) || PyFloat_CheckExact(key) 
+            || PyBool_Check(key) || PyComplex_CheckExact(key)){
+            return type_error("generic type parameter must be a type, " 
+                              "not '%.200s'", key);
+        }
 
         if (_PyObject_LookupAttrId(o, &PyId___class_getitem__, &meth) < 0) {
             return NULL;


### PR DESCRIPTION
Tested working on WIndows 10. I ran the whole test suite and other than some locale tests failing (which are expected and have been reported before), everything seems fine.

This probably needs a backport to 3.9. Though I'm unsure if an issue is required since it doesn't seem like a big change, rather it keeps consistency with previous python versions.

<!-- issue-number: [bpo-42010](https://bugs.python.org/issue42010) -->
https://bugs.python.org/issue42010
<!-- /issue-number -->
