### PR TITLE
bpo-42006: Stop using PyDict_GetItemString()

### DIFF
--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1050,7 +1050,7 @@ fail:
 static PyObject*
 config_dict_get(PyObject *dict, const char *name)
 {
-    PyObject *item = PyMapping_GetItemString(dict, name);
+    PyObject *item = _PyDict_GetItemStringWithError(dict, name);
     if (item == NULL) {
         PyErr_Format(PyExc_ValueError, "missing config key: %s", name);
         return NULL;

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1050,7 +1050,7 @@ fail:
 static PyObject*
 config_dict_get(PyObject *dict, const char *name)
 {
-    PyObject *item = PyDict_GetItemString(dict, name);
+    PyObject *item = PyMapping_GetItemString(dict, name);
     if (item == NULL) {
         PyErr_Format(PyExc_ValueError, "missing config key: %s", name);
         return NULL;


### PR DESCRIPTION
This is a complement to that PR #22648.

<!-- issue-number: [bpo-42006](https://bugs.python.org/issue42006) -->
https://bugs.python.org/issue42006
<!-- /issue-number -->
