### PR TITLE
bpo-31904: fix test_doctest.py failures for VxWorks

### DIFF
--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3039,6 +3039,7 @@ Invalid file name:
     ...         '-m', 'doctest', 'nosuchfile')
     >>> rc, out
     (1, b'')
+    >>> # The exact error message changes depending on the platform.
     >>> print(normalize(err))                    # doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3039,12 +3039,10 @@ Invalid file name:
     ...         '-m', 'doctest', 'nosuchfile')
     >>> rc, out
     (1, b'')
-    >>> if sys.platform == "vxworks":
-    ...     err = err.replace(b'no such file', b'No such file')
     >>> print(normalize(err))                    # doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...
-    FileNotFoundError: [Errno ...] No such file or directory: 'nosuchfile'
+    FileNotFoundError: [Errno ...] ...nosuchfile...
 
 Invalid doctest option:
 

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -3039,6 +3039,8 @@ Invalid file name:
     ...         '-m', 'doctest', 'nosuchfile')
     >>> rc, out
     (1, b'')
+    >>> if sys.platform == "vxworks":
+    ...     err = err.replace(b'no such file', b'No such file')
     >>> print(normalize(err))                    # doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...

--- a/Misc/NEWS.d/next/Tests/2020-11-20-15-07-18.bpo-31904.EBJXjJ.rst
+++ b/Misc/NEWS.d/next/Tests/2020-11-20-15-07-18.bpo-31904.EBJXjJ.rst
@@ -1,1 +1,1 @@
-fix test_doctest.py failures for VxWorks
+Fix test_doctest.py failures for VxWorks.

--- a/Misc/NEWS.d/next/Tests/2020-11-20-15-07-18.bpo-31904.EBJXjJ.rst
+++ b/Misc/NEWS.d/next/Tests/2020-11-20-15-07-18.bpo-31904.EBJXjJ.rst
@@ -1,0 +1,1 @@
+fix test_doctest.py failures for VxWorks


### PR DESCRIPTION
In test_CLI(), "print(normalize(err))" expects "No such file" which has the first letter n as capital. However VxWorks outputs 'no such file with the first letter n as lower case. So tuned accordingly.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
