### PR TITLE
[3.8] bpo-32793: Fix a duplicate debug message in smtplib (GH-15341)

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -333,8 +333,6 @@ class SMTP:
                     raise OSError("nonnumeric port")
         if not port:
             port = self.default_port
-        if self.debuglevel > 0:
-            self._print_debug('connect:', (host, port))
         sys.audit("smtplib.connect", self, host, port)
         self.sock = self._get_socket(host, port, self.timeout)
         self.file = None

--- a/Misc/NEWS.d/next/Library/2019-08-20-05-17-32.bpo-32793.cgpXl6.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-20-05-17-32.bpo-32793.cgpXl6.rst
@@ -1,0 +1,1 @@
+Fix a duplicated debug message when :meth:`smtplib.SMTP.connect` is called.


### PR DESCRIPTION
_get_socket() already prints a debug message for the host and port.

https://bugs.python.org/issue32793

Automerge-Triggered-By: @maxking
(cherry picked from commit 46a7564578f208df1e0c54fc0520d3b7ca32c981)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32793](https://bugs.python.org/issue32793) -->
https://bugs.python.org/issue32793
<!-- /issue-number -->
