### PR TITLE
bpo-34750: [Enum] add `_EnumDict.update()` support

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -112,7 +112,7 @@ class _EnumDict(dict):
                 key = '_order_'
         elif key in self._member_names:
             # descriptor overwriting an enum?
-            raise TypeError('Attempted to reuse key: %r' % key)
+            raise TypeError('%r already defined as: %r' % (key, self[key]))
         elif key in self._ignore:
             pass
         elif not _is_descriptor(value):
@@ -132,6 +132,16 @@ class _EnumDict(dict):
             self._member_names.append(key)
             self._last_values.append(value)
         super().__setitem__(key, value)
+
+    def update(self, members, **more_members):
+        try:
+            for name in members.keys():
+                self[name] = members[name]
+        except AttributeError:
+            for name, value in members:
+                self[name] = value
+        for name, value in more_members.items():
+            self[name] = value
 
 
 # Dummy value for Enum as EnumMeta explicitly checks for it, but of course

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2118,6 +2118,34 @@ class TestEnum(unittest.TestCase):
                 one = '1'
                 two = b'2', 'ascii', 9
 
+    def test_dynamic_members_with_static_methods(self):
+        #
+        foo_defines = {'FOO_CAT': 'aloof', 'BAR_DOG': 'friendly', 'FOO_HORSE': 'big'}
+        class Foo(Enum):
+            vars().update({
+                    k: v
+                    for k, v in foo_defines.items()
+                    if k.startswith('FOO_')
+                    })
+            def upper(self):
+                return self.value.upper()
+        self.assertEqual(list(Foo), [Foo.FOO_CAT, Foo.FOO_HORSE])
+        self.assertEqual(Foo.FOO_CAT.value, 'aloof')
+        self.assertEqual(Foo.FOO_HORSE.upper(), 'BIG')
+        #
+        with self.assertRaisesRegex(TypeError, "'FOO_CAT' already defined as: 'aloof'"):
+            class FooBar(Enum):
+                vars().update({
+                        k: v
+                        for k, v in foo_defines.items()
+                        if k.startswith('FOO_')
+                        },
+                        **{'FOO_CAT': 'small'},
+                        )
+                def upper(self):
+                    return self.value.upper()
+
+
 class TestOrder(unittest.TestCase):
 
     def test_same_members(self):

--- a/Misc/NEWS.d/next/Library/2020-12-09-14-15-48.bpo-34750.x8TASR.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-09-14-15-48.bpo-34750.x8TASR.rst
@@ -1,0 +1,1 @@
+[Enum] `_EnumDict.update()` is now supported


### PR DESCRIPTION
This allows easier Enum construction in unusual cases, such as including dynamic member definitions into a `class` definition:

    # created dynamically
    foo_defines = {'FOO_CAT': 'aloof', 'BAR_DOG': 'friendly', 'FOO_HORSE': 'big'}

    class Foo(Enum):
        vars().update({
                k: v
                for k, v in foo_defines.items()
                if k.startswith('FOO_')
                })
        def upper(self):
            # example method
            return self.value.upper()


<!-- issue-number: [bpo-34750](https://bugs.python.org/issue34750) -->
https://bugs.python.org/issue34750
<!-- /issue-number -->
