### PR TITLE
bpo-41122: Check for required positional argument in singledispatchmethod invocation

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -911,6 +911,16 @@ class singledispatchmethod:
 
     def __get__(self, obj, cls=None):
         def _method(*args, **kwargs):
+            funcname = getattr(
+                self.func,
+                '__name__',
+                'singledispatchmethod'
+            )
+
+            if not args:
+                raise TypeError(f'{funcname!r} requires'
+                                ' at least 1 positional argument')
+
             method = self.dispatcher.dispatch(args[0].__class__)
             return method.__get__(obj, cls)(*args, **kwargs)
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2449,6 +2449,15 @@ class TestSingleDispatch(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, msg):
             f()
 
+        class _:
+            @functools.singledispatchmethod
+            def f(self, *args):
+                pass
+
+        msg = '\'f\' requires at least 1 positional argument'
+        with self.assertRaisesRegex(TypeError, msg):
+            _().f()
+
 
 class CachedCostItem:
     _cost = 1

--- a/Misc/NEWS.d/next/Library/2020-11-10-06-27-54.bpo-41122.dFW3eC.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-10-06-27-54.bpo-41122.dFW3eC.rst
@@ -1,0 +1,3 @@
+singledispatchmethod decorated methods now raise TypeError with an appropriate
+message when called without the required positional argument, previously a
+confusing IndexError was propagated to the user.


### PR DESCRIPTION
<!-- issue-number: [bpo-41122](https://bugs.python.org/issue41122) -->
https://bugs.python.org/issue41122
<!-- /issue-number -->
