### PR TITLE
bpo-39096: Format specification documentation fixes for numeric types

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -550,12 +550,18 @@ The available presentation types for :class:`float` and
    | ``'%'`` | Percentage. Multiplies the number by 100 and displays    |
    |         | in fixed (``'f'``) format, followed by a percent sign.   |
    +---------+----------------------------------------------------------+
-   | None    | Similar to ``'g'``, except that fixed-point notation,    |
-   |         | when used, has at least one digit past the decimal point.|
-   |         | The default precision is as high as needed to represent  |
-   |         | the particular value. The overall effect is to match the |
-   |         | output of :func:`str` as altered by the other format     |
-   |         | modifiers.                                               |
+   | None    | For :class:`float` this is the same as ``'g'``, except   |
+   |         | that when fixed-point notation is used to format the     |
+   |         | result, it always includes at least one digit past the   |
+   |         | decimal point. The precision used is as large as needed  |
+   |         | to represent the given value faithfully.                 |
+   |         |                                                          |
+   |         | For :class:`~decimal.Decimal`, this is the same as       |
+   |         | either ``'g'`` or ``'G'`` depending on the value of      |
+   |         | ``context.capitals`` for the current decimal context.    |
+   |         |
+   |         | The overall effect is to match the output of :func:`str` |
+   |         | as altered by the other format modifiers.                |
    +---------+----------------------------------------------------------+
 
 

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -510,10 +510,12 @@ The available presentation types for :class:`float` and
    | ``'F'`` | Fixed-point notation. Same as ``'f'``, but converts      |
    |         | ``nan`` to  ``NAN`` and ``inf`` to ``INF``.              |
    +---------+----------------------------------------------------------+
-   | ``'g'`` | General format.  For a given precision ``p >= 1``,       |
+   | ``'g'`` | General format. For a given precision ``p >= 1``,        |
    |         | this rounds the number to ``p`` significant digits and   |
    |         | then formats the result in either fixed-point format     |
    |         | or in scientific notation, depending on its magnitude.   |
+   |         | A precision of ``0`` is treated as equivalent to a       |
+   |         | precision of ``1``.                                      |
    |         |                                                          |
    |         | The precise rules are as follows: suppose that the       |
    |         | result formatted with presentation type ``'e'`` and      |
@@ -528,16 +530,19 @@ The available presentation types for :class:`float` and
    |         | removed if there are no remaining digits following it,   |
    |         | unless the ``'#'`` option is used.                       |
    |         |                                                          |
+   |         | With no precision given, uses a precision of ``6``       |
+   |         | significant digits for :class:`float`. For               |
+   |         | :class:`~decimal.Decimal`, the coefficient of the result |
+   |         | is formed from the coefficient digits of the value;      |
+   |         | scientific notation is used for values smaller than      |
+   |         | ``1e-6`` in absolute value and values where the place    |
+   |         | value of the least significant digit is larger than 1,   |
+   |         | and fixed-point notation is used otherwise.              |
+   |         |                                                          |
    |         | Positive and negative infinity, positive and negative    |
    |         | zero, and nans, are formatted as ``inf``, ``-inf``,      |
    |         | ``0``, ``-0`` and ``nan`` respectively, regardless of    |
    |         | the precision.                                           |
-   |         |                                                          |
-   |         | A precision of ``0`` is treated as equivalent to a       |
-   |         | precision of ``1``. With no precision given, uses a      |
-   |         | precision of ``6`` significant digits for                |
-   |         | :class:`float`, and shows all coefficient digits         |
-   |         | for :class:`~decimal.Decimal`.                           |
    +---------+----------------------------------------------------------+
    | ``'G'`` | General format. Same as ``'g'`` except switches to       |
    |         | ``'E'`` if the number gets too large. The                |

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -510,7 +510,7 @@ The available presentation types for :class:`float` and
    | ``'F'`` | Fixed-point notation. Same as ``'f'``, but converts      |
    |         | ``nan`` to  ``NAN`` and ``inf`` to ``INF``.              |
    +---------+----------------------------------------------------------+
-   | ``'g'`` | General format. For a given precision ``p >= 1``,        |
+   | ``'g'`` | General format.  For a given precision ``p >= 1``,       |
    |         | this rounds the number to ``p`` significant digits and   |
    |         | then formats the result in either fixed-point format     |
    |         | or in scientific notation, depending on its magnitude.   |

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -564,7 +564,7 @@ The available presentation types for :class:`float` and
    |         | For :class:`~decimal.Decimal`, this is the same as       |
    |         | either ``'g'`` or ``'G'`` depending on the value of      |
    |         | ``context.capitals`` for the current decimal context.    |
-   |         |
+   |         |                                                          |
    |         | The overall effect is to match the output of :func:`str` |
    |         | as altered by the other format modifiers.                |
    +---------+----------------------------------------------------------+


### PR DESCRIPTION
This is a follow-up to #23537. It revises the text for the `g` presentation type and the `None` presentation type for `float` and `Decimal` instances.

For the `g` type, I've moved some pieces of the existing text around in an attempt to improve the flow (for example, the piece about precision `0` being the same as precision `1` is now closer to the "precision p >= 1" part), and I've attempted to give a more accurate description of the behaviour of the `Decimal` type for `g` with no given precision. It's still not completely accurate in some details (for example, in the handling of zeros like `0E-6` and `0E-8`, the first of which is formatted in fixed-point notation). But I'm not sure that attempting a full, completely accurate, specification in this table is feasible.

For the `None` type, it should now be clearer that the "at least one digit past the decimal point" part applies only to `float`, not to `Decimal`.





<!-- issue-number: [bpo-39096](https://bugs.python.org/issue39096) -->
https://bugs.python.org/issue39096
<!-- /issue-number -->
