### PR TITLE
DOC: attribute PyPy for the idea behind the optimization

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -261,8 +261,7 @@ Optimizations
 
 * The ``LOAD_ATTR`` instruction now uses new "per opcode cache" mechanism.
   It is about 36% faster now.  (Contributed by Pablo Galindo and Yury Selivanov
-  in :issue:`42093`, based on ideas from Victor Stinner and the original
-  implementation in PyPy.)
+  in :issue:`42093`, based on ideas implemented originally in PyPy and MicroPython.)
 
 * When building Python with ``--enable-optimizations`` now
   ``-fno-semantic-interposition`` is added to both the compile and link line.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -261,7 +261,8 @@ Optimizations
 
 * The ``LOAD_ATTR`` instruction now uses new "per opcode cache" mechanism.
   It is about 36% faster now.  (Contributed by Pablo Galindo and Yury Selivanov
-  in :issue:`42093`.)
+  in :issue:`42093`, based on ideas from Victor Stinner and the original
+  implementation in PyPy.)
 
 * When building Python with ``--enable-optimizations`` now
   ``-fno-semantic-interposition`` is added to both the compile and link line.


### PR DESCRIPTION
Based on [this tweet](https://twitter.com/1st1/status/1318558048265404420), the origin for the idea is the [mail](https://mail.python.org/pipermail/python-dev/2016-January/142945.html) from 2016, which mentions @vstinner 's "faster-python" document (which seems to be lost, the link in the mail is broken). In particular this optimization was first implemented in PyPy. 

While normally I don't care about attribution, the recent interchange on the python-dev mailing list that implied PyPy is not important got my hackles up, especially because this is the second such optimization implemented with no mention of PyPy.