### PR TITLE
[3.9] bpo-42727: [Enum] EnumMeta.__prepare__ now accepts **kwds (GH-23917).

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -170,7 +170,7 @@ class EnumMeta(type):
     Metaclass for Enum
     """
     @classmethod
-    def __prepare__(metacls, cls, bases):
+    def __prepare__(metacls, cls, bases, **kwds):
         # check that previous enum members do not exist
         metacls._check_for_existing_members(cls, bases)
         # create the namespace dict

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2049,6 +2049,22 @@ class TestEnum(unittest.TestCase):
         local_ls = {}
         exec(code, global_ns, local_ls)
 
+    @unittest.skipUnless(
+            sys.version_info[:2] == (3, 9),
+            'private variables are now normal attributes',
+            )
+    def test_warning_for_private_variables(self):
+        with self.assertWarns(DeprecationWarning):
+            class Private(Enum):
+                __corporal = 'Radar'
+        self.assertEqual(Private._Private__corporal.value, 'Radar')
+        try:
+            with self.assertWarns(DeprecationWarning):
+                class Private(Enum):
+                    __major_ = 'Hoolihan'
+        except ValueError:
+            pass
+
     def test_strenum(self):
         class GoodStrEnum(StrEnum):
             one = '1'

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2065,65 +2065,6 @@ class TestEnum(unittest.TestCase):
         except ValueError:
             pass
 
-    def test_strenum(self):
-        class GoodStrEnum(StrEnum):
-            one = '1'
-            two = '2'
-            three = b'3', 'ascii'
-            four = b'4', 'latin1', 'strict'
-        self.assertEqual(GoodStrEnum.one, '1')
-        self.assertEqual(str(GoodStrEnum.one), '1')
-        self.assertEqual(GoodStrEnum.one, str(GoodStrEnum.one))
-        self.assertEqual(GoodStrEnum.one, '{}'.format(GoodStrEnum.one))
-        #
-        class DumbMixin:
-            def __str__(self):
-                return "don't do this"
-        class DumbStrEnum(DumbMixin, StrEnum):
-            five = '5'
-            six = '6'
-            seven = '7'
-        self.assertEqual(DumbStrEnum.seven, '7')
-        self.assertEqual(str(DumbStrEnum.seven), "don't do this")
-        #
-        class EnumMixin(Enum):
-            def hello(self):
-                print('hello from %s' % (self, ))
-        class HelloEnum(EnumMixin, StrEnum):
-            eight = '8'
-        self.assertEqual(HelloEnum.eight, '8')
-        self.assertEqual(HelloEnum.eight, str(HelloEnum.eight))
-        #
-        class GoodbyeMixin:
-            def goodbye(self):
-                print('%s wishes you a fond farewell')
-        class GoodbyeEnum(GoodbyeMixin, EnumMixin, StrEnum):
-            nine = '9'
-        self.assertEqual(GoodbyeEnum.nine, '9')
-        self.assertEqual(GoodbyeEnum.nine, str(GoodbyeEnum.nine))
-        #
-        with self.assertRaisesRegex(TypeError, '1 is not a string'):
-            class FirstFailedStrEnum(StrEnum):
-                one = 1
-                two = '2'
-        with self.assertRaisesRegex(TypeError, "2 is not a string"):
-            class SecondFailedStrEnum(StrEnum):
-                one = '1'
-                two = 2,
-                three = '3'
-        with self.assertRaisesRegex(TypeError, '2 is not a string'):
-            class ThirdFailedStrEnum(StrEnum):
-                one = '1'
-                two = 2
-        with self.assertRaisesRegex(TypeError, 'encoding must be a string, not %r' % (sys.getdefaultencoding, )):
-            class ThirdFailedStrEnum(StrEnum):
-                one = '1'
-                two = b'2', sys.getdefaultencoding
-        with self.assertRaisesRegex(TypeError, 'errors must be a string, not 9'):
-            class ThirdFailedStrEnum(StrEnum):
-                one = '1'
-                two = b'2', 'ascii', 9
-                
     def test_init_subclass_calling(self):
         class MyEnum(Enum):
             def __init_subclass__(cls, **kwds):

--- a/Misc/NEWS.d/next/Library/2020-12-23-19-43-06.bpo-42727.WH3ODh.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-23-19-43-06.bpo-42727.WH3ODh.rst
@@ -1,0 +1,2 @@
+`EnumMeta.__prepare__` now accepts `**kwds` to properly support
+`__init_subclass__`


### PR DESCRIPTION
(cherry picked from commit 6ec0adefad60ec7cdec61c44baecf1dccc1461ab)

Co-authored-by: Ethan Furman <ethan@stoneleaf.us>

<!-- issue-number: [bpo-42727](https://bugs.python.org/issue42727) -->
https://bugs.python.org/issue42727
<!-- /issue-number -->
