### PR TITLE
bpo-42340: Document issues around KeyboardInterrupt

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -212,6 +212,12 @@ The following exceptions are the exceptions that are usually raised.
    accidentally caught by code that catches :exc:`Exception` and thus prevent
    the interpreter from exiting.
 
+   .. note::
+
+      Because it can be raised at unpredictable points, a KeyboardInterrupt
+      may, in some circumstances, leave the running program in an inconsistent
+      state. See :ref:`handlers-and-exceptions`.
+
 
 .. exception:: MemoryError
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -215,7 +215,7 @@ The following exceptions are the exceptions that are usually raised.
    .. note::
 
       Catching a :exc:`KeyboardInterrupt` requires special consideration.
-      Because it can be raised at unpredictable points, it may may, in some
+      Because it can be raised at unpredictable points, it may, in some
       circumstances, leave the running program in an inconsistent state. It is
       generally best to allow :exc:`KeyboardInterrupt` to end the program as
       quickly as possible or avoid raising it entirely. (See

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -214,9 +214,12 @@ The following exceptions are the exceptions that are usually raised.
 
    .. note::
 
-      Because it can be raised at unpredictable points, a KeyboardInterrupt
-      may, in some circumstances, leave the running program in an inconsistent
-      state. See :ref:`handlers-and-exceptions`.
+      Catching a :exc:`KeyboardInterrupt` requires special consideration.
+      Because it can be raised at unpredictable points, it may may, in some
+      circumstances, leave the running program in an inconsistent state. It is
+      generally best to allow :exc:`KeyboardInterrupt` to end the program as
+      quickly as possible or avoid raising it entirely. (See
+      :ref:`handlers-and-exceptions`.)
 
 
 .. exception:: MemoryError

--- a/Misc/NEWS.d/next/Documentation/2020-11-12-21-26-31.bpo-42340.apumUL.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-11-12-21-26-31.bpo-42340.apumUL.rst
@@ -1,0 +1,3 @@
+Document that in some circumstances :exc:`KeyboardInterrupt` may cause the
+code to enter an inconsistent state. Provided a sample workaround to avoid
+it if needed.


### PR DESCRIPTION
Update documentation to note that in some circumstances,
KeyboardInterrupt may cause code to enter an inconsistent state. Also
document sample workaround to avoid KeyboardInterrupt, if needed.

<!-- issue-number: [bpo-42340](https://bugs.python.org/issue42340) -->
https://bugs.python.org/issue42340
<!-- /issue-number -->
