### PR TITLE
bpo-2190: make MozillaCookieJar handle HTTP-only cookies

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -140,6 +140,9 @@ The following classes are provided:
 
    :rfc:`2964` - Use of HTTP State Management
 
+   https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
+      Describes the purpose of the ``HttpOnly`` attribute.
+
 .. _cookie-jar-objects:
 
 CookieJar and FileCookieJar Objects
@@ -704,6 +707,13 @@ internal consistency, so you should know what you're doing if you do that.
 
    ``True`` if the domain explicitly specified by the server began with a dot
    (``'.'``).
+
+.. attribute:: Cookie.httponly
+
+   ``True`` if cookie should only be accessible to the web server, and not to
+   client-side scripts running in a web browser.
+
+   .. versionadded:: 3.10
 
 Cookies may have additional non-standard cookie-attributes.  These may be
 accessed using the following methods:

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -2029,9 +2029,15 @@ class MozillaCookieJar(FileCookieJar):
                 # last field may be absent, so keep any trailing tab
                 if line.endswith("\n"): line = line[:-1]
 
+                # support HTTP-only cookies (as stored by curl or old Firefox).
+                # per prior comment, we need to take care NOT to strip trailing
+                # whitespace
+                sline = line.lstrip()
+                if sline.startswith("#HttpOnly_"):
+                    line = sline[10:]
                 # skip comments and blank lines XXX what is $ for?
-                if (line.strip().startswith(("#", "$")) or
-                    line.strip() == ""):
+                elif (sline.startswith(("#", "$")) or
+                      line.strip() == ""):
                     continue
 
                 domain, domain_specified, path, secure, expires, name, value = \
@@ -2107,6 +2113,10 @@ class MozillaCookieJar(FileCookieJar):
                 else:
                     name = cookie.name
                     value = cookie.value
+                if cookie.httponly:
+                    domain = '#HttpOnly_' + cookie.domain
+                else:
+                    domain = cookie.domain
                 f.write(
                     "\t".join([cookie.domain, initial_dot, cookie.path,
                                secure, expires, name, value])+

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -1771,7 +1771,8 @@ class LWPCookieTests(unittest.TestCase):
         interact_netscape(c, "http://www.foo.com/",
                           "foob=bar; Domain=.foo.com; %s" % expires)
         interact_netscape(c, "http://www.foo.com/",
-                          "fooc=bar; Domain=www.foo.com; %s" % expires)
+                          "fooc=bar; Domain=www.foo.com; Secure; HttpOnly; %s"
+                          % expires)
 
         def save_and_restore(cj, ignore_discard):
             try:
@@ -1787,6 +1788,10 @@ class LWPCookieTests(unittest.TestCase):
         new_c = save_and_restore(c, True)
         self.assertEqual(len(new_c), 6)  # none discarded
         self.assertIn("name='foo1', value='bar'", repr(new_c))
+
+        # verify that HttpOnly cookie is preserved, with that flag set on it
+        self.assertIn("name='fooc', value='bar'", repr(new_c))
+        self.assertIn("httponly", repr(new_c))
 
         new_c = save_and_restore(c, False)
         self.assertEqual(len(new_c), 4)  # 2 of them discarded on save

--- a/Misc/NEWS.d/next/Library/2020-10-20-00-34-00.bpo-2190.WNIr6.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-20-00-34-00.bpo-2190.WNIr6.rst
@@ -1,0 +1,4 @@
+:class:`http.cookiejar.MozillaCookieJar` will now correctly load and
+save cookies marked `HTTP-only
+<https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies>`_.  Patch by
+Daniel Lenski.


### PR DESCRIPTION
This resolves a longstanding issue with [`http.cookiejar.MozillaCookieJar`](https://docs.python.org/3/library/http.cookiejar.html#http.cookiejar.MozillaCookieJar), namely the fact that it does not know how to load or save cookies marked [HTTP-only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) in the on-disk file format.

As discussed in [bpo-2190](https://bugs.python.org/issue2190), this file format is **not** obsolete (despite the fact that Mozilla/Firefox browsers no longer store cookies in it).

[cURL](https://curl.haxx.se)'s `-b`/`-c` options still load and store cookies in this format, _including_ marking cookies as HTTP-only in this way.

With these changes applied, `MozillaCookieJar` will…

1. Correctly `.load` HTTP-only cookies,
2. Add a `Cookie.httponly` attribute to mark them as such, and
3. Correctly `.save` cookies with `httponly == True`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-2190](https://bugs.python.org/issue2190) -->
https://bugs.python.org/issue2190
<!-- /issue-number -->
