### PR TITLE
bpo-42260: PyConfig_Read() only parses argv once

### DIFF
--- a/Lib/test/_test_embed_set_config.py
+++ b/Lib/test/_test_embed_set_config.py
@@ -234,6 +234,12 @@ class SetConfigTests(unittest.TestCase):
         self.assertEqual(sys.argv, ['python_program', 'args'])
         self.assertEqual(sys.orig_argv, ['orig', 'orig_args'])
 
+        self.set_config(parse_argv=0,
+                        argv=[],
+                        orig_argv=[])
+        self.assertEqual(sys.argv, [''])
+        self.assertEqual(sys.orig_argv, [])
+
     def test_pycache_prefix(self):
         self.check(pycache_prefix=None)
         self.check(pycache_prefix="pycache_prefix")

--- a/Lib/test/_test_embed_set_config.py
+++ b/Lib/test/_test_embed_set_config.py
@@ -20,7 +20,7 @@ class SetConfigTests(unittest.TestCase):
         self.sys_copy = dict(sys.__dict__)
 
     def tearDown(self):
-        self.set_config(parse_argv=0)
+        _testinternalcapi.set_config(self.old_config)
         sys.__dict__.clear()
         sys.__dict__.update(self.sys_copy)
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -422,7 +422,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     CONFIG_PYTHON = dict(CONFIG_COMPAT,
         _config_init=API_PYTHON,
         configure_c_stdio=1,
-        parse_argv=1,
+        parse_argv=2,
     )
     CONFIG_ISOLATED = dict(CONFIG_COMPAT,
         _config_init=API_ISOLATED,
@@ -800,7 +800,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                           '-X', 'cmdline_xoption',
                           '-c', 'pass',
                           'arg2'],
-            'parse_argv': 1,
+            'parse_argv': 2,
             'xoptions': [
                 'config_xoption1=3',
                 'config_xoption2=',
@@ -1045,7 +1045,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'orig_argv': ['python3', '-c', code, 'arg2'],
             'program_name': './python3',
             'run_command': code + '\n',
-            'parse_argv': 1,
+            'parse_argv': 2,
         }
         self.check_all_configs("test_init_run_main", config, api=API_PYTHON)
 
@@ -1059,7 +1059,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                           'arg2'],
             'program_name': './python3',
             'run_command': code + '\n',
-            'parse_argv': 1,
+            'parse_argv': 2,
             '_init_main': 0,
         }
         self.check_all_configs("test_init_main", config,
@@ -1068,7 +1068,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_init_parse_argv(self):
         config = {
-            'parse_argv': 1,
+            'parse_argv': 2,
             'argv': ['-c', 'arg1', '-v', 'arg3'],
             'orig_argv': ['./argv0', '-E', '-c', 'pass', 'arg1', '-v', 'arg3'],
             'program_name': './argv0',

--- a/Misc/NEWS.d/next/C API/2020-11-05-18-02-07.bpo-42260.pAeaNR.rst
+++ b/Misc/NEWS.d/next/C API/2020-11-05-18-02-07.bpo-42260.pAeaNR.rst
@@ -1,0 +1,5 @@
+The :c:func:`PyConfig_Read` function now only parses :c:member:`PyConfig.argv`
+arguments once: :c:member:`PyConfig.parse_argv` is set to ``2`` after arguments
+are parsed. Since Python arguments are strippped from
+:c:member:`PyConfig.argv`, parsing arguments twice would parse the application
+options as Python options.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -253,14 +253,17 @@ test_set_config(PyObject *Py_UNUSED(self), PyObject *dict)
     PyConfig config;
     PyConfig_InitIsolatedConfig(&config);
     if (_PyConfig_FromDict(&config, dict) < 0) {
-        PyConfig_Clear(&config);
-        return NULL;
+        goto error;
     }
     if (_PyInterpreterState_SetConfig(&config) < 0) {
-        return NULL;
+        goto error;
     }
     PyConfig_Clear(&config);
     Py_RETURN_NONE;
+
+error:
+    PyConfig_Clear(&config);
+    return NULL;
 }
 
 

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1325,8 +1325,6 @@ _PyConfig_FromDict(PyConfig *config, PyObject *dict)
     GET_UINT(_init_main);
     GET_UINT(_isolated_interpreter);
 
-    assert(config_check_consistency(config));
-
 #undef CHECK_VALUE
 #undef GET_UINT
 #undef GET_WSTR

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2145,6 +2145,11 @@ config_read(PyConfig *config)
         config->configure_c_stdio = 1;
     }
 
+    // Only parse arguments once.
+    if (config->parse_argv == 1) {
+        config->parse_argv = 2;
+    }
+
     return _PyStatus_OK();
 }
 
@@ -2635,7 +2640,7 @@ core_read_precmdline(PyConfig *config, _PyPreCmdline *precmdline)
 {
     PyStatus status;
 
-    if (config->parse_argv) {
+    if (config->parse_argv == 1) {
         if (_PyWideStringList_Copy(&precmdline->argv, &config->argv) < 0) {
             return _PyStatus_NO_MEMORY();
         }
@@ -2713,7 +2718,7 @@ config_read_cmdline(PyConfig *config)
         }
     }
 
-    if (config->parse_argv) {
+    if (config->parse_argv == 1) {
         Py_ssize_t opt_index;
         status = config_parse_cmdline(config, &cmdline_warnoptions, &opt_index);
         if (_PyStatus_EXCEPTION(status)) {


### PR DESCRIPTION
The PyConfig_Read() function now only parses PyConfig.argv arguments
once: PyConfig.parse_argv is set to 2 after arguments are parsed.
Since Python arguments are strippped from PyConfig.argv, parsing
arguments twice would parse the application options as Python
options.

* Rework the PyConfig documentation.
* Fix _testinternalcapi.set_config() error handling.
* SetConfigTests no longer needs parse_argv=0 when restoring the old
  configuration.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42260](https://bugs.python.org/issue42260) -->
https://bugs.python.org/issue42260
<!-- /issue-number -->
