### PR TITLE
bpo-31904: add shell requirement for test_pipes

### DIFF
--- a/Doc/library/pipes.rst
+++ b/Doc/library/pipes.rst
@@ -17,6 +17,8 @@ The :mod:`pipes` module defines a class to abstract the concept of a *pipeline*
 Because the module uses :program:`/bin/sh` command lines, a POSIX or compatible
 shell for :func:`os.system` and :func:`os.popen` is required.
 
+.. availability:: Unix. Not available on VxWorks.
+
 The :mod:`pipes` module defines the following class:
 
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -421,7 +421,7 @@ is_jython = sys.platform.startswith('java')
 
 is_android = hasattr(sys, 'getandroidapilevel')
 
-if sys.platform != 'win32':
+if sys.platform not in ('win32', 'vxworks'):
     unix_shell = '/system/bin/sh' if is_android else '/bin/sh'
 else:
     unix_shell = None

--- a/Lib/test/test_pipes.py
+++ b/Lib/test/test_pipes.py
@@ -3,12 +3,15 @@ import os
 import string
 import unittest
 import shutil
-from test.support import run_unittest, reap_children
+from test.support import run_unittest, reap_children, unix_shell
 from test.support.os_helper import TESTFN, unlink
 
 
 if os.name != 'posix':
     raise unittest.SkipTest('pipes module only works on posix')
+
+if not (unix_shell and os.path.exists(unix_shell)):
+    raise unittest.SkipTest('pipes module requires a shell')
 
 TESTFN2 = TESTFN + "2"
 

--- a/Misc/NEWS.d/next/Tests/2020-11-24-17-26-41.bpo-31904.eug834.rst
+++ b/Misc/NEWS.d/next/Tests/2020-11-24-17-26-41.bpo-31904.eug834.rst
@@ -1,0 +1,1 @@
+add shell requirement for test_pipes


### PR DESCRIPTION
VxWorks has no user space shell provided so it can't support pipes module. Also add shell requirement for running test_pipes.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead