### PR TITLE
bpo-42420: Add timeout to queue.Queue().join

### DIFF
--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -79,6 +79,7 @@ class Queue:
     def join(self, timeout=None):
         '''Blocks until all items in the Queue have been gotten and processed.
 
+        If optional args 'timeout' is None (the default)
         The count of unfinished tasks goes up whenever an item is added to the
         queue. The count goes down whenever a consumer thread calls task_done()
         to indicate the item was retrieved and all work on it is complete. If
@@ -86,7 +87,8 @@ class Queue:
         and raises the Full exception if no free slot was available within that
         time.
 
-        When the count of unfinished tasks drops to zero, join() unblocks.
+        When the count of unfinished tasks drops to zero or timeout is reached,
+        join() unblocks.
         '''
         with self.all_tasks_done:
             if timeout is None:

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -79,13 +79,12 @@ class Queue:
     def join(self, timeout=None):
         '''Blocks until all items in the Queue have been gotten and processed.
 
-        If optional args 'timeout' is None (the default)
         The count of unfinished tasks goes up whenever an item is added to the
         queue. The count goes down whenever a consumer thread calls task_done()
         to indicate the item was retrieved and all work on it is complete. If
-        'timeout' is a non-negative number, it blocks at most 'timeout' seconds
-        and raises the Full exception if no free slot was available within that
-        time.
+        optional args 'timeout' is a non-negative number, it blocks at most
+        'timeout' seconds and raises the TimeoutError exception if the number
+        of unfinished tasks is not equal to the task_done in the available time.
 
         When the count of unfinished tasks drops to zero or timeout is reached,
         join() unblocks.

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -76,18 +76,23 @@ class Queue:
                 self.all_tasks_done.notify_all()
             self.unfinished_tasks = unfinished
 
-    def join(self):
+    def join(self, timeout=None):
         '''Blocks until all items in the Queue have been gotten and processed.
 
         The count of unfinished tasks goes up whenever an item is added to the
         queue. The count goes down whenever a consumer thread calls task_done()
-        to indicate the item was retrieved and all work on it is complete.
+        to indicate the item was retrieved and all work on it is complete. If
+        'timeout' is a non-negative number, it blocks at most 'timeout' seconds
+        and raises the Full exception if no free slot was available within that
+        time.
 
         When the count of unfinished tasks drops to zero, join() unblocks.
         '''
+        if timeout and timeout < 0:
+            raise ValueError("'timeout' must be a non-negative number")
         with self.all_tasks_done:
             while self.unfinished_tasks:
-                self.all_tasks_done.wait()
+                self.all_tasks_done.wait(timeout)
 
     def qsize(self):
         '''Return the approximate size of the queue (not reliable!).'''

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -176,6 +176,21 @@ class BaseQueueTestMixin(BlockingTestMixin):
         for thread in threads:
             thread.join()
 
+    def test_join_negative_timeout_raises_exception(self):
+        q = self.type2test(QUEUE_SIZE)
+        with self.assertRaises(ValueError):
+            q.join(timeout=-1)
+        with self.assertRaises(ValueError):
+            q.join(timeout=-1)
+
+    def test_join_timeout_raises_exception(self):
+        q = self.type2test(QUEUE_SIZE)
+        q.put(1)
+        with self.assertRaises(TimeoutError):
+            q.join(timeout=.1)
+        with self.assertRaises(TimeoutError):
+            q.join(timeout=.1)
+
     def test_queue_task_done(self):
         # Test to make sure a queue task completed successfully.
         q = self.type2test()

--- a/Misc/NEWS.d/next/Library/2020-11-20-15-59-30.bpo-42420._9uwFd.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-20-15-59-30.bpo-42420._9uwFd.rst
@@ -1,0 +1,3 @@
+If optional args 'timeout' is a non-negative number, it blocks at most
+'timeout' seconds and raises the TimeoutError exception if the number of
+unfinished tasks is not equal to the task_done in the available time.


### PR DESCRIPTION
$ ./python -m test -v test_queue
----------------------------------------------------------------------

Ran 66 tests in 8.735s

OK

== Tests result: SUCCESS ==

1 test OK.

---

[278/425] test_queue passed -- running: test_peg_generator (53.1 sec)

Tests result: SUCCESS


<!-- issue-number: [bpo-42420](https://bugs.python.org/issue42420) -->
https://bugs.python.org/issue42420
<!-- /issue-number -->
