### PR TITLE
bpo-37324: Remove ABC aliases from collections

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -33,11 +33,6 @@ Python's general purpose built-in containers, :class:`dict`, :class:`list`,
 :class:`UserString`     wrapper around string objects for easier string subclassing
 =====================   ====================================================================
 
-.. deprecated-removed:: 3.3 3.10
-    Moved :ref:`collections-abstract-base-classes` to the :mod:`collections.abc` module.
-    For backwards compatibility, they continue to be visible in this module through
-    Python 3.9.
-
 
 :class:`ChainMap` objects
 -------------------------

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -484,6 +484,10 @@ Removed
   now due to the _warnings module was converted to a builtin module in 2.6.
   (Contributed by Hai Shi in :issue:`42599`.)
 
+* Remove deprecated aliases to :ref:`collections-abstract-base-classes` from
+  the :mod:`collections` module.
+  (Contributed by Victor Stinner in :issue:`37324`.)
+
 
 Porting to Python 3.10
 ======================

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -51,22 +51,6 @@ except ImportError:
     pass
 
 
-def __getattr__(name):
-    # For backwards compatibility, continue to make the collections ABCs
-    # through Python 3.6 available through the collections module.
-    # Note, no new collections ABCs were added in Python 3.7
-    if name in _collections_abc.__all__:
-        obj = getattr(_collections_abc, name)
-        import warnings
-        warnings.warn("Using or importing the ABCs from 'collections' instead "
-                      "of from 'collections.abc' is deprecated since Python 3.3, "
-                      "and in 3.10 it will stop working",
-                      DeprecationWarning, stacklevel=2)
-        globals()[name] = obj
-        return obj
-    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
-
-
 ################################################################################
 ### OrderedDict
 ################################################################################

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-12-20-09-12.bpo-37324.jB-9_U.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-12-20-09-12.bpo-37324.jB-9_U.rst
@@ -1,0 +1,2 @@
+Remove deprecated aliases to :ref:`collections-abstract-base-classes` from
+the :mod:`collections` module.


### PR DESCRIPTION
Remove deprecated aliases to Abstract Base Classes from the collections module.

This is an updated version of @vstinner's https://github.com/python/cpython/pull/14171, but for Python 3.10.

PR https://github.com/python/cpython/pull/14171 was originally for 3.9, but closed as it was decided to postpone the removal to 3.10 (https://github.com/python/cpython/pull/18545) to give 3rd-party modules like html5lib more time to update.

html5lib updated in https://github.com/html5lib/html5lib-python/pull/403 and released in version 1.1  (June 2020) https://github.com/html5lib/html5lib-python/releases/tag/1.1. 

@vstinner I just put your name in `Doc/whatsnew/3.10.rst` because this is an updated version of your PR, let me know if I should update it.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37324](https://bugs.python.org/issue37324) -->
https://bugs.python.org/issue37324
<!-- /issue-number -->
