### PR TITLE
bpo-31904: skip some tests of changing owner in _test_all_chown_common() on VxWorks

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -724,10 +724,13 @@ class PosixTester(unittest.TestCase):
         chown_func(first_param, uid, -1)
         check_stat(uid, gid)
 
-        # On VxWorks root user id is 1 and 0 means no login user. And
-        # both are super users.
-        superuser_uids = ((0,) if sys.platform != "vxworks" else (0, 1))
-        if uid in superuser_uids:
+        if sys.platform == "vxworks":
+            # On VxWorks, root user id is 1 and 0 means no login user:
+            # both are super users.
+            is_root = (uid in (0, 1))
+        else:
+            is_root = (uid == 0)
+        if is_root:
             # Try an amusingly large uid/gid to make sure we handle
             # large unsigned values.  (chown lets you use any
             # uid/gid you like, even if they aren't defined.)

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -724,44 +724,47 @@ class PosixTester(unittest.TestCase):
         chown_func(first_param, uid, -1)
         check_stat(uid, gid)
 
-        # On VxWorks root user id is 1 and 0 means no login user. It also
-        # allows non-root user to chown() to root.
-        if sys.platform != "vxworks":
-            if uid == 0:
-                # Try an amusingly large uid/gid to make sure we handle
-                # large unsigned values.  (chown lets you use any
-                # uid/gid you like, even if they aren't defined.)
-                #
-                # This problem keeps coming up:
-                #   http://bugs.python.org/issue1747858
-                #   http://bugs.python.org/issue4591
-                #   http://bugs.python.org/issue15301
-                # Hopefully the fix in 4591 fixes it for good!
-                #
-                # This part of the test only runs when run as root.
-                # Only scary people run their tests as root.
+        # On VxWorks root user id is 1 and 0 means no login user. And
+        # both are super users.
+        superuser_uids = ((0,) if sys.platform != "vxworks" else (0, 1))
+        if uid in superuser_uids:
+            # Try an amusingly large uid/gid to make sure we handle
+            # large unsigned values.  (chown lets you use any
+            # uid/gid you like, even if they aren't defined.)
+            #
+            # On VxWorks uid_t is defined as unsigned short. A big
+            # value greater than 65535 will result in underflow error.
+            #
+            # This problem keeps coming up:
+            #   http://bugs.python.org/issue1747858
+            #   http://bugs.python.org/issue4591
+            #   http://bugs.python.org/issue15301
+            # Hopefully the fix in 4591 fixes it for good!
+            #
+            # This part of the test only runs when run as root.
+            # Only scary people run their tests as root.
 
-                big_value = 2**31
-                chown_func(first_param, big_value, big_value)
-                check_stat(big_value, big_value)
-                chown_func(first_param, -1, -1)
-                check_stat(big_value, big_value)
-                chown_func(first_param, uid, gid)
+            big_value = (2**31 if sys.platform != "vxworks" else 2**15)
+            chown_func(first_param, big_value, big_value)
+            check_stat(big_value, big_value)
+            chown_func(first_param, -1, -1)
+            check_stat(big_value, big_value)
+            chown_func(first_param, uid, gid)
+            check_stat(uid, gid)
+        elif platform.system() in ('HP-UX', 'SunOS'):
+            # HP-UX and Solaris can allow a non-root user to chown() to root
+            # (issue #5113)
+            raise unittest.SkipTest("Skipping because of non-standard chown() "
+                                    "behavior")
+        else:
+            # non-root cannot chown to root, raises OSError
+            self.assertRaises(OSError, chown_func, first_param, 0, 0)
+            check_stat(uid, gid)
+            self.assertRaises(OSError, chown_func, first_param, 0, -1)
+            check_stat(uid, gid)
+            if 0 not in os.getgroups():
+                self.assertRaises(OSError, chown_func, first_param, -1, 0)
                 check_stat(uid, gid)
-            elif platform.system() in ('HP-UX', 'SunOS'):
-                # HP-UX and Solaris can allow a non-root user to chown() to root
-                # (issue #5113)
-                raise unittest.SkipTest("Skipping because of non-standard chown() "
-                                        "behavior")
-            else:
-                # non-root cannot chown to root, raises OSError
-                self.assertRaises(OSError, chown_func, first_param, 0, 0)
-                check_stat(uid, gid)
-                self.assertRaises(OSError, chown_func, first_param, 0, -1)
-                check_stat(uid, gid)
-                if 0 not in os.getgroups():
-                    self.assertRaises(OSError, chown_func, first_param, -1, 0)
-                    check_stat(uid, gid)
         # test illegal types
         for t in str, float:
             self.assertRaises(TypeError, chown_func, first_param, t(uid), gid)

--- a/Misc/NEWS.d/next/Tests/2020-12-09-15-23-28.bpo-31904.ghj38d.rst
+++ b/Misc/NEWS.d/next/Tests/2020-12-09-15-23-28.bpo-31904.ghj38d.rst
@@ -1,0 +1,1 @@
+Skip some tests in _test_all_chown_common() on VxWorks.


### PR DESCRIPTION
On VxWorks root user id is 1 and 0 means no login user. It also allows non-root user to chown() to root. So related test on VxWorks is invalid. Skip them.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
