### PR TITLE
bpo-40077: Fix typo in simplequeue_get_state_by_type()

### DIFF
--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -15,7 +15,7 @@ simplequeue_get_state(PyObject *module)
     return state;
 }
 static struct PyModuleDef queuemodule;
-#define simplequeue_get_state_by_type(tp) \
+#define simplequeue_get_state_by_type(type) \
     (simplequeue_get_state(_PyType_GetModuleByDef(type, &queuemodule)))
 
 typedef struct {


### PR DESCRIPTION
The typo did no damage, but it looks suspicious and confusing.
Introduced by GH-23136.

Skip news.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40077](https://bugs.python.org/issue40077) -->
https://bugs.python.org/issue40077
<!-- /issue-number -->

Automerge-Triggered-By: GH:pitrou