### PR TITLE
[3.9] bpo-42314: Fix the documentation for venv --upgrade-deps (GH-22113) (GH-23232)

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -67,7 +67,7 @@ The command, if run with ``-h``, will show the available options::
     Once an environment has been created, you may wish to activate it, e.g. by
     sourcing an activate script in its bin directory.
 
-.. versionchanged:: 3.8
+.. versionchanged:: 3.9
    Add ``--upgrade-deps`` option to upgrade pip + setuptools to the latest on PyPI
 
 .. versionchanged:: 3.4


### PR DESCRIPTION
It was added in 3.9, not 3.8.


<!-- issue-number: [bpo-42314](https://bugs.python.org/issue42314) -->
https://bugs.python.org/issue42314
<!-- /issue-number -->
