### PR TITLE
bpo-41877 Check for asert, aseert, assrt in mocks

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -631,9 +631,9 @@ class NonCallableMock(Base):
         elif _is_magic(name):
             raise AttributeError(name)
         if not self._mock_unsafe:
-            if name.startswith(('assert', 'assret')):
+            if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')):
                 raise AttributeError("Attributes cannot start with 'assert' "
-                                     "or 'assret'")
+                                     "or its misspellings")
 
         result = self._mock_children.get(name)
         if result is _deleted:

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1598,14 +1598,23 @@ class MockTest(unittest.TestCase):
     #Issue21238
     def test_mock_unsafe(self):
         m = Mock()
-        msg = "Attributes cannot start with 'assert' or 'assret'"
+        msg = "Attributes cannot start with 'assert' or its misspellings"
         with self.assertRaisesRegex(AttributeError, msg):
             m.assert_foo_call()
         with self.assertRaisesRegex(AttributeError, msg):
             m.assret_foo_call()
+        with self.assertRaisesRegex(AttributeError, msg):
+            m.asert_foo_call()
+        with self.assertRaisesRegex(AttributeError, msg):
+            m.aseert_foo_call()
+        with self.assertRaisesRegex(AttributeError, msg):
+            m.assrt_foo_call()
         m = Mock(unsafe=True)
         m.assert_foo_call()
         m.assret_foo_call()
+        m.asert_foo_call()
+        m.aseert_foo_call()
+        m.assrt_foo_call()
 
     #Issue21262
     def test_assert_not_called(self):

--- a/Misc/NEWS.d/next/Library/2020-11-05-16-00-03.bpo-41877.FHbngM.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-05-16-00-03.bpo-41877.FHbngM.rst
@@ -1,0 +1,2 @@
+Mock objects which are not unsafe will now raise an AttributeError if an attribute with the prefix asert, aseert,
+or assrt is accessed, in addition to this already happening for the prefixes assert or assret.


### PR DESCRIPTION
Currently, a Mock object which is not unsafe will raise an
AttributeError if an attribute with the prefix assert or assret is
accessed on it. This protects against misspellings of real assert
method calls, which lead to tests passing silently even if the tested
code does not satisfy the intended assertion.

Recently a check was done in a large code base and three more frequent
ways of misspelling assert were found causing harm: asert, aseert,
assrt. These are now added to the existing check.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41877](https://bugs.python.org/issue41877) -->
https://bugs.python.org/issue41877
<!-- /issue-number -->
