### PR TITLE
bpo-1635741: Port _random to the multi-phase init

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-19-00-00-20.bpo-1635741.w50sJK.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-19-00-00-20.bpo-1635741.w50sJK.rst
@@ -1,0 +1,2 @@
+Port the ``_random`` extension module to the multi-phase initialization API
+(:pep:`489`).


### PR DESCRIPTION
Port the _random extension module to the multi-phase initialization
API (PEP 489).

* Create Random_Type using PyType_FromModuleAndSpec().
* Add get_random_state_from_type() function. It replaces the removed
  _randomstate_global macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
