### PR TITLE
bpo-42150: Avoid buffer overflow in the new parser

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-25-21-14-18.bpo-42150.b70u_T.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-25-21-14-18.bpo-42150.b70u_T.rst
@@ -1,0 +1,2 @@
+Fix possible buffer overflow in the new parser when checking for
+continuation lines. Patch by Pablo Galindo.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -990,7 +990,8 @@ bad_single_statement(Parser *p)
 
     /* Newlines are allowed if preceded by a line continuation character
        or if they appear inside a string. */
-    if (!cur || *(cur - 1) == '\\' || newline_in_string(p, cur)) {
+    if (!cur || (cur != p->tok->buf && *(cur - 1) == '\\')
+             || newline_in_string(p, cur)) {
         return 0;
     }
     char c = *cur;


### PR DESCRIPTION
With this PR:

```
❯ ./python -m test test_repl -v
== CPython 3.10.0a1+ (heads/master-dirty:d1a0a960ee, Oct 25 2020, 21:09:15) [GCC 10.2.0]
== Linux-5.4.72-1-MANJARO-x86_64-with-glibc2.32 little-endian
== cwd: /home/pablogsal/github/python/master/build/test_python_32693æ
== CPU count: 36
== encodings: locale=UTF-8, FS=utf-8
0:00:00 load avg: 1.78 Run tests sequentially
0:00:00 load avg: 1.78 [1/1] test_repl
test_close_stdin (test.test_repl.TestInteractiveInterpreter) ... ok
test_multiline_string_parsing (test.test_repl.TestInteractiveInterpreter) ... ok
test_no_memory (test.test_repl.TestInteractiveInterpreter) ... ok

----------------------------------------------------------------------

Ran 3 tests in 0.341s

OK

== Tests result: SUCCESS ==

1 test OK.

Total duration: 424 ms
Tests result: SUCCESS
```

<!-- issue-number: [bpo-42150](https://bugs.python.org/issue42150) -->
https://bugs.python.org/issue42150
<!-- /issue-number -->
