### PR TITLE
bpo-32218: Only keep the one-bit flag in `Flag.__iter__`

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -785,7 +785,7 @@ class Flag(Enum):
 
     def __iter__(self):
         members, extra_flags = _decompose(self.__class__, self.value)
-        return (m for m in members if m._value_ != 0)
+        return (m for m in members if m._value_ != 0 and _power_of_two(m._value_))
 
     def __repr__(self):
         cls = self.__class__
@@ -946,3 +946,8 @@ def _decompose(flag, value):
         # we have the breakdown, don't need the value member itself
         members.pop(0)
     return members, not_covered
+
+def _power_of_two(value):
+    if value < 1:
+        return False
+    return not value & (value - 1)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -785,7 +785,7 @@ class Flag(Enum):
 
     def __iter__(self):
         members, extra_flags = _decompose(self.__class__, self.value)
-        return (m for m in members if _power_of_two(m._value_))
+        return (m for m in members if m._value_.bit_count() == 1)
 
     def __repr__(self):
         cls = self.__class__
@@ -946,9 +946,3 @@ def _decompose(flag, value):
         # we have the breakdown, don't need the value member itself
         members.pop(0)
     return members, not_covered
-
-
-def _power_of_two(value):
-    if value < 1:
-        return False
-    return not value & (value - 1)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -785,7 +785,7 @@ class Flag(Enum):
 
     def __iter__(self):
         members, extra_flags = _decompose(self.__class__, self.value)
-        return (m for m in members if m._value_ != 0 and _power_of_two(m._value_))
+        return (m for m in members if _power_of_two(m._value_))
 
     def __repr__(self):
         cls = self.__class__
@@ -946,6 +946,7 @@ def _decompose(flag, value):
         # we have the breakdown, don't need the value member itself
         members.pop(0)
     return members, not_covered
+
 
 def _power_of_two(value):
     if value < 1:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2413,6 +2413,17 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(list(Color.BLUE), [Color.BLUE])
         self.assertEqual(list(Color.GREEN), [Color.GREEN])
 
+    def test_member_iter_one_bit(self):
+        class Foo(Flag):
+            NONE = 0
+            A = 1
+            B = 2
+            C = 4
+            AB = A | B
+            ABC = A | B | C
+
+        self.assertEqual(list(Foo.ABC), [Foo.C, Foo.B, Foo.A])
+
     def test_auto_number(self):
         class Color(Flag):
             red = auto()

--- a/Misc/NEWS.d/next/Library/2020-11-18-22-38-23.bpo-32218.hCjZSQ.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-18-22-38-23.bpo-32218.hCjZSQ.rst
@@ -1,2 +1,2 @@
-Only keep the one-bit flag for :method:`Flag.__iter__` in :mod:`enum`. Patch by
+Only keep the one-bit flag for :meth:`Flag.__iter__` in :mod:`enum`. Patch by
 Weipeng Hong.

--- a/Misc/NEWS.d/next/Library/2020-11-18-22-38-23.bpo-32218.hCjZSQ.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-18-22-38-23.bpo-32218.hCjZSQ.rst
@@ -1,0 +1,2 @@
+Only keep the one-bit flag for :method:`Flag.__iter__` in :mod:`enum`. Patch by
+Weipeng Hong.

--- a/Misc/NEWS.d/next/Library/2020-11-18-22-38-23.bpo-32218.hCjZSQ.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-18-22-38-23.bpo-32218.hCjZSQ.rst
@@ -1,2 +1,2 @@
-Only keep the one-bit flag for :meth:`Flag.__iter__` in :mod:`enum`. Patch by
-Weipeng Hong.
+Only keep the single-bit members for :meth:`enum.Flag.__iter__` in :mod:`enum`.
+Patch by Weipeng Hong.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32218](https://bugs.python.org/issue32218) -->
https://bugs.python.org/issue32218
<!-- /issue-number -->
