### PR TITLE
bpo-42392: Remove deprecated loop parameter from docs

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -23,7 +23,7 @@ See also the `Examples`_ section below.
 Queue
 =====
 
-.. class:: Queue(maxsize=0, \*, loop=None)
+.. class:: Queue(maxsize=0)
 
    A first in, first out (FIFO) queue.
 
@@ -35,9 +35,6 @@ Queue
    Unlike the standard library threading :mod:`queue`, the size of
    the queue is always known and can be returned by calling the
    :meth:`qsize` method.
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -49,8 +49,8 @@ and work with streams:
 
 
 .. coroutinefunction:: open_connection(host=None, port=None, \*, \
-                          loop=None, limit=None, ssl=None, family=0, \
-                          proto=0, flags=0, sock=None, local_addr=None, \
+                          limit=None, ssl=None, family=0, proto=0, \
+                          flags=0, sock=None, local_addr=None, \
                           server_hostname=None, ssl_handshake_timeout=None)
 
    Establish a network connection and return a pair of
@@ -74,7 +74,7 @@ and work with streams:
       The *ssl_handshake_timeout* parameter.
 
 .. coroutinefunction:: start_server(client_connected_cb, host=None, \
-                          port=None, \*, loop=None, limit=None, \
+                          port=None, \*, limit=None, \
                           family=socket.AF_UNSPEC, \
                           flags=socket.AI_PASSIVE, sock=None, \
                           backlog=100, ssl=None, reuse_address=None, \
@@ -109,9 +109,9 @@ and work with streams:
 
 .. rubric:: Unix Sockets
 
-.. coroutinefunction:: open_unix_connection(path=None, \*, loop=None, \
-                        limit=None, ssl=None, sock=None, \
-                        server_hostname=None, ssl_handshake_timeout=None)
+.. coroutinefunction:: open_unix_connection(path=None, \*, limit=None, \
+                        ssl=None, sock=None, server_hostname=None, \
+                        ssl_handshake_timeout=None)
 
    Establish a Unix socket connection and return a pair of
    ``(reader, writer)``.
@@ -132,9 +132,8 @@ and work with streams:
 
 
 .. coroutinefunction:: start_unix_server(client_connected_cb, path=None, \
-                          \*, loop=None, limit=None, sock=None, \
-                          backlog=100, ssl=None, ssl_handshake_timeout=None, \
-                          start_serving=True)
+                          \*, limit=None, sock=None, backlog=100, ssl=None, \
+                          ssl_handshake_timeout=None, start_serving=True)
 
    Start a Unix socket server.
 

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -59,9 +59,6 @@ and work with streams:
    The returned *reader* and *writer* objects are instances of
    :class:`StreamReader` and :class:`StreamWriter` classes.
 
-   The *loop* argument is optional and can always be determined
-   automatically when this function is awaited from a coroutine.
-
    *limit* determines the buffer size limit used by the
    returned :class:`StreamReader` instance.  By default the *limit*
    is set to 64 KiB.
@@ -91,9 +88,6 @@ and work with streams:
    *client_connected_cb* can be a plain callable or a
    :ref:`coroutine function <coroutine>`; if it is a coroutine function,
    it will be automatically scheduled as a :class:`Task`.
-
-   The *loop* argument is optional and can always be determined
-   automatically when this method is awaited from a coroutine.
 
    *limit* determines the buffer size limit used by the
    returned :class:`StreamReader` instance.  By default the *limit*

--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -62,8 +62,7 @@ Creating Subprocesses
 =====================
 
 .. coroutinefunction:: create_subprocess_exec(program, \*args, stdin=None, \
-                          stdout=None, stderr=None, loop=None, \
-                          limit=None, \*\*kwds)
+                          stdout=None, stderr=None, limit=None, \*\*kwds)
 
    Create a subprocess.
 
@@ -76,13 +75,9 @@ Creating Subprocesses
    See the documentation of :meth:`loop.subprocess_exec` for other
    parameters.
 
-   .. deprecated-removed:: 3.8 3.10
-
-      The *loop* parameter.
 
 .. coroutinefunction:: create_subprocess_shell(cmd, stdin=None, \
-                          stdout=None, stderr=None, loop=None, \
-                          limit=None, \*\*kwds)
+                          stdout=None, stderr=None, limit=None, \*\*kwds)
 
    Run the *cmd* shell command.
 
@@ -103,10 +98,6 @@ Creating Subprocesses
       vulnerabilities. The :func:`shlex.quote` function can be used to properly
       escape whitespace and special shell characters in strings that are going
       to be used to construct shell commands.
-
-   .. deprecated-removed:: 3.8 3.10
-
-      The *loop* parameter.
 
 .. note::
 

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -36,7 +36,7 @@ asyncio has the following basic synchronization primitives:
 Lock
 ====
 
-.. class:: Lock(\*, loop=None)
+.. class:: Lock()
 
    Implements a mutex lock for asyncio tasks.  Not thread-safe.
 
@@ -62,9 +62,6 @@ Lock
            # access shared state
        finally:
            lock.release()
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    .. coroutinemethod:: acquire()
 
@@ -96,7 +93,7 @@ Lock
 Event
 =====
 
-.. class:: Event(\*, loop=None)
+.. class:: Event()
 
    An event object.  Not thread-safe.
 
@@ -107,10 +104,6 @@ Event
    with the :meth:`set` method and reset to *false* with the
    :meth:`clear` method.  The :meth:`wait` method blocks until the
    flag is set to *true*.  The flag is set to *false* initially.
-
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    .. _asyncio_example_sync_event:
 
@@ -166,7 +159,7 @@ Event
 Condition
 =========
 
-.. class:: Condition(lock=None, \*, loop=None)
+.. class:: Condition(lock=None)
 
    A Condition object.  Not thread-safe.
 
@@ -183,10 +176,6 @@ Condition
    The optional *lock* argument must be a :class:`Lock` object or
    ``None``.  In the latter case a new Lock object is created
    automatically.
-
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    The preferred way to use a Condition is an :keyword:`async with`
    statement::
@@ -270,7 +259,7 @@ Condition
 Semaphore
 =========
 
-.. class:: Semaphore(value=1, \*, loop=None)
+.. class:: Semaphore(value=1)
 
    A Semaphore object.  Not thread-safe.
 
@@ -283,10 +272,6 @@ Semaphore
    The optional *value* argument gives the initial value for the
    internal counter (``1`` by default). If the given value is
    less than ``0`` a :exc:`ValueError` is raised.
-
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    The preferred way to use a Semaphore is an :keyword:`async with`
    statement::
@@ -332,17 +317,13 @@ Semaphore
 BoundedSemaphore
 ================
 
-.. class:: BoundedSemaphore(value=1, \*, loop=None)
+.. class:: BoundedSemaphore(value=1)
 
    A bounded semaphore object.  Not thread-safe.
 
    Bounded Semaphore is a version of :class:`Semaphore` that raises
    a :exc:`ValueError` in :meth:`~Semaphore.release` if it
    increases the internal counter above the initial *value*.
-
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
 ---------
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -283,7 +283,7 @@ Creating Tasks
 Sleeping
 ========
 
-.. coroutinefunction:: sleep(delay, result=None, \*, loop=None)
+.. coroutinefunction:: sleep(delay, result=None)
 
    Block for *delay* seconds.
 
@@ -292,9 +292,6 @@ Sleeping
 
    ``sleep()`` always suspends the current task, allowing other tasks
    to run.
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    .. _asyncio_example_sleep:
 
@@ -319,7 +316,7 @@ Sleeping
 Running Tasks Concurrently
 ==========================
 
-.. awaitablefunction:: gather(\*aws, loop=None, return_exceptions=False)
+.. awaitablefunction:: gather(\*aws, return_exceptions=False)
 
    Run :ref:`awaitable objects <asyncio-awaitables>` in the *aws*
    sequence *concurrently*.
@@ -347,9 +344,6 @@ Running Tasks Concurrently
    call is **not** cancelled in this case.  This is to prevent the
    cancellation of one submitted Task/Future to cause other
    Tasks/Futures to be cancelled.
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    .. _asyncio_example_gather:
 
@@ -403,7 +397,7 @@ Running Tasks Concurrently
 Shielding From Cancellation
 ===========================
 
-.. awaitablefunction:: shield(aw, \*, loop=None)
+.. awaitablefunction:: shield(aw)
 
    Protect an :ref:`awaitable object <asyncio-awaitables>`
    from being :meth:`cancelled <Task.cancel>`.
@@ -436,14 +430,11 @@ Shielding From Cancellation
        except CancelledError:
            res = None
 
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
-
 
 Timeouts
 ========
 
-.. coroutinefunction:: wait_for(aw, timeout, \*, loop=None)
+.. coroutinefunction:: wait_for(aw, timeout)
 
    Wait for the *aw* :ref:`awaitable <asyncio-awaitables>`
    to complete with a timeout.
@@ -465,9 +456,6 @@ Timeouts
    happens during cancellation, it is propagated.
 
    If the wait is cancelled, the future *aw* is also cancelled.
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    .. _asyncio_example_waitfor:
 
@@ -500,8 +488,7 @@ Timeouts
 Waiting Primitives
 ==================
 
-.. coroutinefunction:: wait(aws, \*, loop=None, timeout=None,\
-                            return_when=ALL_COMPLETED)
+.. coroutinefunction:: wait(aws, \*, timeout=None, return_when=ALL_COMPLETED)
 
    Run :ref:`awaitable objects <asyncio-awaitables>` in the *aws*
    iterable concurrently and block until the condition specified
@@ -553,10 +540,6 @@ Waiting Primitives
       ``wait()`` directly is deprecated as it leads to
       :ref:`confusing behavior <asyncio_example_wait_coroutine>`.
 
-   .. deprecated-removed:: 3.8 3.10
-
-      The *loop* parameter.
-
    .. _asyncio_example_wait_coroutine:
    .. note::
 
@@ -590,7 +573,7 @@ Waiting Primitives
       deprecated.
 
 
-.. function:: as_completed(aws, \*, loop=None, timeout=None)
+.. function:: as_completed(aws, \*, timeout=None)
 
    Run :ref:`awaitable objects <asyncio-awaitables>` in the *aws*
    iterable concurrently.  Return an iterator of coroutines.
@@ -599,9 +582,6 @@ Waiting Primitives
 
    Raises :exc:`asyncio.TimeoutError` if the timeout occurs before
    all Futures are done.
-
-   .. deprecated-removed:: 3.8 3.10
-      The *loop* parameter.
 
    Example::
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Remove deprecated *loop* parameter from docs.


<!-- issue-number: [bpo-42392](https://bugs.python.org/issue42392) -->
https://bugs.python.org/issue42392
<!-- /issue-number -->
