### PR TITLE
Propose to add a funtion heapIndex

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -125,7 +125,7 @@ From all times, sorting has always been a Great Art! :-)
 """
 
 __all__ = ['heappush', 'heappop', 'heapify', 'heapreplace', 'merge',
-           'nlargest', 'nsmallest', 'heappushpop']
+           'nlargest', 'nsmallest', 'heappushpop', 'heapIndex']
 
 def heappush(heap, item):
     """Push item onto heap, maintaining the heap invariant."""
@@ -576,6 +576,49 @@ def nlargest(n, iterable, key=None):
     result.sort(reverse=True)
     return [elem for (k, order, elem) in result]
 
+def _heapIndexHelper(h, x, checkIdx):
+    """A helper function for heapIndex. Giving the heap h, 
+    an element to be found x and the index to start looking of this heap checkIdx,
+    return the index of the element if found, return -1 if element not found.
+
+    leverage the fact that some elements to be searched are in between 
+    h[checkIdx] and h[2checkIndx + 1] or h[2checkIndx + 1] and if not
+    they don't exist.
+    """
+    if h[checkIdx] == x: 
+        return checkIdx
+    ans = -1
+    if 2*checkIdx + 1 < len(h) and x >= h[2*checkIdx + 1]:    
+        ans = _heapIndexHelper(h, x, 2*checkIdx + 1)
+    if ans >= 0: return ans
+    if 2*checkIdx + 2 < len(h) and x >= h[2*checkIdx + 2]:
+        ans = _heapIndexHelper(h, x, 2*checkIdx + 2)
+    return ans
+
+def heapIndex(h, x):
+    """
+    Given a heap h and an element x, return the index of x in this heap.
+    Raise value error if this element does not exist in this heap. 
+    Expected time complexity Theta(lg(n)). 
+    
+    For this function helper is needed because ans will constantly be -1
+    during recursion. And you don't konw if this is finally -1 or in the
+    process still finding get some -1.
+    
+    Test case:
+    lst = [1, 3, 5, 9, 2, 4, 6, 8, 0]
+    heapify(lst)
+    print(lst)
+    for i in range(10):
+        try:
+            print(i, "found at:", heapIndex(lst, i))
+        except ValueError as e: print(e)
+    """
+    if len(h) == 0: return -1 # User may actually trying to check an empty heap.
+    ans = _heapIndexHelper(h, x, 0)
+    if ans != -1: return ans
+    raise ValueError("Element not found!")
+  
 # If available, use C implementation
 try:
     from _heapq import *


### PR DESCRIPTION
For a given element in a heap, we can leverage the fact that we can
    search this element quicker thinking of the property of a heap. Therefore
    out of h.index(x) that a list linear search uses, I propose to use a special
    written index method to look for an index of a heap element.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
