### PR TITLE
bpo-34463: Match python traceback format to the C traceback for a Syn…

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -687,6 +687,31 @@ class BaseExceptionReportingTests:
         msg = self.get_report(e).splitlines()
         self.assertEqual(msg[-2], '               ^')
 
+    def test_syntax_error_no_lineno(self):
+        # See #34463.
+
+        # Without filename
+        e = SyntaxError('bad syntax')
+        msg = self.get_report(e).splitlines()
+        self.assertEqual(msg,
+            ['SyntaxError: bad syntax'])
+        e.lineno = 100
+        msg = self.get_report(e).splitlines()
+        self.assertEqual(msg,
+            ['  File "<string>", line 100', 'SyntaxError: bad syntax'])
+
+        # With filename
+        e = SyntaxError('bad syntax')
+        e.filename = 'myfile.py'
+
+        msg = self.get_report(e).splitlines()
+        self.assertEqual(msg,
+            ['SyntaxError: bad syntax (myfile.py)'])
+        e.lineno = 100
+        msg = self.get_report(e).splitlines()
+        self.assertEqual(msg,
+            ['  File "myfile.py", line 100', 'SyntaxError: bad syntax'])
+
     def test_message_none(self):
         # A message that looks like "None" should not be treated specially
         err = self.get_report(Exception(None))

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -526,7 +526,8 @@ class TracebackException:
         if exc_type and issubclass(exc_type, SyntaxError):
             # Handle SyntaxError's specially
             self.filename = exc_value.filename
-            self.lineno = str(exc_value.lineno)
+            lno = exc_value.lineno
+            self.lineno = str(lno) if lno is not None else None
             self.text = exc_value.text
             self.offset = exc_value.offset
             self.msg = exc_value.msg
@@ -586,8 +587,11 @@ class TracebackException:
         """Format SyntaxError exceptions (internal helper)."""
         # Show exactly where the problem was found.
         filename = self.filename or "<string>"
-        lineno = str(self.lineno) or '?'
-        yield '  File "{}", line {}\n'.format(filename, lineno)
+        filename_suffix = ''
+        if self.lineno is not None:
+            yield '  File "{}", line {}\n'.format(filename, self.lineno)
+        elif self.filename is not None:
+            filename_suffix = ' ({})'.format(self.filename)
 
         text = self.text
         if text is not None:
@@ -605,7 +609,7 @@ class TracebackException:
                 caretspace = ((c if c.isspace() else ' ') for c in ltext[:caret])
                 yield '    {}^\n'.format(''.join(caretspace))
         msg = self.msg or "<no detail available>"
-        yield "{}: {}\n".format(stype, msg)
+        yield "{}: {}{}\n".format(stype, msg, filename_suffix)
 
     def format(self, *, chain=True):
         """Format the exception.

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -586,10 +586,10 @@ class TracebackException:
     def _format_syntax_error(self, stype):
         """Format SyntaxError exceptions (internal helper)."""
         # Show exactly where the problem was found.
-        filename = self.filename or "<string>"
         filename_suffix = ''
         if self.lineno is not None:
-            yield '  File "{}", line {}\n'.format(filename, self.lineno)
+            yield '  File "{}", line {}\n'.format(
+                self.filename or "<string>", self.lineno)
         elif self.filename is not None:
             filename_suffix = ' ({})'.format(self.filename)
 

--- a/Misc/NEWS.d/next/Library/2020-11-20-19-00-27.bpo-34463.aJcm56.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-20-19-00-27.bpo-34463.aJcm56.rst
@@ -1,1 +1,1 @@
-Fixed discrepancy between traceback.py and the interpreter in formatting of SyntaxError with lineno not set (traceback.py was changed to match interpreter).
+Fixed discrepancy between :mod:`traceback` and the interpreter in formatting of SyntaxError with lineno not set (:mod:`traceback` was changed to match interpreter).

--- a/Misc/NEWS.d/next/Library/2020-11-20-19-00-27.bpo-34463.aJcm56.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-20-19-00-27.bpo-34463.aJcm56.rst
@@ -1,0 +1,1 @@
+Fixed discrepancy between traceback.py and the interpreter in formatting of SyntaxError with lineno not set (traceback.py was changed to match interpreter).


### PR DESCRIPTION
…taxError without lineno.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34463](https://bugs.python.org/issue34463) -->
https://bugs.python.org/issue34463
<!-- /issue-number -->
