### PR TITLE
[WIP] bpo-42213: Support cyclic garbage collection in sqlite3

### DIFF
--- a/Modules/_sqlite/cache.h
+++ b/Modules/_sqlite/cache.h
@@ -53,10 +53,6 @@ typedef struct
 
     pysqlite_Node* first;
     pysqlite_Node* last;
-
-    /* if set, decrement the factory function when the Cache is deallocated.
-     * this is almost always desirable, but not in the pysqlite context */
-    int decref_factory;
 } pysqlite_Cache;
 
 extern PyTypeObject *pysqlite_NodeType;


### PR DESCRIPTION
For `sqlite3.Connection` and `sqlite3.Cache`:
- Get rid of old `decref_factory` hack
- Support cyclic GC in both types

Skipping NEWS should be fine for this, I guess.

@berkerpeksag, would you mind reviewing this?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42213](https://bugs.python.org/issue42213) -->
https://bugs.python.org/issue42213
<!-- /issue-number -->
