### PR TITLE
bpo-42163, bpo-42189, bpo-42659: Support uname_tuple._replace (for all but processor)

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -813,14 +813,8 @@ class uname_result(
     def __len__(self):
         return len(tuple(iter(self)))
 
-    def __new__(cls, *args):
-        # exclude 'processor' arg
-        num_fields = len(cls._fields)
-        args = args[:num_fields] + args[num_fields + 1:]
-        return super().__new__(cls, *args)
-
     def __reduce__(self):
-        return uname_result, tuple(self)
+        return uname_result, tuple(self)[:len(self._fields)]
 
 
 _uname_cache = None

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -813,7 +813,7 @@ class uname_result(
         return result
 
     def __getitem__(self, key):
-        return tuple(iter(self))[key]
+        return tuple(self)[key]
 
     def __len__(self):
         return len(tuple(iter(self)))

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -799,9 +799,11 @@ class uname_result(
 
     @classmethod
     def _make(cls, iterable):
-        result = tuple.__new__(cls, itertools.islice(iterable, 5))
-        if len(result) != 6:
-            raise TypeError(f'Expected 5 arguments, got {len(result)}')
+        num_fields = len(cls._fields)
+        result = tuple.__new__(cls, itertools.islice(iterable, num_fields))
+        if len(result) != num_fields + 1:
+            msg = f'Expected {num_fields} arguments, got {len(result)}'
+            raise TypeError(msg)
         return result
 
     def __getitem__(self, key):

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -782,10 +782,15 @@ class uname_result(
         ):
     """
     A uname_result that's largely compatible with a
-    simple namedtuple except that 'platform' is
+    simple namedtuple except that 'processor' is
     resolved late and cached to avoid calling "uname"
     except when needed.
     """
+
+    def __new__(cls, *args):
+        # exclude 'processor' arg
+        args = args[:5] + args[6:]
+        return super().__new__(cls, *args)
 
     @functools.cached_property
     def processor(self):

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -789,7 +789,8 @@ class uname_result(
 
     def __new__(cls, *args):
         # exclude 'processor' arg
-        args = args[:5] + args[6:]
+        num_fields = len(cls._fields)
+        args = args[:num_fields] + args[num_fields + 1:]
         return super().__new__(cls, *args)
 
     @functools.cached_property

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -804,8 +804,9 @@ class uname_result(
 
     @classmethod
     def _make(cls, iterable):
+        # override factory to affect length check
         num_fields = len(cls._fields)
-        result = tuple.__new__(cls, itertools.islice(iterable, num_fields))
+        result = cls.__new__(cls, *iterable)
         if len(result) != num_fields + 1:
             msg = f'Expected {num_fields} arguments, got {len(result)}'
             raise TypeError(msg)

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -787,12 +787,6 @@ class uname_result(
     except when needed.
     """
 
-    def __new__(cls, *args):
-        # exclude 'processor' arg
-        num_fields = len(cls._fields)
-        args = args[:num_fields] + args[num_fields + 1:]
-        return super().__new__(cls, *args)
-
     @functools.cached_property
     def processor(self):
         return _unknown_as_blank(_Processor.get())
@@ -818,6 +812,15 @@ class uname_result(
 
     def __len__(self):
         return len(tuple(iter(self)))
+
+    def __new__(cls, *args):
+        # exclude 'processor' arg
+        num_fields = len(cls._fields)
+        args = args[:num_fields] + args[num_fields + 1:]
+        return super().__new__(cls, *args)
+
+    def __reduce__(self):
+        return uname_result, tuple(self)
 
 
 _uname_cache = None

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -797,6 +797,13 @@ class uname_result(
             (self.processor,)
         )
 
+    @classmethod
+    def _make(cls, iterable):
+        result = tuple.__new__(cls, itertools.islice(iterable, 5))
+        if len(result) != 6:
+            raise TypeError(f'Expected 5 arguments, got {len(result)}')
+        return result
+
     def __getitem__(self, key):
         return tuple(iter(self))[key]
 

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -190,9 +190,17 @@ class PlatformTest(unittest.TestCase):
         # processor cannot be replaced
         self.assertEqual(new.processor, res.processor)
 
-    def test_uname_deepcopy(self):
-        res = platform.uname()
-        self.assertEqual(copy.deepcopy(res), res)
+    def test_uname_copy(self):
+        uname = platform.uname()
+        self.assertEqual(copy.copy(uname), uname)
+        self.assertEqual(copy.deepcopy(uname), uname)
+
+    def test_uname_pickle(self):
+        uname = platform.uname()
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(protocol=proto):
+                pickled = pickle.dumps(uname, proto)
+                self.assertEqual(pickle.loads(pickled), uname)
 
     def test_uname_slices(self):
         res = platform.uname()

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -194,6 +194,12 @@ class PlatformTest(unittest.TestCase):
         res = platform.uname()
         self.assertEqual(copy.deepcopy(res), res)
 
+    def test_uname_slices(self):
+        res = platform.uname()
+        expected = tuple(res)
+        self.assertEqual(res[:], expected)
+        self.assertEqual(res[:5], expected[:5])
+
     @unittest.skipIf(sys.platform in ['win32', 'OpenVMS'], "uname -p not used")
     def test_uname_processor(self):
         """

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -180,9 +180,14 @@ class PlatformTest(unittest.TestCase):
         res = platform.uname()
         new = res._replace(
             system='system', node='node', release='release',
-            version='version', machine='machine', processor='processor')
+            version='version', machine='machine')
         self.assertEqual(new.system, 'system')
-        self.assertEqual(new.processor, 'processor')
+        self.assertEqual(new.node, 'node')
+        self.assertEqual(new.release, 'release')
+        self.assertEqual(new.version, 'version')
+        self.assertEqual(new.machine, 'machine')
+        # processor cannot be replaced
+        self.assertEqual(new.processor, res.processor)
 
     @unittest.skipIf(sys.platform in ['win32', 'OpenVMS'], "uname -p not used")
     def test_uname_processor(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -1,5 +1,6 @@
 import os
 import copy
+import pickle
 import platform
 import subprocess
 import sys

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import platform
 import subprocess
 import sys
@@ -188,6 +189,10 @@ class PlatformTest(unittest.TestCase):
         self.assertEqual(new.machine, 'machine')
         # processor cannot be replaced
         self.assertEqual(new.processor, res.processor)
+
+    def test_uname_deepcopy(self):
+        res = platform.uname()
+        self.assertEqual(copy.deepcopy(res), res)
 
     @unittest.skipIf(sys.platform in ['win32', 'OpenVMS'], "uname -p not used")
     def test_uname_processor(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -197,11 +197,12 @@ class PlatformTest(unittest.TestCase):
         self.assertEqual(copy.deepcopy(uname), uname)
 
     def test_uname_pickle(self):
-        uname = platform.uname()
+        orig = platform.uname()
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.subTest(protocol=proto):
-                pickled = pickle.dumps(uname, proto)
-                self.assertEqual(pickle.loads(pickled), uname)
+                pickled = pickle.dumps(orig, proto)
+                restored = pickle.loads(pickled)
+                self.assertEqual(restored, orig)
 
     def test_uname_slices(self):
         res = platform.uname()

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -176,6 +176,14 @@ class PlatformTest(unittest.TestCase):
         )
         self.assertEqual(tuple(res), expected)
 
+    def test_uname_replace(self):
+        res = platform.uname()
+        new = res._replace(
+            system='system', node='node', release='release',
+            version='version', machine='machine', processor='processor')
+        self.assertEqual(new.system, 'system')
+        self.assertEqual(new.processor, 'processor')
+
     @unittest.skipIf(sys.platform in ['win32', 'OpenVMS'], "uname -p not used")
     def test_uname_processor(self):
         """

--- a/Misc/NEWS.d/next/Library/2020-10-29-09-22-56.bpo-42163.O4VcCY.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-29-09-22-56.bpo-42163.O4VcCY.rst
@@ -1,0 +1,1 @@
+Restore compatibility for ``uname_result`` around deepcopy and _replace.


### PR DESCRIPTION
<!-- issue-number: [bpo-42163](https://bugs.python.org/issue42163) -->
https://bugs.python.org/issue42163
<!-- /issue-number -->

<!-- issue-number: [bpo-42189](https://bugs.python.org/issue42189) -->
https://bugs.python.org/issue42189
<!-- /issue-number -->

<!-- issue-number: [bpo-42659](https://bugs.python.org/issue42659) -->
https://bugs.python.org/issue42659
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco