### PR TITLE
bpo-42351: Avoid error when opening header with non-UTF8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ def is_macosx_sdk_path(path):
 
 def grep_headers_for(function, headers):
     for header in headers:
-        with open(header, 'r') as f:
+        with open(header, 'r', errors='surrogateescape') as f:
             if function in f.read():
                 return True
     return False


### PR DESCRIPTION
grep_headers_for() would error out when a header contained
text that cannot be interpreted as UTF-8.

<!-- issue-number: [bpo-42351](https://bugs.python.org/issue42351) -->
https://bugs.python.org/issue42351
<!-- /issue-number -->
