### PR TITLE
bpo-42222: Modernize integer test/conversion in randrange()

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -135,6 +135,15 @@ Functions for integers
       values.  Formerly it used a style like ``int(random()*n)`` which could produce
       slightly uneven distributions.
 
+   .. deprecated:: 3.10
+      The automatic conversion of non-integer types to equivalent integers is
+      deprecated.  Currently ``randrange(10.0)`` is losslessly converted to
+      ``randrange(10)``.  In the future, this will raise a :exc:`TypeError`.
+
+   .. deprecated:: 3.10
+      The exception raised for non-integral values such as ``range(10.5)``
+      will be changed from :exc:`ValueError` to :exc:`TypeError`.
+
 .. function:: randint(a, b)
 
    Return a random integer *N* such that ``a <= N <= b``.  Alias for

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -51,6 +51,7 @@ from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
 from math import tau as TWOPI, floor as _floor, isfinite as _isfinite
 from os import urandom as _urandom
 from _collections_abc import Set as _Set, Sequence as _Sequence
+from operator import index as _index
 from itertools import accumulate as _accumulate, repeat as _repeat
 from bisect import bisect as _bisect
 import os as _os
@@ -297,8 +298,9 @@ class Random(_random.Random):
 
         # This code is a bit messy to make it fast for the
         # common case while still doing adequate error checking.
-        istart = int(start)
-        if istart != start:
+        try:
+            istart = _index(start)
+        except TypeError:
             raise ValueError("non-integer arg 1 for randrange()")
         if stop is None:
             if istart > 0:
@@ -306,8 +308,9 @@ class Random(_random.Random):
             raise ValueError("empty range for randrange()")
 
         # stop argument supplied.
-        istop = int(stop)
-        if istop != stop:
+        try:
+            istop = _index(stop)
+        except TypeError:
             raise ValueError("non-integer stop for randrange()")
         width = istop - istart
         if step == 1 and width > 0:
@@ -316,8 +319,9 @@ class Random(_random.Random):
             raise ValueError("empty range for randrange() (%d, %d, %d)" % (istart, istop, width))
 
         # Non-unit step argument supplied.
-        istep = int(step)
-        if istep != step:
+        try:
+            istep = _index(step)
+        except TypeError:
             raise ValueError("non-integer step for randrange()")
         if istep > 0:
             n = (width + istep - 1) // istep

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -301,7 +301,16 @@ class Random(_random.Random):
         try:
             istart = _index(start)
         except TypeError:
-            raise ValueError("non-integer arg 1 for randrange()")
+            if int(start) == start:
+                istart = int(start)
+                _warn('Float arguments to randrange() have been deprecated\n'
+                      'since Python 3.10 and will be removed in a subsequent '
+                      'version.',
+                      DeprecationWarning, 2)
+            else:
+                _warn('randrange() will raise TypeError in the future',
+                      DeprecationWarning, 2)
+                raise ValueError("non-integer arg 1 for randrange()")
         if stop is None:
             if istart > 0:
                 return self._randbelow(istart)
@@ -311,7 +320,16 @@ class Random(_random.Random):
         try:
             istop = _index(stop)
         except TypeError:
-            raise ValueError("non-integer stop for randrange()")
+            if int(stop) == stop:
+                istop = int(stop)
+                _warn('Float arguments to randrange() have been deprecated\n'
+                      'since Python 3.10 and will be removed in a subsequent '
+                      'version.',
+                      DeprecationWarning, 2)
+            else:
+                _warn('randrange() will raise TypeError in the future',
+                      DeprecationWarning, 2)
+                raise ValueError("non-integer stop for randrange()")
         width = istop - istart
         if step == 1 and width > 0:
             return istart + self._randbelow(width)
@@ -322,7 +340,16 @@ class Random(_random.Random):
         try:
             istep = _index(step)
         except TypeError:
-            raise ValueError("non-integer step for randrange()")
+            if int(step) == step:
+                istep = int(step)
+                _warn('Float arguments to randrange() have been deprecated\n'
+                      'since Python 3.10 and will be removed in a subsequent '
+                      'version.',
+                      DeprecationWarning, 2)
+            else:
+                _warn('randrange() will raise TypeError in the future',
+                      DeprecationWarning, 2)
+                raise ValueError("non-integer step for randrange()")
         if istep > 0:
             n = (width + istep - 1) // istep
         elif istep < 0:

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -330,13 +330,7 @@ class Random(_random.Random):
                 _warn('randrange() will raise TypeError in the future',
                       DeprecationWarning, 2)
                 raise ValueError("non-integer stop for randrange()")
-        width = istop - istart
-        if step == 1 and width > 0:
-            return istart + self._randbelow(width)
-        if step == 1:
-            raise ValueError("empty range for randrange() (%d, %d, %d)" % (istart, istop, width))
 
-        # Non-unit step argument supplied.
         try:
             istep = _index(step)
         except TypeError:
@@ -350,6 +344,13 @@ class Random(_random.Random):
                 _warn('randrange() will raise TypeError in the future',
                       DeprecationWarning, 2)
                 raise ValueError("non-integer step for randrange()")
+        width = istop - istart
+        if istep == 1 and width > 0:
+            return istart + self._randbelow(width)
+        if istep == 1:
+            raise ValueError("empty range for randrange() (%d, %d, %d)" % (istart, istop, width))
+
+        # Non-unit step argument supplied.
         if istep > 0:
             n = (width + istep - 1) // istep
         elif istep < 0:

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -517,6 +517,24 @@ class SystemRandom_TestBasicOps(TestBasicOps, unittest.TestCase):
         raises(0, 42, 0)
         raises(0, 42, 3.14159)
 
+    def test_randrange_argument_handling(self):
+        randrange = self.gen.randrange
+        with self.assertWarns(DeprecationWarning):
+            randrange(10.0, 20, 2)
+        with self.assertWarns(DeprecationWarning):
+            randrange(10, 20.0, 2)
+        with self.assertWarns(DeprecationWarning):
+            randrange(10, 20, 2.0)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                randrange(10.5)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                randrange(10, 20.5)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                randrange(10, 20, 1.5)
+
     def test_randbelow_logic(self, _log=log, int=int):
         # check bitcount transition points:  2**i and 2**(i+1)-1
         # show that: k = int(1.001 + _log(n, 2))

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -524,6 +524,8 @@ class SystemRandom_TestBasicOps(TestBasicOps, unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             randrange(10, 20.0, 2)
         with self.assertWarns(DeprecationWarning):
+            randrange(10, 20, 1.0)
+        with self.assertWarns(DeprecationWarning):
             randrange(10, 20, 2.0)
         with self.assertWarns(DeprecationWarning):
             with self.assertRaises(ValueError):

--- a/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
@@ -1,0 +1,1 @@
+Modernized integer test/conversion in randrange() to use operator.index().

--- a/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
@@ -1,7 +1,7 @@
-Harmonized random.randrange() argument handling to better match
-that used by range().
+Harmonized random.randrange() argument handling to match range().
 
-* The integer test/conversion in randrange() now uses operator.index().
+* The integer test and conversion in randrange() now uses
+  operator.index().
 * Non-integer arguments to randrange() are deprecated.
 * The *ValueError* is deprecated in favor of a *TypeError*.
 * It now runs a little faster than before.

--- a/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
@@ -2,7 +2,7 @@ Harmonized random.randrange() argument handling to better match
 that used by range().
 
 * The integer test/conversion in randrange() now uses operator.index().
-* Float arguments to randrange() is deprecated.
+* Non-integer arguments to randrange() are deprecated.
 * The *ValueError* is deprecated in favor of a *TypeError*.
 * It now runs a little faster than before.
 

--- a/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-31-10-28-32.bpo-42222.Cfl1eR.rst
@@ -1,1 +1,9 @@
-Modernized integer test/conversion in randrange() to use operator.index().
+Harmonized random.randrange() argument handling to better match
+that used by range().
+
+* The integer test/conversion in randrange() now uses operator.index().
+* Float arguments to randrange() is deprecated.
+* The *ValueError* is deprecated in favor of a *TypeError*.
+* It now runs a little faster than before.
+
+(Contributed by Raymond Hettinger and Serhiy Storchaka.)


### PR DESCRIPTION
Moves the ``int(x) == x`` test and conversion into the C code for *operator.index()*.

Provides a 7% speed up:
```
$ pytime -s 'from random import randrange' 'randrange(15)'  # baseline
500000 loops, best of 11: 540 nsec per loop
$ pytime -s 'from random import randrange' 'randrange(15)'   # new versio
500000 loops, best of 11: 502 nsec per loop
```

It should become even faster when we get a zero-cost *try*.

It's odd that non-integers raise a *ValueError*. I think that should have been *TypeError*.



<!-- issue-number: [bpo-42222](https://bugs.python.org/issue42222) -->
https://bugs.python.org/issue42222
<!-- /issue-number -->
