### PR TITLE
bpo-37193: Revert "remove thread objects which finished process its request"

### DIFF
--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -277,13 +277,6 @@ class SocketServerTest(unittest.TestCase):
             t.join()
             s.server_close()
 
-    def test_close_immediately(self):
-        class MyServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
-            pass
-
-        server = MyServer((HOST, 0), lambda: None)
-        server.server_close()
-
     def test_tcpserver_bind_leak(self):
         # Issue #22435: the server socket wouldn't be closed if bind()/listen()
         # failed.
@@ -496,23 +489,6 @@ class MiscTestCase(unittest.TestCase):
         s.close()
         server.handle_request()
         self.assertEqual(server.shutdown_called, 1)
-        server.server_close()
-
-    def test_threads_reaped(self):
-        """
-        In #37193, users reported a memory leak
-        due to the saving of every request thread. Ensure that the
-        threads are cleaned up after the requests complete.
-        """
-        class MyServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
-            pass
-
-        server = MyServer((HOST, 0), socketserver.StreamRequestHandler)
-        for n in range(10):
-            with socket.create_connection(server.server_address):
-                server.handle_request()
-        [thread.join() for thread in server._threads]
-        self.assertEqual(len(server._threads), 0)
         server.server_close()
 
 

--- a/Misc/NEWS.d/next/Library/2020-06-12-21-23-20.bpo-37193.wJximU.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-12-21-23-20.bpo-37193.wJximU.rst
@@ -1,2 +1,0 @@
-Fixed memory leak in ``socketserver.ThreadingMixIn`` introduced in Python
-3.7.


### PR DESCRIPTION
Reverts python/cpython#13893

According to buildbots, the change introduces a memory leak.

<!-- issue-number: [bpo-37193](https://bugs.python.org/issue37193) -->
https://bugs.python.org/issue37193
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco