### PR TITLE
Fix decorator name

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -768,7 +768,7 @@ to wrap access to the value attribute in a property data descriptor::
     class Cell:
         ...
 
-        @property
+        @Property
         def value(self):
             "Recalculate the cell before returning value"
             self.recalc()


### PR DESCRIPTION
Fix the decorator name from property to Property (capital P) to call the Property class.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
