### PR TITLE
bpo-25821: Fix inaccuracy in threading.enumerate/is_alive documentation

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -98,9 +98,10 @@ This module defines the following functions:
 .. function:: enumerate()
 
    Return a list of all :class:`Thread` objects currently active.  The list
-   includes daemonic threads, dummy thread objects created by
-   :func:`current_thread`, and the main thread.  It excludes terminated threads
-   and threads that have not yet been started.
+   includes daemonic threads and dummy thread objects created by
+   :func:`current_thread`.  It excludes terminated threads and threads
+   that have not yet been started. However, the main thread is always part
+   of the result, even when terminated.
 
 
 .. function:: main_thread()

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -97,7 +97,7 @@ This module defines the following functions:
 
 .. function:: enumerate()
 
-   Return a list of all :class:`Thread` objects currently alive.  The list
+   Return a list of all :class:`Thread` objects currently active.  The list
    includes daemonic threads, dummy thread objects created by
    :func:`current_thread`, and the main thread.  It excludes terminated threads
    and threads that have not yet been started.

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -100,7 +100,7 @@ This module defines the following functions:
    Return a list of all :class:`Thread` objects currently active.  The list
    includes daemonic threads and dummy thread objects created by
    :func:`current_thread`.  It excludes terminated threads and threads
-   that have not yet been started. However, the main thread is always part
+   that have not yet been started.  However, the main thread is always part
    of the result, even when terminated.
 
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1109,7 +1109,7 @@ class Thread:
 
         This method returns True just before the run() method starts until just
         after the run() method terminates. The module function enumerate()
-        returns a list of all alive threads.
+        returns a list that contains all alive threads.
 
         """
         assert self._initialized, "Thread.__init__() not called"

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1108,8 +1108,8 @@ class Thread:
         """Return whether the thread is alive.
 
         This method returns True just before the run() method starts until just
-        after the run() method terminates. The module function enumerate()
-        returns a list that contains all alive threads.
+        after the run() method terminates. See also the module function
+        enumerate().
 
         """
         assert self._initialized, "Thread.__init__() not called"


### PR DESCRIPTION
enumerate() returns a list of all active thread objects, which contains all threads for which is_alive is true but may also contain threads (like the main thread) for which is_alive is False. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-25821](https://bugs.python.org/issue25821) -->
https://bugs.python.org/issue25821
<!-- /issue-number -->
