### PR TITLE
bpo-41229: Add a whatsnew entry about contextlib.aclosing

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -176,6 +176,13 @@ codecs
 Add a :func:`codecs.unregister` function to unregister a codec search function.
 (Contributed by Hai Shi in :issue:`41842`.)
 
+contextlib
+----------
+
+Add a :func:`contextlib.aclosing` context manager to safely close async generators
+and objects representing asynchronously released resources.
+(Contributed by Joongi Kim and John Belmonte in :issue:`41229`.)
+
 curses
 ------
 


### PR DESCRIPTION
This is a small follow-up PR to update the whatsnew document regarding the PR #21545.


<!-- issue-number: [bpo-41229](https://bugs.python.org/issue41229) -->
https://bugs.python.org/issue41229
<!-- /issue-number -->
