### PR TITLE
bpo-42383: pdb: do not fail to restart the target if the current directory changed

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1703,6 +1703,29 @@ def bœr():
 
             self.assertEqual(stdout.split('\n')[2].rstrip('\r'), expected)
 
+    def test_issue42383(self):
+        with os_helper.temp_cwd() as cwd:
+            with open('foo.py', 'w') as f:
+                s = textwrap.dedent("""
+                    print('The correct file was executed')
+
+                    import os
+                    os.chdir("subdir")
+                """)
+                f.write(s)
+
+            subdir = os.path.join(cwd, 'subdir')
+            os.mkdir(subdir)
+            os.mkdir(os.path.join(subdir, 'subdir'))
+            wrong_file = os.path.join(subdir, 'foo.py')
+
+            with open(wrong_file, 'w') as f:
+                f.write('print("The wrong file was executed")')
+
+            stdout, stderr = self._run_pdb(['foo.py'], 'c\nc\nq')
+            expected = '(Pdb) The correct file was executed'
+            self.assertEqual(stdout.split('\n')[6].rstrip('\r'), expected)
+
 
 def load_tests(*args):
     from test import test_pdb

--- a/Misc/NEWS.d/next/Library/2020-11-17-14-30-12.bpo-42383.ubl0Y_.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-17-14-30-12.bpo-42383.ubl0Y_.rst
@@ -1,0 +1,2 @@
+Fix pdb: previously pdb would fail to restart the debugging target if it was
+specified using a relative path and the current directory changed.


### PR DESCRIPTION
https://github.com/python/cpython/pull/23338 should be merged first because it contains the actual fix since both https://bugs.python.org/issue42383 and https://bugs.python.org/issue42384 can be fixed by adding one line.

Following this instructions

https://github.com/python/cpython/pull/23338#discussion_r526146998

> My personal experience(NOT the official way):
> 
>     * Creating the first PR to solve the fist issue you want fixed.
> 
>     * After the first PR merged, we can add some description info in second issue, something like: `After PR-XXX merged, this issue should be resolved by the way.`. MAYBE you can create an another PR to add the testcase of the second issue.

I opened a separate PR for [bpo-42383](https://bugs.python.org/issue42383)

<!-- issue-number: [bpo-42383](https://bugs.python.org/issue42383) -->
https://bugs.python.org/issue42383
<!-- /issue-number -->
