### PR TITLE
bpo-41737: [doc] add error handling example to file open section in IO tutorial

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -283,7 +283,11 @@ two arguments: ``open(filename, mode)``.
 
 ::
 
-   >>> f = open('workfile', 'w')
+    try:
+        f = open('workfile', 'w')
+    except OSError as e:
+        # File open failed
+        ...
 
 .. XXX str(f) is <io.TextIOWrapper object at 0x82e8dc4>
 

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -283,11 +283,12 @@ two arguments: ``open(filename, mode)``.
 
 ::
 
-    try:
-        f = open('workfile', 'w')
-    except OSError as e:
-        # File open failed
-        ...
+   >>> try:
+   ...     f = open('workfile', 'w')
+   ... except OSError as e:
+   ...     print('File open failed')
+   ... 
+   
 
 .. XXX str(f) is <io.TextIOWrapper object at 0x82e8dc4>
 

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -283,12 +283,7 @@ two arguments: ``open(filename, mode)``.
 
 ::
 
-   >>> try:
-   ...     f = open('workfile', 'w')
-   ... except OSError as e:
-   ...     print('Cannot open file: ', e)
-   ... 
-   
+   >>> f = open('workfile', 'w')
 
 .. XXX str(f) is <io.TextIOWrapper object at 0x82e8dc4>
 
@@ -318,6 +313,18 @@ platform-specific line endings.  This behind-the-scenes modification
 to file data is fine for text files, but will corrupt binary data like that in
 :file:`JPEG` or :file:`EXE` files.  Be very careful to use binary mode when
 reading and writing such files.
+
+If the :func:`open` function is unable to open the file, for instance because
+the file does not exist, it raises an :exc:`OSError` (or one of its
+system-dependent subclasses) which can be handled as follows:
+
+::
+
+   >>> try:
+   ...     f = open('workfile', 'w')
+   ... except OSError as e:
+   ...     print('Cannot open file: ', e)
+   ...
 
 It is good practice to use the :keyword:`with` keyword when dealing
 with file objects.  The advantage is that the file is properly closed

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -314,18 +314,6 @@ to file data is fine for text files, but will corrupt binary data like that in
 :file:`JPEG` or :file:`EXE` files.  Be very careful to use binary mode when
 reading and writing such files.
 
-If the :func:`open` function is unable to open the file, for instance because
-the file does not exist, it raises an :exc:`OSError` (or one of its
-system-dependent subclasses) which can be handled as follows:
-
-::
-
-   >>> try:
-   ...     f = open('workfile', 'w')
-   ... except OSError as e:
-   ...     print('Cannot open file: ', e)
-   ...
-
 It is good practice to use the :keyword:`with` keyword when dealing
 with file objects.  The advantage is that the file is properly closed
 after its suite finishes, even if an exception is raised at some
@@ -356,6 +344,18 @@ automatically fail. ::
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    ValueError: I/O operation on closed file.
+
+If the :func:`open` function is unable to open the file, for instance because
+the file does not exist, it raises an :exc:`OSError` (or one of its
+system-dependent subclasses), which can be handled as follows:
+
+::
+
+   >>> try:
+   ...     f = open('workfile', 'w')
+   ... except OSError as e:
+   ...     print('Cannot open file: ', e)
+   ...
 
 
 .. _tut-filemethods:

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -286,7 +286,7 @@ two arguments: ``open(filename, mode)``.
    >>> try:
    ...     f = open('workfile', 'w')
    ... except OSError as e:
-   ...     print('File open failed')
+   ...     print('Cannot open file: ', e)
    ... 
    
 


### PR DESCRIPTION

Tutorial currently doesn't show that OSError is what should be caught for file open errors. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41737](https://bugs.python.org/issue41737) -->
https://bugs.python.org/issue41737
<!-- /issue-number -->
