### PR TITLE
bpo-41832: Update PyType_Slot.pfunc description info in type.rst

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -266,4 +266,4 @@ The following functions and structs are used to create
       The desired value of the slot. In most cases, this is a pointer
       to a function.
 
-      May not be ``NULL``.
+      Slots other than ``Py_tp_doc`` may not be ``NULL``.

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -265,3 +265,5 @@ The following functions and structs are used to create
 
       The desired value of the slot. In most cases, this is a pointer
       to a function.
+
+      May not be ``NULL``.


### PR DESCRIPTION
Revert the PyType_Slot.pfunc description info which was deleted in https://github.com/python/cpython/pull/23123.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41832](https://bugs.python.org/issue41832) -->
https://bugs.python.org/issue41832
<!-- /issue-number -->
