### PR TITLE
Allow unicode keywords

### DIFF
--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -427,7 +427,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
     def _group_keywords_by_length(self) -> Dict[int, List[Tuple[str, int]]]:
         groups: Dict[int, List[Tuple[str, int]]] = {}
         for keyword_str, keyword_type in self.callmakervisitor.keyword_cache.items():
-            length = len(keyword_str)
+            length = len(keyword_str.encode())
             if length in groups:
                 groups[length].append((keyword_str, keyword_type))
             else:


### PR DESCRIPTION
This is a trivial change which will not have any visible effects on CPython, because default keywords are all in ASCII. This merely makes it easier for hobbyist to add their own unicode keywords.

For example, this allows you to simply change the python.gram file from `| 'lambda' ... ` to `| ('lambda' | 'λ') ...` and tweak this: [r"[a-zA-Z_]\w*\Z"](https://github.com/python/cpython/blob/master/Tools/peg_generator/pegen/c_generator.py#L173), for CPython to recognise `λ x:x` as an expression.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
