### PR TITLE
bpo-41877: Check for misspelled speccing arguments

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1245,7 +1245,7 @@ def _importer(target):
 # _check_spec_arg_typos takes kwargs from commands like patch and checks that
 # they don't contain common misspellings of arguments related to autospeccing.
 def _check_spec_arg_typos(kwargs_to_check):
-    typos = ["autospect", "auto_spec", "set_spec"]
+    typos = ("autospect", "auto_spec", "set_spec")
     for typo in typos:
         if typo in kwargs_to_check:
             raise RuntimeError(

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -654,8 +654,8 @@ class NonCallableMock(Base):
 
         elif isinstance(result, _SpecState):
             result = create_autospec(
-                result.spec, result.spec_set, result.instance,
-                result.parent, result.name
+                result.spec, spec_set=result.spec_set, instance=result.instance,
+                _parent=result.parent, _name=result.name
             )
             self._mock_children[name]  = result
 
@@ -1242,6 +1242,17 @@ def _importer(target):
     return thing
 
 
+# _check_spec_arg_typos takes kwargs from commands like patch and checks that
+# they don't contain common misspellings of arguments related to autospeccing.
+def _check_spec_arg_typos(kwargs_to_check):
+    typos = ["autospect", "auto_spec", "set_spec"]
+    for typo in typos:
+        if typo in kwargs_to_check:
+            raise RuntimeError(
+                f"{typo} might be a typo; use unsafe=True if this is intended"
+            )
+
+
 class _patch(object):
 
     attribute_name = None
@@ -1249,7 +1260,7 @@ class _patch(object):
 
     def __init__(
             self, getter, attribute, new, spec, create,
-            spec_set, autospec, new_callable, kwargs
+            spec_set, autospec, new_callable, unsafe, kwargs
         ):
         if new_callable is not None:
             if new is not DEFAULT:
@@ -1260,6 +1271,8 @@ class _patch(object):
                 raise ValueError(
                     "Cannot use 'autospec' and 'new_callable' together"
                 )
+        if not unsafe:
+            _check_spec_arg_typos(kwargs)
 
         self.getter = getter
         self.attribute = attribute
@@ -1278,7 +1291,7 @@ class _patch(object):
         patcher = _patch(
             self.getter, self.attribute, self.new, self.spec,
             self.create, self.spec_set,
-            self.autospec, self.new_callable, self.kwargs
+            self.autospec, self.new_callable, False, self.kwargs
         )
         patcher.attribute_name = self.attribute_name
         patcher.additional_patchers = [
@@ -1569,7 +1582,7 @@ def _get_target(target):
 def _patch_object(
         target, attribute, new=DEFAULT, spec=None,
         create=False, spec_set=None, autospec=None,
-        new_callable=None, **kwargs
+        new_callable=None, unsafe=False, **kwargs
     ):
     """
     patch the named member (`attribute`) on an object (`target`) with a mock
@@ -1591,7 +1604,7 @@ def _patch_object(
     getter = lambda: target
     return _patch(
         getter, attribute, new, spec, create,
-        spec_set, autospec, new_callable, kwargs
+        spec_set, autospec, new_callable, unsafe, kwargs
     )
 
 
@@ -1631,13 +1644,13 @@ def _patch_multiple(target, spec=None, create=False, spec_set=None,
     attribute, new = items[0]
     patcher = _patch(
         getter, attribute, new, spec, create, spec_set,
-        autospec, new_callable, {}
+        autospec, new_callable, False, {}
     )
     patcher.attribute_name = attribute
     for attribute, new in items[1:]:
         this_patcher = _patch(
             getter, attribute, new, spec, create, spec_set,
-            autospec, new_callable, {}
+            autospec, new_callable, False, {}
         )
         this_patcher.attribute_name = attribute
         patcher.additional_patchers.append(this_patcher)
@@ -1646,7 +1659,7 @@ def _patch_multiple(target, spec=None, create=False, spec_set=None,
 
 def patch(
         target, new=DEFAULT, spec=None, create=False,
-        spec_set=None, autospec=None, new_callable=None, **kwargs
+        spec_set=None, autospec=None, new_callable=None, unsafe=False, **kwargs
     ):
     """
     `patch` acts as a function decorator, class decorator or a context
@@ -1708,6 +1721,10 @@ def patch(
     use "as" then the patched object will be bound to the name after the
     "as"; very useful if `patch` is creating a mock object for you.
 
+    Patch will raise a `RuntimeError` if passed some common misspellings of
+    the arguments autospec and spec_set. Pass the argument `unsafe` with the
+    value True to disable that check.
+
     `patch` takes arbitrary keyword arguments. These will be passed to
     `AsyncMock` if the patched object is asynchronous, to `MagicMock`
     otherwise or to `new_callable` if specified.
@@ -1718,7 +1735,7 @@ def patch(
     getter, attribute = _get_target(target)
     return _patch(
         getter, attribute, new, spec, create,
-        spec_set, autospec, new_callable, kwargs
+        spec_set, autospec, new_callable, unsafe, kwargs
     )
 
 
@@ -2567,8 +2584,8 @@ class _Call(tuple):
 call = _Call(from_kall=False)
 
 
-def create_autospec(spec, spec_set=False, instance=False, _parent=None,
-                    _name=None, **kwargs):
+def create_autospec(spec, spec_set=False, instance=False, unsafe=False,
+                    _parent=None, _name=None, **kwargs):
     """Create a mock object using another object as a spec. Attributes on the
     mock will use the corresponding attribute on the `spec` object as their
     spec.
@@ -2583,6 +2600,10 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     instance of the class) will have the same spec. You can use a class as the
     spec for an instance object by passing `instance=True`. The returned mock
     will only be callable if instances of the mock are callable.
+
+    `create_autospec` will raise a `RuntimeError` if passed some common
+    misspellings of the arguments autospec and spec_set. Pass the argument
+    `unsafe` with the value True to disable that check.
 
     `create_autospec` also takes arbitrary keyword arguments that are passed to
     the constructor of the created mock."""
@@ -2601,6 +2622,8 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         _kwargs = {}
     if _kwargs and instance:
         _kwargs['_spec_as_instance'] = True
+    if not unsafe:
+        _check_spec_arg_typos(kwargs)
 
     _kwargs.update(kwargs)
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -2225,7 +2225,7 @@ class MockTest(unittest.TestCase):
         m = create_autospec(Foo, set_spec=True, unsafe=True)
         with patch.multiple(
             f'{__name__}.Typos', autospect=True, set_spec=True, auto_spec=True):
-                pass
+            pass
 
 
 if __name__ == '__main__':

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -38,6 +38,12 @@ class Something(object):
     def smeth(a, b, c, d=None): pass
 
 
+class Typos(object):
+    autospect = None
+    auto_spec = None
+    set_spec = None
+
+
 def something(a): pass
 
 
@@ -2174,6 +2180,52 @@ class MockTest(unittest.TestCase):
         with unittest.mock.patch.object(obj, 'obj_with_bool_func', autospec=True): pass
 
         self.assertEqual(obj.obj_with_bool_func.__bool__.call_count, 0)
+
+    def test_misspelled_arguments(self):
+        class Foo(object):
+            one = 'one'
+        # patch, patch.object and create_autospec need to check for misspelled
+        # arguments explicitly and throw a RuntimError if found.
+        with self.assertRaises(RuntimeError):
+            with patch(f'{__name__}.Something.meth', autospect=True): pass
+        with self.assertRaises(RuntimeError):
+            with patch.object(Foo, 'one', autospect=True): pass
+        with self.assertRaises(RuntimeError):
+            with patch(f'{__name__}.Something.meth', auto_spec=True): pass
+        with self.assertRaises(RuntimeError):
+            with patch.object(Foo, 'one', auto_spec=True): pass
+        with self.assertRaises(RuntimeError):
+            with patch(f'{__name__}.Something.meth', set_spec=True): pass
+        with self.assertRaises(RuntimeError):
+            with patch.object(Foo, 'one', set_spec=True): pass
+        with self.assertRaises(RuntimeError):
+            m = create_autospec(Foo, set_spec=True)
+        # patch.multiple, on the other hand, should flag misspelled arguments
+        # through an AttributeError, when trying to find the keys from kwargs
+        # as attributes on the target.
+        with self.assertRaises(AttributeError):
+            with patch.multiple(
+                f'{__name__}.Something', meth=DEFAULT, autospect=True): pass
+        with self.assertRaises(AttributeError):
+            with patch.multiple(
+                f'{__name__}.Something', meth=DEFAULT, auto_spec=True): pass
+        with self.assertRaises(AttributeError):
+            with patch.multiple(
+                f'{__name__}.Something', meth=DEFAULT, set_spec=True): pass
+
+        with patch(f'{__name__}.Something.meth', unsafe=True, autospect=True):
+            pass
+        with patch.object(Foo, 'one', unsafe=True, autospect=True): pass
+        with patch(f'{__name__}.Something.meth', unsafe=True, auto_spec=True):
+            pass
+        with patch.object(Foo, 'one', unsafe=True, auto_spec=True): pass
+        with patch(f'{__name__}.Something.meth', unsafe=True, set_spec=True):
+            pass
+        with patch.object(Foo, 'one', unsafe=True, set_spec=True): pass
+        m = create_autospec(Foo, set_spec=True, unsafe=True)
+        with patch.multiple(
+            f'{__name__}.Typos', autospect=True, set_spec=True, auto_spec=True):
+                pass
 
 
 if __name__ == '__main__':

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -38,7 +38,7 @@ class Something(object):
     def smeth(a, b, c, d=None): pass
 
 
-class Typos(object):
+class Typos():
     autospect = None
     auto_spec = None
     set_spec = None
@@ -2182,7 +2182,7 @@ class MockTest(unittest.TestCase):
         self.assertEqual(obj.obj_with_bool_func.__bool__.call_count, 0)
 
     def test_misspelled_arguments(self):
-        class Foo(object):
+        class Foo():
             one = 'one'
         # patch, patch.object and create_autospec need to check for misspelled
         # arguments explicitly and throw a RuntimError if found.

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -1678,7 +1678,7 @@ class PatchTest(unittest.TestCase):
             getter, attribute = _get_target(target)
             return custom_patch(
                 getter, attribute, DEFAULT, None, False, None,
-                None, None, {}
+                None, None, False, {}
             )
 
         @with_custom_patch('squizz.squozz')
@@ -1810,7 +1810,7 @@ class PatchTest(unittest.TestCase):
                     stopped.append(attribute)
                     return super(mypatch, self).stop()
             return mypatch(lambda: thing, attribute, None, None,
-                           False, None, None, None, {})
+                           False, None, None, None, False, {})
         [get_patch(val).start() for val in ("one", "two", "three")]
         patch.stopall()
 

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -1678,7 +1678,7 @@ class PatchTest(unittest.TestCase):
             getter, attribute = _get_target(target)
             return custom_patch(
                 getter, attribute, DEFAULT, None, False, None,
-                None, None, False, {}
+                None, None, {}
             )
 
         @with_custom_patch('squizz.squozz')
@@ -1810,7 +1810,7 @@ class PatchTest(unittest.TestCase):
                     stopped.append(attribute)
                     return super(mypatch, self).stop()
             return mypatch(lambda: thing, attribute, None, None,
-                           False, None, None, None, False, {})
+                           False, None, None, None, {})
         [get_patch(val).start() for val in ("one", "two", "three")]
         patch.stopall()
 

--- a/Misc/NEWS.d/next/Library/2020-12-10-19-49-52.bpo-41877.wiVlPc.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-10-19-49-52.bpo-41877.wiVlPc.rst
@@ -1,0 +1,1 @@
+A check is added against misspellings of autospect, auto_spec and set_spec being passed as arguments to patch, patch.object and create_autospec.


### PR DESCRIPTION
patch, patch.object and create_autospec silently ignore misspelled
arguments such as autospect, auto_spec and set_spec. This can lead
to tests failing to check what they are supposed to check.

This change adds a check causing a RuntimeError if the above
functions get any of the above misspellings as arguments. It also
adds a new argument, "unsafe", which can be set to True to disable
this check.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41877](https://bugs.python.org/issue41877) -->
https://bugs.python.org/issue41877
<!-- /issue-number -->
