### PR TITLE
bpo-41919: Avoid resource leak in test_io module

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2520,7 +2520,8 @@ class StatefulIncrementalDecoder(codecs.IncrementalDecoder):
     codecEnabled = False
 
 
-# bpo-41919: Split from StatefulIncrementalDecoder to avoid resource leak.
+# bpo-41919: This method is separated from StatefulIncrementalDecoder to avoid a resource leak
+# when registering codecs and cleanup functions.
 def lookupTestDecoder(name):
     if StatefulIncrementalDecoder.codecEnabled and name == 'test_decoder':
         latin1 = codecs.lookup('latin-1')

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2519,15 +2519,16 @@ class StatefulIncrementalDecoder(codecs.IncrementalDecoder):
 
     codecEnabled = False
 
-    @classmethod
-    def lookupTestDecoder(cls, name):
-        if cls.codecEnabled and name == 'test_decoder':
-            latin1 = codecs.lookup('latin-1')
-            return codecs.CodecInfo(
-                name='test_decoder', encode=latin1.encode, decode=None,
-                incrementalencoder=None,
-                streamreader=None, streamwriter=None,
-                incrementaldecoder=cls)
+
+# bpo-41919: Split from StatefulIncrementalDecoder to avoid resource leak.
+def lookupTestDecoder(name):
+    if StatefulIncrementalDecoder.codecEnabled and name == 'test_decoder':
+        latin1 = codecs.lookup('latin-1')
+        return codecs.CodecInfo(
+            name='test_decoder', encode=latin1.encode, decode=None,
+            incrementalencoder=None,
+            streamreader=None, streamwriter=None,
+            incrementaldecoder=StatefulIncrementalDecoder)
 
 
 class StatefulIncrementalDecoderTest(unittest.TestCase):
@@ -2579,9 +2580,8 @@ class TextIOWrapperTest(unittest.TestCase):
         self.testdata = b"AAA\r\nBBB\rCCC\r\nDDD\nEEE\r\n"
         self.normalized = b"AAA\nBBB\nCCC\nDDD\nEEE\n".decode("ascii")
         os_helper.unlink(os_helper.TESTFN)
-        codecs.register(StatefulIncrementalDecoder.lookupTestDecoder)
-        self.addCleanup(codecs.unregister,
-                        StatefulIncrementalDecoder.lookupTestDecoder)
+        codecs.register(lookupTestDecoder)
+        self.addCleanup(codecs.unregister, lookupTestDecoder)
 
     def tearDown(self):
         os_helper.unlink(os_helper.TESTFN)


### PR DESCRIPTION
lookupTestDecoder function Split from StatefulIncrementalDecoder to avoid resource leak in test_io module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41919](https://bugs.python.org/issue41919) -->
https://bugs.python.org/issue41919
<!-- /issue-number -->
