### PR TITLE
[3.8] bpo-42531: Teach importlib.resources.path to handle packages without __file__

### DIFF
--- a/Lib/importlib/resources.py
+++ b/Lib/importlib/resources.py
@@ -193,9 +193,11 @@ def path(package: Package, resource: Resource) -> Iterator[Path]:
         _check_location(package)
     # Fall-through for both the lack of resource_path() *and* if
     # resource_path() raises FileNotFoundError.
-    package_directory = Path(package.__spec__.origin).parent
-    file_path = package_directory / resource
-    if file_path.exists():
+    file_path = None
+    if package.__spec__.origin is not None:
+        package_directory = Path(package.__spec__.origin).parent
+        file_path = package_directory / resource
+    if file_path is not None and file_path.exists():
         yield file_path
     else:
         with open_binary(package, resource) as fp:

--- a/Lib/test/test_importlib/test_path.py
+++ b/Lib/test/test_importlib/test_path.py
@@ -1,3 +1,4 @@
+from test.support import swap_attr
 import unittest
 
 from importlib import resources
@@ -25,6 +26,17 @@ class PathTests:
 
 class PathDiskTests(PathTests, unittest.TestCase):
     data = data01
+
+    def test_package_spec_origin_is_None(self):
+        import pydoc_data
+        spec = pydoc_data.__spec__
+        # Emulate importing from non-file source by setting spec.origin = None.
+        # Barge past path's sanity checks by ensuring spec.loader.is_resource
+        # returns False.
+        with swap_attr(spec, "origin", None), \
+            swap_attr(spec.loader, "is_resource", lambda *args: False), \
+            resources.path(pydoc_data, '_pydoc.css') as p:
+            pass
 
 
 class PathZipTests(PathTests, util.ZipSetup, unittest.TestCase):

--- a/Lib/test/test_importlib/test_path.py
+++ b/Lib/test/test_importlib/test_path.py
@@ -13,8 +13,6 @@ class CommonTests(util.CommonResourceTests, unittest.TestCase):
 
 
 class PathTests:
-    UTF_8_FILE_CONTENTS = b'Hello, UTF-8 world!\n'
-
     def test_reading(self):
         # Path should be readable.
         # Test also implicitly verifies the returned object is a pathlib.Path
@@ -23,7 +21,7 @@ class PathTests:
             # pathlib.Path.read_text() was introduced in Python 3.5.
             with path.open('r', encoding='utf-8') as file:
                 text = file.read()
-            self.assertEqual(self.UTF_8_FILE_CONTENTS.decode(), text)
+            self.assertEqual('Hello, UTF-8 world!\n', text)
 
 
 class PathDiskTests(PathTests, unittest.TestCase):
@@ -32,10 +30,11 @@ class PathDiskTests(PathTests, unittest.TestCase):
 
 class PathMemoryTests(PathTests, unittest.TestCase):
     def setUp(self):
-        file = io.BytesIO(self.UTF_8_FILE_CONTENTS)
+        file = io.BytesIO(b'Hello, UTF-8 world!\n')
         self.addCleanup(file.close)
         self.data = util.create_package(
-            file=file, path=FileNotFoundError("package exists only in memory"))
+            file=file, path=FileNotFoundError("package exists only in memory")
+        )
         self.data.__spec__.origin = None
         self.data.__spec__.has_location = False
 

--- a/Misc/NEWS.d/next/Library/2020-12-02-16-28-04.bpo-42531.2sLlFW.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-02-16-28-04.bpo-42531.2sLlFW.rst
@@ -1,0 +1,1 @@
+:func:`importlib.resources.path` now works for :term:`package`\ s missing the optional :attr:`__file__` attribute (more specifically, packages whose :attr:`__spec__`\ ``.``\ :attr:`~importlib.machinery.ModuleSpec.origin` :keyword:`is` :data:`None`).


### PR DESCRIPTION
Fixes [bpo-42531](https://bugs.python.org/issue42531) for Python 3.8.

The issue also applies to 3.7. If this PR looks like it'll be accepted, I can cherry-pick it to the 3.7 branch and submit a follow-up PR.

<!-- issue-number: [bpo-42531](https://bugs.python.org/issue42531) -->
https://bugs.python.org/issue42531
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco