### PR TITLE
bpo-42232: mmap module add Darwin specific madvise options.

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -337,6 +337,8 @@ MADV_* Constants
           MADV_NOCORE
           MADV_CORE
           MADV_PROTECT
+          MADV_FREE_REUSABLE
+          MADV_FREE_REUSE
 
    These options can be passed to :meth:`mmap.madvise`.  Not every option will
    be present on every system.

--- a/Misc/NEWS.d/next/macOS/2020-11-01-15-10-28.bpo-42232.2zI1GN.rst
+++ b/Misc/NEWS.d/next/macOS/2020-11-01-15-10-28.bpo-42232.2zI1GN.rst
@@ -1,0 +1,1 @@
+Added Darwin specific madvise options to mmap module.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1648,6 +1648,14 @@ mmap_exec(PyObject *module)
 #ifdef MADV_PROTECT
     ADD_INT_MACRO(module, MADV_PROTECT);
 #endif
+
+    // Darwin-specific
+#ifdef MADV_FREE_REUSABLE // (As MADV_FREE but reclaims more faithful for task_info/Activity Monitor...)
+    ADD_INT_MACRO(module, MADV_FREE_REUSABLE);
+#endif
+#ifdef MADV_FREE_REUSE // (Reuse pages previously tagged as reusable)
+    ADD_INT_MACRO(module, MADV_FREE_REUSE);
+#endif
 #endif // HAVE_MADVISE
     return 0;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-42232](https://bugs.python.org/issue42232) -->
https://bugs.python.org/issue42232
<!-- /issue-number -->

Automerge-Triggered-By: GH:ronaldoussoren