### PR TITLE
Add small validator utility for PEG grammars

### DIFF
--- a/Lib/test/test_peg_generator/test_grammar_validator.py
+++ b/Lib/test/test_peg_generator/test_grammar_validator.py
@@ -1,0 +1,51 @@
+import unittest
+from test import test_tools
+
+test_tools.skip_if_missing('peg_generator')
+with test_tools.imports_under_tool('peg_generator'):
+    from pegen.grammar_parser import GeneratedParser as GrammarParser
+    from pegen.validator import SubRuleValidator, ValidationError
+    from pegen.testutil import parse_string
+    from pegen.grammar import Grammar
+
+
+class TestPegen(unittest.TestCase):
+    def test_rule_with_no_collision(self) -> None:
+        grammar_source = """
+        start: bad_rule
+        sum:
+            | NAME '-' NAME
+            | NAME '+' NAME
+        """
+        grammar: Grammar = parse_string(grammar_source, GrammarParser)
+        validator = SubRuleValidator(grammar)
+        for rule_name, rule in grammar.rules.items():
+            validator.validate_rule(rule_name, rule)
+
+    def test_rule_with_simple_collision(self) -> None:
+        grammar_source = """
+        start: bad_rule
+        sum:
+            | NAME '+' NAME
+            | NAME '+' NAME ';'
+        """
+        grammar: Grammar = parse_string(grammar_source, GrammarParser)
+        validator = SubRuleValidator(grammar)
+        with self.assertRaises(ValidationError):
+            for rule_name, rule in grammar.rules.items():
+                validator.validate_rule(rule_name, rule)
+
+    def test_rule_with_collision_after_some_other_rules(self) -> None:
+        grammar_source = """
+        start: bad_rule
+        sum:
+            | NAME '+' NAME
+            | NAME '*' NAME ';'
+            | NAME '-' NAME
+            | NAME '+' NAME ';'
+        """
+        grammar: Grammar = parse_string(grammar_source, GrammarParser)
+        validator = SubRuleValidator(grammar)
+        with self.assertRaises(ValidationError):
+            for rule_name, rule in grammar.rules.items():
+                validator.validate_rule(rule_name, rule)

--- a/Tools/peg_generator/pegen/__main__.py
+++ b/Tools/peg_generator/pegen/__main__.py
@@ -14,6 +14,7 @@ import traceback
 from typing import Tuple
 
 from pegen.build import Grammar, Parser, Tokenizer, ParserGenerator
+from pegen.validator import validate_grammar
 
 
 def generate_c_code(
@@ -127,6 +128,8 @@ def main() -> None:
     t0 = time.time()
     grammar, parser, tokenizer, gen = args.func(args)
     t1 = time.time()
+
+    validate_grammar(grammar)
 
     if not args.quiet:
         if args.verbose:

--- a/Tools/peg_generator/pegen/validator.py
+++ b/Tools/peg_generator/pegen/validator.py
@@ -1,0 +1,52 @@
+from pegen import grammar
+from pegen.grammar import (
+    Alt,
+    Cut,
+    Gather,
+    GrammarVisitor,
+    Group,
+    Lookahead,
+    NamedItem,
+    NameLeaf,
+    NegativeLookahead,
+    Opt,
+    PositiveLookahead,
+    Repeat0,
+    Repeat1,
+    Rhs,
+    Rule,
+    StringLeaf,
+)
+
+class ValidationError(Exception):
+    pass
+
+class GrammarValidator(GrammarVisitor):
+    def __init__(self, grammar: grammar.Grammar):
+        self.grammar = grammar
+        self.rulename = None
+
+    def validate_rule(self, rulename: str, node: Rule):
+        self.rulename = rulename
+        self.visit(node)
+        self.rulename = None
+
+
+class SubRuleValidator(GrammarValidator):
+    def visit_Rhs(self, node: Rule):
+        for index, alt in enumerate(node.alts):
+            alts_to_consider = node.alts[index+1:]
+            for other_alt in alts_to_consider:
+                self.check_intersection(alt, other_alt)
+
+    def check_intersection(self, first_alt: Alt, second_alt: Alt) -> bool:
+        if str(second_alt).startswith(str(first_alt)):
+            raise ValidationError(
+                    f"In {self.rulename} there is an alternative that will "
+                    f"never be visited:\n{second_alt}")
+
+def validate_grammar(the_grammar: grammar.Grammar):
+    for validator_cls in GrammarValidator.__subclasses__():
+        validator = validator_cls(the_grammar)
+        for rule_name, rule in the_grammar.rules.items():
+            validator.validate_rule(rule_name, rule)


### PR DESCRIPTION
One common gotcha of PEG grammars is having two alternatives in a rule in which one that appears first is contained in one that appears last. In this scenario, the second one will never match as if there is input text that matches it, it will also match the first and that comes first.

To avoid this problem, this PR create an **initial version** of a small utility that detects these cases and raises to alert the user.

We don't need to detect *all* cases, only the ones that is easy enough to implement. The current form is just an initial prototype that does the matching based in the string representation. To make this better we need to improve the matching algorithm into a visitor to allow checking rules that contain options. For example:

```
some_rule:
    | NAME '+' NAME 'blech'?
    | NAME '+' NAME ';'
```

One "straightforward enough" way to do this is to generate all possible string representations: with and without optional and doing substring matching, but at this point a visitor that visits both alternatives at the same time and advances accordingly is probably better.

We could also support *some* rule expansion so we also detect something like this:

```
some_rule:
    | NAME '+' NAME
    | NAME some_other_rule
some_other_rule:
   '+' NAME ';'
```