### PR TITLE
bpo-42687: tokenizer module recognizes Barry as FLUFL

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1409,6 +1409,7 @@ class TestTokenize(TestCase):
         self.assertExactTypeEqual('{}', token.LBRACE, token.RBRACE)
         self.assertExactTypeEqual('==', token.EQEQUAL)
         self.assertExactTypeEqual('!=', token.NOTEQUAL)
+        self.assertExactTypeEqual('<>', token.NOTEQUAL)
         self.assertExactTypeEqual('<=', token.LESSEQUAL)
         self.assertExactTypeEqual('>=', token.GREATEREQUAL)
         self.assertExactTypeEqual('~', token.TILDE)

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -32,7 +32,6 @@ import itertools as _itertools
 import re
 import sys
 from token import *
-from token import EXACT_TOKEN_TYPES
 
 cookie_re = re.compile(r'^[ \t\f]*#.*?coding[:=][ \t]*([-\w.]+)', re.ASCII)
 blank_re = re.compile(br'^[ \t\f]*(?:[#\r\n]|$)', re.ASCII)
@@ -40,6 +39,10 @@ blank_re = re.compile(br'^[ \t\f]*(?:[#\r\n]|$)', re.ASCII)
 import token
 __all__ = token.__all__ + ["tokenize", "generate_tokens", "detect_encoding",
                            "untokenize", "TokenInfo"]
+EXACT_TOKEN_TYPES = {
+    **token.EXACT_TOKEN_TYPES,
+    "<>": NOTEQUAL,
+}
 del token
 
 class TokenInfo(collections.namedtuple('TokenInfo', 'type string start end line')):

--- a/Misc/NEWS.d/next/Library/2020-12-19-11-00-17.bpo-42687.tFuGEe.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-19-11-00-17.bpo-42687.tFuGEe.rst
@@ -1,0 +1,1 @@
+The :mod:`tokenize` module generates a single NOTEQUAL token for '<>'.


### PR DESCRIPTION
https://bugs.python.org/issue42687

Currently, '<>' is not recognized by the tokenize module as a single token, instead it is two tokens.

```
$ python -c "import tokenize; import io; import pprint; pprint.pprint(list(tokenize.tokenize(io.BytesIO(b'<>').readline)))"
[TokenInfo(type=62 (ENCODING), string='utf-8', start=(0, 0), end=(0, 0), line=''),
 TokenInfo(type=54 (OP), string='<', start=(1, 0), end=(1, 1), line='<>'),
 TokenInfo(type=54 (OP), string='>', start=(1, 1), end=(1, 2), line='<>'),
 TokenInfo(type=4 (NEWLINE), string='', start=(1, 2), end=(1, 3), line=''),
 TokenInfo(type=0 (ENDMARKER), string='', start=(2, 0), end=(2, 0), line='')]
```


This PR changes the behavior to:
```
[TokenInfo(type=62 (ENCODING), string='utf-8', start=(0, 0), end=(0, 0), line=''),
 TokenInfo(type=54 (OP), string='<>', start=(1, 0), end=(1, 2), line='<>'),
 TokenInfo(type=4 (NEWLINE), string='', start=(1, 2), end=(1, 3), line=''),
 TokenInfo(type=0 (ENDMARKER), string='', start=(2, 0), end=(2, 0), line='')]
```

This is the behavior of the CPython tokenizer which the tokenizer module tries "to match the working of".


<!-- issue-number: [bpo-42687](https://bugs.python.org/issue42687) -->
https://bugs.python.org/issue42687
<!-- /issue-number -->
