### PR TITLE
Revert "bpo-42160: reduce overhead in tempfile"

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -129,22 +129,24 @@ class _RandomNameSequence:
 
     _RandomNameSequence is an iterator."""
 
-    def __init__(self, characters="abcdefghijklmnopqrstuvwxyz0123456789_", length=8, rng=None):
-        if rng is None:
-            rng = _Random()
-        if hasattr(_os, "fork"):
-            # prevent same state after fork
-            _os.register_at_fork(after_in_child=rng.seed)
-        self.rng = rng
-        self.characters = characters
-        self.length = length
+    characters = "abcdefghijklmnopqrstuvwxyz0123456789_"
+
+    @property
+    def rng(self):
+        cur_pid = _os.getpid()
+        if cur_pid != getattr(self, '_rng_pid', None):
+            self._rng = _Random()
+            self._rng_pid = cur_pid
+        return self._rng
 
     def __iter__(self):
         return self
 
     def __next__(self):
         c = self.characters
-        return ''.join(self.rng.choices(c, k=self.length))
+        choose = self.rng.choice
+        letters = [choose(c) for dummy in range(8)]
+        return ''.join(letters)
 
 def _candidate_tempdir_list():
     """Generate a list of candidate temporary directories which

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -153,8 +153,8 @@ class TestRandomNameSequence(BaseTestCase):
         self.r = tempfile._RandomNameSequence()
         super().setUp()
 
-    def test_get_eight_char_str(self):
-        # _RandomNameSequence returns a eight-character string
+    def test_get_six_char_str(self):
+        # _RandomNameSequence returns a six-character string
         s = next(self.r)
         self.nameCheck(s, '', '', '')
 

--- a/Misc/NEWS.d/next/Library/2020-10-27-00-42-09.bpo-42160.eiLOCi.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-27-00-42-09.bpo-42160.eiLOCi.rst
@@ -1,1 +1,0 @@
-Replaced pid check in ``tempfile._RandomNameSequence`` with ``os.register_at_fork`` to reduce overhead.


### PR DESCRIPTION
`_RandomNameSequence` is not true singleton so using `os.register_at_fork` doesn't make sense unlike `random._inst`.

Reverts python/cpython#22997

<!-- issue-number: [bpo-42160](https://bugs.python.org/issue42160) -->
https://bugs.python.org/issue42160
<!-- /issue-number -->
