### PR TITLE
bpo-42090: zipfile.Path.joinpath now accepts multiple arguments

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -483,7 +483,7 @@ Path Objects
 Path objects expose the following features of :mod:`pathlib.Path`
 objects:
 
-Path objects are traversable using the ``/`` operator.
+Path objects are traversable using the ``/`` operator or ``joinpath``.
 
 .. attribute:: Path.name
 
@@ -531,6 +531,19 @@ Path objects are traversable using the ``/`` operator.
 .. method:: Path.read_bytes()
 
    Read the current file as bytes.
+
+.. method:: Path.joinpath(*other)
+
+   Return a new Path object with each of the *other* arguments
+   joined. The following are equivalent::
+
+   >>> Path(...).joinpath('child').joinpath('grandchild')
+   >>> Path(...).joinpath('child', 'grandchild')
+   >>> Path(...) / 'child' / 'grandchild'
+
+   .. versionchanged:: 3.10
+      Prior to 3.10, ``joinpath`` was undocumented and accepted
+      exactly one parameter.
 
 
 .. _pyzipfile-objects:

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2966,6 +2966,12 @@ class TestPath(unittest.TestCase):
         assert e.read_text() == "content of e"
 
     @pass_alpharep
+    def test_joinpath_multiple(self, alpharep):
+        root = zipfile.Path(alpharep)
+        e = root.joinpath("b", "d", "e.txt")
+        assert e.read_text() == "content of e"
+
+    @pass_alpharep
     def test_traverse_truediv(self, alpharep):
         root = zipfile.Path(alpharep)
         a = root / "a.txt"

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -2379,8 +2379,8 @@ class Path:
     def __repr__(self):
         return self.__repr.format(self=self)
 
-    def joinpath(self, add):
-        next = posixpath.join(self.at, add)
+    def joinpath(self, *other):
+        next = posixpath.join(self.at, *other)
         return self._next(self.root.resolve_dir(next))
 
     __truediv__ = joinpath

--- a/Misc/NEWS.d/next/Library/2020-10-25-14-48-57.bpo-42090.Ubuc0j.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-25-14-48-57.bpo-42090.Ubuc0j.rst
@@ -1,0 +1,2 @@
+``zipfile.Path.joinpath`` now accepts arbitrary arguments, same as
+``pathlib.Path.joinpath``.


### PR DESCRIPTION


<!-- issue-number: [bpo-42090](https://bugs.python.org/issue42090) -->
https://bugs.python.org/issue42090
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco