### PR TITLE
bpo-19561: Remove unnecessary gethostname() prototype for Solaris

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -111,11 +111,6 @@ Local naming conventions:
 #include "pycore_fileutils.h"     // _Py_set_inheritable()
 #include "pycore_moduleobject.h"  // _PyModule_GetState
 
-// gethostname() prototype missing from Solaris standard header files
-#ifdef __sun
-extern int gethostname(char *, int);
-#endif
-
 #ifdef _Py_MEMORY_SANITIZER
 #  include <sanitizer/msan_interface.h>
 #endif


### PR DESCRIPTION
This is no longer necessary because Solaris included `gethostname()` in its header files more than 15 years ago.


<!-- issue-number: [bpo-19561](https://bugs.python.org/issue19561) -->
https://bugs.python.org/issue19561
<!-- /issue-number -->
