### PR TITLE
[WIP/RFC] bpo-15872: tests: remove oddity from test_rmtree_errors

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -280,10 +280,7 @@ class TestRmTree(BaseTest, unittest.TestCase):
         filename = os.path.join(tmpdir, "tstfile")
         with self.assertRaises(NotADirectoryError) as cm:
             shutil.rmtree(filename)
-        # The reason for this rather odd construct is that Windows sprinkles
-        # a \*.* at the end of file names. But only sometimes on some buildbots
-        possible_args = [filename, os.path.join(filename, '*.*')]
-        self.assertIn(cm.exception.filename, possible_args)
+        self.assertEqual(cm.exception.filename, filename)
         self.assertTrue(os.path.exists(filename))
         # test that ignore_errors option is honored
         shutil.rmtree(filename, ignore_errors=True)
@@ -296,11 +293,11 @@ class TestRmTree(BaseTest, unittest.TestCase):
         self.assertIs(errors[0][0], os.scandir)
         self.assertEqual(errors[0][1], filename)
         self.assertIsInstance(errors[0][2][1], NotADirectoryError)
-        self.assertIn(errors[0][2][1].filename, possible_args)
+        self.assertEqual(errors[0][2][1].filename, filename)
         self.assertIs(errors[1][0], os.rmdir)
         self.assertEqual(errors[1][1], filename)
         self.assertIsInstance(errors[1][2][1], NotADirectoryError)
-        self.assertIn(errors[1][2][1].filename, possible_args)
+        self.assertEqual(errors[1][2][1].filename, filename)
 
 
     @unittest.skipIf(sys.platform[:6] == 'cygwin',


### PR DESCRIPTION
This was added for (some) Windows buildbots back in 2012, and should
either not be necessary anymore, or it should probably get investigated
why "\*.*" gets added to filenames in the first place.

Ref: https://bugs.python.org/issue15872

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-15872](https://bugs.python.org/issue15872) -->
https://bugs.python.org/issue15872
<!-- /issue-number -->

Automerge-Triggered-By: GH:hynek