### PR TITLE
bpo-44097: add --enable-pyc-build option to the configure script

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1594,33 +1594,45 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 		$(INSTALL_DATA) $(srcdir)/Modules/xxmodule.c \
 			$(DESTDIR)$(LIBDEST)/distutils/tests ; \
 	fi
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST) -f \
-		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
-		$(DESTDIR)$(LIBDEST)
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST) -f \
-		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
-		$(DESTDIR)$(LIBDEST)
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST) -f \
-		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
-		$(DESTDIR)$(LIBDEST)
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST)/site-packages -f \
-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST)/site-packages -f \
-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
-	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
-		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
-		-j0 -d $(LIBDEST)/site-packages -f \
-		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
+	-if test "@OPT0_PYC_BUILD@" = yes; then \
+		PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
+			$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+			-j0 -d $(LIBDEST) -f \
+			-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+			$(DESTDIR)$(LIBDEST); \
+	fi
+	-if test "@OPT1_PYC_BUILD@" = yes; then \
+		PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+			$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
+			-j0 -d $(LIBDEST) -f \
+			-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+			$(DESTDIR)$(LIBDEST); \
+	fi
+	-if test "@OPT2_PYC_BUILD@" = yes; then \
+		PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+			$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
+			-j0 -d $(LIBDEST) -f \
+			-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+			$(DESTDIR)$(LIBDEST); \
+	fi
+	-if test "@OPT0_PYC_BUILD@" = yes; then \
+		PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+			$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+			-j0 -d $(LIBDEST)/site-packages -f \
+			-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages; \
+	fi
+	-if test "@OPT1_PYC_BUILD@" = yes; then \
+		PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+			$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
+			-j0 -d $(LIBDEST)/site-packages -f \
+			-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages; \
+	fi
+	-if test "@OPT2_PYC_BUILD@" = yes; then \
+		PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+			$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
+			-j0 -d $(LIBDEST)/site-packages -f \
+			-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages; \
+	fi
 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
 		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/Grammar.txt
 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \

--- a/Misc/NEWS.d/next/Build/2020-12-24-10-43-04.bpo-31904.p3h6b6.rst
+++ b/Misc/NEWS.d/next/Build/2020-12-24-10-43-04.bpo-31904.p3h6b6.rst
@@ -1,0 +1,2 @@
+Add option ``--enable-pyc-build`` to the ``configure`` script to choose
+what type of .pyc files to compile at installing libraries.

--- a/configure
+++ b/configure
@@ -623,6 +623,9 @@ ac_includes_default="\
 #endif"
 
 ac_subst_vars='LTLIBOBJS
+OPT2_PYC_BUILD
+OPT1_PYC_BUILD
+OPT0_PYC_BUILD
 TEST_MODULES
 LIBRARY_DEPS
 STATIC_LIBPYTHON
@@ -862,6 +865,7 @@ with_builtin_hashlib_hashes
 with_experimental_isolated_subinterpreters
 with_static_libpython
 enable_test_modules
+enable_pyc_build
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1522,6 +1526,9 @@ Optional Features:
                           use big digits (30 or 15 bits) for Python longs
                           (default is system-dependent)]
   --disable-test-modules  don't build nor install test modules
+  --enable-pyc-build[=all|none|O0[,O1[,O2]]]
+                          choose what type of .pyc files to compile at
+                          installing libraries (default is all)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -17785,6 +17792,61 @@ else
 $as_echo "no" >&6; }
 fi
 
+
+# choose what type of .pyc files to compile at installing libraries
+OPT0_PYC_BUILD=yes
+OPT1_PYC_BUILD=yes
+OPT2_PYC_BUILD=yes
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --enable-pyc-build" >&5
+$as_echo_n "checking for --enable-pyc-build... " >&6; }
+# Check whether --enable-pyc-build was given.
+if test "${enable_pyc_build+set}" = set; then :
+  enableval=$enable_pyc_build;
+case $enableval in
+    yes|all)
+        ;;
+    no|none)
+        OPT0_PYC_BUILD=no
+        OPT1_PYC_BUILD=no
+        OPT2_PYC_BUILD=no
+        ;;
+    O[012]*)
+        OPT0_PYC_BUILD=no
+        OPT1_PYC_BUILD=no
+        OPT2_PYC_BUILD=no
+        for opt in `echo $enableval | sed 's/,/ /g'`; do
+            case $opt in
+                O0)
+                    OPT0_PYC_BUILD=yes
+                    ;;
+                O1)
+                    OPT1_PYC_BUILD=yes
+                    ;;
+                O2)
+                    OPT2_PYC_BUILD=yes
+                    ;;
+                *)
+                    as_fn_error $? "proper usage is --enable-pyc-build[=all|none|O0[,O1[,O2]]]" "$LINENO" 5
+                    ;;
+            esac
+        done
+        ;;
+    *)
+        as_fn_error $? "proper usage is --enable-pyc-build[=all|none|O0[,O1[,O2]]]" "$LINENO" 5
+        ;;
+esac
+
+else
+
+enable_pyc_build=all
+
+fi
+
+
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_pyc_build" >&5
+$as_echo "$enable_pyc_build" >&6; }
 
 
 # generate output files

--- a/configure.ac
+++ b/configure.ac
@@ -5933,6 +5933,56 @@ else
 fi
 AC_SUBST(TEST_MODULES)
 
+# choose what type of .pyc files to compile at installing libraries
+OPT0_PYC_BUILD=yes
+OPT1_PYC_BUILD=yes
+OPT2_PYC_BUILD=yes
+AC_MSG_CHECKING(for --enable-pyc-build)
+AC_ARG_ENABLE(pyc-build,
+              AS_HELP_STRING([--enable-pyc-build@<:@=all|none|O0@<:@,O1@<:@,O2@:>@@:>@@:>@],
+                             [choose what type of .pyc files to compile at installing libraries (default is all)]),
+[
+case $enableval in
+    yes|all)
+        ;;
+    no|none)
+        OPT0_PYC_BUILD=no
+        OPT1_PYC_BUILD=no
+        OPT2_PYC_BUILD=no
+        ;;
+    O@<:@012@:>@*)
+        OPT0_PYC_BUILD=no
+        OPT1_PYC_BUILD=no
+        OPT2_PYC_BUILD=no
+        for opt in `echo $enableval | sed 's/,/ /g'`; do
+            case $opt in
+                O0)
+                    OPT0_PYC_BUILD=yes
+                    ;;
+                O1)
+                    OPT1_PYC_BUILD=yes
+                    ;;
+                O2)
+                    OPT2_PYC_BUILD=yes
+                    ;;
+                *)
+                    AC_MSG_ERROR([proper usage is --enable-pyc-build@<:@=all|none|O0@<:@,O1@<:@,O2@:>@@:>@@:>@])
+                    ;;
+            esac
+        done
+        ;;
+    *)
+        AC_MSG_ERROR([proper usage is --enable-pyc-build@<:@=all|none|O0@<:@,O1@<:@,O2@:>@@:>@@:>@])
+        ;;
+esac
+],[
+enable_pyc_build=all
+])
+AC_SUBST(OPT0_PYC_BUILD)
+AC_SUBST(OPT1_PYC_BUILD)
+AC_SUBST(OPT2_PYC_BUILD)
+AC_MSG_RESULT($enable_pyc_build)
+
 
 # generate output files
 AC_CONFIG_FILES(Makefile.pre Misc/python.pc Misc/python-embed.pc Misc/python-config.sh)


### PR DESCRIPTION
Currently when you build and install Python out of source, unoptimized *.pyc files and 2 types of optimized .pyc files(*.opt-1.pyc and *.opt-2.pyc) are all compiled out and installed. So to reduce package size and build and installation time, we should provide options in configure to disable them.

https://bugs.python.org/issue44097