### PR TITLE
bpo-41471: Ignore invalid prefix lengths in system proxy settings on …

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1449,6 +1449,18 @@ class HandlerTests(unittest.TestCase):
         bypass = {'exclude_simple': True, 'exceptions': []}
         self.assertTrue(_proxy_bypass_macosx_sysconf('test', bypass))
 
+        # Check that invalid prefix lengths are ignored
+        bypass = {
+            'exclude_simple': False,
+            'exceptions': [ '10.0.0.0/40', '172.19.10.0/24' ]
+        }
+        host = '172.19.10.5'
+        self.assertTrue(_proxy_bypass_macosx_sysconf(host, bypass),
+                        'expected bypass of %s to be True' % host)
+        host = '10.0.1.5'
+        self.assertFalse(_proxy_bypass_macosx_sysconf(host, bypass),
+                        'expected bypass of %s to be False' % host)
+
     def check_basic_auth(self, headers, realm):
         with self.subTest(realm=realm, headers=headers):
             opener = OpenerDirector()

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -2596,6 +2596,11 @@ def _proxy_bypass_macosx_sysconf(host, proxy_settings):
                 mask = 8 * (m.group(1).count('.') + 1)
             else:
                 mask = int(mask[1:])
+
+            if mask < 0 or mask > 32:
+                # System libraries ignore invalid prefix lengths
+                continue
+
             mask = 32 - mask
 
             if (hostIP >> mask) == (base >> mask):

--- a/Misc/NEWS.d/next/macOS/2020-10-19-12-25-19.bpo-41471.gwA7un.rst
+++ b/Misc/NEWS.d/next/macOS/2020-10-19-12-25-19.bpo-41471.gwA7un.rst
@@ -1,0 +1,1 @@
+Ignore invalid prefix lengths in system proxy excludes.


### PR DESCRIPTION
Ignore invalid prefix lengths (such as '172.19.0.0/40') in the system proxy settings on macOS. This matches the behaviour of Safari.

<!-- issue-number: [bpo-41471](https://bugs.python.org/issue41471) -->
https://bugs.python.org/issue41471
<!-- /issue-number -->
