### PR TITLE
bpo-42579: Make workaround for various versions of Sphinx more robust

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -394,7 +394,12 @@ class DeprecatedRemoved(Directive):
                                    translatable=False)
             node.append(para)
         env = self.state.document.settings.env
-        env.get_domain('changeset').note_changeset(node)
+        # new method
+        if hasattr(env, 'get_domain'):
+            env.get_domain('changeset').note_changeset(node)
+        # deprecated pre-Sphinx-2 method
+        else:
+            env.note_versionchange('deprecated', version[0], node, self.lineno)
         return [node] + messages
 
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -394,12 +394,12 @@ class DeprecatedRemoved(Directive):
                                    translatable=False)
             node.append(para)
         env = self.state.document.settings.env
-        # new method
-        if hasattr(env, 'get_domain'):
-            env.get_domain('changeset').note_changeset(node)
         # deprecated pre-Sphinx-2 method
-        else:
+        if hasattr(env, 'note_versionchange'):
             env.note_versionchange('deprecated', version[0], node, self.lineno)
+        # new method
+        else:
+            env.get_domain('changeset').note_changeset(node)
         return [node] + messages
 
 


### PR DESCRIPTION
The solution in gh#python/cpython#13236 is too strict, because it effectively requires use of Sphinx >= 2.0. It is not too difficult to make the same solution more robust so it works with all normal versions of Sphinx.

<!-- issue-number: [bpo-42579](https://bugs.python.org/issue42579) -->
https://bugs.python.org/issue42579
<!-- /issue-number -->
