### PR TITLE
bpo-42604: always set EXT_SUFFIX=${SOABI}${SHLIB_SUFFIX} when using configure

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-12-20-02-35-28.bpo-42604.gRd89w.rst
+++ b/Misc/NEWS.d/next/Build/2020-12-20-02-35-28.bpo-42604.gRd89w.rst
@@ -1,0 +1,4 @@
+Now all platforms use a value for the "EXT_SUFFIX" build variable derived
+from SOABI (for instance in freeBSD, "EXT_SUFFIX" is now ".cpython-310d.so"
+instead of ".so"). Previosuly only Linux, Mac and VxWorks were using a value
+for "EXT_SUFFIX" that included "SOABI".

--- a/configure
+++ b/configure
@@ -15429,13 +15429,7 @@ _ACEOF
 
 fi
 
-
-case $ac_sys_system in
-    Linux*|GNU*|Darwin|VxWorks)
-	EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX};;
-    *)
-	EXT_SUFFIX=${SHLIB_SUFFIX};;
-esac
+EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX}
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking LDVERSION" >&5
 $as_echo_n "checking LDVERSION... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -4786,12 +4786,7 @@ if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
 fi
 
 AC_SUBST(EXT_SUFFIX)
-case $ac_sys_system in
-    Linux*|GNU*|Darwin|VxWorks)
-	EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX};;
-    *)
-	EXT_SUFFIX=${SHLIB_SUFFIX};;
-esac
+EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX}
 
 AC_MSG_CHECKING(LDVERSION)
 LDVERSION='$(VERSION)$(ABIFLAGS)'


### PR DESCRIPTION
Continuation of bpo 39825 which was fixed for windows in gh-22088. This fix is for non-linux systems like FreeBSD and AIX. Merging gh-22088 added a test which fails on FreeBSD and AIX:

```
FAIL: test_EXT_SUFFIX_in_vars (test.test_sysconfig.TestSysConfig)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/home/buildbot/python/3.x.koobs-freebsd-564d/build/Lib/test/test_sysconfig.py", line 368, in \
               test_EXT_SUFFIX_in_vars
    self.assertEqual(vars['EXT_SUFFIX'], _imp.extension_suffixes()[0])
AssertionError: '.so' != '.cpython-310d.so'
- .so
+ .cpython-310d.so
```

So `EXT_SUFFIX` is being set to `.so` rather than `.cpython-310d.so`. This is wrong, `EXT_SUFFIX` is expected to be `.cpython-310d.so` in this case. 

The difference in `EXT_SUFFIX` comes from this stanza in `configure` and `configure.ac`:

```
case $ac_sys_system in
    Linux*|GNU*|Darwin|VxWorks)
	EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX};;
    *)
	EXT_SUFFIX=${SHLIB_SUFFIX};;
esac
```

where `$ac_sys_system` is `uname -s`. On FREEBSD, this is `FreeBSD`, and I think on AIX it is `AIX`. This stanza was in the original version of the files, I am not sure why the original author differentiated between the two values for `EXT_SUFFIX`.

<!-- issue-number: [bpo-42604](https://bugs.python.org/issue42604) -->
https://bugs.python.org/issue42604
<!-- /issue-number -->