### PR TITLE
bpo-19733: Re-enable tests for -image option in Tkinter

### DIFF
--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -2,7 +2,6 @@ import unittest
 import tkinter
 from tkinter import TclError
 import os
-import sys
 from test.support import requires
 
 from tkinter.test.support import (tcl_version, requires_tcl,
@@ -265,8 +264,6 @@ class MenubuttonTest(AbstractLabelTest, unittest.TestCase):
 
     test_highlightthickness = StandardOptionsTests.test_highlightthickness
 
-    @unittest.skipIf(sys.platform == 'darwin',
-                     'crashes with Cocoa Tk (issue19733)')
     def test_image(self):
         widget = self.create()
         image = tkinter.PhotoImage(master=self.root, name='image1')

--- a/Lib/tkinter/test/widget_tests.py
+++ b/Lib/tkinter/test/widget_tests.py
@@ -1,7 +1,6 @@
 # Common tests for test_tkinter/test_widgets.py and test_ttk/test_widgets.py
 
 import unittest
-import sys
 import tkinter
 from tkinter.test.support import (AbstractTkTest, tcl_version, requires_tcl,
                                   get_tk_patchlevel, pixels_conv, tcl_obj_eq)
@@ -332,8 +331,6 @@ class StandardOptionsTests:
         self.checkParam(widget, 'highlightthickness', -2, expected=0,
                         conv=self._conv_pixels)
 
-    @unittest.skipIf(sys.platform == 'darwin',
-                     'crashes with Cocoa Tk (issue19733)')
     def test_image(self):
         widget = self.create()
         self.checkImageParam(widget, 'image')


### PR DESCRIPTION


<!-- issue-number: [bpo-19733](https://bugs.python.org/issue19733) -->
https://bugs.python.org/issue19733
<!-- /issue-number -->
