### PR TITLE
bpo-5054: CGIHTTPRequestHandler.run_cgi() HTTP_ACCEPT improperly parsed

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1123,12 +1123,7 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
         referer = self.headers.get('referer')
         if referer:
             env['HTTP_REFERER'] = referer
-        accept = []
-        for line in self.headers.getallmatchingheaders('accept'):
-            if line[:1] in "\t\n\r ":
-                accept.append(line.strip())
-            else:
-                accept = accept + line[7:].split(',')
+        accept = self.headers.get_all('accept', ())
         env['HTTP_ACCEPT'] = ','.join(accept)
         ua = self.headers.get('user-agent')
         if ua:

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -588,7 +588,7 @@ print()
 print(os.environ["%s"])
 """
 
-cgi_env = """\
+cgi_file6 = """\
 #!%s
 import os
 
@@ -675,10 +675,10 @@ class CGIHTTPServerTestCase(BaseTestCase):
             file5.write(cgi_file1 % self.pythonexe)
         os.chmod(self.file5_path, 0o777)
 
-        self.env_path = os.path.join(self.cgi_dir, 'env.py')
-        with open(self.env_path, 'w', encoding='utf-8') as envfile:
-            envfile.write(cgi_env % self.pythonexe)
-        os.chmod(self.env_path, 0o777)
+        self.file6_path = os.path.join(self.cgi_dir, 'file6.py')
+        with open(self.file6_path, 'w', encoding='utf-8') as file6:
+            file6.write(cgi_file6 % self.pythonexe)
+        os.chmod(self.file6_path, 0o777)
 
         os.chdir(self.parent_dir)
 
@@ -699,6 +699,8 @@ class CGIHTTPServerTestCase(BaseTestCase):
                 os.remove(self.file4_path)
             if self.file5_path:
                 os.remove(self.file5_path)
+            if self.file6_path:
+                os.remove(self.file6_path)
             os.rmdir(self.cgi_child_dir)
             os.rmdir(self.cgi_dir)
             os.rmdir(self.cgi_dir_in_sub_dir)
@@ -845,9 +847,9 @@ class CGIHTTPServerTestCase(BaseTestCase):
         for headers, expected in tests:
             headers = OrderedDict(headers)
             with self.subTest(headers):
-                res = self.request('/cgi-bin/env.py', 'GET', headers=headers)
+                res = self.request('/cgi-bin/file6.py', 'GET', headers=headers)
                 self.assertEqual(http.HTTPStatus.OK, res.status)
-                expected = r"'HTTP_ACCEPT': " + repr(expected)
+                expected = f"'HTTP_ACCEPT': {expected!r}"
                 self.assertIn(expected.encode('ascii'), res.read())
 
 

--- a/Misc/NEWS.d/next/Library/2020-12-04-03-51-12.bpo-5054.53StYZ.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-04-03-51-12.bpo-5054.53StYZ.rst
@@ -1,0 +1,5 @@
+CGIHTTPRequestHandler.run_cgi() HTTP_ACCEPT improperly parsed. Replace the
+special purpose getallmatchingheaders with generic get_all method and add
+relevant tests.
+
+Original Patch by Martin Panter. Modified by Senthil Kumaran.


### PR DESCRIPTION
```
[bpo-5054](https://bugs.python.org/issue5054): CGIHTTPRequestHandler.run_cgi() HTTP_ACCEPT improperly parsed
```

Replace the special purpose getallmatchingheaders with generic get_all method and add relevant tests.

Original Patch by Martin Panter. Modified by Senthil Kumaran.

<!-- issue-number: [bpo-5054](https://bugs.python.org/issue5054) -->
https://bugs.python.org/issue5054
<!-- /issue-number -->
