### PR TITLE
bpo-42669: Document that `except` rejects nested tuples

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -254,7 +254,8 @@ present, must be last; it matches any exception.  For an except clause with an
 expression, that expression is evaluated, and the clause matches the exception
 if the resulting object is "compatible" with the exception.  An object is
 compatible with an exception if it is the class or a base class of the exception
-object or a tuple containing an item compatible with the exception.
+object, or a tuple containing an item that is the class or a base class of
+the exception object.  (Nested tuples are not allowed.)
 
 If no except clause matches the exception, the search for an exception handler
 continues in the surrounding code and on the invocation stack.  [#]_

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -255,7 +255,7 @@ expression, that expression is evaluated, and the clause matches the exception
 if the resulting object is "compatible" with the exception.  An object is
 compatible with an exception if it is the class or a base class of the exception
 object, or a tuple containing an item that is the class or a base class of
-the exception object.  (Nested tuples are not allowed.)
+the exception object.
 
 If no except clause matches the exception, the search for an exception handler
 continues in the surrounding code and on the invocation stack.  [#]_

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1848,6 +1848,7 @@ Zachary Ware
 Barry Warsaw
 Steve Waterbury
 Bob Watson
+Colin Watson
 David Watson
 Aaron Watters
 Henrik Weber

--- a/Misc/NEWS.d/next/Documentation/2020-12-17-14-23-16.bpo-42669.fjuDXY.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-12-17-14-23-16.bpo-42669.fjuDXY.rst
@@ -1,1 +1,0 @@
-Explain that :keyword:`except` no longer accepts nested tuples.  (This was changed in Python 3.0, but not previously documented.)

--- a/Misc/NEWS.d/next/Documentation/2020-12-17-14-23-16.bpo-42669.fjuDXY.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-12-17-14-23-16.bpo-42669.fjuDXY.rst
@@ -1,0 +1,1 @@
+Explain that :keyword:`except` no longer accepts nested tuples.  (This was changed in Python 3.0, but not previously documented.)


### PR DESCRIPTION
In Python 2, it was possible to use `except` with a nested tuple, and occasionally natural.  For example, `zope.formlib.interfaces.InputErrors` is a tuple of several exception classes, and one might reasonably think to do something like this:

    try:
        self.getInputValue()
        return True
    except (InputErrors, SomethingElse):
        return False

As of Python 3.0, this raises `TypeError: catching classes that do not inherit from BaseException is not allowed` instead: one must instead either break it up into multiple `except` clauses or flatten the tuple.  However, the reference documentation was never updated to match this new restriction.  Make it clear that the definition is no longer recursive.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42669](https://bugs.python.org/issue42669) -->
https://bugs.python.org/issue42669
<!-- /issue-number -->

Automerge-Triggered-By: GH:ericvsmith