### PR TITLE
bpo-42729: Introduce ast.parse_tokens() to interface with "tokenize"

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -51,6 +51,28 @@ def parse(source, filename='<unknown>', mode='exec', *,
                    _feature_version=feature_version)
 
 
+def parse_tokens(token_stream, filename='<unknown>', mode='exec', *,
+          type_comments=False, feature_version=None):
+    """
+    Parse the token iterable (e.g. as returned by tokenize.tokenize())
+    into an AST node.
+    All other parameters and features are the same as parse().
+    """
+    # Current implementation just naively converts token stream to
+    # character stream. The purpose of this function is to connect
+    # Python's tokenization phase with the rest of the compilation
+    # infrastructure, in the same as it's possible to compile an AST
+    # tree, without converting it to the source program form. So,
+    # the purpose of this function is to establish API, and
+    # implementation can be optimized later as needed (perhaps in
+    # other implementations, frugal in memory usage/wanting to get
+    # last bits of performance.
+    import tokenize
+    source = tokenize.untokenize(token_stream)
+    return parse(source, filename, mode, type_comments=type_comments,
+                 feature_version=feature_version)
+
+
 def literal_eval(node_or_string):
     """
     Safely evaluate an expression node or a string containing a Python


### PR DESCRIPTION
Currently, with Python it's possible:

* To get from stream-of-characters program representation to AST
  representation (AST.parse()).
* To get from AST to code object (compile()).
* To get from a code object to first-class function to the execute the
  program.

Python also offers "tokenize" module, but it stands as a disconnected
island: the only things it allows to do is to get from
stream-of-characters program representation to stream-of-tokens, and
back. At the same time, conceptually, tokenization is not a disconnected
feature, it's the first stage of language processing pipeline. The fact
that "tokenize" is disconnected from the rest of the pipeline, as
listed above, is more an artifact of CPython implementation: both
"ast" module and compile() module are backed by the underlying bytecode
compiler implementation written in C, and that's what connects them.

On the other hand, "tokenize" module is pure-Python, while the
underlying compiler has its own tokenizer implementation (not exposed).
That's the likely reason of such disconnection between "tokenize" and
the rest of the infrastructure.

Thia patch closes that gap, and establishes an API which allows to
parse token stream (iterable) into an AST. The initial implementation
for CPython is naive, making a loop thru surface program representation.
That's considered ok, as the idea is to establish a standard API to be
able to go tokens -> AST. Then individual Python implementation can
make/optimize it based on their needs.

The function introduced here is ast.parse_tokens(). It follows the
signature of the existing ast.parse(), except that first parameter
is "token_stream" instead of "source".

Another alternative would be to overload existing ast.parse() to
accept token iterable. I guess, at the current stage, where we try
to tighten up type strictness of API, and have clear typing signatures
for API functions, this is not favored solution.

Signed-off-by: Paul Sokolovsky <pfalcon@users.sourceforge.net>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42729](https://bugs.python.org/issue42729) -->
https://bugs.python.org/issue42729
<!-- /issue-number -->
