### PR TITLE
bpo-42482: remove reference to exc_traceback from TracebackException

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1132,7 +1132,6 @@ class TestTracebackException(unittest.TestCase):
         refcnt1 = sys.getrefcount(exc_info[1])
         refcnt2 = sys.getrefcount(exc_info[2])
         exc = traceback.TracebackException(*exc_info)
-        _ = exc.format()
         self.assertEqual(sys.getrefcount(exc_info[1]), refcnt1)
         self.assertEqual(sys.getrefcount(exc_info[2]), refcnt2)
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1123,6 +1123,18 @@ class TestTracebackException(unittest.TestCase):
         self.assertEqual(exc_info[0], exc.exc_type)
         self.assertEqual(str(exc_info[1]), str(exc))
 
+    def test_no_refs_to_exception_and_traceback_objects(self):
+        try:
+            1/0
+        except Exception:
+            exc_info = sys.exc_info()
+
+        refcnt1 = sys.getrefcount(exc_info[1])
+        refcnt2 = sys.getrefcount(exc_info[2])
+        _ = traceback.TracebackException(*exc_info).format()
+        self.assertEqual(sys.getrefcount(exc_info[1]), refcnt1)
+        self.assertEqual(sys.getrefcount(exc_info[2]), refcnt2)
+
     def test_comparison_basic(self):
         try:
             1/0

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1131,7 +1131,8 @@ class TestTracebackException(unittest.TestCase):
 
         refcnt1 = sys.getrefcount(exc_info[1])
         refcnt2 = sys.getrefcount(exc_info[2])
-        _ = traceback.TracebackException(*exc_info).format()
+        exc = traceback.TracebackException(*exc_info)
+        _ = exc.format()
         self.assertEqual(sys.getrefcount(exc_info[1]), refcnt1)
         self.assertEqual(sys.getrefcount(exc_info[2]), refcnt2)
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1172,6 +1172,16 @@ class TestTracebackException(unittest.TestCase):
         exc7 = traceback.TracebackException(*exc_info, limit=-2, capture_locals=True)
         self.assertNotEqual(exc6, exc7)
 
+    def test_comparison_equivalent_exceptions_are_equal(self):
+        excs = []
+        for _ in range(2):
+            try:
+                1/0
+            except:
+                excs.append(traceback.TracebackException(*sys.exc_info()))
+        self.assertEqual(excs[0], excs[1])
+        self.assertEqual(list(excs[0].format()), list(excs[1].format()))
+
     def test_unhashable(self):
         class UnhashableException(Exception):
             def __eq__(self, other):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -628,5 +628,5 @@ class TracebackException:
                 yield _context_message
         if self.stack:
             yield 'Traceback (most recent call last):\n'
-        yield from self.stack.format()
+            yield from self.stack.format()
         yield from self.format_exception_only()

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -510,7 +510,6 @@ class TracebackException:
                 _seen=_seen)
         else:
             context = None
-        self._print_traceback_header = exc_traceback is not None
         self.__cause__ = cause
         self.__context__ = context
         self.__suppress_context__ = \
@@ -627,7 +626,7 @@ class TracebackException:
                 not self.__suppress_context__):
                 yield from self.__context__.format(chain=chain)
                 yield _context_message
-        if self._print_traceback_header:
+        if self.stack:
             yield 'Traceback (most recent call last):\n'
         yield from self.stack.format()
         yield from self.format_exception_only()

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -510,7 +510,7 @@ class TracebackException:
                 _seen=_seen)
         else:
             context = None
-        self.exc_traceback = exc_traceback
+        self._print_traceback_header = exc_traceback is not None
         self.__cause__ = cause
         self.__context__ = context
         self.__suppress_context__ = \
@@ -627,7 +627,7 @@ class TracebackException:
                 not self.__suppress_context__):
                 yield from self.__context__.format(chain=chain)
                 yield _context_message
-        if self.exc_traceback is not None:
+        if self._print_traceback_header:
             yield 'Traceback (most recent call last):\n'
         yield from self.stack.format()
         yield from self.format_exception_only()

--- a/Misc/NEWS.d/next/Library/2020-11-27-16-46-58.bpo-42482.EJC3sd.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-27-16-46-58.bpo-42482.EJC3sd.rst
@@ -1,0 +1,1 @@
+:class:`~traceback.TracebackException` no longer holds a reference to the exception's traceback object. Consequently, instances of TracebackException for equivalent but non-equal exceptions now compare as equal.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42482](https://bugs.python.org/issue42482) -->
https://bugs.python.org/issue42482
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum