### PR TITLE
bpo-38902: Add image/webp to list of media types in mimetypes.py

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -501,6 +501,7 @@ def _default_mime_types():
         '.tiff'   : 'image/tiff',
         '.tif'    : 'image/tiff',
         '.ico'    : 'image/vnd.microsoft.icon',
+        '.webp'   : 'image/webp',
         '.ras'    : 'image/x-cmu-raster',
         '.bmp'    : 'image/x-ms-bmp',
         '.pnm'    : 'image/x-portable-anymap',


### PR DESCRIPTION
WebP is an open image format that's existed for 10 years and is supported by most modern web browsers: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#WebP. It should be in the list of media types.

<!-- issue-number: [bpo-42049](https://bugs.python.org/issue42049) -->
https://bugs.python.org/issue42049
<!-- /issue-number -->
