### PR TITLE
bpo-42700: Swap descriptions in pyexpat.errors

### DIFF
--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -665,14 +665,14 @@ The ``errors`` module has the following attributes:
 
 .. data:: codes
 
-   A dictionary mapping numeric error codes to their string descriptions.
+   A dictionary mapping string descriptions to their error codes.
 
    .. versionadded:: 3.2
 
 
 .. data:: messages
 
-   A dictionary mapping string descriptions to their error codes.
+   A dictionary mapping numeric error codes to their string descriptions.
 
    .. versionadded:: 3.2
 


### PR DESCRIPTION
The descriptions of the `codes` and `messages` dictionaries in
`xml.parsers.expat.errors` were swapped, and this commit swaps them
back. For example, `codes` maps string descriptions of errors to numeric
error codes, not the other way around.

<!-- issue-number: [bpo-42700](https://bugs.python.org/issue42700) -->
https://bugs.python.org/issue42700
<!-- /issue-number -->
