### PR TITLE
bpo-42740: Support PEP 604, 612 for typing.py get_args and get_origin

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3050,6 +3050,10 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(list[int]), (int,))
         self.assertEqual(get_args(list), ())
         self.assertEqual(get_args(collections.abc.Callable[[int], str]), ([int], str))
+        self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
+        self.assertEqual(get_args(collections.abc.Callable[[], str]), ([], str))
+        self.assertEqual(get_args(collections.abc.Callable[[int], str]),
+                         get_args(Callable[[int], str]))
         P = ParamSpec('P')
         self.assertEqual(get_args(Callable[P, int]), (P, int))
         self.assertEqual(get_args(Callable[Concatenate[int, P], int]),

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3021,6 +3021,7 @@ class GetUtilitiesTestCase(TestCase):
         self.assertIs(get_origin(Callable), collections.abc.Callable)
         self.assertIs(get_origin(list[int]), list)
         self.assertIs(get_origin(list), None)
+        self.assertIs(get_origin(list | str), types.Union)
 
     def test_get_args(self):
         T = TypeVar('T')
@@ -3048,6 +3049,12 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(Callable), ())
         self.assertEqual(get_args(list[int]), (int,))
         self.assertEqual(get_args(list), ())
+        self.assertEqual(get_args(collections.abc.Callable[[int], str]), ([int], str))
+        P = ParamSpec('P')
+        self.assertEqual(get_args(Callable[P, int]), (P, int))
+        self.assertEqual(get_args(Callable[Concatenate[int, P], int]),
+                         (Concatenate[int, P], int))
+        self.assertEqual(get_args(list | str), (list, str))
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1668,6 +1668,8 @@ def get_origin(tp):
         return tp.__origin__
     if tp is Generic:
         return Generic
+    if isinstance(tp, types.Union):
+        return types.Union
     return None
 
 
@@ -1684,12 +1686,14 @@ def get_args(tp):
     """
     if isinstance(tp, _AnnotatedAlias):
         return (tp.__origin__,) + tp.__metadata__
-    if isinstance(tp, _GenericAlias):
+    if isinstance(tp, (_GenericAlias, GenericAlias)):
         res = tp.__args__
-        if tp.__origin__ is collections.abc.Callable and res[0] is not Ellipsis:
+        if (tp.__origin__ is collections.abc.Callable
+                and not (res[0] is Ellipsis
+                         or isinstance(res[0], (ParamSpec, _ConcatenateGenericAlias)))):
             res = (list(res[:-1]), res[-1])
         return res
-    if isinstance(tp, GenericAlias):
+    if isinstance(tp, types.Union):
         return tp.__args__
     return ()
 

--- a/Misc/NEWS.d/next/Library/2020-12-25-23-23-11.bpo-42740.F0rQ_E.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-25-23-23-11.bpo-42740.F0rQ_E.rst
@@ -1,0 +1,2 @@
+:func:`typing.get_args` and :func:`typing.get_origin` now support :pep:`604`
+union types and :pep:`612` ``Callable``.

--- a/Misc/NEWS.d/next/Library/2020-12-25-23-23-11.bpo-42740.F0rQ_E.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-25-23-23-11.bpo-42740.F0rQ_E.rst
@@ -1,2 +1,2 @@
 :func:`typing.get_args` and :func:`typing.get_origin` now support :pep:`604`
-union types and :pep:`612` ``Callable``.
+union types and :pep:`612` additions to ``Callable``.


### PR DESCRIPTION
PR 2/2. No backport required.

<!-- issue-number: [bpo-42740](https://bugs.python.org/issue42740) -->
https://bugs.python.org/issue42740
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum