### PR TITLE
Fix compiler warnings regarding loss of data

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1601,7 +1601,7 @@ pysqlite_connection_backup_impl(pysqlite_Connection *self,
 {
     int rc;
     int callback_error = 0;
-    int sleep_ms = sleep * 1000.0;
+    int sleep_ms = (int)(sleep * 1000.0);
     sqlite3 *bck_conn;
     sqlite3_backup *bck_handle;
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2302,7 +2302,7 @@ _PyUnicode_FromId(_Py_Identifier *id)
     PyInterpreterState *interp = _PyInterpreterState_GET();
     struct _Py_unicode_ids *ids = &interp->unicode.ids;
 
-    int index = _Py_atomic_size_get(&id->index);
+    Py_ssize_t index = _Py_atomic_size_get(&id->index);
     if (index < 0) {
         struct _Py_unicode_runtime_ids *rt_ids = &interp->runtime->unicode_ids;
 


### PR DESCRIPTION
```
'initializing': conversion from 'Py_ssize_t' to 'int', possible loss of data [D:\a\cpython\cpython\PCbuild\pythoncore.vcxproj]
```

```
'initializing': conversion from 'double' to 'int', possible loss of data [D:\a\cpython\cpython\PCbuild\_sqlite3.vcxproj]
```