### PR TITLE
bpo-38443: Check that the specified universal architectures work

### DIFF
--- a/Misc/NEWS.d/next/macOS/2020-10-23-10-26-53.bpo-38443.vu64tl.rst
+++ b/Misc/NEWS.d/next/macOS/2020-10-23-10-26-53.bpo-38443.vu64tl.rst
@@ -1,0 +1,2 @@
+The ``--enable-universalsdk`` and ``--with-universal-archs`` options for the
+configure script now check that the specified architectures can be used.

--- a/configure
+++ b/configure
@@ -7619,6 +7619,31 @@ $as_echo_n "checking which MACOSX_DEPLOYMENT_TARGET to use... " >&6; }
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MACOSX_DEPLOYMENT_TARGET" >&5
 $as_echo "$MACOSX_DEPLOYMENT_TARGET" >&6; }
 
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if specified universal architectures work" >&5
+$as_echo_n "checking if specified universal architectures work... " >&6; }
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdio.h>
+int
+main ()
+{
+printf("%d", 42);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+             as_fn_error $? "check config.log and use the '--with-universal-archs' option" "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
         # end of Darwin* tests
         ;;
     esac

--- a/configure.ac
+++ b/configure.ac
@@ -1986,6 +1986,13 @@ yes)
         EXPORT_MACOSX_DEPLOYMENT_TARGET=''
         AC_MSG_RESULT($MACOSX_DEPLOYMENT_TARGET)
 
+        AC_MSG_CHECKING(if specified universal architectures work)
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>]], [[printf("%d", 42);]])],
+            [AC_MSG_RESULT(yes)],
+            [AC_MSG_RESULT(no)
+             AC_MSG_ERROR(check config.log and use the '--with-universal-archs' option)
+        ])
+
         # end of Darwin* tests
         ;;
     esac


### PR DESCRIPTION
As [bpo-38443](https://bugs.python.org/issue38443) says the error message from configure when specifying --enable-universalsdk with a set of architectures that is not supported by the compiler is not very helpful.   This PR explicitly checks if the compiler works and bails out if it doesn't.

<!-- issue-number: [bpo-38443](https://bugs.python.org/issue38443) -->
https://bugs.python.org/issue38443
<!-- /issue-number -->

Automerge-Triggered-By: GH:ned-deily