### PR TITLE
bpo-42427: Use the errno attribute of OSError instead of args[0]

### DIFF
--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -113,7 +113,7 @@ def readwrite(obj, flags):
         if flags & (select.POLLHUP | select.POLLERR | select.POLLNVAL):
             obj.handle_close()
     except OSError as e:
-        if e.args[0] not in _DISCONNECTED:
+        if e.errno not in _DISCONNECTED:
             obj.handle_error()
         else:
             obj.handle_close()
@@ -236,7 +236,7 @@ class dispatcher:
             try:
                 self.addr = sock.getpeername()
             except OSError as err:
-                if err.args[0] in (ENOTCONN, EINVAL):
+                if err.errno in (ENOTCONN, EINVAL):
                     # To handle the case where we got an unconnected
                     # socket.
                     self.connected = False
@@ -346,7 +346,7 @@ class dispatcher:
         except TypeError:
             return None
         except OSError as why:
-            if why.args[0] in (EWOULDBLOCK, ECONNABORTED, EAGAIN):
+            if why.errno in (EWOULDBLOCK, ECONNABORTED, EAGAIN):
                 return None
             else:
                 raise
@@ -358,9 +358,9 @@ class dispatcher:
             result = self.socket.send(data)
             return result
         except OSError as why:
-            if why.args[0] == EWOULDBLOCK:
+            if why.errno == EWOULDBLOCK:
                 return 0
-            elif why.args[0] in _DISCONNECTED:
+            elif why.errno in _DISCONNECTED:
                 self.handle_close()
                 return 0
             else:
@@ -378,7 +378,7 @@ class dispatcher:
                 return data
         except OSError as why:
             # winsock sometimes raises ENOTCONN
-            if why.args[0] in _DISCONNECTED:
+            if why.errno in _DISCONNECTED:
                 self.handle_close()
                 return b''
             else:
@@ -393,7 +393,7 @@ class dispatcher:
             try:
                 self.socket.close()
             except OSError as why:
-                if why.args[0] not in (ENOTCONN, EBADF):
+                if why.errno not in (ENOTCONN, EBADF):
                     raise
 
     # log and log_info may be overridden to provide more sophisticated
@@ -557,7 +557,7 @@ def close_all(map=None, ignore_all=False):
         try:
             x.close()
         except OSError as x:
-            if x.args[0] == EBADF:
+            if x.errno == EBADF:
                 pass
             elif not ignore_all:
                 raise

--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -163,7 +163,7 @@ class SMTPChannel(asynchat.async_chat):
             # a race condition  may occur if the other end is closing
             # before we can get the peername
             self.close()
-            if err.args[0] != errno.ENOTCONN:
+            if err.errno != errno.ENOTCONN:
                 raise
             return
         print('Peer:', repr(self.peer), file=DEBUGSTREAM)

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -706,7 +706,7 @@ class SocketIO(io.RawIOBase):
                 self._timeout_occurred = True
                 raise
             except error as e:
-                if e.args[0] in _blocking_errnos:
+                if e.errno in _blocking_errnos:
                     return None
                 raise
 
@@ -722,7 +722,7 @@ class SocketIO(io.RawIOBase):
             return self._sock.send(b)
         except error as e:
             # XXX what about EINTR?
-            if e.args[0] in _blocking_errnos:
+            if e.errno in _blocking_errnos:
                 return None
             raise
 


### PR DESCRIPTION


<!-- issue-number: [bpo-42427](https://bugs.python.org/issue42427) -->
https://bugs.python.org/issue42427
<!-- /issue-number -->
