### PR TITLE
bpo-41987: Fix unnecessary evaluation of return type forward declaratons in singledispatch.

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -856,9 +856,19 @@ def singledispatch(func):
                 )
             func = cls
 
+            # bpo-41987 seems to only affect 3.9+
+            from sys import version_info
+
+            if version_info >= (3, 9) and isinstance(ann.get("return", None), str):
+                _dummy = (lambda: None)
+                _dummy.__annotations__ = {**ann, "return": None}
+                hints = _dummy
+            else:
+                hints = func
+
             # only import typing if annotation parsing is necessary
             from typing import get_type_hints
-            argname, cls = next(iter(get_type_hints(func).items()))
+            argname, cls = next(iter(get_type_hints(hints).items()))
             if not isinstance(cls, type):
                 raise TypeError(
                     f"Invalid annotation for {argname!r}. "

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -856,10 +856,7 @@ def singledispatch(func):
                 )
             func = cls
 
-            # bpo-41987 seems to only affect 3.9+
-            from sys import version_info
-
-            if version_info >= (3, 9) and isinstance(ann.get("return", None), str):
+            if isinstance(ann.get("return", None), str):  # bpo-41987
                 _dummy = (lambda: None)
                 _dummy.__annotations__ = {**ann, "return": None}
                 hints = _dummy

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2441,6 +2441,20 @@ class TestSingleDispatch(unittest.TestCase):
             'typing.Iterable[str] is not a class.'
         ))
 
+    def test_ignore_return_type(self):
+        @functools.singledispatch
+        def _(_) -> "BlahBlah":
+            pass
+
+        class BlahBlah:
+            @functools.singledispatchmethod
+            def f(self, _):
+                pass
+
+            @f.register
+            def _(self, _: int) -> "BlahBlah":
+                return self
+
     def test_invalid_positional_argument(self):
         @functools.singledispatch
         def f(*args):

--- a/Misc/NEWS.d/next/Library/2020-11-10-08-00-24.bpo-41987.xFcjIB.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-10-08-00-24.bpo-41987.xFcjIB.rst
@@ -1,0 +1,2 @@
+Fixed a bug where `singledispatch` and `singledispatchmethod` would trigger
+evaluating forward declarations of the return type unnecessarily.


### PR DESCRIPTION
I know that interest was expressed in the bpo thread about finding the root cause of this issue sadly I have not been able to figure that out yet, instead I offer a patch :sweat_smile: 

<!-- issue-number: [bpo-41987](https://bugs.python.org/issue41987) -->
https://bugs.python.org/issue41987
<!-- /issue-number -->
