### PR TITLE
bpo-42048: Document AC's defining_class converter

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1210,34 +1210,63 @@ Using a "defining class" converter
 ----------------------------------
 
 Argument Clinic facilitates gaining access to the defining class of a method.
-This is useful for heap type methods that need to fetch module level state.
-Example from ``Modules/zlibmodule.c``::
+This is useful for :ref:`heap type <heap-types>` methods that need to fetch
+module level state.  Use :c:func:`PyType_FromModuleAndSpec` to associate a new
+heap type with a module.  You can now use :c:func:`PyType_GetModuleState` on
+the defining class to fetch the module state, for example from a module method.
+
+Example from ``Modules/zlibmodule.c``.  First, ``defining_class`` is added to
+the clinic input::
 
     /*[clinic input]
     zlib.Compress.compress
 
-        cls: defining_class
-        data: Py_buffer
-        /
-    ...
+      cls: defining_class
+      data: Py_buffer
+        Binary data to be compressed.
+      /
+
+
+After running the Argument Clinic tool, the following function signature is
+generated::
+
     [clinic start generated code]*/
     static PyObject *
-    zlib_Compress_compress_impl(...)
-    /*[clinic end generated code ...]*/
-    {
-        zlibstate *state = PyType_GetModuleState(cls)
+    zlib_Compress_compress_impl(compobject *self, PyTypeObject *cls,
+                                Py_buffer *data)
+    /*[clinic end generated code: output=6731b3f0ff357ca6 input=04d00f65ab01d260]*/
+
+
+The follwing code can now use ``PyType_GetModuleState(cls)`` to fetch the
+module state::
+
+    zlibstate *state = PyType_GetModuleState(cls);
 
 
 Each method may only have one argument using this converter, and it must appear
-after ``self``, or, if ``self`` is not used, as the first argument. The argument
-will be of type ``PyTypeObject *``.
-
-When used, Argument Clinic will select ``METH_FASTCALL | METH_KEYWORDS |
-METH_METHOD`` as the calling convention. The argument will not appear in
+after ``self``, or, if ``self`` is not used, as the first argument.  The argument
+will be of type ``PyTypeObject *``.  The argument will not appear in the
 ``__text_signature__``.
 
 The ``defining_class`` converter is not compatible with ``__init__`` and ``__new__``
 methods, which cannot use the ``METH_METHOD`` convention.
+
+It is not possible to use ``defining_class`` with slot methods.  In order to
+fetch the module state from such methods, use ``_PyType_GetModuleByDef`` to
+look up the module and then :c:func:`PyModule_GetState` to fetch the module
+state.  Example from the `setattro` slot method in
+``Modules/_threadmodule.c``::
+
+    static int
+    local_setattro(localobject *self, PyObject *name, PyObject *v)
+    {
+        PyObject *module = _PyType_GetModuleByDef(Py_TYPE(self), &thread_module);
+        thread_module_state *state = get_thread_state(module);
+
+
+Note that ``_PyType_GetModuleByDef`` traverses the MRO cache, and therefore has
+performance impact.
+
 
 See also :pep:`573`.
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1262,6 +1262,8 @@ state.  Example from the `setattro` slot method in
     {
         PyObject *module = _PyType_GetModuleByDef(Py_TYPE(self), &thread_module);
         thread_module_state *state = get_thread_state(module);
+        ...
+    }
 
 
 Note that ``_PyType_GetModuleByDef`` traverses the MRO cache, and therefore has

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1266,10 +1266,6 @@ state.  Example from the `setattro` slot method in
     }
 
 
-Note that ``_PyType_GetModuleByDef`` traverses the MRO cache, and therefore has
-performance impact.
-
-
 See also :pep:`573`.
 
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1206,6 +1206,41 @@ type for ``self``, it's best to create your own converter, subclassing
     [clinic start generated code]*/
 
 
+Using a "defining class" converter
+----------------------------------
+
+Argument Clinic facilitates gaining access to the defining class of a method.
+This is useful for heap type methods that need to fetch module level state.
+Example from `Modules/zlibmodule.c`::
+
+    /*[clinic input]
+    zlib.Compress.compress
+
+        cls: defining_class
+        data: Py_buffer
+        /
+    ...
+    [clinic start generated code]*/
+    static PyObject *
+    zlib_Compress_compress_impl(...)
+    /*[clinic end generated code ...]*/
+    {
+        zlibstate *state = PyType_GetModuleState(cls)
+
+
+Each method may only have one argument using this converter, and it must appear
+after `self`, or, if `self` is not used, as the first argument. The argument
+will be of type `PyTypeObject *`.
+
+When used, Argument Clinic will select `METH_FASTCALL | METH_KEYWORDS |
+METH_METHOD` as the calling convention. The argument will not appear in
+`__text_signature__`.
+
+The `defining_class` converter is not compatible with `__init__` and `__new__`
+methods, which cannot use the `METH_METHOD` convention.
+
+See also PEP 573.
+
 
 Writing a custom converter
 --------------------------

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1254,7 +1254,7 @@ methods, which cannot use the ``METH_METHOD`` convention.
 It is not possible to use ``defining_class`` with slot methods.  In order to
 fetch the module state from such methods, use ``_PyType_GetModuleByDef`` to
 look up the module and then :c:func:`PyModule_GetState` to fetch the module
-state.  Example from the `setattro` slot method in
+state.  Example from the ``setattro`` slot method in
 ``Modules/_threadmodule.c``::
 
     static int

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1239,7 +1239,7 @@ METH_METHOD`` as the calling convention. The argument will not appear in
 The ``defining_class`` converter is not compatible with ``__init__`` and ``__new__``
 methods, which cannot use the ``METH_METHOD`` convention.
 
-See also PEP 573.
+See also :pep:`573`.
 
 
 Writing a custom converter

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1237,7 +1237,7 @@ generated::
     /*[clinic end generated code: output=6731b3f0ff357ca6 input=04d00f65ab01d260]*/
 
 
-The follwing code can now use ``PyType_GetModuleState(cls)`` to fetch the
+The following code can now use ``PyType_GetModuleState(cls)`` to fetch the
 module state::
 
     zlibstate *state = PyType_GetModuleState(cls);

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1230,7 +1230,7 @@ the clinic input::
 After running the Argument Clinic tool, the following function signature is
 generated::
 
-    [clinic start generated code]*/
+    /*[clinic start generated code]*/
     static PyObject *
     zlib_Compress_compress_impl(compobject *self, PyTypeObject *cls,
                                 Py_buffer *data)

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1211,7 +1211,7 @@ Using a "defining class" converter
 
 Argument Clinic facilitates gaining access to the defining class of a method.
 This is useful for heap type methods that need to fetch module level state.
-Example from `Modules/zlibmodule.c`::
+Example from ``Modules/zlibmodule.c``::
 
     /*[clinic input]
     zlib.Compress.compress
@@ -1229,15 +1229,15 @@ Example from `Modules/zlibmodule.c`::
 
 
 Each method may only have one argument using this converter, and it must appear
-after `self`, or, if `self` is not used, as the first argument. The argument
-will be of type `PyTypeObject *`.
+after ``self``, or, if ``self`` is not used, as the first argument. The argument
+will be of type ``PyTypeObject *``.
 
-When used, Argument Clinic will select `METH_FASTCALL | METH_KEYWORDS |
-METH_METHOD` as the calling convention. The argument will not appear in
-`__text_signature__`.
+When used, Argument Clinic will select ``METH_FASTCALL | METH_KEYWORDS |
+METH_METHOD`` as the calling convention. The argument will not appear in
+``__text_signature__``.
 
-The `defining_class` converter is not compatible with `__init__` and `__new__`
-methods, which cannot use the `METH_METHOD` convention.
+The ``defining_class`` converter is not compatible with ``__init__`` and ``__new__``
+methods, which cannot use the ``METH_METHOD`` convention.
 
 See also PEP 573.
 


### PR DESCRIPTION
Parts of this documentation is more or less taken/stolen directly from [PEP 573](https://www.python.org/dev/peps/pep-0573/#argument-clinic)
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42048](https://bugs.python.org/issue42048) -->
https://bugs.python.org/issue42048
<!-- /issue-number -->