### PR TITLE
bpo-30459: Convert PyTuple_SET_ITEM() to a function

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -595,6 +595,10 @@ Porting to Python 3.10
   :ref:`Python Path Configuration.  <init-path-config>`.
   (Contributed by Victor Stinner in :issue:`42260`.)
 
+* Convert the :c:func:`PyTuple_SET_ITEM()`, :c:func:`PyList_SET_ITEM()` and
+  :c:func:`PyCell_SET()` macros to static inline functions.
+  (Contributed by Victor Stinner in :issue:`30459`.)
+
 Deprecated
 ----------
 

--- a/Include/cellobject.h
+++ b/Include/cellobject.h
@@ -19,8 +19,16 @@ PyAPI_FUNC(PyObject *) PyCell_New(PyObject *);
 PyAPI_FUNC(PyObject *) PyCell_Get(PyObject *);
 PyAPI_FUNC(int) PyCell_Set(PyObject *, PyObject *);
 
-#define PyCell_GET(op) (((PyCellObject *)(op))->ob_ref)
-#define PyCell_SET(op, v) (((PyCellObject *)(op))->ob_ref = v)
+// Cast the argument to PyCellObject* type.
+#define _PyCell_CAST(op) (assert(PyCell_Check(op)), (PyCellObject *)(op))
+
+#define PyCell_GET(op) (_PyCell_CAST(op)->ob_ref)
+
+static inline void _PyCell_SET(PyCellObject *cell, PyObject *value)
+{
+    cell->ob_ref = value;
+}
+#define PyCell_SET(op, value) _PyCell_SET(_PyCell_CAST(op), value)
 
 #ifdef __cplusplus
 }

--- a/Include/cpython/listobject.h
+++ b/Include/cpython/listobject.h
@@ -29,6 +29,14 @@ PyAPI_FUNC(void) _PyList_DebugMallocStats(FILE *out);
 /* Cast argument to PyListObject* type. */
 #define _PyList_CAST(op) (assert(PyList_Check(op)), (PyListObject *)(op))
 
-#define PyList_GET_ITEM(op, i) (_PyList_CAST(op)->ob_item[i])
-#define PyList_SET_ITEM(op, i, v) (_PyList_CAST(op)->ob_item[i] = (v))
+#define PyList_GET_ITEM(op, index) (_PyList_CAST(op)->ob_item[index])
+
+static inline void
+_PyList_SET_ITEM(PyListObject *list, Py_ssize_t index, PyObject *item)
+{
+    list->ob_item[index] = item;
+}
+#define PyList_SET_ITEM(op, index, item) \
+    _PyList_SET_ITEM(_PyList_CAST(op), index, item)
+
 #define PyList_GET_SIZE(op)    Py_SIZE(_PyList_CAST(op))

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -20,9 +20,15 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
 #define PyTuple_GET_SIZE(op)    Py_SIZE(_PyTuple_CAST(op))
 
-#define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
+#define PyTuple_GET_ITEM(op, index) (_PyTuple_CAST(op)->ob_item[index])
 
-/* Macro, *only* to be used to fill in brand new tuples */
-#define PyTuple_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
+// Function *only* to be used to fill in brand new tuples.
+static inline void
+_PyTuple_SET_ITEM(PyTupleObject *tuple, Py_ssize_t index, PyObject *item)
+{
+    tuple->ob_item[index] = item;
+}
+#define PyTuple_SET_ITEM(op, index, item) \
+    _PyTuple_SET_ITEM(_PyTuple_CAST(op), index, item)
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);

--- a/Misc/NEWS.d/next/C API/2020-12-04-19-55-51.bpo-30459.3dmPs5.rst
+++ b/Misc/NEWS.d/next/C API/2020-12-04-19-55-51.bpo-30459.3dmPs5.rst
@@ -1,0 +1,2 @@
+Convert the :c:func:`PyTuple_SET_ITEM()`, :c:func:`PyList_SET_ITEM()` and
+:c:func:`PyCell_SET()` macros to static inline functions.


### PR DESCRIPTION
Convert the PyTuple_SET_ITEM(), PyList_SET_ITEM() and PyCell_SET()
macros to static inline functions.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30459](https://bugs.python.org/issue30459) -->
https://bugs.python.org/issue30459
<!-- /issue-number -->
