### PR TITLE
bpo-42385: [Enum] add `_generate_next_value_` to StrEnum

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -67,10 +67,12 @@ helper, :class:`auto`.
 
 .. class:: auto
 
-    Instances are replaced with an appropriate value for Enum members.  By default, the initial value starts at 1.
+    Instances are replaced with an appropriate value for Enum members.
+    :class:`StrEnum` defaults to the lower-cased version of the member name,
+    while other Enums default to 1 and increase from there.
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
-
+.. versionadded:: 3.10  ``StrEnum``
 
 Creating an Enum
 ----------------

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -826,6 +826,12 @@ class StrEnum(str, Enum):
 
     __str__ = str.__str__
 
+    def _generate_next_value_(name, start, count, last_values):
+        """
+        Return the lower-cased version of the member name.
+        """
+        return name.lower()
+
 
 def _reduce_ex_by_name(self, proto):
     return self.name

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2179,6 +2179,12 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(Private._Private__corporal, 'Radar')
         self.assertEqual(Private._Private__major_, 'Hoolihan')
 
+    def test_strenum_auto(self):
+        class Strings(StrEnum):
+            ONE = auto()
+            TWO = auto()
+        self.assertEqual([Strings.ONE, Strings.TWO], ['one', 'two'])
+
 
 class TestOrder(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2020-12-09-19-45-32.bpo-42385.boGbjo.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-09-19-45-32.bpo-42385.boGbjo.rst
@@ -1,0 +1,1 @@
+StrEnum: fix _generate_next_value_ to return a str


### PR DESCRIPTION
The default for `auto()` is to return an integer, which doesn't work for `StrEnum`.

<!-- issue-number: [bpo-42385](https://bugs.python.org/issue42385) -->
https://bugs.python.org/issue42385
<!-- /issue-number -->
