### PR TITLE
bpo-41818: test_master_read() in test_pty.py should be expected to fail on every platform that is not Linux; that includes Solaris.

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -82,9 +82,8 @@ def expectedFailureIfStdinIsTTY(fun):
         pass
     return fun
 
-def expectedFailureOnBSD(fun):
-    PLATFORM = platform.system()
-    if PLATFORM.endswith("BSD") or PLATFORM == "Darwin":
+def expectedFailureIfNotLinux(fun):
+    if platform.system() != "Linux":
         return unittest.expectedFailure(fun)
     return fun
 
@@ -314,7 +313,7 @@ class PtyTest(unittest.TestCase):
 
         os.close(master_fd)
 
-    @expectedFailureOnBSD
+    @expectedFailureIfNotLinux
     def test_master_read(self):
         debug("Calling pty.openpty()")
         master_fd, slave_fd = pty.openpty()

--- a/Misc/NEWS.d/next/Library/2020-11-27-21-46-54.bpo-41818.IXmYhQ.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-27-21-46-54.bpo-41818.IXmYhQ.rst
@@ -1,0 +1,1 @@
+Change expectedFailureOnBSD() to expectedFailureIfNotLinux() in test_pty.py because test_master_read() should be expected to fail on every platform that is not Linux; that includes Solaris.


### PR DESCRIPTION
Change `expectedFailureOnBSD()` to `expectedFailureIfNotLinux()`

Signed-off-by: Soumendra Ganguly <soumendraganguly@gmail.com>

<!-- issue-number: [bpo-41818](https://bugs.python.org/issue41818) -->
https://bugs.python.org/issue41818
<!-- /issue-number -->
