### PR TITLE
bpo-31904: Skip test_expanduser and test_expanduser_pwd on VxWorks

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2467,6 +2467,8 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
 
     @unittest.skipUnless(hasattr(pwd, 'getpwall'),
                          'pwd module does not expose getpwall()')
+    @unittest.skipIf(sys.platform == "vxworks",
+                     "no home directory on VxWorks")
     def test_expanduser(self):
         P = self.cls
         import_helper.import_module('pwd')

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -1,5 +1,6 @@
 import os
 import posixpath
+import sys
 import unittest
 from posixpath import realpath, abspath, dirname, basename
 from test import test_genericpath
@@ -262,6 +263,8 @@ class PosixPathTest(unittest.TestCase):
                     self.assertEqual(posixpath.expanduser("~/"), "/")
                     self.assertEqual(posixpath.expanduser("~/foo"), "/foo")
 
+    @unittest.skipIf(sys.platform == "vxworks",
+                     "no home directory on VxWorks")
     def test_expanduser_pwd(self):
         pwd = import_helper.import_module('pwd')
 


### PR DESCRIPTION
On VxWorks, no user home directory at all. So skip test_expanduser and test_expanduser_pwd on VxWorks.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
