### PR TITLE
bpo-42734: Fix crasher bogus_code_obj.py

### DIFF
--- a/Lib/test/crashers/bogus_code_obj.py
+++ b/Lib/test/crashers/bogus_code_obj.py
@@ -14,6 +14,6 @@ the user build or load random bytecodes anyway.  Otherwise, this is a
 
 import types
 
-co = types.CodeType(0, 0, 0, 0, 0, b'\x04\x71\x00\x00',
+co = types.CodeType(0, 0, 0, 0, 0, 0, b'\x04\x00\x71\x00',
                     (), (), (), '', '', 1, b'')
 exec(co)


### PR DESCRIPTION
It did not work because the signature of code object constructor
was changed. Also, it used old format of bytecode (pre-wordcode).


<!-- issue-number: [bpo-42734](https://bugs.python.org/issue42734) -->
https://bugs.python.org/issue42734
<!-- /issue-number -->
