### PR TITLE
bpo-1635741: Fix NULL ptr deref in multiprocessing

### DIFF
--- a/Modules/_multiprocessing/multiprocessing.c
+++ b/Modules/_multiprocessing/multiprocessing.c
@@ -207,7 +207,6 @@ multiprocessing_exec(PyObject *module)
             py_sem_value_max = PyLong_FromLong(SEM_VALUE_MAX);
 
         if (py_sem_value_max == NULL) {
-            Py_DECREF(py_sem_value_max);
             return -1;
         }
         if (PyDict_SetItemString(_PyMp_SemLockType.tp_dict, "SEM_VALUE_MAX",


### PR DESCRIPTION
Commit 1d541c25c8019f7a0b80b3e1b437abe171e40b65 introduced a NULL
pointer dereference in error path.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->

Automerge-Triggered-By: GH:encukou