### PR TITLE
bpo-42748: Use exec_module instead of load_module

### DIFF
--- a/Lib/test/test_asdl_parser.py
+++ b/Lib/test/test_asdl_parser.py
@@ -6,8 +6,8 @@ import os
 from os.path import dirname
 import sys
 import sysconfig
-import unittest
 import types
+import unittest
 
 
 # This test is only relevant for from-source builds of Python.

--- a/Lib/test/test_asdl_parser.py
+++ b/Lib/test/test_asdl_parser.py
@@ -1,11 +1,13 @@
 """Tests for the asdl parser in Parser/asdl.py"""
 
 import importlib.machinery
+import importlib.util
 import os
 from os.path import dirname
 import sys
 import sysconfig
 import unittest
+import types
 
 
 # This test is only relevant for from-source builds of Python.
@@ -26,7 +28,10 @@ class TestAsdlParser(unittest.TestCase):
         sys.path.insert(0, parser_dir)
         loader = importlib.machinery.SourceFileLoader(
                 'asdl', os.path.join(parser_dir, 'asdl.py'))
-        cls.asdl = loader.load_module()
+        module = types.ModuleType('asdl')
+        module.__spec__ = importlib.util.spec_from_loader('asdl', loader)
+        loader.exec_module(module)
+        cls.asdl = module
         cls.mod = cls.asdl.parse(os.path.join(parser_dir, 'Python.asdl'))
         cls.assertTrue(cls.asdl.check(cls.mod), 'Module validation failed')
 

--- a/Lib/test/test_asdl_parser.py
+++ b/Lib/test/test_asdl_parser.py
@@ -6,7 +6,6 @@ import os
 from os.path import dirname
 import sys
 import sysconfig
-import types
 import unittest
 
 
@@ -28,8 +27,8 @@ class TestAsdlParser(unittest.TestCase):
         sys.path.insert(0, parser_dir)
         loader = importlib.machinery.SourceFileLoader(
                 'asdl', os.path.join(parser_dir, 'asdl.py'))
-        module = types.ModuleType('asdl')
-        module.__spec__ = importlib.util.spec_from_loader('asdl', loader)
+        spec = importlib.util.spec_from_loader('asdl', loader)
+        module = importlib.util.module_from_spec(spec)
         loader.exec_module(module)
         cls.asdl = module
         cls.mod = cls.asdl.parse(os.path.join(parser_dir, 'Python.asdl'))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42748](https://bugs.python.org/issue42748) -->
https://bugs.python.org/issue42748
<!-- /issue-number -->
