### PR TITLE
Fix indentation for get_stats_profile() docs.

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -525,7 +525,7 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
       ordering are identical to the :meth:`~pstats.Stats.print_callers` method.
 
 
-    .. method:: get_stats_profile()
+   .. method:: get_stats_profile()
 
       This method returns an instance of StatsProfile, which contains a mapping
       of function names to instances of FunctionProfile. Each FunctionProfile


### PR DESCRIPTION
The existing method is indented one too many times which makes it look like a sub-method of print_callees()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
