### PR TITLE
bpo-45772: socket.socket should be a class instead of a function

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -562,7 +562,7 @@ Creating sockets
 The following functions all create :ref:`socket objects <socket-objects>`.
 
 
-.. function:: socket(family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None)
+.. class:: socket(family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None)
 
    Create a new socket using the given address family, socket type and protocol
    number.  The address family should be :const:`AF_INET` (the default),

--- a/Misc/NEWS.d/next/Documentation/2021-11-09-13-10-55.bpo-45772.EdrM3t.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-09-13-10-55.bpo-45772.EdrM3t.rst
@@ -1,1 +1,1 @@
-``socket.socket`` is corrected to a class from a function.
+``socket.socket`` documentation is corrected to a class from a function.

--- a/Misc/NEWS.d/next/Documentation/2021-11-09-13-10-55.bpo-45772.EdrM3t.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-11-09-13-10-55.bpo-45772.EdrM3t.rst
@@ -1,0 +1,1 @@
+``socket.socket`` is corrected to a class from a function.


### PR DESCRIPTION
Currently `socket.socket` is documented as a function, but it is really
a class (and thus has function-like usage to construct an object). This
correction would ensure that Python projects that are interlinking
Python's documentation can properly locate `socket.socket` as a type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-45772](https://bugs.python.org/issue45772) -->
https://bugs.python.org/issue45772
<!-- /issue-number -->
