### PR TITLE
bpo-31904: skip test_test of test_mailcap on VxWorks

### DIFF
--- a/Lib/test/test_mailcap.py
+++ b/Lib/test/test_mailcap.py
@@ -4,6 +4,7 @@ import copy
 import test.support
 from test.support import os_helper
 import unittest
+import sys
 
 # Location of mailcap file
 MAILCAPFILE = test.support.findfile("mailcap.txt")
@@ -214,6 +215,7 @@ class FindmatchTest(unittest.TestCase):
         self._run_cases(cases)
 
     @unittest.skipUnless(os.name == "posix", "Requires 'test' command on system")
+    @unittest.skipIf(sys.platform == "vxworks", "'test' command is not supported on VxWorks")
     def test_test(self):
         # findmatch() will automatically check any "test" conditions and skip
         # the entry if the check fails.

--- a/Misc/NEWS.d/next/Tests/2020-11-25-17-00-53.bpo-31904.ue4hd9.rst
+++ b/Misc/NEWS.d/next/Tests/2020-11-25-17-00-53.bpo-31904.ue4hd9.rst
@@ -1,0 +1,1 @@
+skip test_test of test_mailcap on VxWorks


### PR DESCRIPTION
VxWorks has no user space shell provided and also no test command supported.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
