### PR TITLE
bpo-22295: use `python -m pip` rather than plain `pip` in examples

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -43,7 +43,7 @@ something into it:
 
     $ python3 -m venv example
     $ source example/bin/activate
-    (example) $ pip install wheel
+    (example) $ python -m pip install wheel
 
 You can get the version string for ``wheel`` by running the following:
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -721,7 +721,7 @@ Substantially all of these recipes and many, many others can be installed from
 the `more-itertools project <https://pypi.org/project/more-itertools/>`_ found
 on the Python Package Index::
 
-    pip install more-itertools
+    python -m pip install more-itertools
 
 The extended tools offer the same high performance as the underlying toolset.
 The superior memory performance is kept by processing elements one at a time

--- a/Doc/tutorial/venv.rst
+++ b/Doc/tutorial/venv.rst
@@ -130,8 +130,8 @@ package name  followed by ``==`` and the version number:
 
 If you re-run this command, ``pip`` will notice that the requested
 version is already installed and do nothing.  You can supply a
-different version number to get that version, or you can run ``pip
-install --upgrade`` to upgrade the package to the latest version:
+different version number to get that version, or you can run ``python
+-m pip install --upgrade`` to upgrade the package to the latest version:
 
 .. code-block:: bash
 
@@ -143,14 +143,14 @@ install --upgrade`` to upgrade the package to the latest version:
         Successfully uninstalled requests-2.6.0
   Successfully installed requests-2.7.0
 
-``pip uninstall`` followed by one or more package names will remove the
-packages from the virtual environment.
+``python -m pip uninstall`` followed by one or more package names will
+remove the packages from the virtual environment.
 
-``pip show`` will display information about a particular package:
+``python -m pip show`` will display information about a particular package:
 
 .. code-block:: bash
 
-  (tutorial-env) $ pip show requests
+  (tutorial-env) $ python -m pip show requests
   ---
   Metadata-Version: 2.0
   Name: requests
@@ -163,25 +163,25 @@ packages from the virtual environment.
   Location: /Users/akuchling/envs/tutorial-env/lib/python3.4/site-packages
   Requires:
 
-``pip list`` will display all of the packages installed in the virtual
-environment:
+``python -m pip list`` will display all of the packages installed in
+the virtual environment:
 
 .. code-block:: bash
 
-  (tutorial-env) $ pip list
+  (tutorial-env) $ python -m pip list
   novas (3.1.1.3)
   numpy (1.9.2)
   pip (7.0.3)
   requests (2.7.0)
   setuptools (16.0)
 
-``pip freeze`` will produce a similar list of the installed packages,
-but the output uses the format that ``pip install`` expects.
+``python -m pip freeze`` will produce a similar list of the installed packages,
+but the output uses the format that ``python -m pip install`` expects.
 A common convention is to put this list in a ``requirements.txt`` file:
 
 .. code-block:: bash
 
-  (tutorial-env) $ pip freeze > requirements.txt
+  (tutorial-env) $ python -m pip freeze > requirements.txt
   (tutorial-env) $ cat requirements.txt
   novas==3.1.1.3
   numpy==1.9.2


### PR DESCRIPTION
Refs https://bugs.python.org/issue22295

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-22295](https://bugs.python.org/issue22295) -->
https://bugs.python.org/issue22295
<!-- /issue-number -->
