### PR TITLE
bpo-42470: Do not warn on sequences which are also sets in random.sample()

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -424,13 +424,14 @@ class Random(_random.Random):
         # too many calls to _randbelow(), making them slower and
         # causing them to eat more entropy than necessary.
 
-        if isinstance(population, _Set):
-            _warn('Sampling from a set deprecated\n'
-                  'since Python 3.9 and will be removed in a subsequent version.',
-                  DeprecationWarning, 2)
-            population = tuple(population)
         if not isinstance(population, _Sequence):
-            raise TypeError("Population must be a sequence.  For dicts or sets, use sorted(d).")
+            if isinstance(population, _Set):
+                _warn('Sampling from a set deprecated\n'
+                      'since Python 3.9 and will be removed in a subsequent version.',
+                      DeprecationWarning, 2)
+                population = tuple(population)
+            else:
+                raise TypeError("Population must be a sequence.  For dicts or sets, use sorted(d).")
         n = len(population)
         if counts is not None:
             cum_counts = list(_accumulate(counts))

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -11,7 +11,7 @@ from functools import partial
 from math import log, exp, pi, fsum, sin, factorial
 from test import support
 from fractions import Fraction
-from collections import Counter
+from collections import abc, Counter
 
 class TestBasicOps:
     # Superclass with tests common to all generators.
@@ -162,6 +162,24 @@ class TestBasicOps:
         with self.assertWarns(DeprecationWarning):
             population = {10, 20, 30, 40, 50, 60, 70}
             self.gen.sample(population, k=5)
+
+    def test_sample_on_seqsets(self):
+        class SeqSet(abc.Sequence, abc.Set):
+            def __init__(self, items=()):
+                self._items = list(dict.fromkeys(items, None))
+
+            def __len__(self):
+                return len(self._items)
+
+            def __getitem__(self, index):
+                return self._items[index]
+
+        population = SeqSet([1, 2, 3, 4, 1])
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always", DeprecationWarning)
+            self.gen.sample(population, k=2)
+
+        self.assertEqual(ws, [])
 
     def test_sample_with_counts(self):
         sample = self.gen.sample

--- a/Misc/NEWS.d/next/Library/2020-12-04-12-00-00.bpo-42470.iqtC4L.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-04-12-00-00.bpo-42470.iqtC4L.rst
@@ -1,0 +1,1 @@
+random.sample no longer warns on a sequence which is also a set


### PR DESCRIPTION


<!-- issue-number: [bpo-42470](https://bugs.python.org/issue42470) -->
https://bugs.python.org/issue42470
<!-- /issue-number -->
