### PR TITLE
bpo-42143: Ensure PyFunction_NewWithQualName() can't fail after creating the func object

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-27-21-34-05.bpo-42143.N6KXUO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-27-21-34-05.bpo-42143.N6KXUO.rst
@@ -1,2 +1,2 @@
-Fix handling of errors during creation of ``PyFunctionObject``s, which resulted
+Fix handling of errors during creation of ``PyFunctionObject``, which resulted
 in operations on uninitialized memory. Patch by Yonatan Goldschmidt.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-27-21-34-05.bpo-42143.N6KXUO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-27-21-34-05.bpo-42143.N6KXUO.rst
@@ -1,0 +1,2 @@
+Fix handling of errors during creation of ``PyFunctionObject``s, which resulted
+in operations on uninitialized memory. Patch by Yonatan Goldschmidt.

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -20,7 +20,7 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
     }
 
     /* __module__: If module name is in globals, use it.
-    Otherwise, use None. */
+       Otherwise, use None. */
     module = PyDict_GetItemWithError(globals, __name__);
     if (module) {
         Py_INCREF(module);

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -30,8 +30,10 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
     }
 
     op = PyObject_GC_New(PyFunctionObject, &PyFunction_Type);
-    if (op == NULL)
+    if (op == NULL) {
+        Py_XDECREF(module);
         return NULL;
+    }
     /* Note: No failures from this point on, since func_dealloc() does not
        expect a partially-created object. */
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -19,9 +19,21 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
             return NULL;
     }
 
+    /* __module__: If module name is in globals, use it.
+    Otherwise, use None. */
+    module = PyDict_GetItemWithError(globals, __name__);
+    if (module) {
+        Py_INCREF(module);
+    }
+    else if (PyErr_Occurred()) {
+        return NULL;
+    }
+
     op = PyObject_GC_New(PyFunctionObject, &PyFunction_Type);
     if (op == NULL)
         return NULL;
+    /* Note: No failures from this point on, since func_dealloc() does not
+       expect a partially-created object. */
 
     op->func_weakreflist = NULL;
     Py_INCREF(code);
@@ -34,6 +46,7 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
     op->func_kwdefaults = NULL; /* No keyword only defaults */
     op->func_closure = NULL;
     op->vectorcall = _PyFunction_Vectorcall;
+    op->func_module = module;
 
     consts = ((PyCodeObject *)code)->co_consts;
     if (PyTuple_Size(consts) >= 1) {
@@ -47,20 +60,8 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
     op->func_doc = doc;
 
     op->func_dict = NULL;
-    op->func_module = NULL;
     op->func_annotations = NULL;
 
-    /* __module__: If module name is in globals, use it.
-       Otherwise, use None. */
-    module = PyDict_GetItemWithError(globals, __name__);
-    if (module) {
-        Py_INCREF(module);
-        op->func_module = module;
-    }
-    else if (PyErr_Occurred()) {
-        Py_DECREF(op);
-        return NULL;
-    }
     if (qualname)
         op->func_qualname = qualname;
     else


### PR DESCRIPTION
func_dealloc() does not handle partially-created objects. Best not to give it any.

This fixes both issues I have described in the bpo.

<!-- issue-number: [bpo-42143](https://bugs.python.org/issue42143) -->
https://bugs.python.org/issue42143
<!-- /issue-number -->
