### PR TITLE
bpo-31904: remove libnet dependency from detect_socket() for VxWorks

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-11-19-17-01-50.bpo-31904.894dk2.rst
+++ b/Misc/NEWS.d/next/Build/2020-11-19-17-01-50.bpo-31904.894dk2.rst
@@ -1,0 +1,1 @@
+remove libnet dependency from detect_socket() for VxWorks

--- a/setup.py
+++ b/setup.py
@@ -1155,11 +1155,7 @@ class PyBuildExt(build_ext):
     def detect_socket(self):
         # socket(2)
         kwargs = {'depends': ['socketmodule.h']}
-        if VXWORKS:
-            if not self.compiler.find_library_file(self.lib_dirs, 'net'):
-                return
-            kwargs['libraries'] = ['net']
-        elif MACOS:
+        if MACOS:
             # Issue #35569: Expose RFC 3542 socket options.
             kwargs['extra_compile_args'] = ['-D__APPLE_USE_RFC_3542']
 


### PR DESCRIPTION
Previously on VxWorks compiling socket extension module needs the libnet to link. Now VxWorks has moved the replied functions to libc. So removing libnet from setup.py.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead