### PR TITLE
bpo-41966: Fix pickling pure datetime.time subclasses

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1548,7 +1548,7 @@ class time:
         self._tzinfo = tzinfo
 
     def __reduce_ex__(self, protocol):
-        return (time, self._getstate(protocol))
+        return (self.__class__, self._getstate(protocol))
 
     def __reduce__(self):
         return self.__reduce_ex__(2)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1781,6 +1781,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             green = pickler.dumps(orig, proto)
             derived = unpickler.loads(green)
             self.assertEqual(orig, derived)
+            self.assertTrue(isinstance(derived, SubclassDate))
 
     def test_backdoor_resistance(self):
         # For fast unpickling, the constructor accepts a pickle byte string.
@@ -2308,6 +2309,7 @@ class TestDateTime(TestDate):
             green = pickler.dumps(orig, proto)
             derived = unpickler.loads(green)
             self.assertEqual(orig, derived)
+            self.assertTrue(isinstance(derived, SubclassDatetime))
 
     def test_compat_unpickle(self):
         tests = [
@@ -3357,6 +3359,7 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
             green = pickler.dumps(orig, proto)
             derived = unpickler.loads(green)
             self.assertEqual(orig, derived)
+            self.assertTrue(isinstance(derived, SubclassTime))
 
     def test_compat_unpickle(self):
         tests = [

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -787,6 +787,7 @@ Meador Inge
 Peter Ingebretson
 Tony Ingraldi
 John Interrante
+Dean Inwood
 Bob Ippolito
 Roger Irwin
 Atsuo Ishimoto

--- a/Misc/NEWS.d/next/Library/2020-10-17-07-52-53.bpo-41966.gwEQRZ.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-17-07-52-53.bpo-41966.gwEQRZ.rst
@@ -1,0 +1,1 @@
+Fix pickling pure Python :class:`datetime.time` subclasses

--- a/Misc/NEWS.d/next/Library/2020-10-17-07-52-53.bpo-41966.gwEQRZ.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-17-07-52-53.bpo-41966.gwEQRZ.rst
@@ -1,1 +1,2 @@
-Fix pickling pure Python :class:`datetime.time` subclasses
+Fix pickling pure Python :class:`datetime.time` subclasses. Patch by Dean
+Inwood.


### PR DESCRIPTION


<!-- issue-number: [bpo-41966](https://bugs.python.org/issue41966) -->
https://bugs.python.org/issue41966
<!-- /issue-number -->
