### PR TITLE
issue42271: Remove the 'error' and the 'BadZipfile' aliases

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     lzma = None
 
-__all__ = ["BadZipFile", "BadZipfile", "error",
+__all__ = ["BadZipFile",
            "ZIP_STORED", "ZIP_DEFLATED", "ZIP_BZIP2", "ZIP_LZMA",
            "is_zipfile", "ZipInfo", "ZipFile", "PyZipFile", "LargeZipFile",
            "Path"]
@@ -49,8 +49,6 @@ class LargeZipFile(Exception):
     Raised when writing a zipfile, the zipfile requires ZIP64 extensions
     and those extensions are disabled.
     """
-
-error = BadZipfile = BadZipFile      # Pre-3.2 compatibility names
 
 
 ZIP64_LIMIT = (1 << 31) - 1


### PR DESCRIPTION
Removed the long-forgotten aliases 'error' and 'BadZipfile' in 'zipfile.ZipFile' class which are just pre-3.2 compatibility names. Python 3.10 should finally remove these aliases.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
