### PR TITLE
bpo-29566: binhex.binhex now consitently writes MacOS 9 line endings.

### DIFF
--- a/Lib/binhex.py
+++ b/Lib/binhex.py
@@ -117,12 +117,12 @@ class _Hqxcoderengine:
         first = 0
         while first <= len(self.hqxdata) - self.linelen:
             last = first + self.linelen
-            self.ofp.write(self.hqxdata[first:last] + b'\n')
+            self.ofp.write(self.hqxdata[first:last] + b'\r')
             self.linelen = LINELEN
             first = last
         self.hqxdata = self.hqxdata[first:]
         if force:
-            self.ofp.write(self.hqxdata + b':\n')
+            self.ofp.write(self.hqxdata + b':\r')
 
     def close(self):
         if self.data:

--- a/Lib/test/test_binhex.py
+++ b/Lib/test/test_binhex.py
@@ -52,6 +52,18 @@ class BinHexTestCase(unittest.TestCase):
 
         self.assertRaises(binhex.Error, binhex.binhex, self.fname3, self.fname2)
 
+    def test_binhex_line_endings(self):
+        # bpo-29566: Ensure the line endings are those for macOS 9
+        with open(self.fname1, 'wb') as f:
+            f.write(self.DATA)
+
+        binhex.binhex(self.fname1, self.fname2)
+
+        with open(self.fname2, 'rb') as fp:
+            contents = fp.read()
+
+        self.assertNotIn(b'\n', contents)
+
 def test_main():
     support.run_unittest(BinHexTestCase)
 

--- a/Misc/NEWS.d/next/Library/2020-10-31-13-28-36.bpo-29566.6aDbty.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-31-13-28-36.bpo-29566.6aDbty.rst
@@ -1,0 +1,1 @@
+``binhex.binhex()`` consisently writes macOS 9 line endings.


### PR DESCRIPTION
[bpo-29566](https://bugs.python.org/issue29566) notes that binhex.binhex uses inconsistent line endings (both Unix and MacOS9 line endings are used). This PR changes this to use the MacOS9 line endings everywhere.

<!-- issue-number: [bpo-29566](https://bugs.python.org/issue29566) -->
https://bugs.python.org/issue29566
<!-- /issue-number -->

Automerge-Triggered-By: GH:ronaldoussoren