### PR TITLE
bpo-42600: Fix issue when wait_for doesn't wait for canceled future

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -437,7 +437,8 @@ async def wait_for(fut, timeout):
                 return fut.result()
             else:
                 fut.remove_done_callback(cb)
-                fut.cancel()
+                # See https://bugs.python.org/issue42600
+                await _cancel_and_wait(fut, loop=loop)
                 raise
 
         if fut.done():

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1264,6 +1264,23 @@ class BaseTaskTests:
 
         loop.run_until_complete(foo())
 
+    def test_wait_for_must_cancel_child(self):
+        loop = asyncio.new_event_loop()
+        self.addCleanup(loop.close)
+
+        f = loop.create_future()
+
+        async def foo():
+            task = loop.create_task(asyncio.wait_for(f, 10))
+            await asyncio.sleep(0)
+            task.cancel()
+            await task
+
+        with self.assertRaises(asyncio.CancelledError):
+            loop.run_until_complete(foo())
+
+        self.assertTrue(f.cancelled())
+
     def test_wait(self):
 
         def gen():

--- a/Misc/NEWS.d/next/Library/2020-12-18-01-47-35.bpo-42600.WaOvq_.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-18-01-47-35.bpo-42600.WaOvq_.rst
@@ -1,2 +1,2 @@
-Fix issue when ``asyncio.wait_for`` doesn't cancel passed future. Patch
-provided by Yurii Karabas.
+Fix issue when ``asyncio.wait_for`` doesn't wait for canceled future.
+Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2020-12-18-01-47-35.bpo-42600.WaOvq_.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-18-01-47-35.bpo-42600.WaOvq_.rst
@@ -1,0 +1,2 @@
+Fix issue when ``asyncio.wait_for`` doesn't cancel passed future. Patch
+provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Fix issue when ``asyncio.wait_for`` doesn't wait for canceled future.

<!-- issue-number: [bpo-42600](https://bugs.python.org/issue42600) -->
https://bugs.python.org/issue42600
<!-- /issue-number -->
