### PR TITLE
bpo-42238: Doc: Remove make suspicious from the CI and docs builds.

### DIFF
--- a/.azure-pipelines/docs-steps.yml
+++ b/.azure-pipelines/docs-steps.yml
@@ -16,7 +16,7 @@ steps:
   displayName: 'Install build dependencies'
 
 - ${{ if ne(parameters.latex, 'true') }}:
-  - script: make check suspicious html PYTHON=python
+  - script: make check html PYTHON=python
     workingDirectory: '$(build.sourcesDirectory)/Doc'
     displayName: 'Build documentation'
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,7 +36,7 @@ jobs:
     - name: 'Install build dependencies'
       run: make -C Doc/ PYTHON=../python venv
     - name: 'Build documentation'
-      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" doctest suspicious html
+      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W --keep-going -j4" doctest html
     - name: 'Upload'
       uses: actions/upload-artifact@v2.2.0
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
         - cd Doc
         - make venv PYTHON=python
       script:
-        - make check suspicious html SPHINXOPTS="-q -W -j4"
+        - make check html SPHINXOPTS="-q -W -j4"
     - name: "Documentation tests"
       os: linux
       language: c

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -216,7 +216,6 @@ serve:
 # for development releases: always build
 autobuild-dev:
 	make dist SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1'
-	-make suspicious
 
 # for quick rebuilds (HTML only)
 autobuild-dev-html:

--- a/Misc/NEWS.d/next/Documentation/2020-11-24-22-54-49.bpo-42238.62EOTu.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-11-24-22-54-49.bpo-42238.62EOTu.rst
@@ -1,0 +1,2 @@
+Tentative to deprecate ``make suspicious`` by first removing it from the CI
+and documentation builds, but keeping it around for manual uses.


### PR DESCRIPTION
It probably helped a lot a while back, but may not be as usefull
today.  We'll continue monitoring it before deletion, so true
positives can be migrated to rstlint.


<!-- issue-number: [bpo-42238](https://bugs.python.org/issue42238) -->
https://bugs.python.org/issue42238
<!-- /issue-number -->
