### PR TITLE
Fix an error in the news entry for _posixsubprocess multiphase init

### DIFF
--- a/Misc/NEWS.d/next/C API/2020-11-19-16-54-16.bpo-1635741.9tVsZt.rst
+++ b/Misc/NEWS.d/next/C API/2020-11-19-16-54-16.bpo-1635741.9tVsZt.rst
@@ -1,1 +1,2 @@
-Port _posixshmem extension module to multiphase initialization (:pep:`489`).
+Port _posixsubprocess extension module to multiphase initialization
+(:pep:`489`).


### PR DESCRIPTION
Commit 035deee265c7fb227ddc87222fa48761231d8bd7 converted the
_posixsubprocess module to multiphase initialization, but the news entry
mentions the _posixshmem module.

