### PR TITLE
bpo-42153 doc: library imaplib a URL not available

### DIFF
--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -174,10 +174,9 @@ example of usage.
 
 .. seealso::
 
-   Sourcecode Documents describing the protocol, and sources and binaries  for servers
-   implementing it, can all be found at the University of Washington's *IMAP
-   Information Center* (https://github.com/uw-imap/imap).
-
+   Source Code of Documents describing the protocol, sources and binaries for servers
+   implementing it, by the University of Washington's IMAP Information Center 
+   can all be found at (https://github.com/uw-imap/imap) (**Not Maintained**).
 
 .. _imap4-objects:
 

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -174,9 +174,9 @@ example of usage.
 
 .. seealso::
 
-   Documents describing the protocol, and sources and binaries  for servers
+   Sourcecode Documents describing the protocol, and sources and binaries  for servers
    implementing it, can all be found at the University of Washington's *IMAP
-   Information Center* **Source Code** (https://github.com/uw-imap/imap) (Not Maintained).
+   Information Center* (https://github.com/uw-imap/imap).
 
 
 .. _imap4-objects:

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -174,7 +174,7 @@ example of usage.
 
 .. seealso::
 
-   Source Code of Documents describing the protocol, sources and binaries for servers
+   Source Code of Documents describing the protocol, and sources and binaries  for servers
    implementing it, by the University of Washington's *IMAP Information Center* 
    can all be found at (https://github.com/uw-imap/imap) (**Not Maintained**).
 

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -174,9 +174,9 @@ example of usage.
 
 .. seealso::
 
-   Source Code of Documents describing the protocol, and sources and binaries  for servers
-   implementing it, by the University of Washington's *IMAP Information Center* 
-   can all be found at (https://github.com/uw-imap/imap) (**Not Maintained**).
+   Documents describing the protocol, and sources and binaries  for servers
+   implementing it, can all be found at the University of Washington's *IMAP
+   Information Center* **Source Code** (https://github.com/uw-imap/imap) (Not Maintained).
 
 
 .. _imap4-objects:

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -175,7 +175,7 @@ example of usage.
 .. seealso::
 
    Source Code of Documents describing the protocol, sources and binaries for servers
-   implementing it, by the University of Washington's IMAP Information Center 
+   implementing it, by the University of Washington's IMAP Information Center
    can all be found at (https://github.com/uw-imap/imap) (**Not Maintained**).
 
 .. _imap4-objects:

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -174,9 +174,9 @@ example of usage.
 
 .. seealso::
 
-   Documents describing the protocol, and sources and binaries  for servers
-   implementing it, can all be found at the University of Washington's *IMAP
-   Information Center* (https://www.washington.edu/imap/).
+   Source Code of Documents describing the protocol, sources and binaries for servers
+   implementing it, by the University of Washington's *IMAP Information Center* 
+   can all be found at (https://github.com/uw-imap/imap) (**Not Maintained**).
 
 
 .. _imap4-objects:

--- a/Misc/NEWS.d/next/Documentation/2020-11-15-08-19-45.bpo-42153.8cdZUD.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-11-15-08-19-45.bpo-42153.8cdZUD.rst
@@ -1,3 +1,3 @@
-The link provided by University of Washington's *IMAP Information Center is not Available (https://www.washington.edu/imap/)
+The link provided by University of Washington's IMAP Information Center is not Available (https://www.washington.edu/imap/)
 As the link is taken down It should be replaced by another link.
 It is replaced by the Link of Source Code provided by University of Washington's *IMAP Information Center on Github for the same URL (https://github.com/uw-imap/imap) (Not Currently Maintained)

--- a/Misc/NEWS.d/next/Documentation/2020-11-15-08-19-45.bpo-42153.8cdZUD.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-11-15-08-19-45.bpo-42153.8cdZUD.rst
@@ -1,0 +1,3 @@
+The link provided by University of Washington's *IMAP Information Center is not Available (https://www.washington.edu/imap/)
+As the link is taken down It should be replaced by another link.
+It is replaced by the Link of Source Code provided by University of Washington's *IMAP Information Center on Github for the same URL (https://github.com/uw-imap/imap) (Not Currently Maintained)

--- a/Misc/NEWS.d/next/Documentation/2020-11-15-08-19-45.bpo-42153.8cdZUD.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-11-15-08-19-45.bpo-42153.8cdZUD.rst
@@ -1,3 +1,3 @@
 The link provided by University of Washington's IMAP Information Center is not Available (https://www.washington.edu/imap/)
 As the link is taken down It should be replaced by another link.
-It is replaced by the Link of Source Code provided by University of Washington's *IMAP Information Center on Github for the same URL (https://github.com/uw-imap/imap) (Not Currently Maintained)
+It is replaced by the Link of Source Code provided by University of Washington's IMAP Information Center on Github for the same URL (https://github.com/uw-imap/imap) (Not Currently Maintained)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->(https://docs.python.org/3/library/imaplib.html#imap4-objects) in Documentation of imaplib under (See Also :)
The link provided by University of Washington's *IMAP Information Center is not Available (https://www.washington.edu/imap/)
As the link is taken down It should be replaced by another link.
It is replaced by the Link of Source Code provided by University of Washington's *IMAP Information Center on Github for the same URL (https://github.com/uw-imap/imap) (Not Currently Maintained)



<!-- issue-number: [bpo-42153](https://bugs.python.org/issue42153) -->
https://bugs.python.org/issue42153
<!-- /issue-number -->
