### PR TITLE
bpo-34204: Make the shelve library use Pickle's default protocol version instead of defaulting to version 3

### DIFF
--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -25,8 +25,8 @@ lots of shared  sub-objects.  The keys are ordinary strings.
    database file is opened for reading and writing.  The optional *flag* parameter
    has the same interpretation as the *flag* parameter of :func:`dbm.open`.
 
-   By default, version 3 pickles are used to serialize values.  The version of the
-   pickle protocol can be specified with the *protocol* parameter.
+   By default, pickle's default protocol version is used to serialize values.  The
+   version of the pickle protocol can be specified with the *protocol* parameter.
 
    Because of Python semantics, a shelf cannot know when a mutable
    persistent-dictionary entry is modified.  By default modified objects are
@@ -108,9 +108,9 @@ Restrictions
    A subclass of :class:`collections.abc.MutableMapping` which stores pickled
    values in the *dict* object.
 
-   By default, version 3 pickles are used to serialize values.  The version of the
-   pickle protocol can be specified with the *protocol* parameter. See the
-   :mod:`pickle` documentation for a discussion of the pickle protocols.
+   By default, pickle's default protocol version is used to serialize values.  The
+   version of the pickle protocol can be specified with the *protocol* parameter.
+   See the :mod:`pickle` documentation for a discussion of the pickle protocols.
 
    If the *writeback* parameter is ``True``, the object will hold a cache of all
    entries accessed and write them back to the *dict* at sync and close times.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -210,6 +210,13 @@ py_compile
 Added ``--quiet`` option to command-line interface of :mod:`py_compile`.
 (Contributed by Gregory Schevchenko in :issue:`38731`.)
 
+shelve
+------
+
+The :mod:`shelve` module now uses :mod:`pickle` default protocol for the
+Python version in use rather than protocol version 3.
+(Contributed by Marco Castelluccio in :issue:`34204`.)
+
 sys
 ---
 

--- a/Lib/shelve.py
+++ b/Lib/shelve.py
@@ -56,7 +56,7 @@ entries in the cache, and empty the cache (d.sync() also synchronizes
 the persistent dictionary on disk, if feasible).
 """
 
-from pickle import Pickler, Unpickler
+from pickle import Pickler, Unpickler, DEFAULT_PROTOCOL
 from io import BytesIO
 
 import collections.abc
@@ -85,7 +85,7 @@ class Shelf(collections.abc.MutableMapping):
                  keyencoding="utf-8"):
         self.dict = dict
         if protocol is None:
-            protocol = 3
+            protocol = DEFAULT_PROTOCOL
         self._protocol = protocol
         self.writeback = writeback
         self.cache = {}

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -1,4 +1,5 @@
 import unittest
+import pickle
 import shelve
 import glob
 from test import support
@@ -160,7 +161,7 @@ class TestCase(unittest.TestCase):
 
     def test_default_protocol(self):
         with shelve.Shelf({}) as s:
-            self.assertEqual(s._protocol, 3)
+            self.assertEqual(s._protocol, pickle.DEFAULT_PROTOCOL)
 
 from test import mapping_tests
 

--- a/Misc/NEWS.d/next/Library/2020-10-28-00-59-23.bpo-34204.3R6Vqf.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-28-00-59-23.bpo-34204.3R6Vqf.rst
@@ -1,0 +1,2 @@
+The :mod:`shelve` module now uses :mod:`pickle` default protocol for the
+Python version in use rather than protocol version 3.


### PR DESCRIPTION

<!-- issue-number: [bpo-34204](https://bugs.python.org/issue34204) -->
https://bugs.python.org/issue34204
<!-- /issue-number -->
