### PR TITLE
bpo-42775: call init_subclass and set_name from type.__init__

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -62,6 +62,11 @@ Summary -- Release highlights
 .. This section singles out the most important changes in Python 3.10.
    Brevity is key.
 
+The methods :func:`__init_subclass__` and :func:`__set_name__`, introduced
+in :pep:`487`, have been moved from :func:`type.__new__` to
+:func:`type.__init__`.  This ensures that custome metaclasses are able to
+finish creating a class before those two methods are called.
+
 
 .. PEP-sized items next.
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -231,18 +231,18 @@ class EnumMeta(type):
         if '__init_subclass__' in classdict and classdict['__init_subclass__'] is None:
             raise TypeError('%s.__init_subclass__ cannot be None')
         # remove current __init_subclass__ so previous one can be found with getattr
-        new_init_subclass = classdict.pop('__init_subclass__', None)
+        # new_init_subclass = classdict.pop('__init_subclass__', None)
         # create our new Enum type
         if bases:
-            bases = (_NoInitSubclass, ) + bases
+            # bases = (_NoInitSubclass, ) + bases
             enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
-            enum_class.__bases__ = enum_class.__bases__[1:] #or (object, )
+            # enum_class.__bases__ = enum_class.__bases__[1:] #or (object, )
         else:
             enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
-        old_init_subclass = getattr(enum_class, '__init_subclass__', None)
+        # old_init_subclass = getattr(enum_class, '__init_subclass__', None)
         # and restore the new one (if there was one)
-        if new_init_subclass is not None:
-            enum_class.__init_subclass__ = classmethod(new_init_subclass)
+        # if new_init_subclass is not None:
+        #     enum_class.__init_subclass__ = classmethod(new_init_subclass)
         enum_class._member_names_ = []               # names in definition order
         enum_class._member_map_ = {}                 # name->value map
         enum_class._member_type_ = member_type
@@ -355,8 +355,8 @@ class EnumMeta(type):
                 raise TypeError('member order does not match _order_')
 
         # finally, call parents' __init_subclass__
-        if Enum is not None and old_init_subclass is not None:
-            old_init_subclass(**kwds)
+        # if Enum is not None and old_init_subclass is not None:
+        #     old_init_subclass(**kwds)
         return enum_class
 
     def __bool__(self):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -230,19 +230,8 @@ class EnumMeta(type):
         # postpone calling __init_subclass__
         if '__init_subclass__' in classdict and classdict['__init_subclass__'] is None:
             raise TypeError('%s.__init_subclass__ cannot be None')
-        # remove current __init_subclass__ so previous one can be found with getattr
-        # new_init_subclass = classdict.pop('__init_subclass__', None)
         # create our new Enum type
-        if bases:
-            # bases = (_NoInitSubclass, ) + bases
-            enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
-            # enum_class.__bases__ = enum_class.__bases__[1:] #or (object, )
-        else:
-            enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
-        # old_init_subclass = getattr(enum_class, '__init_subclass__', None)
-        # and restore the new one (if there was one)
-        # if new_init_subclass is not None:
-        #     enum_class.__init_subclass__ = classmethod(new_init_subclass)
+        enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
         enum_class._member_names_ = []               # names in definition order
         enum_class._member_map_ = {}                 # name->value map
         enum_class._member_type_ = member_type
@@ -354,9 +343,6 @@ class EnumMeta(type):
             if _order_ != enum_class._member_names_:
                 raise TypeError('member order does not match _order_')
 
-        # finally, call parents' __init_subclass__
-        # if Enum is not None and old_init_subclass is not None:
-        #     old_init_subclass(**kwds)
         return enum_class
 
     def __bool__(self):

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1347,6 +1347,8 @@ order (MRO) for bases """
             def __new__(cls, name, bases, namespace, attr):
                 self.assertIn(attr, namespace)
                 return super().__new__(cls, name, bases, namespace)
+            def __init__(cls, name, bases, namespace, attr):
+                super().__init__(name, bases, namespace)
 
         class C1:
             def __init__(self):

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -49,6 +49,9 @@ class SourceDateEpochTestMeta(type(unittest.TestCase)):
 
         return cls
 
+    def __init__(cls, name, bases, dct, *, source_date_epoch):
+        super().__init__(name, bases, dct)
+
 
 class PyCompileTestsBase:
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2119,6 +2119,9 @@ class _TypedDictMeta(type):
             tp_dict.__total__ = total
         return tp_dict
 
+    def __init__(cls, name, bases, ns, total=True):
+        super().__init__(name, bases, ns)
+
     __call__ = dict  # static method
 
     def __subclasscheck__(cls, other):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-12-28-21-49-34.bpo-42775.qo_40W.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-12-28-21-49-34.bpo-42775.qo_40W.rst
@@ -1,0 +1,4 @@
+Move the calls to ``__init_subclass__`` and ``__set_name__`` from
+``type.__new__`` to ``type.__init__``.  This ensures that custom metaclasses
+are able to completely finish creating a class before the
+``__init_subclass__`` and ``__set_name__`` methods are run.


### PR DESCRIPTION
move the calls to __init_subclass__ and __set_name__ from type.__new__ to type.__init__

<!-- issue-number: [bpo-42775](https://bugs.python.org/issue42775) -->
https://bugs.python.org/issue42775
<!-- /issue-number -->
