### PR TITLE
bpo-41713: Remove PyOS_InitInterrupts() function

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -583,3 +583,8 @@ Removed
   ``Py_END_ALLOW_RECURSION`` and the ``recursion_critical`` field of the
   :c:type:`PyInterpreterState` structure.
   (Contributed by Serhiy Storchaka in :issue:`41936`.)
+
+* Removed the undocumented ``PyOS_InitInterrupts()`` function. Initializing
+  Python already implicitly installs signal handlers: see
+  :c:member:`PyConfig.install_signal_handlers`.
+  (Contributed by Victor Stinner in :issue:`41713`.)

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -68,7 +68,8 @@ extern void _PyFloat_Fini(PyThreadState *tstate);
 extern void _PySlice_Fini(PyThreadState *tstate);
 extern void _PyAsyncGen_Fini(PyThreadState *tstate);
 
-extern void PyOS_FiniInterrupts(void);
+extern int _PySignal_Init(int install_signal_handlers);
+extern void _PySignal_Fini(void);
 
 extern void _PyExc_Fini(PyThreadState *tstate);
 extern void _PyImport_Fini(void);

--- a/Include/intrcheck.h
+++ b/Include/intrcheck.h
@@ -5,7 +5,6 @@ extern "C" {
 #endif
 
 PyAPI_FUNC(int) PyOS_InterruptOccurred(void);
-PyAPI_FUNC(void) PyOS_InitInterrupts(void);
 #ifdef HAVE_FORK
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
 PyAPI_FUNC(void) PyOS_BeforeFork(void);

--- a/Misc/NEWS.d/next/C API/2020-11-17-15-39-10.bpo-41713.Rq99Vc.rst
+++ b/Misc/NEWS.d/next/C API/2020-11-17-15-39-10.bpo-41713.Rq99Vc.rst
@@ -1,0 +1,3 @@
+Removed the undocumented ``PyOS_InitInterrupts()`` function. Initializing
+Python already implicitly installs signal handlers: see
+:c:member:`PyConfig.install_signal_handlers`. Patch by Victor Stinner.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -54,7 +54,6 @@ static PyStatus add_main_module(PyInterpreterState *interp);
 static PyStatus init_import_site(void);
 static PyStatus init_set_builtins_open(void);
 static PyStatus init_sys_streams(PyThreadState *tstate);
-static PyStatus init_signals(PyThreadState *tstate);
 static void call_py_exitfuncs(PyThreadState *tstate);
 static void wait_for_thread_shutdown(PyThreadState *tstate);
 static void call_ll_exitfuncs(_PyRuntimeState *runtime);
@@ -1047,11 +1046,8 @@ init_interp_main(PyThreadState *tstate)
     }
 
     if (is_main_interp) {
-        if (config->install_signal_handlers) {
-            status = init_signals(tstate);
-            if (_PyStatus_EXCEPTION(status)) {
-                return status;
-            }
+        if (_PySignal_Init(config->install_signal_handlers) < 0) {
+            return _PyStatus_ERR("can't initialize signals");
         }
 
         if (_PyTraceMalloc_Init(config->tracemalloc) < 0) {
@@ -1702,7 +1698,7 @@ Py_FinalizeEx(void)
     }
 
     /* Disable signal handling */
-    PyOS_FiniInterrupts();
+    _PySignal_Fini();
 
     /* Collect garbage.  This may call finalizers; it's nice to call these
      * before all modules are destroyed.
@@ -2728,25 +2724,6 @@ Py_Exit(int sts)
     }
 
     exit(sts);
-}
-
-static PyStatus
-init_signals(PyThreadState *tstate)
-{
-#ifdef SIGPIPE
-    PyOS_setsig(SIGPIPE, SIG_IGN);
-#endif
-#ifdef SIGXFZ
-    PyOS_setsig(SIGXFZ, SIG_IGN);
-#endif
-#ifdef SIGXFSZ
-    PyOS_setsig(SIGXFSZ, SIG_IGN);
-#endif
-    PyOS_InitInterrupts(); /* May imply init_signals() */
-    if (_PyErr_Occurred(tstate)) {
-        return _PyStatus_ERR("can't import signal");
-    }
-    return _PyStatus_OK();
 }
 
 


### PR DESCRIPTION
Remove the undocumented PyOS_InitInterrupts() C function.

* Rename PyOS_InitInterrupts() to _PySignal_Init(). It now installs
  other signal handlers, not only SIGINT.
* Rename PyOS_FiniInterrupts() to _PySignal_Fini()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41713](https://bugs.python.org/issue41713) -->
https://bugs.python.org/issue41713
<!-- /issue-number -->
