### PR TITLE
bpo-42694: Cannot create _curses_panel.panel

### DIFF
--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -654,6 +654,7 @@ _curses_panel_exec(PyObject *mod)
     if (state->PyCursesPanel_Type == NULL) {
         return -1;
     }
+    ((PyTypeObject *)state->PyCursesPanel_Type)->tp_new = NULL;
 
     if (PyModule_AddType(mod, state->PyCursesPanel_Type) < 0) {
         return -1;


### PR DESCRIPTION
Fix regression introduced in
commit 1baf030a902392fe92d934ed0fb6a385cf7d8869: restore removed code
to prevent creating a _curses_panel.panel instance directly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42694](https://bugs.python.org/issue42694) -->
https://bugs.python.org/issue42694
<!-- /issue-number -->
