### PR TITLE
Doc: Add a link to buffer protocol in a bytearray doc

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -164,8 +164,8 @@ are always available.  They are listed here in alphabetical order.
    * If it is an *integer*, the array will have that size and will be
      initialized with null bytes.
 
-   * If it is an object conforming to the *buffer* interface, a read-only buffer
-     of the object will be used to initialize the bytes array.
+   * If it is an object conforming to the :ref:`buffer interface <bufferobjects>`,
+     a read-only buffer of the object will be used to initialize the bytes array.
 
    * If it is an *iterable*, it must be an iterable of integers in the range
      ``0 <= x < 256``, which are used as the initial contents of the array.


### PR DESCRIPTION
The _buffer interface_ mentioned in the _bytearray_ section of the library may deserve a link to the buffer protocol in the C-API doc.

Issue originally raised at https://github.com/python/python-docs-fr/pull/1443/files#r502297511

No issue was opened for this PR.