### PR TITLE
[3.8] bpo-39068: Fix race condition in base64 (GH-17627)

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -320,7 +320,7 @@ def a85encode(b, *, foldspaces=False, wrapcol=0, pad=False, adobe=False):
     global _a85chars, _a85chars2
     # Delay the initialization of tables to not waste memory
     # if the function is never called
-    if _a85chars is None:
+    if _a85chars2 is None:
         _a85chars = [bytes((i,)) for i in range(33, 118)]
         _a85chars2 = [(a + b) for a in _a85chars for b in _a85chars]
 
@@ -428,7 +428,7 @@ def b85encode(b, pad=False):
     global _b85chars, _b85chars2
     # Delay the initialization of tables to not waste memory
     # if the function is never called
-    if _b85chars is None:
+    if _b85chars2 is None:
         _b85chars = [bytes((i,)) for i in _b85alphabet]
         _b85chars2 = [(a + b) for a in _b85chars for b in _b85chars]
     return _85encode(b, _b85chars, _b85chars2, pad)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1607,6 +1607,7 @@ Tage Stabell-Kulo
 Quentin Stafford-Fraser
 Frank Stajano
 Joel Stanley
+Brandon Stansbury
 Anthony Starks
 David Steele
 Oliver Steele

--- a/Misc/NEWS.d/next/Library/2019-12-16-17-55-31.bpo-39068.Ti3f9P.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-16-17-55-31.bpo-39068.Ti3f9P.rst
@@ -1,0 +1,2 @@
+Fix initialization race condition in :func:`a85encode` and :func:`b85encode`
+in :mod:`base64`. Patch by Brandon Stansbury.


### PR DESCRIPTION
There was a race condition in base64 in lazy initialization of multiple globals.
(cherry picked from commit 9655434cca5dfbea97bf6d355aec028e840b289c)

Co-authored-by: Brandon Stansbury <brandonrstansbury@gmail.com>


<!-- issue-number: [bpo-39068](https://bugs.python.org/issue39068) -->
https://bugs.python.org/issue39068
<!-- /issue-number -->
