### PR TITLE
bpo-42727: Fix the NEWS entry .rst syntax to fix CI

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-12-23-19-43-06.bpo-42727.WH3ODh.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-23-19-43-06.bpo-42727.WH3ODh.rst
@@ -1,2 +1,2 @@
-`EnumMeta.__prepare__` now accepts `**kwds` to properly support
-`__init_subclass__`
+``EnumMeta.__prepare__`` now accepts ``**kwds`` to properly support
+``__init_subclass__``


### PR DESCRIPTION
It is causing CI failures for everyone.

```
$ cd Doc
$ make venv PYTHON=python
$ make check html SPHINXOPTS="-q -W -j4"
python3 tools/rstlint.py ../Misc/NEWS.d/next/
[2] ../Misc/NEWS.d/next/Library/2020-12-23-19-43-06.[bpo-42727](https://bugs.python.org/issue42727).WH3ODh.rst:1: default role used
[2] ../Misc/NEWS.d/next/Library/2020-12-23-19-43-06.[bpo-42727](https://bugs.python.org/issue42727).WH3ODh.rst:2: default role used
2 problems with severity 2 found.
Makefile:204: recipe for target 'check' failed
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42727](https://bugs.python.org/issue42727) -->
https://bugs.python.org/issue42727
<!-- /issue-number -->
