### PR TITLE
bpo-41712 Vulnerable Regex Changed

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
@@ -1,5 +1,0 @@
-Using suggestion from bug tracker messages
-which should Fix the issue of vulnerable regex. ""can be exploited with the following string "1.1.1"+"1" * 5000 + "!" ""
-
-Test Result : Working as intended
-Sorry if this not much this is my first pr to big org.

--- a/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
@@ -1,4 +1,4 @@
-Using suggestion ""For example, you can modify the sub-pattern \w+\d+ to ([A-Za-z_]*\d)+"" and converted to ([A-za-z_]+\d+)
+Using suggestion ""For example, you can modify the sub-pattern \w+\d+ to ([A-Za-z_]*\d)+"" and converted to "([A-za-z_]+\d+)"
 which should Fix the issue of vulnerable regex. ""can be exploited with the following string "1.1.1"+"1" * 5000 + "!" ""
 
 Test Result : Working as intended

--- a/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
@@ -1,4 +1,4 @@
-Using suggestion ""For example, you can modify the sub-pattern \w+\d+ to ([A-Za-z_]*\d)+"" and converted to "([A-za-z_]+\d+)"
+Using suggestion from bug tracker messages
 which should Fix the issue of vulnerable regex. ""can be exploited with the following string "1.1.1"+"1" * 5000 + "!" ""
 
 Test Result : Working as intended

--- a/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-11-06-07-13-17.bpo-41712.NUnkyX.rst
@@ -1,0 +1,5 @@
+Using suggestion ""For example, you can modify the sub-pattern \w+\d+ to ([A-Za-z_]*\d)+"" and converted to ([A-za-z_]+\d+)
+which should Fix the issue of vulnerable regex. ""can be exploited with the following string "1.1.1"+"1" * 5000 + "!" ""
+
+Test Result : Working as intended
+Sorry if this not much this is my first pr to big org.

--- a/Misc/NEWS.d/next/Tools-Demos/2020-11-06-09-12-13.bpo-41712.WOEkdm.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-11-06-09-12-13.bpo-41712.WOEkdm.rst
@@ -1,0 +1,1 @@
+Using suggestion from bug tracker messages. Regex has been changed which should Fix the issue of vulnerable regex which can be exploited. Test Result is Working as intended

--- a/Misc/NEWS.d/next/Tools-Demos/2020-11-06-09-12-13.bpo-41712.WOEkdm.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-11-06-09-12-13.bpo-41712.WOEkdm.rst
@@ -1,1 +1,1 @@
-Using suggestion from bug tracker messages. Regex has been changed which should Fix the issue of vulnerable regex which can be exploited. Test Result is Working as intended
+A regex pattern in the purge script (which is only used internally for creating Windows installers) was vulnerable to regex denial of service.  The pattern was changed to fix this.

--- a/Misc/NEWS.d/next/Tools-Demos/2020-11-06-09-12-13.bpo-41712.WOEkdm.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-11-06-09-12-13.bpo-41712.WOEkdm.rst
@@ -1,1 +1,1 @@
-A regex pattern in the purge script (which is only used internally for creating Windows installers) was vulnerable to regex denial of service.  The pattern was changed to fix this.
+A regex pattern in the purge script (which is only used internally for creating Windows installers) was vulnerable to regex denial of service.The pattern was changed to fix this.

--- a/Tools/msi/purge.py
+++ b/Tools/msi/purge.py
@@ -12,7 +12,7 @@ import sys
 
 from urllib.request import *
 
-VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)([A-Za-z_]+\d+)$')
+VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)([A-Za-z_]+\d+)?$')
 
 try:
     m = VERSION_RE.match(sys.argv[1])

--- a/Tools/msi/purge.py
+++ b/Tools/msi/purge.py
@@ -12,7 +12,7 @@ import sys
 
 from urllib.request import *
 
-VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)(\w+\d+)?$')
+VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)(\w+)$')
 
 try:
     m = VERSION_RE.match(sys.argv[1])

--- a/Tools/msi/purge.py
+++ b/Tools/msi/purge.py
@@ -12,7 +12,7 @@ import sys
 
 from urllib.request import *
 
-VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)(\w+)$')
+VERSION_RE = re.compile(r'(\d+\.\d+\.\d+)([A-Za-z_]+\d+)$')
 
 try:
     m = VERSION_RE.match(sys.argv[1])


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
The regex is changed because /w contains extra special characters which maybe invalid hence is converted to [A-Za-z_].

<!-- issue-number: [bpo-41712](https://bugs.python.org/issue41712) -->
https://bugs.python.org/issue41712
<!-- /issue-number -->
