### PR TITLE
bpo-42513: Attempt to fix hang caused by failure to test pollfd.revents

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-30-14-18-22.bpo-42513.YT-D_j.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-30-14-18-22.bpo-42513.YT-D_j.rst
@@ -1,0 +1,1 @@
+In the socket library, fix the bug where it was possible for Socket.recv to hang even when there's a timeout specified.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -758,6 +758,8 @@ internal_select(PySocketSockObject *s, int writing, _PyTime_t interval,
 
     Py_BEGIN_ALLOW_THREADS;
     n = poll(&pollfd, 1, (int)ms);
+    if (pollfd.revents & (POLLERR | POLLNVAL))
+    	n = -1;
     Py_END_ALLOW_THREADS;
 #else
     if (interval >= 0) {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -759,7 +759,7 @@ internal_select(PySocketSockObject *s, int writing, _PyTime_t interval,
     Py_BEGIN_ALLOW_THREADS;
     n = poll(&pollfd, 1, (int)ms);
     if (pollfd.revents & (POLLERR | POLLNVAL))
-    	n = -1;
+        n = -1;
     Py_END_ALLOW_THREADS;
 #else
     if (interval >= 0) {


### PR DESCRIPTION
I've been stress-testing my code with a really weedy wireless dongle that drops out frequently and causes all sorts of connection issues for my code to handle gracefully. Unfortunately, the following code eventually hangs:

```
import socket
self.__socket = socket.create_connection ([host, port], 10000)
value = self.__socket.recv (4096)
```
GDB says:

```
(gdb) bt
#0  0x76d33c94 in __GI___poll (fds=0x7ea55148, nfds=1, timeout=10000)
    at ../sysdeps/unix/sysv/linux/poll.c:29
#1  0x001e8014 in poll (__timeout=<optimized out>, __nfds=<optimized out>, 
    __fds=<optimized out>, __fds=<optimized out>, __nfds=<optimized out>, 
    __timeout=<optimized out>)
    at /usr/include/arm-linux-gnueabihf/bits/poll2.h:46
#2  internal_select (writing=writing@entry=0, interval=<optimized out>, 
    connect=0, connect@entry=4156908, s=<optimized out>)
    at ../Modules/socketmodule.c:745
#3  0x001ec588 in sock_call_ex (s=s@entry=0x76979d68, writing=writing@entry=0, 
    sock_func=sock_func@entry=0x1e736c <sock_recv_impl>, data=0x7ea551b0, 
    data@entry=0x7ea551a8, connect=connect@entry=0, err=err@entry=0x0, 
    timeout=10000000000) at ../Modules/socketmodule.c:840
#4  0x001ed394 in sock_call (data=0x7ea551a8, func=0x1e736c <sock_recv_impl>, 
    writing=0, s=0x76979d68) at ../Modules/socketmodule.c:3287
#5  sock_recv_guts (s=s@entry=0x76979d68, cbuf=<optimized out>, 
    len=<optimized out>, flags=<optimized out>)
    at ../Modules/socketmodule.c:3287
#6  0x001ed51c in sock_recv (s=0x76979d68, args=<optimized out>)
    at ../Modules/socketmodule.c:3318
```

It seems that the call to poll(2) is never returning, even with a timeout specified. Googling for this problem, we get:

[https://stackoverflow.com/questions/56038224/poll-waits-indefinitely-although-timeout-is-specified](https://stackoverflow.com/questions/56038224/poll-waits-indefinitely-although-timeout-is-specified)

Looking at the source for socketmodule.c, I can see that we're not checking to see why the poll returned, and failing to handle an error event. It should be an easy fix, but because of the delicate timings, it will take several days to test both that this really is the reason for the hang and that it's the correct fix for it.

I'm creating this PR at an early stage to enable others to see what I'm doing and make comments or criticisms as required. It's not ready to merge yet.

<!-- issue-number: [bpo-42513](https://bugs.python.org/issue42513) -->
https://bugs.python.org/issue42513
<!-- /issue-number -->
