### PR TITLE
bpo-42015: Reorder dereferencing calls in meth_dealloc, to make sure m_self is kept alive long enough

### DIFF
--- a/Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst
+++ b/Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst
@@ -1,0 +1,5 @@
+Order of dereferencing for `PyCFunction` deallocation changed to make sure
+the object passed as ``self`` argument is only dereferenced after the last
+access to the function's associated `PyMethodDef`. The allows extension
+modules to manage the lifetime of dynamically allocated `PyModuleDef`
+instances through ``self``.

--- a/Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst
+++ b/Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst
@@ -1,5 +1,3 @@
-Order of dereferencing for `PyCFunction` deallocation changed to make sure
-the object passed as ``self`` argument is only dereferenced after the last
-access to the function's associated `PyMethodDef`. The allows extension
-modules to manage the lifetime of dynamically allocated `PyModuleDef`
-instances through ``self``.
+Fix potential crash in deallocating method objects when dynamically
+allocated `PyMethodDef`'s lifetime is managed through the ``self``
+argument of a `PyCFunction`.

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -164,6 +164,8 @@ meth_dealloc(PyCFunctionObject *m)
     if (m->m_weakreflist != NULL) {
         PyObject_ClearWeakRefs((PyObject*) m);
     }
+    // Dereference class before m_self: PyCFunction_GET_CLASS accesses
+    // PyMethodDef m_ml, which could be kept alive by m_self
     Py_XDECREF(PyCFunction_GET_CLASS(m));
     Py_XDECREF(m->m_self);
     Py_XDECREF(m->m_module);
@@ -243,9 +245,9 @@ meth_get__qualname__(PyCFunctionObject *m, void *closure)
 static int
 meth_traverse(PyCFunctionObject *m, visitproc visit, void *arg)
 {
+    Py_VISIT(PyCFunction_GET_CLASS(m));
     Py_VISIT(m->m_self);
     Py_VISIT(m->m_module);
-    Py_VISIT(PyCFunction_GET_CLASS(m));
     return 0;
 }
 

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -164,9 +164,9 @@ meth_dealloc(PyCFunctionObject *m)
     if (m->m_weakreflist != NULL) {
         PyObject_ClearWeakRefs((PyObject*) m);
     }
+    Py_XDECREF(PyCFunction_GET_CLASS(m));
     Py_XDECREF(m->m_self);
     Py_XDECREF(m->m_module);
-    Py_XDECREF(PyCFunction_GET_CLASS(m));
     PyObject_GC_Del(m);
 }
 


### PR DESCRIPTION
In Python 3.9, the line `Py_XDECREF(PyCFunction_GET_CLASS(m));` was added to `meth_dealloc` (in `methodobject.c`). Unfortunately for pybind11, it's inserted exactly two lines too low, since it accesses the `PyMethodDef` and we store the `PyMethodDef` instance in the capsule that's used as `self`-argument of the `PyCFunction`.

Result: UB, since `Py_XDECREF(m->m_self);` brings down the refcount of the capsule to 0 and (indirectly) frees the `PyMethodDef`, while its contents are now still accessed.

From the pybind11 perspective, it would be optimal if this could be fixed in CPython itself, by moving up this one `Py_XDECREF` 2 lines. This would a) be more efficient than creating a workaround, and b) allow old, existing versions of pybind11 to work with Python 3.9 (well, 3.9.1, then, hopefully); the user base of pybind11 has grown quite a bit and now includes giants like scipy or some Google libraries.
This PR reorders those lines.

If there's a different, recommended way of creating these `PyCFunctionObject`s dynamically and cleaning up the `PyMethodDef`, we'd be interested as well, to make sure these kinds of breakages are avoided in the future.

Apologies for only figuring out now how to debug this, using valgrind. Up until yesterday, we only saw some failures in CI on macOS, but it was hard to reproduce and debug locally.


- Related issue: https://bugs.python.org/issue41237
- pybind11 issue: https://github.com/pybind/pybind11/issues/2558
- pybind11 PR: https://github.com/pybind/pybind11/pull/2576

<!-- issue-number: [bpo-42015](https://bugs.python.org/issue42015) -->
https://bugs.python.org/issue42015
<!-- /issue-number -->
