### PR TITLE
bpo-38647: Add *name* to webbrowser.MacOSXOSAScript

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -663,10 +663,11 @@ if sys.platform == 'darwin':
 
     class MacOSXOSAScript(BaseBrowser):
         def __init__(self, name):
+            BaseBrowser.__init__(self, name)
             self._name = name
 
         def open(self, url, new=0, autoraise=True):
-            if self._name == 'default':
+            if self.name == 'default':
                 script = 'open location "%s"' % url.replace('"', '%22') # opens in default browser
             else:
                 script = '''
@@ -674,7 +675,7 @@ if sys.platform == 'darwin':
                        activate
                        open location "%s"
                    end
-                   '''%(self._name, url.replace('"', '%22'))
+                   '''%(self.name, url.replace('"', '%22'))
 
             osapipe = os.popen("osascript", "w")
             if osapipe is None:

--- a/Misc/NEWS.d/next/macOS/2020-11-03-20-05-05.bpo-38647.rp7ezH.rst
+++ b/Misc/NEWS.d/next/macOS/2020-11-03-20-05-05.bpo-38647.rp7ezH.rst
@@ -1,0 +1,2 @@
+The ``webbrowser.MacOSXOSAScript`` now has a *name* attribute,
+like other browser classes.


### PR DESCRIPTION
Add a *name* attribute to webbrowser.MacOSXOSAScript and add some tests for the class.

The PR keeps the *_name* attribute for backward compatibility, even if the attribute is (like *name*) not documented.

<!-- issue-number: [bpo-38647](https://bugs.python.org/issue38647) -->
https://bugs.python.org/issue38647
<!-- /issue-number -->
