### PR TITLE
bpo-40939: Document removal of the old parser in 3.10 whatsnew

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -376,6 +376,16 @@ Removed
   moved to the internal C API.
   (Contributed by Victor Stinner in :issue:`42157`.)
 
+* Removed the ``parser`` module, which was deprecated in 3.9 due to the
+  switch to the new PEG parser, as well as all the C source and header files
+  that were only being used by the old parser, including ``node.h``, ``parser.h``,
+  ``graminit.h`` and ``grammar.h``.
+
+* Removed the Public C API functions :c:func:`PyParser_SimpleParseStringFlags`,
+  :c:func:`PyParser_SimpleParseStringFlagsFilename`,
+  :c:func:`PyParser_SimpleParseFileFlags` and :c:func:`PyNode_Compile`
+  that were deprecated in 3.9 due to the switch to the new PEG parser.
+
 
 Porting to Python 3.10
 ======================


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40939](https://bugs.python.org/issue40939) -->
https://bugs.python.org/issue40939
<!-- /issue-number -->

Automerge-Triggered-By: GH:lysnikolaou