### PR TITLE
bpo-42508: Keep IDLE running on macOS

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,10 @@ Released on 2021-10-04?
 ======================================
 
 
+bpo-42508: Keep IDLE running on macOS.  Remove obsolete workaround
+that prevented running files with shortcuts when using new universal2
+installers built on macOS 11.
+
 bpo-42426: Fix reporting offset of the RE error in searchengine.
 
 bpo-42416: Get docstrings for IDLE calltips more often

--- a/Lib/idlelib/runscript.py
+++ b/Lib/idlelib/runscript.py
@@ -11,6 +11,7 @@ TODO: Specify command line arguments in a dialog box.
 """
 import os
 import tabnanny
+import time
 import tokenize
 
 import tkinter.messagebox as tkMessageBox
@@ -42,6 +43,7 @@ class ScriptBinding:
         self.root = self.editwin.root
         # cli_args is list of strings that extends sys.argv
         self.cli_args = []
+        self.perf = 0.0    # Workaround for macOS 11 Uni2; see bpo-42508.
 
     def check_module_event(self, event):
         if isinstance(self.editwin, outwin.OutputWindow):
@@ -116,6 +118,8 @@ class ScriptBinding:
         module being executed and also add that directory to its
         sys.path if not already included.
         """
+        if macosx.isCocoaTk() and (time.perf_counter() - self.perf < .05):
+            return 'break'
         if isinstance(self.editwin, outwin.OutputWindow):
             self.editwin.text.bell()
             return 'break'
@@ -201,6 +205,7 @@ class ScriptBinding:
         # XXX This should really be a function of EditorWindow...
         tkMessageBox.showerror(title, message, parent=self.editwin.text)
         self.editwin.text.focus_set()
+        self.perf = time.perf_counter()
 
 
 if __name__ == "__main__":

--- a/Lib/idlelib/runscript.py
+++ b/Lib/idlelib/runscript.py
@@ -43,9 +43,6 @@ class ScriptBinding:
         # cli_args is list of strings that extends sys.argv
         self.cli_args = []
 
-        if macosx.isCocoaTk():
-            self.editwin.text_frame.bind('<<run-module-event-2>>', self._run_module_event)
-
     def check_module_event(self, event):
         if isinstance(self.editwin, outwin.OutputWindow):
             self.editwin.text.bell()
@@ -107,24 +104,10 @@ class ScriptBinding:
         finally:
             shell.set_warning_stream(saved_stream)
 
-    def run_module_event(self, event):
-        if macosx.isCocoaTk():
-            # Tk-Cocoa in MacOSX is broken until at least
-            # Tk 8.5.9, and without this rather
-            # crude workaround IDLE would hang when a user
-            # tries to run a module using the keyboard shortcut
-            # (the menu item works fine).
-            self.editwin.text_frame.after(200,
-                lambda: self.editwin.text_frame.event_generate(
-                        '<<run-module-event-2>>'))
-            return 'break'
-        else:
-            return self._run_module_event(event)
-
     def run_custom_event(self, event):
-        return self._run_module_event(event, customize=True)
+        return self.run_module_event(event, customize=True)
 
-    def _run_module_event(self, event, *, customize=False):
+    def run_module_event(self, event, *, customize=False):
         """Run the module after setting up the environment.
 
         First check the syntax.  Next get customization.  If OK, make

--- a/Misc/NEWS.d/next/IDLE/2020-11-30-19-46-05.bpo-42508.fE7w4M.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-11-30-19-46-05.bpo-42508.fE7w4M.rst
@@ -1,0 +1,3 @@
+Keep IDLE running on macOS.  Remove obsolete workaround that prevented
+running files with shortcuts when using new universal2 installers built
+on macOS 11.


### PR DESCRIPTION
Remove obsolete workaround that prevented running files with
shortcuts when using new universal2 installers built on macOS 11.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42508](https://bugs.python.org/issue42508) -->
https://bugs.python.org/issue42508
<!-- /issue-number -->
