### PR TITLE
Fix bpo-39416: Change "Numeric" to lower case; an english word, not a class name

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -187,7 +187,7 @@ Ellipsis
    related to mathematical numbers, but subject to the limitations of numerical
    representation in computers.
 
-   The string representations of the Numeric classes, computed by
+   The string representations of the numeric classes, computed by
    :meth:`__repr__` and :meth:`__str__`, have the following
    properties:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title
This is a trivial fix to [bpo-39416](https://bugs.python.org/issue39416), which didn't come up until it was already committed

```
Change "Numeric" to "numeric".

I believe this is trivial enough to not need an issue or a NEWS entry, although
I'm unclear on what branches the original pull request received backports.
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
This is a trivial fix to [bpo-39416](https://bugs.python.org/issue39416), which didn't come up until it was already committed

```
Change "Numeric" to "numeric".

I believe this is trivial enough to not need an issue or a NEWS entry, although
I'm unclear on what branches the original pull request received backports.
```

<!-- issue-number: [bpo-39416](https://bugs.python.org/issue39416) -->
https://bugs.python.org/issue39416
<!-- /issue-number -->

Automerge-Triggered-By: GH:merwok