### PR TITLE
bpo-41473: Reenable test_gdb on gdb 9.2 and newer

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -51,11 +51,6 @@ if gdb_major_version < 7:
                             "embedding. Saw %s.%s:\n%s"
                             % (gdb_major_version, gdb_minor_version,
                                gdb_version))
-if (gdb_major_version, gdb_minor_version) >= (9, 2):
-    # gdb 9.2 on Fedora Rawhide is not reliable, see:
-    # * https://bugs.python.org/issue41473
-    # * https://bugzilla.redhat.com/show_bug.cgi?id=1866884
-    raise unittest.SkipTest("https://bugzilla.redhat.com/show_bug.cgi?id=1866884")
 
 if not sysconfig.is_python_build():
     raise unittest.SkipTest("test_gdb only works on source builds at the moment.")

--- a/Misc/NEWS.d/next/Tests/2020-12-04-11-47-09.bpo-41473.W_updK.rst
+++ b/Misc/NEWS.d/next/Tests/2020-12-04-11-47-09.bpo-41473.W_updK.rst
@@ -1,0 +1,3 @@
+Reenable test_gdb on gdb 9.2 and newer:
+https://bugzilla.redhat.com/show_bug.cgi?id=1866884 bug is fixed in gdb
+10.1.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1866884 is fixed in gdb
10.1 (failed to reproduce on gdb-10.1-1.fc34.aarch64).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41473](https://bugs.python.org/issue41473) -->
https://bugs.python.org/issue41473
<!-- /issue-number -->
