### PR TITLE
bpo-42485: [Doc] Link to PEP 617 from full grammar specification

### DIFF
--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -14,8 +14,7 @@ group indicates a positive lookahead (i.e., is required to match but
 not consumed), while ``!`` indicates a negative lookahead (i.e., is
 required _not_ to match).  We use the ``|`` separator to mean PEG's
 "ordered choice" (written as ``/`` in traditional PEG grammars). See
-`PEP 617<https://www.python.org/dev/peps/pep-0617/#syntax>` for more
-details on the grammar's syntax.
+:pep:`617` for more details on the grammar's syntax.
 
 .. literalinclude:: ../../Grammar/python.gram
   :language: peg

--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -13,7 +13,9 @@ In particular, ``&`` followed by a symbol, token or parenthesized
 group indicates a positive lookahead (i.e., is required to match but
 not consumed), while ``!`` indicates a negative lookahead (i.e., is
 required _not_ to match).  We use the ``|`` separator to mean PEG's
-"ordered choice" (written as ``/`` in traditional PEG grammars).
+"ordered choice" (written as ``/`` in traditional PEG grammars). See
+`PEP 617<https://www.python.org/dev/peps/pep-0617/#syntax>` for more
+details on the grammar's syntax.
 
 .. literalinclude:: ../../Grammar/python.gram
   :language: peg


### PR DESCRIPTION
Now that CPython uses the new PEG parser, it would be helpful to include a reference to the guiding PEP (617) on the docs page (https://docs.python.org/3/reference/grammar.html) that gives the grammar.

https://bugs.python.org/issue42485

<!-- issue-number: [bpo-42485](https://bugs.python.org/issue42485) -->
https://bugs.python.org/issue42485
<!-- /issue-number -->
