### PR TITLE
bpo-42773: fix tests not being run on pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check for source changes
         id: check
         run: |
-          if [ -z "GITHUB_BASE_REF" ]; then
+          if [ -z "$GITHUB_BASE_REF" ]; then
             echo '::set-output name=run_tests::true'
           else
             git fetch origin $GITHUB_BASE_REF --depth=1


### PR DESCRIPTION
There was a typo, we were checking if the "GITHUB_BASE_REF" string
literal was empty instead of the $GITHUB_BASE_REF value. When
$GITHUB_BASE_REF is empty, the action that triggered the run was not a
pull request, so we always run the full test suite.

Signed-off-by: Filipe Laíns <lains@riseup.net>

<!-- issue-number: [bpo-42773](https://bugs.python.org/issue42773) -->
https://bugs.python.org/issue42773
<!-- /issue-number -->

Automerge-Triggered-By: GH:Mariatta