### PR TITLE
bpo-42519: Replace PyMem_MALLOC() with PyMem_Malloc()

### DIFF
--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -138,8 +138,8 @@ PyAPI_FUNC(PyVarObject *) _PyObject_NewVar(PyTypeObject *, Py_ssize_t);
 #define PyObject_NewVar(type, typeobj, n) \
                 ( (type *) _PyObject_NewVar((typeobj), (n)) )
 
-// Alias to PyObject_New(). In Python 3.8, PyObject_NEW() called directly
-// PyObject_MALLOC() with _PyObject_VAR_SIZE().
+// Alias to PyObject_NewVar(). In Python 3.8, PyObject_NEW_VAR() called
+// directly PyObject_MALLOC() with _PyObject_VAR_SIZE().
 #define PyObject_NEW_VAR(type, typeobj, n) PyObject_NewVar(type, typeobj, n)
 
 

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -102,7 +102,7 @@ PyAPI_FUNC(void *) PyObject_Realloc(void *ptr, size_t new_size);
 PyAPI_FUNC(void) PyObject_Free(void *ptr);
 
 
-/* Macros */
+// Deprecated aliases only kept for backward compatibility.
 #define PyObject_MALLOC         PyObject_Malloc
 #define PyObject_REALLOC        PyObject_Realloc
 #define PyObject_FREE           PyObject_Free

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -53,11 +53,6 @@ PyAPI_FUNC(void *) PyMem_Malloc(size_t size);
 PyAPI_FUNC(void *) PyMem_Realloc(void *ptr, size_t new_size);
 PyAPI_FUNC(void) PyMem_Free(void *ptr);
 
-// Aliases kept for backward compatibility.
-#define PyMem_MALLOC(n)         PyMem_Malloc(n)
-#define PyMem_REALLOC(p, n)     PyMem_Realloc(p, n)
-#define PyMem_FREE(p)           PyMem_Free(p)
-
 /*
  * Type-oriented memory interface
  * ==============================
@@ -71,9 +66,6 @@ PyAPI_FUNC(void) PyMem_Free(void *ptr);
 #define PyMem_New(type, n) \
   ( ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :      \
         ( (type *) PyMem_Malloc((n) * sizeof(type)) ) )
-#define PyMem_NEW(type, n) \
-  ( ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :      \
-        ( (type *) PyMem_Malloc((n) * sizeof(type)) ) )
 
 /*
  * The value of (p) is always clobbered by this macro regardless of success.
@@ -84,15 +76,16 @@ PyAPI_FUNC(void) PyMem_Free(void *ptr);
 #define PyMem_Resize(p, type, n) \
   ( (p) = ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :        \
         (type *) PyMem_Realloc((p), (n) * sizeof(type)) )
-#define PyMem_RESIZE(p, type, n) \
-  ( (p) = ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :        \
-        (type *) PyMem_Realloc((p), (n) * sizeof(type)) )
 
-/* PyMem{Del,DEL} are left over from ancient days, and shouldn't be used
- * anymore.  They're just confusing aliases for PyMem_{Free,FREE} now.
- */
-#define PyMem_Del               PyMem_Free
-#define PyMem_DEL               PyMem_Free
+
+// Deprecated aliases only kept for backward compatibility.
+#define PyMem_MALLOC(n)           PyMem_Malloc(n)
+#define PyMem_NEW(type, n)        PyMem_New(type, n)
+#define PyMem_REALLOC(p, n)       PyMem_Realloc(p, n)
+#define PyMem_RESIZE(p, type, n)  PyMem_Resize(p, type, n)
+#define PyMem_FREE(p)             PyMem_Free(p)
+#define PyMem_Del(p)              PyMem_Free(p)
+#define PyMem_DEL(p)              PyMem_Free(p)
 
 
 #ifndef Py_LIMITED_API

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -53,14 +53,7 @@ PyAPI_FUNC(void *) PyMem_Malloc(size_t size);
 PyAPI_FUNC(void *) PyMem_Realloc(void *ptr, size_t new_size);
 PyAPI_FUNC(void) PyMem_Free(void *ptr);
 
-/* Macros. */
-
-/* PyMem_MALLOC(0) means malloc(1). Some systems would return NULL
-   for malloc(0), which would be treated as an error. Some platforms
-   would return a pointer with no memory behind it, which would break
-   pymalloc. To solve these problems, allocate an extra byte. */
-/* Returns NULL to indicate error if a negative size or size larger than
-   Py_ssize_t can represent is supplied.  Helps prevents security holes. */
+// Aliases kept for backward compatibility.
 #define PyMem_MALLOC(n)         PyMem_Malloc(n)
 #define PyMem_REALLOC(p, n)     PyMem_Realloc(p, n)
 #define PyMem_FREE(p)           PyMem_Free(p)
@@ -80,7 +73,7 @@ PyAPI_FUNC(void) PyMem_Free(void *ptr);
         ( (type *) PyMem_Malloc((n) * sizeof(type)) ) )
 #define PyMem_NEW(type, n) \
   ( ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :      \
-        ( (type *) PyMem_MALLOC((n) * sizeof(type)) ) )
+        ( (type *) PyMem_Malloc((n) * sizeof(type)) ) )
 
 /*
  * The value of (p) is always clobbered by this macro regardless of success.
@@ -93,13 +86,13 @@ PyAPI_FUNC(void) PyMem_Free(void *ptr);
         (type *) PyMem_Realloc((p), (n) * sizeof(type)) )
 #define PyMem_RESIZE(p, type, n) \
   ( (p) = ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :        \
-        (type *) PyMem_REALLOC((p), (n) * sizeof(type)) )
+        (type *) PyMem_Realloc((p), (n) * sizeof(type)) )
 
 /* PyMem{Del,DEL} are left over from ancient days, and shouldn't be used
  * anymore.  They're just confusing aliases for PyMem_{Free,FREE} now.
  */
 #define PyMem_Del               PyMem_Free
-#define PyMem_DEL               PyMem_FREE
+#define PyMem_DEL               PyMem_Free
 
 
 #ifndef Py_LIMITED_API

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -370,8 +370,8 @@ _locale_strcoll_impl(PyObject *module, PyObject *os1, PyObject *os2)
     result = PyLong_FromLong(wcscoll(ws1, ws2));
   done:
     /* Deallocate everything. */
-    if (ws1) PyMem_FREE(ws1);
-    if (ws2) PyMem_FREE(ws2);
+    if (ws1) PyMem_Free(ws1);
+    if (ws2) PyMem_Free(ws2);
     return result;
 }
 #endif

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -442,7 +442,7 @@ Pdata_dealloc(Pdata *self)
     while (--i >= 0) {
         Py_DECREF(self->data[i]);
     }
-    PyMem_FREE(self->data);
+    PyMem_Free(self->data);
     PyObject_Del(self);
 }
 
@@ -465,7 +465,7 @@ Pdata_New(void)
     self->mark_set = 0;
     self->fence = 0;
     self->allocated = 8;
-    self->data = PyMem_MALLOC(self->allocated * sizeof(PyObject *));
+    self->data = PyMem_Malloc(self->allocated * sizeof(PyObject *));
     if (self->data)
         return (PyObject *)self;
     Py_DECREF(self);
@@ -726,7 +726,7 @@ static PyTypeObject Unpickler_Type;
 static PyMemoTable *
 PyMemoTable_New(void)
 {
-    PyMemoTable *memo = PyMem_MALLOC(sizeof(PyMemoTable));
+    PyMemoTable *memo = PyMem_Malloc(sizeof(PyMemoTable));
     if (memo == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -735,9 +735,9 @@ PyMemoTable_New(void)
     memo->mt_used = 0;
     memo->mt_allocated = MT_MINSIZE;
     memo->mt_mask = MT_MINSIZE - 1;
-    memo->mt_table = PyMem_MALLOC(MT_MINSIZE * sizeof(PyMemoEntry));
+    memo->mt_table = PyMem_Malloc(MT_MINSIZE * sizeof(PyMemoEntry));
     if (memo->mt_table == NULL) {
-        PyMem_FREE(memo);
+        PyMem_Free(memo);
         PyErr_NoMemory();
         return NULL;
     }
@@ -758,10 +758,10 @@ PyMemoTable_Copy(PyMemoTable *self)
     new->mt_mask = self->mt_mask;
     /* The table we get from _New() is probably smaller than we wanted.
        Free it and allocate one that's the right size. */
-    PyMem_FREE(new->mt_table);
+    PyMem_Free(new->mt_table);
     new->mt_table = PyMem_NEW(PyMemoEntry, self->mt_allocated);
     if (new->mt_table == NULL) {
-        PyMem_FREE(new);
+        PyMem_Free(new);
         PyErr_NoMemory();
         return NULL;
     }
@@ -800,8 +800,8 @@ PyMemoTable_Del(PyMemoTable *self)
         return;
     PyMemoTable_Clear(self);
 
-    PyMem_FREE(self->mt_table);
-    PyMem_FREE(self);
+    PyMem_Free(self->mt_table);
+    PyMem_Free(self);
 }
 
 /* Since entries cannot be deleted from this hashtable, _PyMemoTable_Lookup()
@@ -880,7 +880,7 @@ _PyMemoTable_ResizeTable(PyMemoTable *self, size_t min_size)
     }
 
     /* Deallocate the old table. */
-    PyMem_FREE(oldtable);
+    PyMem_Free(oldtable);
     return 0;
 }
 
@@ -1582,7 +1582,7 @@ _Unpickler_MemoCleanup(UnpicklerObject *self)
     while (--i >= 0) {
         Py_XDECREF(memo[i]);
     }
-    PyMem_FREE(memo);
+    PyMem_Free(memo);
 }
 
 static UnpicklerObject *
@@ -7544,7 +7544,7 @@ Unpickler_set_memo(UnpicklerObject *self, PyObject *obj, void *Py_UNUSED(ignored
         for (size_t i = new_memo_size - 1; i != SIZE_MAX; i--) {
             Py_XDECREF(new_memo[i]);
         }
-        PyMem_FREE(new_memo);
+        PyMem_Free(new_memo);
     }
     return -1;
 }

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -197,7 +197,7 @@ static void
 data_stack_dealloc(SRE_STATE* state)
 {
     if (state->data_stack) {
-        PyMem_FREE(state->data_stack);
+        PyMem_Free(state->data_stack);
         state->data_stack = NULL;
     }
     state->data_stack_size = state->data_stack_base = 0;
@@ -213,7 +213,7 @@ data_stack_grow(SRE_STATE* state, Py_ssize_t size)
         void* stack;
         cursize = minsize+minsize/4+1024;
         TRACE(("allocate/grow stack %zd\n", cursize));
-        stack = PyMem_REALLOC(state->data_stack, cursize);
+        stack = PyMem_Realloc(state->data_stack, cursize);
         if (!stack) {
             data_stack_dealloc(state);
             return SRE_ERROR_MEMORY;
@@ -472,7 +472,7 @@ state_init(SRE_STATE* state, PatternObject* pattern, PyObject* string,
     /* We add an explicit cast here because MSVC has a bug when
        compiling C code where it believes that `const void**` cannot be
        safely casted to `void*`, see bpo-39943 for details. */
-    PyMem_Del((void*) state->mark);
+    PyMem_Free((void*) state->mark);
     state->mark = NULL;
     if (state->buffer.buf)
         PyBuffer_Release(&state->buffer);
@@ -487,7 +487,7 @@ state_fini(SRE_STATE* state)
     Py_XDECREF(state->string);
     data_stack_dealloc(state);
     /* See above PyMem_Del for why we explicitly cast here. */
-    PyMem_Del((void*) state->mark);
+    PyMem_Free((void*) state->mark);
     state->mark = NULL;
 }
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3306,10 +3306,10 @@ context_dealloc(PySSLContext *self)
     context_clear(self);
     SSL_CTX_free(self->ctx);
 #if HAVE_NPN
-    PyMem_FREE(self->npn_protocols);
+    PyMem_Free(self->npn_protocols);
 #endif
 #if HAVE_ALPN
-    PyMem_FREE(self->alpn_protocols);
+    PyMem_Free(self->alpn_protocols);
 #endif
     Py_TYPE(self)->tp_free(self);
     Py_DECREF(tp);
@@ -3510,7 +3510,7 @@ _ssl__SSLContext__set_alpn_protocols_impl(PySSLContext *self,
         return NULL;
     }
 
-    PyMem_FREE(self->alpn_protocols);
+    PyMem_Free(self->alpn_protocols);
     self->alpn_protocols = PyMem_Malloc(protos->len);
     if (!self->alpn_protocols)
         return PyErr_NoMemory();

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1373,14 +1373,14 @@ prepare_s(PyStructObject *self)
 
     self->s_size = size;
     self->s_len = len;
-    codes = PyMem_MALLOC((ncodes + 1) * sizeof(formatcode));
+    codes = PyMem_Malloc((ncodes + 1) * sizeof(formatcode));
     if (codes == NULL) {
         PyErr_NoMemory();
         return -1;
     }
     /* Free any s_codes value left over from a previous initialization. */
     if (self->s_codes != NULL)
-        PyMem_FREE(self->s_codes);
+        PyMem_Free(self->s_codes);
     self->s_codes = codes;
 
     s = fmt;
@@ -1502,7 +1502,7 @@ s_dealloc(PyStructObject *s)
     if (s->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *)s);
     if (s->s_codes != NULL) {
-        PyMem_FREE(s->s_codes);
+        PyMem_Free(s->s_codes);
     }
     Py_XDECREF(s->s_format);
     freefunc free_func = PyType_GetSlot(Py_TYPE(s), Py_tp_free);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1988,12 +1988,12 @@ unicode_asucs4(PyObject *self, PyObject *args)
     buffer[str_len] = 0xffffU;
 
     if (!PyUnicode_AsUCS4(unicode, buffer, buf_len, copy_null)) {
-        PyMem_FREE(buffer);
+        PyMem_Free(buffer);
         return NULL;
     }
 
     result = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, buffer, buf_len);
-    PyMem_FREE(buffer);
+    PyMem_Free(buffer);
     return result;
 }
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1056,7 +1056,7 @@ t_bootstrap(void *boot_raw)
     Py_DECREF(boot->func);
     Py_DECREF(boot->args);
     Py_XDECREF(boot->keyw);
-    PyMem_DEL(boot_raw);
+    PyMem_Free(boot_raw);
     tstate->interp->num_threads--;
     PyThreadState_Clear(tstate);
     _PyThreadState_DeleteCurrent(tstate);
@@ -1107,7 +1107,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
     boot->tstate = _PyThreadState_Prealloc(boot->interp);
     boot->runtime = runtime;
     if (boot->tstate == NULL) {
-        PyMem_DEL(boot);
+        PyMem_Free(boot);
         return PyErr_NoMemory();
     }
     Py_INCREF(func);
@@ -1121,7 +1121,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
         Py_DECREF(args);
         Py_XDECREF(keyw);
         PyThreadState_Clear(boot->tstate);
-        PyMem_DEL(boot);
+        PyMem_Free(boot);
         return NULL;
     }
     return PyLong_FromUnsignedLong(ident);

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -2472,7 +2472,7 @@ PythonCmdDelete(ClientData clientData)
     ENTER_PYTHON
     Py_XDECREF(data->self);
     Py_XDECREF(data->func);
-    PyMem_DEL(data);
+    PyMem_Free(data);
     LEAVE_PYTHON
 }
 
@@ -2545,7 +2545,7 @@ _tkinter_tkapp_createcommand_impl(TkappObject *self, const char *name,
         CommandEvent *ev = (CommandEvent*)attemptckalloc(sizeof(CommandEvent));
         if (ev == NULL) {
             PyErr_NoMemory();
-            PyMem_DEL(data);
+            PyMem_Free(data);
             return NULL;
         }
         ev->ev.proc = (Tcl_EventProc*)Tkapp_CommandProc;
@@ -2568,7 +2568,7 @@ _tkinter_tkapp_createcommand_impl(TkappObject *self, const char *name,
     }
     if (err) {
         PyErr_SetString(Tkinter_TclError, "can't create Tcl command");
-        PyMem_DEL(data);
+        PyMem_Free(data);
         return NULL;
     }
 
@@ -2666,7 +2666,7 @@ DeleteFHCD(int id)
             *pp = p->next;
             Py_XDECREF(p->func);
             Py_XDECREF(p->file);
-            PyMem_DEL(p);
+            PyMem_Free(p);
         }
         else
             pp = &p->next;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -133,7 +133,7 @@ array_resize(arrayobject *self, Py_ssize_t newsize)
     }
 
     if (newsize == 0) {
-        PyMem_FREE(self->ob_item);
+        PyMem_Free(self->ob_item);
         self->ob_item = NULL;
         Py_SET_SIZE(self, 0);
         self->allocated = 0;
@@ -652,7 +652,7 @@ array_dealloc(arrayobject *op)
     if (op->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *) op);
     if (op->ob_item != NULL)
-        PyMem_DEL(op->ob_item);
+        PyMem_Free(op->ob_item);
     Py_TYPE(op)->tp_free((PyObject *)op);
 }
 

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -1191,13 +1191,13 @@ _multibytecodec_MultibyteIncrementalDecoder_decode_impl(MultibyteIncrementalDeco
         goto errorexit;
 
     if (wdata != data)
-        PyMem_Del(wdata);
+        PyMem_Free(wdata);
     Py_XDECREF(buf.excobj);
     return res;
 
 errorexit:
     if (wdata != NULL && wdata != data)
-        PyMem_Del(wdata);
+        PyMem_Free(wdata);
     Py_XDECREF(buf.excobj);
     _PyUnicodeWriter_Dealloc(&buf.writer);
     return NULL;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5480,7 +5480,7 @@ free_string_array(EXECV_CHAR **array, Py_ssize_t count)
     Py_ssize_t i;
     for (i = 0; i < count; i++)
         PyMem_Free(array[i]);
-    PyMem_DEL(array);
+    PyMem_Free(array);
 }
 
 static int
@@ -6510,9 +6510,10 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
         res = Py_BuildValue(_Py_PARSE_INTPTR, spawnval);
 
   fail_2:
-    while (--envc >= 0)
-        PyMem_DEL(envlist[envc]);
-    PyMem_DEL(envlist);
+    while (--envc >= 0) {
+        PyMem_Free(envlist[envc]);
+    }
+    PyMem_Free(envlist);
   fail_1:
     free_string_array(argvlist, lastarg);
   fail_0:
@@ -7444,7 +7445,7 @@ os_getgrouplist_impl(PyObject *module, const char *user, gid_t basegid)
 
     list = PyList_New(ngroups);
     if (list == NULL) {
-        PyMem_Del(groups);
+        PyMem_Free(groups);
         return NULL;
     }
 
@@ -7456,13 +7457,13 @@ os_getgrouplist_impl(PyObject *module, const char *user, gid_t basegid)
 #endif
         if (o == NULL) {
             Py_DECREF(list);
-            PyMem_Del(groups);
+            PyMem_Free(groups);
             return NULL;
         }
         PyList_SET_ITEM(list, i, o);
     }
 
-    PyMem_Del(groups);
+    PyMem_Free(groups);
 
     return list;
 }
@@ -9407,7 +9408,7 @@ iov_setup(struct iovec **iov, Py_buffer **buf, PyObject *seq, Py_ssize_t cnt, in
 
     *buf = PyMem_New(Py_buffer, cnt);
     if (*buf == NULL) {
-        PyMem_Del(*iov);
+        PyMem_Free(*iov);
         PyErr_NoMemory();
         return -1;
     }
@@ -9427,11 +9428,11 @@ iov_setup(struct iovec **iov, Py_buffer **buf, PyObject *seq, Py_ssize_t cnt, in
     return 0;
 
 fail:
-    PyMem_Del(*iov);
+    PyMem_Free(*iov);
     for (j = 0; j < i; j++) {
         PyBuffer_Release(&(*buf)[j]);
     }
-    PyMem_Del(*buf);
+    PyMem_Free(*buf);
     return -1;
 }
 
@@ -9439,11 +9440,11 @@ static void
 iov_cleanup(struct iovec *iov, Py_buffer *buf, int cnt)
 {
     int i;
-    PyMem_Del(iov);
+    PyMem_Free(iov);
     for (i = 0; i < cnt; i++) {
         PyBuffer_Release(&buf[i]);
     }
-    PyMem_Del(buf);
+    PyMem_Free(buf);
 }
 #endif
 
@@ -12815,7 +12816,7 @@ os_listxattr_impl(PyObject *module, path_t *path, int follow_symlinks)
             path_error(path);
             break;
         }
-        buffer = PyMem_MALLOC(buffer_size);
+        buffer = PyMem_Malloc(buffer_size);
         if (!buffer) {
             PyErr_NoMemory();
             break;
@@ -12832,7 +12833,7 @@ os_listxattr_impl(PyObject *module, path_t *path, int follow_symlinks)
 
         if (length < 0) {
             if (errno == ERANGE) {
-                PyMem_FREE(buffer);
+                PyMem_Free(buffer);
                 buffer = NULL;
                 continue;
             }
@@ -12870,7 +12871,7 @@ os_listxattr_impl(PyObject *module, path_t *path, int follow_symlinks)
     }
 exit:
     if (buffer)
-        PyMem_FREE(buffer);
+        PyMem_Free(buffer);
     return result;
 }
 #endif /* USE_XATTRS */

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -294,9 +294,9 @@ select_select_impl(PyObject *module, PyObject *rlist, PyObject *wlist,
     wfd2obj = PyMem_NEW(pylist, FD_SETSIZE + 1);
     efd2obj = PyMem_NEW(pylist, FD_SETSIZE + 1);
     if (rfd2obj == NULL || wfd2obj == NULL || efd2obj == NULL) {
-        if (rfd2obj) PyMem_DEL(rfd2obj);
-        if (wfd2obj) PyMem_DEL(wfd2obj);
-        if (efd2obj) PyMem_DEL(efd2obj);
+        if (rfd2obj) PyMem_Free(rfd2obj);
+        if (wfd2obj) PyMem_Free(wfd2obj);
+        if (efd2obj) PyMem_Free(efd2obj);
         return PyErr_NoMemory();
     }
 #endif /* SELECT_USES_HEAP */
@@ -381,9 +381,9 @@ select_select_impl(PyObject *module, PyObject *rlist, PyObject *wlist,
     reap_obj(wfd2obj);
     reap_obj(efd2obj);
 #ifdef SELECT_USES_HEAP
-    PyMem_DEL(rfd2obj);
-    PyMem_DEL(wfd2obj);
-    PyMem_DEL(efd2obj);
+    PyMem_Free(rfd2obj);
+    PyMem_Free(wfd2obj);
+    PyMem_Free(efd2obj);
 #endif /* SELECT_USES_HEAP */
     return ret;
 }
@@ -740,7 +740,7 @@ poll_dealloc(pollObject *self)
 {
     PyObject* type = (PyObject *)Py_TYPE(self);
     if (self->ufds != NULL)
-        PyMem_DEL(self->ufds);
+        PyMem_Free(self->ufds);
     Py_XDECREF(self->dict);
     PyObject_Del(self);
     Py_DECREF(type);
@@ -1106,7 +1106,7 @@ newDevPollObject(PyObject *module)
     self = PyObject_New(devpollObject, get_select_state(module)->devpoll_Type);
     if (self == NULL) {
         close(fd_devpoll);
-        PyMem_DEL(fds);
+        PyMem_Free(fds);
         return NULL;
     }
     self->fd_devpoll = fd_devpoll;
@@ -1129,7 +1129,7 @@ devpoll_dealloc(devpollObject *self)
 {
     PyObject *type = (PyObject *)Py_TYPE(self);
     (void)devpoll_internal_close(self);
-    PyMem_DEL(self->fds);
+    PyMem_Free(self->fds);
     PyObject_Del(self);
     Py_DECREF(type);
 }

--- a/Objects/capsule.c
+++ b/Objects/capsule.c
@@ -198,7 +198,7 @@ PyCapsule_Import(const char *name, int no_block)
     void *return_value = NULL;
     char *trace;
     size_t name_length = (strlen(name) + 1) * sizeof(char);
-    char *name_dup = (char *)PyMem_MALLOC(name_length);
+    char *name_dup = (char *)PyMem_Malloc(name_length);
 
     if (!name_dup) {
         return PyErr_NoMemory();
@@ -247,7 +247,7 @@ PyCapsule_Import(const char *name, int no_block)
 EXIT:
     Py_XDECREF(object);
     if (name_dup) {
-        PyMem_FREE(name_dup);
+        PyMem_Free(name_dup);
     }
     return return_value;
 }

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -213,7 +213,7 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
                 PyObject *arg = PyTuple_GET_ITEM(varnames, j);
                 int cmp = PyUnicode_Compare(cell, arg);
                 if (cmp == -1 && PyErr_Occurred()) {
-                    PyMem_FREE(cell2arg);
+                    PyMem_Free(cell2arg);
                     return NULL;
                 }
                 if (cmp == 0) {
@@ -224,14 +224,14 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
             }
         }
         if (!used_cell2arg) {
-            PyMem_FREE(cell2arg);
+            PyMem_Free(cell2arg);
             cell2arg = NULL;
         }
     }
     co = PyObject_New(PyCodeObject, &PyCode_Type);
     if (co == NULL) {
         if (cell2arg)
-            PyMem_FREE(cell2arg);
+            PyMem_Free(cell2arg);
         return NULL;
     }
     co->co_argcount = argcount;
@@ -314,12 +314,12 @@ _PyCode_InitOpcache(PyCodeObject *co)
     if (opts) {
         co->co_opcache = (_PyOpcache *)PyMem_Calloc(opts, sizeof(_PyOpcache));
         if (co->co_opcache == NULL) {
-            PyMem_FREE(co->co_opcache_map);
+            PyMem_Free(co->co_opcache_map);
             return -1;
         }
     }
     else {
-        PyMem_FREE(co->co_opcache_map);
+        PyMem_Free(co->co_opcache_map);
         co->co_opcache_map = NULL;
         co->co_opcache = NULL;
     }
@@ -631,10 +631,10 @@ static void
 code_dealloc(PyCodeObject *co)
 {
     if (co->co_opcache != NULL) {
-        PyMem_FREE(co->co_opcache);
+        PyMem_Free(co->co_opcache);
     }
     if (co->co_opcache_map != NULL) {
-        PyMem_FREE(co->co_opcache_map);
+        PyMem_Free(co->co_opcache_map);
     }
     co->co_opcache_flag = 0;
     co->co_opcache_size = 0;
@@ -664,7 +664,7 @@ code_dealloc(PyCodeObject *co)
     Py_XDECREF(co->co_name);
     Py_XDECREF(co->co_linetable);
     if (co->co_cell2arg != NULL)
-        PyMem_FREE(co->co_cell2arg);
+        PyMem_Free(co->co_cell2arg);
     if (co->co_zombieframe != NULL)
         PyObject_GC_Del(co->co_zombieframe);
     if (co->co_weakreflist != NULL)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -640,7 +640,7 @@ free_keys_object(PyDictKeysObject *keys)
 }
 
 #define new_values(size) PyMem_NEW(PyObject *, size)
-#define free_values(values) PyMem_FREE(values)
+#define free_values(values) PyMem_Free(values)
 
 /* Consumes a reference to the keys object */
 static PyObject *

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -341,7 +341,7 @@ list_dealloc(PyListObject *op)
         while (--i >= 0) {
             Py_XDECREF(op->ob_item[i]);
         }
-        PyMem_FREE(op->ob_item);
+        PyMem_Free(op->ob_item);
     }
     struct _Py_list_state *state = get_list_state();
 #ifdef Py_DEBUG
@@ -592,7 +592,7 @@ _list_clear(PyListObject *a)
         while (--i >= 0) {
             Py_XDECREF(item[i]);
         }
-        PyMem_FREE(item);
+        PyMem_Free(item);
     }
     /* Never fails; the return value can be ignored.
        Note that there is no guarantee that the list is actually empty
@@ -668,7 +668,7 @@ list_ass_slice(PyListObject *a, Py_ssize_t ilow, Py_ssize_t ihigh, PyObject *v)
     /* If norig == 0, item might be NULL, in which case we may not memcpy from it. */
     if (s) {
         if (s > sizeof(recycle_on_stack)) {
-            recycle = (PyObject **)PyMem_MALLOC(s);
+            recycle = (PyObject **)PyMem_Malloc(s);
             if (recycle == NULL) {
                 PyErr_NoMemory();
                 goto Error;
@@ -706,7 +706,7 @@ list_ass_slice(PyListObject *a, Py_ssize_t ilow, Py_ssize_t ihigh, PyObject *v)
     result = 0;
  Error:
     if (recycle != recycle_on_stack)
-        PyMem_FREE(recycle);
+        PyMem_Free(recycle);
     Py_XDECREF(v_as_SF);
     return result;
 #undef b
@@ -2230,7 +2230,7 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
             /* Leverage stack space we allocated but won't otherwise use */
             keys = &ms.temparray[saved_ob_size+1];
         else {
-            keys = PyMem_MALLOC(sizeof(PyObject *) * saved_ob_size);
+            keys = PyMem_Malloc(sizeof(PyObject *) * saved_ob_size);
             if (keys == NULL) {
                 PyErr_NoMemory();
                 goto keyfunc_fail;
@@ -2243,7 +2243,7 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
                 for (i=i-1 ; i>=0 ; i--)
                     Py_DECREF(keys[i]);
                 if (saved_ob_size >= MERGESTATE_TEMP_SIZE/2)
-                    PyMem_FREE(keys);
+                    PyMem_Free(keys);
                 goto keyfunc_fail;
             }
         }
@@ -2414,7 +2414,7 @@ fail:
         for (i = 0; i < saved_ob_size; i++)
             Py_DECREF(keys[i]);
         if (saved_ob_size >= MERGESTATE_TEMP_SIZE/2)
-            PyMem_FREE(keys);
+            PyMem_Free(keys);
     }
 
     if (self->allocated != -1 && result != NULL) {
@@ -2442,7 +2442,7 @@ keyfunc_fail:
         while (--i >= 0) {
             Py_XDECREF(final_ob_item[i]);
         }
-        PyMem_FREE(final_ob_item);
+        PyMem_Free(final_ob_item);
     }
     Py_XINCREF(result);
     return result;
@@ -2908,7 +2908,7 @@ list_ass_subscript(PyListObject* self, PyObject* item, PyObject* value)
             }
 
             garbage = (PyObject**)
-                PyMem_MALLOC(slicelength*sizeof(PyObject*));
+                PyMem_Malloc(slicelength*sizeof(PyObject*));
             if (!garbage) {
                 PyErr_NoMemory();
                 return -1;
@@ -2949,7 +2949,7 @@ list_ass_subscript(PyListObject* self, PyObject* item, PyObject* value)
             for (i = 0; i < slicelength; i++) {
                 Py_DECREF(garbage[i]);
             }
-            PyMem_FREE(garbage);
+            PyMem_Free(garbage);
 
             return res;
         }
@@ -2990,7 +2990,7 @@ list_ass_subscript(PyListObject* self, PyObject* item, PyObject* value)
             }
 
             garbage = (PyObject**)
-                PyMem_MALLOC(slicelength*sizeof(PyObject*));
+                PyMem_Malloc(slicelength*sizeof(PyObject*));
             if (!garbage) {
                 Py_DECREF(seq);
                 PyErr_NoMemory();
@@ -3011,7 +3011,7 @@ list_ass_subscript(PyListObject* self, PyObject* item, PyObject* value)
                 Py_DECREF(garbage[i]);
             }
 
-            PyMem_FREE(garbage);
+            PyMem_Free(garbage);
             Py_DECREF(seq);
 
             return 0;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -211,7 +211,7 @@ _PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
         return NULL;
 
     if (module->m_size > 0) {
-        m->md_state = PyMem_MALLOC(module->m_size);
+        m->md_state = PyMem_Malloc(module->m_size);
         if (!m->md_state) {
             PyErr_NoMemory();
             Py_DECREF(m);
@@ -377,7 +377,7 @@ PyModule_ExecDef(PyObject *module, PyModuleDef *def)
         if (md->md_state == NULL) {
             /* Always set a state pointer; this serves as a marker to skip
              * multiple initialization (importlib.reload() is no-op) */
-            md->md_state = PyMem_MALLOC(def->m_size);
+            md->md_state = PyMem_Malloc(def->m_size);
             if (!md->md_state) {
                 PyErr_NoMemory();
                 return -1;
@@ -681,7 +681,7 @@ module_dealloc(PyModuleObject *m)
     Py_XDECREF(m->md_dict);
     Py_XDECREF(m->md_name);
     if (m->md_state != NULL)
-        PyMem_FREE(m->md_state);
+        PyMem_Free(m->md_state);
     Py_TYPE(m)->tp_free((PyObject *)m);
 }
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -567,14 +567,14 @@ _odict_resize(PyODictObject *od)
         i = _odict_get_index_raw(od, _odictnode_KEY(node),
                                  _odictnode_HASH(node));
         if (i < 0) {
-            PyMem_FREE(fast_nodes);
+            PyMem_Free(fast_nodes);
             return -1;
         }
         fast_nodes[i] = node;
     }
 
     /* Replace the old fast nodes table. */
-    PyMem_FREE(od->od_fast_nodes);
+    PyMem_Free(od->od_fast_nodes);
     od->od_fast_nodes = fast_nodes;
     od->od_fast_nodes_size = size;
     od->od_resize_sentinel = ((PyDictObject *)od)->ma_keys;
@@ -683,7 +683,7 @@ _odict_add_new_node(PyODictObject *od, PyObject *key, Py_hash_t hash)
     }
 
     /* must not be added yet */
-    node = (_ODictNode *)PyMem_MALLOC(sizeof(_ODictNode));
+    node = (_ODictNode *)PyMem_Malloc(sizeof(_ODictNode));
     if (node == NULL) {
         Py_DECREF(key);
         PyErr_NoMemory();
@@ -701,7 +701,7 @@ _odict_add_new_node(PyODictObject *od, PyObject *key, Py_hash_t hash)
 #define _odictnode_DEALLOC(node) \
     do { \
         Py_DECREF(_odictnode_KEY(node)); \
-        PyMem_FREE((void *)node); \
+        PyMem_Free((void *)node); \
     } while (0)
 
 /* Repeated calls on the same node are no-ops. */
@@ -776,7 +776,7 @@ _odict_clear_nodes(PyODictObject *od)
 {
     _ODictNode *node, *next;
 
-    PyMem_FREE(od->od_fast_nodes);
+    PyMem_Free(od->od_fast_nodes);
     od->od_fast_nodes = NULL;
     od->od_fast_nodes_size = 0;
     od->od_resize_sentinel = NULL;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -289,7 +289,7 @@ set_table_resize(PySetObject *so, Py_ssize_t minused)
     }
 
     if (is_oldtable_malloced)
-        PyMem_DEL(oldtable);
+        PyMem_Free(oldtable);
     return 0;
 }
 
@@ -424,7 +424,7 @@ set_clear_internal(PySetObject *so)
     }
 
     if (table_is_malloced)
-        PyMem_DEL(table);
+        PyMem_Free(table);
     return 0;
 }
 
@@ -484,7 +484,7 @@ set_dealloc(PySetObject *so)
         }
     }
     if (so->table != so->smalltable)
-        PyMem_DEL(so->table);
+        PyMem_Free(so->table);
     Py_TYPE(so)->tp_free(so);
     Py_TRASHCAN_END
 }

--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -155,7 +155,7 @@ done:
     for (i = 0; i < nbufs; i++)
         PyBuffer_Release(&buffers[i]);
     if (buffers != static_buffers)
-        PyMem_FREE(buffers);
+        PyMem_Free(buffers);
     return res;
 }
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -467,14 +467,14 @@ PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc)
     type->tp_members = members;
 
     if (PyType_Ready(type) < 0) {
-        PyMem_FREE(members);
+        PyMem_Free(members);
         return -1;
     }
     Py_INCREF(type);
 
     if (initialize_structseq_dict(
             desc, type->tp_dict, n_members, n_unnamed_members) < 0) {
-        PyMem_FREE(members);
+        PyMem_Free(members);
         Py_DECREF(type);
         return -1;
     }
@@ -526,7 +526,7 @@ PyStructSequence_NewType(PyStructSequence_Desc *desc)
     spec.slots = slots;
 
     type = (PyTypeObject *)PyType_FromSpecWithBases(&spec, (PyObject *)&PyTuple_Type);
-    PyMem_FREE(members);
+    PyMem_Free(members);
     if (type == NULL) {
         return NULL;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1779,7 +1779,7 @@ pmerge(PyObject *acc, PyObject **to_merge, Py_ssize_t to_merge_size)
     }
 
   out:
-    PyMem_Del(remain);
+    PyMem_Free(remain);
 
     return res;
 }
@@ -1859,7 +1859,7 @@ mro_implementation(PyTypeObject *type)
 
     result = PyList_New(1);
     if (result == NULL) {
-        PyMem_Del(to_merge);
+        PyMem_Free(to_merge);
         return NULL;
     }
 
@@ -1869,7 +1869,7 @@ mro_implementation(PyTypeObject *type)
         Py_CLEAR(result);
     }
 
-    PyMem_Del(to_merge);
+    PyMem_Free(to_merge);
     return result;
 }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3298,7 +3298,7 @@ PyUnicode_AsWideCharString(PyObject *unicode,
         *size = buflen;
     }
     else if (wcslen(buffer) != (size_t)buflen) {
-        PyMem_FREE(buffer);
+        PyMem_Free(buffer);
         PyErr_SetString(PyExc_ValueError,
                         "embedded null character");
         return NULL;
@@ -10211,7 +10211,7 @@ case_operation(PyObject *self,
         PyErr_SetString(PyExc_OverflowError, "string is too long");
         return NULL;
     }
-    tmp = PyMem_MALLOC(sizeof(Py_UCS4) * 3 * length);
+    tmp = PyMem_Malloc(sizeof(Py_UCS4) * 3 * length);
     if (tmp == NULL)
         return PyErr_NoMemory();
     newlength = perform(kind, data, length, tmp, &maxchar);
@@ -10235,7 +10235,7 @@ case_operation(PyObject *self,
         Py_UNREACHABLE();
     }
   leave:
-    PyMem_FREE(tmp);
+    PyMem_Free(tmp);
     return res;
 }
 
@@ -11050,11 +11050,11 @@ replace(PyObject *self, PyObject *str1,
     assert(release1 == (buf1 != PyUnicode_DATA(str1)));
     assert(release2 == (buf2 != PyUnicode_DATA(str2)));
     if (srelease)
-        PyMem_FREE((void *)sbuf);
+        PyMem_Free((void *)sbuf);
     if (release1)
-        PyMem_FREE((void *)buf1);
+        PyMem_Free((void *)buf1);
     if (release2)
-        PyMem_FREE((void *)buf2);
+        PyMem_Free((void *)buf2);
     assert(_PyUnicode_CheckConsistency(u, 1));
     return u;
 
@@ -11064,11 +11064,11 @@ replace(PyObject *self, PyObject *str1,
     assert(release1 == (buf1 != PyUnicode_DATA(str1)));
     assert(release2 == (buf2 != PyUnicode_DATA(str2)));
     if (srelease)
-        PyMem_FREE((void *)sbuf);
+        PyMem_Free((void *)sbuf);
     if (release1)
-        PyMem_FREE((void *)buf1);
+        PyMem_Free((void *)buf1);
     if (release2)
-        PyMem_FREE((void *)buf2);
+        PyMem_Free((void *)buf2);
     return unicode_result_unchanged(self);
 
   error:
@@ -11076,11 +11076,11 @@ replace(PyObject *self, PyObject *str1,
     assert(release1 == (buf1 != PyUnicode_DATA(str1)));
     assert(release2 == (buf2 != PyUnicode_DATA(str2)));
     if (srelease)
-        PyMem_FREE((void *)sbuf);
+        PyMem_Free((void *)sbuf);
     if (release1)
-        PyMem_FREE((void *)buf1);
+        PyMem_Free((void *)buf1);
     if (release2)
-        PyMem_FREE((void *)buf2);
+        PyMem_Free((void *)buf2);
     return NULL;
 }
 

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -1818,7 +1818,7 @@ winreg_SetValueEx_impl(PyObject *module, HKEY key,
     Py_BEGIN_ALLOW_THREADS
     rc = RegSetValueExW(key, value_name, 0, type, data, len);
     Py_END_ALLOW_THREADS
-    PyMem_DEL(data);
+    PyMem_Free(data);
     if (rc != ERROR_SUCCESS)
         return PyErr_SetFromWindowsErrWithFunction(rc,
                                                    "RegSetValueEx");

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -384,7 +384,7 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
 
     int lines, cols;
     if (!fstring_find_expr_location(t, str, &lines, &cols)) {
-        PyMem_FREE(str);
+        PyMem_Free(str);
         return NULL;
     }
 

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -51,7 +51,7 @@ static const char* type_comment_prefix = "# type: ";
 static struct tok_state *
 tok_new(void)
 {
-    struct tok_state *tok = (struct tok_state *)PyMem_MALLOC(
+    struct tok_state *tok = (struct tok_state *)PyMem_Malloc(
                                             sizeof(struct tok_state));
     if (tok == NULL)
         return NULL;
@@ -93,7 +93,7 @@ tok_new(void)
 static char *
 new_string(const char *s, Py_ssize_t len, struct tok_state *tok)
 {
-    char* result = (char *)PyMem_MALLOC(len + 1);
+    char* result = (char *)PyMem_Malloc(len + 1);
     if (!result) {
         tok->done = E_NOMEM;
         return NULL;
@@ -108,7 +108,7 @@ error_ret(struct tok_state *tok) /* XXX */
 {
     tok->decoding_erred = 1;
     if (tok->fp != NULL && tok->buf != NULL) /* see PyTokenizer_Free */
-        PyMem_FREE(tok->buf);
+        PyMem_Free(tok->buf);
     tok->buf = tok->cur = tok->inp = NULL;
     tok->start = NULL;
     tok->end = NULL;
@@ -184,7 +184,7 @@ get_coding_spec(const char *s, char **spec, Py_ssize_t size, struct tok_state *t
                     return 0;
                 q = get_normal_name(r);
                 if (r != q) {
-                    PyMem_FREE(r);
+                    PyMem_Free(r);
                     r = new_string(q, strlen(q), tok);
                     if (!r)
                         return 0;
@@ -244,7 +244,7 @@ check_coding_spec(const char* line, Py_ssize_t size, struct tok_state *tok,
             else {
                 PyErr_Format(PyExc_SyntaxError,
                              "encoding problem: %s", cs);
-                PyMem_FREE(cs);
+                PyMem_Free(cs);
             }
         }
     } else {                /* then, compare cs with BOM */
@@ -252,7 +252,7 @@ check_coding_spec(const char* line, Py_ssize_t size, struct tok_state *tok,
         if (!r)
             PyErr_Format(PyExc_SyntaxError,
                          "encoding problem: %s with BOM", cs);
-        PyMem_FREE(cs);
+        PyMem_Free(cs);
     }
     return r;
 }
@@ -315,7 +315,7 @@ check_bom(int get_char(struct tok_state *),
         return 1;
     }
     if (tok->encoding != NULL)
-        PyMem_FREE(tok->encoding);
+        PyMem_Free(tok->encoding);
     tok->encoding = new_string("utf-8", 5, tok);
     if (!tok->encoding)
         return 0;
@@ -620,7 +620,7 @@ translate_newlines(const char *s, int exec_input, struct tok_state *tok) {
     size_t needed_length = strlen(s) + 2, final_length;
     char *buf, *current;
     char c = '\0';
-    buf = PyMem_MALLOC(needed_length);
+    buf = PyMem_Malloc(needed_length);
     if (buf == NULL) {
         tok->done = E_NOMEM;
         return NULL;
@@ -651,9 +651,9 @@ translate_newlines(const char *s, int exec_input, struct tok_state *tok) {
     final_length = current - buf + 1;
     if (final_length < needed_length && final_length) {
         /* should never fail */
-        char* result = PyMem_REALLOC(buf, final_length);
+        char* result = PyMem_Realloc(buf, final_length);
         if (result == NULL) {
-            PyMem_FREE(buf);
+            PyMem_Free(buf);
         }
         buf = result;
     }
@@ -757,7 +757,7 @@ PyTokenizer_FromUTF8(const char *str, int exec_input)
     tok->read_coding_spec = 1;
     tok->enc = NULL;
     tok->str = translated;
-    tok->encoding = (char *)PyMem_MALLOC(6);
+    tok->encoding = (char *)PyMem_Malloc(6);
     if (!tok->encoding) {
         PyTokenizer_Free(tok);
         return NULL;
@@ -778,7 +778,7 @@ PyTokenizer_FromFile(FILE *fp, const char* enc,
     struct tok_state *tok = tok_new();
     if (tok == NULL)
         return NULL;
-    if ((tok->buf = (char *)PyMem_MALLOC(BUFSIZ)) == NULL) {
+    if ((tok->buf = (char *)PyMem_Malloc(BUFSIZ)) == NULL) {
         PyTokenizer_Free(tok);
         return NULL;
     }
@@ -790,7 +790,7 @@ PyTokenizer_FromFile(FILE *fp, const char* enc,
     if (enc != NULL) {
         /* Must copy encoding declaration since it
            gets copied into the parse tree. */
-        tok->encoding = PyMem_MALLOC(strlen(enc)+1);
+        tok->encoding = PyMem_Malloc(strlen(enc)+1);
         if (!tok->encoding) {
             PyTokenizer_Free(tok);
             return NULL;
@@ -808,15 +808,15 @@ void
 PyTokenizer_Free(struct tok_state *tok)
 {
     if (tok->encoding != NULL)
-        PyMem_FREE(tok->encoding);
+        PyMem_Free(tok->encoding);
     Py_XDECREF(tok->decoding_readline);
     Py_XDECREF(tok->decoding_buffer);
     Py_XDECREF(tok->filename);
     if (tok->fp != NULL && tok->buf != NULL)
-        PyMem_FREE(tok->buf);
+        PyMem_Free(tok->buf);
     if (tok->input)
-        PyMem_FREE(tok->input);
-    PyMem_FREE(tok);
+        PyMem_Free(tok->input);
+    PyMem_Free(tok);
 }
 
 /* Get next char, updating state; error code goes into tok->done */
@@ -852,7 +852,7 @@ tok_nextc(struct tok_state *tok)
             char *newtok = PyOS_Readline(stdin, stdout, tok->prompt);
             if (newtok != NULL) {
                 char *translated = translate_newlines(newtok, 0, tok);
-                PyMem_FREE(newtok);
+                PyMem_Free(newtok);
                 if (translated == NULL)
                     return EOF;
                 newtok = translated;
@@ -862,14 +862,14 @@ tok_nextc(struct tok_state *tok)
                 Py_ssize_t buflen;
                 const char* buf;
                 PyObject *u = translate_into_utf8(newtok, tok->encoding);
-                PyMem_FREE(newtok);
+                PyMem_Free(newtok);
                 if (!u) {
                     tok->done = E_DECODE;
                     return EOF;
                 }
                 buflen = PyBytes_GET_SIZE(u);
                 buf = PyBytes_AS_STRING(u);
-                newtok = PyMem_MALLOC(buflen+1);
+                newtok = PyMem_Malloc(buflen+1);
                 if (newtok == NULL) {
                     Py_DECREF(u);
                     tok->done = E_NOMEM;
@@ -883,7 +883,7 @@ tok_nextc(struct tok_state *tok)
             if (newtok == NULL)
                 tok->done = E_INTR;
             else if (*newtok == '\0') {
-                PyMem_FREE(newtok);
+                PyMem_Free(newtok);
                 tok->done = E_EOF;
             }
             else if (tok->start != NULL) {
@@ -892,12 +892,12 @@ tok_nextc(struct tok_state *tok)
                 size_t newlen = oldlen + strlen(newtok);
                 Py_ssize_t cur_multi_line_start = tok->multi_line_start - tok->buf;
                 char *buf = tok->buf;
-                buf = (char *)PyMem_REALLOC(buf, newlen+1);
+                buf = (char *)PyMem_Realloc(buf, newlen+1);
                 tok->lineno++;
                 if (buf == NULL) {
-                    PyMem_FREE(tok->buf);
+                    PyMem_Free(tok->buf);
                     tok->buf = NULL;
-                    PyMem_FREE(newtok);
+                    PyMem_Free(newtok);
                     tok->done = E_NOMEM;
                     return EOF;
                 }
@@ -906,7 +906,7 @@ tok_nextc(struct tok_state *tok)
                 tok->multi_line_start = tok->buf + cur_multi_line_start;
                 tok->line_start = tok->cur;
                 strcpy(tok->buf + oldlen, newtok);
-                PyMem_FREE(newtok);
+                PyMem_Free(newtok);
                 tok->inp = tok->buf + newlen;
                 tok->end = tok->inp + 1;
                 tok->start = tok->buf + start;
@@ -914,7 +914,7 @@ tok_nextc(struct tok_state *tok)
             else {
                 tok->lineno++;
                 if (tok->buf != NULL)
-                    PyMem_FREE(tok->buf);
+                    PyMem_Free(tok->buf);
                 tok->buf = newtok;
                 tok->cur = tok->buf;
                 tok->line_start = tok->buf;
@@ -929,7 +929,7 @@ tok_nextc(struct tok_state *tok)
             if (tok->start == NULL) {
                 if (tok->buf == NULL) {
                     tok->buf = (char *)
-                        PyMem_MALLOC(BUFSIZ);
+                        PyMem_Malloc(BUFSIZ);
                     if (tok->buf == NULL) {
                         tok->done = E_NOMEM;
                         return EOF;
@@ -966,7 +966,7 @@ tok_nextc(struct tok_state *tok)
                 Py_ssize_t curvalid = tok->inp - tok->buf;
                 Py_ssize_t newsize = curvalid + BUFSIZ;
                 char *newbuf = tok->buf;
-                newbuf = (char *)PyMem_REALLOC(newbuf,
+                newbuf = (char *)PyMem_Realloc(newbuf,
                                                newsize);
                 if (newbuf == NULL) {
                     tok->done = E_NOMEM;
@@ -1851,7 +1851,7 @@ PyTokenizer_Get(struct tok_state *tok, const char **p_start, const char **p_end)
    encoding in the first or second line of the file (in which case the encoding
    should be assumed to be UTF-8).
 
-   The char* returned is malloc'ed via PyMem_MALLOC() and thus must be freed
+   The char* returned is malloc'ed via PyMem_Malloc() and thus must be freed
    by the caller. */
 
 char *
@@ -1894,7 +1894,7 @@ PyTokenizer_FindEncodingFilename(int fd, PyObject *filename)
     }
     fclose(fp);
     if (tok->encoding) {
-        encoding = (char *)PyMem_MALLOC(strlen(tok->encoding) + 1);
+        encoding = (char *)PyMem_Malloc(strlen(tok->encoding) + 1);
         if (encoding)
             strcpy(encoding, tok->encoding);
     }

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2089,7 +2089,7 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
         Py_DECREF(stdin_encoding);
         Py_DECREF(stdin_errors);
         Py_XDECREF(po);
-        PyMem_FREE(s);
+        PyMem_Free(s);
 
         if (result != NULL) {
             if (PySys_Audit("builtins.input/result", "O", result) < 0) {

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -202,7 +202,7 @@ static int
 cleanup_ptr(PyObject *self, void *ptr)
 {
     if (ptr) {
-        PyMem_FREE(ptr);
+        PyMem_Free(ptr);
     }
     return 0;
 }
@@ -246,7 +246,7 @@ cleanreturn(int retval, freelist_t *freelist)
       }
     }
     if (freelist->entries_malloced)
-        PyMem_FREE(freelist->entries);
+        PyMem_Free(freelist->entries);
     return retval;
 }
 

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -638,7 +638,7 @@ r_string(Py_ssize_t n, RFILE *p)
         return res;
     }
     if (p->buf == NULL) {
-        p->buf = PyMem_MALLOC(n);
+        p->buf = PyMem_Malloc(n);
         if (p->buf == NULL) {
             PyErr_NoMemory();
             return NULL;
@@ -646,7 +646,7 @@ r_string(Py_ssize_t n, RFILE *p)
         p->buf_size = n;
     }
     else if (p->buf_size < n) {
-        char *tmp = PyMem_REALLOC(p->buf, n);
+        char *tmp = PyMem_Realloc(p->buf, n);
         if (tmp == NULL) {
             PyErr_NoMemory();
             return NULL;
@@ -1453,7 +1453,7 @@ PyMarshal_ReadShortFromFile(FILE *fp)
     rf.buf = NULL;
     res = r_short(&rf);
     if (rf.buf != NULL)
-        PyMem_FREE(rf.buf);
+        PyMem_Free(rf.buf);
     return res;
 }
 
@@ -1468,7 +1468,7 @@ PyMarshal_ReadLongFromFile(FILE *fp)
     rf.buf = NULL;
     res = r_long(&rf);
     if (rf.buf != NULL)
-        PyMem_FREE(rf.buf);
+        PyMem_Free(rf.buf);
     return res;
 }
 
@@ -1501,11 +1501,11 @@ PyMarshal_ReadLastObjectFromFile(FILE *fp)
     off_t filesize;
     filesize = getfilesize(fp);
     if (filesize > 0 && filesize <= REASONABLE_FILE_LIMIT) {
-        char* pBuf = (char *)PyMem_MALLOC(filesize);
+        char* pBuf = (char *)PyMem_Malloc(filesize);
         if (pBuf != NULL) {
             size_t n = fread(pBuf, 1, (size_t)filesize, fp);
             PyObject* v = PyMarshal_ReadObjectFromString(pBuf, n);
-            PyMem_FREE(pBuf);
+            PyMem_Free(pBuf);
             return v;
         }
 
@@ -1534,7 +1534,7 @@ PyMarshal_ReadObjectFromFile(FILE *fp)
     result = r_object(&rf);
     Py_DECREF(rf.refs);
     if (rf.buf != NULL)
-        PyMem_FREE(rf.buf);
+        PyMem_Free(rf.buf);
     return result;
 }
 
@@ -1555,7 +1555,7 @@ PyMarshal_ReadObjectFromString(const char *str, Py_ssize_t len)
     result = r_object(&rf);
     Py_DECREF(rf.refs);
     if (rf.buf != NULL)
-        PyMem_FREE(rf.buf);
+        PyMem_Free(rf.buf);
     return result;
 }
 
@@ -1684,7 +1684,7 @@ marshal_load(PyObject *module, PyObject *file)
             result = read_object(&rf);
             Py_DECREF(rf.refs);
             if (rf.buf != NULL)
-                PyMem_FREE(rf.buf);
+                PyMem_Free(rf.buf);
         } else
             result = NULL;
     }

--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -255,7 +255,7 @@ _PyOS_ascii_strtod(const char *nptr, char **endptr)
         char *copy, *c;
         /* Create a copy of the input, with the '.' converted to the
            locale-specific decimal point */
-        copy = (char *)PyMem_MALLOC(end - digits_pos +
+        copy = (char *)PyMem_Malloc(end - digits_pos +
                                     1 + decimal_point_len);
         if (copy == NULL) {
             *endptr = (char *)nptr;
@@ -286,7 +286,7 @@ _PyOS_ascii_strtod(const char *nptr, char **endptr)
                     (fail_pos - copy);
         }
 
-        PyMem_FREE(copy);
+        PyMem_Free(copy);
 
     }
     else {

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -419,12 +419,12 @@ _Py_DisplaySourceLine(PyObject *f, PyObject *filename, int lineno, int indent)
     if (lseek(fd, 0, SEEK_SET) == (off_t)-1) {
         Py_DECREF(io);
         Py_DECREF(binary);
-        PyMem_FREE(found_encoding);
+        PyMem_Free(found_encoding);
         return 0;
     }
     fob = _PyObject_CallMethodId(io, &PyId_TextIOWrapper, "Os", binary, encoding);
     Py_DECREF(io);
-    PyMem_FREE(found_encoding);
+    PyMem_Free(found_encoding);
 
     if (fob == NULL) {
         PyErr_Clear();


### PR DESCRIPTION
No longer use old aliases to functions:

* Replace PyMem_MALLOC() with PyMem_Malloc()
* Replace PyMem_FREE() with PyMem_Free()
* Replace PyMem_Del() with PyMem_Free()
* Replace PyMem_DEL() with PyMem_Free()

Modify also the PyMem_DEL() macro to use directly PyMem_Free().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42519](https://bugs.python.org/issue42519) -->
https://bugs.python.org/issue42519
<!-- /issue-number -->
