### PR TITLE
bpo-42345: Fix hash implementation of typing.Literal

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1706,9 +1706,9 @@ Introspection helpers
    For a typing object of the form ``X[Y, Z, ...]`` these functions return
    ``X`` and ``(Y, Z, ...)``. If ``X`` is a generic alias for a builtin or
    :mod:`collections` class, it gets normalized to the original class.
-   If ``X`` is a :class:`Union` contained in another generic type,
-   the order of ``(Y, Z, ...)`` may be different from the order of
-   the original arguments ``[Y, Z, ...]`` due to type caching.
+   If ``X`` is a :class:`Union` or :class:`Literal` contained in another
+   generic type, the order of ``(Y, Z, ...)`` may be different from the order
+   of the original arguments ``[Y, Z, ...]`` due to type caching.
    For unsupported objects return ``None`` and ``()`` correspondingly.
    Examples::
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -570,10 +570,6 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(Literal[1, 2, 3], Literal[1, 2, 3, 3])
 
     def test_hash(self):
-        self.assertNotEqual(hash(Literal[0]), hash(Literal[False]))
-        self.assertNotEqual(hash(Literal[True]), hash(Literal[1]))
-        self.assertNotEqual(hash(Literal[1]), hash(Literal[2]))
-        self.assertNotEqual(hash(Literal[1, True]), hash(Literal[1]))
         self.assertEqual(hash(Literal[1]), hash(Literal[1]))
         self.assertEqual(hash(Literal[1, 2]), hash(Literal[2, 1]))
         self.assertEqual(hash(Literal[1, 2, 3]), hash(Literal[1, 2, 3, 3]))

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -569,6 +569,15 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(Literal[1, 2], Literal[2, 1])
         self.assertEqual(Literal[1, 2, 3], Literal[1, 2, 3, 3])
 
+    def test_hash(self):
+        self.assertNotEqual(hash(Literal[0]), hash(Literal[False]))
+        self.assertNotEqual(hash(Literal[True]), hash(Literal[1]))
+        self.assertNotEqual(hash(Literal[1]), hash(Literal[2]))
+        self.assertNotEqual(hash(Literal[1, True]), hash(Literal[1]))
+        self.assertEqual(hash(Literal[1]), hash(Literal[1]))
+        self.assertEqual(hash(Literal[1, 2]), hash(Literal[2, 1]))
+        self.assertEqual(hash(Literal[1, 2, 3]), hash(Literal[1, 2, 3, 3]))
+
     def test_args(self):
         self.assertEqual(Literal[1, 2, 3].__args__, (1, 2, 3))
         self.assertEqual(Literal[1, 2, 3, 3].__args__, (1, 2, 3))

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -981,7 +981,7 @@ class _LiteralGenericAlias(_GenericAlias, _root=True):
         return set(_value_and_type_iter(self.__args__)) == set(_value_and_type_iter(other.__args__))
 
     def __hash__(self):
-        return hash(tuple(_value_and_type_iter(self.__args__)))
+        return hash(frozenset(_value_and_type_iter(self.__args__)))
 
 
 class Generic:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Fix hash implementation of `typing.Literal`.

Update docs regarding `typing.Litaral` caching.

Base implementation was done in PR #23294.


<!-- issue-number: [bpo-42345](https://bugs.python.org/issue42345) -->
https://bugs.python.org/issue42345
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum