### PR TITLE
bpo-42087: Remove support for AIX 5 and below

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1635,7 +1635,7 @@ libainstall:	@DEF_MAKE_RULE@ python-config
 		$(INSTALL_SCRIPT) Modules/ld_so_aix	\
 				$(DESTDIR)$(LIBPL)/ld_so_aix;		\
 		echo "$(LIBPL)/ld_so_aix";			\
-		echo; echo "See Misc/AIX-NOTES for details.";	\
+		echo; echo "See Misc/README.AIX for details.";	\
 	else true; \
 	fi
 

--- a/Misc/NEWS.d/next/Build/2020-10-19-15-41-05.bpo-42087.2AhRFP.rst
+++ b/Misc/NEWS.d/next/Build/2020-10-19-15-41-05.bpo-42087.2AhRFP.rst
@@ -1,0 +1,1 @@
+Support was removed for AIX 5.3 and below. See :issue:`40680`.

--- a/Misc/README.AIX
+++ b/Misc/README.AIX
@@ -37,11 +37,6 @@ cd Python-3.2
 CC=xlc_r OPT="-O2 -qmaxmem=70000" ./configure --without-computed-gotos --enable-shared
 make
 
-Note:
-On AIX 5.3 and earlier, you will also need to specify the
-"--disable-ipv6" flag to configure. This has been corrected in AIX
-6.1.
-
 
 ======================================================================
 			  Memory Limitations

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -537,7 +537,6 @@ static struct langinfo_constant{
     LANGINFO(PM_STR),
 
     /* The following constants are available only with XPG4, but...
-       AIX 3.2. only has CODESET.
        OpenBSD doesn't have CODESET but has T_FMT_AMPM, and doesn't have
        a few of the others.
        Solution: ifdef-test them all. */

--- a/Modules/makexp_aix
+++ b/Modules/makexp_aix
@@ -3,7 +3,7 @@
 # ===========================================================================
 # FILE:         makexp_aix
 # TYPE:         standalone executable
-# SYSTEM:	AIX 3.2.5 and AIX 4
+# SYSTEM:	    AIX
 #
 # DESCRIPTION:  This script creates an export list of ALL global symbols
 #               from a list of object or archive files.
@@ -48,34 +48,24 @@ echo "*" >> $expFileName
 echo "* $notemsg" >> $expFileName
 echo "*" >> $expFileName
 
-# Extract the symbol list using 'nm' which produces quite
-# different output under AIX 4 than under AIX 3.2.5.
-# The following handles both versions by using a common flagset.
+# Extract the symbol list using 'nm'
 # Here are some hidden tricks:
-# 1. Use /usr/ccs/bin/nm. Relevant to AIX 3.2.5 which has
-#    another version under /usr/ucb/bin/nm.
-# 2. Use the -B flag to have a standard BSD representation
-#    of the symbol list on both AIX 3.2.5 and AIX 4. The "-B"
-#    flag is missing in the AIX 3.2.5 online usage help of 'nm'.
-# 3. Use the -x flag to have a hex representation of the symbol
-#    values. This fills the leading whitespaces on AIX 4,
-#    thus simplifying the sed statement.
-# 4. Eliminate all entries except those with either "B", "D"
-#    or "T" key letters. We are interested only in the global
-#    (extern) BSS, DATA and TEXT symbols. With the same statement
-#    we eliminate object member lines relevant to AIX 4.
-# 5. Eliminate entries containing a dot. We can have a dot only
-#    as a symbol prefix, but such symbols are undefined externs.
-# 6. Eliminate everything including the key letter, so that we're
-#    left with just the symbol name.
-# 7. Eliminate all entries containing two colons, like Class::method
+# - Use the -B flag to have a standard BSD representation
+#   of the symbol list.
+# - Use the -x flag to have a hex representation of the symbol
+#   values. This fills the leading whitespaces, thus simplifying
+#   the sed statement.
+# - Eliminate all entries except those with either "B", "D"
+#   or "T" key letters. We are interested only in the global
+#   (extern) BSS, DATA and TEXT symbols. With the same statement
+#   we eliminate object member lines relevant to AIX 4.
+# - Eliminate entries containing a dot. We can have a dot only
+#   as a symbol prefix, but such symbols are undefined externs.
+# - Eliminate everything including the key letter, so that we're
+#   left with just the symbol name.
+# - Eliminate all entries containing two colons, like Class::method
 #
 
-# Use -X32_64 if it appears to be implemented in this version of 'nm'.
-NM=/usr/ccs/bin/nm
-xopt=-X32_64
-$NM -e $xopt $1 >/dev/null 2>&1 || xopt=""
-
-$NM -Bex $xopt $inputFiles					\
+/usr/ccs/bin/nm -Bex -X32_64 $inputFiles \
 | sed -e '/ [^BDT] /d' -e '/\./d' -e 's/.* [BDT] //' -e '/::/d'	\
 | sort | uniq >> $expFileName

--- a/configure
+++ b/configure
@@ -3430,16 +3430,6 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
     define_xopen_source=no;;
   Darwin/[12][0-9].*)
     define_xopen_source=no;;
-  # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
-  # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined
-  # or has another value. By not (re)defining it, the defaults come in place.
-  AIX/4)
-    define_xopen_source=no;;
-  AIX/5)
-    if test `uname -r` -eq 1; then
-      define_xopen_source=no
-    fi
-    ;;
   # On QNX 6.3.2, defining _XOPEN_SOURCE prevents netdb.h from
   # defining NI_NUMERICHOST.
   QNX/6.3.2)
@@ -5828,10 +5818,7 @@ $as_echo_n "checking EXPORTSYMS... " >&6; }
 case $ac_sys_system in
 AIX*)
 	EXPORTSYMS="Modules/python.exp"
-	if test $ac_sys_release -ge 5 -o \
-		$ac_sys_release -eq 4 -a `uname -r` -ge 2 ; then
-	    EXPORTSFROM=. # the main executable
-	fi
+	EXPORTSFROM=. # the main executable
 	;;
 esac
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $EXPORTSYMS" >&5
@@ -11604,7 +11591,7 @@ fi
 DLINCLDIR=.
 
 # the dlopen() function means we might want to use dynload_shlib.o. some
-# platforms, such as AIX, have dlopen(), but don't want to use it.
+# platforms have dlopen(), but don't want to use it.
 for ac_func in dlopen
 do :
   ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"

--- a/configure.ac
+++ b/configure.ac
@@ -512,16 +512,6 @@ case $ac_sys_system/$ac_sys_release in
     define_xopen_source=no;;
   Darwin/@<:@[12]@:>@@<:@0-9@:>@.*)
     define_xopen_source=no;;
-  # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
-  # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined
-  # or has another value. By not (re)defining it, the defaults come in place.
-  AIX/4)
-    define_xopen_source=no;;
-  AIX/5)
-    if test `uname -r` -eq 1; then
-      define_xopen_source=no
-    fi
-    ;;
   # On QNX 6.3.2, defining _XOPEN_SOURCE prevents netdb.h from
   # defining NI_NUMERICHOST.
   QNX/6.3.2)
@@ -1048,10 +1038,7 @@ AC_MSG_CHECKING(EXPORTSYMS)
 case $ac_sys_system in
 AIX*)
 	EXPORTSYMS="Modules/python.exp"
-	if test $ac_sys_release -ge 5 -o \
-		$ac_sys_release -eq 4 -a `uname -r` -ge 2 ; then
-	    EXPORTSFROM=. # the main executable
-	fi
+	EXPORTSFROM=. # the main executable
 	;;
 esac
 AC_MSG_RESULT($EXPORTSYMS)
@@ -3612,7 +3599,7 @@ AC_SUBST(DLINCLDIR)
 DLINCLDIR=.
 
 # the dlopen() function means we might want to use dynload_shlib.o. some
-# platforms, such as AIX, have dlopen(), but don't want to use it.
+# platforms have dlopen(), but don't want to use it.
 AC_CHECK_FUNCS(dlopen)
 
 # DYNLOADFILE specifies which dynload_*.o file we will use for dynamic


### PR DESCRIPTION
As AIX 5 and below do not support thread_cputime, it was decided in
https://bugs.python.org/issue40680 to require AIX 6.1 and above. This
commit removes workarounds for — and references to — older, unsupported
AIX versions.

I did leave a few references to older AIX versions, but those are either
[generated by autotools](https://github.com/python/cpython/blob/master/pyconfig.h.in#L1502) or are of [historical documentation](https://github.com/python/cpython/blob/master/Lib/_aix_support.py#L49) and not _code_.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42087](https://bugs.python.org/issue42087) -->
https://bugs.python.org/issue42087
<!-- /issue-number -->
