### PR TITLE
bpo-42216: Optimize dict.popitem()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-10-31-09-44-14.bpo-42216.Y8Tb7r.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-10-31-09-44-14.bpo-42216.Y8Tb7r.rst
@@ -1,0 +1,3 @@
+Optimize ``dict.popitem()`` to use EMPTY entry instead of DUMMY entry in the
+internal hash table. Algorithms using ``dict.popitem()`` and inserting the
+dict in a loop will become faster.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3253,7 +3253,8 @@ dict_popitem_impl(PyDictObject *self)
     self->ma_keys->dk_usable++;
     self->ma_used--;
     self->ma_version_tag = DICT_NEXT_VERSION();
-    ASSERT_CONSISTENT(self);
+    // ASSERT_CONSISTENT(self);
+    assert(_PyDict_CheckConsistency((PyObject *)self, 1));
     return res;
 }
 


### PR DESCRIPTION
Optimize `dict.popitem()` to use EMPTY entry instead of DUMMY entry in the
internal hash table.
Algorithms using `dict.popitem()` and inserting the dict in a loop will become faster.

<!-- issue-number: [bpo-42216](https://bugs.python.org/issue42216) -->
https://bugs.python.org/issue42216
<!-- /issue-number -->
