### PR TITLE
bpo-42233: Add union type expression support for GenericAlias and fix de-duplicating of GenericAlias

### DIFF
--- a/Include/internal/pycore_unionobject.h
+++ b/Include/internal/pycore_unionobject.h
@@ -10,7 +10,7 @@ extern "C" {
 
 PyAPI_FUNC(PyObject *) _Py_Union(PyObject *args);
 PyAPI_DATA(PyTypeObject) _Py_UnionType;
-PyAPI_FUNC(PyObject *) _Py_union_type_or(PyTypeObject* self, PyObject* param);
+PyAPI_FUNC(PyObject *) _Py_union_type_or(PyObject* self, PyObject* param);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_unionobject.h
+++ b/Include/internal/pycore_unionobject.h
@@ -10,6 +10,7 @@ extern "C" {
 
 PyAPI_FUNC(PyObject *) _Py_Union(PyObject *args);
 PyAPI_DATA(PyTypeObject) _Py_UnionType;
+PyAPI_DATA(PyNumberMethods) _Py_union_as_number;
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_unionobject.h
+++ b/Include/internal/pycore_unionobject.h
@@ -10,7 +10,7 @@ extern "C" {
 
 PyAPI_FUNC(PyObject *) _Py_Union(PyObject *args);
 PyAPI_DATA(PyTypeObject) _Py_UnionType;
-PyAPI_DATA(PyNumberMethods) _Py_union_as_number;
+PyAPI_FUNC(PyObject *) _Py_union_type_or(PyTypeObject* self, PyObject* param);
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -713,6 +713,19 @@ class TypesTests(unittest.TestCase):
         assert repr(int | None) == "int | None"
         assert repr(int | typing.GenericAlias(list, int)) == "int | list[int]"
 
+    def test_or_type_operator_with_genericalias(self):
+        a = list[int]
+        b = list[str]
+        c = dict[float, str]
+        # equivalence with typing.Union
+        self.assertEqual(a | b | c, typing.Union[a, b, c])
+        # de-duplicate
+        self.assertEqual(a | c | b | b | a | c, a | b | c)
+        # order shouldn't matter
+        self.assertEqual(a | b, b | a)
+        self.assertEqual(repr(a | b | c),
+                         "list[int] | list[str] | dict[float, str]")
+
     def test_ellipsis_type(self):
         self.assertIsInstance(Ellipsis, types.EllipsisType)
 

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -726,6 +726,15 @@ class TypesTests(unittest.TestCase):
         self.assertEqual(repr(a | b | c),
                          "list[int] | list[str] | dict[float, str]")
 
+        class BadType(type):
+            def __eq__(self, other):
+                return 1 / 0
+
+        bt = BadType('bt', (), {})
+        # Comparison should fail and errors should propagate out for bad types.
+        with self.assertRaises(ZeroDivisionError):
+            list[int] | list[bt]
+
     def test_ellipsis_type(self):
         self.assertIsInstance(Ellipsis, types.EllipsisType)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
@@ -1,5 +1,5 @@
-Allow `GenericAlias` objects to use  :ref:`union type expressions <types-union>`.
+Allow ``GenericAlias`` objects to use :ref:`union type expressions <types-union>`.
 This allows expressions like ``list[int] | dict[float,str]`` where previously a
-``TypeError`` would have been thrown. This also fixes union type expressions 
-not de-duplicating `GenericAlias` objects. (Contributed by Ken Jin in 
+``TypeError`` would have been thrown.  This also fixes union type expressions 
+not de-duplicating ``GenericAlias`` objects.  (Contributed by Ken Jin in 
 :issue:`42233`.)

--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
@@ -1,4 +1,5 @@
 Allow `GenericAlias` objects to use  :ref:`union type expressions <types-union>`.
 This allows expressions like ``list[int] | dict[float,str]`` where previously a
 ``TypeError`` would have been thrown. This also fixes union type expressions 
-not de-duplicating `GenericAlias` objects. (Contributed by Ken Jin in :bpo:`42233`.)
+not de-duplicating `GenericAlias` objects. (Contributed by Ken Jin in 
+:issue:`42233`.)

--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
@@ -1,5 +1,5 @@
 Allow ``GenericAlias`` objects to use :ref:`union type expressions <types-union>`.
-This allows expressions like ``list[int] | dict[float,str]`` where previously a
+This allows expressions like ``list[int] | dict[float, str]`` where previously a
 ``TypeError`` would have been thrown.  This also fixes union type expressions 
 not de-duplicating ``GenericAlias`` objects.  (Contributed by Ken Jin in 
 :issue:`42233`.)

--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-01-23-34-56.bpo-42233.zOSzja.rst
@@ -1,0 +1,4 @@
+Allow `GenericAlias` objects to use  :ref:`union type expressions <types-union>`.
+This allows expressions like ``list[int] | dict[float,str]`` where previously a
+``TypeError`` would have been thrown. This also fixes union type expressions 
+not de-duplicating `GenericAlias` objects. (Contributed by Ken Jin in :bpo:`42233`.)

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -574,6 +574,10 @@ ga_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return Py_GenericAlias(origin, arguments);
 }
 
+static PyNumberMethods union_as_number = {
+        .nb_or = (binaryfunc)_Py_union_type_or, // Add __or__ function
+};
+
 // TODO:
 // - argument clinic?
 // - __doc__?
@@ -587,7 +591,7 @@ PyTypeObject Py_GenericAliasType = {
     .tp_basicsize = sizeof(gaobject),
     .tp_dealloc = ga_dealloc,
     .tp_repr = ga_repr,
-    .tp_as_number = &_Py_union_as_number,  // allow X | Y of GenericAlias objs
+    .tp_as_number = &union_as_number,  // allow X | Y of GenericAlias objs
     .tp_as_mapping = &ga_as_mapping,
     .tp_hash = ga_hash,
     .tp_call = ga_call,

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_object.h"
+#include "pycore_unionobject.h"   // _Py_Union()
 #include "structmember.h"         // PyMemberDef
 
 typedef struct {
@@ -586,6 +587,7 @@ PyTypeObject Py_GenericAliasType = {
     .tp_basicsize = sizeof(gaobject),
     .tp_dealloc = ga_dealloc,
     .tp_repr = ga_repr,
+    .tp_as_number = &_Py_union_as_number,  // allow X | Y of GenericAlias objs
     .tp_as_mapping = &ga_as_mapping,
     .tp_hash = ga_hash,
     .tp_call = ga_call,

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -2,7 +2,7 @@
 
 #include "Python.h"
 #include "pycore_object.h"
-#include "pycore_unionobject.h"   // _Py_Union()
+#include "pycore_unionobject.h"   // _Py_union_as_number
 #include "structmember.h"         // PyMemberDef
 
 typedef struct {

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -574,7 +574,7 @@ ga_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return Py_GenericAlias(origin, arguments);
 }
 
-static PyNumberMethods union_as_number = {
+static PyNumberMethods ga_as_number = {
         .nb_or = (binaryfunc)_Py_union_type_or, // Add __or__ function
 };
 
@@ -591,7 +591,7 @@ PyTypeObject Py_GenericAliasType = {
     .tp_basicsize = sizeof(gaobject),
     .tp_dealloc = ga_dealloc,
     .tp_repr = ga_repr,
-    .tp_as_number = &union_as_number,  // allow X | Y of GenericAlias objs
+    .tp_as_number = &ga_as_number,  // allow X | Y of GenericAlias objs
     .tp_as_mapping = &ga_as_mapping,
     .tp_hash = ga_hash,
     .tp_call = ga_call,

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3749,7 +3749,7 @@ type_is_gc(PyTypeObject *type)
 
 
 static PyNumberMethods type_as_number = {
-        .nb_or = (binaryfunc)_Py_union_type_or, // Add __or__ function
+        .nb_or = _Py_union_type_or, // Add __or__ function
 };
 
 PyTypeObject PyType_Type = {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6,7 +6,7 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "pycore_unionobject.h"   // _Py_Union()
+#include "pycore_unionobject.h"   // _Py_Union(), _Py_union_type_or
 #include "frameobject.h"
 #include "structmember.h"         // PyMemberDef
 
@@ -3747,19 +3747,9 @@ type_is_gc(PyTypeObject *type)
     return type->tp_flags & Py_TPFLAGS_HEAPTYPE;
 }
 
-static PyObject *
-type_or(PyTypeObject* self, PyObject* param) {
-    PyObject *tuple = PyTuple_Pack(2, self, param);
-    if (tuple == NULL) {
-        return NULL;
-    }
-    PyObject *new_union = _Py_Union(tuple);
-    Py_DECREF(tuple);
-    return new_union;
-}
 
 static PyNumberMethods type_as_number = {
-        .nb_or = (binaryfunc)type_or, // Add __or__ function
+        .nb_or = (binaryfunc)_Py_union_type_or, // Add __or__ function
 };
 
 PyTypeObject PyType_Type = {

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -237,10 +237,18 @@ dedup_and_flatten_args(PyObject* args)
         PyObject* i_element = PyTuple_GET_ITEM(args, i);
         for (Py_ssize_t j = i + 1; j < arg_length; j++) {
             PyObject* j_element = PyTuple_GET_ITEM(args, j);
-            // RichCompare to also deduplicate GenericAlias types
-            if (PyObject_RichCompareBool(i_element, j_element, Py_EQ) == 1) {
-                is_duplicate = 1;
+            // RichCompare to also deduplicate GenericAlias types (slower)
+            if (Py_TYPE(i_element) == &Py_GenericAliasType) {
+                if (PyObject_RichCompareBool(i_element, j_element, Py_EQ) == 1) {
+                    is_duplicate = 1;
+                }
             }
+            else {
+                if (i_element == j_element) {
+                    is_duplicate = 1;
+                }
+            }
+            
         }
         if (!is_duplicate) {
             Py_INCREF(i_element);

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -238,7 +238,9 @@ dedup_and_flatten_args(PyObject* args)
         for (Py_ssize_t j = i + 1; j < arg_length; j++) {
             PyObject* j_element = PyTuple_GET_ITEM(args, j);
             // RichCompare to also deduplicate GenericAlias types (slower)
-            if (Py_TYPE(i_element) == &Py_GenericAliasType) {
+            if (Py_TYPE(i_element) == &Py_GenericAliasType &&
+                Py_TYPE(j_element) == &Py_GenericAliasType) 
+            {
                 if (PyObject_RichCompareBool(i_element, j_element, Py_EQ) == 1) {
                     is_duplicate = 1;
                 }

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -245,6 +245,7 @@ dedup_and_flatten_args(PyObject* args)
             // Should only happen if RichCompare fails
             if (is_duplicate < 0) {
                 Py_DECREF(args);
+                Py_DECREF(new_args);
                 return NULL;
             }
             if (is_duplicate)
@@ -300,7 +301,7 @@ is_unionable(PyObject *obj)
 }
 
 PyObject *
-_Py_union_type_or(PyTypeObject* self, PyObject* param)
+_Py_union_type_or(PyObject* self, PyObject* param)
 {
     PyObject *tuple = PyTuple_Pack(2, self, param);
     if (tuple == NULL) {
@@ -413,7 +414,7 @@ static PyMethodDef union_methods[] = {
         {0}};
 
 static PyNumberMethods union_as_number = {
-        .nb_or = (binaryfunc)_Py_union_type_or, // Add __or__ function
+        .nb_or = _Py_union_type_or, // Add __or__ function
 };
 
 PyTypeObject _Py_UnionType = {

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -237,7 +237,8 @@ dedup_and_flatten_args(PyObject* args)
         PyObject* i_element = PyTuple_GET_ITEM(args, i);
         for (Py_ssize_t j = i + 1; j < arg_length; j++) {
             PyObject* j_element = PyTuple_GET_ITEM(args, j);
-            if (i_element == j_element) {
+            // RichCompare to also deduplicate GenericAlias types
+            if (PyObject_RichCompareBool(i_element, j_element, Py_EQ) == 1) {
                 is_duplicate = 1;
             }
         }
@@ -403,7 +404,7 @@ static PyMethodDef union_methods[] = {
         {"__subclasscheck__", union_subclasscheck, METH_O},
         {0}};
 
-static PyNumberMethods union_as_number = {
+PyNumberMethods _Py_union_as_number = {
         .nb_or = (binaryfunc)type_or, // Add __or__ function
 };
 
@@ -423,7 +424,7 @@ PyTypeObject _Py_UnionType = {
     .tp_members = union_members,
     .tp_methods = union_methods,
     .tp_richcompare = union_richcompare,
-    .tp_as_number = &union_as_number,
+    .tp_as_number = &_Py_union_as_number,
     .tp_repr = union_repr,
 };
 

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -244,12 +244,6 @@ dedup_and_flatten_args(PyObject* args)
                 : i_element == j_element;
             // Should only happen if RichCompare fails
             if (is_duplicate < 0) {
-                PyErr_Format(PyExc_TypeError, 
-                    "Could not compare objects of type '%s' and '%s'"
-                    " at indexes %d and %d respectively."
-                    " Their __eq__ methods may be invalid. ",
-                    Py_TYPE(i_element)->tp_name, Py_TYPE(j_element)->tp_name,
-                    i, j);
                 Py_DECREF(args);
                 return NULL;
             }

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -240,10 +240,10 @@ dedup_and_flatten_args(PyObject* args)
             int is_ga = Py_TYPE(i_element) == &Py_GenericAliasType &&
                         Py_TYPE(j_element) == &Py_GenericAliasType;
             // RichCompare to also deduplicate GenericAlias types (slower)
-            int is_same = is_ga ? PyObject_RichCompareBool(i_element, j_element, Py_EQ)
+            is_duplicate = is_ga ? PyObject_RichCompareBool(i_element, j_element, Py_EQ)
                 : i_element == j_element;
             // Should only happen if RichCompare fails
-            if (is_same < 0) {
+            if (is_duplicate < 0) {
                 PyErr_Format(PyExc_TypeError, 
                     "Could not compare objects of type '%s' and '%s'"
                     " at indexes %d and %d respectively."
@@ -253,7 +253,6 @@ dedup_and_flatten_args(PyObject* args)
                 Py_DECREF(args);
                 return NULL;
             }
-            is_duplicate = is_same;
             if (is_duplicate)
                 break;
         }

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -299,8 +299,8 @@ is_unionable(PyObject *obj)
         type == &_Py_UnionType);
 }
 
-static PyObject *
-type_or(PyTypeObject* self, PyObject* param)
+PyObject *
+_Py_union_type_or(PyTypeObject* self, PyObject* param)
 {
     PyObject *tuple = PyTuple_Pack(2, self, param);
     if (tuple == NULL) {
@@ -412,8 +412,8 @@ static PyMethodDef union_methods[] = {
         {"__subclasscheck__", union_subclasscheck, METH_O},
         {0}};
 
-PyNumberMethods _Py_union_as_number = {
-        .nb_or = (binaryfunc)type_or, // Add __or__ function
+static PyNumberMethods union_as_number = {
+        .nb_or = (binaryfunc)_Py_union_type_or, // Add __or__ function
 };
 
 PyTypeObject _Py_UnionType = {
@@ -432,7 +432,7 @@ PyTypeObject _Py_UnionType = {
     .tp_members = union_members,
     .tp_methods = union_methods,
     .tp_richcompare = union_richcompare,
-    .tp_as_number = &_Py_union_as_number,
+    .tp_as_number = &union_as_number,
     .tp_repr = union_repr,
 };
 


### PR DESCRIPTION


<!-- issue-number: [bpo-42233](https://bugs.python.org/issue42233) -->
https://bugs.python.org/issue42233
<!-- /issue-number -->
