### PR TITLE
bpo-38823: Fix compiler warning in _ctypes on Windows

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5745,7 +5745,7 @@ _ctypes_add_types(PyObject *mod)
     TYPE_READY(&StructParam_Type);
 
 #ifdef MS_WIN32
-    TYPE_READY_BASE(&PyComError_Type, PyExc_Exception);
+    TYPE_READY_BASE(&PyComError_Type, (PyTypeObject*)PyExc_Exception);
 #endif
 
 #undef TYPE_READY


### PR DESCRIPTION
Explicitly cast PyExc_Exception to PyTypeObject* to fix the warning:

    modules\_ctypes\_ctypes.c(5748): warning C4133: '=':
    incompatible types - from 'PyObject *' to '_typeobject *'

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38823](https://bugs.python.org/issue38823) -->
https://bugs.python.org/issue38823
<!-- /issue-number -->
