### PR TITLE
bpo-42688: Fix ffi alloc/free when using external libffi on macos

### DIFF
--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -91,11 +91,15 @@ static void more_core(void)
 /* put the item back into the free list */
 void Py_ffi_closure_free(void *p)
 {
-#if USING_APPLE_OS_LIBFFI && HAVE_FFI_CLOSURE_ALLOC
+#if HAVE_FFI_CLOSURE_ALLOC
+#if USING_APPLE_OS_LIBFFI
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
+#endif
         ffi_closure_free(p);
         return;
+#if USING_APPLE_OS_LIBFFI
     }
+#endif
 #endif
     ITEM *item = (ITEM *)p;
     item->next = free_list;
@@ -105,10 +109,14 @@ void Py_ffi_closure_free(void *p)
 /* return one item from the free list, allocating more if needed */
 void *Py_ffi_closure_alloc(size_t size, void** codeloc)
 {
-#if USING_APPLE_OS_LIBFFI && HAVE_FFI_CLOSURE_ALLOC
+#if HAVE_FFI_CLOSURE_ALLOC
+#if USING_APPLE_OS_LIBFFI
     if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
+#endif
         return ffi_closure_alloc(size, codeloc);
+#if USING_APPLE_OS_LIBFFI
     }
+#endif
 #endif
     ITEM *item;
     if (!free_list)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42688](https://bugs.python.org/issue42688) -->
https://bugs.python.org/issue42688
<!-- /issue-number -->

Automerge-Triggered-By: GH:ronaldoussoren