### PR TITLE
gh-86690: Add `retval [variable]` option to pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1149,11 +1149,19 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     do_a = do_args
 
     def do_retval(self, arg):
-        """retval
-        Print the return value for the last return of a function.
+        """retval [variable]
+        Print or store the return value for the last return of a function.
+
+        When used without argument, prints the return value
+
+        When used with an argument, store the return value into a local variable
+
         """
         if '__return__' in self.curframe_locals:
-            self.message(repr(self.curframe_locals['__return__']))
+            if arg:
+                self.curframe_locals[arg] = self.curframe_locals['__return__']
+            else:
+                self.message(repr(self.curframe_locals['__return__']))
         else:
             self.error('Not yet returned!')
     do_rv = do_retval

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -106,6 +106,8 @@ def test_pdb_basic_commands():
     ...     'jump 8',     # jump over second for loop
     ...     'return',     # return out of function
     ...     'retval',     # display return value
+    ...     'retval v1',  # stores the return value in "v1" local variable
+    ...     'v1',         # display the "v1" stored variable
     ...     'next',       # step to test_function3()
     ...     'step',       # stepping into test_function3()
     ...     'args',       # display function args
@@ -139,7 +141,7 @@ def test_pdb_basic_commands():
     [EOF]
     (Pdb) bt
     ...
-      <doctest test.test_pdb.test_pdb_basic_commands[4]>(25)<module>()
+      <doctest test.test_pdb.test_pdb_basic_commands[4]>(27)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_basic_commands[3]>(3)test_function()
     -> ret = test_function_2('baz')
@@ -183,6 +185,9 @@ def test_pdb_basic_commands():
     > <doctest test.test_pdb.test_pdb_basic_commands[0]>(10)test_function_2()->'BAZ'
     -> return foo.upper()
     (Pdb) retval
+    'BAZ'
+    (Pdb) retval v1
+    (Pdb) v1
     'BAZ'
     (Pdb) next
     > <doctest test.test_pdb.test_pdb_basic_commands[3]>(4)test_function()

--- a/Misc/NEWS.d/next/Library/2020-12-01-16-17-13.bpo-42524.lHDAP6.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-01-16-17-13.bpo-42524.lHDAP6.rst
@@ -1,0 +1,1 @@
+Add `retval [variable]` option to pdb


### PR DESCRIPTION
Add optional argument to pdb `retval` command, to allow accessing the
current value being returned in the stack.

For example, given the following code:

```python
def get_thing():
    debugger()
    return Thing(value=123)
```

```
(pdb) retval
<Thing instance at 0x1234>
(pdb) retval xx
(pdb) xx.value
123
```

<!-- issue-number: [bpo-42524](https://bugs.python.org/issue42524) -->
https://bugs.python.org/issue42524
<!-- /issue-number -->

<!-- gh-issue-number: gh-86690 -->
* Issue: gh-86690
<!-- /gh-issue-number -->
