### PR TITLE
bpo-42157: Rename unicodedata.ucnhash_CAPI

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -300,6 +300,11 @@ Removed
   Python 3.5.
   (Contributed by Berker Peksag in :issue:`31844`.)
 
+* Removed the ``unicodedata.ucnhash_CAPI`` attribute which was an internal
+  PyCapsule object. The related private ``_PyUnicode_Name_CAPI`` structure was
+  moved to the internal C API.
+  (Contributed by Victor Stinner in :issue:`42157`.)
+
 
 Porting to Python 3.10
 ======================
@@ -408,7 +413,7 @@ Porting to Python 3.10
   (Contributed by Inada Naoki in :issue:`36346`.)
 
 * The private ``_PyUnicode_Name_CAPI`` structure of the PyCapsule API
-  ``unicodedata.ucnhash_CAPI`` moves to the internal C API.
+  ``unicodedata.ucnhash_CAPI`` has been moved to the internal C API.
   (Contributed by Victor Stinner in :issue:`42157`.)
 
 Deprecated

--- a/Include/internal/pycore_ucnhash.h
+++ b/Include/internal/pycore_ucnhash.h
@@ -11,7 +11,7 @@ extern "C" {
 
 /* revised ucnhash CAPI interface (exported through a "wrapper") */
 
-#define PyUnicodeData_CAPSULE_NAME "unicodedata.ucnhash_CAPI"
+#define PyUnicodeData_CAPSULE_NAME "unicodedata._ucnhash_CAPI"
 
 typedef struct {
 

--- a/Misc/NEWS.d/next/C API/2020-10-16-10-47-17.bpo-42157.e3BcPM.rst
+++ b/Misc/NEWS.d/next/C API/2020-10-16-10-47-17.bpo-42157.e3BcPM.rst
@@ -1,3 +1,3 @@
 The private ``_PyUnicode_Name_CAPI`` structure of the PyCapsule API
-``unicodedata.ucnhash_CAPI`` moves to the internal C API.
+``unicodedata.ucnhash_CAPI`` has been moved to the internal C API.
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2020-10-26-23-29-16.bpo-42157.4wuwTe.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-26-23-29-16.bpo-42157.4wuwTe.rst
@@ -1,0 +1,3 @@
+Removed the ``unicodedata.ucnhash_CAPI`` attribute which was an internal
+PyCapsule object. The related private ``_PyUnicode_Name_CAPI`` structure was
+moved to the internal C API. Patch by Victor Stinner.

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1463,7 +1463,7 @@ unicodedata_exec(PyObject *module)
         return -1;
     }
 
-    /* Previous versions */
+    // Unicode database version 3.2.0 used by the IDNA encoding
     PyObject *v;
     v = new_previous_version(ucd_type, "3.2.0",
                              get_change_3_2_0, normalization_3_2_0);

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1482,7 +1482,7 @@ unicodedata_exec(PyObject *module)
     if (v == NULL) {
         return -1;
     }
-    if (PyModule_AddObject(module, "ucnhash_CAPI", v) < 0) {
+    if (PyModule_AddObject(module, "_ucnhash_CAPI", v) < 0) {
         Py_DECREF(v);
         return -1;
     }


### PR DESCRIPTION
Removed the unicodedata.ucnhash_CAPI attribute which was an internal
PyCapsule object. The related private _PyUnicode_Name_CAPI structure
was moved to the internal C API.

Rename unicodedata.ucnhash_CAPI as unicodedata._ucnhash_CAPI.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42157](https://bugs.python.org/issue42157) -->
https://bugs.python.org/issue42157
<!-- /issue-number -->
