### PR TITLE
bpo-38308: Fix the "versionchanged" for the *weights* of harmonic_mean()

### DIFF
--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -198,7 +198,7 @@ However, for reading convenience, most of the examples show sorted sequences.
 
    .. versionadded:: 3.6
 
-   .. versionchanged:: 3.8
+   .. versionchanged:: 3.10
       Added support for *weights*.
 
 .. function:: median(data)


### PR DESCRIPTION


<!-- issue-number: [bpo-38308](https://bugs.python.org/issue38308) -->
https://bugs.python.org/issue38308
<!-- /issue-number -->
