### PR TITLE
bpo-40522: Store tstate in a Thread Local Storage

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-28-15-58-13.bpo-40522.Q5jhgq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-28-15-58-13.bpo-40522.Q5jhgq.rst
@@ -1,0 +1,2 @@
+If Python is built with GCC or clang, the current interpreter and the current
+Python thread state are now stored in a Thread Local Storage.

--- a/configure
+++ b/configure
@@ -17129,6 +17129,37 @@ $as_echo "#define HAVE_BUILTIN_ATOMIC 1" >>confdefs.h
 
 fi
 
+# Check for _Thread_local keyword
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for _Thread_local keyword" >&5
+$as_echo_n "checking for _Thread_local keyword... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+    _Thread_local int val;
+    int main() {
+      val = 1;
+      return val;
+    }
+
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  have__thread_local_keyword=yes
+else
+  have__thread_local_keyword=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have__thread_local_keyword" >&5
+$as_echo "$have__thread_local_keyword" >&6; }
+
+if test "$have__thread_local_keyword" = yes; then
+
+$as_echo "#define HAVE__THREAD_LOCAL_KEYWORD 1" >>confdefs.h
+
+fi
+
 # ensurepip option
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ensurepip" >&5
 $as_echo_n "checking for ensurepip... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -5606,6 +5606,24 @@ if test "$have_builtin_atomic" = yes; then
     AC_DEFINE(HAVE_BUILTIN_ATOMIC, 1, [Has builtin __atomic_load_n() and __atomic_store_n() functions])
 fi
 
+# Check for _Thread_local keyword
+AC_MSG_CHECKING(for _Thread_local keyword)
+AC_LINK_IFELSE(
+[
+  AC_LANG_SOURCE([[
+    _Thread_local int val;
+    int main() {
+      val = 1;
+      return val;
+    }
+  ]])
+],[have__thread_local_keyword=yes],[have__thread_local_keyword=no])
+AC_MSG_RESULT($have__thread_local_keyword)
+
+if test "$have__thread_local_keyword" = yes; then
+    AC_DEFINE(HAVE__THREAD_LOCAL_KEYWORD, 1, [Has C11 _Thread_local keyword])
+fi
+
 # ensurepip option
 AC_MSG_CHECKING(for ensurepip)
 AC_ARG_WITH(ensurepip,

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1359,6 +1359,9 @@
 /* Define to 1 if you have the `_getpty' function. */
 #undef HAVE__GETPTY
 
+/* Has C11 _Thread_local keyword */
+#undef HAVE__THREAD_LOCAL_KEYWORD
+
 /* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
    */
 #undef MAJOR_IN_MKDEV


### PR DESCRIPTION
If Python is built with GCC or clang, the current interpreter and the
current Python thread state are now stored in a Thread Local Storage.

Changes:

* GCC and clang use the __thread keyword to declare the TLS
  variables.
* Add set_current_tstate() sub-function which sets these two new TLS
  variables (if available).
* _PyThreadState_Swap() and _PyThreadState_DeleteCurrent() now call
  set_current_tstate().
* _PyThreadState_GET() and _PyInterpreterState_GET() now use the TLS
  variable if available.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40522](https://bugs.python.org/issue40522) -->
https://bugs.python.org/issue40522
<!-- /issue-number -->
