### PR TITLE
bpo-31904: skip some tests related to fifo on VxWorks

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2186,6 +2186,8 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\x00').is_fifo(), False)
 
     @unittest.skipUnless(hasattr(os, "mkfifo"), "os.mkfifo() required")
+    @unittest.skipIf(sys.platform == "vxworks",
+                    "fifo requires special path on VxWorks")
     def test_is_fifo_true(self):
         P = self.cls(BASE, 'myfifo')
         try:

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -683,6 +683,8 @@ class TestCopyTree(BaseTest, unittest.TestCase):
     # Issue #3002: copyfile and copytree block indefinitely on named pipes
     @unittest.skipUnless(hasattr(os, "mkfifo"), 'requires os.mkfifo()')
     @os_helper.skip_unless_symlink
+    @unittest.skipIf(sys.platform == "vxworks",
+                    "fifo requires special path on VxWorks")
     def test_copytree_named_pipe(self):
         os.mkdir(TESTFN)
         try:
@@ -1206,6 +1208,8 @@ class TestCopy(BaseTest, unittest.TestCase):
 
     # Issue #3002: copyfile and copytree block indefinitely on named pipes
     @unittest.skipUnless(hasattr(os, "mkfifo"), 'requires os.mkfifo()')
+    @unittest.skipIf(sys.platform == "vxworks",
+                    "fifo requires special path on VxWorks")
     def test_copyfile_named_pipe(self):
         try:
             os.mkfifo(TESTFN)

--- a/Misc/NEWS.d/next/Tests/2020-11-23-11-11-29.bpo-31904.V3sUZk.rst
+++ b/Misc/NEWS.d/next/Tests/2020-11-23-11-11-29.bpo-31904.V3sUZk.rst
@@ -1,0 +1,1 @@
+skip some tests related to fifo on VxWorks


### PR DESCRIPTION
On VxWork RTOS, FIFO must be created under directory "/fifos/". Some test cases related to fifo is invalid on VxWorks. So skip them.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead