### PR TITLE
Clarify that Set._from_iterable is not required to be a classmethod.

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -287,7 +287,7 @@ Notes on using :class:`Set` and :class:`MutableSet` as a mixin:
    Since some set operations create new sets, the default mixin methods need
    a way to create new instances from an iterable. The class constructor is
    assumed to have a signature in the form ``ClassName(iterable)``.
-   That assumption is factored-out to an internal classmethod method called
+   That assumption is factored-out to an internal classmethod called
    :meth:`_from_iterable` which calls ``cls(iterable)`` to produce a new set.
    If the :class:`Set` mixin is being used in a class with a different
    constructor signature, you will need to override :meth:`_from_iterable`

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -287,11 +287,12 @@ Notes on using :class:`Set` and :class:`MutableSet` as a mixin:
    Since some set operations create new sets, the default mixin methods need
    a way to create new instances from an iterable. The class constructor is
    assumed to have a signature in the form ``ClassName(iterable)``.
-   That assumption is factored-out to an internal method called
+   That assumption is factored-out to an internal classmethod method called
    :meth:`_from_iterable` which calls ``cls(iterable)`` to produce a new set.
    If the :class:`Set` mixin is being used in a class with a different
    constructor signature, you will need to override :meth:`_from_iterable`
-   to construct new instances from an iterable argument.
+   with a classmethod or regular method that can construct new instances from
+   an iterable argument.
 
 (2)
    To override the comparisons (presumably for speed, as the

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -287,12 +287,11 @@ Notes on using :class:`Set` and :class:`MutableSet` as a mixin:
    Since some set operations create new sets, the default mixin methods need
    a way to create new instances from an iterable. The class constructor is
    assumed to have a signature in the form ``ClassName(iterable)``.
-   That assumption is factored-out to an internal classmethod called
+   That assumption is factored-out to an internal method called
    :meth:`_from_iterable` which calls ``cls(iterable)`` to produce a new set.
    If the :class:`Set` mixin is being used in a class with a different
    constructor signature, you will need to override :meth:`_from_iterable`
-   with a classmethod that can construct new instances from
-   an iterable argument.
+   to construct new instances from an iterable argument.
 
 (2)
    To override the comparisons (presumably for speed, as the

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1559,8 +1559,65 @@ class TestCollectionABCs(ABCTestCase):
         # coerce both to a real set then check equality
         self.assertSetEqual(set(s1), set(s2))
 
+    def test_Set_from_iterable(self):
+        """Verify _from_iterable overriden to an instance method works."""
+        class SetUsingInstanceFromIterable(MutableSet):
+            def __init__(self, values, created_by):
+                if not created_by:
+                    raise ValueError(f'created_by must be specified')
+                self.created_by = created_by
+                self._values = set(values)
+
+            def _from_iterable(self, values):
+                return type(self)(values, 'from_iterable')
+
+            def __contains__(self, value):
+                return value in self._values
+
+            def __iter__(self):
+                yield from self._values
+
+            def __len__(self):
+                return len(self._values)
+
+            def add(self, value):
+                self._values.add(value)
+
+            def discard(self, value):
+                self._values.discard(value)
+
+        impl = SetUsingInstanceFromIterable([1, 2, 3], 'test')
+
+        actual = impl - {1}
+        self.assertIsInstance(actual, SetUsingInstanceFromIterable)
+        self.assertEqual('from_iterable', actual.created_by)
+        self.assertEqual({2, 3}, actual)
+
+        actual = impl | {4}
+        self.assertIsInstance(actual, SetUsingInstanceFromIterable)
+        self.assertEqual('from_iterable', actual.created_by)
+        self.assertEqual({1, 2, 3, 4}, actual)
+
+        actual = impl & {2}
+        self.assertIsInstance(actual, SetUsingInstanceFromIterable)
+        self.assertEqual('from_iterable', actual.created_by)
+        self.assertEqual({2}, actual)
+
+        actual = impl ^ {3, 4}
+        self.assertIsInstance(actual, SetUsingInstanceFromIterable)
+        self.assertEqual('from_iterable', actual.created_by)
+        self.assertEqual({1, 2, 4}, actual)
+
+        # NOTE: ixor'ing with a list is important here: internally, __ixor__
+        # only calls _from_iterable if the other value isn't already a Set.
+        impl ^= [3, 4]
+        self.assertIsInstance(impl, SetUsingInstanceFromIterable)
+        self.assertEqual('test', impl.created_by)
+        self.assertEqual({1, 2, 4}, impl)
+
+
     def test_Set_interoperability_with_real_sets(self):
-        # Issue: 8743
+            # Issue: 8743
         class ListSet(Set):
             def __init__(self, elements=()):
                 self.data = []

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1615,9 +1615,8 @@ class TestCollectionABCs(ABCTestCase):
         self.assertEqual('test', impl.created_by)
         self.assertEqual({1, 2, 4}, impl)
 
-
     def test_Set_interoperability_with_real_sets(self):
-            # Issue: 8743
+        # Issue: 8743
         class ListSet(Set):
             def __init__(self, elements=()):
                 self.data = []


### PR DESCRIPTION
In the implementation, `_from_iterable` is only used via `self`, and
requiring `_from_iterable` to be a classmethod makes it of little
value to subclasses with different constructor signatures.
