### PR TITLE
bpo-42328: ttk fix handling of default states in style map

### DIFF
--- a/Lib/tkinter/test/test_ttk/test_functions.py
+++ b/Lib/tkinter/test/test_ttk/test_functions.py
@@ -348,6 +348,9 @@ class InternalFunctionsTest(unittest.TestCase):
 
         test_it(('a', 'b', 'c'), MockTclObj('val'), 'val', ('a', 'b', 'c'))
 
+        spec = (MockStateSpec('a'), '#fff', MockStateSpec(''), '#ccc')
+        self.assertEqual(ttk._list_from_statespec(spec),
+                         [('a', '#fff'), ('', '#ccc')])
 
     def test_list_from_layouttuple(self):
         tk = MockTkApp()

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -251,7 +251,7 @@ def _list_from_statespec(stuple):
         else: # this is a Tcl object
             val = str(val)
             if typename == 'StateSpec':
-                val = val.split()
+                val = val.split() if val else ''
             nval.append(val)
 
     it = iter(nval)

--- a/Misc/NEWS.d/next/Library/2020-11-12-01-08-18.bpo-42328.xs9QXy.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-12-01-08-18.bpo-42328.xs9QXy.rst
@@ -1,0 +1,2 @@
+Ammend the ttk._list_from_statespec function to correctly return the state
+specification for the ttk map when a default state is given.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42328](https://bugs.python.org/issue42328) -->
https://bugs.python.org/issue42328
<!-- /issue-number -->
