### PR TITLE
bpo-1635741: _contextvars uses PyModule_AddType()

### DIFF
--- a/Modules/_contextvarsmodule.c
+++ b/Modules/_contextvarsmodule.c
@@ -30,30 +30,15 @@ static PyMethodDef _contextvars_methods[] = {
 static int
 _contextvars_exec(PyObject *m)
 {
-    Py_INCREF(&PyContext_Type);
-    if (PyModule_AddObject(m, "Context",
-                           (PyObject *)&PyContext_Type) < 0)
-    {
-        Py_DECREF(&PyContext_Type);
+    if (PyModule_AddType(m, &PyContext_Type) < 0) {
         return -1;
     }
-
-    Py_INCREF(&PyContextVar_Type);
-    if (PyModule_AddObject(m, "ContextVar",
-                           (PyObject *)&PyContextVar_Type) < 0)
-    {
-        Py_DECREF(&PyContextVar_Type);
+    if (PyModule_AddType(m, &PyContextVar_Type) < 0) {
         return -1;
     }
-
-    Py_INCREF(&PyContextToken_Type);
-    if (PyModule_AddObject(m, "Token",
-                           (PyObject *)&PyContextToken_Type) < 0)
-    {
-        Py_DECREF(&PyContextToken_Type);
+    if (PyModule_AddType(m, &PyContextToken_Type) < 0) {
         return -1;
     }
-
     return 0;
 }
 

--- a/Python/context.c
+++ b/Python/context.c
@@ -703,7 +703,7 @@ static PyMappingMethods PyContext_as_mapping = {
 
 PyTypeObject PyContext_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "Context",
+    "_contextvars.Context",
     sizeof(PyContext),
     .tp_methods = PyContext_methods,
     .tp_as_mapping = &PyContext_as_mapping,
@@ -1056,7 +1056,7 @@ static PyMethodDef PyContextVar_methods[] = {
 
 PyTypeObject PyContextVar_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "ContextVar",
+    "_contextvars.ContextVar",
     sizeof(PyContextVar),
     .tp_methods = PyContextVar_methods,
     .tp_members = PyContextVar_members,
@@ -1197,7 +1197,7 @@ static PyMethodDef PyContextTokenType_methods[] = {
 
 PyTypeObject PyContextToken_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "Token",
+    "_contextvars.Token",
     sizeof(PyContextToken),
     .tp_methods = PyContextTokenType_methods,
     .tp_getset = PyContextTokenType_getsetlist,


### PR DESCRIPTION
Replace PyModule_AddObject() with PyModule_AddType() in the
_contextvars module (Python-ast.c).

Add also the module name to _contextvars types to get qualified
names.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
