### PR TITLE
bpo-31904: support signal module for VxWorks

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -519,10 +519,14 @@ class WakeupSocketSignalTests(unittest.TestCase):
         else:
             write.setblocking(False)
 
-        # Start with large chunk size to reduce the
-        # number of send needed to fill the buffer.
         written = 0
-        for chunk_size in (2 ** 16, 2 ** 8, 1):
+        if sys.platform == "vxworks":
+            CHUNK_SIZES = (1,)
+        else:
+            # Start with large chunk size to reduce the
+            # number of send needed to fill the buffer.
+            CHUNK_SIZES = (2 ** 16, 2 ** 8, 1)
+        for chunk_size in CHUNK_SIZES:
             chunk = b"x" * chunk_size
             try:
                 while True:
@@ -595,6 +599,7 @@ class WakeupSocketSignalTests(unittest.TestCase):
 
 
 @unittest.skipIf(sys.platform == "win32", "Not valid on Windows")
+@unittest.skipUnless(hasattr(signal, 'siginterrupt'), "needs signal.siginterrupt()")
 class SiginterruptTest(unittest.TestCase):
 
     def readpipe_interrupted(self, interrupt):
@@ -680,6 +685,8 @@ class SiginterruptTest(unittest.TestCase):
 
 
 @unittest.skipIf(sys.platform == "win32", "Not valid on Windows")
+@unittest.skipUnless(hasattr(signal, 'getitimer') and hasattr(signal, 'setitimer'),
+                         "needs signal.getitimer() and signal.setitimer()")
 class ItimerTest(unittest.TestCase):
     def setUp(self):
         self.hndl_called = False

--- a/Misc/NEWS.d/next/Library/2020-11-19-16-14-36.bpo-31904.83kf9d.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-19-16-14-36.bpo-31904.83kf9d.rst
@@ -1,0 +1,1 @@
+Support signal module on VxWorks.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -120,7 +120,11 @@ static volatile struct {
 #else
 #define INVALID_FD (-1)
 static volatile struct {
+#ifdef __VXWORKS__
+    int fd;
+#else
     sig_atomic_t fd;
+#endif
     int warn_on_full_buffer;
 } wakeup = {.fd = INVALID_FD, .warn_on_full_buffer = 1};
 #endif


### PR DESCRIPTION
1. There are some discussion about "sig_atomic_t fd;" in PR 12670. POSIX spec doesn't define its type. In practice, most implementation defines it as int. Go to [Atomic-Types](https://www.gnu.org/software/libc/manual/html_node/Atomic-Types.html) So far it works fine on known OSes. However, on VxWorks, sig_atomic_t is defined as 'unsigned char'. Assigning it to -1 will have problem. So we define wakeup.fd as int specially for VxWorks.
2. VxWorks has no getitimer() and setitimer() C api available. So skipping the test on VxWorks.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
