### PR TITLE
bpo-40052: Fix alignment issue in PyVectorcall_Function()

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -63,7 +63,7 @@ PyVectorcall_Function(PyObject *callable)
 {
     PyTypeObject *tp;
     Py_ssize_t offset;
-    vectorcallfunc *ptr;
+    vectorcallfunc ptr;
 
     assert(callable != NULL);
     tp = Py_TYPE(callable);
@@ -73,8 +73,8 @@ PyVectorcall_Function(PyObject *callable)
     assert(PyCallable_Check(callable));
     offset = tp->tp_vectorcall_offset;
     assert(offset > 0);
-    ptr = (vectorcallfunc *)(((char *)callable) + offset);
-    return *ptr;
+    memcpy(&ptr, (char *) callable + offset, sizeof(ptr));
+    return ptr;
 }
 
 /* Call the callable object 'callable' with the "vectorcall" calling

--- a/Misc/NEWS.d/next/C API/2020-03-24-09-27-10.bpo-40052.27P2KG.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-24-09-27-10.bpo-40052.27P2KG.rst
@@ -1,0 +1,2 @@
+Fix an alignment build warning/error in function ``PyVectorcall_Function()``.
+Patch by Andreas Schneider, Antoine Pitrou and Petr Viktorin.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -205,6 +205,7 @@ PyObject *
 PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
 {
     PyThreadState *tstate = _PyThreadState_GET();
+    vectorcallfunc func;
 
     /* get vectorcallfunc as in PyVectorcall_Function, but without
      * the Py_TPFLAGS_HAVE_VECTORCALL check */
@@ -215,7 +216,7 @@ PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
                       Py_TYPE(callable)->tp_name);
         return NULL;
     }
-    vectorcallfunc func = *(vectorcallfunc *)(((char *)callable) + offset);
+    memcpy(&func, (char *) callable + offset, sizeof(func));
     if (func == NULL) {
         _PyErr_Format(tstate, PyExc_TypeError,
                       "'%.200s' object does not support vectorcall",


### PR DESCRIPTION
```
In file included from /usr/include/python3.8/Python.h:147:
In file included from /usr/include/python3.8/abstract.h:837:
/usr/include/python3.8/cpython/abstract.h:91:11: error: cast from 'char *' to 'vectorcallfunc *'
(aka 'struct _object *(**)(struct _object *, struct _object *const *, unsigned long, struct _object *)')
increases required alignment from 1 to 8 [-Werror,-Wcast-align]

    ptr = (vectorcallfunc*)(((char *)callable) + offset);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
Co-Authored-By: Andreas Schneider <asn@cryptomilk.org>
Co-Authored-By: Antoine Pitrou <antoine@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40052](https://bugs.python.org/issue40052) -->
https://bugs.python.org/issue40052
<!-- /issue-number -->

Automerge-Triggered-By: GH:pitrou