### PR TITLE
bpo-41100: Stripping '-arch arm64' didn't work after all

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -128,7 +128,7 @@ def _get_system_version_tuple():
                 _SYSTEM_VERSION_TUPLE = ()
 
     return _SYSTEM_VERSION_TUPLE
-   
+
 
 def _remove_original_values(_config_vars):
     """Remove original unmodified values for testing"""
@@ -357,7 +357,7 @@ def compiler_fixup(compiler_so, cc_args):
 
     elif not _supports_arm64_builds():
         # Look for "-arch arm64" and drop that
-        for idx in range(len(compiler_so)):
+        for idx in reversed(range(len(compiler_so))):
             if compiler_so[idx] == '-arch' and compiler_so[idx+1] == "arm64":
                 del compiler_so[idx:idx+2]
 


### PR DESCRIPTION
A last minute change to #22855 tried to remove all instances of "-arch arm64" instead of just the first one. That resulted in breaking that code :-(. This PR traverses the list in reverse order to avoid looking at items beyond the end of the list.

<!-- issue-number: [bpo-41100](https://bugs.python.org/issue41100) -->
https://bugs.python.org/issue41100
<!-- /issue-number -->
