### PR TITLE
bpo-41724: Explain when the conversion is not possible with detect_types enabled

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -199,7 +199,8 @@ Module functions and constants
    *detect_types* defaults to 0 (i. e. off, no type detection), you can set it to
    any combination of :const:`PARSE_DECLTYPES` and :const:`PARSE_COLNAMES` to turn
    type detection on. Due to SQLite behaviour, types can't be detected for generated
-   fields (for example ``max(data)``), even when *detect_types* parameter is set.
+   fields (for example ``max(data)``), even when *detect_types* parameter is set. In
+   such case, the returned type is :class:`str`.
 
    By default, *check_same_thread* is :const:`True` and only the creating thread may
    use the connection. If set :const:`False`, the returned connection may be shared

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -198,7 +198,8 @@ Module functions and constants
 
    *detect_types* defaults to 0 (i. e. off, no type detection), you can set it to
    any combination of :const:`PARSE_DECLTYPES` and :const:`PARSE_COLNAMES` to turn
-   type detection on.
+   type detection on. Due to SQLite behaviour, types can't be detected for generated
+   fields (for example ``max(data)``), even when *detect_types* parameter is set.
 
    By default, *check_same_thread* is :const:`True` and only the creating thread may
    use the connection. If set :const:`False`, the returned connection may be shared


### PR DESCRIPTION
This PR adds a line explaining the limit of the sqlite module as suggested by https://bugs.python.org/msg376447

I don't think this patch needs a News entry.

<!-- issue-number: [bpo-41724](https://bugs.python.org/issue41724) -->
https://bugs.python.org/issue41724
<!-- /issue-number -->
