### PR TITLE
[3.8] bpo-42574: Use format() instead of f-string in Tools/clinic/clinic.py to allow using older Python versions

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1769,7 +1769,7 @@ def write_file(filename, new_contents):
         pass
 
     # Atomic write using a temporary file and os.replace()
-    filename_new = f"{filename}.new"
+    filename_new = "{}.new".format(filename)
     with open(filename_new, "w", encoding="utf-8") as fp:
         fp.write(new_contents)
 


### PR DESCRIPTION
… 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42574](https://bugs.python.org/issue42574) -->
https://bugs.python.org/issue42574
<!-- /issue-number -->
