### PR TITLE
bpo-42294: Grammar fixes in glossary strong/weak references

### DIFF
--- a/Doc/c-api/weakref.rst
+++ b/Doc/c-api/weakref.rst
@@ -59,7 +59,7 @@ as much as it can.
 
       This function returns a :term:`borrowed reference` to the referenced object.
       This means that you should always call :c:func:`Py_INCREF` on the object
-      except it cannot be destroyed before the last usage of the borrowed
+      except when it cannot be destroyed before the last usage of the borrowed
       reference.
 
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -159,14 +159,14 @@ Glossary
       :class:`str` objects.
 
    borrowed reference
-      In the Python's C API, a borrowed reference is a reference to an object.
+      In Python's C API, a borrowed reference is a reference to an object.
       It does not modify the object reference count. It becomes a dangling
       pointer if the object is destroyed. For example, a garbage collection can
       remove the last :term:`strong reference` to the object and so destroy it.
 
       Calling :c:func:`Py_INCREF` on the :term:`borrowed reference` is
       recommended to convert it to a :term:`strong reference` in-place, except
-      if the object cannot be destroyed before the last usage of the borrowed
+      when the object cannot be destroyed before the last usage of the borrowed
       reference. The :c:func:`Py_NewRef` function can be used to create a new
       :term:`strong reference`.
 
@@ -1113,9 +1113,9 @@ Glossary
       as :keyword:`if`, :keyword:`while` or :keyword:`for`.
 
    strong reference
-      In the Python's C API, a strong reference is a reference to an object
-      which increments object reference count when it is created and
-      decrements the object reference count when it is deleted.
+      In Python's C API, a strong reference is a reference to an object
+      which increments the object's reference count when it is created and
+      decrements the object's reference count when it is deleted.
 
       The :c:func:`Py_NewRef` function can be used to create a strong reference
       to an object. Usually, the :c:func:`Py_DECREF` function must be called on


### PR DESCRIPTION
Entries for strong/weak references were added to the glossary in 23c5f93. This just touches up some minor things.

CC: @vstinner

<!-- issue-number: [bpo-42294](https://bugs.python.org/issue42294) -->
https://bugs.python.org/issue42294
<!-- /issue-number -->
