### PR TITLE
Docs: Remove stray semicolon in init.rst

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1192,7 +1192,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
 
    .. versionadded:: 3.9
 
-.. c:function:: void _PyInterpreterState_SetEvalFrameFunc(PyInterpreterState *interp, _PyFrameEvalFunction eval_frame);
+.. c:function:: void _PyInterpreterState_SetEvalFrameFunc(PyInterpreterState *interp, _PyFrameEvalFunction eval_frame)
 
    Set the frame evaluation function.
 


### PR DESCRIPTION
Removed stray semicolon which was causing the docs to render weirdly (it's the function right under the one [here](https://docs.python.org/3/c-api/init.html#c._PyInterpreterState_GetEvalFrameFunc)).

Automerge-Triggered-By: GH:Mariatta