### PR TITLE
bpo-42229: Fix SQLite warnings on macOS

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -33,7 +33,9 @@
 #define ACTION_FINALIZE 1
 #define ACTION_RESET 2
 
-#if SQLITE_VERSION_NUMBER >= 3014000
+#if SQLITE_VERSION_NUMBER >= 3014000 || \
+    defined(__APPLE__) && defined(__MACH__) \
+    && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
 #define HAVE_TRACE_V2
 #endif
 


### PR DESCRIPTION
```c
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Wstrict-prototypes -Werror=implicit-function-declaration -fvisibility=hidden -fprofile-instr-generate -I./Include/internal -DMODULE_NAME="sqlite3" -DSQLITE_OMIT_LOAD_EXTENSION=1 -IModules/_sqlite -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -I./Include -I/opt/python3.9/include -I. -I/usr/local/opt/zlib/include -I/usr/local/opt/openssl@1.1/include -I/usr/local/include -IPython-3.9.0/Include -IPython-3.9.0 -c Python-3.9.0/Modules/_sqlite/connection.c -o build/temp.macosx-10.15-x86_64-3.9/Python-3.9.0/Modules/_sqlite/connection.o
Python-3.9.0/Modules/_sqlite/connection.c:1066:9: warning: 'sqlite3_trace' is deprecated: first deprecated in macOS 10.12
      [-Wdeprecated-declarations]
        sqlite3_trace(self->db, 0, (void*)0);
        ^~~~~~~~~~~~~
        sqlite3_trace_v2
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sqlite3.h:3022:36: note: 'sqlite3_trace' has
      been explicitly marked deprecated here
SQLITE_API SQLITE_DEPRECATED void *sqlite3_trace(
                                   ^
Python-3.9.0/Modules/_sqlite/connection.c:1069:9: warning: 'sqlite3_trace' is deprecated: first deprecated in macOS 10.12
      [-Wdeprecated-declarations]
        sqlite3_trace(self->db, _trace_callback, trace_callback);
        ^~~~~~~~~~~~~
        sqlite3_trace_v2
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sqlite3.h:3022:36: note: 'sqlite3_trace' has
      been explicitly marked deprecated here
SQLITE_API SQLITE_DEPRECATED void *sqlite3_trace(
                                   ^
2 warnings generated.
```
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sqlite3.h
```
```c
#define SQLITE_VERSION        "3.28.0"
#define SQLITE_VERSION_NUMBER 3028000
#define SQLITE_SOURCE_ID      "2019-04-15 14:49:49 378230ae7f4b721c8b8d83c8ceb891449685cd23b1702a57841f1be40b5daapl
```


<!-- issue-number: [bpo-42229](https://bugs.python.org/issue42229) -->
https://bugs.python.org/issue42229
<!-- /issue-number -->
