### PR TITLE
bpo-42258: argparse: show choices once per argument

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -559,12 +559,14 @@ class HelpFormatter(object):
                 parts.extend(action.option_strings)
 
             # if the Optional takes a value, format is:
-            #    -s ARGS, --long ARGS
+            #    -s, --long ARGS
             else:
                 default = self._get_default_metavar_for_optional(action)
+                for option_string in action.option_strings[:-1]:
+                    parts.append('%s' % (option_string))
+
                 args_string = self._format_args(action, default)
-                for option_string in action.option_strings:
-                    parts.append('%s %s' % (option_string, args_string))
+                parts.append('%s %s' % (action.option_strings[-1], args_string))
 
             return ', '.join(parts)
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4049,8 +4049,8 @@ class TestHelpAlternatePrefixChars(HelpTestCase):
     help = usage + '''\
 
         optional arguments:
-          ^^foo              foo help
-          ;b BAR, ;;bar BAR  bar help
+          ^^foo          foo help
+          ;b, ;;bar BAR  bar help
         '''
     version = ''
 

--- a/Misc/NEWS.d/next/Library/2020-11-04-07-07-21.bpo-42258.9jhwvd.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-04-07-07-21.bpo-42258.9jhwvd.rst
@@ -1,0 +1,1 @@
+argparse: show choices once per argument


### PR DESCRIPTION
When using more than one flag for an argument, it is redundant to have the choices more than once, since they are the same argument and have the same choices.
Showing it once means cleaner output, and often means that the other option lines are shorter, like in the test case.

### sample code
```py
import argparse

ap = argparse.ArgumentParser(allow_abbrev=False)
ap.add_argument('-c', '--choices', choices=['a', 'b', 'c'])
ap.parse_args()
```

### previous output
```
usage: main.py [-h] [-c {a,b,c}]

optional arguments:
  -h, --help            show this help message and exit
  -c {a,b,c}, --choices {a,b,c}
```

### new output
```
usage: main.py [-h] [-c {a,b,c}]

optional arguments:
  -h, --help            show this help message and exit
  -c, --choices {a,b,c}
```


<!-- issue-number: [bpo-42258](https://bugs.python.org/issue42258) -->
https://bugs.python.org/issue42258
<!-- /issue-number -->
