### PR TITLE
bpo-42772: Step argument ignored when stop is None.

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -96,6 +96,7 @@ LOG4 = _log(4.0)
 SG_MAGICCONST = 1.0 + _log(4.5)
 BPF = 53        # Number of bits in a float
 RECIP_BPF = 2 ** -BPF
+_ONE = 1
 
 
 class Random(_random.Random):
@@ -288,7 +289,7 @@ class Random(_random.Random):
 
     ## -------------------- integer methods  -------------------
 
-    def randrange(self, start, stop=None, step=1):
+    def randrange(self, start, stop=None, step=_ONE):
         """Choose a random item from range(start, stop[, step]).
 
         This fixes the problem with randint() which includes the
@@ -311,7 +312,12 @@ class Random(_random.Random):
                 _warn('randrange() will raise TypeError in the future',
                       DeprecationWarning, 2)
                 raise ValueError("non-integer arg 1 for randrange()")
+
         if stop is None:
+            # We don't check for "step != 1" because it hasn't been
+            # type checked and converted to an integer yet.
+            if step is not _ONE:
+                raise TypeError('Missing a non-None stop argument')
             if istart > 0:
                 return self._randbelow(istart)
             raise ValueError("empty range for randrange()")

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -562,6 +562,14 @@ class SystemRandom_TestBasicOps(TestBasicOps, unittest.TestCase):
             with self.assertRaises(ValueError):
                 randrange(10, 20, 1.5)
 
+    def test_randrange_step(self):
+        # bpo-42772: When stop is None, the step argument was being ignored.
+        randrange = self.gen.randrange
+        with self.assertRaises(TypeError):
+            randrange(1000, step=100)
+        with self.assertRaises(TypeError):
+            randrange(1000, None, step=100)
+
     def test_randbelow_logic(self, _log=log, int=int):
         # check bitcount transition points:  2**i and 2**(i+1)-1
         # show that: k = int(1.001 + _log(n, 2))

--- a/Misc/NEWS.d/next/Library/2020-12-30-17-16-43.bpo-42772.Xe7WFV.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-30-17-16-43.bpo-42772.Xe7WFV.rst
@@ -1,0 +1,2 @@
+randrange() now raises a TypeError when step is specified without a stop
+argument.  Formerly, it silently ignored the step argument.


### PR DESCRIPTION


<!-- issue-number: [bpo-42772](https://bugs.python.org/issue42772) -->
https://bugs.python.org/issue42772
<!-- /issue-number -->
