### PR TITLE
Fixed typo in itertools documentation

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -582,7 +582,7 @@ loops that truncate the stream.
 
    Before :func:`product` runs, it completely consumes the input iterables,
    keeping pools of values in memory to generate the products.  Accordingly,
-   it only useful with finite inputs.
+   it is only useful with finite inputs.
 
 .. function:: repeat(object[, times])
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1624,6 +1624,7 @@ Ville Skyttä
 Michael Sloan
 Nick Sloan
 Václav Šmilauer
+Casper W. Smet
 Allen W. Smith
 Christopher Smith
 Eric V. Smith


### PR DESCRIPTION
# Fixed typo in itertools documentation

As I was perusing the documentation for itertools.product, I noticed a small typo in the last sentence:

``` Accordingly, it only useful with finite inputs.```

This pull request simply adds the word "is" in order to make this sentence grammatically correct:

``` Accordingly, it is only useful with finite inputs.```

--------------------------------------------------------
I also added my name to the misc/ACKS file, per the contribution guidelines. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
