### PR TITLE
bpo-42282: Fold constants inside named expressions

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-07-21-02-05.bpo-42282.M1W4Wj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-07-21-02-05.bpo-42282.M1W4Wj.rst
@@ -1,0 +1,3 @@
+Optimise constant subexpressions that appear as part of named expressions
+(previously the AST optimiser did not descend into named expressions).
+Patch by Nick Coghlan.

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -49,7 +49,7 @@ fold_unaryop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
                of !=. Detecting such cases doesn't seem worthwhile.
                Python uses </> for 'is subset'/'is superset' operations on sets.
                They don't satisfy not folding laws. */
-            int op = asdl_seq_GET(arg->v.Compare.ops, 0);
+            cmpop_ty op = asdl_seq_GET(arg->v.Compare.ops, 0);
             switch (op) {
             case Is:
                 op = IsNot;
@@ -62,6 +62,15 @@ fold_unaryop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
                 break;
             case NotIn:
                 op = In;
+                break;
+            // The remaining comparison operators can't be safely inverted
+            case Eq:
+            case NotEq:
+            case Lt:
+            case LtE:
+            case Gt:
+            case GtE:
+                op = 0; // The AST enums leave "0" free as an "unused" marker
                 break;
             // No default case, so the compiler will emit a warning if new
             // unary operators are added without being handled here

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -279,10 +279,8 @@ fold_binop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
     // operators are added without being handled here
     }
 
-    // If no new value was calculated, there's nothing to do
-    if (newval == NULL) {
-        return 1;
-    }
+    // Even if no new value was calculated, make_const may still
+    // need to clear an error (e.g. for division by zero)
 
     return make_const(node, newval, arena);
 }

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -7,6 +7,8 @@
 static int
 make_const(expr_ty node, PyObject *val, PyArena *arena)
 {
+    // Even if no new value was calculated, make_const may still
+    // need to clear an error (e.g. for division by zero)
     if (val == NULL) {
         if (PyErr_ExceptionMatches(PyExc_KeyboardInterrupt)) {
             return 0;
@@ -274,13 +276,10 @@ fold_binop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
         break;
     // No builtin constants implement the following operators
     case MatMult:
-        break;
+        return 1;
     // No default case, so the compiler will emit a warning if new binary
     // operators are added without being handled here
     }
-
-    // Even if no new value was calculated, make_const may still
-    // need to clear an error (e.g. for division by zero)
 
     return make_const(node, newval, arena);
 }

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -73,7 +73,7 @@ fold_unaryop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
                 op = 0; // The AST enums leave "0" free as an "unused" marker
                 break;
             // No default case, so the compiler will emit a warning if new
-            // unary operators are added without being handled here
+            // comparison operators are added without being handled here
             }
             if (op) {
                 asdl_seq_SET(arg->v.Compare.ops, 0, op);


### PR DESCRIPTION
* The AST optimiser wasn't descending into named expressions, so
  any constant subexpressions weren't being folded at compile time
* Remove "default:" clauses inside the AST optimiser code to reduce the
  risk of similar bugs passing unnoticed in future compiler changes


<!-- issue-number: [bpo-42282](https://bugs.python.org/issue42282) -->
https://bugs.python.org/issue42282
<!-- /issue-number -->
