### PR TITLE
Add GitHub sponsor info for Python

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 custom: https://www.python.org/psf/donations/python-dev/
+github: [python]


### PR DESCRIPTION
Sponsor Python on GitHub

