### PR TITLE
bpo-28660: make TextWrapper break long words on hyphens 

### DIFF
--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -643,55 +643,74 @@ How *do* you spell that odd word, anyways?
 class LongWordWithHyphensTestCase(BaseTestCase):
     def setUp(self):
         self.wrapper = TextWrapper()
-        self.text = '''\
+        self.text1 = '''\
 We used enyzme 2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate synthase.
+'''
+        self.text2 = '''\
+1234567890-1234567890--this_is_a_very_long_option_indeed-good-bye"
 '''
 
     def test_break_long_words_on_hyphen(self):
         expected = ['We used enyzme 2-succinyl-6-hydroxy-2,4-',
                     'cyclohexadiene-1-carboxylate synthase.']
-        self.check_wrap(self.text, 50, expected)
+        self.check_wrap(self.text1, 50, expected)
 
         expected = ['We used', 'enyzme 2-', 'succinyl-', '6-hydroxy-', '2,4-',
                     'cyclohexad', 'iene-1-', 'carboxylat', 'e', 'synthase.']
-        self.check_wrap(self.text, 10, expected)
+        self.check_wrap(self.text1, 10, expected)
+
+        expected = ['1234567890',  '-123456789', '0--this_is', '_a_very_lo',
+                    'ng_option_', 'indeed-', 'good-bye"']
+        self.check_wrap(self.text2, 10, expected)
 
     def test_break_long_words_not_on_hyphen(self):
         expected = ['We used enyzme 2-succinyl-6-hydroxy-2,4-cyclohexad',
                     'iene-1-carboxylate synthase.']
-        self.check_wrap(self.text, 50, expected, break_on_hyphens=False)
+        self.check_wrap(self.text1, 50, expected, break_on_hyphens=False)
 
         expected = ['We used', 'enyzme 2-s', 'uccinyl-6-', 'hydroxy-2,',
                     '4-cyclohex', 'adiene-1-c', 'arboxylate', 'synthase.']
-        self.check_wrap(self.text, 10, expected, break_on_hyphens=False)
+        self.check_wrap(self.text1, 10, expected, break_on_hyphens=False)
+
+        expected = ['1234567890',  '-123456789', '0--this_is', '_a_very_lo',
+                    'ng_option_', 'indeed-', 'good-bye"']
+        self.check_wrap(self.text2, 10, expected)
 
     def test_break_on_hyphen_but_not_long_words(self):
         expected = ['We used enyzme',
                     '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
                     'synthase.']
 
-        self.check_wrap(self.text, 50, expected, break_long_words=False)
+        self.check_wrap(self.text1, 50, expected, break_long_words=False)
 
         expected = ['We used', 'enyzme',
                     '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
                     'synthase.']
-        self.check_wrap(self.text, 10, expected, break_long_words=False)
+        self.check_wrap(self.text1, 10, expected, break_long_words=False)
+
+        expected = ['1234567890',  '-123456789', '0--this_is', '_a_very_lo',
+                    'ng_option_', 'indeed-', 'good-bye"']
+        self.check_wrap(self.text2, 10, expected)
+
 
     def test_do_not_break_long_words_or_on_hyphens(self):
         expected = ['We used enyzme',
                     '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
                     'synthase.']
-        self.check_wrap(self.text, 50, expected,
+        self.check_wrap(self.text1, 50, expected,
                         break_long_words=False,
                         break_on_hyphens=False)
 
         expected = ['We used', 'enyzme',
                     '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
                     'synthase.']
-        self.check_wrap(self.text, 10, expected,
+        self.check_wrap(self.text1, 10, expected,
                         break_long_words=False,
                         break_on_hyphens=False)
 
+        expected = ['1234567890',  '-123456789', '0--this_is', '_a_very_lo',
+                    'ng_option_', 'indeed-', 'good-bye"']
+        self.check_wrap(self.text2, 10, expected)
 
 class IndentTestCases(BaseTestCase):
 

--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -640,6 +640,59 @@ How *do* you spell that odd word, anyways?
                         max_lines=4)
 
 
+class LongWordWithHyphensTestCase(BaseTestCase):
+    def setUp(self):
+        self.wrapper = TextWrapper()
+        self.text = '''\
+We used enyzme 2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate synthase.
+'''
+
+    def test_break_long_words_on_hyphen(self):
+        expected = ['We used enyzme 2-succinyl-6-hydroxy-2,4-',
+                    'cyclohexadiene-1-carboxylate synthase.']
+        self.check_wrap(self.text, 50, expected)
+
+        expected = ['We used', 'enyzme 2-', 'succinyl-', '6-hydroxy-', '2,4-',
+                    'cyclohexad', 'iene-1-', 'carboxylat', 'e', 'synthase.']
+        self.check_wrap(self.text, 10, expected)
+
+    def test_break_long_words_not_on_hyphen(self):
+        expected = ['We used enyzme 2-succinyl-6-hydroxy-2,4-cyclohexad',
+                    'iene-1-carboxylate synthase.']
+        self.check_wrap(self.text, 50, expected, break_on_hyphens=False)
+
+        expected = ['We used', 'enyzme 2-s', 'uccinyl-6-', 'hydroxy-2,',
+                    '4-cyclohex', 'adiene-1-c', 'arboxylate', 'synthase.']
+        self.check_wrap(self.text, 10, expected, break_on_hyphens=False)
+
+    def test_break_on_hyphen_but_not_long_words(self):
+        expected = ['We used enyzme',
+                    '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
+                    'synthase.']
+
+        self.check_wrap(self.text, 50, expected, break_long_words=False)
+
+        expected = ['We used', 'enyzme',
+                    '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
+                    'synthase.']
+        self.check_wrap(self.text, 10, expected, break_long_words=False)
+
+    def test_do_not_break_long_words_or_on_hyphens(self):
+        expected = ['We used enyzme',
+                    '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
+                    'synthase.']
+        self.check_wrap(self.text, 50, expected,
+                        break_long_words=False,
+                        break_on_hyphens=False)
+
+        expected = ['We used', 'enyzme',
+                    '2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate',
+                    'synthase.']
+        self.check_wrap(self.text, 10, expected,
+                        break_long_words=False,
+                        break_on_hyphens=False)
+
+
 class IndentTestCases(BaseTestCase):
 
     # called before each test method

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -215,8 +215,14 @@ class TextWrapper:
         # If we're allowed to break long words, then do so: put as much
         # of the next chunk onto the current line as will fit.
         if self.break_long_words:
-            cur_line.append(reversed_chunks[-1][:space_left])
-            reversed_chunks[-1] = reversed_chunks[-1][space_left:]
+            end = space_left
+            chunk = reversed_chunks[-1]
+            if self.break_on_hyphens and len(chunk) > space_left:
+                hyphen = chunk.rfind('-', 0, space_left)
+                if hyphen != -1:
+                    end = hyphen+1
+            cur_line.append(chunk[:end])
+            reversed_chunks[-1] = chunk[end:]
 
         # Otherwise, we have to preserve the long word intact.  Only add
         # it to the current line if there's nothing already there --

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -220,7 +220,7 @@ class TextWrapper:
             if self.break_on_hyphens and len(chunk) > space_left:
                 hyphen = chunk.rfind('-', 0, space_left)
                 if hyphen != -1:
-                    end = hyphen+1
+                    end = hyphen + 1
             cur_line.append(chunk[:end])
             reversed_chunks[-1] = chunk[end:]
 

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -221,7 +221,7 @@ class TextWrapper:
                 # break after last hyphen, but only if there are
                 # non-hyphens before it
                 hyphen = chunk.rfind('-', 0, space_left)
-                if hyphen > 0 and any(c != '-' for c in chunk[0:hyphen]):
+                if hyphen > 0 and any(c != '-' for c in chunk[:hyphen]):
                     end = hyphen + 1
             cur_line.append(chunk[:end])
             reversed_chunks[-1] = chunk[end:]

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -218,8 +218,10 @@ class TextWrapper:
             end = space_left
             chunk = reversed_chunks[-1]
             if self.break_on_hyphens and len(chunk) > space_left:
+                # break after last hyphen, but only if there are
+                # non-hyphens before it
                 hyphen = chunk.rfind('-', 0, space_left)
-                if hyphen != -1:
+                if hyphen > 0 and any(c != '-' for c in chunk[0:hyphen]):
                     end = hyphen + 1
             cur_line.append(chunk[:end])
             reversed_chunks[-1] = chunk[end:]

--- a/Misc/NEWS.d/next/Library/2020-10-16-16-08-04.bpo-28660.eX9pvD.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-16-16-08-04.bpo-28660.eX9pvD.rst
@@ -1,1 +1,1 @@
-textwrap.wrap() attempts to break long words after hyphens when break_long_words=True and break_on_hyphens=True.
+textwrap.wrap() now attempts to break long words after hyphens when break_long_words=True and break_on_hyphens=True.

--- a/Misc/NEWS.d/next/Library/2020-10-16-16-08-04.bpo-28660.eX9pvD.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-16-16-08-04.bpo-28660.eX9pvD.rst
@@ -1,1 +1,1 @@
-textwrap.wrap() now attempts to break long words after hyphens when break_long_words=True and break_on_hyphens=True.
+:func:`textwrap.wrap` now attempts to break long words after hyphens when ``break_long_words=True`` and ``break_on_hyphens=True``.

--- a/Misc/NEWS.d/next/Library/2020-10-16-16-08-04.bpo-28660.eX9pvD.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-16-16-08-04.bpo-28660.eX9pvD.rst
@@ -1,0 +1,1 @@
+textwrap.wrap() attempts to break long words after hyphens when break_long_words=True and break_on_hyphens=True.


### PR DESCRIPTION
textwrap currently ignores hyphens when breaking up words longer than width (with the break_long_words=True option), even if break_on_hyphens=True was selected.  This PR makes it break long words on hyphens if those exist.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28660](https://bugs.python.org/issue28660) -->
https://bugs.python.org/issue28660
<!-- /issue-number -->
