### PR TITLE
bpo-37205: time.perf_counter() and time.monotonic() are system-wide

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -166,6 +166,9 @@ Functions
    Return the time of the specified clock *clk_id*.  Refer to
    :ref:`time-clock-id-constants` for a list of accepted values for *clk_id*.
 
+   Use :func:`clock_gettime_ns` to avoid the precision loss caused by the
+   :class:`float` type.
+
    .. availability:: Unix.
 
    .. versionadded:: 3.3
@@ -184,6 +187,9 @@ Functions
 
    Set the time of the specified clock *clk_id*.  Currently,
    :data:`CLOCK_REALTIME` is the only accepted value for *clk_id*.
+
+   Use :func:`clock_settime_ns` to avoid the precision loss caused by the
+   :class:`float` type.
 
    .. availability:: Unix.
 
@@ -273,9 +279,16 @@ Functions
    The reference point of the returned value is undefined, so that only the
    difference between the results of consecutive calls is valid.
 
+   Use :func:`monotonic_ns` to avoid the precision loss caused by the
+   :class:`float` type.
+
    .. versionadded:: 3.3
+
    .. versionchanged:: 3.5
       The function is now always available and always system-wide.
+
+   .. versionchanged:: 3.10
+      On macOS, the function is now system-wide.
 
 
 .. function:: monotonic_ns() -> int
@@ -295,7 +308,13 @@ Functions
    point of the returned value is undefined, so that only the difference between
    the results of consecutive calls is valid.
 
+   Use :func:`perf_counter_ns` to avoid the precision loss caused by the
+   :class:`float` type.
+
    .. versionadded:: 3.3
+
+   .. versionchanged:: 3.10
+      On Windows, the function is now system-wide.
 
 .. function:: perf_counter_ns() -> int
 
@@ -316,6 +335,9 @@ Functions
    sleep.  It is process-wide by definition.  The reference point of the
    returned value is undefined, so that only the difference between the results
    of consecutive calls is valid.
+
+   Use :func:`process_time_ns` to avoid the precision loss caused by the
+   :class:`float` type.
 
    .. versionadded:: 3.3
 
@@ -581,6 +603,17 @@ Functions
    :class:`struct_time` object is returned, from which the components
    of the calendar date may be accessed as attributes.
 
+   Use :func:`time_ns` to avoid the precision loss caused by the :class:`float`
+   type.
+
+
+.. function:: time_ns() -> int
+
+   Similar to :func:`~time.time` but returns time as an integer number of nanoseconds
+   since the epoch_.
+
+   .. versionadded:: 3.7
+
 
 .. function:: thread_time() -> float
 
@@ -595,6 +628,9 @@ Functions
    returned value is undefined, so that only the difference between the results
    of consecutive calls in the same thread is valid.
 
+   Use :func:`thread_time_ns` to avoid the precision loss caused by the
+   :class:`float` type.
+
    .. availability::  Windows, Linux, Unix systems supporting
       ``CLOCK_THREAD_CPUTIME_ID``.
 
@@ -607,13 +643,6 @@ Functions
 
    .. versionadded:: 3.7
 
-
-.. function:: time_ns() -> int
-
-   Similar to :func:`~time.time` but returns time as an integer number of nanoseconds
-   since the epoch_.
-
-   .. versionadded:: 3.7
 
 .. function:: tzset()
 

--- a/Misc/NEWS.d/next/Library/2020-11-14-14-34-32.bpo-37205.iDbHrw.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-14-14-34-32.bpo-37205.iDbHrw.rst
@@ -1,0 +1,5 @@
+:func:`time.perf_counter()` on Windows and :func:`time.monotonic()` on macOS
+are now system-wide. Previously, they used an offset computed at startup to
+reduce the precision loss caused by the float type. Use
+:func:`time.perf_counter_ns()` and :func:`time.monotonic_ns()` added in Python
+3.7 to avoid this precision loss.

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -6,7 +6,7 @@
 #if defined(__APPLE__)
 #include <mach/mach_time.h>   /* mach_absolute_time(), mach_timebase_info() */
 
-#if defined(__APPLE__) && defined(__has_builtin) 
+#if defined(__APPLE__) && defined(__has_builtin)
 #  if __has_builtin(__builtin_available)
 #    define HAVE_CLOCK_GETTIME_RUNTIME __builtin_available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 #  endif
@@ -730,7 +730,7 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
     }
 
 #ifdef HAVE_CLOCK_GETTIME_RUNTIME
-    } else { 
+    } else {
 #endif
 
 #endif
@@ -822,7 +822,6 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
 
 #elif defined(__APPLE__)
     static mach_timebase_info_data_t timebase;
-    static uint64_t t0 = 0;
     uint64_t ticks;
 
     if (timebase.denom == 0) {
@@ -859,8 +858,6 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
                             "mach_timebase_info is too large");
             return -1;
         }
-
-        t0 = mach_absolute_time();
     }
 
     if (info) {
@@ -871,9 +868,6 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
     }
 
     ticks = mach_absolute_time();
-    /* Use a "time zero" to reduce precision loss when converting time
-       to floatting point number, as in time.monotonic(). */
-    ticks -= t0;
     *tp = _PyTime_MulDiv(ticks,
                          (_PyTime_t)timebase.numer,
                          (_PyTime_t)timebase.denom);
@@ -960,7 +954,6 @@ static int
 win_perf_counter(_PyTime_t *tp, _Py_clock_info_t *info)
 {
     static LONGLONG frequency = 0;
-    static LONGLONG t0 = 0;
     LARGE_INTEGER now;
     LONGLONG ticksll;
     _PyTime_t ticks;
@@ -1000,7 +993,6 @@ win_perf_counter(_PyTime_t *tp, _Py_clock_info_t *info)
         }
 
         QueryPerformanceCounter(&now);
-        t0 = now.QuadPart;
     }
 
     if (info) {
@@ -1012,10 +1004,6 @@ win_perf_counter(_PyTime_t *tp, _Py_clock_info_t *info)
 
     QueryPerformanceCounter(&now);
     ticksll = now.QuadPart;
-
-    /* Use a "time zero" to reduce precision loss when converting time
-       to floatting point number, as in time.perf_counter(). */
-    ticksll -= t0;
 
     /* Make sure that casting LONGLONG to _PyTime_t cannot overflow,
        both types are signed */


### PR DESCRIPTION
time.perf_counter() on Windows and time.monotonic() on macOS are now
system-wide. Previously, they used an offset computed at startup to
reduce the precision loss caused by the float type. Use
time.perf_counter_ns() and time.monotonic_ns() added in Python 3.7 to
avoid this precision loss.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37205](https://bugs.python.org/issue37205) -->
https://bugs.python.org/issue37205
<!-- /issue-number -->
