### PR TITLE
bpo-42506: Fix unexpected output in test_format

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -275,9 +275,9 @@ class FormatTest(unittest.TestCase):
         test_exc_common('% %s', 1, ValueError,
                         "unsupported format character '%' (0x25) at index 2")
         test_exc_common('%d', '1', TypeError,
-                        "%d format: a number is required, not str")
+                        "%d format: a real number is required, not str")
         test_exc_common('%d', b'1', TypeError,
-                        "%d format: a number is required, not bytes")
+                        "%d format: a real number is required, not bytes")
         test_exc_common('%x', '1', TypeError,
                         "%x format: an integer is required, not str")
         test_exc_common('%x', 3.14, TypeError,


### PR DESCRIPTION
The error message was modified in e2ec0b27c02a158d0007c11dcc1f2d7a95948712.


<!-- issue-number: [bpo-42506](https://bugs.python.org/issue42506) -->
https://bugs.python.org/issue42506
<!-- /issue-number -->
