### PR TITLE
bpo-42233: Correctly repr GenericAlias when used with typing module

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -300,6 +300,8 @@ class UnionTests(BaseTestCase):
         self.assertEqual(repr(u), repr(int))
         u = Union[List[int], int]
         self.assertEqual(repr(u), 'typing.Union[typing.List[int], int]')
+        u = Union[list[int], dict[str, float]]
+        self.assertEqual(repr(u), 'typing.Union[list[int], dict[str, float]]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
@@ -407,6 +409,7 @@ class TupleTests(BaseTestCase):
         self.assertEqual(repr(Tuple[()]), 'typing.Tuple[()]')
         self.assertEqual(repr(Tuple[int, float]), 'typing.Tuple[int, float]')
         self.assertEqual(repr(Tuple[int, ...]), 'typing.Tuple[int, ...]')
+        self.assertEqual(repr(Tuple[list[int]]), 'typing.Tuple[list[int]]')
 
     def test_errors(self):
         with self.assertRaises(TypeError):
@@ -479,6 +482,8 @@ class CallableTests(BaseTestCase):
         self.assertEqual(repr(ct2), 'typing.Callable[[str, float], int]')
         ctv = Callable[..., str]
         self.assertEqual(repr(ctv), 'typing.Callable[..., str]')
+        ct3 = Callable[[str, float], list[int]]
+        self.assertEqual(repr(ct3), 'typing.Callable[[str, float], list[int]]')
 
     def test_callable_with_ellipsis(self):
 
@@ -2269,6 +2274,8 @@ class FinalTests(BaseTestCase):
         self.assertEqual(repr(cv), 'typing.Final[int]')
         cv = Final[Employee]
         self.assertEqual(repr(cv), 'typing.Final[%s.Employee]' % __name__)
+        cv = Final[tuple[int]]
+        self.assertEqual(repr(cv), 'typing.Final[tuple[int]]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -162,6 +162,8 @@ def _type_repr(obj):
     typically enough to uniquely identify a type.  For everything
     else, we fall back on repr(obj).
     """
+    if isinstance(obj, types.GenericAlias):
+        return repr(obj)
     if isinstance(obj, type):
         if obj.__module__ == 'builtins':
             return obj.__qualname__

--- a/Misc/NEWS.d/next/Library/2020-11-02-01-31-15.bpo-42233.YxRj-h.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-02-01-31-15.bpo-42233.YxRj-h.rst
@@ -1,3 +1,3 @@
 The :func:`repr` of :mod:`typing` types containing 
 :ref:`Generic Alias Types <types-genericalias>` previously did not show the 
-parameterized types in the `GenericAlias`.  They have now been changed to do so.
+parameterized types in the ``GenericAlias``.  They have now been changed to do so.

--- a/Misc/NEWS.d/next/Library/2020-11-02-01-31-15.bpo-42233.YxRj-h.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-02-01-31-15.bpo-42233.YxRj-h.rst
@@ -1,0 +1,3 @@
+The :func:`repr` of :mod:`typing` types containing 
+:ref:`Generic Alias Types <types-genericalias>` previously did not show the 
+parameterized types in the `GenericAlias`.  They have now been changed to do so.


### PR DESCRIPTION
Noticed by @serhiy-storchaka in the bpo.  `typing`'s types were not showing the parameterized generic. 
Eg. previously:
```python
>>> typing.Union[dict[str, float], list[int]]
'typing.Union[dict, list]'
```
Now:
```python
>>> typing.Union[dict[str, float], list[int]]
'typing.Union[dict[str, float], list[int]]'
```

<!-- issue-number: [bpo-42233](https://bugs.python.org/issue42233) -->
https://bugs.python.org/issue42233
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum