### PR TITLE
[WIP] bpo-42671: Make Python finalization deterministic

### DIFF
--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -29,7 +29,7 @@ Py_DEPRECATED(3.2) PyAPI_FUNC(const char *) PyModule_GetFilename(PyObject *);
 PyAPI_FUNC(PyObject *) PyModule_GetFilenameObject(PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) _PyModule_Clear(PyObject *);
-PyAPI_FUNC(void) _PyModule_ClearDict(PyObject *);
+PyAPI_FUNC(void) _PyModule_ClearDict(PyObject *, PyObject *);
 PyAPI_FUNC(int) _PyModuleSpec_IsInitializing(PyObject *);
 #endif
 PyAPI_FUNC(struct PyModuleDef*) PyModule_GetDef(PyObject*);

--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -266,14 +266,15 @@ a = A(destroyed)"""
                          '{!r} does not end with {!r}'.format(r, ends_with))
 
     def test_module_finalization_at_shutdown(self):
-        # Module globals and builtins should still be available during shutdown
+        # Most module globals and builtins should still be available during
+        # shutdown.
         rc, out, err = assert_python_ok("-c", "from test import final_a")
         self.assertFalse(err)
         lines = out.splitlines()
         self.assertEqual(set(lines), {
             b"x = a",
             b"x = b",
-            b"final_a.x = a",
+            b"final_a.x = None",
             b"final_b.x = b",
             b"len = len",
             b"shutil.rmtree = rmtree"})

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -901,8 +901,8 @@ class SysModuleTest(unittest.TestCase):
         self.assertIn(b'sys.flags', out[0])
         self.assertIn(b'sys.float_info', out[1])
 
-    def test_sys_ignores_cleaning_up_user_data(self):
-        code = """if 1:
+    def test_sys_cleaning_up_user_data(self):
+        code = textwrap.dedent("""
             import struct, sys
 
             class C:
@@ -912,11 +912,11 @@ class SysModuleTest(unittest.TestCase):
                     self.pack('I', -42)
 
             sys.x = C()
-            """
+        """)
         rc, stdout, stderr = assert_python_ok('-c', code)
         self.assertEqual(rc, 0)
         self.assertEqual(stdout.rstrip(), b"")
-        self.assertEqual(stderr.rstrip(), b"")
+        self.assertIn(b'Exception ignored in: <function C.__del__ at ', stderr)
 
     @unittest.skipUnless(hasattr(sys, 'getandroidapilevel'),
                          'need sys.getandroidapilevel()')

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -615,18 +615,23 @@ class ThreadTests(BaseTestCase):
         code = """if 1:
             import gc, threading
 
-            main_thread = threading.current_thread()
-            assert main_thread is threading.main_thread()  # sanity check
-
             class RefCycle:
                 def __init__(self):
                     self.cycle = self
 
+                    self.current_thread = threading.current_thread
+                    self.main_thread = threading.main_thread
+                    self.enumerate = threading.enumerate
+
+                    self.thread = self.current_thread()
+                    assert self.thread is threading.main_thread()  # sanity check
+
+
                 def __del__(self):
                     print("GC:",
-                          threading.current_thread() is main_thread,
-                          threading.main_thread() is main_thread,
-                          threading.enumerate() == [main_thread])
+                          self.current_thread() is self.thread,
+                          self.main_thread() is self.thread,
+                          self.enumerate() == [self.thread])
 
             RefCycle()
             gc.collect()  # sanity check

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-17-22-18-44.bpo-42671.M_xDGc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-17-22-18-44.bpo-42671.M_xDGc.rst
@@ -1,0 +1,8 @@
+Make the Python finalization more deterministic:
+
+* First, clear the ``__main__`` module.
+* Then, clear modules from the most recently imported to the least
+  recently imported: ``reversed(sys.modules)``.
+* :mod:`builtins` and :mod:`sys` modules are always cleared last.
+* Module attributes are set to None from the most recently defined to the
+  least recently defined: ``reversed(module.__dict__)``.


### PR DESCRIPTION
Make the Python finalization more deterministic:

* First, clear the __main__ module.
* Then, clear modules from the most recently imported to the least
  recently imported: reversed(sys.modules).
* builtins and sys modumes are always cleared last.
* Module attributes are set to None from the most recently defined to the
  least recently defined: reversed(module.__dict__).

Changes:

* finalize_modules() no longer uses a list of weak references to
  modules while clearing sys.modules dict.
* When -vv command line option is used, the module name is now also
  logged, not only the attribute name.
* test_module.test_module_finalization_at_shutdown(): final_a.x is
  now None when final_a.c is cleared.
* test_sys.test_sys_ignores_cleaning_up_user_data(): the exception is
  no longer silently ignored. Rename the test to
  test_sys_cleaning_up_user_data().
* test_threading.test_main_thread_during_shutdown() keeps a reference
  to threading functions since threading module variables are cleared
  before RefCycle object is deleted by the garbage collector.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42671](https://bugs.python.org/issue42671) -->
https://bugs.python.org/issue42671
<!-- /issue-number -->
