### PR TITLE
gh-86542: New C-APIs to simplify module attribute declaration

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -571,6 +571,143 @@ state:
 
    .. versionadded:: 3.9
 
+.. c:function:: PyTypeeObject * PyModule_AddNewTypeFromSpec(PyObject *module, PyType_Spec *spec, PyObject *base)
+
+   Initialize a new type and add it to *module*.
+   The function is equivalent to :c:func:`PyType_FromModuleAndSpec` followed
+   by :c:func:`PyModule_AddType`. *base* must be either ``NULL``, a single
+   type object, or a tuple of types.
+   Return ``NULL`` on error; otherwise a borrowed reference to a
+   ``PyTypeObject *``, which can be assigned to a module state object.
+
+   .. versionadded:: 3.10
+
+.. c:function:: PyObject * PyModule_AddNewException(PyObject *module, const char *name, const char *doc, PyObject *base, PyObject *dict)
+
+   Create a new exception and add it to *module*.
+   The function is equivalent to :c:func:`PyErr_NewExceptionWithDoc` followed
+   by :c:func:`PyModule_AddObjectRef`. The name of the exception object is
+   taken from the last component of *name* after dot.
+   Return ``NULL`` on error; otherwise a borrowed reference to a
+   ``PyObject *``, which can be assigned to a module state object.
+
+   .. versionadded:: 3.10
+
+.. c:function:: int PyModule_AddConstants(PyObject *module, PyModuleConst_Def *def)
+
+   Initialize module constants from a PyModuleConst_Def array. The function
+   provides a convenient way to declare module-level constants.
+   Return ``-1`` on error, ``0`` on success.
+
+   Example::
+
+      static PyObject*
+      example_call(void *)
+      {
+          return PyBytes_FromString("23");
+      }
+
+      #define EXAMPLE_INT 23
+      #define EXAMPLE_STRING "world"
+
+      static PyModuleConst_Def example_constants[] = {
+          PyModuleConst_None("none_value"),
+          PyModuleConst_Long("integer", 42),
+          PyModuleConst_Bool("false_value", 0),
+          PyModuleConst_Bool("true_value", 1),
+      #ifdef Py_MATH_PI
+          PyModuleConst_Double("pi", Py_MATH_PI),
+      #endif
+          PyModuleConst_String("somestring", "Hello"),
+          PyModuleConst_Call("call", example_call),
+          PyModuleConst_LongMacro(EXAMPLE_INT),
+          PyModuleConst_StringMacro(EXAMPLE_STRING),
+          {NULL},
+      }
+
+      static int
+      example_init_constants(PyObject *module)
+      {
+          return PyModule_AddConstants(module, posix_constants);
+      }
+
+      static PyModuleDef_Slot example_slots[] = {
+          {Py_mod_exec, example_init_constants},
+          {0, NULL}
+      };
+
+
+.. c:type:: PyModuleConst_Def
+
+   The values for *type* and the definition of the *value* union are
+   internal implementation details. Use any of the ``PyModuleConst_`` macros
+   to define entries. The array must be terminated by an entry with name
+   set to ``NULL``.
+
+   .. c:member:: const char *name
+
+      Attribute name.
+
+   .. c:member:: int type
+
+      Attribute type.
+
+   .. c:member:: union value
+
+      Value of the module constant definition, whose meaning depends on
+      *type*.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_None(name)
+
+   Add an entry for None.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_Long(name, value)
+
+   Add an entry for an int constant.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_Bool(name, value)
+
+   Add an entry for a bool constant.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_Double(name, value)
+
+   Add an entry for a float constant.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_String(name, value)
+
+   Add an entry for a string constant.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_Call(name, c_function)
+
+   Add an entry for a constant as returned by *c_function*.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_LongMacro(macro)
+
+   Add an entry for an int constant. The name and the value are taken from
+   *macro*.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_StringMacro(macro)
+
+   Add an entry for a string constant. The name and the value are taken from
+   *macro*.
+
+   .. versionadded:: 3.10
 
 Module lookup
 ^^^^^^^^^^^^^

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -672,7 +672,7 @@ state:
 
    .. versionadded:: 3.10
 
-.. c:macro:: PyModuleConst_Long(name, value)
+.. c:macro:: PyModuleConst_ULong(name, value)
 
    Add an entry for an unsigned integer constant.
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -602,7 +602,7 @@ state:
    Example::
 
       static PyObject*
-      example_call(void *)
+      example_call(PyObject *module)
       {
           return PyBytes_FromString("23");
       }
@@ -613,6 +613,7 @@ state:
       static PyModuleConst_Def example_constants[] = {
           PyModuleConst_None("none_value"),
           PyModuleConst_Long("integer", 42),
+          PyModuleConst_ULong("unsigned", 42UL),
           PyModuleConst_Bool("false_value", 0),
           PyModuleConst_Bool("true_value", 1),
       #ifdef Py_MATH_PI
@@ -628,7 +629,7 @@ state:
       static int
       example_init_constants(PyObject *module)
       {
-          return PyModule_AddConstants(module, posix_constants);
+          return PyModule_AddConstants(module, example_constants);
       }
 
       static PyModuleDef_Slot example_slots[] = {
@@ -667,13 +668,19 @@ state:
 
 .. c:macro:: PyModuleConst_Long(name, value)
 
-   Add an entry for an int constant.
+   Add an entry for an integer constant.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: PyModuleConst_Long(name, value)
+
+   Add an entry for an unsigned integer constant.
 
    .. versionadded:: 3.10
 
 .. c:macro:: PyModuleConst_Bool(name, value)
 
-   Add an entry for a bool constant.
+   Add an entry for a bool constant. ``0`` is false, ``1`` is true.
 
    .. versionadded:: 3.10
 
@@ -689,9 +696,10 @@ state:
 
    .. versionadded:: 3.10
 
-.. c:macro:: PyModuleConst_Call(name, c_function)
+.. c:macro:: PyModuleConst_Call(name, func)
 
-   Add an entry for a constant as returned by *c_function*.
+   Add an entry for a constant as returned by callback with signature
+   ``PyObject* (*func)(PyObject *module)``.
 
    .. versionadded:: 3.10
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -577,8 +577,8 @@ state:
    The function is equivalent to :c:func:`PyType_FromModuleAndSpec` followed
    by :c:func:`PyModule_AddType`. *base* must be either ``NULL``, a single
    type object, or a tuple of types.
-   Return ``NULL`` on error; otherwise a borrowed reference to a
-   ``PyTypeObject *``, which can be assigned to a module state object.
+   Return ``NULL`` on error; otherwise a ``PyTypeObject *``, which can
+   be assigned to a module state object.
 
    .. versionadded:: 3.10
 
@@ -588,8 +588,8 @@ state:
    The function is equivalent to :c:func:`PyErr_NewExceptionWithDoc` followed
    by :c:func:`PyModule_AddObjectRef`. The name of the exception object is
    taken from the last component of *name* after dot.
-   Return ``NULL`` on error; otherwise a borrowed reference to a
-   ``PyObject *``, which can be assigned to a module state object.
+   Return ``NULL`` on error; otherwise ``PyObject *``, which can be assigned
+   to a module state object.
 
    .. versionadded:: 3.10
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -571,7 +571,7 @@ state:
 
    .. versionadded:: 3.9
 
-.. c:function:: PyTypeeObject * PyModule_AddNewTypeFromSpec(PyObject *module, PyType_Spec *spec, PyObject *base)
+.. c:function:: PyTypeObject * PyModule_AddNewTypeFromSpec(PyObject *module, PyType_Spec *spec, PyObject *base)
 
    Initialize a new type and add it to *module*.
    The function is equivalent to :c:func:`PyType_FromModuleAndSpec` followed
@@ -652,7 +652,7 @@ state:
 
       Attribute type.
 
-   .. c:member:: union value
+   .. c:member:: void *value
 
       Value of the module constant definition, whose meaning depends on
       *type*.

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -1325,6 +1325,10 @@ PyMethod_New:PyObject*:class:0:
 PyMethod_Self:PyObject*::0:
 PyMethod_Self:PyObject*:im:0:
 
+PyModule_AddConstants:int:::
+PyModule_AddConstants:PyObject*:module:0:
+PyModule_AddConstants:PyModuleConst_Def*:def::
+
 PyModule_AddFunctions:int:::
 PyModule_AddFunctions:PyObject*:module:0:
 PyModule_AddFunctions:PyMethodDef*:functions::
@@ -1342,6 +1346,18 @@ PyModule_AddObject:int:::
 PyModule_AddObject:PyObject*:module:0:
 PyModule_AddObject:const char*:name::
 PyModule_AddObject:PyObject*:value:+1:
+
+PyModule_AddNewException:PyObject*::+1:
+PyModule_AddNewException:PyObject*:module:0:
+PyModule_AddNewException:const char*:name::
+PyModule_AddNewException:const char*:doc::
+PyModule_AddNewException:PyObject*:base:0:
+PyModule_AddNewException:PyObject*:dict:0:
+
+PyModule_AddNewTypeFromSpec:PyObject*::+1:
+PyModule_AddNewTypeFromSpec:PyObject*:module:0:
+PyModule_AddNewTypeFromSpec:PyType_spec*:spec::
+PyModule_AddNewTypeFromSpec:PyObject*:base:0:
 
 PyModule_AddStringConstant:int:::
 PyModule_AddStringConstant:PyObject*:module:0:

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -154,6 +154,11 @@ PyAPI_FUNC(int) PyModule_AddType(PyObject *module, PyTypeObject *type);
 #define PyModule_AddIntMacro(m, c) PyModule_AddIntConstant(m, #c, c)
 #define PyModule_AddStringMacro(m, c) PyModule_AddStringConstant(m, #c, c)
 
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
+/* New in 3.9 */
+PyAPI_FUNC(int) PyModule_AddTypeFromSpec(PyObject *module, PyType_Spec *spec, PyObject *bases, PyTypeObject **rtype);
+#endif
+
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000
 /* New in 3.5 */
 PyAPI_FUNC(int) PyModule_SetDocString(PyObject *, const char *);

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -156,7 +156,11 @@ PyAPI_FUNC(int) PyModule_AddType(PyObject *module, PyTypeObject *type);
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
 /* New in 3.9 */
-PyAPI_FUNC(int) PyModule_AddTypeFromSpec(PyObject *module, PyType_Spec *spec, PyObject *bases, PyTypeObject **rtype);
+PyAPI_FUNC(PyTypeObject *) PyModule_AddNewTypeFromSpec(
+    PyObject *module, PyType_Spec *spec, PyObject *base);
+PyAPI_FUNC(PyObject *) PyModule_AddNewException(
+    PyObject *module, const char *name, const char *doc,
+    PyObject *base, PyObject *dict);
 #endif
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -75,40 +75,44 @@ typedef struct PyModuleDef_Slot{
 struct PyModuleConst_Def;
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
 /* New in 3.10 */
-enum PyModuleConst_type {
-    PyModuleConst_none_type = 1,
-    PyModuleConst_long_type = 2,
-    PyModuleConst_bool_type = 3,
-    PyModuleConst_double_type = 4,
-    PyModuleConst_string_type = 5,
-    PyModuleConst_call_type = 6,
+enum _PyModuleConst_type {
+    _PyModuleConst_none_type = 1,
+    _PyModuleConst_long_type = 2,
+    _PyModuleConst_ulong_type = 3,
+    _PyModuleConst_bool_type = 4,
+    _PyModuleConst_double_type = 5,
+    _PyModuleConst_string_type = 6,
+    _PyModuleConst_call_type = 7,
 };
 
 typedef struct PyModuleConst_Def {
     const char *name;
-    enum PyModuleConst_type type;
+    enum _PyModuleConst_type type;
     union {
         const char *m_str;
         long m_long;
+        unsigned long m_ulong;
         double m_double;
-        PyObject* (*m_call)(void);
+        PyObject* (*m_call)(PyObject *module);
     } value;
 } PyModuleConst_Def;
 
 PyAPI_FUNC(int) PyModule_AddConstants(PyObject *, PyModuleConst_Def *);
 
 #define PyModuleConst_None(name) \
-    {(name), PyModuleConst_none_type, {.m_long=0}}
+    {(name), _PyModuleConst_none_type, {.m_long=0}}
 #define PyModuleConst_Long(name, value) \
-    {(name), PyModuleConst_long_type, {.m_long=(value)}}
+    {(name), _PyModuleConst_long_type, {.m_long=(value)}}
+#define PyModuleConst_ULong(name, value) \
+    {(name), _PyModuleConst_ulong_type, {.m_ulong=(value)}}
 #define PyModuleConst_Bool(name, value) \
-    {(name), PyModuleConst_bool_type, {.m_long=(value)}}
+    {(name), _PyModuleConst_bool_type, {.m_long=(value)}}
 #define PyModuleConst_Double(name, value) \
-    {(name), PyModuleConst_double_type, {.m_double=(value)}}
+    {(name), _PyModuleConst_double_type, {.m_double=(value)}}
 #define PyModuleConst_String(name, value) \
-    {(name), PyModuleConst_string_type, {.m_string=(value)}}
+    {(name), _PyModuleConst_string_type, {.m_str=(value)}}
 #define PyModuleConst_Call(name, value) \
-    {(name), PyModuleConst_call_type, {.m_call=(value)}}
+    {(name), _PyModuleConst_call_type, {.m_call=(value)}}
 
 #define PyModuleConst_LongMacro(m) PyModuleConst_Long(#m, m)
 #define PyModuleConst_StringMacro(m) PyModuleConst_String(#m, m)

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -66,8 +66,12 @@ typedef struct PyModuleDef_Slot{
 #define Py_mod_create 1
 #define Py_mod_exec 2
 
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
+#define Py_mod_constants 3
+#endif
+
 #ifndef Py_LIMITED_API
-#define _Py_mod_LAST_SLOT 2
+#define _Py_mod_LAST_SLOT 3
 #endif
 
 #endif /* New in 3.5 */
@@ -125,7 +129,6 @@ typedef struct PyModuleDef{
   traverseproc m_traverse;
   inquiry m_clear;
   freefunc m_free;
-  struct PyModuleConst_Def* m_constants;
 } PyModuleDef;
 
 

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -66,12 +66,8 @@ typedef struct PyModuleDef_Slot{
 #define Py_mod_create 1
 #define Py_mod_exec 2
 
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
-#define Py_mod_constants 3
-#endif
-
 #ifndef Py_LIMITED_API
-#define _Py_mod_LAST_SLOT 3
+#define _Py_mod_LAST_SLOT 2
 #endif
 
 #endif /* New in 3.5 */
@@ -129,6 +125,7 @@ typedef struct PyModuleDef{
   traverseproc m_traverse;
   inquiry m_clear;
   freefunc m_free;
+  struct PyModuleConst_Def* m_constants;
 } PyModuleDef;
 
 

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -94,8 +94,6 @@ typedef struct PyModuleConstants_Def {
     } value;
 } PyModuleConstants_Def;
 
-PyAPI_FUNC(int) PyModule_AddConstants(PyObject *, PyModuleConstants_Def *);
-
 #define PyMC_None(name) {(name), Py_mc_none, {.m_long=0}}
 #define PyMC_Long(name, value) {(name), Py_mc_long, {.m_long=(value)}}
 #define PyMC_Bool(name, value) {(name), Py_mc_bool, {.m_long=(value)}}

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -72,6 +72,42 @@ typedef struct PyModuleDef_Slot{
 
 #endif /* New in 3.5 */
 
+struct PyModuleConstants_Def;
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
+/* New in 3.10 */
+#define Py_mc_none 1
+#define Py_mc_long 2
+#define Py_mc_bool 3
+#define Py_mc_double 4
+#define Py_mc_string 5
+#define Py_mc_call 6
+#define Py_mc_type 7
+
+typedef struct PyModuleConstants_Def {
+    const char *name;
+    int type;
+    union {
+        const char *m_str;
+        long m_long;
+        double m_double;
+        PyObject* (*m_call)(void);
+    } value;
+} PyModuleConstants_Def;
+
+PyAPI_FUNC(int) PyModule_AddConstants(PyObject *, PyModuleConstants_Def *);
+
+#define PyMC_None(name) {(name), Py_mc_none, {.m_long=0}}
+#define PyMC_Long(name, value) {(name), Py_mc_long, {.m_long=(value)}}
+#define PyMC_Bool(name, value) {(name), Py_mc_bool, {.m_long=(value)}}
+#define PyMC_Double(name, value) {(name), Py_mc_double, {.m_double=(value)}}
+#define PyMC_String(name, value) {(name), Py_mc_string, {.m_string=(value)}}
+#define PyMC_Call(name, value) {(name), Py_mc_call, {.m_call=(value)}}
+
+#define PyMC_LongMacro(m) PyMC_Long(#m, m)
+#define PyMC_StringMacro(m) PyMC_String(#m, m)
+
+#endif /* New in 3.10 */
+
 typedef struct PyModuleDef{
   PyModuleDef_Base m_base;
   const char* m_name;
@@ -82,6 +118,7 @@ typedef struct PyModuleDef{
   traverseproc m_traverse;
   inquiry m_clear;
   freefunc m_free;
+  struct PyModuleConstants_Def* m_constants;
 } PyModuleDef;
 
 

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -72,37 +72,46 @@ typedef struct PyModuleDef_Slot{
 
 #endif /* New in 3.5 */
 
-struct PyModuleConstants_Def;
+struct PyModuleConst_Def;
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
 /* New in 3.10 */
-#define Py_mc_none 1
-#define Py_mc_long 2
-#define Py_mc_bool 3
-#define Py_mc_double 4
-#define Py_mc_string 5
-#define Py_mc_call 6
-#define Py_mc_type 7
+enum PyModuleConst_type {
+    PyModuleConst_none_type = 1,
+    PyModuleConst_long_type = 2,
+    PyModuleConst_bool_type = 3,
+    PyModuleConst_double_type = 4,
+    PyModuleConst_string_type = 5,
+    PyModuleConst_call_type = 6,
+};
 
-typedef struct PyModuleConstants_Def {
+typedef struct PyModuleConst_Def {
     const char *name;
-    int type;
+    enum PyModuleConst_type type;
     union {
         const char *m_str;
         long m_long;
         double m_double;
         PyObject* (*m_call)(void);
     } value;
-} PyModuleConstants_Def;
+} PyModuleConst_Def;
 
-#define PyMC_None(name) {(name), Py_mc_none, {.m_long=0}}
-#define PyMC_Long(name, value) {(name), Py_mc_long, {.m_long=(value)}}
-#define PyMC_Bool(name, value) {(name), Py_mc_bool, {.m_long=(value)}}
-#define PyMC_Double(name, value) {(name), Py_mc_double, {.m_double=(value)}}
-#define PyMC_String(name, value) {(name), Py_mc_string, {.m_string=(value)}}
-#define PyMC_Call(name, value) {(name), Py_mc_call, {.m_call=(value)}}
+PyAPI_FUNC(int) PyModule_AddConstants(PyObject *, PyModuleConst_Def *);
 
-#define PyMC_LongMacro(m) PyMC_Long(#m, m)
-#define PyMC_StringMacro(m) PyMC_String(#m, m)
+#define PyModuleConst_None(name) \
+    {(name), PyModuleConst_none_type, {.m_long=0}}
+#define PyModuleConst_Long(name, value) \
+    {(name), PyModuleConst_long_type, {.m_long=(value)}}
+#define PyModuleConst_Bool(name, value) \
+    {(name), PyModuleConst_bool_type, {.m_long=(value)}}
+#define PyModuleConst_Double(name, value) \
+    {(name), PyModuleConst_double_type, {.m_double=(value)}}
+#define PyModuleConst_String(name, value) \
+    {(name), PyModuleConst_string_type, {.m_string=(value)}}
+#define PyModuleConst_Call(name, value) \
+    {(name), PyModuleConst_call_type, {.m_call=(value)}}
+
+#define PyModuleConst_LongMacro(m) PyModuleConst_Long(#m, m)
+#define PyModuleConst_StringMacro(m) PyModuleConst_String(#m, m)
 
 #endif /* New in 3.10 */
 
@@ -116,7 +125,7 @@ typedef struct PyModuleDef{
   traverseproc m_traverse;
   inquiry m_clear;
   freefunc m_free;
-  struct PyModuleConstants_Def* m_constants;
+  struct PyModuleConst_Def* m_constants;
 } PyModuleDef;
 
 

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -125,7 +125,6 @@ typedef struct PyModuleDef{
   traverseproc m_traverse;
   inquiry m_clear;
   freefunc m_free;
-  struct PyModuleConst_Def* m_constants;
 } PyModuleDef;
 
 

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -971,5 +971,19 @@ class Test_ModuleStateAccess(unittest.TestCase):
                     increment_count(1, 2, 3)
 
 
+class Test_PyModuleConst_Def(unittest.TestCase):
+    def test_constants(self):
+        self.assertIs(_testcapi.const_none, None)
+        self.assertEqual(_testcapi.const_int, 42)
+        self.assertEqual(_testcapi.const_uint, _testcapi.ULONG_MAX)
+        self.assertIs(_testcapi.const_true, True)
+        self.assertIs(_testcapi.const_false, False)
+        self.assertEqual(_testcapi.const_almost_tau, 6.2831)
+        self.assertEqual(_testcapi.const_str, "Hello")
+        self.assertEqual(_testcapi.const_call, b"23")
+        self.assertEqual(_testcapi.CONST_INT, 7)
+        self.assertEqual(_testcapi.CONST_STRING, "world")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/C API/2020-11-16-20-29-59.bpo-42376.vO9Tvu.rst
+++ b/Misc/NEWS.d/next/C API/2020-11-16-20-29-59.bpo-42376.vO9Tvu.rst
@@ -1,0 +1,3 @@
+Add new functions :c:func:`PyModule_AddConstants`,
+:c:func:`PyModule_AddNewTypeFromSpec`, :c:func:`PyModule_AddNewException` to
+simplify the declaration of attribute in modules.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -2023,8 +2023,11 @@ hashlib_free(void *m)
 static int
 hashlib_init_evptype(PyObject *module)
 {
-    return PyModule_AddTypeFromSpec(
-        module, &EVPtype_spec, NULL, &(get_hashlib_state(module)->EVPtype));
+    _hashlibstate *state = get_hashlib_state(module);
+
+    state->EVPtype = PyModule_AddNewTypeFromSpec(
+        module, &EVPtype_spec, NULL);
+    return state->EVPtype == NULL ? -1 : 0;
 }
 
 static int
@@ -2036,12 +2039,9 @@ hashlib_init_evpxoftype(PyObject *module)
     if (state->EVPtype == NULL) {
         return -1;
     }
-    bases = PyTuple_Pack(1, state->EVPtype);
-    if (bases == NULL) {
-        return -1;
-    }
-    return PyModule_AddTypeFromSpec(
-        module, &EVPXOFtype_spec, state->EVPtype, &(state->EVPXOFtype));
+    state->EVPXOFtype = PyModule_AddNewTypeFromSpec(
+        module, &EVPXOFtype_spec, (PyObject *)state->EVPtype);
+    return state->EVPXOFtype == NULL ? -1 : 0;
 #endif
     return 0;
 }
@@ -2049,8 +2049,11 @@ hashlib_init_evpxoftype(PyObject *module)
 static int
 hashlib_init_hmactype(PyObject *module)
 {
-    return PyModule_AddTypeFromSpec(
-        module, &HMACtype_spec, NULL, &(get_hashlib_state(module)->HMACtype));
+     _hashlibstate *state = get_hashlib_state(module);
+
+    state->HMACtype = PyModule_AddNewTypeFromSpec(
+        module, &HMACtype_spec, NULL);
+    return state->HMACtype == NULL ? -1 : 0;
 }
 
 static int

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -2023,16 +2023,8 @@ hashlib_free(void *m)
 static int
 hashlib_init_evptype(PyObject *module)
 {
-    _hashlibstate *state = get_hashlib_state(module);
-
-    state->EVPtype = (PyTypeObject *)PyType_FromSpec(&EVPtype_spec);
-    if (state->EVPtype == NULL) {
-        return -1;
-    }
-    if (PyModule_AddType(module, state->EVPtype) < 0) {
-        return -1;
-    }
-    return 0;
+    return PyModule_AddTypeFromSpec(
+        module, &EVPtype_spec, NULL, &(get_hashlib_state(module)->EVPtype));
 }
 
 static int
@@ -2044,16 +2036,12 @@ hashlib_init_evpxoftype(PyObject *module)
     if (state->EVPtype == NULL) {
         return -1;
     }
-
-    state->EVPXOFtype = (PyTypeObject *)PyType_FromSpecWithBases(
-        &EVPXOFtype_spec, (PyObject *)state->EVPtype
-    );
-    if (state->EVPXOFtype == NULL) {
+    bases = PyTuple_Pack(1, state->EVPtype);
+    if (bases == NULL) {
         return -1;
     }
-    if (PyModule_AddType(module, state->EVPXOFtype) < 0) {
-        return -1;
-    }
+    return PyModule_AddTypeFromSpec(
+        module, &EVPXOFtype_spec, state->EVPtype, &(state->EVPXOFtype));
 #endif
     return 0;
 }
@@ -2061,16 +2049,8 @@ hashlib_init_evpxoftype(PyObject *module)
 static int
 hashlib_init_hmactype(PyObject *module)
 {
-    _hashlibstate *state = get_hashlib_state(module);
-
-    state->HMACtype = (PyTypeObject *)PyType_FromSpec(&HMACtype_spec);
-    if (state->HMACtype == NULL) {
-        return -1;
-    }
-    if (PyModule_AddType(module, state->HMACtype) < 0) {
-        return -1;
-    }
-    return 0;
+    return PyModule_AddTypeFromSpec(
+        module, &HMACtype_spec, NULL, &(get_hashlib_state(module)->HMACtype));
 }
 
 static int

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5459,37 +5459,28 @@ static PyMethodDef PySSL_methods[] = {
 static int
 sslmodule_init_types(PyObject *module)
 {
-    PySSLContext_Type = (PyTypeObject *)PyType_FromModuleAndSpec(
+    PySSLContext_Type = PyModule_AddNewTypeFromSpec(
         module, &PySSLContext_spec, NULL
     );
     if (PySSLContext_Type == NULL)
         return -1;
 
-    PySSLSocket_Type = (PyTypeObject *)PyType_FromModuleAndSpec(
+    PySSLSocket_Type = PyModule_AddNewTypeFromSpec(
         module, &PySSLSocket_spec, NULL
     );
     if (PySSLSocket_Type == NULL)
         return -1;
 
-    PySSLMemoryBIO_Type = (PyTypeObject *)PyType_FromModuleAndSpec(
+    PySSLMemoryBIO_Type = PyModule_AddNewTypeFromSpec(
         module, &PySSLMemoryBIO_spec, NULL
     );
     if (PySSLMemoryBIO_Type == NULL)
         return -1;
 
-    PySSLSession_Type = (PyTypeObject *)PyType_FromModuleAndSpec(
+    PySSLSession_Type = PyModule_AddNewTypeFromSpec(
         module, &PySSLSession_spec, NULL
     );
     if (PySSLSession_Type == NULL)
-        return -1;
-
-    if (PyModule_AddType(module, PySSLContext_Type))
-        return -1;
-    if (PyModule_AddType(module, PySSLSocket_Type))
-        return -1;
-    if (PyModule_AddType(module, PySSLMemoryBIO_Type))
-        return -1;
-    if (PyModule_AddType(module, PySSLSession_Type))
         return -1;
 
     return 0;

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -7010,6 +7010,29 @@ static PyTypeObject ContainerNoGC_type = {
     .tp_new = ContainerNoGC_new,
 };
 
+static PyObject *
+_testcapimodule_const_call(PyObject *module)
+{
+    return PyBytes_FromString("23");
+}
+
+#define CONST_INT 7
+#define CONST_STRING "world"
+
+static PyModuleConst_Def _testcapimodule_consts[] = {
+    PyModuleConst_None("const_none"),
+    PyModuleConst_Long("const_int", 42),
+    PyModuleConst_ULong("const_uint", ULONG_MAX),
+    PyModuleConst_Bool("const_false", 0),
+    PyModuleConst_Bool("const_true", 1),
+    PyModuleConst_Double("const_almost_tau", 6.2831),
+    PyModuleConst_String("const_str", "Hello"),
+    PyModuleConst_Call("const_call", _testcapimodule_const_call),
+    PyModuleConst_LongMacro(CONST_INT),
+    PyModuleConst_StringMacro(CONST_STRING),
+    {NULL},
+};
+
 
 static struct PyModuleDef _testcapimodule = {
     PyModuleDef_HEAD_INIT,
@@ -7034,6 +7057,11 @@ PyInit__testcapi(void)
     m = PyModule_Create(&_testcapimodule);
     if (m == NULL)
         return NULL;
+
+    if (PyModule_AddConstants(m, _testcapimodule_consts) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
 
     Py_SET_TYPE(&_HashInheritanceTester_Type, &PyType_Type);
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3583,14 +3583,14 @@ static PyMethodDef math_methods[] = {
     {NULL,              NULL}           /* sentinel */
 };
 
-static PyModuleConstants_Def math_constants[] = {
-    PyMC_Double("pi", Py_MATH_PI),
-    PyMC_Double("e", Py_MATH_E),
+static PyModuleConst_Def math_constants[] = {
+    PyModuleConst_Double("pi", Py_MATH_PI),
+    PyModuleConst_Double("e", Py_MATH_E),
     // 2pi
-    PyMC_Double("tau", Py_MATH_TAU),
-    PyMC_Call("inf", m_inf_o),
+    PyModuleConst_Double("tau", Py_MATH_TAU),
+    PyModuleConst_Call("inf", m_inf_o),
 #if !defined(PY_NO_SHORT_FLOAT_REPR) || defined(Py_NAN)
-    PyMC_Call("nan", m_nan_o),
+    PyModuleConst_Call("nan", m_nan_o),
 #endif
     {NULL, 0},
 };

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3595,6 +3595,17 @@ static PyModuleConst_Def math_constants[] = {
     {NULL, 0},
 };
 
+static int
+math_init_constants(PyObject *module)
+{
+    return PyModule_AddConstants(module, math_constants);
+}
+
+static PyModuleDef_Slot math_slots[] = {
+    {Py_mod_exec, math_init_constants},
+    {0, NULL}
+};
+
 PyDoc_STRVAR(module_doc,
 "This module provides access to the mathematical functions\n"
 "defined by the C standard.");
@@ -3605,7 +3616,7 @@ static struct PyModuleDef mathmodule = {
     .m_doc = module_doc,
     .m_size = 0,
     .m_methods = math_methods,
-    .m_constants = math_constants,
+    .m_slots = math_slots,
 };
 
 PyMODINIT_FUNC

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3599,18 +3599,13 @@ PyDoc_STRVAR(module_doc,
 "This module provides access to the mathematical functions\n"
 "defined by the C standard.");
 
-static PyModuleDef_Slot math_slots[] = {
-    {Py_mod_constants, math_constants},
-    {0, NULL}
-};
-
 static struct PyModuleDef mathmodule = {
     PyModuleDef_HEAD_INIT,
     .m_name = "math",
     .m_doc = module_doc,
     .m_size = 0,
     .m_methods = math_methods,
-    .m_slots = math_slots,
+    .m_constants = math_constants,
 };
 
 PyMODINIT_FUNC

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3599,13 +3599,18 @@ PyDoc_STRVAR(module_doc,
 "This module provides access to the mathematical functions\n"
 "defined by the C standard.");
 
+static PyModuleDef_Slot math_slots[] = {
+    {Py_mod_constants, math_constants},
+    {0, NULL}
+};
+
 static struct PyModuleDef mathmodule = {
     PyModuleDef_HEAD_INIT,
     .m_name = "math",
     .m_doc = module_doc,
     .m_size = 0,
     .m_methods = math_methods,
-    .m_constants = math_constants,
+    .m_slots = math_slots,
 };
 
 PyMODINIT_FUNC

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -271,7 +271,7 @@ m_inf(void)
 }
 
 static PyObject*
-m_inf_o(void)
+m_inf_o(PyObject *module)
 {
     return PyFloat_FromDouble(m_inf());
 }
@@ -292,7 +292,7 @@ m_nan(void)
 }
 
 static PyObject*
-m_nan_o(void)
+m_nan_o(PyObject *module)
 {
     return PyFloat_FromDouble(m_nan());
 }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15687,7 +15687,7 @@ posixmodule_exec(PyObject *m)
     return 0;
 }
 
-static PyModuleConst_Def _posix_constants[] = {
+static PyModuleConst_Def posix_constants[] = {
 #ifdef F_OK
     PyModuleConst_LongMacro(F_OK),
 #endif
@@ -15769,9 +15769,16 @@ static PyModuleConst_Def _posix_constants[] = {
     {NULL, 0},
 };
 
+static int
+posixmodule_init_constants(PyObject *module)
+{
+    return PyModule_AddConstants(module, posix_constants);
+}
+
 
 static PyModuleDef_Slot posixmodile_slots[] = {
     {Py_mod_exec, posixmodule_exec},
+    {Py_mod_exec, posixmodule_init_constants},
     {0, NULL}
 };
 
@@ -15785,7 +15792,6 @@ static struct PyModuleDef posixmodule = {
     .m_traverse = _posix_traverse,
     .m_clear = _posix_clear,
     .m_free = _posix_free,
-    .m_constants = _posix_constants,
 };
 
 PyMODINIT_FUNC

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15772,6 +15772,7 @@ static PyModuleConst_Def _posix_constants[] = {
 
 static PyModuleDef_Slot posixmodile_slots[] = {
     {Py_mod_exec, posixmodule_exec},
+    {Py_mod_constants, _posix_constants},
     {0, NULL}
 };
 
@@ -15785,7 +15786,6 @@ static struct PyModuleDef posixmodule = {
     .m_traverse = _posix_traverse,
     .m_clear = _posix_clear,
     .m_free = _posix_free,
-    .m_constants = _posix_constants,
 };
 
 PyMODINIT_FUNC

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -14834,84 +14834,6 @@ static PyMethodDef posix_methods[] = {
 static int
 all_ins(PyObject *m)
 {
-#ifdef F_OK
-    if (PyModule_AddIntMacro(m, F_OK)) return -1;
-#endif
-#ifdef R_OK
-    if (PyModule_AddIntMacro(m, R_OK)) return -1;
-#endif
-#ifdef W_OK
-    if (PyModule_AddIntMacro(m, W_OK)) return -1;
-#endif
-#ifdef X_OK
-    if (PyModule_AddIntMacro(m, X_OK)) return -1;
-#endif
-#ifdef NGROUPS_MAX
-    if (PyModule_AddIntMacro(m, NGROUPS_MAX)) return -1;
-#endif
-#ifdef TMP_MAX
-    if (PyModule_AddIntMacro(m, TMP_MAX)) return -1;
-#endif
-#ifdef WCONTINUED
-    if (PyModule_AddIntMacro(m, WCONTINUED)) return -1;
-#endif
-#ifdef WNOHANG
-    if (PyModule_AddIntMacro(m, WNOHANG)) return -1;
-#endif
-#ifdef WUNTRACED
-    if (PyModule_AddIntMacro(m, WUNTRACED)) return -1;
-#endif
-#ifdef O_RDONLY
-    if (PyModule_AddIntMacro(m, O_RDONLY)) return -1;
-#endif
-#ifdef O_WRONLY
-    if (PyModule_AddIntMacro(m, O_WRONLY)) return -1;
-#endif
-#ifdef O_RDWR
-    if (PyModule_AddIntMacro(m, O_RDWR)) return -1;
-#endif
-#ifdef O_NDELAY
-    if (PyModule_AddIntMacro(m, O_NDELAY)) return -1;
-#endif
-#ifdef O_NONBLOCK
-    if (PyModule_AddIntMacro(m, O_NONBLOCK)) return -1;
-#endif
-#ifdef O_APPEND
-    if (PyModule_AddIntMacro(m, O_APPEND)) return -1;
-#endif
-#ifdef O_DSYNC
-    if (PyModule_AddIntMacro(m, O_DSYNC)) return -1;
-#endif
-#ifdef O_RSYNC
-    if (PyModule_AddIntMacro(m, O_RSYNC)) return -1;
-#endif
-#ifdef O_SYNC
-    if (PyModule_AddIntMacro(m, O_SYNC)) return -1;
-#endif
-#ifdef O_NOCTTY
-    if (PyModule_AddIntMacro(m, O_NOCTTY)) return -1;
-#endif
-#ifdef O_CREAT
-    if (PyModule_AddIntMacro(m, O_CREAT)) return -1;
-#endif
-#ifdef O_EXCL
-    if (PyModule_AddIntMacro(m, O_EXCL)) return -1;
-#endif
-#ifdef O_TRUNC
-    if (PyModule_AddIntMacro(m, O_TRUNC)) return -1;
-#endif
-#ifdef O_BINARY
-    if (PyModule_AddIntMacro(m, O_BINARY)) return -1;
-#endif
-#ifdef O_TEXT
-    if (PyModule_AddIntMacro(m, O_TEXT)) return -1;
-#endif
-#ifdef O_XATTR
-    if (PyModule_AddIntMacro(m, O_XATTR)) return -1;
-#endif
-#ifdef O_LARGEFILE
-    if (PyModule_AddIntMacro(m, O_LARGEFILE)) return -1;
-#endif
 #ifndef __GNU__
 #ifdef O_SHLOCK
     if (PyModule_AddIntMacro(m, O_SHLOCK)) return -1;
@@ -15765,6 +15687,88 @@ posixmodule_exec(PyObject *m)
     return 0;
 }
 
+static PyModuleConstants_Def _posix_constants[] = {
+#ifdef F_OK
+    PyMC_LongMacro(F_OK),
+#endif
+#ifdef R_OK
+    PyMC_LongMacro(R_OK),
+#endif
+#ifdef W_OK
+    PyMC_LongMacro(W_OK),
+#endif
+#ifdef X_OK
+    PyMC_LongMacro(X_OK),
+#endif
+#ifdef NGROUPS_MAX
+    PyMC_LongMacro(NGROUPS_MAX),
+#endif
+#ifdef TMP_MAX
+    PyMC_LongMacro(TMP_MAX),
+#endif
+#ifdef WCONTINUED
+    PyMC_LongMacro(WCONTINUED),
+#endif
+#ifdef WNOHANG
+    PyMC_LongMacro(WNOHANG),
+#endif
+#ifdef WUNTRACED
+    PyMC_LongMacro(WUNTRACED),
+#endif
+#ifdef O_RDONLY
+    PyMC_LongMacro(O_RDONLY),
+#endif
+#ifdef O_WRONLY
+    PyMC_LongMacro(O_WRONLY),
+#endif
+#ifdef O_RDWR
+    PyMC_LongMacro(O_RDWR),
+#endif
+#ifdef O_NDELAY
+    PyMC_LongMacro(O_NDELAY),
+#endif
+#ifdef O_NONBLOCK
+    PyMC_LongMacro(O_NONBLOCK),
+#endif
+#ifdef O_APPEND
+    PyMC_LongMacro(O_APPEND),
+#endif
+#ifdef O_DSYNC
+    PyMC_LongMacro(O_DSYNC),
+#endif
+#ifdef O_RSYNC
+    PyMC_LongMacro(O_RSYNC),
+#endif
+#ifdef O_SYNC
+    PyMC_LongMacro(O_SYNC),
+#endif
+#ifdef O_NOCTTY
+    PyMC_LongMacro(O_NOCTTY),
+#endif
+#ifdef O_CREAT
+    PyMC_LongMacro(O_CREAT),
+#endif
+#ifdef O_EXCL
+    PyMC_LongMacro(O_EXCL),
+#endif
+#ifdef O_TRUNC
+    PyMC_LongMacro(O_TRUNC),
+#endif
+#ifdef O_BINARY
+    PyMC_LongMacro(O_BINARY),
+#endif
+#ifdef O_TEXT
+    PyMC_LongMacro(O_TEXT),
+#endif
+#ifdef O_XATTR
+    PyMC_LongMacro(O_XATTR),
+#endif
+#ifdef O_LARGEFILE
+    PyMC_LongMacro(O_LARGEFILE),
+#endif
+    {NULL, 0},
+};
+
 
 static PyModuleDef_Slot posixmodile_slots[] = {
     {Py_mod_exec, posixmodule_exec},
@@ -15781,6 +15785,7 @@ static struct PyModuleDef posixmodule = {
     .m_traverse = _posix_traverse,
     .m_clear = _posix_clear,
     .m_free = _posix_free,
+    .m_constants = _posix_constants,
 };
 
 PyMODINIT_FUNC

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15687,84 +15687,84 @@ posixmodule_exec(PyObject *m)
     return 0;
 }
 
-static PyModuleConstants_Def _posix_constants[] = {
+static PyModuleConst_Def _posix_constants[] = {
 #ifdef F_OK
-    PyMC_LongMacro(F_OK),
+    PyModuleConst_LongMacro(F_OK),
 #endif
 #ifdef R_OK
-    PyMC_LongMacro(R_OK),
+    PyModuleConst_LongMacro(R_OK),
 #endif
 #ifdef W_OK
-    PyMC_LongMacro(W_OK),
+    PyModuleConst_LongMacro(W_OK),
 #endif
 #ifdef X_OK
-    PyMC_LongMacro(X_OK),
+    PyModuleConst_LongMacro(X_OK),
 #endif
 #ifdef NGROUPS_MAX
-    PyMC_LongMacro(NGROUPS_MAX),
+    PyModuleConst_LongMacro(NGROUPS_MAX),
 #endif
 #ifdef TMP_MAX
-    PyMC_LongMacro(TMP_MAX),
+    PyModuleConst_LongMacro(TMP_MAX),
 #endif
 #ifdef WCONTINUED
-    PyMC_LongMacro(WCONTINUED),
+    PyModuleConst_LongMacro(WCONTINUED),
 #endif
 #ifdef WNOHANG
-    PyMC_LongMacro(WNOHANG),
+    PyModuleConst_LongMacro(WNOHANG),
 #endif
 #ifdef WUNTRACED
-    PyMC_LongMacro(WUNTRACED),
+    PyModuleConst_LongMacro(WUNTRACED),
 #endif
 #ifdef O_RDONLY
-    PyMC_LongMacro(O_RDONLY),
+    PyModuleConst_LongMacro(O_RDONLY),
 #endif
 #ifdef O_WRONLY
-    PyMC_LongMacro(O_WRONLY),
+    PyModuleConst_LongMacro(O_WRONLY),
 #endif
 #ifdef O_RDWR
-    PyMC_LongMacro(O_RDWR),
+    PyModuleConst_LongMacro(O_RDWR),
 #endif
 #ifdef O_NDELAY
-    PyMC_LongMacro(O_NDELAY),
+    PyModuleConst_LongMacro(O_NDELAY),
 #endif
 #ifdef O_NONBLOCK
-    PyMC_LongMacro(O_NONBLOCK),
+    PyModuleConst_LongMacro(O_NONBLOCK),
 #endif
 #ifdef O_APPEND
-    PyMC_LongMacro(O_APPEND),
+    PyModuleConst_LongMacro(O_APPEND),
 #endif
 #ifdef O_DSYNC
-    PyMC_LongMacro(O_DSYNC),
+    PyModuleConst_LongMacro(O_DSYNC),
 #endif
 #ifdef O_RSYNC
-    PyMC_LongMacro(O_RSYNC),
+    PyModuleConst_LongMacro(O_RSYNC),
 #endif
 #ifdef O_SYNC
-    PyMC_LongMacro(O_SYNC),
+    PyModuleConst_LongMacro(O_SYNC),
 #endif
 #ifdef O_NOCTTY
-    PyMC_LongMacro(O_NOCTTY),
+    PyModuleConst_LongMacro(O_NOCTTY),
 #endif
 #ifdef O_CREAT
-    PyMC_LongMacro(O_CREAT),
+    PyModuleConst_LongMacro(O_CREAT),
 #endif
 #ifdef O_EXCL
-    PyMC_LongMacro(O_EXCL),
+    PyModuleConst_LongMacro(O_EXCL),
 #endif
 #ifdef O_TRUNC
-    PyMC_LongMacro(O_TRUNC),
+    PyModuleConst_LongMacro(O_TRUNC),
 #endif
 #ifdef O_BINARY
-    PyMC_LongMacro(O_BINARY),
+    PyModuleConst_LongMacro(O_BINARY),
 #endif
 #ifdef O_TEXT
-    PyMC_LongMacro(O_TEXT),
+    PyModuleConst_LongMacro(O_TEXT),
 #endif
 #ifdef O_XATTR
-    PyMC_LongMacro(O_XATTR),
+    PyModuleConst_LongMacro(O_XATTR),
 #endif
 #ifdef O_LARGEFILE
-    PyMC_LongMacro(O_LARGEFILE),
+    PyModuleConst_LongMacro(O_LARGEFILE),
 #endif
     {NULL, 0},
 };

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15772,7 +15772,6 @@ static PyModuleConst_Def _posix_constants[] = {
 
 static PyModuleDef_Slot posixmodile_slots[] = {
     {Py_mod_exec, posixmodule_exec},
-    {Py_mod_constants, _posix_constants},
     {0, NULL}
 };
 
@@ -15786,6 +15785,7 @@ static struct PyModuleDef posixmodule = {
     .m_traverse = _posix_traverse,
     .m_clear = _posix_clear,
     .m_free = _posix_free,
+    .m_constants = _posix_constants,
 };
 
 PyMODINIT_FUNC

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -299,12 +299,6 @@ _PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
             return NULL;
         }
     }
-    if (module->m_constants != NULL) {
-        if (PyModule_AddConstants((PyObject *) m, module->m_constants) != 0) {
-            Py_DECREF(m);
-            return NULL;
-        }
-    }
     m->md_def = module;
     return (PyObject*)m;
 }
@@ -421,13 +415,6 @@ PyModule_FromDefAndSpec2(struct PyModuleDef* def, PyObject *spec, int module_api
         ret = PyModule_SetDocString(m, def->m_doc);
         if (ret != 0) {
             goto error;
-        }
-    }
-
-    if (def->m_constants != NULL) {
-        if (PyModule_AddConstants(m, def->m_constants) != 0) {
-            Py_DECREF(m);
-            return NULL;
         }
     }
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -299,12 +299,6 @@ _PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
             return NULL;
         }
     }
-    if (module->m_constants != NULL) {
-        if (PyModule_AddConstants((PyObject *) m, module->m_constants) != 0) {
-            Py_DECREF(m);
-            return NULL;
-        }
-    }
     m->md_def = module;
     return (PyObject*)m;
 }
@@ -424,13 +418,6 @@ PyModule_FromDefAndSpec2(struct PyModuleDef* def, PyObject *spec, int module_api
         }
     }
 
-    if (def->m_constants != NULL) {
-        if (PyModule_AddConstants(m, def->m_constants) != 0) {
-            Py_DECREF(m);
-            return NULL;
-        }
-    }
-
     Py_DECREF(nameobj);
     return m;
 
@@ -491,6 +478,12 @@ PyModule_ExecDef(PyObject *module, PyModuleDef *def)
                         PyExc_SystemError,
                         "execution of module %s raised unreported exception",
                         name);
+                    return -1;
+                }
+                break;
+            case Py_mod_constants:
+                ret = PyModule_AddConstants(module, (PyModuleConst_Def *)cur_slot->value);
+                if (ret == -1) {
                     return -1;
                 }
                 break;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -190,24 +190,27 @@ PyModule_AddConstants(PyObject *module, PyModuleConst_Def *def)
 
     for (cur_def = def; cur_def && cur_def->name; cur_def++) {
         switch(cur_def->type) {
-        case PyModuleConst_none_type:
+        case _PyModuleConst_none_type:
             v = Py_None;
             Py_INCREF(v);
             break;
-        case PyModuleConst_long_type:
+        case _PyModuleConst_long_type:
             v = PyLong_FromLong(cur_def->value.m_long);
             break;
-        case PyModuleConst_bool_type:
+        case _PyModuleConst_ulong_type:
+            v = PyLong_FromUnsignedLong(cur_def->value.m_ulong);
+            break;
+        case _PyModuleConst_bool_type:
             v = PyBool_FromLong(cur_def->value.m_long);
             break;
-        case PyModuleConst_double_type:
+        case _PyModuleConst_double_type:
             v = PyFloat_FromDouble(cur_def->value.m_double);
             break;
-        case PyModuleConst_string_type:
+        case _PyModuleConst_string_type:
             v =  PyUnicode_FromString(cur_def->value.m_str);
             break;
-        case PyModuleConst_call_type:
-            v = cur_def->value.m_call();
+        case _PyModuleConst_call_type:
+            v = cur_def->value.m_call(module);
             break;
         default:
             v = NULL;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -299,6 +299,12 @@ _PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
             return NULL;
         }
     }
+    if (module->m_constants != NULL) {
+        if (PyModule_AddConstants((PyObject *) m, module->m_constants) != 0) {
+            Py_DECREF(m);
+            return NULL;
+        }
+    }
     m->md_def = module;
     return (PyObject*)m;
 }
@@ -418,6 +424,13 @@ PyModule_FromDefAndSpec2(struct PyModuleDef* def, PyObject *spec, int module_api
         }
     }
 
+    if (def->m_constants != NULL) {
+        if (PyModule_AddConstants(m, def->m_constants) != 0) {
+            Py_DECREF(m);
+            return NULL;
+        }
+    }
+
     Py_DECREF(nameobj);
     return m;
 
@@ -478,12 +491,6 @@ PyModule_ExecDef(PyObject *module, PyModuleDef *def)
                         PyExc_SystemError,
                         "execution of module %s raised unreported exception",
                         name);
-                    return -1;
-                }
-                break;
-            case Py_mod_constants:
-                ret = PyModule_AddConstants(module, (PyModuleConst_Def *)cur_slot->value);
-                if (ret == -1) {
                     return -1;
                 }
                 break;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -175,11 +175,11 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
     return 0;
 }
 
-static int
-module_add_constants(PyObject *module, PyModuleConstants_Def *def)
+int
+PyModule_AddConstants(PyObject *module, PyModuleConst_Def *def)
 {
     PyObject *dict;
-    PyModuleConstants_Def *cur_def;
+    PyModuleConst_Def *cur_def;
     PyObject *v;
     int res;
 
@@ -190,23 +190,23 @@ module_add_constants(PyObject *module, PyModuleConstants_Def *def)
 
     for (cur_def = def; cur_def && cur_def->name; cur_def++) {
         switch(cur_def->type) {
-        case Py_mc_none:
+        case PyModuleConst_none_type:
             v = Py_None;
             Py_INCREF(v);
             break;
-        case Py_mc_long:
+        case PyModuleConst_long_type:
             v = PyLong_FromLong(cur_def->value.m_long);
             break;
-        case Py_mc_bool:
+        case PyModuleConst_bool_type:
             v = PyBool_FromLong(cur_def->value.m_long);
             break;
-        case Py_mc_double:
+        case PyModuleConst_double_type:
             v = PyFloat_FromDouble(cur_def->value.m_double);
             break;
-        case Py_mc_string:
+        case PyModuleConst_string_type:
             v =  PyUnicode_FromString(cur_def->value.m_str);
             break;
-        case Py_mc_call:
+        case PyModuleConst_call_type:
             v = cur_def->value.m_call();
             break;
         default:
@@ -300,7 +300,7 @@ _PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
         }
     }
     if (module->m_constants != NULL) {
-        if (module_add_constants((PyObject *) m, module->m_constants) != 0) {
+        if (PyModule_AddConstants((PyObject *) m, module->m_constants) != 0) {
             Py_DECREF(m);
             return NULL;
         }
@@ -425,7 +425,7 @@ PyModule_FromDefAndSpec2(struct PyModuleDef* def, PyObject *spec, int module_api
     }
 
     if (def->m_constants != NULL) {
-        if (module_add_constants((PyObject *) m, def->m_constants) != 0) {
+        if (PyModule_AddConstants(m, def->m_constants) != 0) {
             Py_DECREF(m);
             return NULL;
         }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -175,6 +175,60 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
     return 0;
 }
 
+static int
+module_add_constants(PyObject *module, PyModuleConstants_Def *def)
+{
+    PyObject *dict;
+    PyModuleConstants_Def *cur_def;
+    PyObject *v;
+    int res;
+
+    dict = PyModule_GetDict(module);
+    if (dict == NULL) {
+        return -1;
+    }
+
+    for (cur_def = def; cur_def && cur_def->name; cur_def++) {
+        switch(cur_def->type) {
+        case Py_mc_none:
+            v = Py_None;
+            Py_INCREF(v);
+            break;
+        case Py_mc_long:
+            v = PyLong_FromLong(cur_def->value.m_long);
+            break;
+        case Py_mc_bool:
+            v = PyBool_FromLong(cur_def->value.m_long);
+            break;
+        case Py_mc_double:
+            v = PyFloat_FromDouble(cur_def->value.m_double);
+            break;
+        case Py_mc_string:
+            v =  PyUnicode_FromString(cur_def->value.m_str);
+            break;
+        case Py_mc_call:
+            v = cur_def->value.m_call();
+            break;
+        default:
+            v = NULL;
+            PyErr_Format(PyExc_SystemError,
+                         "Invalid format for '%s'",
+                          cur_def->name);
+            break;
+        }
+        if (v == NULL) {
+            return -1;
+        }
+        res = PyDict_SetItemString(dict, cur_def->name, v);
+        Py_DECREF(v);
+        if (res < 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
@@ -246,7 +300,7 @@ _PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
         }
     }
     if (module->m_constants != NULL) {
-        if (PyModule_AddConstants((PyObject *) m, module->m_constants) != 0) {
+        if (module_add_constants((PyObject *) m, module->m_constants) != 0) {
             Py_DECREF(m);
             return NULL;
         }
@@ -371,7 +425,7 @@ PyModule_FromDefAndSpec2(struct PyModuleDef* def, PyObject *spec, int module_api
     }
 
     if (def->m_constants != NULL) {
-        if (PyModule_AddConstants((PyObject *) m, def->m_constants) != 0) {
+        if (module_add_constants((PyObject *) m, def->m_constants) != 0) {
             Py_DECREF(m);
             return NULL;
         }
@@ -448,60 +502,6 @@ PyModule_ExecDef(PyObject *module, PyModuleDef *def)
                 return -1;
         }
     }
-    return 0;
-}
-
-int
-PyModule_AddConstants(PyObject *module, PyModuleConstants_Def *def)
-{
-    PyObject *dict;
-    PyModuleConstants_Def *cur_def;
-    PyObject *v;
-    int res;
-
-    dict = PyModule_GetDict(module);
-    if (dict == NULL) {
-        return -1;
-    }
-
-    for (cur_def = def; cur_def && cur_def->name; cur_def++) {
-        switch(cur_def->type) {
-        case Py_mc_none:
-            v = Py_None;
-            Py_INCREF(v);
-            break;
-        case Py_mc_long:
-            v = PyLong_FromLong(cur_def->value.m_long);
-            break;
-        case Py_mc_bool:
-            v = PyBool_FromLong(cur_def->value.m_long);
-            break;
-        case Py_mc_double:
-            v = PyFloat_FromDouble(cur_def->value.m_double);
-            break;
-        case Py_mc_string:
-            v =  PyUnicode_FromString(cur_def->value.m_str);
-            break;
-        case Py_mc_call:
-            v = cur_def->value.m_call();
-            break;
-        default:
-            v = NULL;
-            PyErr_Format(PyExc_SystemError,
-                         "Invalid format for '%s'",
-                          cur_def->name);
-            break;
-        }
-        if (v == NULL) {
-            return -1;
-        }
-        res = PyDict_SetItemString(dict, cur_def->name, v);
-        Py_DECREF(v);
-        if (res < 0) {
-            return -1;
-        }
-    }
-
     return 0;
 }
 

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -712,3 +712,23 @@ PyModule_AddType(PyObject *module, PyTypeObject *type)
 
     return PyModule_AddObjectRef(module, name, (PyObject *)type);
 }
+
+int
+PyModule_AddTypeFromSpec(PyObject *module, PyType_Spec *spec, PyObject *bases, PyTypeObject **rtype)
+{
+    PyTypeObject *type;
+
+    type = (PyTypeObject *)PyType_FromModuleAndSpec(module, spec, bases);
+    /* steal ref to bases */
+    Py_XDECREF(bases);
+    if (type == NULL) {
+        return -1;
+    }
+    if (PyModule_AddType(module, type) < 0) {
+        return -1;
+    }
+    if (rtype != NULL) {
+        *rtype = type;
+    }
+    return 0;
+}

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -715,26 +715,11 @@ PyModule_AddType(PyObject *module, PyTypeObject *type)
 
 PyTypeObject *
 PyModule_AddNewTypeFromSpec(PyObject *module, PyType_Spec *spec,
-                            PyObject *base)
+                            PyObject *bases)
 {
     PyTypeObject *type;
-    PyObject *bases;
-
-    /* Support single, optional type like PyErr_NewException() */
-    if (base == NULL) {
-        bases = NULL;
-    }
-    else if (PyTuple_Check(base)) {
-        bases = base;
-        Py_INCREF(bases);
-    } else {
-        bases = PyTuple_Pack(1, base);
-        if (bases == NULL)
-            return NULL;
-    }
 
     type = (PyTypeObject *)PyType_FromModuleAndSpec(module, spec, bases);
-    Py_XDECREF(bases);
     if (type == NULL) {
         return NULL;
     }


### PR DESCRIPTION
- [ ] Check for reference leaks
- [ ] verify ``refcounts.dat``
- [x] add CAPI tests

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-42376](https://bugs.python.org/issue42376) -->
https://bugs.python.org/issue42376
<!-- /issue-number -->


<!-- gh-issue-number: gh-86542 -->
* Issue: gh-86542
<!-- /gh-issue-number -->
