### PR TITLE
[3.9] bpo-42198: Document __new__ for types.GenericAlias (GH-23039)

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4760,7 +4760,8 @@ The ``GenericAlias`` object acts as a proxy for :term:`generic types
 of a generic which provides the types for container elements.
 
 The user-exposed type for the ``GenericAlias`` object can be accessed from
-:data:`types.GenericAlias` and used for :func:`isinstance` checks.
+:class:`types.GenericAlias` and used for :func:`isinstance` checks.  It can
+also be used to create ``GenericAlias`` objects directly.
 
 .. describe:: T[X, Y, ...]
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -242,10 +242,21 @@ Standard names are defined for the following types:
          Defaults to ``None``. Previously the attribute was optional.
 
 
-.. data:: GenericAlias
+.. class:: GenericAlias(t_origin, t_args)
 
    The type of :ref:`parameterized generics <types-genericalias>` such as
    ``list[int]``.
+
+   ``t_origin`` should be a non-parameterized generic class, such as ``list``,
+   ``tuple`` or ``dict``.  ``t_args`` should be a :class:`tuple` (possibly of
+   length 1) of types which parameterize ``t_origin``::
+
+      >>> from types import GenericAlias
+
+      >>> list[int] == GenericAlias(list, (int,))
+      True
+      >>> dict[str, int] == GenericAlias(dict, (str, int))
+      True
 
    .. versionadded:: 3.9
 


### PR DESCRIPTION
(cherry picked from commit bcbf758476c1148993ddf4b54d3f6169b973ee1c)

<!-- issue-number: [bpo-42198](https://bugs.python.org/issue42198) -->
https://bugs.python.org/issue42198
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum