### PR TITLE
bpo-42641: Enhance test_select.test_select()

### DIFF
--- a/Lib/test/test_select.py
+++ b/Lib/test/test_select.py
@@ -1,7 +1,9 @@
 import errno
 import os
 import select
+import subprocess
 import sys
+import textwrap
 import unittest
 from test import support
 
@@ -45,16 +47,25 @@ class SelectTestCase(unittest.TestCase):
         self.assertIsNot(w, x)
 
     def test_select(self):
-        cmd = 'for i in 0 1 2 3 4 5 6 7 8 9; do echo testing...; sleep 1; done'
-        with os.popen(cmd) as p:
-            for tout in (0, 1, 2, 4, 8, 16) + (None,)*10:
+        code = textwrap.dedent('''
+            import time
+            for i in range(10):
+                print("testing...", flush=True)
+                time.sleep(0.050)
+        ''')
+        cmd = [sys.executable, '-I', '-c', code]
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE) as proc:
+            pipe = proc.stdout
+            for timeout in (0, 1, 2, 4, 8, 16) + (None,)*10:
                 if support.verbose:
-                    print('timeout =', tout)
-                rfd, wfd, xfd = select.select([p], [], [], tout)
-                if (rfd, wfd, xfd) == ([], [], []):
+                    print(f'timeout = {timeout}')
+                rfd, wfd, xfd = select.select([pipe], [], [], timeout)
+                self.assertEqual(wfd, [])
+                self.assertEqual(xfd, [])
+                if not rfd:
                     continue
-                if (rfd, wfd, xfd) == ([p], [], []):
-                    line = p.readline()
+                if rfd == [pipe]:
+                    line = pipe.readline()
                     if support.verbose:
                         print(repr(line))
                     if not line:
@@ -62,7 +73,8 @@ class SelectTestCase(unittest.TestCase):
                             print('EOF')
                         break
                     continue
-                self.fail('Unexpected return values from select():', rfd, wfd, xfd)
+                self.fail('Unexpected return values from select():',
+                          rfd, wfd, xfd)
 
     # Issue 16230: Crash on select resized list
     def test_select_mutated(self):

--- a/Misc/NEWS.d/next/Tests/2020-12-15-17-38-04.bpo-42641.uzwlF_.rst
+++ b/Misc/NEWS.d/next/Tests/2020-12-15-17-38-04.bpo-42641.uzwlF_.rst
@@ -1,0 +1,2 @@
+Enhance ``test_select.test_select()``: it now takes 500 ms rather than 10
+seconds. Use Python rather than a shell to make the test more portable.


### PR DESCRIPTION
Enhance test_select.test_select(): it now takes 500 ms rather than 10
seconds.

* Use Python rather than a shell as the child process to make the
  test more portable.
* Use a sleep of 50 ms per line rather than 1 second.
* Use subprocess.Popen rather than os.popen().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42641](https://bugs.python.org/issue42641) -->
https://bugs.python.org/issue42641
<!-- /issue-number -->
