### PR TITLE
bpo-42582: Remove asyncio._all_tasks_compat().

### DIFF
--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -20,10 +20,6 @@ from .tasks import *
 from .threads import *
 from .transports import *
 
-# Exposed for _asynciomodule.c to implement now deprecated
-# Task.all_tasks() method.  This function will be removed in 3.9.
-from .tasks import _all_tasks_compat  # NoQA
-
 __all__ = (base_events.__all__ +
            coroutines.__all__ +
            events.__all__ +

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -61,30 +61,6 @@ def all_tasks(loop=None):
             if futures._get_loop(t) is loop and not t.done()}
 
 
-def _all_tasks_compat(loop=None):
-    # Different from "all_task()" by returning *all* Tasks, including
-    # the completed ones.  Used to implement deprecated "Tasks.all_task()"
-    # method.
-    if loop is None:
-        loop = events.get_event_loop()
-    # Looping over a WeakSet (_all_tasks) isn't safe as it can be updated from another
-    # thread while we do so. Therefore we cast it to list prior to filtering. The list
-    # cast itself requires iteration, so we repeat it several times ignoring
-    # RuntimeErrors (which are not very likely to occur). See issues 34970 and 36607 for
-    # details.
-    i = 0
-    while True:
-        try:
-            tasks = list(_all_tasks)
-        except RuntimeError:
-            i += 1
-            if i >= 1000:
-                raise
-        else:
-            break
-    return {t for t in tasks if futures._get_loop(t) is loop}
-
-
 def _set_task_name(task, name):
     if name is not None:
         try:


### PR DESCRIPTION
It was used to implement now removed asyncio.Task.all_tasks().


<!-- issue-number: [bpo-42582](https://bugs.python.org/issue42582) -->
https://bugs.python.org/issue42582
<!-- /issue-number -->
