### PR TITLE
bpo-42207:  Disable peg generator tests when building with PGO

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -1,3 +1,4 @@
+import sysconfig
 import textwrap
 import unittest
 from distutils.tests.support import TempdirManager
@@ -7,6 +8,11 @@ from test import test_tools
 from test import support
 from test.support import os_helper
 from test.support.script_helper import assert_python_ok
+
+_py_cflags_nodist = sysconfig.get_config_var('PY_CFLAGS_NODIST')
+_pgo_flag = sysconfig.get_config_var('PGO_PROF_USE_FLAG')
+if _pgo_flag and _py_cflags_nodist and _pgo_flag in _py_cflags_nodist:
+    raise unittest.SkipTest("peg_generator test disabled under PGO build")
 
 test_tools.skip_if_missing("peg_generator")
 with test_tools.imports_under_tool("peg_generator"):


### PR DESCRIPTION
Otherwise, when running the testsuite, test_peg_generator tries to compile C
code using the optimized flags and fails because it cannot find the profile
data.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42207](https://bugs.python.org/issue42207) -->
https://bugs.python.org/issue42207
<!-- /issue-number -->
