### PR TITLE
[3.9] bpo-42756: Configure LMTP Unix-domain socket to use global default timeout when timeout not provided

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -1082,7 +1082,8 @@ class LMTP(SMTP):
         # Handle Unix-domain sockets.
         try:
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.sock.settimeout(self.timeout)
+            if self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                self.sock.settimeout(self.timeout)
             self.file = None
             self.sock.connect(host)
         except OSError:

--- a/Lib/test/mock_socket.py
+++ b/Lib/test/mock_socket.py
@@ -107,6 +107,9 @@ class MockSocket:
     def close(self):
         pass
 
+    def connect(self, host):
+        pass
+
 
 def socket(family=None, type=None, proto=None):
     return MockSocket(family)
@@ -152,8 +155,12 @@ error = socket_module.error
 
 
 # Constants
+_GLOBAL_DEFAULT_TIMEOUT = socket_module._GLOBAL_DEFAULT_TIMEOUT
 AF_INET = socket_module.AF_INET
 AF_INET6 = socket_module.AF_INET6
 SOCK_STREAM = socket_module.SOCK_STREAM
 SOL_SOCKET = None
 SO_REUSEADDR = None
+
+if hasattr(socket_module, 'AF_UNIX'):
+    AF_UNIX = socket_module.AF_UNIX

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -165,6 +165,17 @@ class LMTPGeneralTests(GeneralTests, unittest.TestCase):
 
     client = smtplib.LMTP
 
+    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), "test requires Unix domain socket")
+    def testUnixDomainSocketTimeoutDefault(self):
+        local_host = '/some/local/lmtp/delivery/program'
+        mock_socket.reply_with(b"220 Hello world")
+        try:
+            client = self.client(local_host, self.port)
+        finally:
+            mock_socket.setdefaulttimeout(None)
+        self.assertIsNone(client.sock.gettimeout())
+        client.close()
+
     def testTimeoutZero(self):
         super().testTimeoutZero()
         local_host = '/some/local/lmtp/delivery/program'

--- a/Misc/NEWS.d/next/Library/2020-12-27-21-22-01.bpo-42756.dHMPJ9.rst
+++ b/Misc/NEWS.d/next/Library/2020-12-27-21-22-01.bpo-42756.dHMPJ9.rst
@@ -1,0 +1,2 @@
+Configure LMTP Unix-domain socket to use socket global default timeout when
+a timeout is not explicitly provided.


### PR DESCRIPTION
…ult timeout when timeout not provided (GH-23969)

(cherry picked from commit 3bf05327c2b25d42b92795d9d280288c22a0963d)

Co-authored-by: Ross <rrhodes@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42756](https://bugs.python.org/issue42756) -->
https://bugs.python.org/issue42756
<!-- /issue-number -->
