### PR TITLE
[3.8] bpo-35455: Fix thread_time for Solaris OS (GH-11118).

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-02-14-10-48.bpo-35455.Q1xTIo.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-02-14-10-48.bpo-35455.Q1xTIo.rst
@@ -1,0 +1,3 @@
+On Solaris, :func:`~time.thread_time` is now implemented with
+``gethrvtime()`` because ``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` is not
+always available. Patch by Jakub Kulik.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1344,6 +1344,23 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
     return 0;
 }
 
+#elif defined(__sun) && defined(__SVR4)
+#define HAVE_THREAD_TIME
+static int
+_PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
+{
+    /* bpo-35455: On Solaris, CLOCK_THREAD_CPUTIME_ID clock is not always
+       available; use gethrvtime() to substitute this functionality. */
+    if (info) {
+        info->implementation = "gethrvtime()";
+        info->resolution = 1e-9;
+        info->monotonic = 1;
+        info->adjustable = 0;
+    }
+    *tp = _PyTime_FromNanoseconds(gethrvtime());
+    return 0;
+}
+
 #elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_PROCESS_CPUTIME_ID)
 #define HAVE_THREAD_TIME
 static int


### PR DESCRIPTION
(cherry picked from commit 9568622c9983b682b2a2a7bacfd3c341028ea099)

Author: Jakub Kulík <Kulikjak@gmail.com>


<!-- issue-number: [bpo-35455](https://bugs.python.org/issue35455) -->
https://bugs.python.org/issue35455
<!-- /issue-number -->
