### PR TITLE
bpo-42029: Remove IRIX code

### DIFF
--- a/Doc/library/posix.rst
+++ b/Doc/library/posix.rst
@@ -37,7 +37,7 @@ Large File Support
 
 .. sectionauthor:: Steve Clift <clift@mail.anacapa.net>
 
-Several operating systems (including AIX, HP-UX, Irix and Solaris) provide
+Several operating systems (including AIX, HP-UX and Solaris) provide
 support for files that are larger than 2 GiB from a C programming model where
 :c:type:`int` and :c:type:`long` are 32-bit values. This is typically accomplished
 by defining the relevant size and offset types as 64-bit values. Such files are
@@ -47,8 +47,8 @@ Large file support is enabled in Python when the size of an :c:type:`off_t` is
 larger than a :c:type:`long` and the :c:type:`long long` is at least as large
 as an :c:type:`off_t`.
 It may be necessary to configure and compile Python with certain compiler flags
-to enable this mode. For example, it is enabled by default with recent versions
-of Irix, but with Solaris 2.6 and 2.7 you need to do something like::
+to enable this mode. For example, with Solaris 2.6 and 2.7 you need to do
+something like::
 
    CFLAGS="`getconf LFS_CFLAGS`" OPT="-g -O2 $CFLAGS" \
            ./configure

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -524,16 +524,6 @@ def system_alias(system, release, version):
             # XXX Whatever the new SunOS marketing name is...
             system = 'Solaris'
 
-    elif system == 'IRIX64':
-        # IRIX reports IRIX64 on platforms with 64-bit support; yet it
-        # is really a version and not a different platform, since 32-bit
-        # apps are also supported..
-        system = 'IRIX'
-        if version:
-            version = version + ' (64bit)'
-        else:
-            version = '64bit'
-
     elif system in ('win32', 'win16'):
         # In case one of the other tricks
         system = 'Windows'
@@ -698,9 +688,6 @@ def architecture(executable=sys.executable, bits='', linkage=''):
     # Bits
     if '32-bit' in fileout:
         bits = '32bit'
-    elif 'N32' in fileout:
-        # On Irix only
-        bits = 'n32bit'
     elif '64-bit' in fileout:
         bits = '64bit'
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6763,12 +6763,11 @@ error:
 
 
 /* AIX uses /dev/ptc but is otherwise the same as /dev/ptmx */
-/* IRIX has both /dev/ptc and /dev/ptmx, use ptmx */
 #if defined(HAVE_DEV_PTC) && !defined(HAVE_DEV_PTMX)
-#define DEV_PTY_FILE "/dev/ptc"
-#define HAVE_DEV_PTMX
+#  define DEV_PTY_FILE "/dev/ptc"
+#  define HAVE_DEV_PTMX
 #else
-#define DEV_PTY_FILE "/dev/ptmx"
+#  define DEV_PTY_FILE "/dev/ptmx"
 #endif
 
 #if defined(HAVE_OPENPTY) || defined(HAVE_FORKPTY) || defined(HAVE_DEV_PTMX)

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -313,13 +313,10 @@ resource_getpagesize_impl(PyObject *module)
     long pagesize = 0;
 #if defined(HAVE_GETPAGESIZE)
     pagesize = getpagesize();
-#elif defined(HAVE_SYSCONF)
-#if defined(_SC_PAGE_SIZE)
+#elif defined(HAVE_SYSCONF) && defined(_SC_PAGE_SIZE)
     pagesize = sysconf(_SC_PAGE_SIZE);
 #else
-    /* Irix 5.3 has _SC_PAGESIZE, but not _SC_PAGE_SIZE */
-    pagesize = sysconf(_SC_PAGESIZE);
-#endif
+#   error "unsupported platform: resource.getpagesize()"
 #endif
     return pagesize;
 }


### PR DESCRIPTION
IRIX code was slowy removed in Python 2.4 (--with-sgi-dl), Python 3.3
(Irix threads), and Python 3.7.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42029](https://bugs.python.org/issue42029) -->
https://bugs.python.org/issue42029
<!-- /issue-number -->
