### PR TITLE
Let dependabot create PRs against the maintenance branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     labels:
       - "skip issue"
       - "skip news"
+    target_branch:
+      - "master"
+      - "3.9"
+      - "3.8"


### PR DESCRIPTION
With this, we don't have to manually trigger backport whenever there is update to GitHub Actions dependencies.

Automerge-Triggered-By: GH:Mariatta