### PR TITLE
bpo-42673 prevent branch misprediction in round_size (used in rehash)

### DIFF
--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -187,7 +187,7 @@ _Py_bit_length_size_t(size_t x)
 #elif defined(_MSC_VER)
     // _BitScanReverse() is documented to search 32 bits.
     Py_BUILD_ASSERT(sizeof(size_t) <= 4);
-    size_t msb;
+    unsigned long msb;
     if (_BitScanReverse(&msb, x)) {
         return (int)msb + 1;
     }

--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -172,7 +172,7 @@ _Py_bit_length(unsigned long x)
 
 // Same routine as above, for size_t, if that is bigger than unsigned long
 // This means bitscanreverse (as used above) is not going to work
-#if SIZEOF_SIZE_T > 4
+#if SIZEOF_SIZE_T > SIZEOF_LONG
 static inline int
 _Py_bit_length(size_t x)
 {

--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -186,9 +186,12 @@ _Py_bit_length_size_t(size_t x)
     }
 #elif defined(_MSC_VER)
     // _BitScanReverse() is documented to search 32 bits.
-    Py_BUILD_ASSERT(sizeof(size_t) <= 4);
-    unsigned long msb;
+    size_t msb;
+#if SIZEOF_SIZE_T == 8
+    if (_BitScanReverse64(&msb, x)) {
+#else
     if (_BitScanReverse(&msb, x)) {
+#endif
         return (int)msb + 1;
     }
     else {

--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -172,7 +172,7 @@ _Py_bit_length(unsigned long x)
 
 // Same routine as above, for size_t, if that is bigger than unsigned long
 // This means bitscanreverse (as used above) is not going to work
-#if sizeof(size_t) > sizeof(unsigned long)
+#if SIZEOF_SIZE_T > 4
 static inline int
 _Py_bit_length(size_t x)
 {

--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -198,9 +198,8 @@ _Py_bit_length(size_t x)
     msb += BIT_LENGTH_TABLE[x];
     return msb;
 #endif
-
-#endif
 }
+#endif
 
 
 #ifdef __cplusplus

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-18-09-39-44.bpo-42673.nvocEF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-18-09-39-44.bpo-42673.nvocEF.rst
@@ -1,0 +1,2 @@
+Improved the performance of the round_size routine in hashtable.c by calling bit_length instead of using a loop.
+This prevents branch misprediction delays.

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -111,7 +111,7 @@ round_size(size_t s)
     if (s < HASHTABLE_MIN_SIZE)
         return HASHTABLE_MIN_SIZE;
     // 1 << _Py_bit_length(s) is the smallest value k so that 1 << k > s
-    // subtract one in case s is an exact power of two
+    // subtract one in case s is an exact power of two, saving space
     return 1 << _Py_bit_length(s - 1);
 }
 

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -109,10 +109,9 @@ round_size(size_t s)
     size_t i;
     if (s < HASHTABLE_MIN_SIZE)
         return HASHTABLE_MIN_SIZE;
-    i = 1;
-    while (i < s)
-        i <<= 1;
-    return i;
+    // 1 << _Py_bit_length(s) is the smallest value k so that 1 << k > s
+    // subtract one in case s is an exact power of two
+    return 1 << _Py_bit_length(s - 1);
 }
 
 

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -107,7 +107,6 @@ _Py_hashtable_compare_direct(const void *key1, const void *key2)
 static size_t
 round_size(size_t s)
 {
-    size_t i;
     if (s < HASHTABLE_MIN_SIZE)
         return HASHTABLE_MIN_SIZE;
     // 1 << _Py_bit_length(s) is the smallest value k so that 1 << k > s

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -111,7 +111,7 @@ round_size(size_t s)
         return HASHTABLE_MIN_SIZE;
     // 1 << _Py_bit_length(s) is the smallest value k so that 1 << k > s
     // subtract one in case s is an exact power of two, saving space
-    return 1 << _Py_bit_length_size_t(s - 1);
+    return (size_t)1 << _Py_bit_length_size_t(s - 1);
 }
 
 

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -46,6 +46,7 @@
 
 #include "Python.h"
 #include "pycore_hashtable.h"
+#include "pycore_bitutils.h"
 
 #define HASHTABLE_MIN_SIZE 16
 #define HASHTABLE_HIGH 0.50

--- a/Python/hashtable.c
+++ b/Python/hashtable.c
@@ -111,7 +111,7 @@ round_size(size_t s)
         return HASHTABLE_MIN_SIZE;
     // 1 << _Py_bit_length(s) is the smallest value k so that 1 << k > s
     // subtract one in case s is an exact power of two, saving space
-    return 1 << _Py_bit_length(s - 1);
+    return 1 << _Py_bit_length_size_t(s - 1);
 }
 
 


### PR DESCRIPTION
Replace the loop in round_size using bit_length to prevent branch misprediction delays.

<!-- issue-number: [bpo-42673](https://bugs.python.org/issue42673) -->
https://bugs.python.org/issue42673
<!-- /issue-number -->
