### PR TITLE
bpo-42197: Disable automatic update of frame locals during tracing

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1292,6 +1292,11 @@ always available.
    ``'c_exception'``
       A C function has raised an exception.  *arg* is the C function object.
 
+   .. versionchanged:: 3.10
+      `PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` are no longer
+      called before and after the profile function (they must now be explicitly
+      called when manipulating `PyFrameObject.f_locals`).
+
 .. function:: setrecursionlimit(limit)
 
    Set the maximum depth of the Python interpreter stack to *limit*.  This limit
@@ -1416,6 +1421,12 @@ always available.
 
       ``'opcode'`` event type added; :attr:`f_trace_lines` and
       :attr:`f_trace_opcodes` attributes added to frames
+
+   .. versionchanged:: 3.10
+      `PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` are no longer
+      called before and after the trace function (they must now be
+      explicitly called when manipulating `PyFrameObject.f_locals`).
+
 
 .. function:: set_asyncgen_hooks(firstiter, finalizer)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -417,6 +417,9 @@ Optimizations
   bytecode level.  It is now around 100% faster to create a function with parameter
   annotations.  (Contributed by Yurii Karabas and Inada Naoki in :issue:`42202`)
 
+* `PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` are no longer called during profile and tracing.
+  (Contributed by Fabio Zadrozny in :issue:`issue42197`)
+
 Deprecated
 ==========
 
@@ -655,6 +658,12 @@ Porting to Python 3.10
   ``PyList_SET_ITEM(a, b, c) = x`` now fail with a compiler error. It prevents
   bugs like ``if (PyList_SET_ITEM (a, b, c) < 0) ...`` test.
   (Contributed by Zackery Spytz and Victor Stinner in :issue:`30459`.)
+
+* `PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` are no longer
+  called before and after the trace or profile function, so, they must now
+  be explicitly called when manipulating `PyFrameObject.f_locals`.
+  (Contributed by Fabio Zadrozny in :issue:`issue42197`)
+
 
 Deprecated
 ----------

--- a/Misc/NEWS.d/next/C API/2020-10-29-12-58-58.bpo-42197.-7wLUI.rst
+++ b/Misc/NEWS.d/next/C API/2020-10-29-12-58-58.bpo-42197.-7wLUI.rst
@@ -1,0 +1,4 @@
+`PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` are no longer
+called during profile nor tracing. To inspect the `PyFrameObject.f_locals` member,
+debuggers and profilers implemented in C must now call `PyFrame_FastToLocalsWithError`
+to update locals and `PyFrame_LocalsToFast` after `PyFrameObject.f_locals` are updated.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -950,10 +950,6 @@ static PyObject *
 call_trampoline(PyThreadState *tstate, PyObject* callback,
                 PyFrameObject *frame, int what, PyObject *arg)
 {
-    if (PyFrame_FastToLocalsWithError(frame) < 0) {
-        return NULL;
-    }
-
     PyObject *stack[3];
     stack[0] = (PyObject *)frame;
     stack[1] = whatstrings[what];
@@ -962,7 +958,6 @@ call_trampoline(PyThreadState *tstate, PyObject* callback,
     /* call the Python-level function */
     PyObject *result = _PyObject_FastCallTstate(tstate, callback, stack, 3);
 
-    PyFrame_LocalsToFast(frame, 1);
     if (result == NULL) {
         PyTraceBack_Here(frame);
     }


### PR DESCRIPTION
This pull request removes the calls to `PyFrame_FastToLocalsWithError` and `PyFrame_LocalsToFast` inside the tracing.

<!-- issue-number: [bpo-42197](https://bugs.python.org/issue42197) -->
https://bugs.python.org/issue42197
<!-- /issue-number -->
