### PR TITLE
bpo-42345: Fix three issues with typing.Literal parameters

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -560,6 +560,9 @@ class LiteralTests(BaseTestCase):
             Literal[1][1]
 
     def test_equal(self):
+        self.assertNotEqual(Literal[0], Literal[False])
+        self.assertNotEqual(Literal[True], Literal[1])
+        self.assertNotEqual(Literal[1], Literal[2])
         self.assertNotEqual(Literal[1, True], Literal[1])
         self.assertEqual(Literal[1], Literal[1])
         self.assertEqual(Literal[1, 2], Literal[2, 1])

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -560,6 +560,7 @@ class LiteralTests(BaseTestCase):
             Literal[1][1]
 
     def test_equal(self):
+        self.assertNotEqual(Literal[1, True], Literal[1])
         self.assertEqual(Literal[1], Literal[1])
         self.assertEqual(Literal[1, 2], Literal[2, 1])
         self.assertEqual(Literal[1, 2, 3], Literal[1, 2, 3, 3])

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -528,6 +528,7 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(repr(Literal[int]), "typing.Literal[int]")
         self.assertEqual(repr(Literal), "typing.Literal")
         self.assertEqual(repr(Literal[None]), "typing.Literal[None]")
+        self.assertEqual(repr(Literal[1, 2, 3, 3]), "typing.Literal[1, 2, 3]")
 
     def test_cannot_init(self):
         with self.assertRaises(TypeError):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -560,8 +560,9 @@ class LiteralTests(BaseTestCase):
             Literal[1][1]
 
     def test_equal(self):
+        self.assertEqual(Literal[1], Literal[1])
         self.assertEqual(Literal[1, 2], Literal[2, 1])
-        self.assertNotEqual(Literal[1, True], Literal[1])
+        self.assertEqual(Literal[1, 2, 3], Literal[1, 2, 3, 3])
 
     def test_flatten(self):
         self.assertEqual(Literal[Literal[1], Literal[2], Literal[3]], Literal[1, 2, 3])

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -559,6 +559,15 @@ class LiteralTests(BaseTestCase):
         with self.assertRaises(TypeError):
             Literal[1][1]
 
+    def test_equal(self):
+        self.assertEqual(Literal[1, 2], Literal[2, 1])
+        self.assertNotEqual(Literal[1, True], Literal[1])
+
+    def test_flatten(self):
+        self.assertEqual(Literal[Literal[1], Literal[2], Literal[3]], Literal[1, 2, 3])
+        self.assertEqual(Literal[Literal[1, 2], 3], Literal[1, 2, 3])
+        self.assertEqual(Literal[Literal[1, 2, 3]], Literal[1, 2, 3])
+
 
 XK = TypeVar('XK', str, bytes)
 XV = TypeVar('XV')

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -569,10 +569,20 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(Literal[1, 2], Literal[2, 1])
         self.assertEqual(Literal[1, 2, 3], Literal[1, 2, 3, 3])
 
+    def test_args(self):
+        self.assertEqual(Literal[1, 2, 3].__args__, (1, 2, 3))
+        self.assertEqual(Literal[1, 2, 3, 3].__args__, (1, 2, 3))
+        self.assertEqual(Literal[1, Literal[2], Literal[3, 4]].__args__, (1, 2, 3, 4))
+        # Mutable arguments will not be deduplicated
+        self.assertEqual(Literal[[], []].__args__, ([], []))
+
     def test_flatten(self):
-        self.assertEqual(Literal[Literal[1], Literal[2], Literal[3]], Literal[1, 2, 3])
-        self.assertEqual(Literal[Literal[1, 2], 3], Literal[1, 2, 3])
-        self.assertEqual(Literal[Literal[1, 2, 3]], Literal[1, 2, 3])
+        l1 = Literal[Literal[1], Literal[2], Literal[3]]
+        l2 = Literal[Literal[1, 2], 3]
+        l3 = Literal[Literal[1, 2, 3]]
+        for l in l1, l2, l3:
+            self.assertEqual(l, Literal[1, 2, 3])
+            self.assertEqual(l.__args__, (1, 2, 3))
 
 
 XK = TypeVar('XK', str, bytes)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -242,12 +242,12 @@ def _flatten_literal_params(parameters):
 _cleanups = []
 
 
-def _tp_cache(typed=False):
+def _tp_cache(func=None, /, *, typed=False):
     """Internal wrapper caching __getitem__ of generic types with a fallback to
     original function for non-hashable arguments.
     """
-    if callable(typed):
-        return _tp_cache()(typed)
+    if func is not None:
+        return _tp_cache(typed=typed)(func)
 
     def decorator(func):
         cached = functools.lru_cache(typed=typed)(func)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -251,9 +251,6 @@ def _tp_cache(func=None, /, *, typed=False):
     """Internal wrapper caching __getitem__ of generic types with a fallback to
     original function for non-hashable arguments.
     """
-    if func is not None:
-        return _tp_cache(typed=typed)(func)
-
     def decorator(func):
         cached = functools.lru_cache(typed=typed)(func)
         _cleanups.append(cached.cache_clear)
@@ -266,6 +263,9 @@ def _tp_cache(func=None, /, *, typed=False):
                 pass  # All real errors (not unhashable args) are raised below.
             return func(*args, **kwds)
         return inner
+
+    if func is not None:
+        return decorator(func)
 
     return decorator
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -945,13 +945,20 @@ class _UnionGenericAlias(_GenericAlias, _root=True):
                 return True
 
 
+def _value_and_type_iter(parameters):
+    return ((p, type(p)) for p in parameters)
+
+
 class _LiteralGenericAlias(_GenericAlias, _root=True):
 
     def __eq__(self, other):
         if not isinstance(other, _LiteralGenericAlias):
             return NotImplemented
 
-        return len(self.__args__) == len(other.__args__) and set(self.__args__) == set(other.__args__)
+        return set(_value_and_type_iter(self.__args__)) == set(_value_and_type_iter(other.__args__))
+
+    def __hash__(self):
+        return hash(tuple(_value_and_type_iter(self.__args__)))
 
 
 class Generic:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -861,6 +861,7 @@ Jan Kanis
 Rafe Kaplan
 Jacob Kaplan-Moss
 Allison Kaptur
+Yurii Karabas
 Janne Karila
 Per Øyvind Karlsen
 Anton Kasyanov

--- a/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
@@ -1,0 +1,2 @@
+Literal equality no longer depends on order of arguments. Patch provided by
+Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
@@ -1,3 +1,4 @@
 Fix ``typing.Literal`` equals method to ignore the order of arguments.
 Fix issue related to ``typing.Literal`` caching by adding ``typed``
-parameter to ``typing._tp_cache`` function. Patch provided by Yurii Karabas.
+parameter to ``typing._tp_cache`` function. Add deduplication of
+``typing.Literal`` arguments. Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
@@ -1,4 +1,2 @@
-Fix ``typing.Literal`` equals method to ignore the order of arguments.
-Fix issue related to ``typing.Literal`` caching by adding ``typed``
-parameter to ``typing._tp_cache`` function. Add deduplication of
-``typing.Literal`` arguments. Patch provided by Yurii Karabas.
+Fix various issues with ``typing.Literal`` parameter handling (flatten,
+deduplicate, use type to cache key). Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
@@ -1,2 +1,2 @@
-Literal equality no longer depends on order of arguments. Patch provided by
-Yurii Karabas.
+Fix ``typing.Literal`` equals method to ignore the order of arguments.
+Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-15-15-23-34.bpo-42345.hiIR7x.rst
@@ -1,2 +1,3 @@
 Fix ``typing.Literal`` equals method to ignore the order of arguments.
-Patch provided by Yurii Karabas.
+Fix issue related to ``typing.Literal`` caching by adding ``typed``
+parameter to ``typing._tp_cache`` function. Patch provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Literal equality no longer depends on the order of arguments.

Fix issue related to `typing.Literal` caching by adding `typed` parameter to `typing._tp_cache` function.

Add deduplication of `typing.Literal` arguments. 

<!-- issue-number: [bpo-42345](https://bugs.python.org/issue42345) -->
https://bugs.python.org/issue42345
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum