### PR TITLE
bpo-41818: Make test_openpty() avoid unexpected success due to number of rows and/or number of columns being == 0.

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-27-09-19-43.bpo-41818.KWYUbL.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-27-09-19-43.bpo-41818.KWYUbL.rst
@@ -1,0 +1,1 @@
+Make test_openpty() avoid unexpected success due to number of rows and/or number of columns being == 0.


### PR DESCRIPTION
Proposed proper fix for buildbot failures introduced after #22962 merging.

To check if `pty.openpty()` properly sets pty slave size based on the size of current stdin, `PtyTest.test_openpty()` was modifying the size of current stdin first. Let 'x' be the number of rows of stdin; then, we set the number of rows of stdin to some f(x) such that the function f does not have any fixed points; that is, f(x) != x for all x. In #22962, f(x) := x//5; unfortunately, in that case, f does have 0 as a fixed point [ 0//5 = 0 ]. Upon running

```
./python -c "import pty;pty.spawn('./python -m test -v test_pty'.split())"
```

unexpected success was reported on Debian; this indeed was due to the # of (rows, cols) being (0,0). The Gentoo buildbot was probably also running with stdin being a tty of size (0,0). The new choice of f(x) := x+1 solves the problem, since this f has no fixed points [ x+1=x has no solution. ]

TL;DR: instead of letting rows and cols of stdin be the floor of 1/5 of their original values, we now only increment their respective values by 1. Note, however, that the former is a more noticeable change when # of rows, cols are fairly large.

Signed-off-by: Soumendra Ganguly <soumendraganguly@gmail.com>

<!-- issue-number: [bpo-41818](https://bugs.python.org/issue41818) -->
https://bugs.python.org/issue41818
<!-- /issue-number -->
