### PR TITLE
Remove unnecessary text from copyreg, as it's no longer applicable

### DIFF
--- a/Lib/copyreg.py
+++ b/Lib/copyreg.py
@@ -1,8 +1,4 @@
-"""Helper to provide extensibility for pickle.
-
-This is only useful to add pickle support for extension types defined in
-C, not for instances of user-defined classes.
-"""
+"""Helper to provide extensibility for pickle."""
 
 __all__ = ["pickle", "constructor",
            "add_extension", "remove_extension", "clear_extension_cache"]


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Removes a docstring implying that copyreg cannot be used for serializing dynamic classes, whereas that's no longer the case.

Doc added [here](https://hg.python.org/cpython/log/53fa224b95f4/Lib/copy_reg.py?patch=&linerange=3:4)

Underlying issue solved [here](https://hg.python.org/cpython/rev/64053bd79590)

Example modern usage not conforming to this docstring [here](https://github.com/evinism/TinyBaker/blob/main/tinybaker/combinators/combinatormeta.py)

