### PR TITLE
bpo-41754: Ignore NotADirectoryError in invocation of xdg-settings

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -550,7 +550,7 @@ def register_standard_browsers():
                 cmd = "xdg-settings get default-web-browser".split()
                 raw_result = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
                 result = raw_result.decode().strip()
-            except (FileNotFoundError, subprocess.CalledProcessError, PermissionError) :
+            except (FileNotFoundError, subprocess.CalledProcessError, PermissionError, NotADirectoryError) :
                 pass
             else:
                 global _os_preferred_browser

--- a/Misc/NEWS.d/next/Library/2020-11-01-15-07-20.bpo-41754.DraSZh.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-01-15-07-20.bpo-41754.DraSZh.rst
@@ -1,0 +1,1 @@
+webbrowser: Ignore *NotADirectoryError* when calling ``xdg-settings``.


### PR DESCRIPTION
It is not clear why this can happen, but several users have mentioned
getting this exception on macOS.

<!-- issue-number: [bpo-41754](https://bugs.python.org/issue41754) -->
https://bugs.python.org/issue41754
<!-- /issue-number -->

Automerge-Triggered-By: GH:ronaldoussoren