### PR TITLE
bpo-32381: pymain_run_command() uses PyCF_IGNORE_COOKIE

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -153,11 +153,13 @@ class CmdLineTest(unittest.TestCase):
                    % (os_helper.FS_NONASCII, ord(os_helper.FS_NONASCII)))
         assert_python_ok('-c', command)
 
+    @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_coding(self):
         # bpo-32381: the -c command ignores the coding cookie
-        cmd = f"# coding: latin1\nprint(ascii('\xe9'))"
+        ch = os_helper.FS_NONASCII
+        cmd = f"# coding: latin1\nprint(ascii('{ch}'))"
         res = assert_python_ok('-c', cmd)
-        self.assertEqual(res.out.rstrip(), b"'\\xe9'")
+        self.assertEqual(res.out.rstrip(), ascii(ch).encode('ascii'))
 
     # On Windows, pass bytes to subprocess doesn't test how Python decodes the
     # command line, but how subprocess does decode bytes to unicode. Python

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -153,6 +153,12 @@ class CmdLineTest(unittest.TestCase):
                    % (os_helper.FS_NONASCII, ord(os_helper.FS_NONASCII)))
         assert_python_ok('-c', command)
 
+    def test_coding(self):
+        # bpo-32381: the -c command ignores the coding cookie
+        cmd = f"# coding: latin1\nprint(ascii('\xe9'))"
+        res = assert_python_ok('-c', cmd)
+        self.assertEqual(res.out.rstrip(), b"'\\xe9'")
+
     # On Windows, pass bytes to subprocess doesn't test how Python decodes the
     # command line, but how subprocess does decode bytes to unicode. Python
     # doesn't decode the command line because Windows provides directly the

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-15-18-43-43.bpo-32381.3tIofL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-15-18-43-43.bpo-32381.3tIofL.rst
@@ -1,0 +1,2 @@
+The coding cookie (ex: ``# coding: latin1``) is now ignored in the command
+passed to the :option:`-c` command line option. Patch by Victor Stinner.


### PR DESCRIPTION
Since pymain_run_command() uses UTF-8, pass PyCF_IGNORE_COOKIE
compiler flag to the parser.

And pymain_run_python() no longer propage compiler flags between
function calls.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32381](https://bugs.python.org/issue32381) -->
https://bugs.python.org/issue32381
<!-- /issue-number -->
