### PR TITLE
bpo-23328 Allow / character in username,password fields in _PROXY envvars.

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1851,8 +1851,16 @@ class MiscTests(unittest.TestCase):
              ('ftp', 'joe', 'password', 'proxy.example.com')),
             # Test for no trailing '/' case
             ('http://joe:password@proxy.example.com',
-             ('http', 'joe', 'password', 'proxy.example.com'))
+             ('http', 'joe', 'password', 'proxy.example.com')),
+            # Testcases with '/' character in username, password
+            ('http://user/name:password@localhost:22',
+             ('http', 'user/name', 'password', 'localhost:22')),
+            ('http://username:pass/word@localhost:22',
+             ('http', 'username', 'pass/word', 'localhost:22')),
+            ('http://user/name:pass/word@localhost:22',
+             ('http', 'user/name', 'pass/word', 'localhost:22')),
         ]
+
 
         for tc, expected in parse_proxy_test_cases:
             self.assertEqual(_parse_proxy(tc), expected)

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -773,7 +773,11 @@ def _parse_proxy(proxy):
             raise ValueError("proxy URL with no authority: %r" % proxy)
         # We have an authority, so for RFC 3986-compliant URLs (by ss 3.
         # and 3.3.), path is empty or starts with '/'
-        end = r_scheme.find("/", 2)
+        if '@' in r_scheme:
+            host_separator = r_scheme.find('@')
+            end = r_scheme.find("/", host_separator)
+        else:
+            end = r_scheme.find("/", 2)
         if end == -1:
             end = None
         authority = r_scheme[2:end]

--- a/Misc/NEWS.d/next/Library/2020-12-27-18-47-01.bpo-23328._xqepZ.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-27-18-47-01.bpo-23328._xqepZ.rst
@@ -1,0 +1,1 @@
+Allow / character in username, password fields on _PROXY envars.


### PR DESCRIPTION
[bpo-23328](https://bugs.python.org/issue23328) Allow / character in username,password fields in _PROXY envvars.

When urllib was using _parse_proxy method to read proxies from environ variables, if the env had a username, password component and if those had an un-encoded '/' character, the parsing failed.

* It seems curl allows '/' in unencoded format in username and password fields.

This change will not break any existing parsing behavior and is localized to username,password scenarios  with '/' character in them.


<!-- issue-number: [bpo-23328](https://bugs.python.org/issue23328) -->
https://bugs.python.org/issue23328
<!-- /issue-number -->
