### PR TITLE
Add GCC pragmas to silence compiler warning about ffi_prep_closure

### DIFF
--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -427,14 +427,21 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
         PyErr_Format(PyExc_NotImplementedError, "ffi_prep_closure_loc() is missing");
         goto error;
 #else
-#ifdef MACOSX
+#if defined(__clang__) || defined(MACOSX)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
+#if defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         result = ffi_prep_closure(p->pcl_write, &p->cif, closure_fcn, p);
 
-#ifdef MACOSX
+#if defined(__clang__) || defined(MACOSX)
         #pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+        #pragma GCC diagnostic pop
 #endif
 
 #endif


### PR DESCRIPTION
This silences this warning also for GCC and clang on Linux:

```
~/github/python/master master* 1m 20s
❯ make -j -s
 CC='gcc -pthread' LDSHARED='gcc -pthread -shared    ' OPT='-g -Og -Wall'       _TCLTK_INCLUDES='' _TCLTK_LIBS=''       ./python -E ./setup.py -q build
/home/pablogsal/github/python/master/Modules/_ctypes/callbacks.c: In function ‘_ctypes_alloc_callback’:
/home/pablogsal/github/python/master/Modules/_ctypes/callbacks.c:437:9: warning: ‘ffi_prep_closure’ is deprecated: use ffi_prep_closure_loc instead [-Wdeprecated-declarations]
  437 |         result = ffi_prep_closure(p->pcl_write, &p->cif, closure_fcn, p);
      |         ^~~~~~
In file included from /home/pablogsal/github/python/master/Modules/_ctypes/callbacks.c:6:
/usr/include/ffi.h:334:1: note: declared here
  334 | ffi_prep_closure (ffi_closure*,
      | ^~~~~~~~~~~~~~~~

The following modules found by detect_modules() in setup.py, have been
built by the Makefile instead, as configured by the Setup files:
_abc                  atexit                pwd
time
```