### PR TITLE
[3.9] bpo-42591: Export missing Py_FrozenMain() symbol (GH-23730)

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -32,6 +32,8 @@ PyAPI_FUNC(void) _Py_NO_RETURN Py_Exit(int);
 /* Bootstrap __main__ (defined in Modules/main.c) */
 PyAPI_FUNC(int) Py_Main(int argc, wchar_t **argv);
 
+PyAPI_FUNC(int) Py_FrozenMain(int argc, char **argv);
+
 PyAPI_FUNC(int) Py_BytesMain(int argc, char **argv);
 
 /* In pathconfig.c */

--- a/Misc/NEWS.d/next/C API/2020-12-10-10-43-03.bpo-42591.CXNY8G.rst
+++ b/Misc/NEWS.d/next/C API/2020-12-10-10-43-03.bpo-42591.CXNY8G.rst
@@ -1,0 +1,3 @@
+Export the :c:func:`Py_FrozenMain` function: fix a Python 3.9.0 regression.
+Python 3.9 uses ``-fvisibility=hidden`` and the function was not exported
+explicitly and so not exported.


### PR DESCRIPTION
Export the Py_FrozenMain() function: fix a Python 3.9.0 regression.
Python 3.9 uses -fvisibility=hidden and the function was not exported
explicitly and so not exported.

(cherry picked from commit b5c7b38f5ebbc84b5b80192db1743d3e1cdcf4c5)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42591](https://bugs.python.org/issue42591) -->
https://bugs.python.org/issue42591
<!-- /issue-number -->
