### PR TITLE
bpo-41116: Ensure system supplied libraries are found on macOS 11

### DIFF
--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -290,7 +290,7 @@ class UnixCCompiler(CCompiler):
             cflags = sysconfig.get_config_var('CFLAGS')
             m = re.search(r'-isysroot\s*(\S+)', cflags)
             if m is None:
-                sysroot = '/'
+                sysroot = _osx_support._default_sysroot(sysconfig.get_config_var('CC'))
             else:
                 sysroot = m.group(1)
 

--- a/Misc/NEWS.d/next/macOS/2020-11-15-16-43-45.bpo-41116.oCkbrF.rst
+++ b/Misc/NEWS.d/next/macOS/2020-11-15-16-43-45.bpo-41116.oCkbrF.rst
@@ -1,0 +1,1 @@
+Ensure distutils.unixxcompiler.find_library_file can find system provided libraries on macOS 11.


### PR DESCRIPTION
On macOS system provided libraries are in a shared library cache
and not at their usual location. This PR teaches distutils to search
in the SDK, even if there was no "-sysroot" argument in
the compiler flags.

The logic is ported from setup.py. 

<!-- issue-number: [bpo-41116](https://bugs.python.org/issue41116) -->
https://bugs.python.org/issue41116
<!-- /issue-number -->

Automerge-Triggered-By: GH:ned-deily