### PR TITLE
bpo-42345: Add whatsnew for typing.Literal in 3.10

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -303,16 +303,14 @@ of types readily interpretable by type checkers.
 typing
 ------
 
-The internally used type cache now supports differentiating types.  For example,
-``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is now
-``False``.
-(Contributed by Yurii Karabas in :issue:`42345`.)
-
 The behavior of :class:`typing.Literal` was changed.
    1. ``Literal`` now de-duplicates parameters.
    2. Equality comparisons between ``Literal`` objects are now order independent.
-      Their :func:`hash` results are also order independent.
-   3. ``Literal`` comparisons now respects types.
+   3. ``Literal`` comparisons now respects types.  For example,
+      ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
+      now ``False``.  This matches the behavior of static type checkers as per
+      :pep:`586`.  To support this change, the internally used type cache now
+      supports differentiating types.
    4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
       equality comparisons if one of their parameters are not :term:`immutable`
       to conform with :pep:`586`. Note that declaring ``Literal`` with mutable

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -300,6 +300,27 @@ and :data:`types.NotImplementedType` classes, providing a new set
 of types readily interpretable by type checkers.
 (Contributed by Bas van Beek in :issue:`41810`.)
 
+typing
+------
+
+The behavior of :class:`typing.Literal` was changed.
+   1. ``Literal`` now de-duplicates parameters.
+   2. Equality comparisons between ``Literal`` objects are now order independent.
+      Their :func:`hash` results are also order independent.
+   3. ``Literal`` objects will now raise a :exc:`TypeError` exception during
+      equality comparisons if one of their parameters are :term:`immutable` to
+      conform with :pep:`586`. Note that declaring ``Literal`` with mutable
+      parameters will not throw an error.::
+
+         >>> from typing import Literal
+         >>> Literal[{0}]
+         >>> Literal[{0}] == Literal[{False}]
+         Traceback (most recent call last):
+           File "<stdin>", line 1, in <module>
+         TypeError: unhashable type: 'set'
+
+(Contributed by Yurii Karabas in :issue:`42345`.)
+
 unittest
 --------
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -303,11 +303,17 @@ of types readily interpretable by type checkers.
 typing
 ------
 
+The internally used type cache now supports differentiating types.  For example,
+``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is now
+``False``.
+(Contributed by Yurii Karabas in :issue:`42345`.)
+
 The behavior of :class:`typing.Literal` was changed.
    1. ``Literal`` now de-duplicates parameters.
    2. Equality comparisons between ``Literal`` objects are now order independent.
       Their :func:`hash` results are also order independent.
-   3. ``Literal`` objects will now raise a :exc:`TypeError` exception during
+   3. ``Literal`` comparisons now respects types.
+   4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
       equality comparisons if one of their parameters are :term:`immutable` to
       conform with :pep:`586`. Note that declaring ``Literal`` with mutable
       parameters will not throw an error.::

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -305,23 +305,24 @@ typing
 
 The behavior of :class:`typing.Literal` was changed to conform with :pep:`586`
 and to match the behavior of static type checkers specified in the PEP.
-   1. ``Literal`` now de-duplicates parameters.
-   2. Equality comparisons between ``Literal`` objects are now order independent.
-   3. ``Literal`` comparisons now respects types.  For example,
-      ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
-      now ``False``.  To support this change, the internally used type cache now
-      supports differentiating types.
-   4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
-      equality comparisons if one of their parameters are not :term:`immutable`.
-      Note that declaring ``Literal`` with mutable parameters will not throw
-      an error::
 
-         >>> from typing import Literal
-         >>> Literal[{0}]
-         >>> Literal[{0}] == Literal[{False}]
-         Traceback (most recent call last):
-           File "<stdin>", line 1, in <module>
-         TypeError: unhashable type: 'set'
+1. ``Literal`` now de-duplicates parameters.
+2. Equality comparisons between ``Literal`` objects are now order independent.
+3. ``Literal`` comparisons now respects types.  For example,
+   ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
+   now ``False``.  To support this change, the internally used type cache now
+   supports differentiating types.
+4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
+   equality comparisons if one of their parameters are not :term:`immutable`.
+   Note that declaring ``Literal`` with mutable parameters will not throw
+   an error::
+
+      >>> from typing import Literal
+      >>> Literal[{0}]
+      >>> Literal[{0}] == Literal[{False}]
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      TypeError: unhashable type: 'set'
 
 (Contributed by Yurii Karabas in :issue:`42345`.)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -316,7 +316,7 @@ The behavior of :class:`typing.Literal` was changed.
    4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
       equality comparisons if one of their parameters are :term:`immutable` to
       conform with :pep:`586`. Note that declaring ``Literal`` with mutable
-      parameters will not throw an error.::
+      parameters will not throw an error::
 
          >>> from typing import Literal
          >>> Literal[{0}]

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -314,8 +314,8 @@ The behavior of :class:`typing.Literal` was changed.
       Their :func:`hash` results are also order independent.
    3. ``Literal`` comparisons now respects types.
    4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
-      equality comparisons if one of their parameters are :term:`immutable` to
-      conform with :pep:`586`. Note that declaring ``Literal`` with mutable
+      equality comparisons if one of their parameters are not :term:`immutable`
+      to conform with :pep:`586`. Note that declaring ``Literal`` with mutable
       parameters will not throw an error::
 
          >>> from typing import Literal

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -303,18 +303,18 @@ of types readily interpretable by type checkers.
 typing
 ------
 
-The behavior of :class:`typing.Literal` was changed.
+The behavior of :class:`typing.Literal` was changed to conform with :pep:`586`
+and to match the behavior of static type checkers specified in the PEP.
    1. ``Literal`` now de-duplicates parameters.
    2. Equality comparisons between ``Literal`` objects are now order independent.
    3. ``Literal`` comparisons now respects types.  For example,
       ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
-      now ``False``.  This matches the behavior of static type checkers as per
-      :pep:`586`.  To support this change, the internally used type cache now
+      now ``False``.  To support this change, the internally used type cache now
       supports differentiating types.
    4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
-      equality comparisons if one of their parameters are not :term:`immutable`
-      to conform with :pep:`586`. Note that declaring ``Literal`` with mutable
-      parameters will not throw an error::
+      equality comparisons if one of their parameters are not :term:`immutable`.
+      Note that declaring ``Literal`` with mutable parameters will not throw
+      an error::
 
          >>> from typing import Literal
          >>> Literal[{0}]


### PR DESCRIPTION
I noticed that there were 4 changes in behavior rather than 3.

This is PR 1 of 2. A second PR is needed for 3.9 and backporting.

<!-- issue-number: [bpo-42345](https://bugs.python.org/issue42345) -->
https://bugs.python.org/issue42345
<!-- /issue-number -->
