### PR TITLE
bpo-42093: Add opcode cache for LOAD_ATTR

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -252,6 +252,9 @@ Optimizations
   average.
   (Contributed by Victor Stinner in :issue:`41006`.)
 
+* The ``LOAD_ATTR`` instruction now uses new "per opcode cache" mechanism.
+  It is about 36% faster now.  (Contributed by Pablo Galindo and Yury Selivanov
+  in :issue:`42093`.)
 
 Deprecated
 ==========

--- a/Include/cpython/dictobject.h
+++ b/Include/cpython/dictobject.h
@@ -71,6 +71,7 @@ PyAPI_FUNC(void) _PyDict_DebugMallocStats(FILE *out);
 
 int _PyObjectDict_SetItem(PyTypeObject *tp, PyObject **dictptr, PyObject *name, PyObject *value);
 PyObject *_PyDict_LoadGlobal(PyDictObject *, PyDictObject *, PyObject *);
+Py_ssize_t _PyDict_GetItemHint(PyDictObject *, PyObject *, Py_ssize_t, PyObject **);
 
 /* _PyDictView */
 

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -10,9 +10,16 @@ typedef struct {
     uint64_t builtins_ver; /* ma_version of builtin dict */
 } _PyOpcache_LoadGlobal;
 
+typedef struct {
+    PyTypeObject *type;
+    Py_ssize_t hint;
+    unsigned int tp_version_tag;
+} _PyOpCodeOpt_LoadAttr;
+
 struct _PyOpcache {
     union {
         _PyOpcache_LoadGlobal lg;
+        _PyOpCodeOpt_LoadAttr la;
     } u;
     char optimized;
 };

--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-20-04-24-07.bpo-42093.ooZZNh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-20-04-24-07.bpo-42093.ooZZNh.rst
@@ -1,0 +1,2 @@
+The ``LOAD_ATTR`` instruction now uses new "per opcode cache" mechanism and
+it is about 36% faster now. Patch by Pablo Galindo and Yury Selivanov.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -301,8 +301,8 @@ _PyCode_InitOpcache(PyCodeObject *co)
         unsigned char opcode = _Py_OPCODE(opcodes[i]);
         i++;  // 'i' is now aligned to (next_instr - first_instr)
 
-        // TODO: LOAD_METHOD, LOAD_ATTR
-        if (opcode == LOAD_GLOBAL) {
+        // TODO: LOAD_METHOD
+        if (opcode == LOAD_GLOBAL || opcode == LOAD_ATTR) {
             opts++;
             co->co_opcache_map[i] = (unsigned char)opts;
             if (opts > 254) {


### PR DESCRIPTION
These are the benchmark results for the pyperformance test suite with PGO/LTO/CPU ISOLATION in a tuned system with pyperf:

```
+-------------------------+--------------------------------------+-------------------------------------+
| Benchmark               | 2020-10-20_01-18-master-de73d432bb29 | 2020-10-20_02-28-cache-68f931f6938a |
+=========================+======================================+=====================================+
| go                      | 407 ms                               | 349 ms: 1.17x faster (-14%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| raytrace                | 822 ms                               | 730 ms: 1.13x faster (-11%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| unpickle_pure_python    | 497 us                               | 447 us: 1.11x faster (-10%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| scimark_sor             | 311 ms                               | 280 ms: 1.11x faster (-10%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| hexiom                  | 15.4 ms                              | 14.0 ms: 1.10x faster (-9%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| logging_silent          | 302 ns                               | 276 ns: 1.10x faster (-9%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| chaos                   | 176 ms                               | 163 ms: 1.08x faster (-7%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| pyflate                 | 1.01 sec                             | 948 ms: 1.06x faster (-6%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| scimark_lu              | 246 ms                               | 232 ms: 1.06x faster (-6%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| pickle_pure_python      | 712 us                               | 674 us: 1.06x faster (-5%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| regex_effbot            | 4.49 ms                              | 4.26 ms: 1.05x faster (-5%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| scimark_monte_carlo     | 160 ms                               | 153 ms: 1.05x faster (-5%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| richards                | 120 ms                               | 115 ms: 1.05x faster (-4%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| 2to3                    | 458 ms                               | 442 ms: 1.04x faster (-4%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| regex_v8                | 33.7 ms                              | 32.5 ms: 1.04x faster (-3%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| scimark_sparse_mat_mult | 7.16 ms                              | 6.93 ms: 1.03x faster (-3%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| deltablue               | 12.1 ms                              | 11.7 ms: 1.03x faster (-3%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| regex_dna               | 268 ms                               | 261 ms: 1.03x faster (-3%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| meteor_contest          | 152 ms                               | 148 ms: 1.03x faster (-3%)          |
+-------------------------+--------------------------------------+-------------------------------------+
| genshi_xml              | 89.0 ms                              | 87.1 ms: 1.02x faster (-2%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| logging_simple          | 12.8 us                              | 12.5 us: 1.02x faster (-2%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| genshi_text             | 42.4 ms                              | 41.5 ms: 1.02x faster (-2%)         |
+-------------------------+--------------------------------------+-------------------------------------+
| nbody                   | 215 ms                               | 211 ms: 1.02x faster (-2%)          |
+-------------------------+--------------------------------------+-------------------------------------+

Not significant (35): chameleon; django_template; dulwich_log; fannkuch; float; json_dumps; json_loads; logging_format; mako; nqueens; pathlib; pickle; pickle_dict; pickle_list; pidigits; python_startup; python_startup_no_site; regex_compile; scimark_fft; spectral_norm; sqlalchemy_declarative; sqlalchemy_imperative; sqlite_synth; sympy_expand; sympy_sum; sympy_str; telco; tornado_http; unpack_sequence; unpickle; unpickle_list; xml_etree_parse; xml_etree_iterparse; xml_etree_generate; xml_etree_process; sympy_integrate
```

<!-- issue-number: [bpo-42093](https://bugs.python.org/issue42093) -->
https://bugs.python.org/issue42093
<!-- /issue-number -->
