### PR TITLE
typo-ish: improved comment that indicates state of Barrier

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -608,7 +608,7 @@ class Barrier:
         self._action = action
         self._timeout = timeout
         self._parties = parties
-        self._state = 0 #0 filling, 1, draining, -1 resetting, -2 broken
+        self._state = 0 # 0 filling, 1 draining, -1 resetting, -2 broken
         self._count = 0
 
     def wait(self, timeout=None):

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -608,7 +608,7 @@ class Barrier:
         self._action = action
         self._timeout = timeout
         self._parties = parties
-        self._state = 0 # 0 filling, 1 draining, -1 resetting, -2 broken
+        self._state = 0  # 0 filling, 1 draining, -1 resetting, -2 broken
         self._count = 0
 
     def wait(self, timeout=None):


### PR DESCRIPTION
removed extra comma in comment that indicates state of a `Barrier` as it was confusing and breaking the flow while reading. Also added missing space after `#` that began the comment