### PR TITLE
bpo-41818: Add termios.tcgetwinsize(), termios.tcsetwinsize(). Update docs.

### DIFF
--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -84,7 +84,7 @@ The module defines the following functions:
 
     Set the tty window size for file descriptor *fd* from *winsize*, which is
     a list like the one returned by :func:`tcgetwinsize`. Requires
-    :const:`termios.TIOCSWINSZ`.
+    :const:`termios.TIOCGWINSZ` and :const:`termios.TIOCSWINSZ`.
 
 
 .. seealso::

--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -84,8 +84,9 @@ The module defines the following functions:
 .. function:: tcsetwinsize(fd, winsize)
 
     Set the tty window size for file descriptor *fd* from *winsize*, which is
-    a list like the one returned by :func:`tcgetwinsize`. Requires
-    :const:`termios.TIOCGWINSZ` and :const:`termios.TIOCSWINSZ`.
+    a list like the one returned by :func:`tcgetwinsize`. Requires at least
+    one of the pairs (:const:`termios.TIOCGWINSZ`, :const:`termios.TIOCSWINSZ`);
+    (:const:`termios.TIOCGSIZE`, :const:`termios.TIOCSSIZE`) to be defined.
 
 
 .. seealso::

--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -77,7 +77,8 @@ The module defines the following functions:
 .. function:: tcgetwinsize(fd)
 
    Return a list ``[ws_row, ws_col]`` containing the tty window size for file
-   descriptor *fd*. Requires :const:`termios.TIOCGWINSZ`.
+   descriptor *fd*. Requires :const:`termios.TIOCGWINSZ` or
+   :const:`termios.TIOCGSIZE`.
 
 
 .. function:: tcsetwinsize(fd, winsize)

--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -74,6 +74,19 @@ The module defines the following functions:
    output, :const:`TCIOFF` to suspend input, or :const:`TCION` to restart input.
 
 
+.. function:: tcgetwinsize(fd)
+
+   Return a list ``[ws_row, ws_col]`` containing the tty window size for file
+   descriptor *fd*. Requires :const:`termios.TIOCGWINSZ`.
+
+
+.. function:: tcsetwinsize(fd, winsize)
+
+    Set the tty window size for file descriptor *fd* from *winsize*, which is
+    a list like the one returned by :func:`tcgetwinsize`. Requires
+    :const:`termios.TIOCSWINSZ`.
+
+
 .. seealso::
 
    Module :mod:`tty`

--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -76,7 +76,7 @@ The module defines the following functions:
 
 .. function:: tcgetwinsize(fd)
 
-   Return a list ``[ws_row, ws_col]`` containing the tty window size for file
+   Return a tuple ``(ws_row, ws_col)`` containing the tty window size for file
    descriptor *fd*. Requires :const:`termios.TIOCGWINSZ` or
    :const:`termios.TIOCGSIZE`.
 
@@ -84,8 +84,9 @@ The module defines the following functions:
 .. function:: tcsetwinsize(fd, winsize)
 
     Set the tty window size for file descriptor *fd* from *winsize*, which is
-    a list like the one returned by :func:`tcgetwinsize`. Requires at least
-    one of the pairs (:const:`termios.TIOCGWINSZ`, :const:`termios.TIOCSWINSZ`);
+    a two-item tuple ``(ws_row, ws_col)`` like the one returned by
+    :func:`tcgetwinsize`. Requires at least one of the pairs
+    (:const:`termios.TIOCGWINSZ`, :const:`termios.TIOCSWINSZ`);
     (:const:`termios.TIOCGSIZE`, :const:`termios.TIOCSSIZE`) to be defined.
 
 

--- a/Misc/NEWS.d/next/Library/2020-12-08-01-08-58.bpo-41818.zO8vV7.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-08-01-08-58.bpo-41818.zO8vV7.rst
@@ -1,0 +1,1 @@
+Soumendra Ganguly: add termios.tcgetwinsize(), termios.tcsetwinsize().

--- a/Modules/clinic/termios.c.h
+++ b/Modules/clinic/termios.c.h
@@ -222,4 +222,68 @@ termios_tcflow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a129179f1e2545cc input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(termios_tcgetwinsize__doc__,
+"tcgetwinsize($module, fd, /)\n"
+"--\n"
+"\n"
+"Get the tty winsize for file descriptor fd.\n"
+"\n"
+"Returns a list [ws_row, ws_col].");
+
+#define TERMIOS_TCGETWINSIZE_METHODDEF    \
+    {"tcgetwinsize", (PyCFunction)termios_tcgetwinsize, METH_O, termios_tcgetwinsize__doc__},
+
+static PyObject *
+termios_tcgetwinsize_impl(PyObject *module, int fd);
+
+static PyObject *
+termios_tcgetwinsize(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int fd;
+
+    if (!_PyLong_FileDescriptor_Converter(arg, &fd)) {
+        goto exit;
+    }
+    return_value = termios_tcgetwinsize_impl(module, fd);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(termios_tcsetwinsize__doc__,
+"tcsetwinsize($module, fd, winsize, /)\n"
+"--\n"
+"\n"
+"Set the tty winsize for file descriptor fd.\n"
+"\n"
+"The winsize to be set is taken from the winsize argument, which\n"
+"is a list like the one returned by tcgetwinsize().");
+
+#define TERMIOS_TCSETWINSIZE_METHODDEF    \
+    {"tcsetwinsize", (PyCFunction)(void(*)(void))termios_tcsetwinsize, METH_FASTCALL, termios_tcsetwinsize__doc__},
+
+static PyObject *
+termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz);
+
+static PyObject *
+termios_tcsetwinsize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    int fd;
+    PyObject *winsz;
+
+    if (!_PyArg_CheckPositional("tcsetwinsize", nargs, 2, 2)) {
+        goto exit;
+    }
+    if (!_PyLong_FileDescriptor_Converter(args[0], &fd)) {
+        goto exit;
+    }
+    winsz = args[1];
+    return_value = termios_tcsetwinsize_impl(module, fd, winsz);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=c71166c2d959710d input=a9049054013a1b77]*/

--- a/Modules/clinic/termios.c.h
+++ b/Modules/clinic/termios.c.h
@@ -229,7 +229,7 @@ PyDoc_STRVAR(termios_tcgetwinsize__doc__,
 "\n"
 "Get the tty winsize for file descriptor fd.\n"
 "\n"
-"Returns a list [ws_row, ws_col].");
+"Returns a tuple (ws_row, ws_col).");
 
 #define TERMIOS_TCGETWINSIZE_METHODDEF    \
     {"tcgetwinsize", (PyCFunction)termios_tcgetwinsize, METH_O, termios_tcgetwinsize__doc__},
@@ -259,7 +259,7 @@ PyDoc_STRVAR(termios_tcsetwinsize__doc__,
 "Set the tty winsize for file descriptor fd.\n"
 "\n"
 "The winsize to be set is taken from the winsize argument, which\n"
-"is a list like the one returned by tcgetwinsize().");
+"is a two-item tuple (ws_row, ws_col) like the one returned by tcgetwinsize().");
 
 #define TERMIOS_TCSETWINSIZE_METHODDEF    \
     {"tcsetwinsize", (PyCFunction)(void(*)(void))termios_tcsetwinsize, METH_FASTCALL, termios_tcsetwinsize__doc__},
@@ -286,4 +286,4 @@ termios_tcsetwinsize(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c71166c2d959710d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=db808d31296f6643 input=a9049054013a1b77]*/

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -432,8 +432,8 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
         return PyErr_SetFromErrno(state->TermiosError);
     }
 
-    s.ts_lines = (unsigned short) PyLong_AsLong(PyList_GetItem(winsz, 0));
-    s.ts_cols = (unsigned short) PyLong_AsLong(PyList_GetItem(winsz, 1));
+    s.ts_lines = (int) PyLong_AsLong(PyList_GetItem(winsz, 0));
+    s.ts_cols = (int) PyLong_AsLong(PyList_GetItem(winsz, 1));
     if (PyErr_Occurred()) {
         return NULL;
     }

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -392,14 +392,32 @@ static PyObject *
 termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
 /*[clinic end generated code: output=2ac3c9bb6eda83e1 input=4a06424465b24aee]*/
 {
-#if defined(TIOCGWINSZ) && defined(TIOCSWINSZ)
-    if (!PyTuple_Check(winsz) || PyTuple_Size(winsz) != 2) {
+    if (!PySequence_Check(winsz) || PySequence_Size(winsz) != 2) {
         PyErr_SetString(PyExc_TypeError,
-                     "tcsetwinsize, arg 2: must be a two-item tuple");
+                     "tcsetwinsize, arg 2: must be a two-item sequence");
         return NULL;
     }
 
+    PyObject *tmp_item;
+    long winsz_0, winsz_1;
+    tmp_item = PySequence_GetItem(winsz, 0);
+    winsz_0 = PyLong_AsLong(tmp_item);
+    if (winsz_0 == -1 && PyErr_Occurred()) {
+        Py_XDECREF(tmp_item);
+        return NULL;
+    }
+    Py_XDECREF(tmp_item);
+    tmp_item = PySequence_GetItem(winsz, 1);
+    winsz_1 = PyLong_AsLong(tmp_item);                             
+    if (winsz_1 == -1 && PyErr_Occurred()) {
+        Py_XDECREF(tmp_item);
+        return NULL;
+    }
+    Py_XDECREF(tmp_item);
+
     termiosmodulestate *state = PyModule_GetState(module);
+
+#if defined(TIOCGWINSZ) && defined(TIOCSWINSZ)
     struct winsize w;
     /* Get the old winsize because it might have
        more fields such as xpixel, ypixel. */
@@ -407,9 +425,11 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
         return PyErr_SetFromErrno(state->TermiosError);
     }
 
-    w.ws_row = (unsigned short) PyLong_AsLong(PyTuple_GetItem(winsz, 0));
-    w.ws_col = (unsigned short) PyLong_AsLong(PyTuple_GetItem(winsz, 1));
-    if (PyErr_Occurred()) {
+    w.ws_row = (unsigned short) winsz_0;
+    w.ws_col = (unsigned short) winsz_1;
+    if (((long)w.ws_row) != winsz_0) || (((long)w.ws_col) != winsz_1) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "winsize value(s) out of range.");
         return NULL;
     }
 
@@ -419,22 +439,17 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
 
     Py_RETURN_NONE;
 #elif defined(TIOCGSIZE) && defined(TIOCSSIZE)
-    if (!PyTuple_Check(winsz) || PyTuple_Size(winsz) != 2) {
-        PyErr_SetString(PyExc_TypeError,
-                     "tcsetwinsize, arg 2: must be a two-item tuple");
-        return NULL;
-    }
-
-    termiosmodulestate *state = PyModule_GetState(module);
     struct ttysize s;
     /* Get the old ttysize because it might have more fields. */
     if (ioctl(fd, TIOCGSIZE, &s) == -1) {
         return PyErr_SetFromErrno(state->TermiosError);
     }
 
-    s.ts_lines = (int) PyLong_AsLong(PyTuple_GetItem(winsz, 0));
-    s.ts_cols = (int) PyLong_AsLong(PyTuple_GetItem(winsz, 1));
-    if (PyErr_Occurred()) {
+    s.ts_lines = (int) winsz_0;
+    s.ts_cols = (int) winsz_1;
+    if (((long)s.ts_lines) != winsz_0) || (((long)s.ts_cols) != winsz_1) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "winsize value(s) out of range.");
         return NULL;
     }
 

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -323,12 +323,12 @@ termios.tcgetwinsize
 
 Get the tty winsize for file descriptor fd.
 
-Returns a list [ws_row, ws_col].
+Returns a tuple (ws_row, ws_col).
 [clinic start generated code]*/
 
 static PyObject *
 termios_tcgetwinsize_impl(PyObject *module, int fd)
-/*[clinic end generated code: output=31825977d5325fb6 input=c7ed8aa957d108c0]*/
+/*[clinic end generated code: output=31825977d5325fb6 input=5706c379d7fd984d]*/
 {
 #if defined(TIOCGWINSZ)
     termiosmodulestate *state = PyModule_GetState(module);
@@ -338,12 +338,12 @@ termios_tcgetwinsize_impl(PyObject *module, int fd)
     }
 
     PyObject *v;
-    if (!(v = PyList_New(2))) {
+    if (!(v = PyTuple_New(2))) {
         return NULL;
     }
 
-    PyList_SetItem(v, 0, PyLong_FromLong((long)w.ws_row));
-    PyList_SetItem(v, 1, PyLong_FromLong((long)w.ws_col));
+    PyTuple_SetItem(v, 0, PyLong_FromLong((long)w.ws_row));
+    PyTuple_SetItem(v, 1, PyLong_FromLong((long)w.ws_col));
     if (PyErr_Occurred()) {
         Py_DECREF(v);
         return NULL;
@@ -357,12 +357,12 @@ termios_tcgetwinsize_impl(PyObject *module, int fd)
     }
 
     PyObject *v;
-    if (!(v = PyList_New(2))) {
+    if (!(v = PyTuple_New(2))) {
         return NULL;
     }
 
-    PyList_SetItem(v, 0, PyLong_FromLong((long)s.ts_lines));
-    PyList_SetItem(v, 1, PyLong_FromLong((long)s.ts_cols));
+    PyTuple_SetItem(v, 0, PyLong_FromLong((long)s.ts_lines));
+    PyTuple_SetItem(v, 1, PyLong_FromLong((long)s.ts_cols));
     if (PyErr_Occurred()) {
         Py_DECREF(v);
         return NULL;
@@ -385,17 +385,17 @@ termios.tcsetwinsize
 Set the tty winsize for file descriptor fd.
 
 The winsize to be set is taken from the winsize argument, which
-is a list like the one returned by tcgetwinsize().
+is a two-item tuple (ws_row, ws_col) like the one returned by tcgetwinsize().
 [clinic start generated code]*/
 
 static PyObject *
 termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
-/*[clinic end generated code: output=2ac3c9bb6eda83e1 input=c495180b2b932a30]*/
+/*[clinic end generated code: output=2ac3c9bb6eda83e1 input=4a06424465b24aee]*/
 {
 #if defined(TIOCGWINSZ) && defined(TIOCSWINSZ)
-    if (!PyList_Check(winsz) || PyList_Size(winsz) != 2) {
+    if (!PyTuple_Check(winsz) || PyTuple_Size(winsz) != 2) {
         PyErr_SetString(PyExc_TypeError,
-                     "tcsetwinsize, arg 2: must be 2 element list");
+                     "tcsetwinsize, arg 2: must be a two-item tuple");
         return NULL;
     }
 
@@ -407,8 +407,8 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
         return PyErr_SetFromErrno(state->TermiosError);
     }
 
-    w.ws_row = (unsigned short) PyLong_AsLong(PyList_GetItem(winsz, 0));
-    w.ws_col = (unsigned short) PyLong_AsLong(PyList_GetItem(winsz, 1));
+    w.ws_row = (unsigned short) PyLong_AsLong(PyTuple_GetItem(winsz, 0));
+    w.ws_col = (unsigned short) PyLong_AsLong(PyTuple_GetItem(winsz, 1));
     if (PyErr_Occurred()) {
         return NULL;
     }
@@ -419,9 +419,9 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
 
     Py_RETURN_NONE;
 #elif defined(TIOCGSIZE) && defined(TIOCSSIZE)
-    if (!PyList_Check(winsz) || PyList_Size(winsz) != 2) {
+    if (!PyTuple_Check(winsz) || PyTuple_Size(winsz) != 2) {
         PyErr_SetString(PyExc_TypeError,
-                     "tcsetwinsize, arg 2: must be 2 element list");
+                     "tcsetwinsize, arg 2: must be a two-item tuple");
         return NULL;
     }
 
@@ -432,8 +432,8 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
         return PyErr_SetFromErrno(state->TermiosError);
     }
 
-    s.ts_lines = (int) PyLong_AsLong(PyList_GetItem(winsz, 0));
-    s.ts_cols = (int) PyLong_AsLong(PyList_GetItem(winsz, 1));
+    s.ts_lines = (int) PyLong_AsLong(PyTuple_GetItem(winsz, 0));
+    s.ts_cols = (int) PyLong_AsLong(PyTuple_GetItem(winsz, 1));
     if (PyErr_Occurred()) {
         return NULL;
     }

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -427,7 +427,7 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
 
     w.ws_row = (unsigned short) winsz_0;
     w.ws_col = (unsigned short) winsz_1;
-    if (((long)w.ws_row) != winsz_0) || (((long)w.ws_col) != winsz_1) {
+    if ((((long)w.ws_row) != winsz_0) || (((long)w.ws_col) != winsz_1)) {
         PyErr_SetString(PyExc_OverflowError,
                         "winsize value(s) out of range.");
         return NULL;
@@ -447,7 +447,7 @@ termios_tcsetwinsize_impl(PyObject *module, int fd, PyObject *winsz)
 
     s.ts_lines = (int) winsz_0;
     s.ts_cols = (int) winsz_1;
-    if (((long)s.ts_lines) != winsz_0) || (((long)s.ts_cols) != winsz_1) {
+    if ((((long)s.ts_lines) != winsz_0) || (((long)s.ts_cols) != winsz_1)) {
         PyErr_SetString(PyExc_OverflowError,
                         "winsize value(s) out of range.");
         return NULL;


### PR DESCRIPTION
This follows #23536. Also, see #23546, #23740.

`tcgetwinsize()` and `tcsetwinsize()` are expected to appear in IEEE Std 1003.1 ("POSIX.1") issue 8 [ the upcoming version of POSIX ] as declarations in `<termios.h>`; see https://www.austingroupbugs.net/view.php?id=1151#c3856.

NetBSD already has them (thanks to user "kre"):

1. http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/termios/tcgetwinsize.c?only_with_tag=MAIN
2. http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/termios/tcsetwinsize.c?only_with_tag=MAIN

Update: musl libc also has these functions.
Update2: The patches that I had submitted to add tcgetwinsize() and tcsetwinsize() to the FreeBSD libc have been merged. I am still working on getting them included in glibc.

When POSIX.1 issue 8 is released, `termios.tcgetwinsize()`, `termios.tcsetwinsize()` can be updated to utilize the native versions.

Post #23686, #23546, #23740 goals:
1. add `test_winsize()` to "Lib/test/test_pty.py";
2. major revision of "Lib/pty.py", which has not happened since the beginning of the millennium.

Signed-off-by: Soumendra Ganguly <soumendraganguly@gmail.com>

<!-- issue-number: [bpo-41818](https://bugs.python.org/issue41818) -->
https://bugs.python.org/issue41818
<!-- /issue-number -->
