### PR TITLE
bpo-42362: Switch to clang/clang++ as the default compiler in build-installer.py

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -158,8 +158,11 @@ def getTargetCompilers():
         '10.4': ('gcc-4.0', 'g++-4.0'),
         '10.5': ('gcc', 'g++'),
         '10.6': ('gcc', 'g++'),
+        '10.7': ('gcc', 'g++'),
+        '10.8': ('gcc', 'g++'),
+        '10.9': ('gcc', 'g++'),
     }
-    return target_cc_map.get(DEPTARGET, ('gcc', 'g++') )
+    return target_cc_map.get(DEPTARGET, ('clang', 'clang++') )
 
 CC, CXX = getTargetCompilers()
 


### PR DESCRIPTION
This change is cosmetic only, the "gcc" command in Apple's compiler tools is an alias for "clang" (and using non-system tooling for building the installer is not supported by this script).

<!-- issue-number: [bpo-42362](https://bugs.python.org/issue42362) -->
https://bugs.python.org/issue42362
<!-- /issue-number -->

Automerge-Triggered-By: GH:ned-deily