### PR TITLE
bpo-42272: fix misleading warning filter message/module docs

### DIFF
--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -154,14 +154,19 @@ the disposition of the match.  Each entry is a tuple of the form (*action*,
   +---------------+----------------------------------------------+
 
 * *message* is a string containing a regular expression that the start of
-  the warning message must match.  The expression is compiled to always be
-  case-insensitive.
+  the warning message must match, case-insensitively.  In :option:`-W` and
+  :envvar:`PYTHONWARNINGS`, *message* is a literal string that the start of the
+  warning message must contain (case-insensitively), ignoring any whitespace at
+  the start or end of *message*.
 
 * *category* is a class (a subclass of :exc:`Warning`) of which the warning
   category must be a subclass in order to match.
 
-* *module* is a string containing a regular expression that the module name must
-  match.  The expression is compiled to be case-sensitive.
+* *module* is a string containing a regular expression that the start of the
+  fully-qualified module name must match, case-sensitively.  In :option:`-W` and
+  :envvar:`PYTHONWARNINGS`, *module* is a literal string that the
+  fully-qualified module name must be equal to (case-sensitively), ignoring any
+  whitespace at the start or end of *module*.
 
 * *lineno* is an integer that the line number where the warning occurred must
   match, or ``0`` to match all line numbers.

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -212,8 +212,7 @@ Some examples::
    error::ResourceWarning       # Treat ResourceWarning messages as errors
    default::DeprecationWarning  # Show DeprecationWarning messages
    ignore,default:::mymodule    # Only report warnings triggered by "mymodule"
-   error:::mymodule[.*]         # Convert warnings to errors in "mymodule"
-                                # and any subpackages of "mymodule"
+   error:::mymodule             # Convert warnings to errors in "mymodule"
 
 
 .. _default-warning-filter:

--- a/Misc/NEWS.d/next/Documentation/2022-05-26-11-33-23.gh-issue-86438.kEGGmK.rst
+++ b/Misc/NEWS.d/next/Documentation/2022-05-26-11-33-23.gh-issue-86438.kEGGmK.rst
@@ -1,0 +1,3 @@
+Clarify that :option:`-W` and :envvar:`PYTHONWARNINGS` are matched literally
+and case-insensitively, rather than as regular expressions, in
+:mod:`warnings`.


### PR DESCRIPTION
"The Warnings Filter" section of the warnings module documentation describes the message and module filters as "a string containing a regular expression".  While that is true when they are arguments to the filterwarnings function, it is not true when they appear in -W orPYTHONWARNINGS where they are matched literally (after stripping any starting/ending whitespace).  This PR updates the documentation to note when they are matched literally and clarifies that module matches the "fully-qualified module name", rather than "module name" which is ambiguous.

Additionally, the `error:::mymodule[.*]` example in the "Describing Warning Filters" section of the warnings module documentation does not behave as the comment describes.  Since the module portion of the filter string is interpreted literally, it would match a module with a fully-qualified name that is literally `mymodule[.*]`.  

Unfortunately, there is not a way to match '"module" and any subpackages of "mymodule"' as documented, since the module part of a filter string is matched literally.  Instead, this PR updates the filter and comment to match only "mymodule".

Thanks for considering,
Kevin

<!-- issue-number: [bpo-42272](https://bugs.python.org/issue42272) -->
https://bugs.python.org/issue42272
<!-- /issue-number -->
