### PR TITLE
bpo-42547: fix add_argument(metavar=<tuple>, nargs='+') for positional arguments

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -547,7 +547,7 @@ class HelpFormatter(object):
     def _format_action_invocation(self, action):
         if not action.option_strings:
             default = self._get_default_metavar_for_positional(action)
-            metavar, = self._metavar_formatter(action, default)(1)
+            metavar = self._metavar_formatter(action, default)(1)[0]
             return metavar
 
         else:

--- a/Misc/NEWS.d/next/Library/2020-12-03-00-40-12.bpo-42547.O2BJhp.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-03-00-40-12.bpo-42547.O2BJhp.rst
@@ -1,0 +1,1 @@
+argparse: fixed `add_argument(metavar=<tuple>, nargs='+')` for positional arguments


### PR DESCRIPTION
<!-- issue-number: [bpo-42547](https://bugs.python.org/issue42547) -->
https://bugs.python.org/issue42547
<!-- /issue-number -->
<!-- gh-issue-number: gh-86713 -->
* Issue: gh-86713
<!-- /gh-issue-number -->
