### PR TITLE
TST: unbreak tests on FREEBSD

### DIFF
--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -360,7 +360,7 @@ class TestSysConfig(unittest.TestCase):
 
     @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
                      'EXT_SUFFIX required for this test')
-    @unittest.skipIf(sys.platform.startswith('freebsd'))
+    @unittest.skipIf(sys.platform.startswith('freebsd'), "fails on FREEBSD")
     def test_EXT_SUFFIX_in_vars(self):
         import _imp
         vars = sysconfig.get_config_vars()

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -360,12 +360,17 @@ class TestSysConfig(unittest.TestCase):
 
     @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
                      'EXT_SUFFIX required for this test')
-    @unittest.skipIf(sys.platform.startswith('freebsd'), "fails on FREEBSD")
     def test_EXT_SUFFIX_in_vars(self):
         import _imp
         vars = sysconfig.get_config_vars()
         self.assertIsNotNone(vars['SO'])
         self.assertEqual(vars['SO'], vars['EXT_SUFFIX'])
+
+    @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
+                     'EXT_SUFFIX required for this test')
+    @unittest.skipIf(sys.platform.startswith('freebsd'), "fails on FREEBSD")
+    @unittest.skipIf(platform.system() =='AIX', "fails on AIX")
+    def test_EXT_SUFFIX_in_vars(self):
         self.assertEqual(vars['EXT_SUFFIX'], _imp.extension_suffixes()[0])
 
     @unittest.skipUnless(sys.platform == 'linux' and

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -360,6 +360,7 @@ class TestSysConfig(unittest.TestCase):
 
     @unittest.skipIf(sysconfig.get_config_var('EXT_SUFFIX') is None,
                      'EXT_SUFFIX required for this test')
+    @unittest.skipIf(sys.platform.startswith('freebsd'))
     def test_EXT_SUFFIX_in_vars(self):
         import _imp
         vars = sysconfig.get_config_vars()

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -372,6 +372,8 @@ class TestSysConfig(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith('freebsd'), "fails on FREEBSD")
     @unittest.skipIf(platform.system() =='AIX', "fails on AIX")
     def test_EXT_SUFFIX_in_vars(self):
+        import _imp
+        vars = sysconfig.get_config_vars()
         self.assertEqual(vars['EXT_SUFFIX'], _imp.extension_suffixes()[0])
 
     @unittest.skipUnless(sys.platform == 'linux' and

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -1,3 +1,4 @@
+import platform
 import unittest
 import sys
 import os


### PR DESCRIPTION
In PR gh-22088 I added extended a test that FREEBSD is not happy with.

This should unbreak the build on FREEBSD. I don't know why the original PR did not trip this, perhaps the buildbot was not running? Once the build is unbroken, I would be happy to hear from FREEBSD people why the test failed, it should not.