### PR TITLE
bpo-42099: Fix reference to ob_type in unionobject.c and ceval

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-20-12-20-24.bpo-42099.GKcRR6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-20-12-20-24.bpo-42099.GKcRR6.rst
@@ -1,0 +1,1 @@
+Replace references to ob_type with Py_TYPE() in unionobject and in ceval.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-20-12-20-24.bpo-42099.GKcRR6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-20-12-20-24.bpo-42099.GKcRR6.rst
@@ -1,1 +1,0 @@
-Replace references to ob_type with Py_TYPE() in unionobject and in ceval.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -15,7 +15,7 @@ unionobject_dealloc(PyObject *self)
     unionobject *alias = (unionobject *)self;
 
     Py_XDECREF(alias->args);
-    self->ob_type->tp_free(self);
+    Py_TYPE(self)->tp_free(self);
 }
 
 static Py_hash_t

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3186,7 +3186,7 @@ main_loop:
 
                         descr = _PyType_Lookup(type, name);
                         if (descr == NULL ||
-                            descr->ob_type->tp_descr_get == NULL ||
+                            Py_TYPE(descr)->tp_descr_get == NULL ||
                             !PyDescr_IsData(descr))
                         {
                             dictptr = (PyObject **) ((char *)owner + type->tp_dictoffset);


### PR DESCRIPTION
Replace references to ob_type with Py_TYPE() in unionobject and in ceval.

<!-- issue-number: [bpo-42099](https://bugs.python.org/issue42099) -->
https://bugs.python.org/issue42099
<!-- /issue-number -->
