### PR TITLE
bpo-42183: Fix a stack overflow error for asyncio Task or Future repr()

### DIFF
--- a/Lib/asyncio/base_futures.py
+++ b/Lib/asyncio/base_futures.py
@@ -42,6 +42,13 @@ def _format_callbacks(cb):
     return f'cb=[{cb}]'
 
 
+# bpo-42183: _repr_running is needed for repr protection
+# when a Future or Task result contains itself directly or indirectly.
+# The logic is borrowed from @reprlib.recursive_repr decorator.
+# Unfortunately, the direct decorator usage is impossible because of
+# AttributeError: '_asyncio.Task' object has no attribute '__module__' error.
+#
+# After fixing this thing we can return to the decorator based approach.
 _repr_running = set()
 
 

--- a/Lib/test/test_asyncio/test_futures2.py
+++ b/Lib/test/test_asyncio/test_futures2.py
@@ -12,4 +12,7 @@ class FutureTests(unittest.IsolatedAsyncioTestCase):
         async def func():
             return asyncio.all_tasks()
 
+        # The repr() call should not raise RecursiveError at first.
+        # The check for returned string is not very reliable but
+        # exact comparison for the whole string is even weaker.
         self.assertIn('...', repr(await asyncio.wait_for(func(), timeout=10)))

--- a/Lib/test/test_asyncio/test_futures2.py
+++ b/Lib/test/test_asyncio/test_futures2.py
@@ -1,0 +1,15 @@
+# IsolatedAsyncioTestCase based tests
+import asyncio
+import unittest
+
+
+class FutureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_recursive_repr_for_pending_tasks(self):
+        # The call crashes if the guard for recursive call
+        # in base_futures:_future_repr_info is absent
+        # See Also: https://bugs.python.org/issue42183
+
+        async def func():
+            return asyncio.all_tasks()
+
+        self.assertIn('...', repr(await asyncio.wait_for(func(), timeout=10)))

--- a/Misc/NEWS.d/next/Library/2020-10-29-11-17-35.bpo-42183.50ZcIi.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-29-11-17-35.bpo-42183.50ZcIi.rst
@@ -1,2 +1,4 @@
-Fix a stack overflow error when repr() is given for task or future that
+Fix a stack overflow error for asyncio Task or Future repr()
+
+The overflow occurs under some circumstances when a task or future
 recursively returns itself.

--- a/Misc/NEWS.d/next/Library/2020-10-29-11-17-35.bpo-42183.50ZcIi.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-29-11-17-35.bpo-42183.50ZcIi.rst
@@ -1,0 +1,2 @@
+Fix a stack overflow error when repr() is given for task or future that
+recursively returns itself.

--- a/Misc/NEWS.d/next/Library/2020-10-29-11-17-35.bpo-42183.50ZcIi.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-29-11-17-35.bpo-42183.50ZcIi.rst
@@ -1,4 +1,4 @@
-Fix a stack overflow error for asyncio Task or Future repr()
+Fix a stack overflow error for asyncio Task or Future repr().
 
-The overflow occurs under some circumstances when a task or future
+The overflow occurs under some circumstances when a Task or Future
 recursively returns itself.


### PR DESCRIPTION
The overflow occurs under some circumstances when a task or future
recursively returns itself.


<!-- issue-number: [bpo-42183](https://bugs.python.org/issue42183) -->
https://bugs.python.org/issue42183
<!-- /issue-number -->
