### PR TITLE
bpo-15450: Allow subclassing of filecmp.dircmp

### DIFF
--- a/Doc/library/filecmp.rst
+++ b/Doc/library/filecmp.rst
@@ -173,7 +173,13 @@ The :class:`dircmp` class
    .. attribute:: subdirs
 
       A dictionary mapping names in :attr:`common_dirs` to :class:`dircmp`
-      objects.
+      instances (or MyDirCmp instances if this instance is of type MyDirCmp, a
+      subclass of :class:`dircmp`).
+
+      .. versionchanged:: 3.10
+         Previously entries were always :class:`dircmp` instances. Now entries
+         are the same type as *self*, if *self* is a subclass of
+         :class:`dircmp`.
 
 .. attribute:: DEFAULT_IGNORES
 

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -115,7 +115,9 @@ class dircmp:
      same_files: list of identical files.
      diff_files: list of filenames which differ.
      funny_files: list of files which could not be compared.
-     subdirs: a dictionary of dircmp objects, keyed by names in common_dirs.
+     subdirs: a dictionary of dircmp instances (or MyDirCmp instances if this
+       object is of type MyDirCmp, a subclass of dircmp), keyed by names
+       in common_dirs.
      """
 
     def __init__(self, a, b, ignore=None, hide=None): # Initialize
@@ -185,14 +187,15 @@ class dircmp:
         self.same_files, self.diff_files, self.funny_files = xx
 
     def phase4(self): # Find out differences between common subdirectories
-        # A new dircmp object is created for each common subdirectory,
+        # A new dircmp (or MyDirCmp if dircmp was subclassed) object is created
+        # for each common subdirectory,
         # these are stored in a dictionary indexed by filename.
         # The hide and ignore properties are inherited from the parent
         self.subdirs = {}
         for x in self.common_dirs:
             a_x = os.path.join(self.left, x)
             b_x = os.path.join(self.right, x)
-            self.subdirs[x]  = dircmp(a_x, b_x, self.ignore, self.hide)
+            self.subdirs[x]  = self.__class__(a_x, b_x, self.ignore, self.hide)
 
     def phase4_closure(self): # Recursively call phase4() on subdirectories
         self.phase4()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -367,6 +367,7 @@ Ryan Coyner
 Christopher A. Craig
 Jeremy Craven
 Laura Creighton
+Nick Crews
 Tyler Crompton
 Simon Cross
 Felipe Cruz

--- a/Misc/NEWS.d/next/Library/2020-11-20-10-38-34.bpo-15450.E-y9PA.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-20-10-38-34.bpo-15450.E-y9PA.rst
@@ -1,0 +1,2 @@
+Make :class:`filecmp.dircmp` respect subclassing. Now the
+:attr:`filecmp.dircmp.subdirs` behaves as expected when subclassing dircmp.


### PR DESCRIPTION
Currently, the subdirs attribute of filecmp.dircmp does not respect subclassing:

>>> from filecmp import dircmp
>>> class MyDirCmp(dircmp):
...   pass
... 
>>> my_dcmp = MyDirCmp('dir1', 'dir2')
>>> for item in my_dcmp.subdirs.values():
...   print(type(item))
...   break
... 
<class 'filecmp.dircmp'>

This is the only place where dircmp does not respect subclassing.  It can be corrected here:

def phase4(self): # Find out differences between common subdirectories
    ...
        ...
        self.subdirs[x]  = dircmp(a_x, b_x, self.ignore, self.hide)

This would let one do things like override dircmp.report() and have dircmp.report_full_closure() behave as expected, or replace the phaseN()
methods with your custom behavior and have that work for all 
subdirectories.

Co-authored-by: Chris Jerdonek <chris.jerdonek@gmail.com>

<!-- issue-number: [bpo-15450](https://bugs.python.org/issue15450) -->
https://bugs.python.org/issue15450
<!-- /issue-number -->
