### PR TITLE
[3.8] bpo-34463: Make python tracebacks identical to C tracebacks for

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -679,7 +679,30 @@ class BaseExceptionReportingTests:
         err = self.get_report(Exception(''))
         self.assertIn('Exception\n', err)
 
+    def test_syntax_error_no_lineno(self):
+            # See #34463.
 
+            # Without filename
+            e = SyntaxError('bad syntax')
+            msg = self.get_report(e).splitlines()
+            self.assertEqual(msg,
+                ['SyntaxError: bad syntax'])
+            e.lineno = 100
+            msg = self.get_report(e).splitlines()
+            self.assertEqual(msg,
+                ['  File "<string>", line 100', 'SyntaxError: bad syntax'])
+
+            # With filename
+            e = SyntaxError('bad syntax')
+            e.filename = 'myfile.py'
+
+            msg = self.get_report(e).splitlines()
+            self.assertEqual(msg,
+                ['SyntaxError: bad syntax (myfile.py)'])
+            e.lineno = 100
+            msg = self.get_report(e).splitlines()
+            self.assertEqual(msg,
+                ['  File "myfile.py", line 100', 'SyntaxError: bad syntax'])
 class PyExcReportingTests(BaseExceptionReportingTests, unittest.TestCase):
     #
     # This checks reporting through the 'traceback' module, with both

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -703,6 +703,7 @@ class BaseExceptionReportingTests:
             msg = self.get_report(e).splitlines()
             self.assertEqual(msg,
                 ['  File "myfile.py", line 100', 'SyntaxError: bad syntax'])
+
 class PyExcReportingTests(BaseExceptionReportingTests, unittest.TestCase):
     #
     # This checks reporting through the 'traceback' module, with both

--- a/Misc/NEWS.d/next/Library/2020-12-22-22-51-48.bpo-34463.TUD8V5.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-22-22-51-48.bpo-34463.TUD8V5.rst
@@ -1,0 +1,1 @@
+Fixed discrepancy between :mod:`traceback` and the interpreter in formatting of SyntaxError with lineno not set (:mod:`traceback` was changed to match interpreter).


### PR DESCRIPTION
SyntaxErrors without a lineno (GH-23427)

(cherry picked from commit 069560b1171eb6385121ff3b6331e8814a4e7454)

Co-authored-by: Irit Katriel <iritkatriel@yahoo.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34463](https://bugs.python.org/issue34463) -->
https://bugs.python.org/issue34463
<!-- /issue-number -->
