### PR TITLE
Change code example in sys.display_hook docs

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -278,11 +278,7 @@ always available.
                sys.stdout.write(text)
            except UnicodeEncodeError:
                bytes = text.encode(sys.stdout.encoding, 'backslashreplace')
-               if hasattr(sys.stdout, 'buffer'):
-                   sys.stdout.buffer.write(bytes)
-               else:
-                   text = bytes.decode(sys.stdout.encoding, 'strict')
-                   sys.stdout.write(text)
+               sys.stdout.buffer.write(bytes)
            sys.stdout.write("\n")
            builtins._ = value
 


### PR DESCRIPTION
The current example pseudo-code checks for `hasattr(sys.stdout, 'buffer')`, which is redundant in Python 3 as it always evaluates to `True` (while in Python 2, `sys.stdout.buffer` did not exist). This makes the code example needlessly confusing. Now that Python 2 is unmaintained, there is no longer a need to ensure compatibility and it should be removed.

Please skip issue and skip news. Thanks.

Edit: This probably needs a backport to all branches with docs still being actively maintained (guessing 3.8).