### PR TITLE
bpo-28468: Fix typo in _os_release_candidates

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -1241,7 +1241,7 @@ _os_release_line = re.compile(
 # unescape five special characters mentioned in the standard
 _os_release_unescape = re.compile(r"\\([\\\$\"\'`])")
 # /etc takes precedence over /usr/lib
-_os_release_candidates = ("/etc/os-release", "/usr/lib/os-relesase")
+_os_release_candidates = ("/etc/os-release", "/usr/lib/os-release")
 _os_release_cache = None
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28468](https://bugs.python.org/issue28468) -->
https://bugs.python.org/issue28468
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran