### PR TITLE
bpo-42553: Fix test_asyncio.test_call_later()

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -294,11 +294,8 @@ class EventLoopTestsMixin:
             self.loop.stop()
 
         self.loop.call_later(0.1, callback, 'hello world')
-        t0 = time.monotonic()
         self.loop.run_forever()
-        t1 = time.monotonic()
         self.assertEqual(results, ['hello world'])
-        self.assertTrue(0.08 <= t1-t0 <= 0.8, t1-t0)
 
     def test_call_soon(self):
         results = []

--- a/Misc/NEWS.d/next/Tests/2020-12-03-13-32-44.bpo-42553.2TRE2N.rst
+++ b/Misc/NEWS.d/next/Tests/2020-12-03-13-32-44.bpo-42553.2TRE2N.rst
@@ -1,0 +1,3 @@
+Fix ``test_asyncio.test_call_later()`` race condition: don't measure asyncio
+performance in the ``call_later()`` unit test. The test failed randomly on
+the CI.


### PR DESCRIPTION
Fix test_asyncio.test_call_later() race condition: don't measure
asyncio performance in the call_later() unit test. The test failed
randomly on the CI.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42553](https://bugs.python.org/issue42553) -->
https://bugs.python.org/issue42553
<!-- /issue-number -->
