### PR TITLE
[doc] Fix markup in symtable

### DIFF
--- a/Doc/library/symtable.rst
+++ b/Doc/library/symtable.rst
@@ -156,7 +156,7 @@ Examining Symbol Tables
 
       Return ``True`` if the symbol is local to its block.
 
-    .. method:: is_annotated()
+   .. method:: is_annotated()
 
       Return ``True`` if the symbol is annotated.
 


### PR DESCRIPTION
The difference can be seen in the rendered output: https://docs.python.org/3.10/library/symtable.html#symtable.Symbol.is_annotated