### PR TITLE
_testmultiphase: Fix possible ref leak

### DIFF
--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -359,6 +359,7 @@ static int execfunc(PyObject *m)
         goto fail;
     }
     if (PyModule_AddObject(m, "Example", temp) != 0) {
+        Py_DECREF(temp);
         goto fail;
     }
 
@@ -369,6 +370,7 @@ static int execfunc(PyObject *m)
         goto fail;
     }
     if (PyModule_AddObject(m, "error", temp) != 0) {
+        Py_DECREF(temp);
         goto fail;
     }
 
@@ -378,6 +380,7 @@ static int execfunc(PyObject *m)
         goto fail;
     }
     if (PyModule_AddObject(m, "Str", temp) != 0) {
+        Py_DECREF(temp);
         goto fail;
     }
 
@@ -807,6 +810,7 @@ meth_state_access_exec(PyObject *m)
         return -1;
     }
     if (PyModule_AddObject(m, "StateAccessType", temp) != 0) {
+        Py_DECREF(temp);
         return -1;
     }
 


### PR DESCRIPTION
This is just test code, but sometimes external contributors reference the code snippets from test code.
`PyModule_AddObject` should be handled in the proper way.

https://docs.python.org/3/c-api/module.html#c.PyModule_AddObject

Automerge-Triggered-By: GH:encukou