### PR TITLE
bpo-42235: [macOS] Use LTO/PGO in build-installer.py with new enough compilers

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -387,9 +387,9 @@ def library_recipes():
 
 def compilerCanOptimize():
     """
-    Return True iff the default Xcode version can use PGO
+    Return True iff the default Xcode version can use PGO and LTO
     """
-    # The version check is pretty conservative, can be
+    # bpo-42235: The version check is pretty conservative, can be
     # adjusted after testing
     mac_ver = tuple(map(int, platform.mac_ver()[0].split('.')))
     return mac_ver >= (10, 15)

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1149,7 +1149,7 @@ def buildPython():
                             shellQuote(WORKDIR)[1:-1],))[internalTk()],
         (' ', "--with-tcltk-libs='-L%s/libraries/usr/local/lib -ltcl8.6 -ltk8.6'"%(
                             shellQuote(WORKDIR)[1:-1],))[internalTk()],
-        (' ', "--enable-optimizations")[compilerCanOptimize()],
+        (' ', "--enable-optimizations --with-lto")[compilerCanOptimize()],
         shellQuote(WORKDIR)[1:-1],
         shellQuote(WORKDIR)[1:-1]))
 

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -385,6 +385,14 @@ def library_recipes():
 
     return result
 
+def compilerCanOptimize():
+    """
+    Return True iff the default Xcode version can use PGO
+    """
+    # The version check is pretty conservative, can be
+    # adjusted after testing
+    mac_ver = tuple(map(int, platform.mac_ver()[0].split('.')))
+    return mac_ver >= (10, 15)
 
 # Instructions for building packages inside the .mpkg.
 def pkg_recipes():
@@ -1128,6 +1136,7 @@ def buildPython():
                "%s "
                "%s "
                "%s "
+               "%s "
                "LDFLAGS='-g -L%s/libraries/usr/local/lib' "
                "CFLAGS='-g -I%s/libraries/usr/local/include' 2>&1"%(
         shellQuote(os.path.join(SRCDIR, 'configure')),
@@ -1140,6 +1149,7 @@ def buildPython():
                             shellQuote(WORKDIR)[1:-1],))[internalTk()],
         (' ', "--with-tcltk-libs='-L%s/libraries/usr/local/lib -ltcl8.6 -ltk8.6'"%(
                             shellQuote(WORKDIR)[1:-1],))[internalTk()],
+        (' ', "--enable-optimizations")[compilerCanOptimize()],
         shellQuote(WORKDIR)[1:-1],
         shellQuote(WORKDIR)[1:-1]))
 

--- a/Misc/NEWS.d/next/macOS/2020-11-01-17-37-16.bpo-42235.A97_BN.rst
+++ b/Misc/NEWS.d/next/macOS/2020-11-01-17-37-16.bpo-42235.A97_BN.rst
@@ -1,2 +1,2 @@
 ``Mac/BuildScript/build-installer.py`` will now use "--enable-optimizations"
-when building on macOS 10.15 or later.
+and ``--with-lto`` when building on macOS 10.15 or later.

--- a/Misc/NEWS.d/next/macOS/2020-11-01-17-37-16.bpo-42235.A97_BN.rst
+++ b/Misc/NEWS.d/next/macOS/2020-11-01-17-37-16.bpo-42235.A97_BN.rst
@@ -1,0 +1,2 @@
+``Mac/BuildScript/build-installer.py`` will now use "--enable-optimizations"
+when building on macOS 10.15 or later.


### PR DESCRIPTION
This PR enables ``--with-optimizations`` in build-installer.py when using a new enough compiler.

For now "new enough" is gated on being on macOS 10.15 or later, as that's what I've tested with.



<!-- issue-number: [bpo-42235](https://bugs.python.org/issue42235) -->
https://bugs.python.org/issue42235
<!-- /issue-number -->
