### PR TITLE
bpo-40736: Improve the error message for re.search() TypeError

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2104,6 +2104,12 @@ ELSE
                           {'tag': 'foo', 'text': None},
                           {'tag': 'foo', 'text': None}])
 
+    def test_bug_40736(self):
+        with self.assertRaisesRegex(TypeError, "got 'int'"):
+            re.search("x*", 5)
+        with self.assertRaisesRegex(TypeError, "got 'type'"):
+            re.search("x*", type)
+
 
 class PatternReprTests(unittest.TestCase):
     def check(self, pattern, expected):

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -374,7 +374,8 @@ getstring(PyObject* string, Py_ssize_t* p_length,
 
     /* get pointer to byte string buffer */
     if (PyObject_GetBuffer(string, view, PyBUF_SIMPLE) != 0) {
-        PyErr_SetString(PyExc_TypeError, "expected string or bytes-like object");
+        PyErr_Format(PyExc_TypeError, "expected string or bytes-like "
+                     "object, got '%.200s'", Py_TYPE(string)->tp_name);
         return NULL;
     }
 


### PR DESCRIPTION
Include the invalid type in the error message.

<!-- issue-number: [bpo-40736](https://bugs.python.org/issue40736) -->
https://bugs.python.org/issue40736
<!-- /issue-number -->
