### PR TITLE
bpo-42692: fix __builtin_available check on older compilers

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-01-04-05-07-30.bpo-42692.OO11SN.rst
+++ b/Misc/NEWS.d/next/Build/2021-01-04-05-07-30.bpo-42692.OO11SN.rst
@@ -1,0 +1,1 @@
+Fix __builtin_available check on older compilers. Patch by Joshua Root.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -61,7 +61,13 @@
  */
 #if defined(__APPLE__)
 
-#if defined(__has_builtin) && __has_builtin(__builtin_available)
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_available)
+#define HAVE_BUILTIN_AVAILABLE 1
+#endif
+#endif
+
+#ifdef HAVE_BUILTIN_AVAILABLE
 #  define HAVE_FSTATAT_RUNTIME __builtin_available(macOS 10.10, iOS 8.0, *)
 #  define HAVE_FACCESSAT_RUNTIME __builtin_available(macOS 10.10, iOS 8.0, *)
 #  define HAVE_FCHMODAT_RUNTIME __builtin_available(macOS 10.10, iOS 8.0, *)


### PR DESCRIPTION
A compiler that doesn't define `__has_builtin` will error out when it is
used on the same line as the check for it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42692](https://bugs.python.org/issue42692) -->
https://bugs.python.org/issue42692
<!-- /issue-number -->

Automerge-Triggered-By: GH:ronaldoussoren