### PR TITLE
bpo-42782: Fail fast for permission errors in shutil.move()

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -813,8 +813,9 @@ def move(src, dst, copy_function=copy2):
             if _destinsrc(src, dst):
                 raise Error("Cannot move a directory '%s' into itself"
                             " '%s'." % (src, dst))
-            if ((not os.access(src, os.W_OK) and os.listdir(src))
-                    or _is_immutable(src)):
+            if (_is_immutable(src)
+                    or (not os.access(src, os.W_OK) and os.listdir(src)
+                        and sys.platform == 'darwin')):
                 raise PermissionError("Cannot move the non-empty directory "
                                       "'%s': Lacking write permission to '%s'."
                                       % (src, src))

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -813,7 +813,8 @@ def move(src, dst, copy_function=copy2):
             if _destinsrc(src, dst):
                 raise Error("Cannot move a directory '%s' into itself"
                             " '%s'." % (src, dst))
-            if not os.access(src, os.W_OK) and os.listdir(src):
+            if ((not os.access(src, os.W_OK) and os.listdir(src))
+                    or _is_immutable(src)):
                 raise PermissionError("Cannot move the non-empty directory "
                                       "'%s': Lacking write permission to '%s'."
                                       % (src, src))
@@ -833,6 +834,11 @@ def _destinsrc(src, dst):
     if not dst.endswith(os.path.sep):
         dst += os.path.sep
     return dst.startswith(src)
+
+def _is_immutable(src):
+    st = _stat(src)
+    immutable_states = [stat.UF_IMMUTABLE, stat.SF_IMMUTABLE]
+    return hasattr(st, 'st_flags') and st.st_flags in immutable_states
 
 def _get_gid(name):
     """Returns a gid, given a group name."""

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -814,9 +814,9 @@ def move(src, dst, copy_function=copy2):
                 raise Error("Cannot move a directory '%s' into itself"
                             " '%s'." % (src, dst))
             if not os.access(src, os.W_OK) and os.listdir(src):
-                raise Error("Cannot move the non-empty directory '%s': "
-                            "Lacking write permission to '%s'."
-                            % (src, src))
+                raise PermissionError("Cannot move the non-empty directory "
+                                      "'%s': Lacking write permission to '%s'."
+                                      % (src, src))
             copytree(src, real_dst, copy_function=copy_function,
                      symlinks=True)
             rmtree(src)

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -813,6 +813,10 @@ def move(src, dst, copy_function=copy2):
             if _destinsrc(src, dst):
                 raise Error("Cannot move a directory '%s' into itself"
                             " '%s'." % (src, dst))
+            if not os.access(src, os.W_OK) and os.listdir(src):
+                raise Error("Cannot move the non-empty directory '%s': "
+                            "Lacking write permission to '%s'."
+                            % (src, src))
             copytree(src, real_dst, copy_function=copy_function,
                      symlinks=True)
             rmtree(src)

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2097,10 +2097,21 @@ class TestMove(BaseTest, unittest.TestCase):
         # if the source directory cannot be removed.
         try:
             os.mkdir(TESTFN_SRC)
+            os.lchflags(TESTFN_SRC, stat.SF_IMMUTABLE)
+
+            # Testing on an empty immutable directory
+            # TESTFN_DST should not exist if shutil.move failed
+            self.assertRaises(PermissionError, shutil.move, TESTFN_SRC, TESTFN_DST)
+            self.assertFalse(TESTFN_DST in os.listdir())
+
+            # Create a file and keep the directory immutable
+            os.lchflags(TESTFN_SRC, stat.UF_OPAQUE)
             os_helper.create_empty_file(os.path.join(TESTFN_SRC, 'child'))
             os.lchflags(TESTFN_SRC, stat.SF_IMMUTABLE)
-            self.assertRaises(PermissionError, shutil.move, TESTFN_SRC, TESTFN_DST)
+
+            # Testing on a non-empty immutable directory
             # TESTFN_DST should not exist if shutil.move failed
+            self.assertRaises(PermissionError, shutil.move, TESTFN_SRC, TESTFN_DST)
             self.assertFalse(TESTFN_DST in os.listdir())
         finally:
             if os.path.exists(TESTFN_SRC):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2084,6 +2084,22 @@ class TestMove(BaseTest, unittest.TestCase):
         finally:
             os.rmdir(dst_dir)
 
+    def test_move_dir_permission_denied(self):
+        # Move a dir to another location on the same filesystem.
+        os.setuid(0)
+        '''
+        dst_dir = tempfile.mktemp(dir=self.mkdtemp())
+        try:
+            shutil.chown(self.src_dir, user=0)
+            # os.setuid(1000)
+            os.setuid(0)
+            with self.assertRaises(PermissionError) as pe:
+                self._check_move_dir(self.src_dir, dst_dir, dst_dir)
+            # self.assertEqual(cm.exception.filename, filename)
+        finally:
+            os_helper.rmtree(dst_dir)
+        '''
+
 
 class TestCopyFile(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2020-12-29-13-46-57.bpo-42782.3r0HFY.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-29-13-46-57.bpo-42782.3r0HFY.rst
@@ -1,2 +1,2 @@
-Fail fast in shutil.move() to avoid creating destination directories on
+Fail fast in :func:`shutil.move()` to avoid creating destination directories on
 failure.

--- a/Misc/NEWS.d/next/Library/2020-12-29-13-46-57.bpo-42782.3r0HFY.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-29-13-46-57.bpo-42782.3r0HFY.rst
@@ -1,0 +1,2 @@
+Fail fast in shutil.move() to avoid creating destination directories on
+failure.


### PR DESCRIPTION
# [bpo-42782](https://bugs.python.org/issue42782): Fail fast for permission errors in shutil.move()

<!-- issue-number: [bpo-42782](https://bugs.python.org/issue42782) -->
https://bugs.python.org/issue42782
<!-- /issue-number -->

`shutil.move` calls `shutil.copytree()`, then `shutil.rmtree()` (in that order). If the user does not have permission to delete the source directory, `copytree` succeeds but `rmtree` fails. The user sees an error (Permission Denied), but the destination directory is still created. The expected behavior should be a Permission Denied without the creation of the destination directory.

To reproduce:
```
$ mkdir foo
$ sudo chown root foo
$ sudo touch foo/child
$ python3
>>> import shutil
>>> shutil.move('foo', 'bar')
PermissionError
$ ls foo
child
$ ls bar
child
```

If `shutil.move()` encountered a permission error and failed, `bar/` should not have been created. This PR changes the `shutil.move` behavior to return an error before `shutil.copytree()` is called, preventing the creation of the destination directory on failure.