### PR TITLE
[3.8] bpo-32498: Improve exception message on passing bytes to urllib.parse.unquote

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1245,6 +1245,12 @@ class UnquotingTests(unittest.TestCase):
         self.assertEqual(expect, result,
                          "using unquote(): %r != %r" % (expect, result))
 
+    def test_unquoting_with_bytes_input(self):
+        # Bytes not supported yet
+        with self.assertRaisesRegex(TypeError, 'Expected str, got bytes'):
+            given = b'bl\xc3\xa5b\xc3\xa6rsyltet\xc3\xb8y'
+            urllib.parse.unquote(given)
+
 class urlencode_Tests(unittest.TestCase):
     """Tests for urlencode()"""
 

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -631,6 +631,8 @@ def unquote(string, encoding='utf-8', errors='replace'):
 
     unquote('abc%20def') -> 'abc def'.
     """
+    if isinstance(string, bytes):
+        raise TypeError('Expected str, got bytes')
     if '%' not in string:
         string.split
         return string

--- a/Misc/NEWS.d/next/Library/2020-10-18-19-22-39.bpo-32498.MoqSgo.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-18-19-22-39.bpo-32498.MoqSgo.rst
@@ -1,0 +1,1 @@
+Clearer exception message when passing an argument of type bytes to :func:`urllib.parse.unquote`.

--- a/Misc/NEWS.d/next/Library/2020-10-18-19-22-39.bpo-32498.MoqSgo.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-18-19-22-39.bpo-32498.MoqSgo.rst
@@ -1,1 +1,3 @@
-Clearer exception message when passing an argument of type bytes to :func:`urllib.parse.unquote`.
+Clearer exception message when passing an argument of type bytes to
+:func:`urllib.parse.unquote`.  This is only for 3.8; in 3.9 and later this
+function accepts bytes inputs as well.  PR by Irit Katriel.


### PR DESCRIPTION
bytes input is supported in 3.9, but not in 3.8. This improves the exception message for 3.8.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32498](https://bugs.python.org/issue32498) -->
https://bugs.python.org/issue32498
<!-- /issue-number -->
