### PR TITLE
bpo-42307: No longer install python.o file

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1616,7 +1616,6 @@ libainstall:	@DEF_MAKE_RULE@ python-config
 		fi; \
 	fi
 	$(INSTALL_DATA) Modules/config.c $(DESTDIR)$(LIBPL)/config.c
-	$(INSTALL_DATA) Programs/python.o $(DESTDIR)$(LIBPL)/python.o
 	$(INSTALL_DATA) $(srcdir)/Modules/config.c.in $(DESTDIR)$(LIBPL)/config.c.in
 	$(INSTALL_DATA) Makefile $(DESTDIR)$(LIBPL)/Makefile
 	$(INSTALL_DATA) $(srcdir)/Modules/Setup $(DESTDIR)$(LIBPL)/Setup

--- a/Misc/NEWS.d/next/Build/2020-11-10-12-43-42.bpo-42307.er20_5.rst
+++ b/Misc/NEWS.d/next/Build/2020-11-10-12-43-42.bpo-42307.er20_5.rst
@@ -1,0 +1,2 @@
+The ``make install`` command no longer installs the ``python.o`` file. Patch
+by Victor Stinner.


### PR DESCRIPTION
The "make install" command no longer installs the python.o file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42307](https://bugs.python.org/issue42307) -->
https://bugs.python.org/issue42307
<!-- /issue-number -->
