### PR TITLE
bpo-25246: Optimize deque.remove()

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-12-22-13-16-43.bpo-25246.GhhCTl.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-22-13-16-43.bpo-25246.GhhCTl.rst
@@ -1,1 +1,1 @@
-Optimized collections.deque.remove().
+Optimized :meth:`collections.deque.remove`.

--- a/Misc/NEWS.d/next/Library/2020-12-22-13-16-43.bpo-25246.GhhCTl.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-22-13-16-43.bpo-25246.GhhCTl.rst
@@ -1,0 +1,1 @@
+Optimized collections.deque.remove().

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1129,6 +1129,7 @@ PyDoc_STRVAR(insert_doc,
 "D.insert(index, object) -- insert object before index");
 
 static int deque_del_item(dequeobject *deque, Py_ssize_t i);
+static int valid_index(Py_ssize_t i, Py_ssize_t limit);
 
 static PyObject *
 deque_remove(dequeobject *deque, PyObject *value)
@@ -1145,6 +1146,10 @@ deque_remove(dequeobject *deque, PyObject *value)
     i = PyLong_AsSsize_t(index_object);
     Py_DECREF(index_object);
     if (i == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+    if (!valid_index(i, Py_SIZE(deque))) {
+        PyErr_SetString(PyExc_IndexError, "deque index out of range");
         return NULL;
     }
     rv = deque_del_item(deque, i);

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1206,7 +1206,9 @@ deque_remove(dequeobject *deque, PyObject *value)
 
     for (i = 0 ; i < n; i++) {
         item = b->data[index];
+        Py_INCREF(item);
         cmp = PyObject_RichCompareBool(item, value, Py_EQ);
+        Py_DECREF(item);
         if (cmp < 0) {
             return NULL;
         }

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1205,7 +1205,6 @@ deque_remove(dequeobject *deque, PyObject *value)
     int cmp, rv;
 
     for (i = 0 ; i < n; i++) {
-        CHECK_NOT_END(b);
         item = b->data[index];
         cmp = PyObject_RichCompareBool(item, value, Py_EQ);
         if (cmp < 0) {

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1128,37 +1128,6 @@ deque_insert(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
 PyDoc_STRVAR(insert_doc,
 "D.insert(index, object) -- insert object before index");
 
-static int deque_del_item(dequeobject *deque, Py_ssize_t i);
-static int valid_index(Py_ssize_t i, Py_ssize_t limit);
-
-static PyObject *
-deque_remove(dequeobject *deque, PyObject *value)
-{
-    PyObject * args[1] = {value};
-    PyObject *index_object;
-    Py_ssize_t i;
-    int rv;
-
-    index_object = deque_index(deque, args, 1);
-    if (index_object == NULL) {
-        return NULL;
-    }
-    i = PyLong_AsSsize_t(index_object);
-    Py_DECREF(index_object);
-    if (i == -1 && PyErr_Occurred()) {
-        return NULL;
-    }
-    if (!valid_index(i, Py_SIZE(deque))) {
-        PyErr_SetString(PyExc_IndexError, "deque index out of range");
-        return NULL;
-    }
-    rv = deque_del_item(deque, i);
-    if (rv == -1) {
-        return NULL;
-    }
-    Py_RETURN_NONE;
-}
-
 PyDoc_STRVAR(remove_doc,
 "D.remove(value) -- remove first occurrence of value.");
 
@@ -1224,6 +1193,34 @@ deque_del_item(dequeobject *deque, Py_ssize_t i)
     assert (item != NULL);
     Py_DECREF(item);
     return rv;
+}
+
+static PyObject *
+deque_remove(dequeobject *deque, PyObject *value)
+{
+    PyObject * args[1] = {value};
+    PyObject *index_object;
+    Py_ssize_t i;
+    int rv;
+
+    index_object = deque_index(deque, args, 1);
+    if (index_object == NULL) {
+        return NULL;
+    }
+    i = PyLong_AsSsize_t(index_object);
+    Py_DECREF(index_object);
+    if (i == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+    if (!valid_index(i, Py_SIZE(deque))) {
+        PyErr_SetString(PyExc_IndexError, "deque mutated during remove().");
+        return NULL;
+    }
+    rv = deque_del_item(deque, i);
+    if (rv == -1) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
 }
 
 static int


### PR DESCRIPTION
Alternate PR without an API change.  Equivalent to:  ``i = d.index(v); del d[i]``.

Baseline timing:
```
$ ./python.exe -m timeit -r 11 -s 'from collections import deque' 'd=deque(range(1000))' 'for i in reversed(range(1000)): d.remove(i)'
50 loops, best of 11: 9.83 msec per loop
```

Timing with the PR:
```
$ ./python.exe -m timeit -r 11  -s 'from collections import deque' 'd=deque(range(1000))' 'for i in reversed(range(1000)): d.remove(i)'
50 loops, best of 11: 5.19 msec per loop
```

<!-- issue-number: [bpo-25246](https://bugs.python.org/issue25246) -->
https://bugs.python.org/issue25246
<!-- /issue-number -->
