### PR TITLE
bpo-39791: importlib.abc: avoid use of deprecated abstractproperty

### DIFF
--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -401,7 +401,8 @@ class Traversable(Protocol):
         accepted by io.TextIOWrapper.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self):
         # type: () -> str
         """


### PR DESCRIPTION


<!-- issue-number: [bpo-39791](https://bugs.python.org/issue39791) -->
https://bugs.python.org/issue39791
<!-- /issue-number -->
