### PR TITLE
[WIP] bpo-41713: Move _signal variables into a state structure

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -583,3 +583,7 @@ Removed
   ``Py_END_ALLOW_RECURSION`` and the ``recursion_critical`` field of the
   :c:type:`PyInterpreterState` structure.
   (Contributed by Serhiy Storchaka in :issue:`41936`.)
+
+* Removed the undocumented ``PyOS_InitInterrupts()`` function. Initializing
+  Python already implicitly installs signal handlers.
+  (Contributed by Victor Stinner in :issue:`41713`.)

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -68,7 +68,9 @@ extern void _PyFloat_Fini(PyThreadState *tstate);
 extern void _PySlice_Fini(PyThreadState *tstate);
 extern void _PyAsyncGen_Fini(PyThreadState *tstate);
 
-extern void PyOS_FiniInterrupts(void);
+extern int _PyOS_InitInterrupts(void);
+extern int _PySignal_Init(void);
+extern void _PySignal_Fini(void);
 
 extern void _PyExc_Fini(PyThreadState *tstate);
 extern void _PyImport_Fini(void);

--- a/Include/intrcheck.h
+++ b/Include/intrcheck.h
@@ -5,7 +5,6 @@ extern "C" {
 #endif
 
 PyAPI_FUNC(int) PyOS_InterruptOccurred(void);
-PyAPI_FUNC(void) PyOS_InitInterrupts(void);
 #ifdef HAVE_FORK
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
 PyAPI_FUNC(void) PyOS_BeforeFork(void);

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -142,14 +142,14 @@ PyDoc_STRVAR(signal_signal__doc__,
     {"signal", (PyCFunction)(void(*)(void))signal_signal, METH_FASTCALL, signal_signal__doc__},
 
 static PyObject *
-signal_signal_impl(PyObject *module, int signalnum, PyObject *handler);
+signal_signal_impl(PyObject *module, int signalnum, PyObject *handler_func);
 
 static PyObject *
 signal_signal(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int signalnum;
-    PyObject *handler;
+    PyObject *handler_func;
 
     if (!_PyArg_CheckPositional("signal", nargs, 2, 2)) {
         goto exit;
@@ -158,8 +158,8 @@ signal_signal(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (signalnum == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    handler = args[1];
-    return_value = signal_signal_impl(module, signalnum, handler);
+    handler_func = args[1];
+    return_value = signal_signal_impl(module, signalnum, handler_func);
 
 exit:
     return return_value;
@@ -698,4 +698,4 @@ exit:
 #ifndef SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
     #define SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
 #endif /* !defined(SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF) */
-/*[clinic end generated code: output=59c33f0af42aebb5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e2f45381e22a8315 input=a9049054013a1b77]*/


### PR DESCRIPTION
* Set volatile keyword on structure members, rather than on the whole
  structure.
* PyInit__signal() now checks for CreateEvent() failure.
* On Windows, PyOS_FiniInterrupts() now closes sigint_event.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41713](https://bugs.python.org/issue41713) -->
https://bugs.python.org/issue41713
<!-- /issue-number -->
