### PR TITLE
bpo-42345: Add whatsnew and versionchanged for typing.Literal in 3.9

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -674,6 +674,12 @@ These can be used as types in annotations using ``[]``, each having a unique syn
 
    .. versionadded:: 3.8
 
+   .. versionchanged:: 3.9.1
+      ``Literal`` now de-duplicates parameters.  Equality comparison of
+      ``Literal`` objects are no longer order dependent. ``Literal`` objects
+      will now raise a :exc:`TypeError` exception during equality comparisons
+      if one of their parameters are not :term:`immutable`.
+
 .. data:: ClassVar
 
    Special type construct to mark class variables.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -694,6 +694,29 @@ types with context-specific metadata and new ``include_extras`` parameter to
 :func:`typing.get_type_hints` to access the metadata at runtime. (Contributed
 by Till Varoquaux and Konstantin Kashin.)
 
+The behavior of :class:`typing.Literal` was changed to conform with :pep:`586`
+and to match the behavior of static type checkers specified in the PEP.
+
+1. ``Literal`` now de-duplicates parameters.
+2. Equality comparisons between ``Literal`` objects are now order independent.
+3. ``Literal`` comparisons now respect types.  For example,
+   ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
+   now ``False``.  To support this change, the internally used type cache now
+   supports differentiating types.
+4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
+   equality comparisons if one of their parameters are not :term:`immutable`.
+   Note that declaring ``Literal`` with mutable parameters will not throw
+   an error::
+
+      >>> from typing import Literal
+      >>> Literal[{0}]
+      >>> Literal[{0}] == Literal[{False}]
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      TypeError: unhashable type: 'set'
+
+(Contributed by Yurii Karabas in :issue:`42345`.)
+
 unicodedata
 -----------
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -694,29 +694,6 @@ types with context-specific metadata and new ``include_extras`` parameter to
 :func:`typing.get_type_hints` to access the metadata at runtime. (Contributed
 by Till Varoquaux and Konstantin Kashin.)
 
-The behavior of :class:`typing.Literal` was changed to conform with :pep:`586`
-and to match the behavior of static type checkers specified in the PEP.
-
-1. ``Literal`` now de-duplicates parameters.
-2. Equality comparisons between ``Literal`` objects are now order independent.
-3. ``Literal`` comparisons now respect types.  For example,
-   ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
-   now ``False``.  To support this change, the internally used type cache now
-   supports differentiating types.
-4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
-   equality comparisons if one of their parameters are not :term:`immutable`.
-   Note that declaring ``Literal`` with mutable parameters will not throw
-   an error::
-
-      >>> from typing import Literal
-      >>> Literal[{0}]
-      >>> Literal[{0}] == Literal[{False}]
-      Traceback (most recent call last):
-        File "<stdin>", line 1, in <module>
-      TypeError: unhashable type: 'set'
-
-(Contributed by Yurii Karabas in :issue:`42345`.)
-
 unicodedata
 -----------
 
@@ -1477,3 +1454,32 @@ Removed
   ``PyNullImporter_Type``, ``PyCmpWrapper_Type``, ``PySortWrapper_Type``,
   ``PyNoArgsFunction``.
   (Contributed by Pablo Galindo Salgado in :issue:`39372`.)
+
+Notable changes in Python 3.9.1
+===============================
+
+typing
+------
+
+The behavior of :class:`typing.Literal` was changed to conform with :pep:`586`
+and to match the behavior of static type checkers specified in the PEP.
+
+1. ``Literal`` now de-duplicates parameters.
+2. Equality comparisons between ``Literal`` objects are now order independent.
+3. ``Literal`` comparisons now respect types.  For example,
+   ``Literal[0] == Literal[False]`` previously evaluated to ``True``.  It is
+   now ``False``.  To support this change, the internally used type cache now
+   supports differentiating types.
+4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
+   equality comparisons if one of their parameters are not :term:`immutable`.
+   Note that declaring ``Literal`` with mutable parameters will not throw
+   an error::
+
+      >>> from typing import Literal
+      >>> Literal[{0}]
+      >>> Literal[{0}] == Literal[{False}]
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      TypeError: unhashable type: 'set'
+
+(Contributed by Yurii Karabas in :issue:`42345`.)


### PR DESCRIPTION
* Whatsnew entry in 3.9 same as the one in 3.10.
* versionchanged for typing.Literal docs

Needs backport to 3.9.

<!-- issue-number: [bpo-42345](https://bugs.python.org/issue42345) -->
https://bugs.python.org/issue42345
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum