### PR TITLE
[3.9] bpo-40492: Fix --outfile with relative path when the program changes it working dir (GH-19910)

### DIFF
--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -152,6 +152,11 @@ def main():
     (options, args) = parser.parse_args()
     sys.argv[:] = args
 
+    # The script that we're profiling may chdir, so capture the absolute path
+    # to the output file at startup.
+    if options.outfile is not None:
+        options.outfile = os.path.abspath(options.outfile)
+
     if len(args) > 0:
         if options.module:
             code = "run_module(modname, run_name='__main__')"

--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -571,6 +571,11 @@ def main():
     (options, args) = parser.parse_args()
     sys.argv[:] = args
 
+    # The script that we're profiling may chdir, so capture the absolute path
+    # to the output file at startup.
+    if options.outfile is not None:
+        options.outfile = os.path.abspath(options.outfile)
+
     if len(args) > 0:
         if options.module:
             import runpy

--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -6,7 +6,7 @@ import unittest
 import os
 from difflib import unified_diff
 from io import StringIO
-from test.support import TESTFN, run_unittest, unlink
+from test.support import TESTFN, run_unittest, unlink, temp_dir, change_cwd
 from contextlib import contextmanager
 
 import profile
@@ -110,6 +110,20 @@ class ProfileTest(unittest.TestCase):
         # Test successful run
         assert_python_ok('-m', self.profilermodule.__name__,
                          '-m', 'timeit', '-n', '1')
+
+    def test_output_file_when_changing_directory(self):
+        with temp_dir() as tmpdir, change_cwd(tmpdir):
+            os.mkdir('dest')
+            with open('demo.py', 'w') as f:
+                f.write('import os; os.chdir("dest")')
+
+            assert_python_ok(
+                '-m', self.profilermodule.__name__,
+                '-o', 'out.pstats',
+                'demo.py',
+            )
+
+            self.assertTrue(os.path.exists('out.pstats'))
 
 
 def regenerate_expected_output(filename, cls):

--- a/Misc/NEWS.d/next/Library/2020-05-04-12-16-00.bpo-40492.ONk9Na.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-04-12-16-00.bpo-40492.ONk9Na.rst
@@ -1,0 +1,3 @@
+Fix ``--outfile`` for :mod:`cProfile` / :mod:`profile` not writing the output
+file in the original directory when the program being profiled changes the
+working directory.  PR by Anthony Sottile.


### PR DESCRIPTION
(cherry picked from commit 3c0ac18504cfeed822439024339d5717f42bdd66)


<!-- issue-number: [bpo-40492](https://bugs.python.org/issue40492) -->
https://bugs.python.org/issue40492
<!-- /issue-number -->
