### PR TITLE
bpo-42532: Check if NonCallableMock's spec_arg is not None instead of call its __bool__ function

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -406,7 +406,7 @@ class NonCallableMock(Base):
             # Check if spec is an async object or function
             bound_args = _MOCK_SIG.bind_partial(cls, *args, **kw).arguments
             spec_arg = bound_args.get('spec_set', bound_args.get('spec'))
-            if spec_arg and _is_async_obj(spec_arg):
+            if spec_arg is not None and _is_async_obj(spec_arg):
                 bases = (AsyncMockMixin, cls)
         new = type(cls.__name__, bases, {'__doc__': cls.__doc__})
         instance = _safe_super(NonCallableMock, cls).__new__(new)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -2164,7 +2164,7 @@ class MockTest(unittest.TestCase):
             for mock in mocks:
                 obj = mock(spec=Something)
                 self.assertIsInstance(obj, Something)
-    
+
     def test_bool_not_called_when_passing_spec_arg(self):
         class Something:
             def __init__(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -2164,6 +2164,16 @@ class MockTest(unittest.TestCase):
             for mock in mocks:
                 obj = mock(spec=Something)
                 self.assertIsInstance(obj, Something)
+    
+    def test_bool_not_called_when_passing_spec_arg(self):
+        class Something:
+            def __init__(self):
+                self.obj_with_bool_func = unittest.mock.MagicMock()
+
+        obj = Something()
+        with unittest.mock.patch.object(obj, 'obj_with_bool_func', autospec=True):
+            pass
+        self.assertEqual(obj.obj_with_bool_func.__bool__.call_count, 0)
 
 
 if __name__ == '__main__':

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -2171,8 +2171,8 @@ class MockTest(unittest.TestCase):
                 self.obj_with_bool_func = unittest.mock.MagicMock()
 
         obj = Something()
-        with unittest.mock.patch.object(obj, 'obj_with_bool_func', autospec=True):
-            pass
+        with unittest.mock.patch.object(obj, 'obj_with_bool_func', autospec=True): pass
+
         self.assertEqual(obj.obj_with_bool_func.__bool__.call_count, 0)
 
 

--- a/Misc/NEWS.d/next/Library/2020-12-02-07-37-59.bpo-42532.ObNep_.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-02-07-37-59.bpo-42532.ObNep_.rst
@@ -1,1 +1,1 @@
-Check if NonCallableMock.__new__'s spec_arg is not None instead of calling its __bool__ function
+Remove unexpected call of ``__bool__`` when passing a ``spec_arg`` argument to a Mock.

--- a/Misc/NEWS.d/next/Library/2020-12-02-07-37-59.bpo-42532.ObNep_.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-02-07-37-59.bpo-42532.ObNep_.rst
@@ -1,0 +1,1 @@
+Check if NonCallableMock.__new__'s spec_arg is not None instead of calling its __bool__ function


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42532](https://bugs.python.org/issue42532) -->
https://bugs.python.org/issue42532
<!-- /issue-number -->

If an object has logic in its `__bool__` function, it'll be called here, but it shouldn't be called.