### PR TITLE
bpo-42778: Add `follow_symlinks` optional argument to os.path and pathlib samefile methods

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -377,7 +377,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: samefile(path1, path2)
+.. function:: samefile(path1, path2, follow_symlinks=True)
 
    Return ``True`` if both pathname arguments refer to the same file or directory.
    This is determined by the device number and i-node number and raises an
@@ -393,6 +393,9 @@ the :mod:`glob` module.)
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
+
+   .. versionchanged:: 3.10
+      Supports optional argument ``follow_symlinks``.
 
 
 .. function:: sameopenfile(fp1, fp2)

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1078,7 +1078,7 @@ call fails (for example because the path doesn't exist).
    Remove this directory.  The directory must be empty.
 
 
-.. method:: Path.samefile(other_path)
+.. method:: Path.samefile(other_path, follow_symlinks=True)
 
    Return whether this path points to the same file as *other_path*, which
    can be either a Path object, or a string.  The semantics are similar
@@ -1097,6 +1097,9 @@ call fails (for example because the path doesn't exist).
       True
 
    .. versionadded:: 3.5
+
+   .. versionchanged:: 3.10
+      Supports optional argument ``follow_symlinks``.
 
 
 .. method:: Path.symlink_to(target, target_is_directory=False)

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -264,6 +264,9 @@ descriptors without copying between kernel address space and user
 address space, where one of the file descriptors must refer to a
 pipe. (Contributed by Pablo Galindo in :issue:`41625`.)
 
+Added optional ``follow_symlinks`` argument to :func:`os.path.samefile`.
+(Contributed by Ross Rhodes in :issue:`42778`.)
+
 pathlib
 -------
 
@@ -273,6 +276,9 @@ Added slice support to :attr:`PurePath.parents <pathlib.PurePath.parents>`.
 Added negative indexing support to :attr:`PurePath.parents
 <pathlib.PurePath.parents>`.
 (Contributed by Yaroslav Pankovych in :issue:`21041`)
+
+Added optional ``follow_symlinks`` argument to :func:`pathlib.samefile`.
+(Contributed by Ross Rhodes in :issue:`42778`.)
 
 platform
 --------

--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -91,14 +91,14 @@ def samestat(s1, s2):
 
 
 # Are two filenames really pointing to the same file?
-def samefile(f1, f2):
+def samefile(f1, f2, follow_symlinks=True):
     """Test whether two pathnames reference the same actual file or directory
 
     This is determined by the device number and i-node number and
     raises an exception if an os.stat() call on either pathname fails.
     """
-    s1 = os.stat(f1)
-    s2 = os.stat(f2)
+    s1 = os.stat(f1, follow_symlinks=follow_symlinks)
+    s2 = os.stat(f2, follow_symlinks=follow_symlinks)
     return samestat(s1, s2)
 
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1134,15 +1134,15 @@ class Path(PurePath):
         """
         return cls(cls()._flavour.gethomedir(None))
 
-    def samefile(self, other_path):
+    def samefile(self, other_path, follow_symlinks=True):
         """Return whether other_path is the same or not as this file
         (as returned by os.path.samefile()).
         """
-        st = self.stat()
+        st = self.stat(follow_symlinks=follow_symlinks)
         try:
-            other_st = other_path.stat()
+            other_st = other_path.stat(follow_symlinks=follow_symlinks)
         except AttributeError:
-            other_st = self._accessor.stat(other_path)
+            other_st = self._accessor.stat(other_path, follow_symlinks=follow_symlinks)
         return os.path.samestat(st, other_st)
 
     def iterdir(self):
@@ -1216,12 +1216,12 @@ class Path(PurePath):
         obj._init(template=self)
         return obj
 
-    def stat(self):
+    def stat(self, follow_symlinks=True):
         """
         Return the result of the stat() system call on this path, like
         os.stat() does.
         """
-        return self._accessor.stat(self)
+        return self._accessor.stat(self, follow_symlinks=follow_symlinks)
 
     def owner(self):
         """

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1431,6 +1431,7 @@ Bernhard Reiter
 Steven Reiz
 Roeland Rengelink
 Antoine Reversat
+Ross Rhodes
 Flávio Ribeiro
 Francesco Ricciardi
 Tim Rice

--- a/Misc/NEWS.d/next/Library/2020-12-29-12-32-49.bpo-42778.SNVoXG.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-29-12-32-49.bpo-42778.SNVoXG.rst
@@ -1,0 +1,2 @@
+Add 'follow_symlinks' optional argument to os.path and pathlib samefile
+methods


### PR DESCRIPTION
What?
=====
Add `follow_symlinks` optional argument to os.path and pathlib `samefile` methods.

Why?
====
To allow users to compare files without following symlinks. By default symlinks will be followed for backward compatibility.

<!-- issue-number: [bpo-42778](https://bugs.python.org/issue42778) -->
https://bugs.python.org/issue42778
<!-- /issue-number -->
