### PR TITLE
[doc] Pin version for 3.9 what's new

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -2,7 +2,7 @@
   What's New In Python 3.9
 ****************************
 
-:Release: |release|
+:Release: 3.9.0
 :Date: |today|
 :Editor: Łukasz Langa
 


### PR DESCRIPTION
I'm not sure if this is an actual bug, but I noticed that at https://docs.python.org/3.10/whatsnew/3.9.html, the `Release:` is  `3.10.0a2`. This may confuse some people, so the version has been manually pinned to `3.9.0`.

This doesn't need a backport to 3.9, because `|version|` is 3.9.0 on that branch, as seen [here](https://docs.python.org/3/whatsnew/3.9.html).

Please skip news, as this is only a minor edit. I'll open an issue if people feel that this change is contentious.

CC @ambv 