### PR TITLE
bpo-42740: Fix get_args for PEP 585 collections.abc.Callable

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3050,6 +3050,9 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(list), ())
         self.assertEqual(get_args(collections.abc.Callable[[int], str]), ([int], str))
         self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
+        self.assertEqual(get_args(collections.abc.Callable[[], str]), ([], str))
+        self.assertEqual(get_args(collections.abc.Callable[[int], str]),
+                         get_args(Callable[[int], str]))
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3048,6 +3048,8 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(Callable), ())
         self.assertEqual(get_args(list[int]), (int,))
         self.assertEqual(get_args(list), ())
+        self.assertEqual(get_args(collections.abc.Callable[[int], str]), ([int], str))
+        self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1684,13 +1684,11 @@ def get_args(tp):
     """
     if isinstance(tp, _AnnotatedAlias):
         return (tp.__origin__,) + tp.__metadata__
-    if isinstance(tp, _GenericAlias):
+    if isinstance(tp, (_GenericAlias, GenericAlias)):
         res = tp.__args__
         if tp.__origin__ is collections.abc.Callable and res[0] is not Ellipsis:
             res = (list(res[:-1]), res[-1])
         return res
-    if isinstance(tp, GenericAlias):
-        return tp.__args__
     return ()
 
 

--- a/Misc/NEWS.d/next/Library/2020-12-27-17-36-10.bpo-42740.vubNWp.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-27-17-36-10.bpo-42740.vubNWp.rst
@@ -1,0 +1,2 @@
+:func:`typing.get_args` is now consistent between the parameterized generic
+of ``collections.abc.Callable`` and ``typing.Callable``.

--- a/Misc/NEWS.d/next/Library/2020-12-27-17-36-10.bpo-42740.vubNWp.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-27-17-36-10.bpo-42740.vubNWp.rst
@@ -1,2 +1,0 @@
-:func:`typing.get_args` is now consistent between the parameterized generic
-of ``collections.abc.Callable`` and ``typing.Callable``.


### PR DESCRIPTION
PR 1/2. Needs backport to 3.9.

<!-- issue-number: [bpo-42740](https://bugs.python.org/issue42740) -->
https://bugs.python.org/issue42740
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum