### PR TITLE
bpo-42662: Explict __annotations__ key ordering

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -552,8 +552,9 @@ Callable types
       | :attr:`__annotations__` | A dict containing annotations | Writable  |
       |                         | of parameters.  The keys of   |           |
       |                         | the dict are the parameter    |           |
-      |                         | names, and ``'return'`` for   |           |
-      |                         | the return annotation, if     |           |
+      |                         | names in the order declared,  |           |
+      |                         | and ``'return'`` for the      |           |
+      |                         | return annotation, if         |           |
       |                         | provided.                     |           |
       +-------------------------+-------------------------------+-----------+
       | :attr:`__kwdefaults__`  | A dict containing defaults    | Writable  |


### PR DESCRIPTION
Currently the data model documentation does not specify the order of keys in `__annotations__` dictionary. It is currently in the order that arguments or attributes are declared. This PR would make this explicit.

<!-- issue-number: [bpo-42662](https://bugs.python.org/issue42662) -->
https://bugs.python.org/issue42662
<!-- /issue-number -->
