### PR TITLE
Correct return type in Modules/_ssl.c::sslmodule_legacy

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6416,7 +6416,7 @@ sslmodule_legacy(PyObject *module)
 #ifdef HAVE_OPENSSL_CRYPTO_LOCK
     /* note that this will start threading if not already started */
     if (!_setup_ssl_threads()) {
-        return NULL;
+        return 0;
     }
 #elif OPENSSL_VERSION_1_1
     /* OpenSSL 1.1.0 builtin thread support is enabled */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Fixing

```
/home/shager/cpython-buildarea/custom.edelsohn-aix-ppc64/build/Modules/_ssl.c: In function 'sslmodule_legacy':
/home/shager/cpython-buildarea/custom.edelsohn-aix-ppc64/build/Modules/_ssl.c:6419:16: warning: return makes integer from pointer without a cast [-Wint-conversion]
         return NULL;
                ^~~~
```