### PR TITLE
bpo-42246: Fix memory leak in compiler

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5533,18 +5533,24 @@ assemble_init(struct assembler *a, int nblocks, int firstlineno)
 {
     memset(a, 0, sizeof(struct assembler));
     a->a_prevlineno = a->a_lineno = firstlineno;
+    a->a_lnotab = NULL;
     a->a_bytecode = PyBytes_FromStringAndSize(NULL, DEFAULT_CODE_SIZE);
-    if (!a->a_bytecode)
-        return 0;
+    if (a->a_bytecode == NULL) {
+        goto error;
+    }
     a->a_lnotab = PyBytes_FromStringAndSize(NULL, DEFAULT_LNOTAB_SIZE);
-    if (!a->a_lnotab)
-        return 0;
+    if (a->a_lnotab == NULL) {
+        goto error;
+    }
     if ((size_t)nblocks > SIZE_MAX / sizeof(basicblock *)) {
         PyErr_NoMemory();
-        return 0;
+        goto error;
     }
-
     return 1;
+error:
+    Py_XDECREF(a->a_bytecode);
+    Py_XDECREF(a->a_lnotab);
+    return 0;
 }
 
 static void

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2276,7 +2276,7 @@ compiler_function(struct compiler *c, stmt_ty s, int is_async)
     c->u->u_posonlyargcount = asdl_seq_LEN(args->posonlyargs);
     c->u->u_kwonlyargcount = asdl_seq_LEN(args->kwonlyargs);
     for (i = docstring ? 1 : 0; i < asdl_seq_LEN(body); i++) {
-        VISIT(c, stmt, (stmt_ty)asdl_seq_GET(body, i));
+        VISIT_IN_SCOPE(c, stmt, (stmt_ty)asdl_seq_GET(body, i));
     }
     co = assemble(c, 1);
     qualname = c->u->u_qualname;


### PR DESCRIPTION
The actual memory leak fix is the change on line 2279.

It looks like `assemble_init` could potentially leak as well, so I've fixed that as well.

<!-- issue-number: [bpo-42246](https://bugs.python.org/issue42246) -->
https://bugs.python.org/issue42246
<!-- /issue-number -->
