### PR TITLE
bpo-42260: Reorganize PyConfig

### DIFF
--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -41,7 +41,7 @@ PyAPI_FUNC(PyStatus) PyWideStringList_Insert(PyWideStringList *list,
 
 /* --- PyPreConfig ----------------------------------------------- */
 
-typedef struct {
+typedef struct PyPreConfig {
     int _config_init;     /* _PyConfigInitEnum value */
 
     /* Parse Py_PreInitializeFromBytesArgs() arguments?
@@ -128,7 +128,7 @@ PyAPI_FUNC(void) PyPreConfig_InitIsolatedConfig(PyPreConfig *config);
 /* --- PyConfig ---------------------------------------------- */
 
 /* This structure is best documented in the Doc/c-api/init_config.rst file. */
-typedef struct {
+typedef struct PyConfig {
     int _config_init;     /* _PyConfigInitEnum value */
 
     int isolated;
@@ -147,8 +147,8 @@ typedef struct {
     wchar_t *filesystem_errors;
     wchar_t *pycache_prefix;
     int parse_argv;
+    PyWideStringList orig_argv;
     PyWideStringList argv;
-    wchar_t *program_name;
     PyWideStringList xoptions;
     PyWideStringList warnoptions;
     int site_import;
@@ -169,12 +169,13 @@ typedef struct {
     int legacy_windows_stdio;
 #endif
     wchar_t *check_hash_pycs_mode;
-    PyWideStringList orig_argv;
 
     /* --- Path configuration inputs ------------ */
     int pathconfig_warnings;
+    wchar_t *program_name;
     wchar_t *pythonpath_env;
     wchar_t *home;
+    wchar_t *platlibdir;
 
     /* --- Path configuration outputs ----------- */
     int module_search_paths_set;
@@ -185,7 +186,6 @@ typedef struct {
     wchar_t *base_prefix;
     wchar_t *exec_prefix;
     wchar_t *base_exec_prefix;
-    wchar_t *platlibdir;
 
     /* --- Parameter only used by Py_Main() ---------- */
     int skip_source_first_line;


### PR DESCRIPTION
* Move orig_argv before argv
* Move program_name and platlibdir with other path configuration
  inputs

Give a name to the PyPreConfig and PyConfig structures and separate
the type definitions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42260](https://bugs.python.org/issue42260) -->
https://bugs.python.org/issue42260
<!-- /issue-number -->
