### PR TITLE
bpo-42391: Clarify documentation of TestCase.assertIs

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -897,8 +897,7 @@ Test cases
    .. method:: assertIs(first, second, msg=None)
                assertIsNot(first, second, msg=None)
 
-      Test that *first* and *second* evaluate (or don't evaluate) to the
-      same object.
+      Test that *first* and *second* are (or are not) the same object.
 
       .. versionadded:: 3.1
 


### PR DESCRIPTION
I believe the current phrasing with "evaluate to the same object" might be seen by some as `first == second` which is not the case.

Can I please get labels for skipping news and maybe backporting? 

<!-- issue-number: [bpo-42391](https://bugs.python.org/issue42391) -->
https://bugs.python.org/issue42391
<!-- /issue-number -->
