### PR TITLE
bpo-41939: do not skip test_site.test_license_exists_at_url for pre-releases

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -516,8 +516,6 @@ class ImportSideEffectTests(unittest.TestCase):
 
     @test.support.requires_resource('network')
     @test.support.system_must_validate_cert
-    @unittest.skipUnless(sys.version_info[3] == 'final',
-                         'only for released versions')
     @unittest.skipUnless(hasattr(urllib.request, "HTTPSHandler"),
                          'need SSL support to download license')
     def test_license_exists_at_url(self):


### PR DESCRIPTION
This test is skipped for pre-releases because the license file URL in `Lib/site.py` used to be to a release-dependent URL.  But [bpo-21572](https://bugs.python.org/issue21572) changed `Lib/site.py` to use a license URL that is independent of the release. So there is no longer a reason to skip the test for pre-releases and, by no longer skipping, we would catch problems like the one in this issue prior to release.

<!-- issue-number: [bpo-41939](https://bugs.python.org/issue41939) -->
https://bugs.python.org/issue41939
<!-- /issue-number -->
