### PR TITLE
[3.9] bpo-41617: Add _Py__has_builtin() macro (GH-23260)

### DIFF
--- a/Include/internal/pycore_byteswap.h
+++ b/Include/internal/pycore_byteswap.h
@@ -15,12 +15,9 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#if ((defined(__GNUC__) \
-      && ((__GNUC__ >= 5) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8))) \
-     || (defined(__clang__) \
-         && (__clang_major__ >= 4 \
-             || (__clang_major__ == 3 && __clang_minor__ >= 2))))
-   /* __builtin_bswap16() is available since GCC 4.8 and clang 3.2,
+#if defined(__GNUC__) \
+      && ((__GNUC__ >= 5) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8))
+   /* __builtin_bswap16() is available since GCC 4.8,
       __builtin_bswap32() is available since GCC 4.3,
       __builtin_bswap64() is available since GCC 4.3. */
 #  define _PY_HAVE_BUILTIN_BSWAP
@@ -34,7 +31,7 @@ extern "C" {
 static inline uint16_t
 _Py_bswap16(uint16_t word)
 {
-#ifdef _PY_HAVE_BUILTIN_BSWAP
+#if defined(_PY_HAVE_BUILTIN_BSWAP) || _Py__has_builtin(__builtin_bswap16)
     return __builtin_bswap16(word);
 #elif defined(_MSC_VER)
     Py_BUILD_ASSERT(sizeof(word) == sizeof(unsigned short));
@@ -49,7 +46,7 @@ _Py_bswap16(uint16_t word)
 static inline uint32_t
 _Py_bswap32(uint32_t word)
 {
-#ifdef _PY_HAVE_BUILTIN_BSWAP
+#if defined(_PY_HAVE_BUILTIN_BSWAP) || _Py__has_builtin(__builtin_bswap32)
     return __builtin_bswap32(word);
 #elif defined(_MSC_VER)
     Py_BUILD_ASSERT(sizeof(word) == sizeof(unsigned long));
@@ -66,7 +63,7 @@ _Py_bswap32(uint32_t word)
 static inline uint64_t
 _Py_bswap64(uint64_t word)
 {
-#ifdef _PY_HAVE_BUILTIN_BSWAP
+#if defined(_PY_HAVE_BUILTIN_BSWAP) || _Py__has_builtin(__builtin_bswap64)
     return __builtin_bswap64(word);
 #elif defined(_MSC_VER)
     return _byteswap_uint64(word);

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -863,4 +863,16 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #  define _Py_NO_RETURN
 #endif
 
+
+// Preprocessor check for a builtin preprocessor function. Always return 0
+// if __has_builtin() macro is not defined.
+//
+// __has_builtin() is available on clang and GCC 10.
+#ifdef __has_builtin
+#  define _Py__has_builtin(x) __has_builtin(x)
+#else
+#  define _Py__has_builtin(x) 0
+#endif
+
+
 #endif /* Py_PYPORT_H */

--- a/Misc/NEWS.d/next/Build/2020-11-13-15-04-53.bpo-41617.98_oaE.rst
+++ b/Misc/NEWS.d/next/Build/2020-11-13-15-04-53.bpo-41617.98_oaE.rst
@@ -1,0 +1,3 @@
+Fix building ``pycore_bitutils.h`` internal header on old clang version
+without ``__builtin_bswap16()`` (ex: Xcode 4.6.3 on Mac OS X 10.7). Patch by
+Joshua Root and Victor Stinner.


### PR DESCRIPTION
Fix building pycore_bitutils.h internal header on old clang version
without __builtin_bswap16() (ex: Xcode 4.6.3 on Mac OS X 10.7).

Add a new private _Py__has_builtin() macro to check for availability
of a preprocessor builtin function.

Co-Authored-By: Joshua Root <jmr@macports.org>

Co-authored-by: Joshua Root <jmr@macports.org>
(cherry picked from commit b3b98082c5431e77c64cab2c85525a804436b505)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41617](https://bugs.python.org/issue41617) -->
https://bugs.python.org/issue41617
<!-- /issue-number -->
