### PR TITLE
bpo-42357: Fix wrong availability for signal.SIGCHLD

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -117,7 +117,7 @@ The variables defined in the :mod:`signal` module are:
 
    Child process stopped or terminated.
 
-   .. availability:: Windows.
+   .. availability:: Unix.
 
 .. data:: SIGCLD
 


### PR DESCRIPTION
I believe this is a mistake. SIGCHLD is only available on Unix systems, not Windows.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42357](https://bugs.python.org/issue42357) -->
https://bugs.python.org/issue42357
<!-- /issue-number -->
