### PR TITLE
bpo-42392: Remove loop parameter from asyncio.streams

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -23,7 +23,7 @@ _DEFAULT_LIMIT = 2 ** 16  # 64 KiB
 
 
 async def open_connection(host=None, port=None, *,
-                          loop=None, limit=_DEFAULT_LIMIT, **kwds):
+                          limit=_DEFAULT_LIMIT, **kwds):
     """A wrapper for create_connection() returning a (reader, writer) pair.
 
     The reader returned is a StreamReader instance; the writer is a
@@ -41,12 +41,7 @@ async def open_connection(host=None, port=None, *,
     StreamReaderProtocol classes, just copy the code -- there's
     really nothing special here except some convenience.)
     """
-    if loop is None:
-        loop = events.get_event_loop()
-    else:
-        warnings.warn("The loop argument is deprecated since Python 3.8, "
-                      "and scheduled for removal in Python 3.10.",
-                      DeprecationWarning, stacklevel=2)
+    loop = events.get_running_loop()
     reader = StreamReader(limit=limit, loop=loop)
     protocol = StreamReaderProtocol(reader, loop=loop)
     transport, _ = await loop.create_connection(
@@ -56,7 +51,7 @@ async def open_connection(host=None, port=None, *,
 
 
 async def start_server(client_connected_cb, host=None, port=None, *,
-                       loop=None, limit=_DEFAULT_LIMIT, **kwds):
+                       limit=_DEFAULT_LIMIT, **kwds):
     """Start a socket server, call back for each client connected.
 
     The first parameter, `client_connected_cb`, takes two parameters:
@@ -78,12 +73,7 @@ async def start_server(client_connected_cb, host=None, port=None, *,
     The return value is the same as loop.create_server(), i.e. a
     Server object which can be used to stop the service.
     """
-    if loop is None:
-        loop = events.get_event_loop()
-    else:
-        warnings.warn("The loop argument is deprecated since Python 3.8, "
-                      "and scheduled for removal in Python 3.10.",
-                      DeprecationWarning, stacklevel=2)
+    loop = events.get_running_loop()
 
     def factory():
         reader = StreamReader(limit=limit, loop=loop)
@@ -98,14 +88,10 @@ if hasattr(socket, 'AF_UNIX'):
     # UNIX Domain Sockets are supported on this platform
 
     async def open_unix_connection(path=None, *,
-                                   loop=None, limit=_DEFAULT_LIMIT, **kwds):
+                                   limit=_DEFAULT_LIMIT, **kwds):
         """Similar to `open_connection` but works with UNIX Domain Sockets."""
-        if loop is None:
-            loop = events.get_event_loop()
-        else:
-            warnings.warn("The loop argument is deprecated since Python 3.8, "
-                          "and scheduled for removal in Python 3.10.",
-                          DeprecationWarning, stacklevel=2)
+        loop = events.get_running_loop()
+
         reader = StreamReader(limit=limit, loop=loop)
         protocol = StreamReaderProtocol(reader, loop=loop)
         transport, _ = await loop.create_unix_connection(
@@ -114,14 +100,9 @@ if hasattr(socket, 'AF_UNIX'):
         return reader, writer
 
     async def start_unix_server(client_connected_cb, path=None, *,
-                                loop=None, limit=_DEFAULT_LIMIT, **kwds):
+                                limit=_DEFAULT_LIMIT, **kwds):
         """Similar to `start_server` but works with UNIX Domain Sockets."""
-        if loop is None:
-            loop = events.get_event_loop()
-        else:
-            warnings.warn("The loop argument is deprecated since Python 3.8, "
-                          "and scheduled for removal in Python 3.10.",
-                          DeprecationWarning, stacklevel=2)
+        loop = events.get_running_loop()
 
         def factory():
             reader = StreamReader(limit=limit, loop=loop)

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1160,9 +1160,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
     @unittest.skipUnless(socket_helper.IPV6_ENABLED, 'no IPv6 support')
     def test_create_server_ipv6(self):
         async def main():
-            with self.assertWarns(DeprecationWarning):
-                srv = await asyncio.start_server(
-                    lambda: None, '::1', 0, loop=self.loop)
+            srv = await asyncio.start_server(lambda: None, '::1', 0)
             try:
                 self.assertGreater(len(srv.sockets), 0)
             finally:

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -45,9 +45,8 @@ class BaseStartServer(func_tests.FunctionalTestCaseMixin):
             async with srv:
                 await srv.serve_forever()
 
-        with self.assertWarns(DeprecationWarning):
-            srv = self.loop.run_until_complete(asyncio.start_server(
-                serve, socket_helper.HOSTv4, 0, loop=self.loop, start_serving=False))
+        srv = self.loop.run_until_complete(asyncio.start_server(
+            serve, socket_helper.HOSTv4, 0, start_serving=False))
 
         self.assertFalse(srv.is_serving())
 
@@ -102,9 +101,8 @@ class SelectorStartServerTests(BaseStartServer, unittest.TestCase):
                 await srv.serve_forever()
 
         with test_utils.unix_socket_path() as addr:
-            with self.assertWarns(DeprecationWarning):
-                srv = self.loop.run_until_complete(asyncio.start_unix_server(
-                    serve, addr, loop=self.loop, start_serving=False))
+            srv = self.loop.run_until_complete(asyncio.start_unix_server(
+                serve, addr, start_serving=False))
 
             main_task = self.loop.create_task(main(srv))
 

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -657,13 +657,11 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                 sock.close()
 
         async def client(addr):
-            with self.assertWarns(DeprecationWarning):
-                reader, writer = await asyncio.open_connection(
-                    *addr,
-                    ssl=client_sslctx,
-                    server_hostname='',
-                    loop=self.loop,
-                    ssl_handshake_timeout=1.0)
+            reader, writer = await asyncio.open_connection(
+                *addr,
+                ssl=client_sslctx,
+                server_hostname='',
+                ssl_handshake_timeout=1.0)
 
         with self.tcp_server(server,
                              max_clients=1,
@@ -697,13 +695,11 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                 sock.close()
 
         async def client(addr):
-            with self.assertWarns(DeprecationWarning):
-                reader, writer = await asyncio.open_connection(
-                    *addr,
-                    ssl=client_sslctx,
-                    server_hostname='',
-                    loop=self.loop,
-                    ssl_handshake_timeout=support.LOOPBACK_TIMEOUT)
+            reader, writer = await asyncio.open_connection(
+                *addr,
+                ssl=client_sslctx,
+                server_hostname='',
+                ssl_handshake_timeout=support.LOOPBACK_TIMEOUT)
 
         with self.tcp_server(server,
                              max_clients=1,
@@ -734,12 +730,10 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                 sock.close()
 
         async def client(addr):
-            with self.assertWarns(DeprecationWarning):
-                reader, writer = await asyncio.open_connection(
-                    *addr,
-                    ssl=client_sslctx,
-                    server_hostname='',
-                    loop=self.loop)
+            reader, writer = await asyncio.open_connection(
+                *addr,
+                ssl=client_sslctx,
+                server_hostname='')
 
             self.assertEqual(await reader.readline(), b'A\n')
             writer.write(b'B')

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -48,8 +48,7 @@ class StreamTests(test_utils.TestCase):
     def _basetest_open_connection(self, open_connection_fut):
         messages = []
         self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
-        with self.assertWarns(DeprecationWarning):
-            reader, writer = self.loop.run_until_complete(open_connection_fut)
+        reader, writer = self.loop.run_until_complete(open_connection_fut)
         writer.write(b'GET / HTTP/1.0\r\n\r\n')
         f = reader.readline()
         data = self.loop.run_until_complete(f)
@@ -62,23 +61,20 @@ class StreamTests(test_utils.TestCase):
 
     def test_open_connection(self):
         with test_utils.run_test_server() as httpd:
-            conn_fut = asyncio.open_connection(*httpd.address,
-                                               loop=self.loop)
+            conn_fut = asyncio.open_connection(*httpd.address)
             self._basetest_open_connection(conn_fut)
 
     @socket_helper.skip_unless_bind_unix_socket
     def test_open_unix_connection(self):
         with test_utils.run_test_unix_server() as httpd:
-            conn_fut = asyncio.open_unix_connection(httpd.address,
-                                                    loop=self.loop)
+            conn_fut = asyncio.open_unix_connection(httpd.address)
             self._basetest_open_connection(conn_fut)
 
     def _basetest_open_connection_no_loop_ssl(self, open_connection_fut):
         messages = []
         self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
         try:
-            with self.assertWarns(DeprecationWarning):
-                reader, writer = self.loop.run_until_complete(open_connection_fut)
+            reader, writer = self.loop.run_until_complete(open_connection_fut)
         finally:
             asyncio.set_event_loop(None)
         writer.write(b'GET / HTTP/1.0\r\n\r\n')
@@ -94,8 +90,7 @@ class StreamTests(test_utils.TestCase):
         with test_utils.run_test_server(use_ssl=True) as httpd:
             conn_fut = asyncio.open_connection(
                 *httpd.address,
-                ssl=test_utils.dummy_ssl_context(),
-                loop=self.loop)
+                ssl=test_utils.dummy_ssl_context())
 
             self._basetest_open_connection_no_loop_ssl(conn_fut)
 
@@ -107,15 +102,14 @@ class StreamTests(test_utils.TestCase):
                 httpd.address,
                 ssl=test_utils.dummy_ssl_context(),
                 server_hostname='',
-                loop=self.loop)
+            )
 
             self._basetest_open_connection_no_loop_ssl(conn_fut)
 
     def _basetest_open_connection_error(self, open_connection_fut):
         messages = []
         self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
-        with self.assertWarns(DeprecationWarning):
-            reader, writer = self.loop.run_until_complete(open_connection_fut)
+        reader, writer = self.loop.run_until_complete(open_connection_fut)
         writer._protocol.connection_lost(ZeroDivisionError())
         f = reader.read()
         with self.assertRaises(ZeroDivisionError):
@@ -126,15 +120,13 @@ class StreamTests(test_utils.TestCase):
 
     def test_open_connection_error(self):
         with test_utils.run_test_server() as httpd:
-            conn_fut = asyncio.open_connection(*httpd.address,
-                                               loop=self.loop)
+            conn_fut = asyncio.open_connection(*httpd.address)
             self._basetest_open_connection_error(conn_fut)
 
     @socket_helper.skip_unless_bind_unix_socket
     def test_open_unix_connection_error(self):
         with test_utils.run_test_unix_server() as httpd:
-            conn_fut = asyncio.open_unix_connection(httpd.address,
-                                                    loop=self.loop)
+            conn_fut = asyncio.open_unix_connection(httpd.address)
             self._basetest_open_connection_error(conn_fut)
 
     def test_feed_empty_data(self):
@@ -596,8 +588,7 @@ class StreamTests(test_utils.TestCase):
                 sock = socket.create_server(('127.0.0.1', 0))
                 self.server = self.loop.run_until_complete(
                     asyncio.start_server(self.handle_client,
-                                         sock=sock,
-                                         loop=self.loop))
+                                         sock=sock))
                 return sock.getsockname()
 
             def handle_client_callback(self, client_reader, client_writer):
@@ -610,8 +601,7 @@ class StreamTests(test_utils.TestCase):
                 sock.close()
                 self.server = self.loop.run_until_complete(
                     asyncio.start_server(self.handle_client_callback,
-                                         host=addr[0], port=addr[1],
-                                         loop=self.loop))
+                                         host=addr[0], port=addr[1]))
                 return addr
 
             def stop(self):
@@ -621,9 +611,7 @@ class StreamTests(test_utils.TestCase):
                     self.server = None
 
         async def client(addr):
-            with self.assertWarns(DeprecationWarning):
-                reader, writer = await asyncio.open_connection(
-                    *addr, loop=self.loop)
+            reader, writer = await asyncio.open_connection(*addr)
             # send a line
             writer.write(b"hello world!\n")
             # read it back
@@ -637,16 +625,14 @@ class StreamTests(test_utils.TestCase):
 
         # test the server variant with a coroutine as client handler
         server = MyServer(self.loop)
-        with self.assertWarns(DeprecationWarning):
-            addr = server.start()
+        addr = server.start()
         msg = self.loop.run_until_complete(self.loop.create_task(client(addr)))
         server.stop()
         self.assertEqual(msg, b"hello world!\n")
 
         # test the server variant with a callback as client handler
         server = MyServer(self.loop)
-        with self.assertWarns(DeprecationWarning):
-            addr = server.start_callback()
+        addr = server.start_callback()
         msg = self.loop.run_until_complete(self.loop.create_task(client(addr)))
         server.stop()
         self.assertEqual(msg, b"hello world!\n")
@@ -673,8 +659,7 @@ class StreamTests(test_utils.TestCase):
             def start(self):
                 self.server = self.loop.run_until_complete(
                     asyncio.start_unix_server(self.handle_client,
-                                              path=self.path,
-                                              loop=self.loop))
+                                              path=self.path))
 
             def handle_client_callback(self, client_reader, client_writer):
                 self.loop.create_task(self.handle_client(client_reader,
@@ -682,8 +667,7 @@ class StreamTests(test_utils.TestCase):
 
             def start_callback(self):
                 start = asyncio.start_unix_server(self.handle_client_callback,
-                                                  path=self.path,
-                                                  loop=self.loop)
+                                                  path=self.path)
                 self.server = self.loop.run_until_complete(start)
 
             def stop(self):
@@ -693,9 +677,7 @@ class StreamTests(test_utils.TestCase):
                     self.server = None
 
         async def client(path):
-            with self.assertWarns(DeprecationWarning):
-                reader, writer = await asyncio.open_unix_connection(
-                    path, loop=self.loop)
+            reader, writer = await asyncio.open_unix_connection(path)
             # send a line
             writer.write(b"hello world!\n")
             # read it back
@@ -710,8 +692,7 @@ class StreamTests(test_utils.TestCase):
         # test the server variant with a coroutine as client handler
         with test_utils.unix_socket_path() as path:
             server = MyServer(self.loop, path)
-            with self.assertWarns(DeprecationWarning):
-                server.start()
+            server.start()
             msg = self.loop.run_until_complete(
                 self.loop.create_task(client(path)))
             server.stop()
@@ -720,8 +701,7 @@ class StreamTests(test_utils.TestCase):
         # test the server variant with a callback as client handler
         with test_utils.unix_socket_path() as path:
             server = MyServer(self.loop, path)
-            with self.assertWarns(DeprecationWarning):
-                server.start_callback()
+            server.start_callback()
             msg = self.loop.run_until_complete(
                 self.loop.create_task(client(path)))
             server.stop()
@@ -809,9 +789,7 @@ os.close(fd)
                 clt.close()
 
         async def client(host, port):
-            with self.assertWarns(DeprecationWarning):
-                reader, writer = await asyncio.open_connection(
-                    host, port, loop=self.loop)
+            reader, writer = await asyncio.open_connection(host, port)
 
             while True:
                 writer.write(b"foo\n")
@@ -895,9 +873,8 @@ os.close(fd)
 
     def test_wait_closed_on_close(self):
         with test_utils.run_test_server() as httpd:
-            with self.assertWarns(DeprecationWarning):
-                rd, wr = self.loop.run_until_complete(
-                    asyncio.open_connection(*httpd.address, loop=self.loop))
+            rd, wr = self.loop.run_until_complete(
+                asyncio.open_connection(*httpd.address))
 
             wr.write(b'GET / HTTP/1.0\r\n\r\n')
             f = rd.readline()
@@ -913,9 +890,8 @@ os.close(fd)
 
     def test_wait_closed_on_close_with_unread_data(self):
         with test_utils.run_test_server() as httpd:
-            with self.assertWarns(DeprecationWarning):
-                rd, wr = self.loop.run_until_complete(
-                    asyncio.open_connection(*httpd.address, loop=self.loop))
+            rd, wr = self.loop.run_until_complete(
+                asyncio.open_connection(*httpd.address))
 
             wr.write(b'GET / HTTP/1.0\r\n\r\n')
             f = rd.readline()
@@ -972,10 +948,8 @@ os.close(fd)
         self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
 
         with test_utils.run_test_server() as httpd:
-            with self.assertWarns(DeprecationWarning):
-                rd, wr = self.loop.run_until_complete(
-                    asyncio.open_connection(*httpd.address,
-                                            loop=self.loop))
+            rd, wr = self.loop.run_until_complete(
+                    asyncio.open_connection(*httpd.address))
 
             wr.close()
             f = wr.wait_closed()

--- a/Misc/NEWS.d/next/Library/2020-11-25-22-44-59.bpo-42392.T_DAEl.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-25-22-44-59.bpo-42392.T_DAEl.rst
@@ -1,0 +1,2 @@
+Remove loop parameter from ``asyncio.open_connection`` and
+``asyncio.start_server`` functions. Patch provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Remove loop parameter from ``asyncio.open_connection`` and ``asyncio.start_server`` functions.

This PR is a part of the loop parameter removal that should be done in the scope of python 3.10.

<!-- issue-number: [bpo-42392](https://bugs.python.org/issue42392) -->
https://bugs.python.org/issue42392
<!-- /issue-number -->
