### PR TITLE
bpo-42208: Call GC collect earlier in PyInterpreterState_Clear()

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -267,6 +267,7 @@ extern PyStatus _PyInterpreterState_SetConfig(
     PyInterpreterState *interp,
     const PyConfig *config);
 
+extern void _PyInterpreterState_Clear(PyThreadState *tstate);
 
 
 /* cross-interpreter data registry */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1576,10 +1576,7 @@ finalize_interp_clear(PyThreadState *tstate)
     int is_main_interp = _Py_IsMainInterpreter(tstate);
 
     /* Clear interpreter state and all thread states */
-    PyInterpreterState_Clear(tstate->interp);
-
-    /* Last explicit GC collection */
-    _PyGC_CollectNoFail(tstate);
+    _PyInterpreterState_Clear(tstate);
 
     /* Clear all loghooks */
     /* Both _PySys_Audit function and users still need PyObject, such as tuple.
@@ -1587,8 +1584,6 @@ finalize_interp_clear(PyThreadState *tstate)
     if (is_main_interp) {
         _PySys_ClearAuditHooks(tstate);
     }
-
-    _PyGC_Fini(tstate);
 
     if (is_main_interp) {
         _Py_HashRandomization_Fini();


### PR DESCRIPTION
The last GC collection is now done before clearing builtins and sys
dictionaries. Add also assertions to ensure that gc.collect() is no
longer called after _PyGC_Fini().

Pass also the tstate to PyInterpreterState_Clear() to pass the
correct tstate to _PyGC_CollectNoFail() and _PyGC_Fini().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42208](https://bugs.python.org/issue42208) -->
https://bugs.python.org/issue42208
<!-- /issue-number -->
