### PR TITLE
bpo-41491: plistlib: accept hexadecimal integer values in xml plist f…

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -245,7 +245,11 @@ class _PlistParser:
         self.add_object(False)
 
     def end_integer(self):
-        self.add_object(int(self.get_data()))
+        raw = self.get_data()
+        if raw.startswith('0x') or raw.startswith('0X'):
+            self.add_object(int(raw, 16))
+        else:
+            self.add_object(int(raw))
 
     def end_real(self):
         self.add_object(float(self.get_data()))

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -485,6 +485,19 @@ class TestPlistlib(unittest.TestCase):
         self.assertRaises(ValueError, plistlib.loads,
                           b"<plist><integer>not real</integer></plist>")
 
+    def test_integer_notations(self):
+        pl = b"<plist><integer>456</integer></plist>"
+        value = plistlib.loads(pl)
+        self.assertEqual(value, 456)
+
+        pl = b"<plist><integer>0xa</integer></plist>"
+        value = plistlib.loads(pl)
+        self.assertEqual(value, 10)
+
+        pl = b"<plist><integer>0123</integer></plist>"
+        value = plistlib.loads(pl)
+        self.assertEqual(value, 123)
+
     def test_xml_encodings(self):
         base = TESTDATA[plistlib.FMT_XML]
 

--- a/Misc/NEWS.d/next/Library/2020-10-19-14-02-09.bpo-41491.d1BUWH.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-19-14-02-09.bpo-41491.d1BUWH.rst
@@ -1,0 +1,1 @@
+plistlib: fix parsing XML plists with hexadecimal integer values


### PR DESCRIPTION
Turns out that Apple's plist parsing code accepts hexadecimal notation in <integer> tags. 

<!-- issue-number: [bpo-41491](https://bugs.python.org/issue41491) -->
https://bugs.python.org/issue41491
<!-- /issue-number -->
