### PR TITLE
bpo-42199: Fix bytecode_helper assertNotInBytecode

### DIFF
--- a/Lib/test/support/bytecode_helper.py
+++ b/Lib/test/support/bytecode_helper.py
@@ -35,7 +35,8 @@ class BytecodeTestCase(unittest.TestCase):
                 disassembly = self.get_disassembly_as_string(x)
                 if argval is _UNSPECIFIED:
                     msg = '%s occurs in bytecode:\n%s' % (opname, disassembly)
+                    self.fail(msg)
                 elif instr.argval == argval:
                     msg = '(%s,%r) occurs in bytecode:\n%s'
                     msg = msg % (opname, argval, disassembly)
-                self.fail(msg)
+                    self.fail(msg)

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1196,5 +1196,24 @@ class BytecodeTests(unittest.TestCase):
         b = dis.Bytecode.from_traceback(tb)
         self.assertEqual(b.dis(), dis_traceback)
 
+
+class TestBytecodeTestCase(BytecodeTestCase):
+    def test_assert_not_in_with_op_not_in_bytecode(self):
+        code = compile("a = 1", "<string>", "exec")
+        self.assertInBytecode(code, "LOAD_CONST", 1)
+        self.assertNotInBytecode(code, "LOAD_NAME")
+        self.assertNotInBytecode(code, "LOAD_NAME", "a")
+
+    def test_assert_not_in_with_arg_not_in_bytecode(self):
+        code = compile("a = 1", "<string>", "exec")
+        self.assertInBytecode(code, "LOAD_CONST")
+        self.assertInBytecode(code, "LOAD_CONST", 1)
+        self.assertNotInBytecode(code, "LOAD_CONST", 2)
+
+    def test_assert_not_in_with_arg_in_bytecode(self):
+        code = compile("a = 1", "<string>", "exec")
+        with self.assertRaises(AssertionError):
+            self.assertNotInBytecode(code, "LOAD_CONST", 1)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Tests/2020-10-29-21-26-46.bpo-42199.KksGCV.rst
+++ b/Misc/NEWS.d/next/Tests/2020-10-29-21-26-46.bpo-42199.KksGCV.rst
@@ -1,0 +1,1 @@
+Fix bytecode helper assertNotInBytecode.


### PR DESCRIPTION
Ensure that the helper will only fail if the programmer provided an `arg` *and* it matches an instruction `arg`. Add tests.

<!-- issue-number: [bpo-42199](https://bugs.python.org/issue42199) -->
https://bugs.python.org/issue42199
<!-- /issue-number -->
