### PR TITLE
bpo-42557:  importable asyncio.__main__ with preamble feature

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-01-02-11-22-47.bpo-42557.ODFMlB.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-02-11-22-47.bpo-42557.ODFMlB.rst
@@ -1,0 +1,4 @@
+Make module `asyncio.__main__` importable, adding function
+`main(preamble=())` for easy customization of the async REPL. The preamble
+specifies the lines of code that will be executed at the start of the async
+REPL.

--- a/Misc/NEWS.d/next/Library/2021-01-02-11-22-47.bpo-42557.ODFMlB.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-02-11-22-47.bpo-42557.ODFMlB.rst
@@ -1,4 +1,4 @@
-Make module `asyncio.__main__` importable, adding function
-`main(preamble=())` for easy customization of the async REPL. The preamble
+Make module ``asyncio.__main__`` importable, adding function
+``main(preamble=())`` for easy customization of the async REPL. The preamble
 specifies the lines of code that will be executed at the start of the async
 REPL.


### PR DESCRIPTION
Making asyncio.__main__ importable for easy customization of async REPL.
Also, function main(preamble=()) lets one specify a few lines of code that 
will be executed at the start of the REPL, after importing asyncio.

This way developers of packages building on asyncio can create their own
__main__.py with a simple call to asyncio.__main__.main().

<!-- issue-number: [bpo-42557](https://bugs.python.org/issue42557) -->
https://bugs.python.org/issue42557
<!-- /issue-number -->
