### PR TITLE
bpo-42756: Configure LMTP Unix-domain socket to use global default timeout when timeout not provided

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -1070,7 +1070,7 @@ class LMTP(SMTP):
         """Initialize a new instance."""
         super().__init__(host, port, local_hostname=local_hostname,
                          source_address=source_address, timeout=timeout)
-
+ 
     def connect(self, host='localhost', port=0, source_address=None):
         """Connect to the LMTP daemon, on either a Unix or a TCP socket."""
         if host[0] != '/':
@@ -1082,7 +1082,9 @@ class LMTP(SMTP):
         # Handle Unix-domain sockets.
         try:
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.sock.settimeout(self.timeout)
+
+            if self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                self.sock.settimeout(self.timeout)
             self.file = None
             self.sock.connect(host)
         except OSError:

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -1070,7 +1070,7 @@ class LMTP(SMTP):
         """Initialize a new instance."""
         super().__init__(host, port, local_hostname=local_hostname,
                          source_address=source_address, timeout=timeout)
- 
+
     def connect(self, host='localhost', port=0, source_address=None):
         """Connect to the LMTP daemon, on either a Unix or a TCP socket."""
         if host[0] != '/':

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -1082,7 +1082,6 @@ class LMTP(SMTP):
         # Handle Unix-domain sockets.
         try:
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-
             if self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
                 self.sock.settimeout(self.timeout)
             self.file = None

--- a/Lib/test/mock_socket.py
+++ b/Lib/test/mock_socket.py
@@ -107,16 +107,16 @@ class MockSocket:
     def close(self):
         pass
 
+    def connect(self, host):
+        pass
+
 
 def socket(family=None, type=None, proto=None):
     return MockSocket(family)
 
+
 def create_connection(address, timeout=socket_module._GLOBAL_DEFAULT_TIMEOUT,
                       source_address=None):
-    try:
-        int_port = int(address[1])
-    except ValueError:
-        raise error
     ms = MockSocket()
     if timeout is socket_module._GLOBAL_DEFAULT_TIMEOUT:
         timeout = getdefaulttimeout()
@@ -152,8 +152,10 @@ error = socket_module.error
 
 
 # Constants
+_GLOBAL_DEFAULT_TIMEOUT = socket_module._GLOBAL_DEFAULT_TIMEOUT
 AF_INET = socket_module.AF_INET
 AF_INET6 = socket_module.AF_INET6
+AF_UNIX = socket_module.AF_UNIX
 SOCK_STREAM = socket_module.SOCK_STREAM
 SOL_SOCKET = None
 SO_REUSEADDR = None

--- a/Lib/test/mock_socket.py
+++ b/Lib/test/mock_socket.py
@@ -119,7 +119,7 @@ def create_connection(address, timeout=socket_module._GLOBAL_DEFAULT_TIMEOUT,
     try:
         int_port = int(address[1])
     except ValueError:
-        raise
+        raise error
     ms = MockSocket()
     if timeout is socket_module._GLOBAL_DEFAULT_TIMEOUT:
         timeout = getdefaulttimeout()

--- a/Lib/test/mock_socket.py
+++ b/Lib/test/mock_socket.py
@@ -114,9 +114,12 @@ class MockSocket:
 def socket(family=None, type=None, proto=None):
     return MockSocket(family)
 
-
 def create_connection(address, timeout=socket_module._GLOBAL_DEFAULT_TIMEOUT,
                       source_address=None):
+    try:
+        int_port = int(address[1])
+    except ValueError:
+        raise
     ms = MockSocket()
     if timeout is socket_module._GLOBAL_DEFAULT_TIMEOUT:
         timeout = getdefaulttimeout()

--- a/Lib/test/mock_socket.py
+++ b/Lib/test/mock_socket.py
@@ -155,7 +155,9 @@ error = socket_module.error
 _GLOBAL_DEFAULT_TIMEOUT = socket_module._GLOBAL_DEFAULT_TIMEOUT
 AF_INET = socket_module.AF_INET
 AF_INET6 = socket_module.AF_INET6
-AF_UNIX = socket_module.AF_UNIX
 SOCK_STREAM = socket_module.SOCK_STREAM
 SOL_SOCKET = None
 SO_REUSEADDR = None
+
+if hasattr(socket_module, 'AF_UNIX'):
+    AF_UNIX = socket_module.AF_UNIX

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -165,8 +165,10 @@ class LMTPGeneralTests(GeneralTests, unittest.TestCase):
 
     client = smtplib.LMTP
 
-    def testTimeoutDefault(self):
-        super().testTimeoutDefault()
+    def testUnixDomainSocketTimeoutDefault(self):
+        if not hasattr(socket, "AF_UNIX"):
+            self.skipTest("requires Unix domain socket")
+
         local_host = '/some/local/lmtp/delivery/program'
         mock_socket.reply_with(b"220 Hello world")
 

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -165,11 +165,25 @@ class LMTPGeneralTests(GeneralTests, unittest.TestCase):
 
     client = smtplib.LMTP
 
+    def testTimeoutDefault(self):
+        super().testTimeoutDefault()
+        local_host = '/some/local/lmtp/delivery/program'
+        mock_socket.reply_with(b"220 Hello world")
+
+        try:
+            client = self.client(local_host, self.port)
+        finally:
+            mock_socket.setdefaulttimeout(None)
+
+        self.assertIsNone(client.sock.gettimeout())
+        client.close()
+
     def testTimeoutZero(self):
         super().testTimeoutZero()
         local_host = '/some/local/lmtp/delivery/program'
         with self.assertRaises(ValueError):
             self.client(local_host, timeout=0)
+
 
 # Test server thread using the specified SMTP server class
 def debugging_server(serv, serv_evt, client_evt):

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -165,18 +165,14 @@ class LMTPGeneralTests(GeneralTests, unittest.TestCase):
 
     client = smtplib.LMTP
 
+    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), "test requires Unix domain socket")
     def testUnixDomainSocketTimeoutDefault(self):
-        if not hasattr(socket, "AF_UNIX"):
-            self.skipTest("requires Unix domain socket")
-
         local_host = '/some/local/lmtp/delivery/program'
         mock_socket.reply_with(b"220 Hello world")
-
         try:
             client = self.client(local_host, self.port)
         finally:
             mock_socket.setdefaulttimeout(None)
-
         self.assertIsNone(client.sock.gettimeout())
         client.close()
 
@@ -185,7 +181,6 @@ class LMTPGeneralTests(GeneralTests, unittest.TestCase):
         local_host = '/some/local/lmtp/delivery/program'
         with self.assertRaises(ValueError):
             self.client(local_host, timeout=0)
-
 
 # Test server thread using the specified SMTP server class
 def debugging_server(serv, serv_evt, client_evt):

--- a/Misc/NEWS.d/next/Library/2020-12-27-21-22-01.bpo-42756.dHMPJ9.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-27-21-22-01.bpo-42756.dHMPJ9.rst
@@ -1,0 +1,2 @@
+Configure LMTP Unix-domain socket to use socket global default timeout when
+a timeout is not explicitly provided.


### PR DESCRIPTION
What?
=====
1. Configure LMTP Unix-domain socket to use socket global default timeout when a timeout is not explicitly provided.
2. Removed unused "int_port" from the mock socket `create_connection` method.

Why?
====
To allow users to apply the default timeout without explicitly needing to pass in `None`.

<!-- issue-number: [bpo-42756](https://bugs.python.org/issue42756) -->
https://bugs.python.org/issue42756
<!-- /issue-number -->
