### PR TITLE
bpo-32381: Remove unused _Py_fopen() function

### DIFF
--- a/Include/cpython/fileutils.h
+++ b/Include/cpython/fileutils.h
@@ -95,10 +95,6 @@ PyAPI_FUNC(FILE *) _Py_wfopen(
     const wchar_t *path,
     const wchar_t *mode);
 
-PyAPI_FUNC(FILE*) _Py_fopen(
-    const char *pathname,
-    const char *mode);
-
 PyAPI_FUNC(FILE*) _Py_fopen_obj(
     PyObject *path,
     const char *mode);

--- a/Misc/NEWS.d/next/C API/2020-12-09-00-35-25.bpo-32381.Je08Ny.rst
+++ b/Misc/NEWS.d/next/C API/2020-12-09-00-35-25.bpo-32381.Je08Ny.rst
@@ -1,0 +1,3 @@
+Remove the private :c:func:`_Py_fopen` function which is no longer needed.
+Use :c:func:`_Py_wfopen` or :c:func:`_Py_fopen_obj` instead. Patch by Victor
+Stinner.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1455,33 +1455,6 @@ _Py_wfopen(const wchar_t *path, const wchar_t *mode)
     return f;
 }
 
-/* Wrapper to fopen().
-
-   The file descriptor is created non-inheritable.
-
-   If interrupted by a signal, fail with EINTR. */
-FILE*
-_Py_fopen(const char *pathname, const char *mode)
-{
-    PyObject *pathname_obj = PyUnicode_DecodeFSDefault(pathname);
-    if (pathname_obj == NULL) {
-        return NULL;
-    }
-    if (PySys_Audit("open", "Osi", pathname_obj, mode, 0) < 0) {
-        Py_DECREF(pathname_obj);
-        return NULL;
-    }
-    Py_DECREF(pathname_obj);
-
-    FILE *f = fopen(pathname, mode);
-    if (f == NULL)
-        return NULL;
-    if (make_non_inheritable(fileno(f)) < 0) {
-        fclose(f);
-        return NULL;
-    }
-    return f;
-}
 
 /* Open a file. Call _wfopen() on Windows, or encode the path to the filesystem
    encoding and call fopen() otherwise.


### PR DESCRIPTION
Remove the private _Py_fopen() function which is no longer needed.
Use _Py_wfopen` or _Py_fopen_obj() instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32381](https://bugs.python.org/issue32381) -->
https://bugs.python.org/issue32381
<!-- /issue-number -->
