### PR TITLE
bpo-41928: Add support for Unicode Path Extra Field in ZipFile

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -317,7 +317,7 @@ def _EndRecData(fpin):
 def _sanitize_filename(filename):
     """Terminate the file name at the first null byte and
     ensure paths always use forward slashes as the directory separator."""
-    
+
     # Terminate the file name at the first null byte.  Null bytes in file
     # names are used as tricks by viruses in archives.
     null_byte = filename.find(chr(0))

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -504,11 +504,14 @@ class ZipInfo (object):
                         if up_unicode_name:
                             self.filename = _sanitize_filename(up_unicode_name)
                         else:
-                            raise BadZipFile("Empty unicode path extra field (0x7075)")
+                            import warnings
+                            warnings.warn("Empty unicode path extra field (0x7075)", stacklevel=2)
                 except struct.error:
-                    raise BadZipFile("Corrupt unicode path extra field (0x7075)")
+                    import warnings
+                    warnings.warn("Corrupt unicode path extra field (0x7075)", stacklevel=2)
                 except UnicodeDecodeError:
-                    raise BadZipFile("Corrupt unicode path extra field (0x7075) - invalid unicode bytes")
+                    import warnings
+                    warnings.warn('Corrupt unicode path extra field (0x7075): invalid utf-8 bytes', stacklevel=2)
 
             extra = extra[ln+4:]
 

--- a/Misc/NEWS.d/next/Library/2020-12-10-19-48-31.bpo-41928.9TH76z.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-10-19-48-31.bpo-41928.9TH76z.rst
@@ -1,0 +1,1 @@
+Add support for Unicode Path Extra Field in ZipFile.


### PR DESCRIPTION
Add support for Unicode Path Extra Field (0x7075) following [4.6.9 APPNOTE.TXT - .ZIP File Format Specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).

<!-- issue-number: [bpo-41928](https://bugs.python.org/issue41928) -->
https://bugs.python.org/issue41928
<!-- /issue-number -->
