### PR TITLE
bpo-42308: Add `threading.__excepthook__`

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -73,7 +73,7 @@ This module defines the following functions:
 
 .. data:: __excepthook__
 
-   Holds the original value of :func:`excepthook`. It is saved so that the
+   Holds the original value of :func:`threading.excepthook`. It is saved so that the
    original value can be restored in case they happen to get replaced with
    broken or alternative objects.
 

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -71,6 +71,13 @@ This module defines the following functions:
 
    .. versionadded:: 3.8
 
+.. data:: __excepthook__
+
+   Holds the original value of :func:`excepthook`. It is saved so that the
+   original value can be restored in case they happen to get replaced with
+   broken or alternative objects.
+
+   .. versionadded:: 3.10
 
 .. function:: get_ident()
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -256,6 +256,11 @@ retrieve the functions set by :func:`threading.settrace` and
 :func:`threading.setprofile` respectively.
 (Contributed by Mario Corchero in :issue:`42251`.)
 
+Add :data:`threading.__excepthook__` to allow retrieving the original value
+of :func:`threading.excepthook` in case it is set to a broken or a different
+value.
+(Contributed by Mario Corchero in :issue:`42308`.)
+
 traceback
 ---------
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1200,6 +1200,9 @@ except ImportError:
         stderr.flush()
 
 
+__excepthook__ = excepthook
+
+
 def _make_invoke_excepthook():
     # Create a local namespace to ensure that variables remain alive
     # when _invoke_excepthook() is called, even if it is called late during

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1200,6 +1200,7 @@ except ImportError:
         stderr.flush()
 
 
+# Original value of threading.excepthook
 __excepthook__ = excepthook
 
 

--- a/Misc/NEWS.d/next/Library/2020-11-10-12-09-13.bpo-42308.yaJHH9.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-10-12-09-13.bpo-42308.yaJHH9.rst
@@ -1,0 +1,3 @@
+Add :data:`threading.__excepthook__` to allow retrieving the original value
+of :func:`threading.excepthook` in case it is set to a broken or a different
+value. Patch by Mario Corchero.


### PR DESCRIPTION
Add the new attribute to retrieve the original value of excephook in
case a broken or different value is set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42308](https://bugs.python.org/issue42308) -->
https://bugs.python.org/issue42308
<!-- /issue-number -->
