### PR TITLE
bpo-40422: Move _Py_*_SUPPRESS_IPH bits into _Py_closerange

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8781,8 +8781,8 @@ _fdwalk_close_func(void *lohi, int fd)
 void
 _Py_closerange(int first, int last)
 {
-    _Py_BEGIN_SUPPRESS_IPH
     first = Py_MAX(first, 0);
+    _Py_BEGIN_SUPPRESS_IPH
 #ifdef HAVE_CLOSE_RANGE
     if (close_range(first, last, 0) == 0 || errno != ENOSYS) {
         /* Any errors encountered while closing file descriptors are ignored;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8781,6 +8781,7 @@ _fdwalk_close_func(void *lohi, int fd)
 void
 _Py_closerange(int first, int last)
 {
+    _Py_BEGIN_SUPPRESS_IPH
     first = Py_MAX(first, 0);
 #ifdef HAVE_CLOSE_RANGE
     if (close_range(first, last, 0) == 0 || errno != ENOSYS) {
@@ -8812,6 +8813,7 @@ _Py_closerange(int first, int last)
         }
     }
 #endif /* USE_FDWALK */
+    _Py_END_SUPPRESS_IPH
 }
 
 /*[clinic input]
@@ -8829,9 +8831,7 @@ os_closerange_impl(PyObject *module, int fd_low, int fd_high)
 /*[clinic end generated code: output=0ce5c20fcda681c2 input=5855a3d053ebd4ec]*/
 {
     Py_BEGIN_ALLOW_THREADS
-    _Py_BEGIN_SUPPRESS_IPH
     _Py_closerange(fd_low, fd_high - 1);
-    _Py_END_SUPPRESS_IPH
     Py_END_ALLOW_THREADS
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
This suppression is no longer needed in os_closerange_impl, as it just
invokes the internal _Py_closerange implementation. On the other hand,
consumers of _Py_closerange may not have any other reason to suppress
invalid parameter issues, so narrow the scope to here.

<!-- issue-number: [bpo-40422](https://bugs.python.org/issue40422) -->
https://bugs.python.org/issue40422
<!-- /issue-number -->
