### PR TITLE
bpo-42770: Fix a typo in the email.headerregistry docs

### DIFF
--- a/Doc/library/email.headerregistry.rst
+++ b/Doc/library/email.headerregistry.rst
@@ -289,7 +289,7 @@ variant, :attr:`~.BaseHeader.max_count` is set to 1.
     A :class:`ParameterizedMIMEHeader` class that handles the
     :mailheader:`Content-Disposition` header.
 
-    .. attribute:: content-disposition
+    .. attribute:: content_disposition
 
        ``inline`` and ``attachment`` are the only valid values in common use.
 


### PR DESCRIPTION


<!-- issue-number: [bpo-42770](https://bugs.python.org/issue42770) -->
https://bugs.python.org/issue42770
<!-- /issue-number -->

Automerge-Triggered-By: GH:zware