### PR TITLE
[3.6] [doc] Update asyncio lock usage on Synchronization Primitives document (GH-23878)

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -51,37 +51,29 @@ Lock
    resets the state to unlocked; first coroutine which is blocked in acquire()
    is being processed.
 
-   :meth:`acquire` is a coroutine and should be called with ``yield from``.
-
-   Locks also support the context management protocol.  ``(yield from lock)``
-   should be used as the context manager expression.
-
    This class is :ref:`not thread safe <asyncio-multithreading>`.
+
+   The preferred way to use a Lock is an :keyword:`async with`
+   statement.
 
    Usage::
 
-       lock = Lock()
-       ...
-       yield from lock
+       lock = asyncio.Lock()
+
+       # ... later
+       async with lock:
+           # access shared state
+
+   which is equivalent to::
+
+       lock = asyncio.Lock()
+
+       # ... later
+       await lock.acquire()
        try:
-           ...
+           # access shared state
        finally:
            lock.release()
-
-   Context manager usage::
-
-       lock = Lock()
-       ...
-       with (yield from lock):
-           ...
-
-   Lock objects can be tested for locking state::
-
-       if not lock.locked():
-           yield from lock
-       else:
-           # lock is acquired
-           ...
 
    .. method:: locked()
 


### PR DESCRIPTION
The old usage can not using with async def function, that will raise a SyntaxError, because it's for old generator-based coroutines. Change it by new syntax.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
