### PR TITLE
bpo-38912: fix close before connect callback on SSL tests

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1076,6 +1076,7 @@ class EventLoopTestsMixin:
                                                ssl=sslcontext_client,
                                                server_hostname='localhost')
         client, pr = self.loop.run_until_complete(f_c)
+        self.loop.run_until_complete(proto.connected)
 
         # close connection
         proto.transport.close()
@@ -1101,6 +1102,7 @@ class EventLoopTestsMixin:
                                           ssl=sslcontext_client,
                                           server_hostname='localhost')
         client, pr = self.loop.run_until_complete(f_c)
+        self.loop.run_until_complete(proto.connected)
 
         # extra info is available
         self.check_ssl_extra_info(client, peername=(host, port),

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -70,6 +70,7 @@ Alexandru Ardelean
 Emmanuel Arias
 Alicia Arlen
 Jeffrey Armstrong
+Justin Turner Arthur
 Jason Asbahr
 David Ascher
 Ammar Askar


### PR DESCRIPTION
As shown in [bpo-38912](https://bugs.python.org/issue38912) comments' log entries, `test_create_unix_server_ssl_verified` and `test_create_server_ssl_verified` could end up trying to close a transport they didn't have a reference to yet because a test `Protocol`'s `connection_made` callback had yet to be called by the event loop:

```
======================================================================
ERROR: test_create_server_ssl_verified (test.test_asyncio.test_events.SelectEventLoopTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vstinner/python/master/Lib/test/test_asyncio/test_events.py", line 1110, in test_create_server_ssl_verified
    proto.transport.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

This PR ensures the callback is waited on before closing the connection to the client (and assuming that the desired SSL connectivity was established).

<!-- issue-number: [bpo-38912](https://bugs.python.org/issue38912) -->
https://bugs.python.org/issue38912
<!-- /issue-number -->


