### PR TITLE
bpo-42085: Add documentation for Py_TPFLAGS_HAVE_AM_SEND

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1170,6 +1170,14 @@ and :c:type:`PyType_Type` effectively act as defaults.)
       .. versionadded:: 3.9
 
 
+   .. data:: Py_TPFLAGS_HAVE_AM_SEND
+
+      This bit is set when the :c:member:`~PyAsyncMethods.am_send` entry is present in the
+      :c:member:`~PyTypeObject.tp_as_async` slot of type structure.
+
+      .. versionadded:: 3.10
+
+
 .. c:member:: const char* PyTypeObject.tp_doc
 
    An optional pointer to a NUL-terminated C string giving the docstring for this


### PR DESCRIPTION
Updated docs to include `Py_TPFLAGS_HAVE_AM_SEND`. News section should not be necessary.


<!-- issue-number: [bpo-42085](https://bugs.python.org/issue42085) -->
https://bugs.python.org/issue42085
<!-- /issue-number -->

Automerge-Triggered-By: GH:asvetlov