### PR TITLE
gh-86627: show f_fsid when pring os.statvfs object

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -624,14 +624,14 @@ class StatAttributeTests(unittest.TestCase):
 
         # Make sure all the attributes are there.
         members = ('bsize', 'frsize', 'blocks', 'bfree', 'bavail', 'files',
-                    'ffree', 'favail', 'flag', 'namemax')
+                    'ffree', 'favail', 'flag', 'namemax', 'fsid')
         for value, member in enumerate(members):
             self.assertEqual(getattr(result, 'f_' + member), result[value])
 
         self.assertTrue(isinstance(result.f_fsid, int))
 
         # Test that the size of the tuple doesn't change
-        self.assertEqual(len(result), 10)
+        self.assertEqual(len(result), 11)
 
         # Make sure that assignment really fails
         try:

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2182,7 +2182,7 @@ static PyStructSequence_Desc stat_result_desc = {
 PyDoc_STRVAR(statvfs_result__doc__,
 "statvfs_result: Result from statvfs or fstatvfs.\n\n\
 This object may be accessed either as a tuple of\n\
-  (bsize, frsize, blocks, bfree, bavail, files, ffree, favail, flag, namemax),\n\
+  (bsize, frsize, blocks, bfree, bavail, files, ffree, favail, flag, namemax, fsid),\n\
 or via the attributes f_bsize, f_frsize, f_blocks, f_bfree, and so on.\n\
 \n\
 See os.statvfs for more information.");
@@ -2206,7 +2206,7 @@ static PyStructSequence_Desc statvfs_result_desc = {
     "statvfs_result", /* name */
     statvfs_result__doc__, /* doc */
     statvfs_result_fields,
-    10
+    11
 };
 
 #if defined(HAVE_WAITID) && !defined(__APPLE__)


### PR DESCRIPTION
Since python 3.7, f_fsid was added to os.statvfs, but it didn't show
up when print the object. So add one more field to output.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42461](https://bugs.python.org/issue42461) -->
https://bugs.python.org/issue42461
<!-- /issue-number -->

<!-- gh-issue-number: gh-86627 -->
* Issue: gh-86627
<!-- /gh-issue-number -->
