### PR TITLE
bpo-42434: function floatstr should be a class-level function

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -201,6 +201,29 @@ class JSONEncoder(object):
             chunks = list(chunks)
         return ''.join(chunks)
 
+    def floatstr(o, allow_nan=self.allow_nan,
+            _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
+        """Return a representation of float value Infinity, -Infinity
+        and NaN. Note that this type of test is processor and/or 
+        platform-specific, so do tests which don't depend on the
+        internals.
+        """
+        if o != o:
+            text = 'NaN'
+        elif o == _inf:
+            text = 'Infinity'
+        elif o == _neginf:
+            text = '-Infinity'
+        else:
+            return _repr(o)
+
+        if not allow_nan:
+            raise ValueError(
+                "Out of range float values are not JSON compliant: " +
+                repr(o))
+
+        return text
+
     def iterencode(self, o, _one_shot=False):
         """Encode the given object and yield each string
         representation as available.
@@ -220,29 +243,6 @@ class JSONEncoder(object):
         else:
             _encoder = encode_basestring
 
-        def floatstr(o, allow_nan=self.allow_nan,
-                _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
-            # Check for specials.  Note that this type of test is processor
-            # and/or platform-specific, so do tests which don't depend on the
-            # internals.
-
-            if o != o:
-                text = 'NaN'
-            elif o == _inf:
-                text = 'Infinity'
-            elif o == _neginf:
-                text = '-Infinity'
-            else:
-                return _repr(o)
-
-            if not allow_nan:
-                raise ValueError(
-                    "Out of range float values are not JSON compliant: " +
-                    repr(o))
-
-            return text
-
-
         if (_one_shot and c_make_encoder is not None
                 and self.indent is None):
             _iterencode = c_make_encoder(
@@ -251,9 +251,10 @@ class JSONEncoder(object):
                 self.skipkeys, self.allow_nan)
         else:
             _iterencode = _make_iterencode(
-                markers, self.default, _encoder, self.indent, floatstr,
-                self.key_separator, self.item_separator, self.sort_keys,
-                self.skipkeys, _one_shot)
+                markers, self.default, _encoder, self.indent, 
+                self.floatstr, self.key_separator, 
+                self.item_separator, self.sort_keys, self.skipkeys, 
+                _one_shot)
         return _iterencode(o, 0)
 
 def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -201,8 +201,8 @@ class JSONEncoder(object):
             chunks = list(chunks)
         return ''.join(chunks)
 
-    def floatstr(o, allow_nan=self.allow_nan,
-            _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
+    def floatstr(self, o, allow_nan, _repr=float.__repr__,
+                 _inf=INFINITY, _neginf=-INFINITY):
         """Return a representation of float value Infinity, -Infinity
         and NaN. Note that this type of test is processor and/or 
         platform-specific, so do tests which don't depend on the


### PR DESCRIPTION
# [bpo-42434](https://bugs.python.org/issue42434): Function floatstr should be a class-level function

The logic as it is implemented now does not allow to user to override floatstr function. That makes things enormously inconvenient for people who need any different of behaviour (for example return string values defining Infinity, NaN or -Infinity). This enhanced logic makes it easier because it makes floatstr to be a class-level function.


<!-- issue-number: [bpo-42434](https://bugs.python.org/issue42434) -->
https://bugs.python.org/issue42434
<!-- /issue-number -->
