### PR TITLE
bpo-31904: Skip some asyncio tests on VxWorks

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1745,6 +1745,8 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             MyDatagramProto, allow_broadcast=True, sock=FakeSock())
         self.assertRaises(ValueError, self.loop.run_until_complete, fut)
 
+    @unittest.skipIf(sys.platform == 'vxworks',
+                    "SO_BROADCAST is enabled by default on VxWorks")
     def test_create_datagram_endpoint_sockopts(self):
         # Socket options should not be applied unless asked for.
         # SO_REUSEPORT is not available on all platforms.

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -22,7 +22,7 @@ import unittest
 from unittest import mock
 import weakref
 
-if sys.platform != 'win32':
+if sys.platform not in ('win32', 'vxworks'):
     import tty
 
 import asyncio
@@ -465,6 +465,8 @@ class EventLoopTestsMixin:
         self.assertFalse(self.loop.remove_signal_handler(signal.SIGINT))
 
     @unittest.skipUnless(hasattr(signal, 'SIGALRM'), 'No SIGALRM')
+    @unittest.skipUnless(hasattr(signal, 'setitimer'),
+                         'need signal.setitimer()')
     def test_signal_handling_while_selecting(self):
         # Test with a signal actually arriving during a select() call.
         caught = 0
@@ -482,6 +484,8 @@ class EventLoopTestsMixin:
         self.assertEqual(caught, 1)
 
     @unittest.skipUnless(hasattr(signal, 'SIGALRM'), 'No SIGALRM')
+    @unittest.skipUnless(hasattr(signal, 'setitimer'),
+                         'need signal.setitimer()')
     def test_signal_handling_args(self):
         some_args = (42,)
         caught = 0
@@ -1371,6 +1375,7 @@ class EventLoopTestsMixin:
 
     @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
+    @unittest.skipUnless(hasattr(os, 'openpty'), 'need os.openpty()')
     def test_read_pty_output(self):
         proto = MyReadPipeProto(loop=self.loop)
 
@@ -1468,6 +1473,7 @@ class EventLoopTestsMixin:
 
     @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
+    @unittest.skipUnless(hasattr(os, 'openpty'), 'need os.openpty()')
     # select, poll and kqueue don't support character devices (PTY) on Mac OS X
     # older than 10.6 (Snow Leopard)
     @support.requires_mac_ver(10, 6)
@@ -1512,6 +1518,7 @@ class EventLoopTestsMixin:
 
     @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
+    @unittest.skipUnless(hasattr(os, 'openpty'), 'need os.openpty()')
     # select, poll and kqueue don't support character devices (PTY) on Mac OS X
     # older than 10.6 (Snow Leopard)
     @support.requires_mac_ver(10, 6)

--- a/Misc/NEWS.d/next/Tests/2020-12-17-15-42-44.bpo-31904.d8g3l0d5.rst
+++ b/Misc/NEWS.d/next/Tests/2020-12-17-15-42-44.bpo-31904.d8g3l0d5.rst
@@ -1,0 +1,1 @@
+Skip some asyncio tests on VxWorks.


### PR DESCRIPTION
VxWorks can't support termios and tty module. Reason: tty module is based on termios module. And VxWorks just has partial native support for POSIX termios spec.
VxWorks can't support os.openpty. Reason: VxWorks doesn't have apis openpty() and _getpty provided. It also has no devices /dev/ptc and /dev/ptmx defined.
VxWorks has no getitimer() and setitimer() C api available. So skipping impacted tests on VxWorks.
<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
