### PR TITLE
bpo-42455: Add decorator_factory to functools module

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -12,7 +12,7 @@
 __all__ = ['update_wrapper', 'wraps', 'WRAPPER_ASSIGNMENTS', 'WRAPPER_UPDATES',
            'total_ordering', 'cache', 'cmp_to_key', 'lru_cache', 'reduce',
            'partial', 'partialmethod', 'singledispatch', 'singledispatchmethod',
-           'cached_property']
+           'cached_property', 'decorator_with_params']
 
 from abc import get_cache_token
 from collections import namedtuple
@@ -979,3 +979,19 @@ class cached_property:
         return val
 
     __class_getitem__ = classmethod(GenericAlias)
+
+
+def decorator_with_params(deco):
+    """Transform function into decorator with parameters"""
+
+    @wraps(deco)
+    def decorator(func=None, /, *args, **kwargs):
+        if func is not None:
+            return deco(func, *args, **kwargs)
+
+        def wrapper(f):
+            return deco(f, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -985,9 +985,9 @@ def decorator_factory(func):
     """Transform function into decorator"""
 
     @wraps(func)
-    def decorator(fn=None, /, *args, **kwargs):
-        if fn is not None:
-            return func(fn, *args, **kwargs)
+    def decorator(*args, **kwargs):
+        if args and callable(args[0]):
+            return func(*args, **kwargs)
 
         def wrapper(f):
             return func(f, *args, **kwargs)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -12,7 +12,7 @@
 __all__ = ['update_wrapper', 'wraps', 'WRAPPER_ASSIGNMENTS', 'WRAPPER_UPDATES',
            'total_ordering', 'cache', 'cmp_to_key', 'lru_cache', 'reduce',
            'partial', 'partialmethod', 'singledispatch', 'singledispatchmethod',
-           'cached_property', 'decorator_with_params']
+           'cached_property', 'decorator_factory']
 
 from abc import get_cache_token
 from collections import namedtuple
@@ -981,16 +981,16 @@ class cached_property:
     __class_getitem__ = classmethod(GenericAlias)
 
 
-def decorator_with_params(deco):
-    """Transform function into decorator with parameters"""
+def decorator_factory(func):
+    """Transform function into decorator"""
 
-    @wraps(deco)
-    def decorator(func=None, /, *args, **kwargs):
-        if func is not None:
-            return deco(func, *args, **kwargs)
+    @wraps(func)
+    def decorator(fn=None, /, *args, **kwargs):
+        if fn is not None:
+            return func(fn, *args, **kwargs)
 
         def wrapper(f):
-            return deco(f, *args, **kwargs)
+            return func(f, *args, **kwargs)
 
         return wrapper
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2615,5 +2615,57 @@ class TestCachedProperty(unittest.TestCase):
         self.assertEqual(CachedCostItem.cost.__doc__, "The cost of the item.")
 
 
+class TestDecoratorWithParams(unittest.TestCase):
+    def test_wrapping_attributes(self):
+        @py_functools.decorator_with_params
+        def function(func, /, a, b):
+            """This is function"""
+            return "Test"
+
+        self.assertEqual(function.__name__, "function")
+        if sys.flags.optimize < 2:
+            self.assertEqual(function.__doc__, "This is function")
+
+    def test_default_values(self):
+        @py_functools.decorator_with_params
+        def decorator(func, /, a=1):
+            def wrapper(*args, **kwargs):
+                return a
+
+            return wrapper
+
+        @decorator
+        def a():
+            pass
+
+        @decorator(a=2)
+        def b():
+            pass
+
+        self.assertEqual(a(), 1)
+        self.assertEqual(b(), 2)
+
+    def test_params_without_default_value(self):
+        @py_functools.decorator_with_params
+        def decorator(func, /, a):
+            return func
+
+        with self.assertRaises(TypeError):
+            @decorator
+            def a():
+                pass
+
+    def test_wraps_correct_function(self):
+        @py_functools.decorator_with_params
+        def decorator(func, /):
+            return func
+
+        def a():
+            pass
+
+        self.assertIs(decorator(a), a)
+        self.assertIs(decorator()(a), a)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2638,12 +2638,17 @@ class TestDecoratorFactory(unittest.TestCase):
         def a():
             pass
 
-        @decorator(a=2)
+        @decorator()
         def b():
             pass
 
+        @decorator(a=2)
+        def c():
+            pass
+
         self.assertEqual(a(), 1)
-        self.assertEqual(b(), 2)
+        self.assertEqual(b(), 1)
+        self.assertEqual(c(), 2)
 
     def test_params_without_default_value(self):
         @py_functools.decorator_factory

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2615,9 +2615,9 @@ class TestCachedProperty(unittest.TestCase):
         self.assertEqual(CachedCostItem.cost.__doc__, "The cost of the item.")
 
 
-class TestDecoratorWithParams(unittest.TestCase):
+class TestDecoratorFactory(unittest.TestCase):
     def test_wrapping_attributes(self):
-        @py_functools.decorator_with_params
+        @py_functools.decorator_factory
         def function(func, /, a, b):
             """This is function"""
             return "Test"
@@ -2627,7 +2627,7 @@ class TestDecoratorWithParams(unittest.TestCase):
             self.assertEqual(function.__doc__, "This is function")
 
     def test_default_values(self):
-        @py_functools.decorator_with_params
+        @py_functools.decorator_factory
         def decorator(func, /, a=1):
             def wrapper(*args, **kwargs):
                 return a
@@ -2646,7 +2646,7 @@ class TestDecoratorWithParams(unittest.TestCase):
         self.assertEqual(b(), 2)
 
     def test_params_without_default_value(self):
-        @py_functools.decorator_with_params
+        @py_functools.decorator_factory
         def decorator(func, /, a):
             return func
 
@@ -2656,7 +2656,7 @@ class TestDecoratorWithParams(unittest.TestCase):
                 pass
 
     def test_wraps_correct_function(self):
-        @py_functools.decorator_with_params
+        @py_functools.decorator_factory
         def decorator(func, /):
             return func
 

--- a/Misc/NEWS.d/next/Library/2020-11-24-22-36-09.bpo-42455.QhQV_V.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-24-22-36-09.bpo-42455.QhQV_V.rst
@@ -1,0 +1,2 @@
+Add ``decorator_with_params`` function to ``functools`` module. Patch
+provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2020-11-24-22-36-09.bpo-42455.QhQV_V.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-24-22-36-09.bpo-42455.QhQV_V.rst
@@ -1,2 +1,2 @@
-Add ``decorator_with_params`` function to ``functools`` module. Patch
+Add ``decorator_factory`` function to ``functools`` module. Patch
 provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Add `decorator_factory` to `functools` module.

More information regarding this feature: https://bugs.python.org/issue42455#msg381773

I have just gone through the standard library code to find places where `decorator_factory` can be used.


1. `dataclasses.dataclass`
```python
def dataclass(cls=None, /, *, init=True, repr=True, eq=True, order=False,
              unsafe_hash=False, frozen=False):
    """Returns the same class as was passed in, with dunder methods
    added based on the fields defined in the class.

    Examines PEP 526 __annotations__ to determine fields.

    If init is true, an __init__() method is added to the class. If
    repr is true, a __repr__() method is added. If order is true, rich
    comparison dunder methods are added. If unsafe_hash is true, a
    __hash__() method function is added. If frozen is true, fields may
    not be assigned to after instance creation.
    """

    def wrap(cls):
        return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)

    # See if we're being called as @dataclass or @dataclass().
    if cls is None:
        # We're called with parens.
        return wrap

    # We're called as @dataclass without parens.
    return wrap(cls)
```
```python
@functools.decorator_factory
def dataclass(cls, /, *, init=True, repr=True, eq=True, order=False,
              unsafe_hash=False, frozen=False):
    """Returns the same class as was passed in, with dunder methods
    added based on the fields defined in the class.

    Examines PEP 526 __annotations__ to determine fields.

    If init is true, an __init__() method is added to the class. If
    repr is true, a __repr__() method is added. If order is true, rich
    comparison dunder methods are added. If unsafe_hash is true, a
    __hash__() method function is added. If frozen is true, fields may
    not be assigned to after instance creation.
    """
    return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
```

2. `functools.lru_cache`
```python
def lru_cache(maxsize=128, typed=False):
    """Least-recently-used cache decorator.

    If *maxsize* is set to None, the LRU features are disabled and the cache
    can grow without bound.

    If *typed* is True, arguments of different types will be cached separately.
    For example, f(3.0) and f(3) will be treated as distinct calls with
    distinct results.

    Arguments to the cached function must be hashable.

    View the cache statistics named tuple (hits, misses, maxsize, currsize)
    with f.cache_info().  Clear the cache and statistics with f.cache_clear().
    Access the underlying function with f.__wrapped__.

    See:  http://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)

    """

    # Users should only access the lru_cache through its public API:
    #       cache_info, cache_clear, and f.__wrapped__
    # The internals of the lru_cache are encapsulated for thread safety and
    # to allow the implementation to change (including a possible C version).

    if isinstance(maxsize, int):
        # Negative maxsize is treated as 0
        if maxsize < 0:
            maxsize = 0
    elif callable(maxsize) and isinstance(typed, bool):
        # The user_function was passed in directly via the maxsize argument
        user_function, maxsize = maxsize, 128
        wrapper = _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo)
        wrapper.cache_parameters = lambda : {'maxsize': maxsize, 'typed': typed}
        return update_wrapper(wrapper, user_function)
    elif maxsize is not None:
        raise TypeError(
            'Expected first argument to be an integer, a callable, or None')

    def decorating_function(user_function):
        wrapper = _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo)
        wrapper.cache_parameters = lambda : {'maxsize': maxsize, 'typed': typed}
        return update_wrapper(wrapper, user_function)

    return decorating_function
```
```python
@decorator_factory
def lru_cache(user_function, /, maxsize=128, typed=False):
    """Least-recently-used cache decorator.

    If *maxsize* is set to None, the LRU features are disabled and the cache
    can grow without bound.

    If *typed* is True, arguments of different types will be cached separately.
    For example, f(3.0) and f(3) will be treated as distinct calls with
    distinct results.

    Arguments to the cached function must be hashable.

    View the cache statistics named tuple (hits, misses, maxsize, currsize)
    with f.cache_info().  Clear the cache and statistics with f.cache_clear().
    Access the underlying function with f.__wrapped__.

    See:  http://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)

    """

    # Users should only access the lru_cache through its public API:
    #       cache_info, cache_clear, and f.__wrapped__
    # The internals of the lru_cache are encapsulated for thread safety and
    # to allow the implementation to change (including a possible C version).

    if isinstance(maxsize, int):
        # Negative maxsize is treated as 0
        if maxsize < 0:
            maxsize = 0
    elif maxsize is not None:
        raise TypeError(
            'Expected first argument to be an integer, a callable, or None')

    wrapper = _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo)
    wrapper.cache_parameters = lambda : {'maxsize': maxsize, 'typed': typed}
    return update_wrapper(wrapper, user_function)
```

3. `reprlib.recursive_repr`
```python
def recursive_repr(fillvalue='...'):
    'Decorator to make a repr function return fillvalue for a recursive call'

    def decorating_function(user_function):
        repr_running = set()

        def wrapper(self):
            key = id(self), get_ident()
            if key in repr_running:
                return fillvalue
            repr_running.add(key)
            try:
                result = user_function(self)
            finally:
                repr_running.discard(key)
            return result

        # Can't use functools.wraps() here because of bootstrap issues
        wrapper.__module__ = getattr(user_function, '__module__')
        wrapper.__doc__ = getattr(user_function, '__doc__')
        wrapper.__name__ = getattr(user_function, '__name__')
        wrapper.__qualname__ = getattr(user_function, '__qualname__')
        wrapper.__annotations__ = getattr(user_function, '__annotations__', {})
        return wrapper

    return decorating_function
```
```python
@decorator_factory
def recursive_repr(user_function, fillvalue='...'):
    'Decorator to make a repr function return fillvalue for a recursive call'
    repr_running = set()

    def wrapper(self):
        key = id(self), get_ident()
        if key in repr_running:
            return fillvalue
        repr_running.add(key)
        try:
            result = user_function(self)
        finally:
            repr_running.discard(key)
        return result

    # Can't use functools.wraps() here because of bootstrap issues
    wrapper.__module__ = getattr(user_function, '__module__')
    wrapper.__doc__ = getattr(user_function, '__doc__')
    wrapper.__name__ = getattr(user_function, '__name__')
    wrapper.__qualname__ = getattr(user_function, '__qualname__')
    wrapper.__annotations__ = getattr(user_function, '__annotations__', {})
    return wrapper
```

4. `typing._tp_cache`
```python
def _tp_cache(func=None, /, *, typed=False):
    """Internal wrapper caching __getitem__ of generic types with a fallback to
    original function for non-hashable arguments.
    """
    def decorator(func):
        cached = functools.lru_cache(typed=typed)(func)
        _cleanups.append(cached.cache_clear)

        @functools.wraps(func)
        def inner(*args, **kwds):
            try:
                return cached(*args, **kwds)
            except TypeError:
                pass  # All real errors (not unhashable args) are raised below.
            return func(*args, **kwds)
        return inner

    if func is not None:
        return decorator(func)

    return decorator
```
```python
@functools.decorator_factory
def _tp_cache(func, /, *, typed=False):
    """Internal wrapper caching __getitem__ of generic types with a fallback to
    original function for non-hashable arguments.
    """
    cached = functools.lru_cache(typed=typed)(func)
    _cleanups.append(cached.cache_clear)

    @functools.wraps(func)
    def inner(*args, **kwds):
        try:
            return cached(*args, **kwds)
        except TypeError:
            pass  # All real errors (not unhashable args) are raised below.
        return func(*args, **kwds)

    return inner
```

<!-- issue-number: [bpo-42455](https://bugs.python.org/issue42455) -->
https://bugs.python.org/issue42455
<!-- /issue-number -->
