### PR TITLE
bpo-42260: Initialize warnings and time early at startup

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -190,10 +190,14 @@ struct _is {
     struct _ceval_state ceval;
     struct _gc_runtime_state gc;
 
+    // sys.modules dictionary
     PyObject *modules;
     PyObject *modules_by_index;
+    // Dictionary of the sys module
     PyObject *sysdict;
+    // Dictionary of the builtins module
     PyObject *builtins;
+    // importlib module
     PyObject *importlib;
 
     /* Used in Modules/_threadmodule.c. */
@@ -218,7 +222,7 @@ struct _is {
 
     PyObject *builtins_copy;
     PyObject *import_func;
-    /* Initialized to PyEval_EvalFrameDefault(). */
+    // Initialized to _PyEval_EvalFrameDefault().
     _PyFrameEvalFunction eval_frame;
 
     Py_ssize_t co_extra_user_count;

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -48,7 +48,6 @@ extern int _PySys_UpdateConfig(PyThreadState *tstate);
 extern PyStatus _PyExc_Init(PyThreadState *tstate);
 extern PyStatus _PyErr_Init(void);
 extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);
-extern PyStatus _PyImportHooks_Init(PyThreadState *tstate);
 extern int _PyFloat_Init(void);
 extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 

--- a/Include/internal/pycore_warnings.h
+++ b/Include/internal/pycore_warnings.h
@@ -17,7 +17,7 @@ struct _warnings_runtime_state {
     long filters_version;
 };
 
-extern PyStatus _PyWarnings_InitState(PyThreadState *tstate);
+extern int _PyWarnings_InitState(PyThreadState *tstate);
 
 #ifdef __cplusplus
 }

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -114,37 +114,34 @@ init_filters(void)
 }
 
 /* Initialize the given warnings module state. */
-static int
-warnings_init_state(WarningsState *st)
+int
+_PyWarnings_InitState(PyThreadState *tstate)
 {
+    WarningsState *st = &tstate->interp->warnings;
+
     if (st->filters == NULL) {
         st->filters = init_filters();
         if (st->filters == NULL) {
-            goto error;
+            return -1;
         }
     }
 
     if (st->once_registry == NULL) {
         st->once_registry = PyDict_New();
         if (st->once_registry == NULL) {
-            goto error;
+            return -1;
         }
     }
 
     if (st->default_action == NULL) {
         st->default_action = PyUnicode_FromString("default");
         if (st->default_action == NULL) {
-            goto error;
+            return -1;
         }
     }
 
     st->filters_version = 0;
-
     return 0;
-
-error:
-    warnings_clear_state(st);
-    return -1;
 }
 
 
@@ -1367,16 +1364,6 @@ static struct PyModuleDef warningsmodule = {
 };
 
 
-PyStatus
-_PyWarnings_InitState(PyThreadState *tstate)
-{
-    if (warnings_init_state(&tstate->interp->warnings) < 0) {
-        return _PyStatus_ERR("can't initialize warnings");
-    }
-    return _PyStatus_OK();
-}
-
-
 PyMODINIT_FUNC
 _PyWarnings_Init(void)
 {
@@ -1389,9 +1376,6 @@ _PyWarnings_Init(void)
 
     WarningsState *st = warnings_get_state();
     if (st == NULL) {
-        goto error;
-    }
-    if (warnings_init_state(st) < 0) {
         goto error;
     }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -52,43 +52,6 @@ module _imp
 /* Initialize things */
 
 PyStatus
-_PyImportHooks_Init(PyThreadState *tstate)
-{
-    PyObject *v, *path_hooks = NULL;
-    int err = 0;
-
-    /* adding sys.path_hooks and sys.path_importer_cache */
-    v = PyList_New(0);
-    if (v == NULL)
-        goto error;
-    err = PySys_SetObject("meta_path", v);
-    Py_DECREF(v);
-    if (err)
-        goto error;
-    v = PyDict_New();
-    if (v == NULL)
-        goto error;
-    err = PySys_SetObject("path_importer_cache", v);
-    Py_DECREF(v);
-    if (err)
-        goto error;
-    path_hooks = PyList_New(0);
-    if (path_hooks == NULL)
-        goto error;
-    err = PySys_SetObject("path_hooks", path_hooks);
-    if (err) {
-        goto error;
-    }
-    Py_DECREF(path_hooks);
-    return _PyStatus_OK();
-
-  error:
-    _PyErr_Print(tstate);
-    return _PyStatus_ERR("initializing sys.meta_path, sys.path_hooks, "
-                        "or path_importer_cache failed");
-}
-
-PyStatus
 _PyImportZip_Init(PyThreadState *tstate)
 {
     PyObject *path_hooks, *zipimport;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2841,6 +2841,11 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
         }
     }
 
+    /* adding sys.path_hooks and sys.path_importer_cache */
+    SET_SYS("meta_path", PyList_New(0));
+    SET_SYS("path_importer_cache", PyDict_New());
+    SET_SYS("path_hooks", PyList_New(0));
+
     if (_PyErr_Occurred(tstate)) {
         goto err_occurred;
     }


### PR DESCRIPTION
* Call _PyTime_Init() and _PyWarnings_InitState() earlier during the
  Python initialization.
* Inline _PyImportHooks_Init() into _PySys_InitCore().
* The _warnings initialization function no longer call
  _PyWarnings_InitState() to prevent resetting filters_version to 0.
* _PyWarnings_InitState() now returns an int and no longer clear the
  state in case of error (it's done anyway at Python exit).
* Rework init_importlib(), fix refleaks on errors.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42260](https://bugs.python.org/issue42260) -->
https://bugs.python.org/issue42260
<!-- /issue-number -->
