### PR TITLE
[3.8] bpo-41686: Always create the SIGINT event on Windows (GH-23344) (GH-23347)

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -69,6 +69,8 @@ extern void PyList_Fini(void);
 extern void PySet_Fini(void);
 extern void PyBytes_Fini(void);
 extern void PyFloat_Fini(void);
+
+extern int _PySignal_Init(int install_signal_handlers);
 extern void PyOS_FiniInterrupts(void);
 extern void PySlice_Fini(void);
 extern void PyAsyncGen_Fini(void);

--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-17-16-25-50.bpo-41686.hX77kL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-17-16-25-50.bpo-41686.hX77kL.rst
@@ -1,0 +1,4 @@
+On Windows, the ``SIGINT`` event, ``_PyOS_SigintEvent()``, is now created
+even if Python is configured to not install signal handlers (if
+:c:member:`PyConfig.install_signal_handlers` equals to 0, or
+``Py_InitializeEx(0)``).

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -63,7 +63,6 @@ extern grammar _PyParser_Grammar; /* From graminit.c */
 static PyStatus add_main_module(PyInterpreterState *interp);
 static PyStatus init_import_size(void);
 static PyStatus init_sys_streams(PyInterpreterState *interp);
-static PyStatus init_signals(void);
 static void call_py_exitfuncs(PyInterpreterState *);
 static void wait_for_thread_shutdown(void);
 static void call_ll_exitfuncs(_PyRuntimeState *runtime);
@@ -952,11 +951,8 @@ pyinit_main(_PyRuntimeState *runtime, PyInterpreterState *interp)
         return status;
     }
 
-    if (config->install_signal_handlers) {
-        status = init_signals();
-        if (_PyStatus_EXCEPTION(status)) {
-            return status;
-        }
+    if (_PySignal_Init(config->install_signal_handlers) < 0) {
+        return _PyStatus_ERR("can't initialize signals");
     }
 
     if (_PyTraceMalloc_Init(config->tracemalloc) < 0) {
@@ -2297,25 +2293,6 @@ Py_Exit(int sts)
     }
 
     exit(sts);
-}
-
-static PyStatus
-init_signals(void)
-{
-#ifdef SIGPIPE
-    PyOS_setsig(SIGPIPE, SIG_IGN);
-#endif
-#ifdef SIGXFZ
-    PyOS_setsig(SIGXFZ, SIG_IGN);
-#endif
-#ifdef SIGXFSZ
-    PyOS_setsig(SIGXFSZ, SIG_IGN);
-#endif
-    PyOS_InitInterrupts(); /* May imply init_signals() */
-    if (PyErr_Occurred()) {
-        return _PyStatus_ERR("can't import signal");
-    }
-    return _PyStatus_OK();
 }
 
 


### PR DESCRIPTION
[bpo-41686](https://bugs.python.org/issue41686), [bpo-41713](https://bugs.python.org/issue41713): On Windows, the SIGINT event,
_PyOS_SigintEvent(), is now created even if Python is configured to
not install signal handlers (PyConfig.install_signal_handlers=0 or
Py_InitializeEx(0)).

(cherry picked from commit 05a5d697f4f097f37c5c1e2ed0e2338a33c3fb6a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41686](https://bugs.python.org/issue41686) -->
https://bugs.python.org/issue41686
<!-- /issue-number -->
