### PR TITLE
[3.9] bpo-42567: [Enum] call __init_subclass__ after members are added (GH-23714)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -9,6 +9,14 @@ __all__ = [
         ]
 
 
+class _NoInitSubclass:
+    """
+    temporary base class to suppress calling __init_subclass__
+    """
+    @classmethod
+    def __init_subclass__(cls, **kwds):
+        pass
+
 def _is_descriptor(obj):
     """
     Returns True if obj is a descriptor, False otherwise.
@@ -176,7 +184,7 @@ class EnumMeta(type):
                     )
         return enum_dict
 
-    def __new__(metacls, cls, bases, classdict):
+    def __new__(metacls, cls, bases, classdict, **kwds):
         # an Enum class is final once enumeration items have been defined; it
         # cannot be mixed with other types (int, float, etc.) if it has an
         # inherited __new__ unless a new __new__ is defined (or the resulting
@@ -211,8 +219,22 @@ class EnumMeta(type):
         if '__doc__' not in classdict:
             classdict['__doc__'] = 'An enumeration.'
 
+        # postpone calling __init_subclass__
+        if '__init_subclass__' in classdict and classdict['__init_subclass__'] is None:
+            raise TypeError('%s.__init_subclass__ cannot be None')
+        # remove current __init_subclass__ so previous one can be found with getattr
+        new_init_subclass = classdict.pop('__init_subclass__', None)
         # create our new Enum type
-        enum_class = super().__new__(metacls, cls, bases, classdict)
+        if bases:
+            bases = (_NoInitSubclass, ) + bases
+            enum_class = type.__new__(metacls, cls, bases, classdict)
+            enum_class.__bases__ = enum_class.__bases__[1:] #or (object, )
+        else:
+            enum_class = type.__new__(metacls, cls, bases, classdict)
+        old_init_subclass = getattr(enum_class, '__init_subclass__', None)
+        # and restore the new one (if there was one)
+        if new_init_subclass is not None:
+            enum_class.__init_subclass__ = classmethod(new_init_subclass)
         enum_class._member_names_ = []               # names in definition order
         enum_class._member_map_ = {}                 # name->value map
         enum_class._member_type_ = member_type
@@ -324,6 +346,9 @@ class EnumMeta(type):
             if _order_ != enum_class._member_names_:
                 raise TypeError('member order does not match _order_')
 
+        # finally, call parents' __init_subclass__
+        if Enum is not None and old_init_subclass is not None:
+            old_init_subclass(**kwds)
         return enum_class
 
     def __bool__(self):
@@ -700,6 +725,9 @@ class Enum(metaclass=EnumMeta):
                 pass
         else:
             return start
+
+    def __init_subclass__(cls, **kwds):
+        super().__init_subclass__(**kwds)
 
     @classmethod
     def _missing_(cls, value):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2065,65 +2065,6 @@ class TestEnum(unittest.TestCase):
         except ValueError:
             pass
 
-    def test_strenum(self):
-        class GoodStrEnum(StrEnum):
-            one = '1'
-            two = '2'
-            three = b'3', 'ascii'
-            four = b'4', 'latin1', 'strict'
-        self.assertEqual(GoodStrEnum.one, '1')
-        self.assertEqual(str(GoodStrEnum.one), '1')
-        self.assertEqual(GoodStrEnum.one, str(GoodStrEnum.one))
-        self.assertEqual(GoodStrEnum.one, '{}'.format(GoodStrEnum.one))
-        #
-        class DumbMixin:
-            def __str__(self):
-                return "don't do this"
-        class DumbStrEnum(DumbMixin, StrEnum):
-            five = '5'
-            six = '6'
-            seven = '7'
-        self.assertEqual(DumbStrEnum.seven, '7')
-        self.assertEqual(str(DumbStrEnum.seven), "don't do this")
-        #
-        class EnumMixin(Enum):
-            def hello(self):
-                print('hello from %s' % (self, ))
-        class HelloEnum(EnumMixin, StrEnum):
-            eight = '8'
-        self.assertEqual(HelloEnum.eight, '8')
-        self.assertEqual(HelloEnum.eight, str(HelloEnum.eight))
-        #
-        class GoodbyeMixin:
-            def goodbye(self):
-                print('%s wishes you a fond farewell')
-        class GoodbyeEnum(GoodbyeMixin, EnumMixin, StrEnum):
-            nine = '9'
-        self.assertEqual(GoodbyeEnum.nine, '9')
-        self.assertEqual(GoodbyeEnum.nine, str(GoodbyeEnum.nine))
-        #
-        with self.assertRaisesRegex(TypeError, '1 is not a string'):
-            class FirstFailedStrEnum(StrEnum):
-                one = 1
-                two = '2'
-        with self.assertRaisesRegex(TypeError, "2 is not a string"):
-            class SecondFailedStrEnum(StrEnum):
-                one = '1'
-                two = 2,
-                three = '3'
-        with self.assertRaisesRegex(TypeError, '2 is not a string'):
-            class ThirdFailedStrEnum(StrEnum):
-                one = '1'
-                two = 2
-        with self.assertRaisesRegex(TypeError, 'encoding must be a string, not %r' % (sys.getdefaultencoding, )):
-            class ThirdFailedStrEnum(StrEnum):
-                one = '1'
-                two = b'2', sys.getdefaultencoding
-        with self.assertRaisesRegex(TypeError, 'errors must be a string, not 9'):
-            class ThirdFailedStrEnum(StrEnum):
-                one = '1'
-                two = b'2', 'ascii', 9
-                
     def test_init_subclass(self):
         class MyEnum(Enum):
             def __init_subclass__(cls, **kwds):

--- a/Misc/NEWS.d/next/Library/2020-12-08-22-43-35.bpo-42678.ba9ktU.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-08-22-43-35.bpo-42678.ba9ktU.rst
@@ -1,0 +1,1 @@
+`Enum`: call `__init_subclass__` after members have been added


### PR DESCRIPTION
When creating an Enum, `type.__new__` calls `__init_subclass__`, but at that point the members have not been added.

This patch suppresses the initial call, then manually calls the ancestor `__init_subclass__` before returning the new Enum class.

(cherry picked from commit 6bd94de168b58ac9358277ed6f200490ab26c174)

<!-- issue-number: [bpo-42567](https://bugs.python.org/issue42567) -->
https://bugs.python.org/issue42567
<!-- /issue-number -->
