### PR TITLE
bpo-42375: subprocess DragonFlyBSD build update.

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-19-04-13-53.bpo-42375.U8bp4s.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-19-04-13-53.bpo-42375.U8bp4s.rst
@@ -1,0 +1,1 @@
+subprocess module update for DragonFlyBSD support.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -55,7 +55,7 @@
 # endif
 #endif
 
-#if defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__DragonFly__)
 # define FD_DIR "/dev/fd"
 #else
 # define FD_DIR "/proc/self/fd"
@@ -127,9 +127,9 @@ _pos_int_from_ascii(const char *name)
 }
 
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 /* When /dev/fd isn't mounted it is often a static directory populated
- * with 0 1 2 or entries for 0 .. 63 on FreeBSD, NetBSD and OpenBSD.
+ * with 0 1 2 or entries for 0 .. 63 on FreeBSD, NetBSD, OpenBSD and DragonFlyBSD.
  * NetBSD and OpenBSD have a /proc fs available (though not necessarily
  * mounted) and do not have fdescfs for /dev/fd.  MacOS X has a devfs
  * that properly supports /dev/fd.
@@ -377,7 +377,7 @@ _close_open_fds_maybe_unsafe(long start_fd, PyObject* py_fds_to_keep)
     ++start_fd;
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
     if (!_is_fdescfs_mounted_on_dev_fd())
         proc_fd_dir = NULL;
     else


### PR DESCRIPTION
Same as FreeBSD, file descriptors in /dev/fd id from 0 to 63.

<!-- issue-number: [bpo-42375](https://bugs.python.org/issue42375) -->
https://bugs.python.org/issue42375
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran