### PR TITLE
bpo-38902: Add image/webp to list of non-standard mimetypes

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -558,6 +558,7 @@ def _default_mime_types():
         '.pict': 'image/pict',
         '.pct' : 'image/pict',
         '.pic' : 'image/pict',
+        '.webp': 'image/webp',
         '.xul' : 'text/xul',
         }
 


### PR DESCRIPTION
WebP is an open-source image format that isn't included in Python's mimetypes. It hasn't been added because it has no IANA registration: https://bugs.python.org/issue38902

In mimetypes.py there is a list of common but non-standard media types that only match if strict=0 flag is given to the API methods. If WebP isn't going to be added to the big standard list, it could be added to the non-standard list.

<!-- issue-number: [bpo-42205](https://bugs.python.org/issue42205) -->
https://bugs.python.org/issue42205
<!-- /issue-number -->
