### PR TITLE
bpo-42363: enhance _check_running() ValueError output in Pool class

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -347,7 +347,7 @@ class Pool(object):
 
     def _check_running(self):
         if self._state != RUN:
-            raise ValueError("Pool not running")
+            raise ValueError(f"Pool not running, state is {self._state}")
 
     def apply(self, func, args=(), kwds={}):
         '''

--- a/Misc/NEWS.d/next/Core and Builtins/2022-09-27-03-52-49.gh-issue-86529.rWk1tr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-09-27-03-52-49.gh-issue-86529.rWk1tr.rst
@@ -1,0 +1,1 @@
+enhance _check_running() ValuError error message


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

The current `ValueError` does not give any information about `self._state`.
So I think it will be good to output: `self._state` for the ease of debugging.

<!-- issue-number: [bpo-42363](https://bugs.python.org/issue42363) -->
https://bugs.python.org/issue42363
<!-- /issue-number -->
