### PR TITLE
bpo-42576: Raise TypeError when passing in keyword arguments to GenericAlias

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -302,6 +302,11 @@ class BaseTest(unittest.TestCase):
                 alias = t[int]
                 self.assertEqual(ref(alias)(), alias)
 
+    def test_no_kwargs(self):
+        # bpo-42576
+        with self.assertRaises(TypeError):
+            GenericAlias(bad=float)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-05-22-34-47.bpo-42576.lEeEl7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-05-22-34-47.bpo-42576.lEeEl7.rst
@@ -1,0 +1,3 @@
+``types.GenericAlias`` will now raise a ``TypeError`` when attempting to
+initialize with a keyword argument.  Previously, this would cause the
+interpreter to crash.  Patch by Ken Jin.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -567,7 +567,7 @@ static PyGetSetDef ga_properties[] = {
 static PyObject *
 ga_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    if (!_PyArg_NoKwnames("GenericAlias", kwds)) {
+    if (!_PyArg_NoKeywords("GenericAlias", kwds)) {
         return NULL;
     }
     if (!_PyArg_CheckPositional("GenericAlias", PyTuple_GET_SIZE(args), 2, 2)) {


### PR DESCRIPTION
Use `_PyArg_NoKeywords` instead of `_PyArg_NoKwnames` when checking the `kwds` tuple when creating `GenericAlias`. This fixes an interpreter crash when passing in keyword arguments to `GenericAlias`'s constructor.

Needs backport to 3.9.
<!-- issue-number: [bpo-42576](https://bugs.python.org/issue42576) -->
https://bugs.python.org/issue42576
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum