### PR TITLE
bpo-42398: Fix "make regen-all" race condition

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -795,17 +795,29 @@ class ClinicExternalTest(TestCase):
     maxDiff = None
 
     def test_external(self):
+        # bpo-42398: Test that the destination file is left unchanged if the
+        # content does not change. Moreover, check also that the file
+        # modification time does not change in this case.
         source = support.findfile('clinic.test')
         with open(source, 'r', encoding='utf-8') as f:
-            original = f.read()
-        with os_helper.temp_dir() as testdir:
-            testfile = os.path.join(testdir, 'clinic.test.c')
+            orig_contents = f.read()
+
+        with os_helper.temp_dir() as tmp_dir:
+            testfile = os.path.join(tmp_dir, 'clinic.test.c')
             with open(testfile, 'w', encoding='utf-8') as f:
-                f.write(original)
-            clinic.parse_file(testfile, force=True)
+                f.write(orig_contents)
+            old_mtime_ns = os.stat(testfile).st_mtime_ns
+
+            clinic.parse_file(testfile)
+
             with open(testfile, 'r', encoding='utf-8') as f:
-                result = f.read()
-            self.assertEqual(result, original)
+                new_contents = f.read()
+            new_mtime_ns = os.stat(testfile).st_mtime_ns
+
+        self.assertEqual(new_contents, orig_contents)
+        # Don't change the file modification time
+        # if the content does not change
+        self.assertEqual(new_mtime_ns, old_mtime_ns)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Build/2020-11-18-11-58-44.bpo-42398.Yt5wO8.rst
+++ b/Misc/NEWS.d/next/Build/2020-11-18-11-58-44.bpo-42398.Yt5wO8.rst
@@ -1,0 +1,4 @@
+Fix a race condition in "make regen-all" when make -jN option is used to run
+jobs in parallel. The clinic.py script now only use atomic write to write
+files. Moveover, generated files are now left unchanged if the content does not
+change, to not change the file modification time.


### PR DESCRIPTION
Fix a race condition in "make regen-all" when make -jN option is used
to run jobs in parallel. The clinic.py script now only use atomic
write to write files. Moveover, generated files are now left
unchanged if the content does not change, to not change the file
modification time.

The "make regen-all" command runs "make clinic" and "make
regen-importlib" targets:

* "make regen-importlib" builds object files (ex: Modules/_weakref.o)
  from source files (ex: Modules/_weakref.c) and clinic files (ex:
  Modules/clinic/_weakref.c.h)
* "make clinic" always rewrites all clinic files
  (ex: Modules/clinic/_weakref.c.h)

Since there is no dependency between "clinic" and "regen-importlib"
Makefile targets, these two targets can be run in parallel. Moreover,
half of clinic.py file writes are not atomic and so there is a race
condition when "make regen-all" runs jobs in parallel using make -jN
option (which can be passed in MAKEFLAGS environment variable).

Fix clinic.py to make all file writes atomic:

* Add write_file() function to ensure that all file writes are
  atomic: write into a temporary file and then use os.replace().
* Moreover, write_file() doesn't recreate or modify the file if the
  content does not change to avoid modifying the file modification
  file.
* Update test_clinic to verify these assertions with a functional
  test.
* Remove Clinic.force attribute which was no longer used, whereas
  Clinic.verify remains useful.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42398](https://bugs.python.org/issue42398) -->
https://bugs.python.org/issue42398
<!-- /issue-number -->
