### PR TITLE
bpo-42277: Use PEP 3149 version tagged .so files on Solaris

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-06-16-31-51.bpo-42277.JTYgod.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-06-16-31-51.bpo-42277.JTYgod.rst
@@ -1,0 +1,1 @@
+On Solaris, C extension file names are now ABI version tagged as per PEP 3149.

--- a/configure
+++ b/configure
@@ -15355,7 +15355,7 @@ fi
 
 
 case $ac_sys_system in
-    Linux*|GNU*|Darwin|VxWorks)
+    Linux*|GNU*|Darwin|VxWorks|SunOS)
 	EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX};;
     *)
 	EXT_SUFFIX=${SHLIB_SUFFIX};;

--- a/configure.ac
+++ b/configure.ac
@@ -4767,7 +4767,7 @@ fi
 
 AC_SUBST(EXT_SUFFIX)
 case $ac_sys_system in
-    Linux*|GNU*|Darwin|VxWorks)
+    Linux*|GNU*|Darwin|VxWorks|SunOS)
 	EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX};;
     *)
 	EXT_SUFFIX=${SHLIB_SUFFIX};;


### PR DESCRIPTION
Almost every Solaris distribution patches this in, hence making it official makes sense.

<!-- issue-number: [bpo-42277](https://bugs.python.org/issue42277) -->
https://bugs.python.org/issue42277
<!-- /issue-number -->
