### PR TITLE
bpo-42085: Fix memory leak introduced by GH-22780

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1628,6 +1628,7 @@ FutureIter_am_send(futureiterobject *it,
     it->future = NULL;
     res = _asyncio_Future_result_impl(fut);
     if (res != NULL) {
+        Py_DECREF(fut);
         *result = res;
         return PYGEN_RETURN;
     }


### PR DESCRIPTION
`./python -m test test_asyncgen -R 3:3 -m test.test_asyncgen.AsyncGenAsyncioTest.test_async_gen_asyncio_03` doesn't report about leaks now.

<!-- issue-number: [bpo-42085](https://bugs.python.org/issue42085) -->
https://bugs.python.org/issue42085
<!-- /issue-number -->
