### PR TITLE
bpo-42405: fix C extensions build on Windows ARM64

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-11-23-10-14-03.bpo-42405.4vQUja.rst
+++ b/Misc/NEWS.d/next/Windows/2020-11-23-10-14-03.bpo-42405.4vQUja.rst
@@ -1,0 +1,1 @@
+Fix C extensions build on Windows ARM64

--- a/Misc/NEWS.d/next/Windows/2020-11-23-10-14-03.bpo-42405.4vQUja.rst
+++ b/Misc/NEWS.d/next/Windows/2020-11-23-10-14-03.bpo-42405.4vQUja.rst
@@ -1,1 +1,1 @@
-Fix C extensions build on Windows ARM64
+In distutils, add support for building C extensions on Windows ARM64.


### PR DESCRIPTION
    The following changes are required:

      * add a new platform win-arm64
      * replace the emulated compiler executable paths
      * bump the linker base addressed as ARM64 requires more memory
        this change might not be needed (investigation required)

    On Windows 10 ARM64, VS compiler paths look like this:
    C:\Program Files (x86)\Microsoft Visual
    Studio\2019\Community\VC\Tools\MSVC\14.27.29110\bin\HostX86\ARM64\cl.exe

    Note that the cl.exe for ARM64 is an x32 binary, which can run emulated
    on Windows 10 ARM64 (it has builtin emulation for x32).

    The rc.exe and mc.exe paths have to also be changed, as the initial
    discovery has to be fixed.

    Work in progress to remove the hardcoded bits and to change the path
    query fixes to the proper location.


<!-- issue-number: [bpo-42405](https://bugs.python.org/issue42405) -->
https://bugs.python.org/issue42405
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco