### PR TITLE
bpo-42051: Reject XML entity declarations in plist files

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -173,8 +173,15 @@ class _PlistParser:
         self.parser.StartElementHandler = self.handle_begin_element
         self.parser.EndElementHandler = self.handle_end_element
         self.parser.CharacterDataHandler = self.handle_data
+        self.parser.EntityDeclHandler = self.handle_entity_decl
         self.parser.ParseFile(fileobj)
         return self.root
+
+    def handle_entity_decl(self, entity_name, is_parameter_entity, value, base, system_id, public_id, notation_name):
+        # Reject plist files with entity declarations to avoid XML vulnerabilies in expat.
+        # Regular plist files don't contain those declerations, and Apple's plutil tool does not
+        # accept them either.
+        raise InvalidFileException("XML entity declarations are not supported in plist files")
 
     def handle_begin_element(self, element, attrs):
         self.data = []

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -106,6 +106,19 @@ TESTDATA={
         AAABOQ=='''),
 }
 
+XML_PLIST_WITH_ENTITY=b'''\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd" [
+   <!ENTITY entity "replacement text">
+  ]>
+<plist version="1.0">
+  <dict>
+    <key>A</key>
+    <string>&entity;</string>
+  </dict>
+</plist>
+'''
+
 
 class TestPlistlib(unittest.TestCase):
 
@@ -523,6 +536,11 @@ class TestPlistlib(unittest.TestCase):
         huge_uid.data = 2 ** 64  # dodge the size check in the constructor
         with self.assertRaises(OverflowError):
             plistlib.dumps(huge_uid, fmt=plistlib.FMT_BINARY)
+
+    def test_xml_plist_with_entity_decl(self):
+        with self.assertRaisesRegex(plistlib.InvalidFileException,
+                                    "XML entity declarations are not supported"):
+            plistlib.loads(XML_PLIST_WITH_ENTITY, fmt=plistlib.FMT_XML)
 
 
 class TestBinaryPlistlib(unittest.TestCase):

--- a/Misc/NEWS.d/next/Security/2020-10-19-10-56-27.bpo-42051.EU_B7u.rst
+++ b/Misc/NEWS.d/next/Security/2020-10-19-10-56-27.bpo-42051.EU_B7u.rst
@@ -1,0 +1,3 @@
+The :mod:`plistlib` module no longer accepts entity declarations in XML
+plist files to avoid XML vulnerabilities. This should not affect users as
+entity declarations are not used in regular plist files.


### PR DESCRIPTION
plistlib uses ElementTree to parse XML files, and therefore is subject to a number of XML vulnerabilities.  Those can be avoided by rejecting entity declarations in XML plist files.

Doing this is safe because Apple tools like plutil(1) also reject XML files with entity declarations. 

<!-- issue-number: [bpo-42051](https://bugs.python.org/issue42051) -->
https://bugs.python.org/issue42051
<!-- /issue-number -->
