### PR TITLE
gh-86772: Support POSIX atomicity guarantee of O_APPEND on Windows

### DIFF
--- a/Include/cpython/fileutils.h
+++ b/Include/cpython/fileutils.h
@@ -91,6 +91,13 @@ PyAPI_FUNC(int) _Py_open_noraise(
     const char *pathname,
     int flags);
 
+#ifdef MS_WINDOWS
+PyAPI_FUNC(int) _Py_wopen_noraise(
+    const wchar_t *pathname,
+    int flags,
+    int mode);
+#endif
+
 PyAPI_FUNC(FILE *) _Py_wfopen(
     const wchar_t *path,
     const wchar_t *mode);

--- a/Misc/NEWS.d/next/Windows/2020-12-09-03-03-02.bpo-42606.IJ9e6N.rst
+++ b/Misc/NEWS.d/next/Windows/2020-12-09-03-03-02.bpo-42606.IJ9e6N.rst
@@ -1,0 +1,2 @@
+Support POSIX atomicity guarantee of ``O_APPEND`` on Windows for :func:`open`
+and :func:`os.open`.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -381,7 +381,7 @@ _Py_COMP_DIAG_POP
             do {
                 Py_BEGIN_ALLOW_THREADS
 #ifdef MS_WINDOWS
-                self->fd = _wopen(widename, flags, 0666);
+                self->fd = _Py_wopen_noraise(widename, flags, 0666);
 #else
                 self->fd = open(name, flags, 0666);
 #endif

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9060,7 +9060,7 @@ os_open_impl(PyObject *module, path_t *path, int flags, int mode, int dir_fd)
     do {
         Py_BEGIN_ALLOW_THREADS
 #ifdef MS_WINDOWS
-        fd = _wopen(path->wide, flags, mode);
+        fd = _Py_wopen_noraise(path->wide, flags, mode);
 #else
 #ifdef HAVE_OPENAT
         if (dir_fd != DEFAULT_DIR_FD) {


### PR DESCRIPTION
On POSIX-conforming systems, O_APPEND flag for open() must ensure
that no intervening file modification occurs between changing the file
offset and the write operation[1]. In effect, two processes that
independently opened the same file with O_APPEND can't overwrite
each other's data. On Windows, however, the Microsoft C runtime
implements O_APPEND as an lseek(fd, 0, SEEK_END) followed by write(),
which obviously doesn't provide the above guarantee. This affects
both os.open() and the builtin open() Python functions, which rely on
_wopen() from MSVCRT.

One way to achieve the desired behavior is to ensure that the Windows
handle backing the MSVCRT file descriptor has FILE_APPEND_DATA access
right, but doesn't have FILE_WRITE_DATA. This makes the Windows kernel
enforce the described semantics.

To avoid full reimplementation of _wopen(), implement the above by
duplicating the MSVCRT-created handle with fixed up access rights and
wrapping it with a new file descriptor. Note that handles created by
functions like os.dup() will still have the correct access rights (and
thus atomic behavior) because MSVCRT duplicates them with
DUPLICATE_SAME_ACCESS flag.

[1] https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42606](https://bugs.python.org/issue42606) -->
https://bugs.python.org/issue42606
<!-- /issue-number -->

<!-- gh-issue-number: gh-86772 -->
* Issue: gh-86772
<!-- /gh-issue-number -->
