### PR TITLE
Minor doc fixes - add missing indentation and space

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5065,7 +5065,7 @@ instantiated from the type::
 
       >>> class M(type):
       ...     def __or__(self, other):
-      ...     return "Hello"
+      ...         return "Hello"
       ...
       >>> class C(metaclass=M):
       ...     pass

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -120,8 +120,8 @@ See :pep:`613` for more details.
 
 (Contributed by Mikhail Golubev in :issue:`41923`.)
 
-PEP604: New Type Union Operator
--------------------------------
+PEP 604: New Type Union Operator
+--------------------------------
 
 A new type union operator was introduced which enables the syntax ``X | Y``.
 This provides a cleaner way of expressing 'either type X or type Y' instead of


### PR DESCRIPTION
* Fix a missing indentation in one of the code examples which caused a `IndentationError` to be thrown when the code is copied.
* Add a missing space in section title to match the other titles seen in the [3.10 whatsnew here](https://docs.python.org/3.10/whatsnew/3.10.html).

Please skip news and issue. Thank you. A backport isn't necessary as those docs are only in 3.10.