### PR TITLE
bpo-42655: Fix subprocess extra_groups gid conversion

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-12-25-12-32-47.bpo-42655.W5ytpV.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-25-12-32-47.bpo-42655.W5ytpV.rst
@@ -1,0 +1,2 @@
+:mod:`subprocess` *extra_groups* is now correctly passed into setgroups()
+system call.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -900,7 +900,7 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
     if (groups_list != Py_None) {
 #ifdef HAVE_SETGROUPS
         Py_ssize_t i;
-        unsigned long gid;
+        gid_t gid;
 
         if (!PyList_Check(groups_list)) {
             PyErr_SetString(PyExc_TypeError,

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -934,10 +934,6 @@ subprocess_fork_exec(PyObject *module, PyObject *args)
                 Py_DECREF(elem);
                 goto cleanup;
             } else {
-                /* In posixmodule.c UnsignedLong is used as a fallback value
-                * if the value provided does not fit in a Long. Since we are
-                * already doing the bounds checking on the Python side, we
-                * can go directly to an UnsignedLong here. */
                 if (!_Py_Gid_Converter(elem, &gid)) {
                     Py_DECREF(elem);
                     PyErr_SetString(PyExc_ValueError, "invalid group id");

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -672,7 +672,7 @@ _PyLong_FromGid(gid_t gid)
 }
 
 int
-_Py_Uid_Converter(PyObject *obj, void *p)
+_Py_Uid_Converter(PyObject *obj, uid_t *p)
 {
     uid_t uid;
     PyObject *index;
@@ -759,7 +759,7 @@ _Py_Uid_Converter(PyObject *obj, void *p)
 
 success:
     Py_DECREF(index);
-    *(uid_t *)p = uid;
+    *p = uid;
     return 1;
 
 underflow:
@@ -778,7 +778,7 @@ fail:
 }
 
 int
-_Py_Gid_Converter(PyObject *obj, void *p)
+_Py_Gid_Converter(PyObject *obj, gid_t *p)
 {
     gid_t gid;
     PyObject *index;
@@ -866,7 +866,7 @@ _Py_Gid_Converter(PyObject *obj, void *p)
 
 success:
     Py_DECREF(index);
-    *(gid_t *)p = gid;
+    *p = gid;
     return 1;
 
 underflow:

--- a/Modules/posixmodule.h
+++ b/Modules/posixmodule.h
@@ -14,8 +14,8 @@ extern "C" {
 #ifndef MS_WINDOWS
 PyAPI_FUNC(PyObject *) _PyLong_FromUid(uid_t);
 PyAPI_FUNC(PyObject *) _PyLong_FromGid(gid_t);
-PyAPI_FUNC(int) _Py_Uid_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _Py_Gid_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _Py_Uid_Converter(PyObject *, uid_t *);
+PyAPI_FUNC(int) _Py_Gid_Converter(PyObject *, gid_t *);
 #endif /* MS_WINDOWS */
 
 #if defined(PYPTHREAD_SIGMASK) || defined(HAVE_SIGWAIT) || \


### PR DESCRIPTION
C function `subprocess_fork_exec` incorrectly transforms gids from `extra_groups` argument because it passes `unsigned long*` rather than `pid_t*` into the `_Py_Gid_Converter()`. Assuming that `gid_t` is 32 bit and `unsigned long` is 64 bit (which it often is), `*(gid_t *)p = gid;` then incorrectly overwrites only part of that variable, leaving the other one filled with previous garbage.

I found this on Solaris, but I am pretty sure that this doesn't work correctly on Linux as well, since both use `unsigned int` as `gid_t`.

I am not sure whether a small fix like this one needs an issue, but if so, I am happy to create one.


<!-- issue-number: [bpo-42655](https://bugs.python.org/issue42655) -->
https://bugs.python.org/issue42655
<!-- /issue-number -->
