### PR TITLE
bpo-42160: reduce overhead in tempfile

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -144,8 +144,7 @@ class _RandomNameSequence:
 
     def __next__(self):
         c = self.characters
-        choose = self.rng.choice
-        return ''.join(choose(c) for _ in range(self.length))
+        return ''.join(self.rng.choices(c, k=self.length))
 
 def _candidate_tempdir_list():
     """Generate a list of candidate temporary directories which

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -230,9 +230,12 @@ def _get_candidate_names():
 
     global _name_sequence
     if _name_sequence is None:
-        with _once_lock:
+        _once_lock.acquire()
+        try:
             if _name_sequence is None:
                 _name_sequence = _RandomNameSequence()
+        finally:
+            _once_lock.release()
     return _name_sequence
 
 

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -139,10 +139,6 @@ class _RandomNameSequence:
         self.characters = characters
         self.length = length
 
-    @property
-    def variants(self):
-        return len(self.characters) ** self.length
-
     def __iter__(self):
         return self
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -153,8 +153,8 @@ class TestRandomNameSequence(BaseTestCase):
         self.r = tempfile._RandomNameSequence()
         super().setUp()
 
-    def test_get_six_char_str(self):
-        # _RandomNameSequence returns a six-character string
+    def test_get_eight_char_str(self):
+        # _RandomNameSequence returns a eight-character string
         s = next(self.r)
         self.nameCheck(s, '', '', '')
 

--- a/Misc/NEWS.d/next/Library/2020-10-27-00-42-09.bpo-42160.eiLOCi.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-27-00-42-09.bpo-42160.eiLOCi.rst
@@ -1,0 +1,1 @@
+replaced pid check in tempfile._RandomNameSequence with os.register_at_fork to reduce overhead

--- a/Misc/NEWS.d/next/Library/2020-10-27-00-42-09.bpo-42160.eiLOCi.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-27-00-42-09.bpo-42160.eiLOCi.rst
@@ -1,1 +1,1 @@
-replaced pid check in tempfile._RandomNameSequence with os.register_at_fork to reduce overhead
+Replaced pid check in ``tempfile._RandomNameSequence`` with ``os.register_at_fork`` to reduce overhead.


### PR DESCRIPTION
* replace pid check in `_RandomNameSequence` with `os.register_at_fork`
* add `variants` property to allow replacing `TMP_MAX` with a calculated value
* fix small typo in test_tempfile

<!-- issue-number: [bpo-42160](https://bugs.python.org/issue42160) -->
https://bugs.python.org/issue42160
<!-- /issue-number -->
