### PR TITLE
bpo-35753: Fix crash in doctest with unwrap-able functions

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -976,6 +976,17 @@ class DocTestFinder:
         else:
             raise ValueError("object must be a class or function")
 
+    def _is_routine(self, obj):
+        """
+        Safely unwrap objects and determine if they are functions.
+        """
+        maybe_routine = obj
+        try:
+            maybe_routine = inspect.unwrap(maybe_routine)
+        except ValueError:
+            pass
+        return inspect.isroutine(maybe_routine)
+
     def _find(self, tests, obj, name, module, source_lines, globs, seen):
         """
         Find tests for the given object and any contained objects, and
@@ -998,9 +1009,9 @@ class DocTestFinder:
         if inspect.ismodule(obj) and self._recurse:
             for valname, val in obj.__dict__.items():
                 valname = '%s.%s' % (name, valname)
+
                 # Recurse to functions & classes.
-                if ((inspect.isroutine(inspect.unwrap(val))
-                     or inspect.isclass(val)) and
+                if ((self._is_routine(val) or inspect.isclass(val)) and
                     self._from_module(module, val)):
                     self._find(tests, val, valname, module, source_lines,
                                globs, seen)

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -15,6 +15,7 @@ import importlib.util
 import unittest
 import tempfile
 import shutil
+import types
 import contextlib
 
 # NOTE: There are some additional tests relating to interaction with
@@ -697,6 +698,18 @@ and 'int' is a type.
 
 
 class TestDocTestFinder(unittest.TestCase):
+
+    def test_issue35753(self):
+        # This import of `call` should trigger issue35753 when
+        # `support.run_doctest` is called due to unwrap failing,
+        # however with a patched doctest this should succeed.
+        from unittest.mock import call
+        dummy_module = types.ModuleType("dummy")
+        dummy_module.__dict__['inject_call'] = call
+        try:
+            support.run_doctest(dummy_module, verbosity=True)
+        except ValueError as e:
+            raise support.TestFailed("Doctest unwrap failed") from e
 
     def test_empty_namespace_package(self):
         pkg_name = 'doctest_empty_pkg'

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -443,7 +443,7 @@ We'll simulate a __file__ attr that ends in pyc:
     >>> tests = finder.find(sample_func)
 
     >>> print(tests)  # doctest: +ELLIPSIS
-    [<DocTest sample_func from ...:27 (1 example)>]
+    [<DocTest sample_func from test_doctest.py:28 (1 example)>]
 
 The exact name depends on how test_doctest was invoked, so allow for
 leading path components.

--- a/Misc/NEWS.d/next/Tests/2020-10-25-19-20-26.bpo-35753.2LT-hO.rst
+++ b/Misc/NEWS.d/next/Tests/2020-10-25-19-20-26.bpo-35753.2LT-hO.rst
@@ -1,0 +1,2 @@
+Fix crash in doctest when doctest parses modules that include unwrappable
+functions by skipping those functions.


### PR DESCRIPTION
Doctest needs to Ignore objects that inspect.unwrap throws ValueError due to "infinite" nesting.

This case is relatively commonly reproduced by importing unittest.mock.call into a module's namespace.

The following code produces a module that will crash doctest:

```
from unittest.mock import call
```

This is due to the call to unwrap throwing an uncaught ValueError.

For this case we can simply ignore the function and not attempt to extract docstring from this function.

This diff is intentionally done as a branch with two commits to provide failing test case and then a fix to show the problem is contained.

Future thoughts:
1. Should catching this be optional defaulting to true, but allowing for folks to rethrow the exception to insist on truly clean code?
2. Should we break out _find() into more sub functions so that we can more easily derive our own versions for each sub function that _find does making it easier to fix future issues?
3. Should we include a way to denylist by `id` some objects so that future objects that cause problems with doctest can be passed in to ignore?

<!-- issue-number: [bpo-35753](https://bugs.python.org/issue35753) -->
https://bugs.python.org/issue35753
<!-- /issue-number -->
