### PR TITLE
bpo-42406: Fix whichmodule() with multiprocessing

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -340,8 +340,9 @@ def whichmodule(obj, name):
     # Protect the iteration by using a list copy of sys.modules against dynamic
     # modules that trigger imports of other modules upon calls to getattr.
     for module_name, module in sys.modules.copy().items():
-        if module_name == '__main__' or module_name == '__mp_main__' \
-                or module is None:
+        if (module_name == '__main__'
+            or module_name == '__mp_main__'  # bpo-42406
+            or module is None):
             continue
         try:
             if _getattribute(module, name)[0] is obj:

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -340,7 +340,8 @@ def whichmodule(obj, name):
     # Protect the iteration by using a list copy of sys.modules against dynamic
     # modules that trigger imports of other modules upon calls to getattr.
     for module_name, module in sys.modules.copy().items():
-        if module_name == '__main__' or module is None:
+        if module_name == '__main__' or module_name == '__mp_main__' \
+                or module is None:
             continue
         try:
             if _getattribute(module, name)[0] is obj:

--- a/Misc/NEWS.d/next/Library/2020-11-19-10-44-41.bpo-42406.r9rNCj.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-19-10-44-41.bpo-42406.r9rNCj.rst
@@ -1,0 +1,3 @@
+We fixed an issue in `pickle.whichmodule` in which importing
+`multiprocessing` could change the how pickle identifies which module an
+object belongs to, potentially breaking the unpickling of those objects.


### PR DESCRIPTION
This fixes the behavior of the `pickle.whichmodule()` function when `multiprocessing` is imported before the `pickle` module.

Prior to this patch, the following incorrect output would be found when trying to determine the module of the (for example) `gdtrix` function:

```
>>> import multiprocessing
>>> import pickle
>>> from scipy.special import gdtrix
>>> pickle.whichmodule(gdtrix, gdtrix.__name__)
'__mp_main__'
```

With the patch, now we get correct behavior:

```
>>> import multiprocessing
>>> import pickle
>>> from scipy.special import gdtrix
>>> pickle.whichmodule(gdtrix, gdtrix.__name__)
'scipy.special._ufuncs'
```

This also fixes uqfoundation/dill#392.

Signed-off-by: Renato L. de F. Cunha <renatoc@br.ibm.com>

<!-- issue-number: [bpo-42406](https://bugs.python.org/issue42406) -->
https://bugs.python.org/issue42406
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead