### PR TITLE
bpo-42344: Improve pseudo implementation for SimpleNamespace

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -409,10 +409,9 @@ Additional Utility Classes and Functions
                return "{}({})".format(type(self).__name__, ", ".join(items))
 
            def __eq__(self, other):
-               return (
-                   isinstance(self, SimpleNamespace) == isinstance(other, SimpleNamespace)
-                   and self.__dict__ == other.__dict__
-               )
+               if isinstance(other, SimpleNamespace):
+                  return self.__dict__ == other.__dict__
+               return NotImplemented
 
    ``SimpleNamespace`` may be useful as a replacement for ``class NS: pass``.
    However, for a structured record type use :func:`~collections.namedtuple`

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -409,7 +409,10 @@ Additional Utility Classes and Functions
                return "{}({})".format(type(self).__name__, ", ".join(items))
 
            def __eq__(self, other):
-               return self.__dict__ == other.__dict__ and type(self) == type(other)
+               return (
+                   isinstance(self, SimpleNamespace) == isinstance(other, SimpleNamespace)
+                   and self.__dict__ == other.__dict__
+               )
 
    ``SimpleNamespace`` may be useful as a replacement for ``class NS: pass``.
    However, for a structured record type use :func:`~collections.namedtuple`

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -409,7 +409,7 @@ Additional Utility Classes and Functions
                return "{}({})".format(type(self).__name__, ", ".join(items))
 
            def __eq__(self, other):
-               if isinstance(other, SimpleNamespace):
+               if isinstance(self, SimpleNamespace) and isinstance(other, SimpleNamespace):
                   return self.__dict__ == other.__dict__
                return NotImplemented
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -409,7 +409,7 @@ Additional Utility Classes and Functions
                return "{}({})".format(type(self).__name__, ", ".join(items))
 
            def __eq__(self, other):
-               return self.__dict__ == other.__dict__
+               return self.__dict__ == other.__dict__ and type(self) == type(other)
 
    ``SimpleNamespace`` may be useful as a replacement for ``class NS: pass``.
    However, for a structured record type use :func:`~collections.namedtuple`


### PR DESCRIPTION
Wheras `SimpleNamespace` is implemented in C, the documentation shows a
pseudo implementation in Python for easier understanding.

The magic method for the comparison did not take into account that the
actual C implementation also compares the types.

`__eq__` of the Python pseudo implementation now also compares the types.

<!-- issue-number: [bpo-42344](https://bugs.python.org/issue42344) -->
https://bugs.python.org/issue42344
<!-- /issue-number -->
