### PR TITLE
bpo-42056: macOS - allow arm64 as a supported arch

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-10-16-23-00-21.bpo-42056.ZwUWgu.rst
+++ b/Misc/NEWS.d/next/Build/2020-10-16-23-00-21.bpo-42056.ZwUWgu.rst
@@ -1,0 +1,1 @@
+Accept arm64 as an architecture for Apple ARM Macs.

--- a/configure
+++ b/configure
@@ -9349,6 +9349,9 @@ fi
     	ppc)
     		MACOSX_DEFAULT_ARCH="ppc64"
     		;;
+    	arm64)
+    		MACOSX_DEFAULT_ARCH="arm64"
+    		;;
     	*)
     		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
     		;;

--- a/configure.ac
+++ b/configure.ac
@@ -2490,6 +2490,9 @@ case $ac_sys_system/$ac_sys_release in
     	ppc)
     		MACOSX_DEFAULT_ARCH="ppc64"
     		;;
+    	arm64)
+    		MACOSX_DEFAULT_ARCH="arm64"
+    		;;
     	*)
     		AC_MSG_ERROR([Unexpected output of 'arch' on OSX])
     		;;


### PR DESCRIPTION
This section of the configure script only accepts Intel and PowerPC as valid architectures, but Apple's new ARM Macs means that `arm64` can occur too. Without this, configure will fail with the message `Unexpected output of 'arch' on OSX`.

I didn't include a 32-bit option since Apple no longer ship any devices that support 32-bit ARM. Apple's ARM Macs are 64-bit only.

<!-- issue-number: [bpo-42056](https://bugs.python.org/issue42056) -->
https://bugs.python.org/issue42056
<!-- /issue-number -->
