### PR TITLE
bpo-37640: Fix telnetlib crash in Python3 while receiving un-printable characters from server

### DIFF
--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -552,18 +552,7 @@ class Telnet:
                             print('*** Connection closed by remote host ***')
                             return
                         if text:
-                            try:
-                                sys.stdout.write(text.decode('ascii'))
-                            except UnicodeDecodeError:
-                                if hasattr(sys.stdout, 'buffer'):
-                                    sys.stdout.buffer.write(text)
-                                else:
-                                    sys.stdout.write(
-                                        text.decode(
-                                            sys.stdout.encoding,
-                                            'strict'
-                                        )
-                                    )
+                            sys.stdout.write(text.decode(sys.stdout.encoding))
                             sys.stdout.flush()
                     elif key.fileobj is sys.stdin:
                         line = sys.stdin.readline().encode('ascii')
@@ -590,18 +579,7 @@ class Telnet:
                 print('*** Connection closed by remote host ***')
                 return
             if data:
-                try:
-                    sys.stdout.write(text.decode('ascii'))
-                except UnicodeDecodeError:
-                    if hasattr(sys.stdout, 'buffer'):
-                        sys.stdout.buffer.write(text)
-                    else:
-                        sys.stdout.write(
-                            text.decode(
-                                sys.stdout.encoding,
-                                'strict'
-                            )
-                        )
+                sys.stdout.write(text.decode(sys.stdout.encoding))
             else:
                 sys.stdout.flush()
 

--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -552,7 +552,18 @@ class Telnet:
                             print('*** Connection closed by remote host ***')
                             return
                         if text:
-                            sys.stdout.write(text.decode('ascii'))
+                            try:
+                                sys.stdout.write(text.decode('ascii'))
+                            except UnicodeDecodeError:
+                                if hasattr(sys.stdout, 'buffer'):
+                                    sys.stdout.buffer.write(text)
+                                else:
+                                    sys.stdout.write(
+                                        text.decode(
+                                            sys.stdout.encoding,
+                                            'strict'
+                                        )
+                                    )
                             sys.stdout.flush()
                     elif key.fileobj is sys.stdin:
                         line = sys.stdin.readline().encode('ascii')
@@ -579,7 +590,18 @@ class Telnet:
                 print('*** Connection closed by remote host ***')
                 return
             if data:
-                sys.stdout.write(data.decode('ascii'))
+                try:
+                    sys.stdout.write(text.decode('ascii'))
+                except UnicodeDecodeError:
+                    if hasattr(sys.stdout, 'buffer'):
+                        sys.stdout.buffer.write(text)
+                    else:
+                        sys.stdout.write(
+                            text.decode(
+                                sys.stdout.encoding,
+                                'strict'
+                            )
+                        )
             else:
                 sys.stdout.flush()
 

--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -555,15 +555,8 @@ class Telnet:
                             try:
                                 sys.stdout.write(text.decode('ascii'))
                             except UnicodeDecodeError:
-                                if hasattr(sys.stdout, 'buffer'):
-                                    sys.stdout.buffer.write(text)
-                                else:
-                                    sys.stdout.write(
-                                        text.decode(
-                                            sys.stdout.encoding,
-                                            'strict'
-                                        )
-                                    )
+                                # bpo-37640
+                                sys.stdout.buffer.write(text)
                             sys.stdout.flush()
                     elif key.fileobj is sys.stdin:
                         line = sys.stdin.readline().encode('ascii')
@@ -593,15 +586,8 @@ class Telnet:
                 try:
                     sys.stdout.write(text.decode('ascii'))
                 except UnicodeDecodeError:
-                    if hasattr(sys.stdout, 'buffer'):
-                        sys.stdout.buffer.write(text)
-                    else:
-                        sys.stdout.write(
-                            text.decode(
-                                sys.stdout.encoding,
-                                'strict'
-                            )
-                        )
+                    # bpo-37640
+                    sys.stdout.buffer.write(text)
             else:
                 sys.stdout.flush()
 

--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -584,10 +584,10 @@ class Telnet:
                 return
             if data:
                 try:
-                    sys.stdout.write(text.decode('ascii'))
+                    sys.stdout.write(data.decode('ascii'))
                 except UnicodeDecodeError:
                     # bpo-37640
-                    sys.stdout.buffer.write(text)
+                    sys.stdout.buffer.write(data)
             else:
                 sys.stdout.flush()
 

--- a/Lib/test/test_telnetlib.py
+++ b/Lib/test/test_telnetlib.py
@@ -404,22 +404,24 @@ class InteractTests(ExpectAndReadTestCase):
     def test_interact(self, stdin):
         encoding = 'ascii'
         want = ['x'.encode(encoding)]
-        f = io.TextIOWrapper(io.BytesIO(), encoding)
+        out = io.TextIOWrapper(io.BytesIO(), encoding)
         telnet = test_telnet(want)
-        with contextlib.redirect_stdout(f):
+        with contextlib.redirect_stdout(out):
             telnet.interact()
-        self.assertEqual(f.buffer.getvalue(), want[0])
+        out.seek(0)
+        self.assertEqual(out.read().encode(encoding), want[0])
 
     @unittest.mock.patch('telnetlib.sys.stdin', new_callable=io.StringIO)
     def test_interact_utf8(self, stdin):
         # bpo-37640
         encoding = 'utf-8'
         want = ['\xff'.encode(encoding)]
-        f = io.TextIOWrapper(io.BytesIO(), encoding)
+        out = io.TextIOWrapper(io.BytesIO(), encoding)
         telnet = test_telnet(want)
-        with contextlib.redirect_stdout(f):
+        with contextlib.redirect_stdout(out):
             telnet.interact()
-        self.assertEqual(f.buffer.getvalue(), want[0])
+        out.seek(0)
+        self.assertEqual(out.read().encode(encoding), want[0])
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-10-20-13-31-32.bpo-37640.JfvXk-.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-20-13-31-32.bpo-37640.JfvXk-.rst
@@ -1,1 +1,1 @@
-Fix the interact and the listener method use sys.stdout.buffer if exists
+Fix :mod:`telnetlib` crash while receiving un-printable characters in the :method:`Telnet.interact` and ``listener`` methods. 

--- a/Misc/NEWS.d/next/Library/2020-10-20-13-31-32.bpo-37640.JfvXk-.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-20-13-31-32.bpo-37640.JfvXk-.rst
@@ -1,1 +1,1 @@
-Fix :mod:`telnetlib` crash while receiving un-printable characters in the :method:`Telnet.interact` and ``listener`` methods. 
+Fix :mod:`telnetlib` crash while receiving un-printable characters in the :meth:`Telnet.interact` and ``listener`` methods. 

--- a/Misc/NEWS.d/next/Library/2020-10-20-13-31-32.bpo-37640.JfvXk-.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-20-13-31-32.bpo-37640.JfvXk-.rst
@@ -1,0 +1,1 @@
+Fix the interact and the listener method use sys.stdout.buffer if exists


### PR DESCRIPTION
Hi,
This pull request is based on the [bpo-37640](https://bugs.python.org/issue37640), this closed pull request #14877 and the pseudocode of [sys.displayhook](https://docs.python.org/3/library/sys.html#sys.displayhook).

This fix doesn't break the current telnetlib tests:
```
python -m unittest test_telnetlib.py
...................
----------------------------------------------------------------------
Ran 19 tests in 0.035s

OK
```
**If you have any suggestions for adding tests, let me know.**

As requested in #14877, I added an entry in Misc/NEWS.

This fix should be backported by creating a pull request for each version above or equal to 3.6. Are you agree?

<!-- issue-number: [bpo-37640](https://bugs.python.org/issue37640) -->
https://bugs.python.org/issue37640
<!-- /issue-number -->
