### PR TITLE
bpo-1635741: Fix typo in PyModule_AddObjectRef() doc

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -424,7 +424,7 @@ New Features
   (Contributed by Alex Gaynor in :issue:`41784`.)
 
 * Added :c:func:`PyModule_AddObjectRef` function: similar to
-  :c:func:`PyModule_AddObjectRef` but don't steal a reference to the value on
+  :c:func:`PyModule_AddObject` but don't steal a reference to the value on
   success.
   (Contributed by Victor Stinner in :issue:`1635741`.)
 

--- a/Misc/NEWS.d/next/C API/2020-11-03-11-52-27.bpo-1635741.aDYJKB.rst
+++ b/Misc/NEWS.d/next/C API/2020-11-03-11-52-27.bpo-1635741.aDYJKB.rst
@@ -1,3 +1,3 @@
 Added :c:func:`PyModule_AddObjectRef` function: similar to
-:c:func:`PyModule_AddObjectRef` but don't steal a reference to the value on
+:c:func:`PyModule_AddObject` but don't steal a reference to the value on
 success. Patch by Victor Stinner.


### PR DESCRIPTION
It is similar to PyModule_AddObject(), not to itself.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
