### PR TITLE
bpo-41116: Fix setup.py test for macOS Tcl/Tk frameworks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,10 +177,11 @@ def macosx_sdk_root():
     m = re.search(r'-isysroot\s*(\S+)', cflags)
     if m is not None:
         MACOS_SDK_ROOT = m.group(1)
+        MACOS_SDK_SPECIFIED = MACOS_SDK_ROOT != '/'
     else:
         MACOS_SDK_ROOT = _osx_support._default_sysroot(
             sysconfig.get_config_var('CC'))
-    MACOS_SDK_SPECIFIED = MACOS_SDK_ROOT != '/'
+        MACOS_SDK_SPECIFIED = False
 
     return MACOS_SDK_ROOT
 
@@ -1898,7 +1899,6 @@ class PyBuildExt(build_ext):
                 join('/', 'Library', 'Frameworks'),
                 join(sysroot, 'System', 'Library', 'Frameworks'),
             ]
-
         # Find the directory that contains the Tcl.framework and
         # Tk.framework bundles.
         for F in framework_dirs:

--- a/setup.py
+++ b/setup.py
@@ -1899,6 +1899,7 @@ class PyBuildExt(build_ext):
                 join('/', 'Library', 'Frameworks'),
                 join(sysroot, 'System', 'Library', 'Frameworks'),
             ]
+
         # Find the directory that contains the Tcl.framework and
         # Tk.framework bundles.
         for F in framework_dirs:


### PR DESCRIPTION
If no explicit macOS SDK was specified, setup.py should check for
Tcl and TK frameworks in /Library/Frameworks; the previous commit
inadvertently broke that test.


<!-- issue-number: [bpo-41116](https://bugs.python.org/issue41116) -->
https://bugs.python.org/issue41116
<!-- /issue-number -->
