### PR TITLE
bpo-42416: Use inspect.getdoc for IDLE calltips

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2021-10-04?
 ======================================
 
 
+bpo-42416: Get docstrings for IDLE calltips more often
+by using inspect.getdoc.
+
 bpo-33987: Mostly finish using ttk widgets, mainly for editor,
 settings, and searches.  Some patches by Mark Roseman.
 

--- a/Lib/idlelib/calltip.py
+++ b/Lib/idlelib/calltip.py
@@ -165,6 +165,7 @@ def get_argspec(ob):
         ob_call = ob.__call__
     except BaseException:  # Buggy user object could raise anything.
         return ''  # No popup for non-callables.
+    # For Get_argspecTest.test_buggy_getattr_class, CallA() & CallB().
     fob = ob_call if isinstance(ob_call, types.MethodType) else ob
 
     # Initialize argspec and wrap it to get lines.
@@ -185,10 +186,7 @@ def get_argspec(ob):
              if len(argspec) > _MAX_COLS else [argspec] if argspec else [])
 
     # Augment lines from docstring, if any, and join to get argspec.
-    if isinstance(ob_call, types.MethodType):
-        doc = ob_call.__doc__
-    else:
-        doc = getattr(ob, "__doc__", "")
+    doc = inspect.getdoc(ob)
     if doc:
         for line in doc.split('\n', _MAX_LINES)[:_MAX_LINES]:
             line = line.strip()

--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -99,7 +99,12 @@ non-overlapping occurrences o...''')
 (width=70, initial_indent='', subsequent_indent='', expand_tabs=True,
     replace_whitespace=True, fix_sentence_endings=False, break_long_words=True,
     drop_whitespace=True, break_on_hyphens=True, tabsize=8, *, max_lines=None,
-    placeholder=' [...]')''')
+    placeholder=' [...]')
+Object for wrapping/filling text.  The public interface consists of
+the wrap() and fill() methods; the other methods are just there for
+subclasses to override in order to tweak the default behaviour.
+If you want to completely replace the main wrapping algorithm,
+you\'ll probably have to override _wrap_chunks().''')
 
     def test_properly_formated(self):
 
@@ -241,7 +246,7 @@ bytes() -> empty bytes object''')
             __class__ = property({}.__getitem__, {}.__setitem__)
         class Object(metaclass=Type):
             __slots__ = '__class__'
-        for meth, mtip  in ((Type, default_tip), (Object, default_tip),
+        for meth, mtip  in ((Type, get_spec(type)), (Object, default_tip),
                             (Object(), '')):
             with self.subTest(meth=meth, mtip=mtip):
                 self.assertEqual(get_spec(meth), mtip)

--- a/Misc/NEWS.d/next/IDLE/2020-11-20-01-30-27.bpo-42415.CyD-va.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-11-20-01-30-27.bpo-42415.CyD-va.rst
@@ -1,0 +1,1 @@
+Get docstrings for IDLE calltips more often by using inspect.getdoc.


### PR DESCRIPTION
Inspect.getdoc sometimes gets docstrings when ob.__doc__ is None.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42416](https://bugs.python.org/issue42416) -->
https://bugs.python.org/issue42416
<!-- /issue-number -->
