### PR TITLE
bpo-42116: Fix inspect.getsource handling of trailing comments

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -930,7 +930,7 @@ class BlockFinder:
         self.indecorator = False
         self.decoratorhasargs = False
         self.last = 1
-        self.block_start_col = None
+        self.body_col0 = None
 
     def tokeneater(self, type, token, srowcol, erowcol, line):
         if not self.started and not self.indecorator:
@@ -942,10 +942,6 @@ class BlockFinder:
                 if token == "lambda":
                     self.islambda = True
                 self.started = True
-                if self.block_start_col is None:
-                    self.block_start_col = srowcol[1]
-            elif token == "async":
-                self.block_start_col = srowcol[1]
             self.passline = True    # skip to the end of the line
         elif token == "(":
             if self.indecorator:
@@ -966,6 +962,8 @@ class BlockFinder:
         elif self.passline:
             pass
         elif type == tokenize.INDENT:
+            if self.body_col0 is None and self.started:
+                self.body_col0 = erowcol[1]
             self.indent = self.indent + 1
             self.passline = True
         elif type == tokenize.DEDENT:
@@ -976,9 +974,8 @@ class BlockFinder:
             if self.indent <= 0:
                 raise EndOfBlock
         elif type == tokenize.COMMENT:
-            if self.started and srowcol[1] > self.block_start_col:
-                # Include comments which are indented more than the block's
-                # start statement
+            if self.body_col0 is not None and srowcol[1] >= self.body_col0:
+                # Include comments if indented at least as much as the block
                 self.last = srowcol[0]
         elif self.indent == 0 and type not in (tokenize.COMMENT, tokenize.NL):
             # any other token on the same indentation level end the previous

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -111,4 +111,5 @@ class WhichComments:
         return 2
         # end asyncf
        # after asyncf - line 113
-  # after WhichComments - line 114
+    # end of WhichComments - line 114
+  # after WhichComments - line 115

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -101,8 +101,8 @@ class WhichComments:
         # start f
         return 1
         # line 103
-      # end f
-    # line 105
+        # end f
+      # line 105
     # after f
 
     # before asyncf - line 108
@@ -110,7 +110,5 @@ class WhichComments:
         # start asyncf
         return 2
         # end asyncf
-      # line 113
-    # after asyncf
-  # almost finished WhichComments
-# after WhichComments - line 116
+    # after asyncf - line 113
+  # after WhichComments - line 114

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -102,7 +102,7 @@ class WhichComments:
         return 1
         # line 103
         # end f
-      # line 105
+       # line 105
     # after f
 
     # before asyncf - line 108
@@ -110,5 +110,5 @@ class WhichComments:
         # start asyncf
         return 2
         # end asyncf
-    # after asyncf - line 113
+       # after asyncf - line 113
   # after WhichComments - line 114

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -91,3 +91,26 @@ class Callable:
 
 custom_method = Callable().as_method_of(42)
 del Callable
+
+# line 95
+class WhichComments:
+  # line 97
+    # before f
+    def f(self):
+      # line 100
+        # start f
+        return 1
+        # line 103
+      # end f
+    # line 105
+    # after f
+
+    # before asyncf - line 108
+    async def asyncf(self):
+        # start asyncf
+        return 2
+        # end asyncf
+      # line 113
+    # after asyncf
+  # almost finished WhichComments
+# after WhichComments - line 116

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -653,7 +653,7 @@ class TestBlockComments(GetSourceBase):
     fodderModule = mod
 
     def test_toplevel_class(self):
-        self.assertSourceEqual(mod.WhichComments, 96, 113)
+        self.assertSourceEqual(mod.WhichComments, 96, 114)
 
     def test_class_method(self):
         self.assertSourceEqual(mod.WhichComments.f, 99, 104)

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -653,13 +653,13 @@ class TestBlockComments(GetSourceBase):
     fodderModule = mod
 
     def test_toplevel_class(self):
-        self.assertSourceEqual(mod.WhichComments, 96, 115)
+        self.assertSourceEqual(mod.WhichComments, 96, 113)
 
     def test_class_method(self):
         self.assertSourceEqual(mod.WhichComments.f, 99, 104)
 
     def test_class_async_method(self):
-        self.assertSourceEqual(mod.WhichComments.asyncf, 109, 113)
+        self.assertSourceEqual(mod.WhichComments.asyncf, 109, 112)
 
 class TestBuggyCases(GetSourceBase):
     fodderModule = mod2

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -390,6 +390,7 @@ class TestRetrievingSourceCode(GetSourceBase):
                           ('ParrotDroppings', mod.ParrotDroppings),
                           ('StupidGit', mod.StupidGit),
                           ('Tit', mod.MalodorousPervert),
+                          ('WhichComments', mod.WhichComments),
                          ])
         tree = inspect.getclasstree([cls[1] for cls in classes])
         self.assertEqual(tree,
@@ -403,7 +404,8 @@ class TestRetrievingSourceCode(GetSourceBase):
                             [(mod.FesteringGob, (mod.MalodorousPervert,
                                                     mod.ParrotDroppings))
                              ]
-                            ]
+                            ],
+                            (mod.WhichComments, (object,),)
                            ]
                           ])
         tree = inspect.getclasstree([cls[1] for cls in classes], True)
@@ -415,7 +417,8 @@ class TestRetrievingSourceCode(GetSourceBase):
                             [(mod.FesteringGob, (mod.MalodorousPervert,
                                                     mod.ParrotDroppings))
                              ]
-                            ]
+                            ],
+                            (mod.WhichComments, (object,),)
                            ]
                           ])
 
@@ -645,6 +648,18 @@ class TestOneliners(GetSourceBase):
         # Test inspect.getsource with a lambda function defined
         # as argument to another function.
         self.assertSourceEqual(mod2.anonymous, 55, 55)
+
+class TestBlockComments(GetSourceBase):
+    fodderModule = mod
+
+    def test_toplevel_class(self):
+        self.assertSourceEqual(mod.WhichComments, 96, 115)
+
+    def test_class_method(self):
+        self.assertSourceEqual(mod.WhichComments.f, 99, 104)
+
+    def test_class_async_method(self):
+        self.assertSourceEqual(mod.WhichComments.asyncf, 109, 113)
 
 class TestBuggyCases(GetSourceBase):
     fodderModule = mod2
@@ -4014,8 +4029,8 @@ def foo():
 
 def test_main():
     run_unittest(
-        TestDecorators, TestRetrievingSourceCode, TestOneliners, TestBuggyCases,
-        TestInterpreterStack, TestClassesAndFunctions, TestPredicates,
+        TestDecorators, TestRetrievingSourceCode, TestOneliners, TestBlockComments,
+        TestBuggyCases, TestInterpreterStack, TestClassesAndFunctions, TestPredicates,
         TestGetcallargsFunctions, TestGetcallargsMethods,
         TestGetcallargsUnboundMethods, TestGetattrStatic, TestGetGeneratorState,
         TestNoEOL, TestSignatureObject, TestSignatureBind, TestParameterObject,

--- a/Misc/NEWS.d/next/Library/2020-12-03-15-42-32.bpo-42116.yIwroP.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-03-15-42-32.bpo-42116.yIwroP.rst
@@ -1,0 +1,1 @@
+Fix handling of trailing comments by :func:`inspect.getsource`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42116](https://bugs.python.org/issue42116) -->
https://bugs.python.org/issue42116
<!-- /issue-number -->
