### PR TITLE
Add two spaces around equal sign in documentation

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1281,7 +1281,7 @@ be used directly:
 
 becomes::
 
-   output=check_output("dmesg | grep hda", shell=True)
+   output = check_output("dmesg | grep hda", shell=True)
 
 
 Replacing :func:`os.system`


### PR DESCRIPTION
So it fits to PEP8 coding style.

This PR is an aesthetic improvement, so I don't think it needs a bpo number nor a line in NEWS.