### PR TITLE
bpo-42060: Remove `assert` from http/client.py

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -572,7 +572,9 @@ class HTTPResponse(io.BufferedIOBase):
         return chunk_left
 
     def _read_chunked(self, amt=None):
-        assert self.chunked != _UNKNOWN
+        if self.chunked == _UNKNOWN:
+            raise IncompleteRead("Unkown chunk detected.")
+        
         value = []
         try:
             while True:
@@ -594,7 +596,8 @@ class HTTPResponse(io.BufferedIOBase):
             raise IncompleteRead(b''.join(value))
 
     def _readinto_chunked(self, b):
-        assert self.chunked != _UNKNOWN
+        if self.chunked == _UNKNOWN:
+            raise IncompleteRead("Unkown chunk detected.")
         total_bytes = 0
         mvb = memoryview(b)
         try:
@@ -1363,7 +1366,8 @@ class HTTPConnection:
             except ConnectionError:
                 self.close()
                 raise
-            assert response.will_close != _UNKNOWN
+            if self.chunked == _UNKNOWN:
+                raise HTTPException("Unkown chunk detected.")
             self.__state = _CS_IDLE
 
             if response.will_close:

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1366,8 +1366,8 @@ class HTTPConnection:
             except ConnectionError:
                 self.close()
                 raise
-            if self.chunked == _UNKNOWN:
-                raise HTTPException("Unkown chunk detected.")
+            if response.will_close == _UNKNOWN:
+                raise ConnectionError("Unknown if response will close.")
             self.__state = _CS_IDLE
 
             if response.will_close:

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -574,7 +574,7 @@ class HTTPResponse(io.BufferedIOBase):
     def _read_chunked(self, amt=None):
         if self.chunked == _UNKNOWN:
             raise IncompleteRead("Unkown chunk detected.")
-        
+
         value = []
         try:
             while True:

--- a/Misc/NEWS.d/next/Library/2020-10-17-14-46-16.bpo-42060.du-IYq.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-17-14-46-16.bpo-42060.du-IYq.rst
@@ -1,0 +1,1 @@
+Replace `asserts` on HTTPResponse and HTTPConnection with `if...raises` so that the conditional checks work while running with the optimization flag switched on


### PR DESCRIPTION
This PR removes `assert` statement from the stdlib's HTTP `client.py` and switches by an `if...raise` approach that won't be removed if optimization is requested

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42060](https://bugs.python.org/issue42060) -->
https://bugs.python.org/issue42060
<!-- /issue-number -->
