### PR TITLE
bpo-38435: Detect preexec_fn=os.setsid as start_new_session=True

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -937,6 +937,10 @@ class Popen(object):
             if uid < 0:
                 raise ValueError(f"User ID cannot be negative, got {uid}")
 
+        if preexec_fn == os.setsid:  # A common unnecessary legacy use.
+            start_new_session = True
+            preexec_fn = None
+
         try:
             if p2cwrite != -1:
                 self.stdin = io.open(p2cwrite, 'wb', bufsize)


### PR DESCRIPTION
This is a somewhat common use case, this makes it more reliable.

I'd rather see code that does this be cleaned up.  But until it is, this at least makes it more reliable and a little faster.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38435](https://bugs.python.org/issue38435) -->
https://bugs.python.org/issue38435
<!-- /issue-number -->
