### PR TITLE
[3.9] bpo-42532: Check if NonCallableMock's spec_arg is not None instead of call its __bool__ function (GH-23613)

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -406,7 +406,7 @@ class NonCallableMock(Base):
             # Check if spec is an async object or function
             bound_args = _MOCK_SIG.bind_partial(cls, *args, **kw).arguments
             spec_arg = bound_args.get('spec_set', bound_args.get('spec'))
-            if spec_arg and _is_async_obj(spec_arg):
+            if spec_arg is not None and _is_async_obj(spec_arg):
                 bases = (AsyncMockMixin, cls)
         new = type(cls.__name__, bases, {'__doc__': cls.__doc__})
         instance = _safe_super(NonCallableMock, cls).__new__(new)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -2156,6 +2156,16 @@ class MockTest(unittest.TestCase):
                 obj = mock(spec=Something)
                 self.assertIsInstance(obj, Something)
 
+    def test_bool_not_called_when_passing_spec_arg(self):
+        class Something:
+            def __init__(self):
+                self.obj_with_bool_func = unittest.mock.MagicMock()
+
+        obj = Something()
+        with unittest.mock.patch.object(obj, 'obj_with_bool_func', autospec=True): pass
+
+        self.assertEqual(obj.obj_with_bool_func.__bool__.call_count, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-12-02-07-37-59.bpo-42532.ObNep_.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-02-07-37-59.bpo-42532.ObNep_.rst
@@ -1,0 +1,1 @@
+Remove unexpected call of ``__bool__`` when passing a ``spec_arg`` argument to a Mock.


### PR DESCRIPTION
Check if NonCallableMock's spec_arg is not None instead of call its __bool__ function
(cherry picked from commit c598a04dd29b89ad072245ddaf738badcfb41ac7)

Co-authored-by: idanw206 <31290383+idanw206@users.noreply.github.com>

<!-- issue-number: [bpo-42532](https://bugs.python.org/issue42532) -->
https://bugs.python.org/issue42532
<!-- /issue-number -->
