### PR TITLE
bpo-42262: Py_NewRef() casts its argument to PyObject*

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -426,7 +426,6 @@ static inline void _Py_INCREF(PyObject *op)
 #endif
     op->ob_refcnt++;
 }
-
 #define Py_INCREF(op) _Py_INCREF(_PyObject_CAST(op))
 
 static inline void _Py_DECREF(
@@ -449,7 +448,6 @@ static inline void _Py_DECREF(
         _Py_Dealloc(op);
     }
 }
-
 #ifdef Py_REF_DEBUG
 #  define Py_DECREF(op) _Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
 #else
@@ -548,8 +546,8 @@ static inline PyObject* _Py_XNewRef(PyObject *obj)
 // Py_NewRef() and Py_XNewRef() are exported as functions for the stable ABI.
 // Names overriden with macros by static inline functions for best
 // performances.
-#define Py_NewRef(obj) _Py_NewRef(obj)
-#define Py_XNewRef(obj) _Py_XNewRef(obj)
+#define Py_NewRef(obj) _Py_NewRef(_PyObject_CAST(obj))
+#define Py_XNewRef(obj) _Py_XNewRef(_PyObject_CAST(obj))
 
 
 /*

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5614,7 +5614,7 @@ static PyObject *test_buildvalue_issue38913(PyObject *, PyObject *);
 
 
 static PyObject*
-test_set_type_size(PyObject* self, PyObject* ignored)
+test_set_type_size(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *obj = PyList_New(0);
     if (obj == NULL) {
@@ -5630,6 +5630,35 @@ test_set_type_size(PyObject* self, PyObject* ignored)
     // as l-values to set an object type and size.
     Py_TYPE(obj) = &PyList_Type;
     Py_SIZE(obj) = 0;
+
+    Py_DECREF(obj);
+    Py_RETURN_NONE;
+}
+
+
+// Test Py_NewRef() and Py_XNewRef() functions
+static PyObject*
+test_refcount(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *obj = PyList_New(0);
+    if (obj == NULL) {
+        return NULL;
+    }
+    assert(Py_REFCNT(obj) == 1);
+
+    // Test Py_NewRef()
+    PyObject *ref = Py_NewRef(obj);
+    assert(ref == obj);
+    assert(Py_REFCNT(obj) == 2);
+    Py_DECREF(ref);
+
+    // Test Py_XNewRef()
+    PyObject *xref = Py_XNewRef(obj);
+    assert(xref == obj);
+    assert(Py_REFCNT(obj) == 2);
+    Py_DECREF(xref);
+
+    assert(Py_XNewRef(NULL) == NULL);
 
     Py_DECREF(obj);
     Py_RETURN_NONE;
@@ -5908,6 +5937,7 @@ static PyMethodDef TestMethods[] = {
     {"pynumber_tobase", pynumber_tobase, METH_VARARGS},
     {"without_gc", without_gc, METH_O},
     {"test_set_type_size", test_set_type_size, METH_NOARGS},
+    {"test_refcount", test_refcount, METH_NOARGS},
     {NULL, NULL} /* sentinel */
 };
 


### PR DESCRIPTION
Write also unit tests on Py_NewRef() and Py_XNewRef().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42262](https://bugs.python.org/issue42262) -->
https://bugs.python.org/issue42262
<!-- /issue-number -->
