### PR TITLE
[3.9] bpo-40998: Fix a refleak in create_filter() (GH-23365)

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -69,11 +69,14 @@ create_filter(PyObject *category, _Py_Identifier *id, const char *modname)
         }
     } else {
         modname_obj = Py_None;
+        Py_INCREF(modname_obj);
     }
 
     /* This assumes the line number is zero for now. */
-    return PyTuple_Pack(5, action_str, Py_None,
-                        category, modname_obj, _PyLong_Zero);
+    PyObject *filter = PyTuple_Pack(5, action_str, Py_None,
+                                    category, modname_obj, _PyLong_Zero);
+    Py_DECREF(modname_obj);
+    return filter;
 }
 #endif
 


### PR DESCRIPTION
(cherry picked from commit d1e38d4023aa29e7ed64d4f8eb9c1e4a3c86a2e5)


<!-- issue-number: [bpo-40998](https://bugs.python.org/issue40998) -->
https://bugs.python.org/issue40998
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran