### PR TITLE
bpo-42670: Fix a missing word in the itertools.product() docs

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -582,7 +582,7 @@ loops that truncate the stream.
 
    Before :func:`product` runs, it completely consumes the input iterables,
    keeping pools of values in memory to generate the products.  Accordingly,
-   it only useful with finite inputs.
+   it is only useful with finite inputs.
 
 .. function:: repeat(object[, times])
 


### PR DESCRIPTION


<!-- issue-number: [bpo-42670](https://bugs.python.org/issue42670) -->
https://bugs.python.org/issue42670
<!-- /issue-number -->

Automerge-Triggered-By: GH:Mariatta