### PR TITLE
bpo-41818: Fix test_master_read() so that it succeeds on all platforms that either raise OSError or return b"" upon reading from master

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-28-06-34-53.bpo-41818.mFSMc2.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-28-06-34-53.bpo-41818.mFSMc2.rst
@@ -1,0 +1,1 @@
+Fix test_master_read() so that it succeeds on all platforms that either raise OSError or return b"" upon reading from master.


### PR DESCRIPTION
This replaces #23533. Build was failing on Solaris since, like the BSDs and Darwin, Solaris does not raise OSError in `test_master_read()`. Therefore, now we make `test_master_read()` succeed on all platforms that either raise OSError [ such as Linux ] or return b"" [ such as BSDs, Darwin, and possibly Solaris ] upon reading from master when the slave is closed. Any platform that does not exhibit such behavior can now be detected using `test_master_read()`. On any given platform, exiting from `pty.spawn()`'s copy loop depends on our exact knowledge of the behavior of `test_master_read()` on that platform.

Signed-off-by: Soumendra Ganguly <soumendraganguly@gmail.com>

<!-- issue-number: [bpo-41818](https://bugs.python.org/issue41818) -->
https://bugs.python.org/issue41818
<!-- /issue-number -->
