### PR TITLE
bpo-42043: Inheritance support for zipfile.Path for `.parent`, /, joinpath

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -3019,6 +3019,12 @@ class TestPath(unittest.TestCase):
                 for rep in range(2):
                     zipfile.Path(file, 'a.txt').read_text()
 
+    def test_inheritance(self):
+      cls = type('PathChild', (zipfile.Path,), {})
+      for alpharep in self.zipfile_alpharep():
+          file = cls(alpharep).joinpath('some dir').parent
+          assert isinstance(file, cls)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -2337,7 +2337,8 @@ class Path:
         return posixpath.dirname(path.at.rstrip("/")) == self.at.rstrip("/")
 
     def _next(self, at):
-        return Path(self.root, at)
+        # Use `type()` to support inheritance
+        return type(self)(self.root, at)
 
     def is_dir(self):
         return not self.at or self.at.endswith("/")


### PR DESCRIPTION
Copying https://bugs.python.org/issue42043

Currently, zipfile.Path inheritance behavior is inconsistent with pathlib.Path:

```
class MyPath(zipfile.Path):
  pass


path = MyPath(zf)
path = path.joinpath('other')
assert isinstance(path, MyPath)  # Oups, type(path) is zipfile.Path
```

Calling parent, /,... should keep the class, as for pathlib.Path

Use case: I'm writing a wrapper around `zipfile.Path` which adds `os.fspath` compatibility (the file is extracted in a tmp dir when os.path.join, open,...).

<!-- issue-number: [bpo-42043](https://bugs.python.org/issue42043) -->
https://bugs.python.org/issue42043
<!-- /issue-number -->
