### PR TITLE
bpo-28764: mailbox.mbox: handle lines with non-ascii more graceful

### DIFF
--- a/Lib/mailbox.py
+++ b/Lib/mailbox.py
@@ -781,7 +781,7 @@ class _mboxMMDF(_singlefileMailbox):
         from_line = self._file.readline().replace(linesep, b'')
         string = self._file.read(stop - self._file.tell())
         msg = self._message_factory(string.replace(linesep, b'\n'))
-        msg.set_from(from_line[5:].decode('ascii'))
+        msg.set_from(from_line[5:].decode('ascii', errors='replace'))
         return msg
 
     def get_string(self, key, from_=False):


### PR DESCRIPTION
Don't fail to parse if non-ascii characters occur after a From: line.

https://bugs.python.org/issue42433

<!-- issue-number: [bpo-28764](https://bugs.python.org/issue28764) -->
https://bugs.python.org/issue28764
<!-- /issue-number -->
