### PR TITLE
bpo-41713: Port _signal module to multi-phase init

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-17-23-00-27.bpo-41713.-Us0tf.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-17-23-00-27.bpo-41713.-Us0tf.rst
@@ -1,0 +1,2 @@
+Port the ``_signal`` extension module to the multi-phase initialization API
+(:pep:`489`). Patch by Victor Stinner and Mohamed Koubaa.


### PR DESCRIPTION
Port the _signal extension module to the multi-phase initialization
API (PEP 489).

Co-Authored-By: Mohamed Koubaa <koubaa.m@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41713](https://bugs.python.org/issue41713) -->
https://bugs.python.org/issue41713
<!-- /issue-number -->
