### PR TITLE
bpo-41879: Doc: Fix description of async for statement

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -796,9 +796,9 @@ The :keyword:`!async for` statement
 .. productionlist:: python-grammar
    async_for_stmt: "async" `for_stmt`
 
-An :term:`asynchronous iterable` provides an `__aiter__` method that directly
+An :term:`asynchronous iterable` provides an ``__aiter__`` method that directly
 returns an :term:`asynchronous iterator`, which can call asynchronous code in
-its `__anext__` method.
+its ``__anext__`` method.
 
 The ``async for`` statement allows convenient iteration over asynchronous
 iterables.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -796,12 +796,12 @@ The :keyword:`!async for` statement
 .. productionlist:: python-grammar
    async_for_stmt: "async" `for_stmt`
 
-An :term:`asynchronous iterable` is able to call asynchronous code in its
-*iter* implementation, and :term:`asynchronous iterator` can call asynchronous
-code in its *next* method.
+An :term:`asynchronous iterable` provides an *iter* method that returns an
+:term:`asynchronous iterator, which can call asynchronous code in its *next*
+method.
 
 The ``async for`` statement allows convenient iteration over asynchronous
-iterators.
+iterables.
 
 The following code::
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -797,7 +797,7 @@ The :keyword:`!async for` statement
    async_for_stmt: "async" `for_stmt`
 
 An :term:`asynchronous iterable` provides an *iter* method that returns an
-:term:`asynchronous iterator, which can call asynchronous code in its *next*
+:term:`asynchronous iterator`, which can call asynchronous code in its *next*
 method.
 
 The ``async for`` statement allows convenient iteration over asynchronous

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -796,9 +796,9 @@ The :keyword:`!async for` statement
 .. productionlist:: python-grammar
    async_for_stmt: "async" `for_stmt`
 
-An :term:`asynchronous iterable` provides an *iter* method that returns an
-:term:`asynchronous iterator`, which can call asynchronous code in its *next*
-method.
+An :term:`asynchronous iterable` provides an `__aiter__` method that directly
+returns an :term:`asynchronous iterator`, which can call asynchronous code in
+its `__anext__` method.
 
 The ``async for`` statement allows convenient iteration over asynchronous
 iterables.


### PR DESCRIPTION
Fix the wording in the documentation of `async for` to correctly describe asynchronous iterables.  This fix is relevant for version 3.7 onward.

<!-- issue-number: [bpo-41879](https://bugs.python.org/issue41879) -->
https://bugs.python.org/issue41879
<!-- /issue-number -->

Automerge-Triggered-By: GH:aeros