### PR TITLE
Add descriptive error message when environment variable not detected

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -676,7 +676,7 @@ class _Environ(MutableMapping):
             value = self._data[self.encodekey(key)]
         except KeyError:
             # raise KeyError with the original key value
-            raise KeyError(key) from None
+            raise KeyError("Environment variable '{}' was requested, but not found.".format(key)) from None
         return self.decodevalue(value)
 
     def __setitem__(self, key, value):
@@ -692,7 +692,7 @@ class _Environ(MutableMapping):
             del self._data[encodedkey]
         except KeyError:
             # raise KeyError with the original key value
-            raise KeyError(key) from None
+            raise KeyError("Environment variable '{}' was requested, but not found.".format(key)) from None
 
     def __iter__(self):
         # list() from dict object is an atomic operation

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -676,7 +676,7 @@ class _Environ(MutableMapping):
             value = self._data[self.encodekey(key)]
         except KeyError:
             # raise KeyError with the original key value
-            raise KeyError("Environment variable '{}' was requested, but not found.".format(key)) from None
+            raise KeyError(f"Environment variable '{repr(key)}' requested but not provided.") from None
         return self.decodevalue(value)
 
     def __setitem__(self, key, value):
@@ -692,7 +692,7 @@ class _Environ(MutableMapping):
             del self._data[encodedkey]
         except KeyError:
             # raise KeyError with the original key value
-            raise KeyError("Environment variable '{}' was requested, but not found.".format(key)) from None
+            raise KeyError(key) from None
 
     def __iter__(self):
         # list() from dict object is an atomic operation

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1133,12 +1133,12 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
 
         with self.assertRaises(KeyError) as cm:
             os.environ[missing]
-        self.assertIs(cm.exception.args[0], missing)
+        self.assertIn(missing, cm.exception.args[0])
         self.assertTrue(cm.exception.__suppress_context__)
 
         with self.assertRaises(KeyError) as cm:
             del os.environ[missing]
-        self.assertIs(cm.exception.args[0], missing)
+        self.assertIn(missing, cm.exception.args[0])
         self.assertTrue(cm.exception.__suppress_context__)
 
     def _test_environ_iteration(self, collection):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1133,12 +1133,12 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
 
         with self.assertRaises(KeyError) as cm:
             os.environ[missing]
-        self.assertIn(missing, cm.exception.args[0])
+        self.assertIs(cm.exception.args[0], missing)
         self.assertTrue(cm.exception.__suppress_context__)
 
         with self.assertRaises(KeyError) as cm:
             del os.environ[missing]
-        self.assertIn(missing, cm.exception.args[0])
+        self.assertIs(cm.exception.args[0], missing)
         self.assertTrue(cm.exception.__suppress_context__)
 
     def _test_environ_iteration(self, collection):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1133,7 +1133,7 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
 
         with self.assertRaises(KeyError) as cm:
             os.environ[missing]
-        self.assertTrue(repr(missing) in cm.exception.args[0])
+        self.assertIn(repr(missing), cm.exception.args[0])
         self.assertTrue(cm.exception.__suppress_context__)
 
         with self.assertRaises(KeyError) as cm:

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1133,7 +1133,7 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
 
         with self.assertRaises(KeyError) as cm:
             os.environ[missing]
-        self.assertIs(cm.exception.args[0], missing)
+        self.assertTrue(repr(missing) in cm.exception.args[0])
         self.assertTrue(cm.exception.__suppress_context__)
 
         with self.assertRaises(KeyError) as cm:


### PR DESCRIPTION
Using `os.environ[KEY]` with a non-existent environment variable key only gave a simple KeyError, so now, the error message should make more sense when encountered. Obviously, fix my style if it's not up to standard.

Linked bugtracker post: https://bugs.python.org/issue44264