### PR TITLE
bpo-42142: Skip select ttk tests when on Ubuntu

### DIFF
--- a/Lib/tkinter/test/support.py
+++ b/Lib/tkinter/test/support.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import re
 import tkinter
 import unittest
@@ -115,3 +116,9 @@ def widget_eq(actual, expected):
         if isinstance(expected, (str, tkinter.Widget)):
             return str(actual) == str(expected)
     return False
+
+def ubuntu():
+    try:
+        return "Ubuntu" in os.uname().version
+    except AttributeError:
+        return False

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import unittest
 import tkinter
@@ -184,6 +185,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
         x.destroy()
 
 
+    @unittest.skipIf("Ubuntu" in os.uname(), "Skipped")
     def test_resize(self):
         x = ttk.LabeledScale(self.root)
         x.pack(expand=True, fill='both')

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -185,7 +185,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
         x.destroy()
 
 
-    @unittest.skipIf("Ubuntu" in os.uname(), "Skipped")
+    @unittest.skipIf("Ubuntu" in os.uname().version, "Skipped")
     def test_resize(self):
         x = ttk.LabeledScale(self.root)
         x.pack(expand=True, fill='both')

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import unittest
 import tkinter

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -110,7 +110,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
         # extra, and invalid, kwargs
         self.assertRaises(tkinter.TclError, ttk.LabeledScale, master, a='b')
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_horizontal_range(self):
         lscale = ttk.LabeledScale(self.root, from_=0, to=10)
         lscale.pack()
@@ -140,7 +140,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
 
         lscale.destroy()
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_variable_change(self):
         x = ttk.LabeledScale(self.root)
         x.pack()
@@ -239,7 +239,7 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
 
         optmenu.destroy()
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_menu(self):
         items = ('a', 'b', 'c')
         default = 'a'
@@ -292,6 +292,7 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
 
         optmenu.destroy()
 
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_unique_radiobuttons(self):
         # check that radiobuttons are unique across instances (bpo25684)
         items = ('a', 'b', 'c')

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -4,7 +4,7 @@ import unittest
 import tkinter
 from tkinter import ttk
 from test.support import requires, run_unittest, swap_attr
-from tkinter.test.support import AbstractTkTest, destroy_default_root
+from tkinter.test.support import AbstractTkTest, destroy_default_root, ubuntu
 
 requires('gui')
 
@@ -185,7 +185,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
         x.destroy()
 
 
-    @unittest.skipIf("Ubuntu" in os.uname().version, "Skipped")
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_resize(self):
         x = ttk.LabeledScale(self.root)
         x.pack(expand=True, fill='both')

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 import tkinter
 from tkinter import ttk, TclError

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -443,7 +443,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.combo.update_idletasks()
 
 
-    @unittest.skipIf("Ubuntu" in os.uname(), "Skipped")
+    @unittest.skipIf("Ubuntu" in os.uname().version, "Skipped")
     def test_virtual_event(self):
         success = []
 

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -60,7 +60,8 @@ class WidgetTest(AbstractTkTest, unittest.TestCase):
         super().setUp()
         self.widget = ttk.Button(self.root, width=0, text="Text")
         self.widget.pack()
-        #self.widget.wait_visibility()
+        if not ubuntu():
+            self.widget.wait_visibility()
 
 
     def test_identify(self):

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -60,7 +60,7 @@ class WidgetTest(AbstractTkTest, unittest.TestCase):
         super().setUp()
         self.widget = ttk.Button(self.root, width=0, text="Text")
         self.widget.pack()
-        self.widget.wait_visibility()
+        #self.widget.wait_visibility()
 
 
     def test_identify(self):
@@ -323,7 +323,7 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, self.entry.bbox, 'noindex')
         self.assertRaises(tkinter.TclError, self.entry.bbox, None)
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_identify(self):
         self.entry.pack()
         self.entry.wait_visibility()
@@ -460,7 +460,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
 
         self.assertTrue(success)
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_postcommand(self):
         success = []
 
@@ -652,7 +652,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, self.paned.pane, 0,
             badoption='somevalue')
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_sashpos(self):
         self.assertRaises(tkinter.TclError, self.paned.sashpos, None)
         self.assertRaises(tkinter.TclError, self.paned.sashpos, '')
@@ -921,6 +921,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Notebook(self.root, **kwargs)
 
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_tab_identifiers(self):
         self.nb.forget(0)
         self.nb.hide(self.child2)
@@ -1039,7 +1040,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, self.nb.insert, None, 0)
         self.assertRaises(tkinter.TclError, self.nb.insert, None, None)
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_select(self):
         self.nb.pack()
         self.nb.wait_visibility()
@@ -1082,7 +1083,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
         self.assertEqual(self.nb.tabs(), ())
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_traversal(self):
         self.nb.pack()
         self.nb.wait_visibility()
@@ -1340,6 +1341,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         self.checkParam(widget, 'show', 'tree', expected=('tree',))
         self.checkParam(widget, 'show', 'headings', expected=('headings',))
 
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_bbox(self):
         self.tv.pack()
         self.assertEqual(self.tv.bbox(''), '')
@@ -1529,6 +1531,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, self.tv.heading, '#0',
             anchor=1)
 
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_heading_callback(self):
         def simulate_heading_click(x, y):
             simulate_mouse_click(self.tv, x, y)
@@ -1774,7 +1777,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         # inexistent item
         self.assertRaises(tkinter.TclError, self.tv.set, 'notme')
 
-
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_tag_bind(self):
         events = []
         item1 = self.tv.insert('', 'end', tags=['call'])

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -7,7 +7,7 @@ import sys
 
 from tkinter.test.test_ttk.test_functions import MockTclObj
 from tkinter.test.support import (AbstractTkTest, tcl_version, get_tk_patchlevel,
-                                  simulate_mouse_click)
+                                  simulate_mouse_click, ubuntu)
 from tkinter.test.widget_tests import (add_standard_options, noconv,
     AbstractWidgetTest, StandardOptionsTests, IntegerSizeTests, PixelSizeTests,
     setUpModule)
@@ -443,7 +443,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.combo.update_idletasks()
 
 
-    @unittest.skipIf("Ubuntu" in os.uname().version, "Skipped")
+    @unittest.skipIf(ubuntu(), "Skipped")
     def test_virtual_event(self):
         success = []
 

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import tkinter
 from tkinter import ttk, TclError
@@ -442,6 +443,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.combo.update_idletasks()
 
 
+    @unittest.skipIf("Ubuntu" in os.uname(), "Skipped")
     def test_virtual_event(self):
         success = []
 


### PR DESCRIPTION
Note: This is only designed as a temporary solution to avoid the inconvenience inevitably caused to other (unrelated) PRs.

Note: This will apply (I believe) for all Ubuntu machines (it will certainly affect [Azure Pipelines](https://dev.azure.com/Python/cpython/_build/results?buildId=71333&view=logs&j=256d7e09-002a-52d7-8661-29ee3960640e&t=56b7dbaa-139f-55fd-b27b-53e01e0ad59a&l=149), [Travis CI](https://travis-ci.com/github/python/cpython/jobs/428404170#L1765) & the [Github Action](https://github.com/python/cpython/pull/23156/checks?check_run_id=1355643876#step:9:142))

<!-- issue-number: [bpo-42142](https://bugs.python.org/issue42142) -->
https://bugs.python.org/issue42142
<!-- /issue-number -->
