### PR TITLE
[3.9] bpo-42675: Document collections.abc.Callable changes (GH-23839)

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -260,6 +260,9 @@ Standard names are defined for the following types:
 
    .. versionadded:: 3.9
 
+   .. versionchanged:: 3.9.2
+      This type can now be subclassed.
+
 
 .. class:: TracebackType(tb_next, tb_frame, tb_lasti, tb_lineno)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -1497,3 +1497,22 @@ functions and options conditionally available based on the operating system
 version in use at runtime ("weaklinking").
 
 (Contributed by Ronald Oussoren and Lawrence D'Anna in :issue:`41100`.)
+
+Notable changes in Python 3.9.2
+===============================
+
+collections.abc
+---------------
+
+:class:`collections.abc.Callable` generic now flattens type parameters, similar
+to what :data:`typing.Callable` currently does.  This means that
+``collections.abc.Callable[[int, str], str]`` will have ``__args__`` of
+``(int, str, str)``; previously this was ``([int, str], str)``.  To allow this
+change, :class:`types.GenericAlias` can now be subclassed, and a subclass will
+be returned when subscripting the :class:`collections.abc.Callable` type.
+Code which accesses the arguments via :func:`typing.get_args` or ``__args__``
+need to account for this change.  A :exc:`DeprecationWarning` may be emitted for
+invalid forms of parameterizing :class:`collections.abc.Callable` which may have
+passed silently in Python 3.9.1.  This :exc:`DeprecationWarning` will instead
+raise a :exc:`TypeError` in Python 3.10.
+(Contributed by Ken Jin in :issue:`42195`.)

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -1513,6 +1513,6 @@ be returned when subscripting the :class:`collections.abc.Callable` type.
 Code which accesses the arguments via :func:`typing.get_args` or ``__args__``
 need to account for this change.  A :exc:`DeprecationWarning` may be emitted for
 invalid forms of parameterizing :class:`collections.abc.Callable` which may have
-passed silently in Python 3.9.1.  This :exc:`DeprecationWarning` will instead
-raise a :exc:`TypeError` in Python 3.10.
+passed silently in Python 3.9.1.  This :exc:`DeprecationWarning` will
+become a :exc:`TypeError` in Python 3.10.
 (Contributed by Ken Jin in :issue:`42195`.)


### PR DESCRIPTION
(cherry picked from commit d75f6f78e6ca230d0dacc116dca9d8bf91509b68)

<!-- issue-number: [bpo-42675](https://bugs.python.org/issue42675) -->
https://bugs.python.org/issue42675
<!-- /issue-number -->
