### PR TITLE
bpo-41877: Improve docs for assert misspellings check in mock

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -262,9 +262,10 @@ the *new_callable* argument to :func:`patch`.
       this is a new Mock (created on first access). See the
       :attr:`return_value` attribute.
 
-    * *unsafe*: By default if any attribute starts with *assert* or
-      *assret* will raise an :exc:`AttributeError`. Passing ``unsafe=True``
-      will allow access to these attributes.
+    * *unsafe*: By default, accessing any attribute with name starting with
+      *assert*, *assret*, *asert*, *aseert* or *assrt* will raise an
+      :exc:`AttributeError`. Passing ``unsafe=True`` will allow access to
+      these attributes.
 
       .. versionadded:: 3.5
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -632,8 +632,10 @@ class NonCallableMock(Base):
             raise AttributeError(name)
         if not self._mock_unsafe:
             if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')):
-                raise AttributeError("Attributes cannot start with 'assert' "
-                                     "or its misspellings")
+                raise AttributeError(
+                    "%r is not a valid assertion. "
+                    "Use a spec for the mock if %r is meant to be an attribute."
+                    % (name, name))
 
         result = self._mock_children.get(name)
         if result is _deleted:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -633,9 +633,8 @@ class NonCallableMock(Base):
         if not self._mock_unsafe:
             if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')):
                 raise AttributeError(
-                    "%r is not a valid assertion. "
-                    "Use a spec for the mock if %r is meant to be an attribute."
-                    % (name, name))
+                    f"{name} is not a valid assertion. Use a spec "
+                    f"for the mock if {name} is meant to be an attribute.")
 
         result = self._mock_children.get(name)
         if result is _deleted:

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1598,7 +1598,7 @@ class MockTest(unittest.TestCase):
     #Issue21238
     def test_mock_unsafe(self):
         m = Mock()
-        msg = "Attributes cannot start with 'assert' or its misspellings"
+        msg = "is not a valid assertion. Use a spec for the mock"
         with self.assertRaisesRegex(AttributeError, msg):
             m.assert_foo_call()
         with self.assertRaisesRegex(AttributeError, msg):

--- a/Misc/NEWS.d/next/Library/2020-12-10-09-24-44.bpo-41877.iJSCvM.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-10-09-24-44.bpo-41877.iJSCvM.rst
@@ -1,0 +1,1 @@
+AttributeError for suspected misspellings of assertions on mocks are now pointing out that the cause are misspelled assertions and also what to do if the misspelling is actually an intended attribute name. The unittest.mock document is also updated to reflect the current set of recognised misspellings.


### PR DESCRIPTION
This is a follow-up to
https://github.com/python/cpython/commit/4662fa9bfe4a849fe87bfb321d8ef0956c89a772.
That original commit expanded guards against misspelling assertions on
mocks. This follow-up updates the documentation and improves the error
message by pointing out the potential cause and solution.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41877](https://bugs.python.org/issue41877) -->
https://bugs.python.org/issue41877
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead