### PR TITLE
bpo-42589: Change URL for 'from' link when used in a raised exception

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -42,12 +42,12 @@ include the originating exception(s) and the final exception.
 
 When raising a new exception (rather than using a bare ``raise`` to re-raise
 the exception currently being handled), the implicit exception context can be
-supplemented with an explicit cause by using :keyword:`from` with
+supplemented with an explicit cause by using :keyword:`from<raise>` with
 :keyword:`raise`::
 
    raise new_exc from original_exc
 
-The expression following :keyword:`from` must be an exception or ``None``. It
+The expression following :keyword:`from<raise>` must be an exception or ``None``. It
 will be set as :attr:`__cause__` on the raised exception. Setting
 :attr:`__cause__` also implicitly sets the :attr:`__suppress_context__`
 attribute to ``True``, so that using ``raise new_exc from None``

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -272,7 +272,7 @@ re-raise the exception::
 Exception Chaining
 ==================
 
-The :keyword:`raise` statement allows an optional :keyword:`from` which enables
+The :keyword:`raise` statement allows an optional :keyword:`from<raise>` which enables
 chaining exceptions. For example::
 
     # exc must be exception instance or None.


### PR DESCRIPTION
Links for 'raise Exception from x' target to 'The raise statement' (7.8) section instead of 'The import statement' (7.11) section.

There are more modified links than in the bug report because I searched some other ones which can get the same improvement.


<!-- issue-number: [bpo-42589](https://bugs.python.org/issue42589) -->
https://bugs.python.org/issue42589
<!-- /issue-number -->

Automerge-Triggered-By: GH:Mariatta