### PR TITLE
bpo-42278: Use tempfile.TemporaryDirectory rather than tempfile.mktemp in pydoc

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -65,7 +65,6 @@ import os
 import pkgutil
 import platform
 import re
-import subprocess
 import sys
 import sysconfig
 import time
@@ -1619,13 +1618,10 @@ def pipepager(text, cmd):
 def tempfilepager(text, cmd):
     """Page through text by invoking a program on a temporary file."""
     import tempfile
-    try:
-        with tempfile.NamedTemporaryFile('w', delete=False, errors='backslashreplace') as file:
-            file.write(text)
-            file.close()
-            subprocess.run([cmd, file.name])
-    finally:
-        os.unlink(file.name)
+    with tempfile.NamedTemporaryFile('w', errors='backslashreplace') as file:
+        file.write(text)
+        file.flush()
+        os.system(cmd + ' "' + file.name + '"')
 
 def _escape_stdout(text):
     # Escape non-encodable characters to avoid encoding errors later

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1620,7 +1620,10 @@ def tempfilepager(text, cmd):
     import tempfile
     with tempfile.TemporaryDirectory() as tempdir:
         filename = os.path.join(tempdir, 'pydoc.out')
-        with open(filename, 'w', errors='backslashreplace') as file:
+        with open(filename, 'w', errors='backslashreplace',
+                  encoding=os.device_encoding(0) if
+                  sys.platform == 'win32' else None
+                  ) as file:
             file.write(text)
         os.system(cmd + ' "' + filename + '"')
 

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1618,10 +1618,11 @@ def pipepager(text, cmd):
 def tempfilepager(text, cmd):
     """Page through text by invoking a program on a temporary file."""
     import tempfile
-    with tempfile.NamedTemporaryFile('w', errors='backslashreplace') as file:
-        file.write(text)
-        file.flush()
-        os.system(cmd + ' "' + file.name + '"')
+    with tempfile.TemporaryDirectory() as tempdir:
+        filename = os.path.join(tempdir, 'pydoc.out')
+        with open(filename, 'w', errors='backslashreplace') as file:
+            file.write(text)
+        os.system(cmd + ' "' + filename + '"')
 
 def _escape_stdout(text):
     # Escape non-encodable characters to avoid encoding errors later

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1620,7 +1620,7 @@ def tempfilepager(text, cmd):
     """Page through text by invoking a program on a temporary file."""
     import tempfile
     try:
-        with tempfile.NamedTemporaryFile('w', delete=False) as file:
+        with tempfile.NamedTemporaryFile('w', delete=False, errors='backslashreplace') as file:
             file.write(text)
             file.close()
             subprocess.run([cmd, file.name])

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -65,6 +65,7 @@ import os
 import pkgutil
 import platform
 import re
+import subprocess
 import sys
 import sysconfig
 import time
@@ -1618,13 +1619,13 @@ def pipepager(text, cmd):
 def tempfilepager(text, cmd):
     """Page through text by invoking a program on a temporary file."""
     import tempfile
-    filename = tempfile.mktemp()
-    with open(filename, 'w', errors='backslashreplace') as file:
-        file.write(text)
     try:
-        os.system(cmd + ' "' + filename + '"')
+        with tempfile.NamedTemporaryFile('w', delete=False) as file:
+            file.write(text)
+            file.close()
+            subprocess.run([cmd, file.name])
     finally:
-        os.unlink(filename)
+        os.unlink(file.name)
 
 def _escape_stdout(text):
     # Escape non-encodable characters to avoid encoding errors later

--- a/Misc/NEWS.d/next/Security/2021-08-29-12-39-44.bpo-42278.jvmQz_.rst
+++ b/Misc/NEWS.d/next/Security/2021-08-29-12-39-44.bpo-42278.jvmQz_.rst
@@ -1,0 +1,2 @@
+Replaced usage of :func:`tempfile.mktemp` with
+:class:`~tempfile.TemporaryDirectory` to avoid a potential race condition.


### PR DESCRIPTION
Also replaces a call to `os.system` with one to `subprocess.run`

I consider this a fairly trivial change so do not intend to write a blurb for it.

<!-- issue-number: [bpo-42278](https://bugs.python.org/issue42278) -->
https://bugs.python.org/issue42278
<!-- /issue-number -->
