### PR TITLE
bpo-41625: Add a guard for Linux for splice() constants in the os module

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15142,7 +15142,7 @@ all_ins(PyObject *m)
 #endif
 
 /* constants for splice */
-#ifdef HAVE_SPLICE
+#if defined(HAVE_SPLICE) && defined(__linux__)
     if (PyModule_AddIntConstant(m, "SPLICE_F_MOVE", SPLICE_F_MOVE)) return -1;
     if (PyModule_AddIntConstant(m, "SPLICE_F_NONBLOCK", SPLICE_F_NONBLOCK)) return -1;
     if (PyModule_AddIntConstant(m, "SPLICE_F_MORE", SPLICE_F_MORE)) return -1;


### PR DESCRIPTION


<!-- issue-number: [bpo-41625](https://bugs.python.org/issue41625) -->
https://bugs.python.org/issue41625
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran