### PR TITLE
 bpo-17852: Fixed the documentation about closing files

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -347,8 +347,8 @@ resources used by it. :meth:`__del__` of the returned :term:`file object` also c
 .. warning::
    Calling ``f.write()`` without using the :keyword:`!with` keyword or calling
    ``f.close()``, ``f.flush()`` or ``del(f)`` **might** result in the arguments
-   of write() not being completely written to the disk, even if the program
-   exists successfully. This is because Python does not guarantee that
+   of ``f.write()`` not being completely written to the disk, even if the
+   program exists successfully. This is because Python does not guarantee that
    :meth:`__del__` is called when the interpreter exists.
 
 ..

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -329,11 +329,31 @@ equivalent :keyword:`try`\ -\ :keyword:`finally` blocks::
 
 If you're not using the :keyword:`with` keyword, then you should call
 ``f.close()`` to close the file and immediately free up any system
-resources used by it. If you don't explicitly close a file, Python's
-garbage collector will eventually destroy the object and close the
-open file for you, but the file may stay open for a while.  Another
-risk is that different Python implementations will do this clean-up at
-different times.
+resources used by it. :meth:`__del__` of the returned :term:`file object` also calls ``f.close()``.
+
+..
+   Source for the claim that the ``del(f)`` calls .close():
+   Take a look at the source code of open() in _pyio.py and check the
+   returned type. It will always be one of these 5 classes: 
+   FileIO
+   TextIOWrapper
+   BufferedRandom
+   BufferedWriter
+   BufferedReader
+   FileIO defines the __del__ method that calls .close().
+   The other 4 classes inherit indirectly (without overwriting __del__) from
+   IOBase which defines the __del__ method that calls .close().
+
+.. warning::
+   Calling ``f.write()`` without using the :keyword:`!with` keyword or calling
+   ``f.close()`` or calling ``del(f)`` **might** result in the arguments of
+   write not being completely written to the disk, even if the program exists
+   successfully.
+   This is because Python does not guarantee that
+   :meth:`__del__` is called when the interpreter exists.
+
+..
+   See also https://bugs.python.org/issue17852
 
 After a file object is closed, either by a :keyword:`with` statement
 or by calling ``f.close()``, attempts to use the file object will

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -334,7 +334,7 @@ resources used by it. :meth:`__del__` of the returned :term:`file object` also c
 ..
    Source for the claim that the ``del(f)`` calls .close():
    Take a look at the source code of open() in _pyio.py and check the
-   returned type. It will always be one of these 5 classes: 
+   returned type. It will always be one of these 5 classes:
    FileIO
    TextIOWrapper
    BufferedRandom

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -329,27 +329,13 @@ equivalent :keyword:`try`\ -\ :keyword:`finally` blocks::
 
 If you're not using the :keyword:`with` keyword, then you should call
 ``f.close()`` to close the file and immediately free up any system
-resources used by it. :meth:`__del__` of the returned :term:`file object` also calls ``f.close()``.
-
-..
-   Source for the claim that the ``del(f)`` calls .close():
-   Take a look at the source code of open() in _pyio.py and check the
-   returned type. It will always be one of these 5 classes:
-   FileIO
-   TextIOWrapper
-   BufferedRandom
-   BufferedWriter
-   BufferedReader
-   FileIO defines the __del__ method that calls .close().
-   The other 4 classes inherit indirectly (without overwriting __del__) from
-   IOBase which defines the __del__ method that calls .close().
+resources used by it.
 
 .. warning::
    Calling ``f.write()`` without using the :keyword:`!with` keyword or calling
    ``f.close()``, ``f.flush()`` or ``del(f)`` **might** result in the arguments
    of ``f.write()`` not being completely written to the disk, even if the
-   program exists successfully. This is because Python does not guarantee that
-   :meth:`__del__` is called when the interpreter exists.
+   program exits successfully.
 
 ..
    See also https://bugs.python.org/issue17852

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -333,7 +333,7 @@ resources used by it.
 
 .. warning::
    Calling ``f.write()`` without using the :keyword:`!with` keyword or calling
-   ``f.close()``, ``f.flush()`` or ``del f`` **might** result in the arguments
+   ``f.close()`` **might** result in the arguments
    of ``f.write()`` not being completely written to the disk, even if the
    program exits successfully.
 

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -346,7 +346,7 @@ resources used by it. :meth:`__del__` of the returned :term:`file object` also c
 
 .. warning::
    Calling ``f.write()`` without using the :keyword:`!with` keyword or calling
-   ``f.close()``, ``f.flush()`` or ``del(f)`` **might** result in the arguments
+   ``f.close()``, ``f.flush()`` or ``del f`` **might** result in the arguments
    of ``f.write()`` not being completely written to the disk, even if the
    program exists successfully. This is because Python does not guarantee that
    :meth:`__del__` is called when the interpreter exists.

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -346,10 +346,9 @@ resources used by it. :meth:`__del__` of the returned :term:`file object` also c
 
 .. warning::
    Calling ``f.write()`` without using the :keyword:`!with` keyword or calling
-   ``f.close()`` or calling ``del(f)`` **might** result in the arguments of
-   write not being completely written to the disk, even if the program exists
-   successfully.
-   This is because Python does not guarantee that
+   ``f.close()``, ``f.flush()`` or ``del(f)`` **might** result in the arguments
+   of write() not being completely written to the disk, even if the program
+   exists successfully. This is because Python does not guarantee that
    :meth:`__del__` is called when the interpreter exists.
 
 ..


### PR DESCRIPTION
Most programming languages, including Python 2 call all the destructor of global variables if the program exists successfully.
Python 3 is not guaranteed to.
This can result in the arguments of file.write() not being written to the disk.
The guys in [this issue](https://bugs.python.org/issue17852) also released this problem and discussed if it should be this way, but apparently all of them were completely brain-dead idiots because they did not check if the documentation of Python matches the actual behaviour. Instead, the documentation stated that Python will call f.close() (and I quote) "eventually", which is completely BS, because Python may never call f.close().
I can't fix the (imho stupid) behavior of Python 3 not calling destructors, but at least I can fix the documentation (this PR).

Especially for a programming language like Python, that is supposed to be used by people with limited CS knowledge, it is important that no features in the programming language yields surprising behavior and good documentation that is correct is also very important.

Excuse me for my language, but if one of the most popular programming languages doesn't manage to fix a simple but important documentation error within a year after someone reports it, it is a disgrace and failure of the open source model. If you support this kind of misleading documentation, you are 100 % responsible to every bug written by someone who thought that f.close() is called when the program exists. And they are 0 % responsible for the bug, because they trusted the documentation.

<!-- issue-number: [bpo-17852](https://bugs.python.org/issue17852) -->
https://bugs.python.org/issue17852
<!-- /issue-number -->
