### PR TITLE
bpo-42382: Make sure each `EntryPoint` carries it's `Distribution` information

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -76,10 +76,11 @@ Entry points
 
 The ``entry_points()`` function returns a dictionary of all entry points,
 keyed by group.  Entry points are represented by ``EntryPoint`` instances;
-each ``EntryPoint`` has a ``.name``, ``.group``, and ``.value`` attributes and
-a ``.load()`` method to resolve the value.  There are also ``.module``,
-``.attr``, and ``.extras`` attributes for getting the components of the
-``.value`` attribute::
+each ``EntryPoint`` has a ``.name``, ``.group``, ``.value`` and ``.dist``
+attributes and a ``.load()`` method to resolve the value.  There are also
+``.module``, ``.attr``, and ``.extras`` attributes for getting the components of the
+``.value`` attribute and ``.distribution`` to get the ``Distribution`` instance
+from where the ``EntryPoint`` was loaded::
 
     >>> eps = entry_points()  # doctest: +SKIP
     >>> list(eps)  # doctest: +SKIP
@@ -87,13 +88,15 @@ a ``.load()`` method to resolve the value.  There are also ``.module``,
     >>> scripts = eps['console_scripts']  # doctest: +SKIP
     >>> wheel = [ep for ep in scripts if ep.name == 'wheel'][0]  # doctest: +SKIP
     >>> wheel  # doctest: +SKIP
-    EntryPoint(name='wheel', value='wheel.cli:main', group='console_scripts')
+    EntryPoint(name='wheel', value='wheel.cli:main', group='console_scripts', dist='wheel')
     >>> wheel.module  # doctest: +SKIP
     'wheel.cli'
     >>> wheel.attr  # doctest: +SKIP
     'main'
     >>> wheel.extras  # doctest: +SKIP
     []
+    >>> wheel.distributuion  # doctest: +SKIP
+    <importlib.metadata.PathDistribution object at 0x7f6b309fc668>
     >>> main = wheel.load()  # doctest: +SKIP
     >>> main  # doctest: +SKIP
     <function main at 0x103528488>

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -70,6 +70,7 @@ class ImportTests(fixtures.DistInfoPkg, unittest.TestCase):
             name='ep',
             value='importlib.metadata',
             group='grp',
+            dist='distribution'
             )
         assert ep.load() is importlib.metadata
 
@@ -232,7 +233,7 @@ class InaccessibleSysPath(fixtures.OnSysPath, ffs.TestCase):
 class TestEntryPoints(unittest.TestCase):
     def __init__(self, *args):
         super(TestEntryPoints, self).__init__(*args)
-        self.ep = importlib.metadata.EntryPoint('name', 'value', 'group')
+        self.ep = importlib.metadata.EntryPoint('name', 'value', 'group', 'dist')
 
     def test_entry_point_pickleable(self):
         revived = pickle.loads(pickle.dumps(self.ep))

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -51,6 +51,13 @@ class APITests(
         self.assertEqual(ep.value, 'mod:main')
         self.assertEqual(ep.extras, [])
 
+    def test_entry_points_distribution(self):
+        entries = dict(entry_points()['entries'])
+        for entry in ("main", "ns:sub"):
+            ep = entries[entry]
+            self.assertEqual(ep.dist.name, "distinfo-pkg")
+            self.assertEqual(ep.dist.version, "1.0.0")
+
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')
         assert md['author'] == 'Steven Ma'

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -55,8 +55,10 @@ class APITests(
         entries = dict(entry_points()['entries'])
         for entry in ("main", "ns:sub"):
             ep = entries[entry]
-            self.assertEqual(ep.dist.name, "distinfo-pkg")
-            self.assertEqual(ep.dist.version, "1.0.0")
+            self.assertIsInstance(ep.distribution, Distribution)
+            dist = Distribution.from_name(ep.dist)
+            self.assertEqual(ep.distribution.name, dist.name)
+            self.assertEqual(ep.distribution.version, dist.version)
 
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')

--- a/Misc/NEWS.d/next/Library/2020-11-17-07-55-48.bpo-42382.0HEUzF.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-17-07-55-48.bpo-42382.0HEUzF.rst
@@ -1,0 +1,4 @@
+Each `importlib.metadata.EntryPoint` now has a `.dist` attribute which is the
+`importlib.metadata.Distribution` name from where the `EntryPoint` was loaded
+and a `.distribution` property which is the `importlib.metadata.Distribution`
+instance from where the ``EntryPoint`` was loaded.


### PR DESCRIPTION
This avoids a low performance workaround to get the `EntryPoint`'s `Distribution`, for example:

```python
USE_IMPORTLIB_METADATA_STDLIB = USE_IMPORTLIB_METADATA = False
try:
    # Py3.8+
    import importlib.metadata

    USE_IMPORTLIB_METADATA_STDLIB = True
except ImportError:
    # < Py3.8 backport package
    import importlib_metadata

    USE_IMPORTLIB_METADATA = True


def get_distribution_from_entry_point(entry_point):
    loaded_entry_point = entry_point.load()
    if isinstance(loaded_entry_point, types.ModuleType):
        module_path = loaded_entry_point.__file__
    else:
        module_path = sys.modules[loaded_entry_point.__module__].__file__
    if USE_IMPORTLIB_METADATA_STDLIB:
        distributions = importlib.metadata.distributions
    else:
        distributions = importlib_metadata.distributions

    for distribution in distributions():
        try:
            relative = pathlib.Path(module_path).relative_to(
                distribution.locate_file("")
            )
        except ValueError:
            pass
        else:
            if relative in distribution.files:
                return distribution
```

<!-- issue-number: [bpo-42382](https://bugs.python.org/issue42382) -->
https://bugs.python.org/issue42382
<!-- /issue-number -->
