### PR TITLE
bpo-41910: specify the default implementations of object.__eq__ and object.__ne__

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1395,14 +1395,14 @@ Basic customization
    context (e.g., in the condition of an ``if`` statement), Python will call
    :func:`bool` on the value to determine if the result is true or false.
 
-   By default, ``object`` implements :meth:`__eq__` by using ``is``: ``x is y``.
-   For :meth:`__ne__`, by default it delegates to :meth:`__eq__` and
-   inverts the result unless it is ``NotImplemented``, in which case it falls
-   back to ``is not``: ``x is not y``.  There are no other
-   implied relationships among the comparison operators or default
-   implementations; for example, the truth of ``(x<y or x==y)`` does not imply
-   ``x<=y``. To automatically generate ordering operations from a single root
-   operation, see :func:`functools.total_ordering`.
+   By default, ``object`` implements :meth:`__eq__` by using ``is``, returning
+   ``NotImplemented`` in the case of a false comparison:
+   ``True if x is y else NotImplemented``. For :meth:`__ne__`, by default it
+   delegates to :meth:`__eq__` and inverts the result unless it is
+   ``NotImplemented``.  There are no other implied relationships among the
+   comparison operators or default implementations; for example, the truth of
+   ``(x<y or x==y)`` does not imply ``x<=y``. To automatically generate ordering
+   operations from a single root operation, see :func:`functools.total_ordering`.
 
    See the paragraph on :meth:`__hash__` for
    some important notes on creating :term:`hashable` objects which support

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1395,12 +1395,14 @@ Basic customization
    context (e.g., in the condition of an ``if`` statement), Python will call
    :func:`bool` on the value to determine if the result is true or false.
 
-   By default, :meth:`__ne__` delegates to :meth:`__eq__` and
-   inverts the result unless it is ``NotImplemented``.  There are no other
-   implied relationships among the comparison operators, for example,
-   the truth of ``(x<y or x==y)`` does not imply ``x<=y``.
-   To automatically generate ordering operations from a single root operation,
-   see :func:`functools.total_ordering`.
+   By default, ``object`` implements :meth:`__eq__` by using ``is``: ``x is y``.
+   For :meth:`__ne__`, by default it delegates to :meth:`__eq__` and
+   inverts the result unless it is ``NotImplemented``, in which case it falls
+   back to ``is not``: ``x is not y``.  There are no other
+   implied relationships among the comparison operators or default
+   implementations; for example, the truth of ``(x<y or x==y)`` does not imply
+   ``x<=y``. To automatically generate ordering operations from a single root
+   operation, see :func:`functools.total_ordering`.
 
    See the paragraph on :meth:`__hash__` for
    some important notes on creating :term:`hashable` objects which support

--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-21-14-40-54.bpo-41910.CzBMit.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-21-14-40-54.bpo-41910.CzBMit.rst
@@ -1,0 +1,1 @@
+Document the default implementation of `object.__eq__`.


### PR DESCRIPTION
See Objects/typeobject.c:object_richcompare() for the implementation of this in CPython.

<!-- issue-number: [bpo-41910](https://bugs.python.org/issue41910) -->
https://bugs.python.org/issue41910
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon