### PR TITLE
bpo-42249: Fix writing binary Plist files larger than 4 GiB.

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -611,7 +611,7 @@ def _count_to_size(count):
     elif count < 1 << 16:
         return 2
 
-    elif count << 1 << 32:
+    elif count < 1 << 32:
         return 4
 
     else:

--- a/Misc/NEWS.d/next/Library/2020-11-03-09-22-56.bpo-42249.vfNO2u.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-03-09-22-56.bpo-42249.vfNO2u.rst
@@ -1,0 +1,1 @@
+Fixed writing binary Plist files larger than 4 GiB.


### PR DESCRIPTION


<!-- issue-number: [bpo-42249](https://bugs.python.org/issue42249) -->
https://bugs.python.org/issue42249
<!-- /issue-number -->
