### PR TITLE
bpo-42644: Validate values in logging.disable()

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1289,6 +1289,14 @@ class Manager(object):
         self.loggerClass = None
         self.logRecordFactory = None
 
+    @property
+    def disable(self):
+        return self._disable
+
+    @disable.setter
+    def disable(self, value):
+        self._disable = _checkLevel(value)
+
     def getLogger(self, name):
         """
         Get a logger with the specified name (channel name), creating it

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4219,6 +4219,15 @@ class ModuleLevelMiscTest(BaseTest):
         logging.disable(83)
         self.assertEqual(logging.root.manager.disable, 83)
 
+        self.assertRaises(ValueError, logging.disable, "doesnotexists")
+
+        class _NotAnIntOrString:
+            pass
+
+        self.assertRaises(TypeError, logging.disable, _NotAnIntOrString())
+
+        logging.disable("WARN")
+
         # test the default value introduced in 3.7
         # (Issue #28524)
         logging.disable()

--- a/Misc/NEWS.d/next/Library/2020-12-15-10-00-04.bpo-42644.XgLCNx.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-15-10-00-04.bpo-42644.XgLCNx.rst
@@ -1,0 +1,7 @@
+`logging.disable` will now validate the types and value of its parameter. It
+also now accepts strings representing the levels (as does `loging.setLevel`)
+instead of only the numerical values.
+
+# Write your Misc/NEWS entry below.  It should be a simple ReST paragraph. #
+Don't start with "- Issue #<n>: " or "- bpo-<n>: " or that sort of stuff.
+###########################################################################

--- a/Misc/NEWS.d/next/Library/2020-12-15-10-00-04.bpo-42644.XgLCNx.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-15-10-00-04.bpo-42644.XgLCNx.rst
@@ -1,7 +1,3 @@
 `logging.disable` will now validate the types and value of its parameter. It
 also now accepts strings representing the levels (as does `loging.setLevel`)
 instead of only the numerical values.
-
-# Write your Misc/NEWS entry below.  It should be a simple ReST paragraph. #
-Don't start with "- Issue #<n>: " or "- bpo-<n>: " or that sort of stuff.
-###########################################################################


### PR DESCRIPTION
Technically make the value of manager a property that checks and convert
values assigned to it properly. This has the side effect of making
`logging.disable` also accept strings representing the various level of
warnings.

We want to validate the type of the disable attribute at assignment
time, as it is later compared to other levels when emitting warnings and
would generate a `TypeError: '>=' not supported between ....` in a
different part of the code base, which can make it difficult to track
down.

When assigned an incorrect value; it will raise a TypeError when the
wrong type, or ValueError if an invalid str.


<!-- issue-number: [bpo-42644](https://bugs.python.org/issue42644) -->
https://bugs.python.org/issue42644
<!-- /issue-number -->
