### PR TITLE
bpo-41804: Enhance test_epoll.test_control_and_wait()

### DIFF
--- a/Lib/test/test_epoll.py
+++ b/Lib/test/test_epoll.py
@@ -160,44 +160,42 @@ class TestEPoll(unittest.TestCase):
             self.fail("epoll on closed fd didn't raise EBADF")
 
     def test_control_and_wait(self):
+        # create the epoll object
         client, server = self._connected_pair()
-
         ep = select.epoll(16)
         ep.register(server.fileno(),
                     select.EPOLLIN | select.EPOLLOUT | select.EPOLLET)
         ep.register(client.fileno(),
                     select.EPOLLIN | select.EPOLLOUT | select.EPOLLET)
 
+        # EPOLLOUT
         now = time.monotonic()
         events = ep.poll(1, 4)
         then = time.monotonic()
         self.assertFalse(then - now > 0.1, then - now)
 
-        events.sort()
         expected = [(client.fileno(), select.EPOLLOUT),
                     (server.fileno(), select.EPOLLOUT)]
-        expected.sort()
+        self.assertEqual(sorted(events), sorted(expected))
 
-        self.assertEqual(events, expected)
-
-        events = ep.poll(timeout=2.1, maxevents=4)
+        # no event
+        events = ep.poll(timeout=0.1, maxevents=4)
         self.assertFalse(events)
 
-        client.send(b"Hello!")
-        server.send(b"world!!!")
+        # send: EPOLLIN and EPOLLOUT
+        client.sendall(b"Hello!")
+        server.sendall(b"world!!!")
 
         now = time.monotonic()
-        events = ep.poll(1, 4)
+        events = ep.poll(1.0, 4)
         then = time.monotonic()
         self.assertFalse(then - now > 0.01)
 
-        events.sort()
         expected = [(client.fileno(), select.EPOLLIN | select.EPOLLOUT),
                     (server.fileno(), select.EPOLLIN | select.EPOLLOUT)]
-        expected.sort()
+        self.assertEqual(sorted(events), sorted(expected))
 
-        self.assertEqual(events, expected)
-
+        # unregister, modify
         ep.unregister(client.fileno())
         ep.modify(server.fileno(), select.EPOLLOUT)
         now = time.monotonic()


### PR DESCRIPTION
Use shorter timeout and replace send() with sendall().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41804](https://bugs.python.org/issue41804) -->
https://bugs.python.org/issue41804
<!-- /issue-number -->
