### PR TITLE
bpo-42120: Remove macro defining copysign to _copysign on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-11-16-22-41-02.bpo-42120.9scgko.rst
+++ b/Misc/NEWS.d/next/Windows/2020-11-16-22-41-02.bpo-42120.9scgko.rst
@@ -1,0 +1,1 @@
+Remove macro definition of ``copysign`` (to ``_copysign``) in headers.

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -193,7 +193,6 @@ typedef int pid_t;
 #define Py_IS_NAN _isnan
 #define Py_IS_INFINITY(X) (!_finite(X) && !_isnan(X))
 #define Py_IS_FINITE(X) _finite(X)
-#define copysign _copysign
 
 /* define some ANSI types that are not defined in earlier Win headers */
 #if _MSC_VER >= 1200


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42120](https://bugs.python.org/issue42120) -->
https://bugs.python.org/issue42120
<!-- /issue-number -->
