### PR TITLE
bpo-10486 - Remove the conditional for setting query.

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1092,8 +1092,7 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
         env['PATH_INFO'] = uqrest
         env['PATH_TRANSLATED'] = self.translate_path(uqrest)
         env['SCRIPT_NAME'] = scriptname
-        if query:
-            env['QUERY_STRING'] = query
+        env['QUERY_STRING'] = query
         env['REMOTE_ADDR'] = self.client_address[0]
         authorization = self.headers.get("authorization")
         if authorization:


### PR DESCRIPTION
```
bpo-issue10486: Remove the conditional for setting the query string.
```

In https://bugs.python.org/issue10486, there was a discussion about setting all the environment variables in CGI.  I am not certain if we need that, I plan to recommend closing the issue without any changes, since the request is stale, and CGI specification leaves it to implementation. Two of the commenters in that issue agree

There is a minor change that is not related to the issue but was observed in the discussion.

QUERY_STRING is always set in the env

```
        for k in ('QUERY_STRING', 'REMOTE_HOST', 'CONTENT_LENGTH',
                  'HTTP_USER_AGENT', 'HTTP_COOKIE', 'HTTP_REFERER'):
            env.setdefault(k, "")
```

However, earlier in the code, it was being tested for a non-empty value. This test condition was not required. Instead of leaving that no-op test condition, I am removing it in this PR.  Since this is not a bug fix, but a cosmetic improvement, I don't think we need to backport.


<!-- issue-number: [bpo-10486](https://bugs.python.org/issue10486) -->
https://bugs.python.org/issue10486
<!-- /issue-number -->
