### PR TITLE
bpo-29030: Document interaction between *choices* and *metavar*.

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1152,6 +1152,11 @@ Any container can be passed as the *choices* value, so :class:`list` objects,
 Use of :class:`enum.Enum` is not recommended because it is difficult to
 control its appearance in usage, help, and error messages.
 
+Formatted choices overrides the default *metavar* which is normally derived
+from *dest*.  This is usually what you want because the user never sees the
+*dest* parameter.  If this display isn't desirable (perhaps because there are
+many choices), just specify an explicit metavar_.
+
 
 required
 ^^^^^^^^


### PR DESCRIPTION


<!-- issue-number: [bpo-29030](https://bugs.python.org/issue29030) -->
https://bugs.python.org/issue29030
<!-- /issue-number -->
