### PR TITLE
closes bpo-42726: gdb libpython: InstanceProxy support for py3

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2020-12-23-19-42-11.bpo-42726.a5EkTv.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-12-23-19-42-11.bpo-42726.a5EkTv.rst
@@ -1,0 +1,2 @@
+Fixed compatibility issue with gdb/libpython.py handling of attribute
+dictionaries.

--- a/Misc/NEWS.d/next/Tools-Demos/2020-12-23-19-42-11.bpo-42726.a5EkTv.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-12-23-19-42-11.bpo-42726.a5EkTv.rst
@@ -1,2 +1,2 @@
-Fixed compatibility issue with gdb/libpython.py handling of attribute
+Fixed Python 3 compatibility issue with gdb/libpython.py handling of attribute
 dictionaries.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -468,7 +468,7 @@ class InstanceProxy(object):
     def __repr__(self):
         if isinstance(self.attrdict, dict):
             kwargs = ', '.join(["%s=%r" % (arg, val)
-                                for arg, val in self.attrdict.iteritems()])
+                                for arg, val in self.attrdict.items()])
             return '<%s(%s) at remote 0x%x>' % (self.cl_name,
                                                 kwargs, self.address)
         else:


### PR DESCRIPTION
On Fedora 31 gdb is using python 3.7.9, calling `proxyval` on an instance with a dictionary fails because of the `dict.iteritems` usage. This PR changes the code to be compatible with py2 and py3.

This changed seemed small enough to not need an issue and news blurb, if one is required please let me know.

<!-- issue-number: [bpo-42726](https://bugs.python.org/issue42726) -->
https://bugs.python.org/issue42726
<!-- /issue-number -->

Automerge-Triggered-By: GH:benjaminp