### PR TITLE
bpo-42536: GC track recycled tuples

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1760,7 +1760,7 @@ class BuiltinTest(unittest.TestCase):
     @support.cpython_only
     def test_zip_result_gc(self):
         # bpo-42536: zip's tuple-reuse speed trick breaks the GC's assumptions
-        # about what can be un-tracked. Make sure we re-track result tuples
+        # about what can be untracked. Make sure we re-track result tuples
         # whenever we reuse them.
         z = zip([[]])
         gc.collect()

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1762,12 +1762,12 @@ class BuiltinTest(unittest.TestCase):
         # bpo-42536: zip's tuple-reuse speed trick breaks the GC's assumptions
         # about what can be untracked. Make sure we re-track result tuples
         # whenever we reuse them.
-        z = zip([[]])
+        it = zip([[]])
         gc.collect()
         # That GC collection probably untracked the recycled internal result
         # tuple, which is initialized to (None,). Make sure it's re-tracked when
         # it's mutated and returned from __next__:
-        self.assertTrue(gc.is_tracked(next(z)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
     def test_format(self):
         # Test the basic machinery of the format() builtin.  Don't test

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -6,6 +6,7 @@ import builtins
 import collections
 import decimal
 import fractions
+import gc
 import io
 import locale
 import os
@@ -1755,6 +1756,15 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(l7, [(1, "A"), (0, "B")])
         l8 = self.iter_error(zip(Iter(3), "AB", strict=True), ValueError)
         self.assertEqual(l8, [(2, "A"), (1, "B")])
+
+    def test_zip_result_gc(self):
+        try:
+            gc.disable()
+            z = zip([[]])
+            gc.collect()
+            self.assertTrue(gc.is_tracked(next(z)))
+        finally:
+            gc.enable()
 
     def test_format(self):
         # Test the basic machinery of the format() builtin.  Don't test

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1457,19 +1457,19 @@ class DictTest(unittest.TestCase):
         # bpo-42536: dict.items's tuple-reuse speed trick breaks the GC's
         # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
-        i = iter({None: []}.items())
+        it = iter({None: []}.items())
         gc.collect()
         # That GC collection probably untracked the recycled internal result
         # tuple, which is initialized to (None, None). Make sure it's re-tracked
         # when it's mutated and returned from __next__:
-        self.assertTrue(gc.is_tracked(next(i)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
     @support.cpython_only
     def test_dict_items_result_gc(self):
         # Same as test_dict_items_result_gc above, but reversed.
-        i = reversed({None: []}.items())
+        it = reversed({None: []}.items())
         gc.collect()
-        self.assertTrue(gc.is_tracked(next(i)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
 
 class CAPITest(unittest.TestCase):

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1455,7 +1455,7 @@ class DictTest(unittest.TestCase):
     @support.cpython_only
     def test_dict_items_result_gc(self):
         # bpo-42536: dict.items's tuple-reuse speed trick breaks the GC's
-        # assumptions about what can be un-tracked. Make sure we re-track result
+        # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
         i = iter({None: []}.items())
         gc.collect()

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1452,6 +1452,25 @@ class DictTest(unittest.TestCase):
         d = CustomReversedDict(pairs)
         self.assertEqual(pairs[::-1], list(dict(d).items()))
 
+    @support.cpython_only
+    def test_dict_items_result_gc(self):
+        # bpo-42536: dict.items's tuple-reuse speed trick breaks the GC's
+        # assumptions about what can be un-tracked. Make sure we re-track result
+        # tuples whenever we reuse them.
+        i = iter({None: []}.items())
+        gc.collect()
+        # That GC collection probably untracked the recycled internal result
+        # tuple, which is initialized to (None, None). Make sure it's re-tracked
+        # when it's mutated and returned from __next__:
+        self.assertTrue(gc.is_tracked(next(i)))
+
+    @support.cpython_only
+    def test_dict_items_result_gc(self):
+        # Same as test_dict_items_result_gc above, but reversed.
+        i = reversed({None: []}.items())
+        gc.collect()
+        self.assertTrue(gc.is_tracked(next(i)))
+
 
 class CAPITest(unittest.TestCase):
 

--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -147,13 +147,6 @@ class EnumerateTestCase(unittest.TestCase, PickleTest):
         # when it's mutated and returned from __next__:
         self.assertTrue(gc.is_tracked(next(e)))
 
-    # @support.cpython_only
-    # def test_enumerate_long_result_gc(self):
-    #     # Same as test_enumerate_result_gc, above.
-    #     e = self.enum([[]], sys.maxsize)
-    #     gc.collect()
-    #     self.assertTrue(gc.is_tracked(next(e)))
-
 class MyEnum(enumerate):
     pass
 

--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -140,12 +140,12 @@ class EnumerateTestCase(unittest.TestCase, PickleTest):
         # bpo-42536: enumerate's tuple-reuse speed trick breaks the GC's
         # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
-        e = self.enum([[]])
+        it = self.enum([[]])
         gc.collect()
         # That GC collection probably untracked the recycled internal result
         # tuple, which is initialized to (None, None). Make sure it's re-tracked
         # when it's mutated and returned from __next__:
-        self.assertTrue(gc.is_tracked(next(e)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
 class MyEnum(enumerate):
     pass

--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -138,7 +138,7 @@ class EnumerateTestCase(unittest.TestCase, PickleTest):
     @support.cpython_only
     def test_enumerate_result_gc(self):
         # bpo-42536: enumerate's tuple-reuse speed trick breaks the GC's
-        # assumptions about what can be un-tracked. Make sure we re-track result
+        # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
         e = self.enum([[]])
         gc.collect()

--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -2,6 +2,7 @@ import unittest
 import operator
 import sys
 import pickle
+import gc
 
 from test import support
 
@@ -133,6 +134,25 @@ class EnumerateTestCase(unittest.TestCase, PickleTest):
         # whenever nothing else holds a reference to it
         self.assertEqual(len(set(map(id, list(enumerate(self.seq))))), len(self.seq))
         self.assertEqual(len(set(map(id, enumerate(self.seq)))), min(1,len(self.seq)))
+
+    @support.cpython_only
+    def test_enumerate_result_gc(self):
+        # bpo-42536: enumerate's tuple-reuse speed trick breaks the GC's
+        # assumptions about what can be un-tracked. Make sure we re-track result
+        # tuples whenever we reuse them.
+        e = self.enum([[]])
+        gc.collect()
+        # That GC collection probably untracked the recycled internal result
+        # tuple, which is initialized to (None, None). Make sure it's re-tracked
+        # when it's mutated and returned from __next__:
+        self.assertTrue(gc.is_tracked(next(e)))
+
+    # @support.cpython_only
+    # def test_enumerate_long_result_gc(self):
+    #     # Same as test_enumerate_result_gc, above.
+    #     e = self.enum([[]], sys.maxsize)
+    #     gc.collect()
+    #     self.assertTrue(gc.is_tracked(next(e)))
 
 class MyEnum(enumerate):
     pass

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -399,15 +399,11 @@ class TestBasicOps(unittest.TestCase):
 
     @support.cpython_only
     def test_combinations_with_replacement_result_gc(self):
-        # bpo-42536: combinations_with_replacement's tuple-reuse speed trick
-        # breaks the GC's assumptions about what can be un-tracked. Make sure we
-        # re-track result tuples whenever we reuse them.
+        # Same as test_combinations_result_gc above, but for
+        # combinations_with_replacement.
         c = combinations_with_replacement([None, []], 1)
         next(c)
         gc.collect()
-        # That GC collection probably untracked the recycled internal result
-        # tuple, which has the value (None,). Make sure it's re-tracked when
-        # it's mutated and returned from __next__:
         self.assertTrue(gc.is_tracked(next(c)))
 
     def test_permutations(self):
@@ -485,15 +481,10 @@ class TestBasicOps(unittest.TestCase):
 
     @support.cpython_only
     def test_permutations_result_gc(self):
-        # bpo-42536: combinations's tuple-reuse speed trick breaks the GC's
-        # assumptions about what can be un-tracked. Make sure we re-track result
-        # tuples whenever we reuse them.
+        # Same as test_combinations_result_gc above, but for permutations.
         p = permutations([None, []], 1)
         next(p)
         gc.collect()
-        # That GC collection probably untracked the recycled internal result
-        # tuple, which has the value (None,). Make sure it's re-tracked when
-        # it's mutated and returned from __next__:
         self.assertTrue(gc.is_tracked(next(p)))
 
     def test_combinatorics(self):
@@ -1008,14 +999,9 @@ class TestBasicOps(unittest.TestCase):
 
     @support.cpython_only
     def test_zip_longest_result_gc(self):
-        # bpo-42536: zip_longest's tuple-reuse speed trick breaks the GC's
-        # assumptions about what can be un-tracked. Make sure we re-track result
-        # tuples whenever we reuse them.
+        # Same as test_combinations_result_gc above, but for zip_longest.
         z = zip_longest([[]])
         gc.collect()
-        # That GC collection probably untracked the recycled internal result
-        # tuple, which has the value (None,). Make sure it's re-tracked when
-        # it's mutated and returned from __next__:
         self.assertTrue(gc.is_tracked(next(z)))
 
     def test_zip_longest_pickling(self):
@@ -1166,15 +1152,10 @@ class TestBasicOps(unittest.TestCase):
 
     @support.cpython_only
     def test_product_result_gc(self):
-        # bpo-42536: produce's tuple-reuse speed trick breaks the GC's
-        # assumptions about what can be un-tracked. Make sure we re-track result
-        # tuples whenever we reuse them.
+        # Same as test_combinations_result_gc above, but for product.
         p = product([None, []])
         next(p)
         gc.collect()
-        # That GC collection probably untracked the recycled internal result
-        # tuple, which has the value (None,). Make sure it's re-tracked when
-        # it's mutated and returned from __next__:
         self.assertTrue(gc.is_tracked(next(p)))
 
     def test_product_pickling(self):

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -301,13 +301,13 @@ class TestBasicOps(unittest.TestCase):
         # bpo-42536: combinations's tuple-reuse speed trick breaks the GC's
         # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
-        c = combinations([None, []], 1)
-        next(c)
+        it = combinations([None, []], 1)
+        next(it)
         gc.collect()
         # That GC collection probably untracked the recycled internal result
         # tuple, which has the value (None,). Make sure it's re-tracked when
         # it's mutated and returned from __next__:
-        self.assertTrue(gc.is_tracked(next(c)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
     def test_combinations_with_replacement(self):
         cwr = combinations_with_replacement
@@ -401,10 +401,10 @@ class TestBasicOps(unittest.TestCase):
     def test_combinations_with_replacement_result_gc(self):
         # Same as test_combinations_result_gc above, but for
         # combinations_with_replacement.
-        c = combinations_with_replacement([None, []], 1)
-        next(c)
+        it = combinations_with_replacement([None, []], 1)
+        next(it)
         gc.collect()
-        self.assertTrue(gc.is_tracked(next(c)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
     def test_permutations(self):
         self.assertRaises(TypeError, permutations)              # too few arguments
@@ -482,10 +482,10 @@ class TestBasicOps(unittest.TestCase):
     @support.cpython_only
     def test_permutations_result_gc(self):
         # Same as test_combinations_result_gc above, but for permutations.
-        p = permutations([None, []], 1)
-        next(p)
+        it = permutations([None, []], 1)
+        next(it)
         gc.collect()
-        self.assertTrue(gc.is_tracked(next(p)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
     def test_combinatorics(self):
         # Test relationships between product(), permutations(),
@@ -1000,9 +1000,9 @@ class TestBasicOps(unittest.TestCase):
     @support.cpython_only
     def test_zip_longest_result_gc(self):
         # Same as test_combinations_result_gc above, but for zip_longest.
-        z = zip_longest([[]])
+        it = zip_longest([[]])
         gc.collect()
-        self.assertTrue(gc.is_tracked(next(z)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
     def test_zip_longest_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1153,10 +1153,10 @@ class TestBasicOps(unittest.TestCase):
     @support.cpython_only
     def test_product_result_gc(self):
         # Same as test_combinations_result_gc above, but for product.
-        p = product([None, []])
-        next(p)
+        it = product([None, []])
+        next(it)
         gc.collect()
-        self.assertTrue(gc.is_tracked(next(p)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
     def test_product_pickling(self):
         # check copy, deepcopy, pickle

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -299,7 +299,7 @@ class TestBasicOps(unittest.TestCase):
     @support.cpython_only
     def test_combinations_result_gc(self):
         # bpo-42536: combinations's tuple-reuse speed trick breaks the GC's
-        # assumptions about what can be un-tracked. Make sure we re-track result
+        # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
         c = combinations([None, []], 1)
         next(c)

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -700,6 +700,17 @@ class OrderedDictTests:
         with self.assertRaises(ValueError):
             a |= "BAD"
 
+    @support.cpython_only
+    def test_ordered_dict_items_result_gc(self):
+        # bpo-42536: OrderedDict.item's tuple-reuse speed trick breaks the GC's
+        # assumptions about what can be un-tracked. Make sure we re-track result
+        # tuples whenever we reuse them.
+        i = iter(self.OrderedDict({None: []}).items())
+        gc.collect()
+        # That GC collection probably untracked the recycled internal result
+        # tuple, which is initialized to (None, None). Make sure it's re-tracked
+        # when it's mutated and returned from __next__:
+        self.assertTrue(gc.is_tracked(next(i)))
 
 class PurePythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
 

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -702,7 +702,7 @@ class OrderedDictTests:
 
     @support.cpython_only
     def test_ordered_dict_items_result_gc(self):
-        # bpo-42536: OrderedDict.item's tuple-reuse speed trick breaks the GC's
+        # bpo-42536: OrderedDict.items's tuple-reuse speed trick breaks the GC's
         # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
         i = iter(self.OrderedDict({None: []}).items())

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -703,7 +703,7 @@ class OrderedDictTests:
     @support.cpython_only
     def test_ordered_dict_items_result_gc(self):
         # bpo-42536: OrderedDict.item's tuple-reuse speed trick breaks the GC's
-        # assumptions about what can be un-tracked. Make sure we re-track result
+        # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
         i = iter(self.OrderedDict({None: []}).items())
         gc.collect()

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -705,12 +705,12 @@ class OrderedDictTests:
         # bpo-42536: OrderedDict.items's tuple-reuse speed trick breaks the GC's
         # assumptions about what can be untracked. Make sure we re-track result
         # tuples whenever we reuse them.
-        i = iter(self.OrderedDict({None: []}).items())
+        it = iter(self.OrderedDict({None: []}).items())
         gc.collect()
         # That GC collection probably untracked the recycled internal result
         # tuple, which is initialized to (None, None). Make sure it's re-tracked
         # when it's mutated and returned from __next__:
-        self.assertTrue(gc.is_tracked(next(i)))
+        self.assertTrue(gc.is_tracked(next(it)))
 
 class PurePythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
@@ -1,4 +1,17 @@
 Several built-in and standard library types now ensure that their internal
-result tuples are always tracked by the garbage collector. Previously, they
-could have become untracked by a prior garbage collection. Patch by Brandt
-Bucher.
+result tuples are always tracked by the :term:`garbage collector
+<garbage collection>`:
+
+- :meth:`collections.OrderedDict.items`
+- :meth:`dict.items`
+- :func:`enumerate`
+- :func:`functools.reduce`
+- :func:`itertools.combinations`
+- :func:`itertools.combinations_with_replacement`
+- :func:`itertools.permutations`
+- :func:`itertools.product`
+- :func:`itertools.zip_longest`
+- :func:`zip`
+
+Previously, they could have become untracked by a prior garbage collection.
+Patch by Brandt Bucher.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
@@ -1,0 +1,2 @@
+Fix an issue where :func:`zip` may create untracked reference cyles. Patch
+by Brandt Bucher.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
@@ -1,3 +1,4 @@
-:func:`zip` now ensures that its internal result tuple is always tracked by the
-garbage collector. Previously, it could have become untracked by a prior garbage
-collection. Patch by Brandt Bucher.
+Several built-in and standard library types now ensure that their internal
+result tuples are always tracked by the garbage collector. Previously, they
+could have become untracked by a prior garbage collection. Patch by Brandt
+Bucher.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
@@ -1,2 +1,3 @@
-Fix an issue where :func:`zip` may create untracked reference cyles. Patch
-by Brandt Bucher.
+:func:`zip` now ensures that its internal result tuple is always tracked by the
+garbage collector. Previously, it could have become untracked by a prior garbage
+collection. Patch by Brandt Bucher.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-02-20-23-31.bpo-42536.Kx3ZOu.rst
@@ -2,15 +2,24 @@ Several built-in and standard library types now ensure that their internal
 result tuples are always tracked by the :term:`garbage collector
 <garbage collection>`:
 
-- :meth:`collections.OrderedDict.items`
+- :meth:`collections.OrderedDict.items() <collections.OrderedDict>`
+
 - :meth:`dict.items`
+
 - :func:`enumerate`
+
 - :func:`functools.reduce`
+
 - :func:`itertools.combinations`
+
 - :func:`itertools.combinations_with_replacement`
+
 - :func:`itertools.permutations`
+
 - :func:`itertools.product`
+
 - :func:`itertools.zip_longest`
+
 - :func:`zip`
 
 Previously, they could have become untracked by a prior garbage collection.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -674,7 +674,7 @@ functools_reduce(PyObject *self, PyObject *args)
             if ((result = PyObject_Call(func, args, NULL)) == NULL) {
                 goto Fail;
             }
-            // bpo-42536: the GC may have untracked this args tuple. Since we're
+            // bpo-42536: The GC may have untracked this args tuple. Since we're
             // recycling it, make sure it's tracked again:
             if (!_PyObject_GC_IS_TRACKED(args)) {
                 _PyObject_GC_TRACK(args);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "pycore_long.h"          // _PyLong_GetZero()
+#include "pycore_object.h"        // _PyObject_GC_TRACK
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "structmember.h"         // PyMemberDef
@@ -672,6 +673,11 @@ functools_reduce(PyObject *self, PyObject *args)
             Py_XSETREF(_PyTuple_ITEMS(args)[1], op2);
             if ((result = PyObject_Call(func, args, NULL)) == NULL) {
                 goto Fail;
+            }
+            // bpo-42536: the GC may have untracked this args tuple. Since we're
+            // recycling it, make sure it's tracked again:
+            if (!_PyObject_GC_IS_TRACKED(args)) {
+                _PyObject_GC_TRACK(args);
             }
         }
     }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -2379,9 +2379,8 @@ product_next(productobject *lz)
             lz->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }
@@ -2708,9 +2707,8 @@ combinations_next(combinationsobject *co)
             co->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }
@@ -3048,9 +3046,8 @@ cwr_next(cwrobject *co)
             co->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }
@@ -3398,9 +3395,8 @@ permutations_next(permutationsobject *po)
             po->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }
@@ -4674,9 +4670,8 @@ zip_longest_next(ziplongestobject *lz)
             PyTuple_SET_ITEM(result, i, item);
             Py_DECREF(olditem);
         }
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3,6 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_long.h"          // _PyLong_GetZero()
+#include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include <stddef.h>               // offsetof()
 
@@ -2378,6 +2379,12 @@ product_next(productobject *lz)
             lz->result = result;
             Py_DECREF(old_result);
         }
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        else if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
+        }
         /* Now, we've got the only copy so we can update it in-place */
         assert (npools==0 || Py_REFCNT(result) == 1);
 
@@ -2700,6 +2707,12 @@ combinations_next(combinationsobject *co)
                 goto empty;
             co->result = result;
             Py_DECREF(old_result);
+        }
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        else if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
         }
         /* Now, we've got the only copy so we can update it in-place
          * CPython's empty tuple is a singleton and cached in
@@ -3034,6 +3047,12 @@ cwr_next(cwrobject *co)
                 goto empty;
             co->result = result;
             Py_DECREF(old_result);
+        }
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        else if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
         }
         /* Now, we've got the only copy so we can update it in-place CPython's
            empty tuple is a singleton and cached in PyTuple's freelist. */
@@ -3378,6 +3397,12 @@ permutations_next(permutationsobject *po)
                 goto empty;
             po->result = result;
             Py_DECREF(old_result);
+        }
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        else if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
         }
         /* Now, we've got the only copy so we can update it in-place */
         assert(r == 0 || Py_REFCNT(result) == 1);
@@ -4648,6 +4673,12 @@ zip_longest_next(ziplongestobject *lz)
             olditem = PyTuple_GET_ITEM(result, i);
             PyTuple_SET_ITEM(result, i, item);
             Py_DECREF(olditem);
+        }
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
         }
     } else {
         result = PyTuple_New(tuplesize);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -2379,7 +2379,7 @@ product_next(productobject *lz)
             lz->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
@@ -2707,7 +2707,7 @@ combinations_next(combinationsobject *co)
             co->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
@@ -3046,7 +3046,7 @@ cwr_next(cwrobject *co)
             co->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
@@ -3395,7 +3395,7 @@ permutations_next(permutationsobject *po)
             po->result = result;
             Py_DECREF(old_result);
         }
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         else if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
@@ -4670,7 +4670,7 @@ zip_longest_next(ziplongestobject *lz)
             PyTuple_SET_ITEM(result, i, item);
             Py_DECREF(olditem);
         }
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3989,7 +3989,7 @@ dictiter_iternextitem(dictiterobject *di)
         Py_INCREF(result);
         Py_DECREF(oldkey);
         Py_DECREF(oldvalue);
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
@@ -4109,7 +4109,7 @@ dictreviter_iternext(dictiterobject *di)
             Py_INCREF(result);
             Py_DECREF(oldkey);
             Py_DECREF(oldvalue);
-            // bpo-42536: the GC may have untracked this result tuple. Since
+            // bpo-42536: The GC may have untracked this result tuple. Since
             // we're recycling it, make sure it's tracked again:
             if (!_PyObject_GC_IS_TRACKED(result)) {
                 _PyObject_GC_TRACK(result);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3989,6 +3989,12 @@ dictiter_iternextitem(dictiterobject *di)
         Py_INCREF(result);
         Py_DECREF(oldkey);
         Py_DECREF(oldvalue);
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
+        }
     }
     else {
         result = PyTuple_New(2);
@@ -4104,6 +4110,13 @@ dictreviter_iternext(dictiterobject *di)
             Py_INCREF(result);
             Py_DECREF(oldkey);
             Py_DECREF(oldvalue);
+            // bpo-42536
+            // The GC may have untracked this result tuple if its elements were
+            // all untracked. Since we're recycling it, make sure it's tracked
+            // again:
+            if (!_PyObject_GC_IS_TRACKED(result)) {
+                _PyObject_GC_TRACK(result);
+            }
         }
         else {
             result = PyTuple_New(2);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3989,9 +3989,8 @@ dictiter_iternextitem(dictiterobject *di)
         Py_INCREF(result);
         Py_DECREF(oldkey);
         Py_DECREF(oldvalue);
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }
@@ -4110,10 +4109,8 @@ dictreviter_iternext(dictiterobject *di)
             Py_INCREF(result);
             Py_DECREF(oldkey);
             Py_DECREF(oldvalue);
-            // bpo-42536
-            // The GC may have untracked this result tuple if its elements were
-            // all untracked. Since we're recycling it, make sure it's tracked
-            // again:
+            // bpo-42536: the GC may have untracked this result tuple. Since
+            // we're recycling it, make sure it's tracked again:
             if (!_PyObject_GC_IS_TRACKED(result)) {
                 _PyObject_GC_TRACK(result);
             }

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -132,9 +132,8 @@ enum_next_long(enumobject *en, PyObject* next_item)
         PyTuple_SET_ITEM(result, 1, next_item);
         Py_DECREF(old_index);
         Py_DECREF(old_item);
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }
@@ -183,9 +182,8 @@ enum_next(enumobject *en)
         PyTuple_SET_ITEM(result, 1, next_item);
         Py_DECREF(old_index);
         Py_DECREF(old_item);
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -132,7 +132,7 @@ enum_next_long(enumobject *en, PyObject* next_item)
         PyTuple_SET_ITEM(result, 1, next_item);
         Py_DECREF(old_index);
         Py_DECREF(old_item);
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
@@ -182,7 +182,7 @@ enum_next(enumobject *en)
         PyTuple_SET_ITEM(result, 1, next_item);
         Py_DECREF(old_index);
         Py_DECREF(old_item);
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_long.h"          // _PyLong_GetOne()
+#include "pycore_object.h"        // _PyObject_GC_TRACK()
 
 #include "clinic/enumobject.c.h"
 
@@ -131,6 +132,12 @@ enum_next_long(enumobject *en, PyObject* next_item)
         PyTuple_SET_ITEM(result, 1, next_item);
         Py_DECREF(old_index);
         Py_DECREF(old_item);
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
+        }
         return result;
     }
     result = PyTuple_New(2);
@@ -176,6 +183,12 @@ enum_next(enumobject *en)
         PyTuple_SET_ITEM(result, 1, next_item);
         Py_DECREF(old_index);
         Py_DECREF(old_item);
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
+        }
         return result;
     }
     result = PyTuple_New(2);

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1814,9 +1814,8 @@ odictiter_iternext(odictiterobject *di)
         Py_INCREF(result);
         Py_DECREF(PyTuple_GET_ITEM(result, 0));  /* borrowed */
         Py_DECREF(PyTuple_GET_ITEM(result, 1));  /* borrowed */
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1814,6 +1814,12 @@ odictiter_iternext(odictiterobject *di)
         Py_INCREF(result);
         Py_DECREF(PyTuple_GET_ITEM(result, 0));  /* borrowed */
         Py_DECREF(PyTuple_GET_ITEM(result, 1));  /* borrowed */
+        // bpo-42536
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
+        }
     }
     else {
         result = PyTuple_New(2);

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1814,7 +1814,7 @@ odictiter_iternext(odictiterobject *di)
         Py_INCREF(result);
         Py_DECREF(PyTuple_GET_ITEM(result, 0));  /* borrowed */
         Py_DECREF(PyTuple_GET_ITEM(result, 1));  /* borrowed */
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2636,6 +2636,7 @@ zip_next(zipobject *lz)
             PyTuple_SET_ITEM(result, i, item);
             Py_DECREF(olditem);
         }
+        // bpo-42536
         // The GC may have untracked this result tuple if its elements were all
         // untracked. Since we're recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2636,6 +2636,11 @@ zip_next(zipobject *lz)
             PyTuple_SET_ITEM(result, i, item);
             Py_DECREF(olditem);
         }
+        // The GC may have untracked this result tuple if its elements were all
+        // untracked. Since we're recycling it, make sure it's tracked again:
+        if (!_PyObject_GC_IS_TRACKED(result)) {
+            _PyObject_GC_TRACK(result);
+        }
     } else {
         result = PyTuple_New(tuplesize);
         if (result == NULL)

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2636,7 +2636,7 @@ zip_next(zipobject *lz)
             PyTuple_SET_ITEM(result, i, item);
             Py_DECREF(olditem);
         }
-        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // bpo-42536: The GC may have untracked this result tuple. Since we're
         // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2636,9 +2636,8 @@ zip_next(zipobject *lz)
             PyTuple_SET_ITEM(result, i, item);
             Py_DECREF(olditem);
         }
-        // bpo-42536
-        // The GC may have untracked this result tuple if its elements were all
-        // untracked. Since we're recycling it, make sure it's tracked again:
+        // bpo-42536: the GC may have untracked this result tuple. Since we're
+        // recycling it, make sure it's tracked again:
         if (!_PyObject_GC_IS_TRACKED(result)) {
             _PyObject_GC_TRACK(result);
         }


### PR DESCRIPTION
This fixes possibly untracked reference cycles in:

- `collections.OrderedDict.items`
- `dict.items`
- `enumerate`
- `functools.reduce`
- `itertools.combinations`
- `itertools.combinations_with_replacement`
- `itertools.permutations`
- `itertools.product`
- `itertools.zip_longest`
- `zip`

<!-- issue-number: [bpo-42536](https://bugs.python.org/issue42536) -->
https://bugs.python.org/issue42536
<!-- /issue-number -->
