### PR TITLE
Fix reStructuredText syntax in NEWS.d.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-11-20-00-57-47.bpo-42195.HeqcpS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-11-20-00-57-47.bpo-42195.HeqcpS.rst
@@ -6,6 +6,6 @@ for :class:`collections.abc.Callable` are now flattened while
 ``collections.abc.Callable``'s ``__class_getitem__`` will now return a subclass
 of ``types.GenericAlias``.  Tests for typing were also updated to not subclass 
 things like ``Callable[..., T]`` as that is not a valid base class.  Finally,
-both ``Callable``s no longer validate their ``argtypes``, in 
+both ``Callable``\ s no longer validate their ``argtypes``, in 
 ``Callable[[argtypes], resulttype]`` to prepare for :pep:`612`.  Patch by Ken Jin.  
 


### PR DESCRIPTION
Without this "separator", the reStructuredText parser gets it wrong.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
