### PR TITLE
[3.8] Rename Tkinter tests for widget options (GH-23944)

### DIFF
--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -23,7 +23,7 @@ def float_round(x):
 class AbstractToplevelTest(AbstractWidgetTest, PixelSizeTests):
     _conv_pad_pixels = noconv
 
-    def test_class(self):
+    def test_configure_class(self):
         widget = self.create()
         self.assertEqual(widget['class'],
                          widget.__class__.__name__.title())
@@ -32,7 +32,7 @@ class AbstractToplevelTest(AbstractWidgetTest, PixelSizeTests):
         widget2 = self.create(class_='Foo')
         self.assertEqual(widget2['class'], 'Foo')
 
-    def test_colormap(self):
+    def test_configure_colormap(self):
         widget = self.create()
         self.assertEqual(widget['colormap'], '')
         self.checkInvalidParam(widget, 'colormap', 'new',
@@ -40,7 +40,7 @@ class AbstractToplevelTest(AbstractWidgetTest, PixelSizeTests):
         widget2 = self.create(colormap='new')
         self.assertEqual(widget2['colormap'], 'new')
 
-    def test_container(self):
+    def test_configure_container(self):
         widget = self.create()
         self.assertEqual(widget['container'], 0 if self.wantobjects else '0')
         self.checkInvalidParam(widget, 'container', 1,
@@ -48,7 +48,7 @@ class AbstractToplevelTest(AbstractWidgetTest, PixelSizeTests):
         widget2 = self.create(container=True)
         self.assertEqual(widget2['container'], 1 if self.wantobjects else '1')
 
-    def test_visual(self):
+    def test_configure_visual(self):
         widget = self.create()
         self.assertEqual(widget['visual'], '')
         self.checkInvalidParam(widget, 'visual', 'default',
@@ -70,13 +70,13 @@ class ToplevelTest(AbstractToplevelTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Toplevel(self.root, **kwargs)
 
-    def test_menu(self):
+    def test_configure_menu(self):
         widget = self.create()
         menu = tkinter.Menu(self.root)
         self.checkParam(widget, 'menu', menu, eq=widget_eq)
         self.checkParam(widget, 'menu', '')
 
-    def test_screen(self):
+    def test_configure_screen(self):
         widget = self.create()
         self.assertEqual(widget['screen'], '')
         try:
@@ -88,7 +88,7 @@ class ToplevelTest(AbstractToplevelTest, unittest.TestCase):
         widget2 = self.create(screen=display)
         self.assertEqual(widget2['screen'], display)
 
-    def test_use(self):
+    def test_configure_use(self):
         widget = self.create()
         self.assertEqual(widget['use'], '')
         parent = self.create(container=True)
@@ -125,14 +125,14 @@ class LabelFrameTest(AbstractToplevelTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.LabelFrame(self.root, **kwargs)
 
-    def test_labelanchor(self):
+    def test_configure_labelanchor(self):
         widget = self.create()
         self.checkEnumParam(widget, 'labelanchor',
                             'e', 'en', 'es', 'n', 'ne', 'nw',
                             's', 'se', 'sw', 'w', 'wn', 'ws')
         self.checkInvalidParam(widget, 'labelanchor', 'center')
 
-    def test_labelwidget(self):
+    def test_configure_labelwidget(self):
         widget = self.create()
         label = tkinter.Label(self.root, text='Mupp', name='foo')
         self.checkParam(widget, 'labelwidget', label, expected='.foo')
@@ -142,7 +142,7 @@ class LabelFrameTest(AbstractToplevelTest, unittest.TestCase):
 class AbstractLabelTest(AbstractWidgetTest, IntegerSizeTests):
     _conv_pixels = noconv
 
-    def test_highlightthickness(self):
+    def test_configure_highlightthickness(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'highlightthickness',
                               0, 1.3, 2.6, 6, -2, '10p')
@@ -180,7 +180,7 @@ class ButtonTest(AbstractLabelTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Button(self.root, **kwargs)
 
-    def test_default(self):
+    def test_configure_default(self):
         widget = self.create()
         self.checkEnumParam(widget, 'default', 'active', 'disabled', 'normal')
 
@@ -205,11 +205,11 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
         return tkinter.Checkbutton(self.root, **kwargs)
 
 
-    def test_offvalue(self):
+    def test_configure_offvalue(self):
         widget = self.create()
         self.checkParams(widget, 'offvalue', 1, 2.3, '', 'any string')
 
-    def test_onvalue(self):
+    def test_configure_onvalue(self):
         widget = self.create()
         self.checkParams(widget, 'onvalue', 1, 2.3, '', 'any string')
 
@@ -232,7 +232,7 @@ class RadiobuttonTest(AbstractLabelTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Radiobutton(self.root, **kwargs)
 
-    def test_value(self):
+    def test_configure_value(self):
         widget = self.create()
         self.checkParams(widget, 'value', 1, 2.3, '', 'any string')
 
@@ -255,20 +255,21 @@ class MenubuttonTest(AbstractLabelTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Menubutton(self.root, **kwargs)
 
-    def test_direction(self):
+    def test_configure_direction(self):
         widget = self.create()
         self.checkEnumParam(widget, 'direction',
                 'above', 'below', 'flush', 'left', 'right')
 
-    def test_height(self):
+    def test_configure_height(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'height', 100, -100, 0, conv=str)
 
-    test_highlightthickness = StandardOptionsTests.test_highlightthickness
+    test_configure_highlightthickness = \
+        StandardOptionsTests.test_configure_highlightthickness
 
     @unittest.skipIf(sys.platform == 'darwin',
                      'crashes with Cocoa Tk (issue19733)')
-    def test_image(self):
+    def test_configure_image(self):
         widget = self.create()
         image = tkinter.PhotoImage(master=self.root, name='image1')
         self.checkParam(widget, 'image', image, conv=str)
@@ -282,23 +283,23 @@ class MenubuttonTest(AbstractLabelTest, unittest.TestCase):
         if errmsg is not None:
             self.assertEqual(str(cm.exception), errmsg)
 
-    def test_menu(self):
+    def test_configure_menu(self):
         widget = self.create()
         menu = tkinter.Menu(widget, name='menu')
         self.checkParam(widget, 'menu', menu, eq=widget_eq)
         menu.destroy()
 
-    def test_padx(self):
+    def test_configure_padx(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'padx', 3, 4.4, 5.6, '12m')
         self.checkParam(widget, 'padx', -2, expected=0)
 
-    def test_pady(self):
+    def test_configure_pady(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'pady', 3, 4.4, 5.6, '12m')
         self.checkParam(widget, 'pady', -2, expected=0)
 
-    def test_width(self):
+    def test_configure_width(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'width', 402, -402, 0, conv=str)
 
@@ -331,18 +332,18 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Entry(self.root, **kwargs)
 
-    def test_disabledbackground(self):
+    def test_configure_disabledbackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'disabledbackground')
 
-    def test_insertborderwidth(self):
+    def test_configure_insertborderwidth(self):
         widget = self.create(insertwidth=100)
         self.checkPixelsParam(widget, 'insertborderwidth',
                               0, 1.3, 2.6, 6, -2, '10p')
         # insertborderwidth is bounded above by a half of insertwidth.
         self.checkParam(widget, 'insertborderwidth', 60, expected=100//2)
 
-    def test_insertwidth(self):
+    def test_configure_insertwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'insertwidth', 1.3, 3.6, '10p')
         self.checkParam(widget, 'insertwidth', 0.1, expected=2)
@@ -352,32 +353,32 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
         else:
             self.checkParam(widget, 'insertwidth', 0.9, expected=1)
 
-    def test_invalidcommand(self):
+    def test_configure_invalidcommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'invalidcommand')
         self.checkCommandParam(widget, 'invcmd')
 
-    def test_readonlybackground(self):
+    def test_configure_readonlybackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'readonlybackground')
 
-    def test_show(self):
+    def test_configure_show(self):
         widget = self.create()
         self.checkParam(widget, 'show', '*')
         self.checkParam(widget, 'show', '')
         self.checkParam(widget, 'show', ' ')
 
-    def test_state(self):
+    def test_configure_state(self):
         widget = self.create()
         self.checkEnumParam(widget, 'state',
                             'disabled', 'normal', 'readonly')
 
-    def test_validate(self):
+    def test_configure_validate(self):
         widget = self.create()
         self.checkEnumParam(widget, 'validate',
                 'all', 'key', 'focus', 'focusin', 'focusout', 'none')
 
-    def test_validatecommand(self):
+    def test_configure_validatecommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'validatecommand')
         self.checkCommandParam(widget, 'vcmd')
@@ -430,25 +431,25 @@ class SpinboxTest(EntryTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Spinbox(self.root, **kwargs)
 
-    test_show = None
+    test_configure_show = None
 
-    def test_buttonbackground(self):
+    def test_configure_buttonbackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'buttonbackground')
 
-    def test_buttoncursor(self):
+    def test_configure_buttoncursor(self):
         widget = self.create()
         self.checkCursorParam(widget, 'buttoncursor')
 
-    def test_buttondownrelief(self):
+    def test_configure_buttondownrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'buttondownrelief')
 
-    def test_buttonuprelief(self):
+    def test_configure_buttonuprelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'buttonuprelief')
 
-    def test_format(self):
+    def test_configure_format(self):
         widget = self.create()
         self.checkParam(widget, 'format', '%2f')
         self.checkParam(widget, 'format', '%2.2f')
@@ -463,25 +464,25 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.checkParam(widget, 'format', '%09.200f')
         self.checkInvalidParam(widget, 'format', '%d')
 
-    def test_from(self):
+    def test_configure_from(self):
         widget = self.create()
         self.checkParam(widget, 'to', 100.0)
         self.checkFloatParam(widget, 'from', -10, 10.2, 11.7)
         self.checkInvalidParam(widget, 'from', 200,
                 errmsg='-to value must be greater than -from value')
 
-    def test_increment(self):
+    def test_configure_increment(self):
         widget = self.create()
         self.checkFloatParam(widget, 'increment', -1, 1, 10.2, 12.8, 0)
 
-    def test_to(self):
+    def test_configure_to(self):
         widget = self.create()
         self.checkParam(widget, 'from', -100.0)
         self.checkFloatParam(widget, 'to', -10, 10.2, 11.7)
         self.checkInvalidParam(widget, 'to', -200,
                 errmsg='-to value must be greater than -from value')
 
-    def test_values(self):
+    def test_configure_values(self):
         # XXX
         widget = self.create()
         self.assertEqual(widget['values'], '')
@@ -492,7 +493,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
                         expected='42 3.14 {} {any string}')
         self.checkParam(widget, 'values', '')
 
-    def test_wrap(self):
+    def test_configure_wrap(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'wrap')
 
@@ -558,17 +559,17 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Text(self.root, **kwargs)
 
-    def test_autoseparators(self):
+    def test_configure_autoseparators(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'autoseparators')
 
     @requires_tcl(8, 5)
-    def test_blockcursor(self):
+    def test_configure_blockcursor(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'blockcursor')
 
     @requires_tcl(8, 5)
-    def test_endline(self):
+    def test_configure_endline(self):
         widget = self.create()
         text = '\n'.join('Line %d' for i in range(100))
         widget.insert('end', text)
@@ -581,50 +582,50 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         self.checkInvalidParam(widget, 'endline', 10,
                 errmsg='-startline must be less than or equal to -endline')
 
-    def test_height(self):
+    def test_configure_height(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'height', 100, 101.2, 102.6, '3c')
         self.checkParam(widget, 'height', -100, expected=1)
         self.checkParam(widget, 'height', 0, expected=1)
 
-    def test_maxundo(self):
+    def test_configure_maxundo(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'maxundo', 0, 5, -1)
 
     @requires_tcl(8, 5)
-    def test_inactiveselectbackground(self):
+    def test_configure_inactiveselectbackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'inactiveselectbackground')
 
     @requires_tcl(8, 6)
-    def test_insertunfocussed(self):
+    def test_configure_insertunfocussed(self):
         widget = self.create()
         self.checkEnumParam(widget, 'insertunfocussed',
                             'hollow', 'none', 'solid')
 
-    def test_selectborderwidth(self):
+    def test_configure_selectborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'selectborderwidth',
                               1.3, 2.6, -2, '10p', conv=noconv,
                               keep_orig=tcl_version >= (8, 5))
 
-    def test_spacing1(self):
+    def test_configure_spacing1(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'spacing1', 20, 21.4, 22.6, '0.5c')
         self.checkParam(widget, 'spacing1', -5, expected=0)
 
-    def test_spacing2(self):
+    def test_configure_spacing2(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'spacing2', 5, 6.4, 7.6, '0.1c')
         self.checkParam(widget, 'spacing2', -1, expected=0)
 
-    def test_spacing3(self):
+    def test_configure_spacing3(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'spacing3', 20, 21.4, 22.6, '0.5c')
         self.checkParam(widget, 'spacing3', -10, expected=0)
 
     @requires_tcl(8, 5)
-    def test_startline(self):
+    def test_configure_startline(self):
         widget = self.create()
         text = '\n'.join('Line %d' for i in range(100))
         widget.insert('end', text)
@@ -637,14 +638,14 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         self.checkInvalidParam(widget, 'startline', 70,
                 errmsg='-startline must be less than or equal to -endline')
 
-    def test_state(self):
+    def test_configure_state(self):
         widget = self.create()
         if tcl_version < (8, 5):
             self.checkParams(widget, 'state', 'disabled', 'normal')
         else:
             self.checkEnumParam(widget, 'state', 'disabled', 'normal')
 
-    def test_tabs(self):
+    def test_configure_tabs(self):
         widget = self.create()
         if get_tk_patchlevel() < (8, 5, 11):
             self.checkParam(widget, 'tabs', (10.2, 20.7, '1i', '2i'),
@@ -660,21 +661,21 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
                                keep_orig=tcl_version >= (8, 5))
 
     @requires_tcl(8, 5)
-    def test_tabstyle(self):
+    def test_configure_tabstyle(self):
         widget = self.create()
         self.checkEnumParam(widget, 'tabstyle', 'tabular', 'wordprocessor')
 
-    def test_undo(self):
+    def test_configure_undo(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'undo')
 
-    def test_width(self):
+    def test_configure_width(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'width', 402)
         self.checkParam(widget, 'width', -402, expected=1)
         self.checkParam(widget, 'width', 0, expected=1)
 
-    def test_wrap(self):
+    def test_configure_wrap(self):
         widget = self.create()
         if tcl_version < (8, 5):
             self.checkParams(widget, 'wrap', 'char', 'none', 'word')
@@ -712,16 +713,16 @@ class CanvasTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Canvas(self.root, **kwargs)
 
-    def test_closeenough(self):
+    def test_configure_closeenough(self):
         widget = self.create()
         self.checkFloatParam(widget, 'closeenough', 24, 2.4, 3.6, -3,
                              conv=float)
 
-    def test_confine(self):
+    def test_configure_confine(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'confine')
 
-    def test_offset(self):
+    def test_configure_offset(self):
         widget = self.create()
         self.assertEqual(widget['offset'], '0,0')
         self.checkParams(widget, 'offset',
@@ -730,7 +731,7 @@ class CanvasTest(AbstractWidgetTest, unittest.TestCase):
         self.checkParam(widget, 'offset', '#5,6')
         self.checkInvalidParam(widget, 'offset', 'spam')
 
-    def test_scrollregion(self):
+    def test_configure_scrollregion(self):
         widget = self.create()
         self.checkParam(widget, 'scrollregion', '0 0 200 150')
         self.checkParam(widget, 'scrollregion', (0, 0, 200, 150),
@@ -742,17 +743,17 @@ class CanvasTest(AbstractWidgetTest, unittest.TestCase):
         self.checkInvalidParam(widget, 'scrollregion', (0, 0, 200))
         self.checkInvalidParam(widget, 'scrollregion', (0, 0, 200, 150, 0))
 
-    def test_state(self):
+    def test_configure_state(self):
         widget = self.create()
         self.checkEnumParam(widget, 'state', 'disabled', 'normal',
                 errmsg='bad state value "{}": must be normal or disabled')
 
-    def test_xscrollincrement(self):
+    def test_configure_xscrollincrement(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'xscrollincrement',
                               40, 0, 41.2, 43.6, -40, '0.5i')
 
-    def test_yscrollincrement(self):
+    def test_configure_yscrollincrement(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'yscrollincrement',
                               10, 0, 11.2, 13.6, -10, '0.1i')
@@ -797,26 +798,26 @@ class ListboxTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Listbox(self.root, **kwargs)
 
-    def test_activestyle(self):
+    def test_configure_activestyle(self):
         widget = self.create()
         self.checkEnumParam(widget, 'activestyle',
                             'dotbox', 'none', 'underline')
 
-    test_justify = requires_tcl(8, 6, 5)(StandardOptionsTests.test_justify)
+    test_justify = requires_tcl(8, 6, 5)(StandardOptionsTests.test_configure_justify)
 
-    def test_listvariable(self):
+    def test_configure_listvariable(self):
         widget = self.create()
         var = tkinter.DoubleVar(self.root)
         self.checkVariableParam(widget, 'listvariable', var)
 
-    def test_selectmode(self):
+    def test_configure_selectmode(self):
         widget = self.create()
         self.checkParam(widget, 'selectmode', 'single')
         self.checkParam(widget, 'selectmode', 'browse')
         self.checkParam(widget, 'selectmode', 'multiple')
         self.checkParam(widget, 'selectmode', 'extended')
 
-    def test_state(self):
+    def test_configure_state(self):
         widget = self.create()
         self.checkEnumParam(widget, 'state', 'disabled', 'normal')
 
@@ -931,53 +932,53 @@ class ScaleTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Scale(self.root, **kwargs)
 
-    def test_bigincrement(self):
+    def test_configure_bigincrement(self):
         widget = self.create()
         self.checkFloatParam(widget, 'bigincrement', 12.4, 23.6, -5)
 
-    def test_digits(self):
+    def test_configure_digits(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'digits', 5, 0)
 
-    def test_from(self):
+    def test_configure_from(self):
         widget = self.create()
         conv = False if get_tk_patchlevel() >= (8, 6, 10) else float_round
         self.checkFloatParam(widget, 'from', 100, 14.9, 15.1, conv=conv)
 
-    def test_label(self):
+    def test_configure_label(self):
         widget = self.create()
         self.checkParam(widget, 'label', 'any string')
         self.checkParam(widget, 'label', '')
 
-    def test_length(self):
+    def test_configure_length(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'length', 130, 131.2, 135.6, '5i')
 
-    def test_resolution(self):
+    def test_configure_resolution(self):
         widget = self.create()
         self.checkFloatParam(widget, 'resolution', 4.2, 0, 6.7, -2)
 
-    def test_showvalue(self):
+    def test_configure_showvalue(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'showvalue')
 
-    def test_sliderlength(self):
+    def test_configure_sliderlength(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'sliderlength',
                               10, 11.2, 15.6, -3, '3m')
 
-    def test_sliderrelief(self):
+    def test_configure_sliderrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'sliderrelief')
 
-    def test_tickinterval(self):
+    def test_configure_tickinterval(self):
         widget = self.create()
         self.checkFloatParam(widget, 'tickinterval', 1, 4.3, 7.6, 0,
                              conv=float_round)
         self.checkParam(widget, 'tickinterval', -2, expected=2,
                         conv=float_round)
 
-    def test_to(self):
+    def test_configure_to(self):
         widget = self.create()
         self.checkFloatParam(widget, 'to', 300, 14.9, 15.1, -10,
                              conv=float_round)
@@ -1001,15 +1002,15 @@ class ScrollbarTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Scrollbar(self.root, **kwargs)
 
-    def test_activerelief(self):
+    def test_configure_activerelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'activerelief')
 
-    def test_elementborderwidth(self):
+    def test_configure_elementborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'elementborderwidth', 4.3, 5.6, -2, '1m')
 
-    def test_orient(self):
+    def test_configure_orient(self):
         widget = self.create()
         self.checkEnumParam(widget, 'orient', 'vertical', 'horizontal',
                 errmsg='bad orientation "{}": must be vertical or horizontal')
@@ -1050,63 +1051,63 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.PanedWindow(self.root, **kwargs)
 
-    def test_handlepad(self):
+    def test_configure_handlepad(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'handlepad', 5, 6.4, 7.6, -3, '1m')
 
-    def test_handlesize(self):
+    def test_configure_handlesize(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'handlesize', 8, 9.4, 10.6, -3, '2m',
                               conv=noconv)
 
-    def test_height(self):
+    def test_configure_height(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'height', 100, 101.2, 102.6, -100, 0, '1i',
                               conv=noconv)
 
-    def test_opaqueresize(self):
+    def test_configure_opaqueresize(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'opaqueresize')
 
     @requires_tcl(8, 6, 5)
-    def test_proxybackground(self):
+    def test_configure_proxybackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'proxybackground')
 
     @requires_tcl(8, 6, 5)
-    def test_proxyborderwidth(self):
+    def test_configure_proxyborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'proxyborderwidth',
                               0, 1.3, 2.9, 6, -2, '10p',
                               conv=noconv)
 
     @requires_tcl(8, 6, 5)
-    def test_proxyrelief(self):
+    def test_configure_proxyrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'proxyrelief')
 
-    def test_sashcursor(self):
+    def test_configure_sashcursor(self):
         widget = self.create()
         self.checkCursorParam(widget, 'sashcursor')
 
-    def test_sashpad(self):
+    def test_configure_sashpad(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'sashpad', 8, 1.3, 2.6, -2, '2m')
 
-    def test_sashrelief(self):
+    def test_configure_sashrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'sashrelief')
 
-    def test_sashwidth(self):
+    def test_configure_sashwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'sashwidth', 10, 11.1, 15.6, -3, '1m',
                               conv=noconv)
 
-    def test_showhandle(self):
+    def test_configure_showhandle(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'showhandle')
 
-    def test_width(self):
+    def test_configure_width(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'width', 402, 403.4, 404.6, -402, 0, '5i',
                               conv=noconv)
@@ -1225,23 +1226,23 @@ class MenuTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Menu(self.root, **kwargs)
 
-    def test_postcommand(self):
+    def test_configure_postcommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'postcommand')
 
-    def test_tearoff(self):
+    def test_configure_tearoff(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'tearoff')
 
-    def test_tearoffcommand(self):
+    def test_configure_tearoffcommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'tearoffcommand')
 
-    def test_title(self):
+    def test_configure_title(self):
         widget = self.create()
         self.checkParam(widget, 'title', 'any string')
 
-    def test_type(self):
+    def test_configure_type(self):
         widget = self.create()
         self.checkEnumParam(widget, 'type',
                 'normal', 'tearoff', 'menubar')
@@ -1294,7 +1295,7 @@ class MessageTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return tkinter.Message(self.root, **kwargs)
 
-    def test_aspect(self):
+    def test_configure_aspect(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'aspect', 250, 0, -300)
 

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -16,7 +16,7 @@ requires('gui')
 
 class StandardTtkOptionsTests(StandardOptionsTests):
 
-    def test_class(self):
+    def test_configure_class(self):
         widget = self.create()
         self.assertEqual(widget['class'], '')
         errmsg='attempt to change read-only option'
@@ -26,7 +26,7 @@ class StandardTtkOptionsTests(StandardOptionsTests):
         widget2 = self.create(class_='Foo')
         self.assertEqual(widget2['class'], 'Foo')
 
-    def test_padding(self):
+    def test_configure_padding(self):
         widget = self.create()
         self.checkParam(widget, 'padding', 0, expected=('0',))
         self.checkParam(widget, 'padding', 5, expected=('5',))
@@ -38,7 +38,7 @@ class StandardTtkOptionsTests(StandardOptionsTests):
         self.checkParam(widget, 'padding', ('5p', '6p', '7p', '8p'))
         self.checkParam(widget, 'padding', (), expected='')
 
-    def test_style(self):
+    def test_configure_style(self):
         widget = self.create()
         self.assertEqual(widget['style'], '')
         errmsg = 'Layout Foo not found'
@@ -139,14 +139,14 @@ class LabelFrameTest(AbstractToplevelTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.LabelFrame(self.root, **kwargs)
 
-    def test_labelanchor(self):
+    def test_configure_labelanchor(self):
         widget = self.create()
         self.checkEnumParam(widget, 'labelanchor',
                 'e', 'en', 'es', 'n', 'ne', 'nw', 's', 'se', 'sw', 'w', 'wn', 'ws',
                 errmsg='Bad label anchor specification {}')
         self.checkInvalidParam(widget, 'labelanchor', 'center')
 
-    def test_labelwidget(self):
+    def test_configure_labelwidget(self):
         widget = self.create()
         label = ttk.Label(self.root, text='Mupp', name='foo')
         self.checkParam(widget, 'labelwidget', label, expected='.foo')
@@ -168,17 +168,17 @@ class AbstractLabelTest(AbstractWidgetTest):
         self.checkInvalidParam(widget, name, 'spam',
                 errmsg='image "spam" doesn\'t exist')
 
-    def test_compound(self):
+    def test_configure_compound(self):
         widget = self.create()
         self.checkEnumParam(widget, 'compound',
                 'none', 'text', 'image', 'center',
                 'top', 'bottom', 'left', 'right')
 
-    def test_state(self):
+    def test_configure_state(self):
         widget = self.create()
         self.checkParams(widget, 'state', 'active', 'disabled', 'normal')
 
-    def test_width(self):
+    def test_configure_width(self):
         widget = self.create()
         self.checkParams(widget, 'width', 402, -402, 0)
 
@@ -197,7 +197,7 @@ class LabelTest(AbstractLabelTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Label(self.root, **kwargs)
 
-    def test_font(self):
+    def test_configure_font(self):
         widget = self.create()
         self.checkParam(widget, 'font',
                         '-Adobe-Helvetica-Medium-R-Normal--*-120-*-*-*-*-*-*')
@@ -215,7 +215,7 @@ class ButtonTest(AbstractLabelTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Button(self.root, **kwargs)
 
-    def test_default(self):
+    def test_configure_default(self):
         widget = self.create()
         self.checkEnumParam(widget, 'default', 'normal', 'active', 'disabled')
 
@@ -240,11 +240,11 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Checkbutton(self.root, **kwargs)
 
-    def test_offvalue(self):
+    def test_configure_offvalue(self):
         widget = self.create()
         self.checkParams(widget, 'offvalue', 1, 2.3, '', 'any string')
 
-    def test_onvalue(self):
+    def test_configure_onvalue(self):
         widget = self.create()
         self.checkParams(widget, 'onvalue', 1, 2.3, '', 'any string')
 
@@ -292,27 +292,27 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Entry(self.root, **kwargs)
 
-    def test_invalidcommand(self):
+    def test_configure_invalidcommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'invalidcommand')
 
-    def test_show(self):
+    def test_configure_show(self):
         widget = self.create()
         self.checkParam(widget, 'show', '*')
         self.checkParam(widget, 'show', '')
         self.checkParam(widget, 'show', ' ')
 
-    def test_state(self):
+    def test_configure_state(self):
         widget = self.create()
         self.checkParams(widget, 'state',
                          'disabled', 'normal', 'readonly')
 
-    def test_validate(self):
+    def test_configure_validate(self):
         widget = self.create()
         self.checkEnumParam(widget, 'validate',
                 'all', 'key', 'focus', 'focusin', 'focusout', 'none')
 
-    def test_validatecommand(self):
+    def test_configure_validatecommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'validatecommand')
 
@@ -429,7 +429,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Combobox(self.root, **kwargs)
 
-    def test_height(self):
+    def test_configure_height(self):
         widget = self.create()
         self.checkParams(widget, 'height', 100, 101.2, 102.6, -100, 0, '1i')
 
@@ -459,7 +459,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.assertTrue(success)
 
 
-    def test_postcommand(self):
+    def test_configure_postcommand(self):
         success = []
 
         self.combo['postcommand'] = lambda: success.append(True)
@@ -475,7 +475,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         self.assertEqual(len(success), 1)
 
 
-    def test_values(self):
+    def test_configure_values(self):
         def check_get_current(getval, currval):
             self.assertEqual(self.combo.get(), getval)
             self.assertEqual(self.combo.current(), currval)
@@ -551,7 +551,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.PanedWindow(self.root, **kwargs)
 
-    def test_orient(self):
+    def test_configure_orient(self):
         widget = self.create()
         self.assertEqual(str(widget['orient']), 'vertical')
         errmsg='attempt to change read-only option'
@@ -684,11 +684,11 @@ class RadiobuttonTest(AbstractLabelTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Radiobutton(self.root, **kwargs)
 
-    def test_value(self):
+    def test_configure_value(self):
         widget = self.create()
         self.checkParams(widget, 'value', 1, 2.3, '', 'any string')
 
-    def test_invoke(self):
+    def test_configure_invoke(self):
         success = []
         def cb_test():
             success.append(1)
@@ -739,7 +739,7 @@ class MenubuttonTest(AbstractLabelTest, unittest.TestCase):
         self.checkEnumParam(widget, 'direction',
                 'above', 'below', 'left', 'right', 'flush')
 
-    def test_menu(self):
+    def test_configure_menu(self):
         widget = self.create()
         menu = tkinter.Menu(widget, name='menu')
         self.checkParam(widget, 'menu', menu, conv=str)
@@ -764,19 +764,19 @@ class ScaleTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Scale(self.root, **kwargs)
 
-    def test_from(self):
+    def test_configure_from(self):
         widget = self.create()
         self.checkFloatParam(widget, 'from', 100, 14.9, 15.1, conv=False)
 
-    def test_length(self):
+    def test_configure_length(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'length', 130, 131.2, 135.6, '5i')
 
-    def test_to(self):
+    def test_configure_to(self):
         widget = self.create()
         self.checkFloatParam(widget, 'to', 300, 14.9, 15.1, -10, conv=False)
 
-    def test_value(self):
+    def test_configure_value(self):
         widget = self.create()
         self.checkFloatParam(widget, 'value', 300, 14.9, 15.1, -10, conv=False)
 
@@ -866,23 +866,23 @@ class ProgressbarTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Progressbar(self.root, **kwargs)
 
-    def test_length(self):
+    def test_configure_length(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'length', 100.1, 56.7, '2i')
 
-    def test_maximum(self):
+    def test_configure_maximum(self):
         widget = self.create()
         self.checkFloatParam(widget, 'maximum', 150.2, 77.7, 0, -10, conv=False)
 
-    def test_mode(self):
+    def test_configure_mode(self):
         widget = self.create()
         self.checkEnumParam(widget, 'mode', 'determinate', 'indeterminate')
 
-    def test_phase(self):
+    def test_configure_phase(self):
         # XXX
         pass
 
-    def test_value(self):
+    def test_configure_value(self):
         widget = self.create()
         self.checkFloatParam(widget, 'value', 150.2, 77.7, 0, -10,
                              conv=False)
@@ -1071,7 +1071,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
         self.assertEqual(self.nb.tab(self.child1, 'text'), 'abc')
 
 
-    def test_tabs(self):
+    def test_configure_tabs(self):
         self.assertEqual(len(self.nb.tabs()), 2)
 
         self.nb.forget(self.child1)
@@ -1147,7 +1147,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.spin.event_generate('<ButtonRelease-1>', x=x, y=y)
         self.spin.update_idletasks()
 
-    def test_command(self):
+    def test_configure_command(self):
         success = []
 
         self.spin['command'] = lambda: success.append(True)
@@ -1167,7 +1167,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.spin.update()
         self.assertEqual(len(success), 2)
 
-    def test_to(self):
+    def test_configure_to(self):
         self.spin['from'] = 0
         self.spin['to'] = 5
         self.spin.set(4)
@@ -1179,7 +1179,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self._click_increment_arrow()  # 5
         self.assertEqual(self.spin.get(), '5')
 
-    def test_from(self):
+    def test_configure_from(self):
         self.spin['from'] = 1
         self.spin['to'] = 10
         self.spin.set(2)
@@ -1189,7 +1189,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self._click_decrement_arrow()  # 1
         self.assertEqual(self.spin.get(), '1')
 
-    def test_increment(self):
+    def test_configure_increment(self):
         self.spin['from'] = 0
         self.spin['to'] = 10
         self.spin['increment'] = 4
@@ -1203,7 +1203,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self._click_decrement_arrow()  # 3
         self.assertEqual(self.spin.get(), '3')
 
-    def test_format(self):
+    def test_configure_format(self):
         self.spin.set(1)
         self.spin['format'] = '%10.3f'
         self.spin.update()
@@ -1220,7 +1220,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.assertTrue('.' not in value)
         self.assertEqual(len(value), 1)
 
-    def test_wrap(self):
+    def test_configure_wrap(self):
         self.spin['to'] = 10
         self.spin['from'] = 1
         self.spin.set(1)
@@ -1239,7 +1239,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self._click_decrement_arrow()
         self.assertEqual(self.spin.get(), '1')
 
-    def test_values(self):
+    def test_configure_values(self):
         self.assertEqual(self.spin['values'],
                          () if tcl_version < (8, 5) else '')
         self.checkParam(self.spin, 'values', 'mon tue wed thur',
@@ -1299,14 +1299,14 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
     def create(self, **kwargs):
         return ttk.Treeview(self.root, **kwargs)
 
-    def test_columns(self):
+    def test_configure_columns(self):
         widget = self.create()
         self.checkParam(widget, 'columns', 'a b c',
                         expected=('a', 'b', 'c'))
         self.checkParam(widget, 'columns', ('a', 'b', 'c'))
         self.checkParam(widget, 'columns', '')
 
-    def test_displaycolumns(self):
+    def test_configure_displaycolumns(self):
         widget = self.create()
         widget['columns'] = ('a', 'b', 'c')
         self.checkParam(widget, 'displaycolumns', 'b a c',
@@ -1322,17 +1322,17 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         self.checkInvalidParam(widget, 'displaycolumns', (1, -2),
                                errmsg='Column index -2 out of bounds')
 
-    def test_height(self):
+    def test_configure_height(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'height', 100, -100, 0, '3c', conv=False)
         self.checkPixelsParam(widget, 'height', 101.2, 102.6, conv=noconv)
 
-    def test_selectmode(self):
+    def test_configure_selectmode(self):
         widget = self.create()
         self.checkEnumParam(widget, 'selectmode',
                             'none', 'browse', 'extended')
 
-    def test_show(self):
+    def test_configure_show(self):
         widget = self.create()
         self.checkParam(widget, 'show', 'tree headings',
                         expected=('tree', 'headings'))

--- a/Lib/tkinter/test/widget_tests.py
+++ b/Lib/tkinter/test/widget_tests.py
@@ -243,31 +243,31 @@ class StandardOptionsTests:
         'underline', 'wraplength', 'xscrollcommand', 'yscrollcommand',
     )
 
-    def test_activebackground(self):
+    def test_configure_activebackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'activebackground')
 
-    def test_activeborderwidth(self):
+    def test_configure_activeborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'activeborderwidth',
                               0, 1.3, 2.9, 6, -2, '10p')
 
-    def test_activeforeground(self):
+    def test_configure_activeforeground(self):
         widget = self.create()
         self.checkColorParam(widget, 'activeforeground')
 
-    def test_anchor(self):
+    def test_configure_anchor(self):
         widget = self.create()
         self.checkEnumParam(widget, 'anchor',
                 'n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw', 'center')
 
-    def test_background(self):
+    def test_configure_background(self):
         widget = self.create()
         self.checkColorParam(widget, 'background')
         if 'bg' in self.OPTIONS:
             self.checkColorParam(widget, 'bg')
 
-    def test_bitmap(self):
+    def test_configure_bitmap(self):
         widget = self.create()
         self.checkParam(widget, 'bitmap', 'questhead')
         self.checkParam(widget, 'bitmap', 'gray50')
@@ -280,52 +280,52 @@ class StandardOptionsTests:
             self.checkInvalidParam(widget, 'bitmap', 'spam',
                     errmsg='bitmap "spam" not defined')
 
-    def test_borderwidth(self):
+    def test_configure_borderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'borderwidth',
                               0, 1.3, 2.6, 6, -2, '10p')
         if 'bd' in self.OPTIONS:
             self.checkPixelsParam(widget, 'bd', 0, 1.3, 2.6, 6, -2, '10p')
 
-    def test_compound(self):
+    def test_configure_compound(self):
         widget = self.create()
         self.checkEnumParam(widget, 'compound',
                 'bottom', 'center', 'left', 'none', 'right', 'top')
 
-    def test_cursor(self):
+    def test_configure_cursor(self):
         widget = self.create()
         self.checkCursorParam(widget, 'cursor')
 
-    def test_disabledforeground(self):
+    def test_configure_disabledforeground(self):
         widget = self.create()
         self.checkColorParam(widget, 'disabledforeground')
 
-    def test_exportselection(self):
+    def test_configure_exportselection(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'exportselection')
 
-    def test_font(self):
+    def test_configure_font(self):
         widget = self.create()
         self.checkParam(widget, 'font',
                         '-Adobe-Helvetica-Medium-R-Normal--*-120-*-*-*-*-*-*')
         self.checkInvalidParam(widget, 'font', '',
                                errmsg='font "" doesn\'t exist')
 
-    def test_foreground(self):
+    def test_configure_foreground(self):
         widget = self.create()
         self.checkColorParam(widget, 'foreground')
         if 'fg' in self.OPTIONS:
             self.checkColorParam(widget, 'fg')
 
-    def test_highlightbackground(self):
+    def test_configure_highlightbackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'highlightbackground')
 
-    def test_highlightcolor(self):
+    def test_configure_highlightcolor(self):
         widget = self.create()
         self.checkColorParam(widget, 'highlightcolor')
 
-    def test_highlightthickness(self):
+    def test_configure_highlightthickness(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'highlightthickness',
                               0, 1.3, 2.6, 6, '10p')
@@ -334,36 +334,36 @@ class StandardOptionsTests:
 
     @unittest.skipIf(sys.platform == 'darwin',
                      'crashes with Cocoa Tk (issue19733)')
-    def test_image(self):
+    def test_configure_image(self):
         widget = self.create()
         self.checkImageParam(widget, 'image')
 
-    def test_insertbackground(self):
+    def test_configure_insertbackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'insertbackground')
 
-    def test_insertborderwidth(self):
+    def test_configure_insertborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'insertborderwidth',
                               0, 1.3, 2.6, 6, -2, '10p')
 
-    def test_insertofftime(self):
+    def test_configure_insertofftime(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'insertofftime', 100)
 
-    def test_insertontime(self):
+    def test_configure_insertontime(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'insertontime', 100)
 
-    def test_insertwidth(self):
+    def test_configure_insertwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'insertwidth', 1.3, 2.6, -2, '10p')
 
-    def test_jump(self):
+    def test_configure_jump(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'jump')
 
-    def test_justify(self):
+    def test_configure_justify(self):
         widget = self.create()
         self.checkEnumParam(widget, 'justify', 'left', 'right', 'center',
                 errmsg='bad justification "{}": must be '
@@ -372,154 +372,155 @@ class StandardOptionsTests:
                 errmsg='ambiguous justification "": must be '
                        'left, right, or center')
 
-    def test_orient(self):
+    def test_configure_orient(self):
         widget = self.create()
         self.assertEqual(str(widget['orient']), self.default_orient)
         self.checkEnumParam(widget, 'orient', 'horizontal', 'vertical')
 
-    def test_padx(self):
+    def test_configure_padx(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'padx', 3, 4.4, 5.6, -2, '12m',
                               conv=self._conv_pad_pixels)
 
-    def test_pady(self):
+    def test_configure_pady(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'pady', 3, 4.4, 5.6, -2, '12m',
                               conv=self._conv_pad_pixels)
 
-    def test_relief(self):
+    def test_configure_relief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'relief')
 
-    def test_repeatdelay(self):
+    def test_configure_repeatdelay(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'repeatdelay', -500, 500)
 
-    def test_repeatinterval(self):
+    def test_configure_repeatinterval(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'repeatinterval', -500, 500)
 
-    def test_selectbackground(self):
+    def test_configure_selectbackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'selectbackground')
 
-    def test_selectborderwidth(self):
+    def test_configure_selectborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'selectborderwidth', 1.3, 2.6, -2, '10p')
 
-    def test_selectforeground(self):
+    def test_configure_selectforeground(self):
         widget = self.create()
         self.checkColorParam(widget, 'selectforeground')
 
-    def test_setgrid(self):
+    def test_configure_setgrid(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'setgrid')
 
-    def test_state(self):
+    def test_configure_state(self):
         widget = self.create()
         self.checkEnumParam(widget, 'state', 'active', 'disabled', 'normal')
 
-    def test_takefocus(self):
+    def test_configure_takefocus(self):
         widget = self.create()
         self.checkParams(widget, 'takefocus', '0', '1', '')
 
-    def test_text(self):
+    def test_configure_text(self):
         widget = self.create()
         self.checkParams(widget, 'text', '', 'any string')
 
-    def test_textvariable(self):
+    def test_configure_textvariable(self):
         widget = self.create()
         var = tkinter.StringVar(self.root)
         self.checkVariableParam(widget, 'textvariable', var)
 
-    def test_troughcolor(self):
+    def test_configure_troughcolor(self):
         widget = self.create()
         self.checkColorParam(widget, 'troughcolor')
 
-    def test_underline(self):
+    def test_configure_underline(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'underline', 0, 1, 10)
 
-    def test_wraplength(self):
+    def test_configure_wraplength(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'wraplength', 100)
 
-    def test_xscrollcommand(self):
+    def test_configure_xscrollcommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'xscrollcommand')
 
-    def test_yscrollcommand(self):
+    def test_configure_yscrollcommand(self):
         widget = self.create()
         self.checkCommandParam(widget, 'yscrollcommand')
 
     # non-standard but common options
 
-    def test_command(self):
+    def test_configure_command(self):
         widget = self.create()
         self.checkCommandParam(widget, 'command')
 
-    def test_indicatoron(self):
+    def test_configure_indicatoron(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'indicatoron')
 
-    def test_offrelief(self):
+    def test_configure_offrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'offrelief')
 
-    def test_overrelief(self):
+    def test_configure_overrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'overrelief')
 
-    def test_selectcolor(self):
+    def test_configure_selectcolor(self):
         widget = self.create()
         self.checkColorParam(widget, 'selectcolor')
 
-    def test_selectimage(self):
+    def test_configure_selectimage(self):
         widget = self.create()
         self.checkImageParam(widget, 'selectimage')
 
     @requires_tcl(8, 5)
-    def test_tristateimage(self):
+    def test_configure_tristateimage(self):
         widget = self.create()
         self.checkImageParam(widget, 'tristateimage')
 
     @requires_tcl(8, 5)
-    def test_tristatevalue(self):
+    def test_configure_tristatevalue(self):
         widget = self.create()
         self.checkParam(widget, 'tristatevalue', 'unknowable')
 
-    def test_variable(self):
+    def test_configure_variable(self):
         widget = self.create()
         var = tkinter.DoubleVar(self.root)
         self.checkVariableParam(widget, 'variable', var)
 
 
 class IntegerSizeTests:
-    def test_height(self):
+    def test_configure_height(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'height', 100, -100, 0)
 
-    def test_width(self):
+    def test_configure_width(self):
         widget = self.create()
         self.checkIntegerParam(widget, 'width', 402, -402, 0)
 
 
 class PixelSizeTests:
-    def test_height(self):
+    def test_configure_height(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'height', 100, 101.2, 102.6, -100, 0, '3c')
 
-    def test_width(self):
+    def test_configure_width(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'width', 402, 403.4, 404.6, -402, 0, '5i')
 
 
 def add_standard_options(*source_classes):
-    # This decorator adds test_xxx methods from source classes for every xxx
-    # option in the OPTIONS class attribute if they are not defined explicitly.
+    # This decorator adds test_configure_xxx methods from source classes for
+    # every xxx option in the OPTIONS class attribute if they are not defined
+    # explicitly.
     def decorator(cls):
         for option in cls.OPTIONS:
-            methodname = 'test_' + option
+            methodname = 'test_configure_' + option
             if not hasattr(cls, methodname):
                 for source_class in source_classes:
                     if hasattr(source_class, methodname):


### PR DESCRIPTION
Every test for widget option starts now with "test_configure_"
to distinguish it from tests for widget commands.
(cherry picked from commit c1ae21c965cb4d0566df2095e4bcb274d0bd9353)
