### PR TITLE
bpo-42142: Try to fix timeouts in ttk tests

### DIFF
--- a/Lib/tkinter/test/support.py
+++ b/Lib/tkinter/test/support.py
@@ -115,9 +115,3 @@ def widget_eq(actual, expected):
         if isinstance(expected, (str, tkinter.Widget)):
             return str(actual) == str(expected)
     return False
-
-def show_widget(widget):
-    if not widget.winfo_ismapped():
-        widget.update_idletasks()
-        if not widget.winfo_ismapped():
-            raise RuntimeError(f"Widget {widget} is still not mapped")

--- a/Lib/tkinter/test/support.py
+++ b/Lib/tkinter/test/support.py
@@ -119,3 +119,5 @@ def widget_eq(actual, expected):
 def show(widget):
     if not widget.winfo_ismapped():
         widget.wait_visibility()
+    else:
+        print(f"Widget {widget} is already mapped")

--- a/Lib/tkinter/test/support.py
+++ b/Lib/tkinter/test/support.py
@@ -115,3 +115,7 @@ def widget_eq(actual, expected):
         if isinstance(expected, (str, tkinter.Widget)):
             return str(actual) == str(expected)
     return False
+
+def show(widget):
+    if not widget.winfo_ismapped():
+        widget.wait_visibility()

--- a/Lib/tkinter/test/support.py
+++ b/Lib/tkinter/test/support.py
@@ -116,8 +116,8 @@ def widget_eq(actual, expected):
             return str(actual) == str(expected)
     return False
 
-def show(widget):
+def show_widget(widget):
     if not widget.winfo_ismapped():
-        widget.wait_visibility()
-    else:
-        print(f"Widget {widget} is already mapped")
+        widget.update_idletasks()
+        if not widget.winfo_ismapped():
+            raise RuntimeError(f"Widget {widget} is still not mapped")

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -3,7 +3,7 @@ import unittest
 import tkinter
 from tkinter import ttk
 from test.support import requires, run_unittest, swap_attr
-from tkinter.test.support import AbstractTkTest, destroy_default_root, show
+from tkinter.test.support import AbstractTkTest, destroy_default_root, show_widget
 
 requires('gui')
 
@@ -114,7 +114,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_horizontal_range(self):
         lscale = ttk.LabeledScale(self.root, from_=0, to=10)
         lscale.pack()
-        show(lscale)
+        show_widget(lscale)
         lscale.update()
 
         linfo_1 = lscale.label.place_info()
@@ -144,7 +144,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_variable_change(self):
         x = ttk.LabeledScale(self.root)
         x.pack()
-        show(x)
+        show_widget(x)
         x.update()
 
         curr_xcoord = x.scale.coords()[0]
@@ -187,7 +187,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_resize(self):
         x = ttk.LabeledScale(self.root)
         x.pack(expand=True, fill='both')
-        show(x)
+        show_widget(x)
         x.update()
 
         width, height = x.master.winfo_width(), x.master.winfo_height()
@@ -268,7 +268,7 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
 
         # check that variable is updated correctly
         optmenu.pack()
-        show(optmenu)
+        show_widget(optmenu)
         optmenu['menu'].invoke(0)
         self.assertEqual(optmenu._variable.get(), items[0])
 
@@ -299,9 +299,9 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         textvar2 = tkinter.StringVar(self.root)
         optmenu2 = ttk.OptionMenu(self.root, textvar2, default, *items)
         optmenu.pack()
-        show(optmenu)
+        show_widget(optmenu)
         optmenu2.pack()
-        show(optmenu2)
+        show_widget(optmenu2)
         optmenu['menu'].invoke(1)
         optmenu2['menu'].invoke(2)
         optmenu_stringvar_name = optmenu['menu'].entrycget(0, 'variable')

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -3,7 +3,7 @@ import unittest
 import tkinter
 from tkinter import ttk
 from test.support import requires, run_unittest, swap_attr
-from tkinter.test.support import AbstractTkTest, destroy_default_root
+from tkinter.test.support import AbstractTkTest, destroy_default_root, show
 
 requires('gui')
 
@@ -114,7 +114,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_horizontal_range(self):
         lscale = ttk.LabeledScale(self.root, from_=0, to=10)
         lscale.pack()
-        lscale.wait_visibility()
+        show(lscale)
         lscale.update()
 
         linfo_1 = lscale.label.place_info()
@@ -144,7 +144,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_variable_change(self):
         x = ttk.LabeledScale(self.root)
         x.pack()
-        x.wait_visibility()
+        show(x)
         x.update()
 
         curr_xcoord = x.scale.coords()[0]
@@ -187,7 +187,7 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_resize(self):
         x = ttk.LabeledScale(self.root)
         x.pack(expand=True, fill='both')
-        x.wait_visibility()
+        show(x)
         x.update()
 
         width, height = x.master.winfo_width(), x.master.winfo_height()
@@ -268,7 +268,7 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
 
         # check that variable is updated correctly
         optmenu.pack()
-        optmenu.wait_visibility()
+        show(optmenu)
         optmenu['menu'].invoke(0)
         self.assertEqual(optmenu._variable.get(), items[0])
 
@@ -299,9 +299,9 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         textvar2 = tkinter.StringVar(self.root)
         optmenu2 = ttk.OptionMenu(self.root, textvar2, default, *items)
         optmenu.pack()
-        optmenu.wait_visibility()
+        show(optmenu)
         optmenu2.pack()
-        optmenu2.wait_visibility()
+        show(optmenu2)
         optmenu['menu'].invoke(1)
         optmenu2['menu'].invoke(2)
         optmenu_stringvar_name = optmenu['menu'].entrycget(0, 'variable')

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -3,7 +3,7 @@ import unittest
 import tkinter
 from tkinter import ttk
 from test.support import requires, run_unittest, swap_attr
-from tkinter.test.support import AbstractTkTest, destroy_default_root, show_widget
+from tkinter.test.support import AbstractTkTest, destroy_default_root
 
 requires('gui')
 
@@ -114,7 +114,6 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_horizontal_range(self):
         lscale = ttk.LabeledScale(self.root, from_=0, to=10)
         lscale.pack()
-        show_widget(lscale)
         lscale.update()
 
         linfo_1 = lscale.label.place_info()
@@ -144,7 +143,6 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_variable_change(self):
         x = ttk.LabeledScale(self.root)
         x.pack()
-        show_widget(x)
         x.update()
 
         curr_xcoord = x.scale.coords()[0]
@@ -187,7 +185,6 @@ class LabeledScaleTest(AbstractTkTest, unittest.TestCase):
     def test_resize(self):
         x = ttk.LabeledScale(self.root)
         x.pack(expand=True, fill='both')
-        show_widget(x)
         x.update()
 
         width, height = x.master.winfo_width(), x.master.winfo_height()
@@ -268,7 +265,6 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
 
         # check that variable is updated correctly
         optmenu.pack()
-        show_widget(optmenu)
         optmenu['menu'].invoke(0)
         self.assertEqual(optmenu._variable.get(), items[0])
 
@@ -299,9 +295,7 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         textvar2 = tkinter.StringVar(self.root)
         optmenu2 = ttk.OptionMenu(self.root, textvar2, default, *items)
         optmenu.pack()
-        show_widget(optmenu)
         optmenu2.pack()
-        show_widget(optmenu2)
         optmenu['menu'].invoke(1)
         optmenu2['menu'].invoke(2)
         optmenu_stringvar_name = optmenu['menu'].entrycget(0, 'variable')

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -6,7 +6,7 @@ import sys
 
 from tkinter.test.test_ttk.test_functions import MockTclObj
 from tkinter.test.support import (AbstractTkTest, tcl_version, get_tk_patchlevel,
-                                  simulate_mouse_click, show_widget)
+                                  simulate_mouse_click)
 from tkinter.test.widget_tests import (add_standard_options, noconv,
     AbstractWidgetTest, StandardOptionsTests, IntegerSizeTests, PixelSizeTests,
     setUpModule)
@@ -60,11 +60,10 @@ class WidgetTest(AbstractTkTest, unittest.TestCase):
         super().setUp()
         self.widget = ttk.Button(self.root, width=0, text="Text")
         self.widget.pack()
-        show_widget(self.widget)
 
 
     def test_identify(self):
-        self.widget.update_idletasks()
+        self.widget.update()
         self.assertEqual(self.widget.identify(
             int(self.widget.winfo_width() / 2),
             int(self.widget.winfo_height() / 2)
@@ -326,8 +325,7 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_identify(self):
         self.entry.pack()
-        show_widget(self.entry)
-        self.entry.update_idletasks()
+        self.entry.update()
 
         # bpo-27313: macOS Cocoa widget differs from X, allow either
         if sys.platform == 'darwin':
@@ -450,7 +448,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.combo.bind('<<ComboboxSelected>>',
             lambda evt: success.append(True))
         self.combo.pack()
-        show_widget(self.combo)
+        self.combo.update()
 
         height = self.combo.winfo_height()
         self._show_drop_down_listbox()
@@ -466,7 +464,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
 
         self.combo['postcommand'] = lambda: success.append(True)
         self.combo.pack()
-        show_widget(self.combo)
+        self.combo.update()
 
         self._show_drop_down_listbox()
         self.assertTrue(success)
@@ -666,7 +664,6 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, self.paned.sashpos, 1)
 
         self.paned.pack(expand=True, fill='both')
-        show_widget(self.paned)
 
         curr_pos = self.paned.sashpos(0)
         self.paned.sashpos(0, 1000)
@@ -934,7 +931,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
         self.nb.add(self.child1, text='a')
 
         self.nb.pack()
-        show_widget(self.nb)
+        self.nb.update()
         if sys.platform == 'darwin':
             tb_idx = "@20,5"
         else:
@@ -1042,7 +1039,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_select(self):
         self.nb.pack()
-        show_widget(self.nb)
+        self.nb.update()
 
         success = []
         tab_changed = []
@@ -1085,7 +1082,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_traversal(self):
         self.nb.pack()
-        show_widget(self.nb)
+        self.nb.update()
 
         self.nb.select(0)
 
@@ -1347,7 +1344,6 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
     def test_bbox(self):
         self.tv.pack()
         self.assertEqual(self.tv.bbox(''), '')
-        show_widget(self.tv)
         self.tv.update()
 
         item_id = self.tv.insert('', 'end')
@@ -1544,7 +1540,6 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         success = [] # no success for now
 
         self.tv.pack()
-        show_widget(self.tv)
         self.tv.heading('#0', command=lambda: success.append(True))
         self.tv.column('#0', width=100)
         self.tv.update()
@@ -1792,7 +1787,6 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
             lambda evt: events.append(2))
 
         self.tv.pack()
-        show_widget(self.tv)
         self.tv.update()
 
         pos_y = set()

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -437,8 +437,10 @@ class ComboboxTest(EntryTest, unittest.TestCase):
 
     def _show_drop_down_listbox(self):
         width = self.combo.winfo_width()
-        self.combo.event_generate('<ButtonPress-1>', x=width - 5, y=5)
-        self.combo.event_generate('<ButtonRelease-1>', x=width - 5, y=5)
+        x, y = width - 5, 5
+        self.assertEqual(self.combo.identify(x, y), 'downarrow')
+        self.combo.event_generate('<ButtonPress-1>', x=x, y=y)
+        self.combo.event_generate('<ButtonRelease-1>', x=x, y=y)
         self.combo.update_idletasks()
 
 
@@ -1132,6 +1134,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         height = self.spin.winfo_height()
         x = width - 5
         y = height//2 - 5
+        self.assertEqual(self.spin.identify(x, y), 'uparrow')
         self.spin.event_generate('<ButtonPress-1>', x=x, y=y)
         self.spin.event_generate('<ButtonRelease-1>', x=x, y=y)
         self.spin.update_idletasks()
@@ -1141,6 +1144,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         height = self.spin.winfo_height()
         x = width - 5
         y = height//2 + 4
+        self.assertEqual(self.spin.identify(x, y), 'downarrow')
         self.spin.event_generate('<ButtonPress-1>', x=x, y=y)
         self.spin.event_generate('<ButtonRelease-1>', x=x, y=y)
         self.spin.update_idletasks()

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -6,7 +6,7 @@ import sys
 
 from tkinter.test.test_ttk.test_functions import MockTclObj
 from tkinter.test.support import (AbstractTkTest, tcl_version, get_tk_patchlevel,
-                                  simulate_mouse_click)
+                                  simulate_mouse_click, show)
 from tkinter.test.widget_tests import (add_standard_options, noconv,
     AbstractWidgetTest, StandardOptionsTests, IntegerSizeTests, PixelSizeTests,
     setUpModule)
@@ -60,7 +60,7 @@ class WidgetTest(AbstractTkTest, unittest.TestCase):
         super().setUp()
         self.widget = ttk.Button(self.root, width=0, text="Text")
         self.widget.pack()
-        self.widget.wait_visibility()
+        show(self.widget)
 
 
     def test_identify(self):
@@ -326,7 +326,7 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_identify(self):
         self.entry.pack()
-        self.entry.wait_visibility()
+        show(self.entry)
         self.entry.update_idletasks()
 
         # bpo-27313: macOS Cocoa widget differs from X, allow either
@@ -449,7 +449,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.combo.bind('<<ComboboxSelected>>',
             lambda evt: success.append(True))
         self.combo.pack()
-        self.combo.wait_visibility()
+        show(self.combo)
 
         height = self.combo.winfo_height()
         self._show_drop_down_listbox()
@@ -465,7 +465,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
 
         self.combo['postcommand'] = lambda: success.append(True)
         self.combo.pack()
-        self.combo.wait_visibility()
+        show(self.combo)
 
         self._show_drop_down_listbox()
         self.assertTrue(success)
@@ -665,7 +665,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, self.paned.sashpos, 1)
 
         self.paned.pack(expand=True, fill='both')
-        self.paned.wait_visibility()
+        show(self.paned)
 
         curr_pos = self.paned.sashpos(0)
         self.paned.sashpos(0, 1000)
@@ -933,7 +933,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
         self.nb.add(self.child1, text='a')
 
         self.nb.pack()
-        self.nb.wait_visibility()
+        show(self.nb)
         if sys.platform == 'darwin':
             tb_idx = "@20,5"
         else:
@@ -1041,7 +1041,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_select(self):
         self.nb.pack()
-        self.nb.wait_visibility()
+        show(self.nb)
 
         success = []
         tab_changed = []
@@ -1084,7 +1084,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_traversal(self):
         self.nb.pack()
-        self.nb.wait_visibility()
+        show(self.nb)
 
         self.nb.select(0)
 
@@ -1342,7 +1342,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
     def test_bbox(self):
         self.tv.pack()
         self.assertEqual(self.tv.bbox(''), '')
-        self.tv.wait_visibility()
+        show(self.tv)
         self.tv.update()
 
         item_id = self.tv.insert('', 'end')
@@ -1536,7 +1536,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         success = [] # no success for now
 
         self.tv.pack()
-        self.tv.wait_visibility()
+        show(self.tv)
         self.tv.heading('#0', command=lambda: success.append(True))
         self.tv.column('#0', width=100)
         self.tv.update()
@@ -1784,7 +1784,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
             lambda evt: events.append(2))
 
         self.tv.pack()
-        self.tv.wait_visibility()
+        show(self.tv)
         self.tv.update()
 
         pos_y = set()

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -6,7 +6,7 @@ import sys
 
 from tkinter.test.test_ttk.test_functions import MockTclObj
 from tkinter.test.support import (AbstractTkTest, tcl_version, get_tk_patchlevel,
-                                  simulate_mouse_click, show)
+                                  simulate_mouse_click, show_widget)
 from tkinter.test.widget_tests import (add_standard_options, noconv,
     AbstractWidgetTest, StandardOptionsTests, IntegerSizeTests, PixelSizeTests,
     setUpModule)
@@ -60,7 +60,7 @@ class WidgetTest(AbstractTkTest, unittest.TestCase):
         super().setUp()
         self.widget = ttk.Button(self.root, width=0, text="Text")
         self.widget.pack()
-        show(self.widget)
+        show_widget(self.widget)
 
 
     def test_identify(self):
@@ -326,7 +326,7 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_identify(self):
         self.entry.pack()
-        show(self.entry)
+        show_widget(self.entry)
         self.entry.update_idletasks()
 
         # bpo-27313: macOS Cocoa widget differs from X, allow either
@@ -451,7 +451,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.combo.bind('<<ComboboxSelected>>',
             lambda evt: success.append(True))
         self.combo.pack()
-        show(self.combo)
+        show_widget(self.combo)
 
         height = self.combo.winfo_height()
         self._show_drop_down_listbox()
@@ -467,7 +467,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
 
         self.combo['postcommand'] = lambda: success.append(True)
         self.combo.pack()
-        show(self.combo)
+        show_widget(self.combo)
 
         self._show_drop_down_listbox()
         self.assertTrue(success)
@@ -667,7 +667,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, self.paned.sashpos, 1)
 
         self.paned.pack(expand=True, fill='both')
-        show(self.paned)
+        show_widget(self.paned)
 
         curr_pos = self.paned.sashpos(0)
         self.paned.sashpos(0, 1000)
@@ -935,7 +935,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
         self.nb.add(self.child1, text='a')
 
         self.nb.pack()
-        show(self.nb)
+        show_widget(self.nb)
         if sys.platform == 'darwin':
             tb_idx = "@20,5"
         else:
@@ -1043,7 +1043,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_select(self):
         self.nb.pack()
-        show(self.nb)
+        show_widget(self.nb)
 
         success = []
         tab_changed = []
@@ -1086,7 +1086,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_traversal(self):
         self.nb.pack()
-        show(self.nb)
+        show_widget(self.nb)
 
         self.nb.select(0)
 
@@ -1346,7 +1346,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
     def test_bbox(self):
         self.tv.pack()
         self.assertEqual(self.tv.bbox(''), '')
-        show(self.tv)
+        show_widget(self.tv)
         self.tv.update()
 
         item_id = self.tv.insert('', 'end')
@@ -1540,7 +1540,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         success = [] # no success for now
 
         self.tv.pack()
-        show(self.tv)
+        show_widget(self.tv)
         self.tv.heading('#0', command=lambda: success.append(True))
         self.tv.column('#0', width=100)
         self.tv.update()
@@ -1788,7 +1788,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
             lambda evt: events.append(2))
 
         self.tv.pack()
-        show(self.tv)
+        show_widget(self.tv)
         self.tv.update()
 
         pos_y = set()

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -438,7 +438,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
     def _show_drop_down_listbox(self):
         width = self.combo.winfo_width()
         x, y = width - 5, 5
-        self.assertEqual(self.combo.identify(x, y), 'downarrow')
+        self.assertRegex(self.combo.identify(x, y), r'.*downarrow\Z')
         self.combo.event_generate('<ButtonPress-1>', x=x, y=y)
         self.combo.event_generate('<ButtonRelease-1>', x=x, y=y)
         self.combo.update_idletasks()
@@ -1134,7 +1134,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         height = self.spin.winfo_height()
         x = width - 5
         y = height//2 - 5
-        self.assertEqual(self.spin.identify(x, y), 'uparrow')
+        self.assertRegex(self.spin.identify(x, y), r'.*uparrow\Z')
         self.spin.event_generate('<ButtonPress-1>', x=x, y=y)
         self.spin.event_generate('<ButtonRelease-1>', x=x, y=y)
         self.spin.update_idletasks()
@@ -1144,7 +1144,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         height = self.spin.winfo_height()
         x = width - 5
         y = height//2 + 4
-        self.assertEqual(self.spin.identify(x, y), 'downarrow')
+        self.assertRegex(self.spin.identify(x, y), r'.*downarrow\Z')
         self.spin.event_generate('<ButtonPress-1>', x=x, y=y)
         self.spin.event_generate('<ButtonRelease-1>', x=x, y=y)
         self.spin.update_idletasks()


### PR DESCRIPTION
Check whether the widget is already visible before waiting a `<VisibilityNotify>` event.


<!-- issue-number: [bpo-42142](https://bugs.python.org/issue42142) -->
https://bugs.python.org/issue42142
<!-- /issue-number -->
