### PR TITLE
bpo-1635741: _warnings uses PyModule_AddObjectRef()

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1395,18 +1395,13 @@ _PyWarnings_Init(void)
         goto error;
     }
 
-    Py_INCREF(st->filters);
-    if (PyModule_AddObject(m, "filters", st->filters) < 0) {
+    if (PyModule_AddObjectRef(m, "filters", st->filters) < 0) {
         goto error;
     }
-
-    Py_INCREF(st->once_registry);
-    if (PyModule_AddObject(m, "_onceregistry", st->once_registry) < 0) {
+    if (PyModule_AddObjectRef(m, "_onceregistry", st->once_registry) < 0) {
         goto error;
     }
-
-    Py_INCREF(st->default_action);
-    if (PyModule_AddObject(m, "_defaultaction", st->default_action) < 0) {
+    if (PyModule_AddObjectRef(m, "_defaultaction", st->default_action) < 0) {
         goto error;
     }
 

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -220,10 +220,9 @@ _PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *fp)
     def->m_base.m_init = p0;
 
     /* Remember the filename as the __file__ attribute */
-    if (PyModule_AddObject(m, "__file__", path) < 0)
+    if (PyModule_AddObjectRef(m, "__file__", path) < 0) {
         PyErr_Clear(); /* Not important enough to report */
-    else
-        Py_INCREF(path);
+    }
 
     PyObject *modules = PyImport_GetModuleDict();
     if (_PyImport_FixupExtensionObject(m, name_unicode, path, modules) < 0)


### PR DESCRIPTION
Replace PyModule_AddObject() with PyModule_AddObjectRef() in the
_warnings module to fix a reference leak on error.

Also use PyModule_AddObjectRef() in importdl.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
