### PR TITLE
gh-85442: Making NamedTemporaryFile act as its own iterator to mimic…

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -499,6 +499,9 @@ class _TemporaryFileWrapper:
         """
         self._closer.close()
 
+    def __next__(self):
+        return next(self.file)
+
     # iter() doesn't use __getattr__ to find the __iter__ method
     def __iter__(self):
         # Don't return iter(self.file), but yield from it to avoid closing

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -892,10 +892,7 @@ class TestNamedTemporaryFile(BaseTestCase):
             fd.write(b''.join(lines))
             fd.seek(0)
 
-            for i, l in enumerate(lines):
-                self.assertEqual(l, next(fd))
-            self.assertEqual(i, len(lines) - 1)
-
+            self.assertEqual(list(fd), lines)
             with self.assertRaises(StopIteration):
                 next(fd)
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -886,6 +886,19 @@ class TestNamedTemporaryFile(BaseTestCase):
             self.assertEqual(l, lines[i])
         self.assertEqual(i, len(lines) - 1)
 
+    def test_next(self):
+        lines = [b'spam\n', b'eggs\n', b'beans\n']
+        with tempfile.NamedTemporaryFile(mode='w+b') as fd:
+            fd.write(b''.join(lines))
+            fd.seek(0)
+
+            for i, l in enumerate(lines):
+                self.assertEqual(l, next(fd))
+            self.assertEqual(i, len(lines) - 1)
+
+            with self.assertRaises(StopIteration):
+                next(fd)
+
     def test_creates_named(self):
         # NamedTemporaryFile creates files with names
         f = tempfile.NamedTemporaryFile()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1599,6 +1599,7 @@ Kirill Simonov
 Nathan Paul Simons
 Guilherme Simões
 Adam Simpkins
+Seth Sims
 Karthikeyan Singaravelan
 Mandeep Singh
 Ravi Sinha

--- a/Misc/NEWS.d/next/Library/2020-07-10-14-33-52.bpo-41270.pjUqyd.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-10-14-33-52.bpo-41270.pjUqyd.rst
@@ -1,0 +1,1 @@
+Added :func:`tempfile._TemporaryFileWrapper.__next__` so that the object returned by :func:`tempfile.NamedTemporaryFile` can be used to iterate over the contents of the file.


### PR DESCRIPTION
… normal file objects.

`NamedTemporaryFile` returns a proxy object `_TemporaryFileWrapper`. However it does not proxy
the `__next__` method so the object cannot be used by for loops or by the `next()` builtin
without calling `iter()` on it first. This changes that by explicitly poxying the `__next__`
method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41270](https://bugs.python.org/issue41270) -->
https://bugs.python.org/issue41270
<!-- /issue-number -->

<!-- gh-issue-number: gh-85442 -->
* Issue: gh-85442
<!-- /gh-issue-number -->
