### PR TITLE
bpo-42374: Allow unparenthesized walrus in genexps

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -517,7 +517,7 @@ group[expr_ty]:
     | '(' a=(yield_expr | named_expression) ')' { a }
     | invalid_group
 genexp[expr_ty]:
-    | '(' a=expression ~ b=for_if_clauses ')' { _Py_GeneratorExp(a, b, EXTRA) }
+    | '(' a=named_expression ~ b=for_if_clauses ')' { _Py_GeneratorExp(a, b, EXTRA) }
     | invalid_comprehension
 set[expr_ty]: '{' a=expressions_list '}' { _Py_Set(a, EXTRA) }
 setcomp[expr_ty]:

--- a/Lib/test/test_named_expressions.py
+++ b/Lib/test/test_named_expressions.py
@@ -518,8 +518,7 @@ spam()"""
         b = [1, 2, 3, 4]
         genexp = (c := i + a for i in b)
 
-        with self.assertRaises(NameError):
-            print(c)  # c is not bound here
+        self.assertNotIn("c", locals())
         for idx, elem in enumerate(genexp):
             self.assertEqual(elem, b[idx] + a)
 

--- a/Lib/test/test_named_expressions.py
+++ b/Lib/test/test_named_expressions.py
@@ -513,6 +513,16 @@ spam()"""
             self.assertEqual(nonlocal_var, None)
         f()
 
+    def test_named_expression_scope_in_genexp(self):
+        a = 1
+        b = [1, 2, 3, 4]
+        genexp = (c := i + a for i in b)
+
+        with self.assertRaises(NameError):
+            print(c)  # c is not bound here
+        for idx, elem in enumerate(genexp):
+            self.assertEqual(elem, b[idx] + a)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-16-17-57-09.bpo-42374.t7np1E.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-16-17-57-09.bpo-42374.t7np1E.rst
@@ -1,0 +1,2 @@
+Fix a regression introduced by the new parser, where an unparenthesized walrus operator
+was not allowed within generator expressions.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -11357,7 +11357,7 @@ group_rule(Parser *p)
     return _res;
 }
 
-// genexp: '(' expression ~ for_if_clauses ')' | invalid_comprehension
+// genexp: '(' named_expression ~ for_if_clauses ')' | invalid_comprehension
 static expr_ty
 genexp_rule(Parser *p)
 {
@@ -11377,12 +11377,12 @@ genexp_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
-    { // '(' expression ~ for_if_clauses ')'
+    { // '(' named_expression ~ for_if_clauses ')'
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> genexp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' expression ~ for_if_clauses ')'"));
+        D(fprintf(stderr, "%*c> genexp[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'(' named_expression ~ for_if_clauses ')'"));
         int _cut_var = 0;
         Token * _literal;
         Token * _literal_1;
@@ -11391,7 +11391,7 @@ genexp_rule(Parser *p)
         if (
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
-            (a = expression_rule(p))  // expression
+            (a = named_expression_rule(p))  // named_expression
             &&
             (_cut_var = 1)
             &&
@@ -11400,7 +11400,7 @@ genexp_rule(Parser *p)
             (_literal_1 = _PyPegen_expect_token(p, 8))  // token=')'
         )
         {
-            D(fprintf(stderr, "%*c+ genexp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' expression ~ for_if_clauses ')'"));
+            D(fprintf(stderr, "%*c+ genexp[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' named_expression ~ for_if_clauses ')'"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -11420,7 +11420,7 @@ genexp_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s genexp[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'(' expression ~ for_if_clauses ')'"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'(' named_expression ~ for_if_clauses ')'"));
         if (_cut_var) {
             D(p->level--);
             return NULL;


### PR DESCRIPTION
This fixes a regression that was introduced by the new parser.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42374](https://bugs.python.org/issue42374) -->
https://bugs.python.org/issue42374
<!-- /issue-number -->

Automerge-Triggered-By: GH:lysnikolaou