### PR TITLE
bpo-42474: add TracebackException comparison tests for non-equal inst…

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1162,7 +1162,7 @@ class TestTracebackException(unittest.TestCase):
         exc3 = traceback.TracebackException(*exc_info, capture_locals=True)
         self.assertNotEqual(exc, exc3)
 
-        # there are no locals in the next-to-innermost frame
+        # there are no locals in the innermost frame
         exc4 = traceback.TracebackException(*exc_info, limit=-1)
         exc5 = traceback.TracebackException(*exc_info, limit=-1, capture_locals=True)
         self.assertEqual(exc4, exc5)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1156,7 +1156,7 @@ class TestTracebackException(unittest.TestCase):
         exc2 = traceback.TracebackException(*exc_info, limit=2)
 
         self.assertEqual(exc, exc1)      # limit=10 gets all frames
-        self.assertNotEqual(exc, exc2)   # limit=1 truncates the output
+        self.assertNotEqual(exc, exc2)   # limit=2 truncates the output
 
         # locals change the output
         exc3 = traceback.TracebackException(*exc_info, capture_locals=True)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1123,7 +1123,7 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(exc_info[0], exc.exc_type)
         self.assertEqual(str(exc_info[1]), str(exc))
 
-    def test_comparison(self):
+    def test_comparison_basic(self):
         try:
             1/0
         except Exception:
@@ -1134,6 +1134,43 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(exc, exc2)
         self.assertNotEqual(exc, object())
         self.assertEqual(exc, ALWAYS_EQ)
+
+    def test_comparison_params_variations(self):
+        def raise_exc():
+            try:
+                raise ValueError('bad value')
+            except:
+                raise
+
+        def raise_with_locals():
+            x, y = 1, 2
+            raise_exc()
+
+        try:
+            raise_with_locals()
+        except Exception:
+            exc_info = sys.exc_info()
+
+        exc = traceback.TracebackException(*exc_info)
+        exc1 = traceback.TracebackException(*exc_info, limit=10)
+        exc2 = traceback.TracebackException(*exc_info, limit=2)
+
+        self.assertEqual(exc, exc1)      # limit=10 gets all frames
+        self.assertNotEqual(exc, exc2)   # limit=1 truncates the output
+
+        # locals change the output
+        exc3 = traceback.TracebackException(*exc_info, capture_locals=True)
+        self.assertNotEqual(exc, exc3)
+
+        # there are no locals in the next-to-innermost frame
+        exc4 = traceback.TracebackException(*exc_info, limit=-1)
+        exc5 = traceback.TracebackException(*exc_info, limit=-1, capture_locals=True)
+        self.assertEqual(exc4, exc5)
+
+        # there are locals in the next-to-innermost frame
+        exc6 = traceback.TracebackException(*exc_info, limit=-2)
+        exc7 = traceback.TracebackException(*exc_info, limit=-2, capture_locals=True)
+        self.assertNotEqual(exc6, exc7)
 
     def test_unhashable(self):
         class UnhashableException(Exception):
@@ -1176,7 +1213,7 @@ class TestTracebackException(unittest.TestCase):
         f = test_frame(c, None, None)
         tb = test_tb(f, 6, None)
         exc = traceback.TracebackException(Exception, e, tb, lookup_lines=False)
-        self.assertEqual({}, linecache.cache)
+        self.assertEqual(linecache.cache, {})
         linecache.updatecache('/foo.py', globals())
         self.assertEqual(exc.stack[0].line, "import sys")
 


### PR DESCRIPTION
…ances of this type


Currently there are no tests for comparison between non-equal instances of traceback.TracebackException, so changing it's __eq__ to return True instead of self.__dict__ == other.__dict__ would not break any tests.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42474](https://bugs.python.org/issue42474) -->
https://bugs.python.org/issue42474
<!-- /issue-number -->
