### PR TITLE
bpo-42194: Add "New in version: 3.9" to argparse.BooleanOptionalAction

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -853,6 +853,8 @@ is available in ``argparse`` and adds support for boolean actions such as
     >>> parser.parse_args(['--no-foo'])
     Namespace(foo=False)
 
+.. versionadded:: 3.9
+
 The recommended way to create a custom action is to extend :class:`Action`,
 overriding the ``__call__`` method and optionally the ``__init__`` and
 ``format_usage`` methods.


### PR DESCRIPTION
Hi :) 

Just noticed that docs for `argparse.BooleanOptionalAction` is missing the "New in version" label as it seems to be a recent addition in 3.9.0.  I'm assuming this will require a backport to a 3.9.x branch?

Cheers!


<!-- issue-number: [bpo-42194](https://bugs.python.org/issue42194) -->
https://bugs.python.org/issue42194
<!-- /issue-number -->
