### PR TITLE
bpo-41843: Reenable use of sendfile in shutil module on Solaris

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -529,8 +529,8 @@ file then shutil will silently fallback on using less efficient
 
 .. versionchanged:: 3.8
 
-.. versionchanged:: 3.11
-    Solaris now uses :func:`os.sendfile` rather than no fast-copy operation.
+.. versionchanged:: 3.12.1
+    Solaris now uses :func:`os.sendfile`.
 
 .. _shutil-copytree-example:
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -517,7 +517,7 @@ the use of userspace buffers in Python as in "``outfd.write(infd.read())``".
 
 On macOS `fcopyfile`_ is used to copy the file content (not metadata).
 
-On Linux :func:`os.sendfile` is used.
+On Linux and Solaris :func:`os.sendfile` is used.
 
 On Windows :func:`shutil.copyfile` uses a bigger default buffer size (1 MiB
 instead of 64 KiB) and a :func:`memoryview`-based variant of
@@ -528,6 +528,9 @@ file then shutil will silently fallback on using less efficient
 :func:`copyfileobj` function internally.
 
 .. versionchanged:: 3.8
+
+.. versionchanged:: 3.10
+    Solaris now uses :func:`os.sendfile` rather than no fast-copy operation.
 
 .. _shutil-copytree-example:
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -529,7 +529,7 @@ file then shutil will silently fallback on using less efficient
 
 .. versionchanged:: 3.8
 
-.. versionchanged:: 3.12.1
+.. versionchanged:: 3.14
     Solaris now uses :func:`os.sendfile`.
 
 .. _shutil-copytree-example:

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -529,7 +529,7 @@ file then shutil will silently fallback on using less efficient
 
 .. versionchanged:: 3.8
 
-.. versionchanged:: 3.10
+.. versionchanged:: 3.11
     Solaris now uses :func:`os.sendfile` rather than no fast-copy operation.
 
 .. _shutil-copytree-example:

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -48,7 +48,7 @@ COPY_BUFSIZE = 1024 * 1024 if _WINDOWS else 64 * 1024
 # This should never be removed, see rationale in:
 # https://bugs.python.org/issue43743#msg393429
 _USE_CP_SENDFILE = (hasattr(os, "sendfile")
-                    and sys.platform.startswith(("linux", "android")))
+                    and sys.platform.startswith(("linux", "android", "solaris")))
 _HAS_FCOPYFILE = posix and hasattr(posix, "_fcopyfile")  # macOS
 
 # CMD defaults in Windows 10
@@ -110,7 +110,7 @@ def _fastcopy_fcopyfile(fsrc, fdst, flags):
 def _fastcopy_sendfile(fsrc, fdst):
     """Copy data from one regular mmap-like fd to another by using
     high-performance sendfile(2) syscall.
-    This should work on Linux >= 2.6.33 only.
+    This should work on Linux >= 2.6.33 and Solaris only.
     """
     # Note: copyfileobj() is left alone in order to not introduce any
     # unexpected breakage. Possible risks by using zero-copy calls
@@ -265,7 +265,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
                             return dst
                         except _GiveupOnFastCopy:
                             pass
-                    # Linux
+                    # Linux / Solaris
                     elif _USE_CP_SENDFILE:
                         try:
                             _fastcopy_sendfile(fsrc, fdst)

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -110,7 +110,7 @@ def _fastcopy_fcopyfile(fsrc, fdst, flags):
 def _fastcopy_sendfile(fsrc, fdst):
     """Copy data from one regular mmap-like fd to another by using
     high-performance sendfile(2) syscall.
-    This should work on Linux >= 2.6.33 and Solaris only.
+    This should work on Linux >= 2.6.33, Android and Solaris.
     """
     # Note: copyfileobj() is left alone in order to not introduce any
     # unexpected breakage. Possible risks by using zero-copy calls
@@ -265,7 +265,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
                             return dst
                         except _GiveupOnFastCopy:
                             pass
-                    # Linux / Solaris
+                    # Linux / Android / Solaris
                     elif _USE_CP_SENDFILE:
                         try:
                             _fastcopy_sendfile(fsrc, fdst)

--- a/Misc/NEWS.d/next/Library/2020-12-22-18-08-12.bpo-41843.q9Nh2r.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-22-18-08-12.bpo-41843.q9Nh2r.rst
@@ -1,0 +1,2 @@
+Solaris now uses :func:`os.sendfile` fast-copy syscall for more efficient
+:mod:`shutil` file copy related functions.


### PR DESCRIPTION
With the integration of #22040, `os.sendfile` now works as expected and hence its use in `shutil` as a fast-copy syscall for file copies should be reenabled (it was disabled with #13675 due to small differences in offset handling and return values).

I am not sure what exactly to write into `shutil.rst` as if backported, the `versionchanged:: 3.10` part would not be correct, but it wasn't there from the beginning of 3.9 either, and it seems that micro versions are not specified there (or maybe this is not a change that should be backported) ??

Also, I enabled the Solaris here explicitly, but maybe reverting the #13675 (and by doing so enabling the use of `sendfile` on every system that has it available, which might actually be just Linux and Solaris...) is a better option.

<!-- issue-number: [bpo-41843](https://bugs.python.org/issue41843) -->
https://bugs.python.org/issue41843
<!-- /issue-number -->

* https://github.com/python/cpython/issues/86009