### PR TITLE
bpo-31904: Define THREAD_STACK_SIZE for VxWorks

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-12-09-15-23-28.bpo-31904.g3k5k3.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-09-15-23-28.bpo-31904.g3k5k3.rst
@@ -1,0 +1,1 @@
+Define THREAD_STACK_SIZE for VxWorks.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -62,6 +62,10 @@
 #   define THREAD_STACK_SIZE    0x800000
 #   endif
 #endif
+#if defined(__VXWORKS__) && defined(THREAD_STACK_SIZE) && THREAD_STACK_SIZE == 0
+#undef  THREAD_STACK_SIZE
+#define THREAD_STACK_SIZE       0x100000
+#endif
 /* for safety, ensure a viable minimum stacksize */
 #define THREAD_STACK_MIN        0x8000  /* 32 KiB */
 #else  /* !_POSIX_THREAD_ATTR_STACKSIZE */


### PR DESCRIPTION
Define empirically determined minimal stack sizes for VxWorks.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
