### PR TITLE
[3.8] bpo-35753: Fix crash in doctest with unwrap-able functions

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -994,9 +994,15 @@ class DocTestFinder:
         if inspect.ismodule(obj) and self._recurse:
             for valname, val in obj.__dict__.items():
                 valname = '%s.%s' % (name, valname)
+
+                # Protect against objects that cause unwrap to throw
+                isroutine = False
+                try:
+                    isroutine = inspect.isroutine(inspect.unwrap(val))
+                except ValueError:
+                    pass
                 # Recurse to functions & classes.
-                if ((inspect.isroutine(inspect.unwrap(val))
-                     or inspect.isclass(val)) and
+                if ((isroutine or inspect.isclass(val)) and
                     self._from_module(module, val)):
                     self._find(tests, val, valname, module, source_lines,
                                globs, seen)

--- a/Lib/test/test_doctest5.py
+++ b/Lib/test/test_doctest5.py
@@ -1,0 +1,33 @@
+"""A module to test whether doctest works properly with
+un-unwrappable functions.
+
+See: https://bugs.python.org/issue35753
+"""
+
+# This should trigger issue35753 when doctest called
+from unittest.mock import call
+
+import sys
+import unittest
+from test import support
+if sys.flags.optimize >= 2:
+    raise unittest.SkipTest("Cannot test docstrings with -O2")
+
+
+def test_main():
+    from test import test_doctest5
+    EXPECTED = 0
+    try:
+        f, t = support.run_doctest(test_doctest5)
+        if t != EXPECTED:
+            raise support.TestFailed("expected %d tests to run, not %d" %
+                                          (EXPECTED, t))
+    except ValueError as e:
+        raise support.TestFailed("Doctest unwrap failed") from e
+
+# Pollute the namespace with a bunch of imported functions and classes,
+# to make sure they don't get tested.
+# from doctest import *
+
+if __name__ == '__main__':
+    test_main()

--- a/Misc/NEWS.d/next/Tests/2020-10-25-19-20-26.bpo-35753.2LT-hO.rst
+++ b/Misc/NEWS.d/next/Tests/2020-10-25-19-20-26.bpo-35753.2LT-hO.rst
@@ -1,0 +1,2 @@
+Fix crash in doctest when doctest parses modules that include unwrappable
+functions by skipping those functions.


### PR DESCRIPTION
Doctest needs to Ignore objects that inspect.unwrap throws ValueError due to "infinite" nesting.

This case is relatively commonly reproduced by importing unittest.mock.call into a module's namespace.

The following code produces a module that will crash doctest:

```
from unittest.mock import call
```

This is due to the call to unwrap throwing an uncaught ValueError.

For this case we can simply ignore the function and not attempt to extract docstring from this function.

This diff is intentionally done as a branch with two commits to provide failing test case and then a fix to show the problem is contained.

Future thoughts:
1. Should catching this be optional defaulting to true, but allowing for folks to rethrow the exception to insist on truly clean code?
2. Should we break out _find() into more sub functions so that we can more easily derive our own versions for each sub function that _find does making it easier to fix future issues?
3. Should we include a way to denylist by `id` some objects so that future objects that cause problems with doctest can be passed in to ignore?

Note: This branch diff will need to be pulled up into 3.9 and master as the bug exists in those branches as well.

<!-- issue-number: [bpo-35753](https://bugs.python.org/issue35753) -->
https://bugs.python.org/issue35753
<!-- /issue-number -->
