### PR TITLE
[3.9] bpo-42425: Fix possible leak in initialization of errmap for OSError (GH-23446).

### DIFF
--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2531,8 +2531,10 @@ _PyExc_Init(void)
     do { \
         PyObject *_code = PyLong_FromLong(CODE); \
         assert(_PyObject_RealIsSubclass(PyExc_ ## TYPE, PyExc_OSError)); \
-        if (!_code || PyDict_SetItem(errnomap, _code, PyExc_ ## TYPE)) \
+        if (!_code || PyDict_SetItem(errnomap, _code, PyExc_ ## TYPE)) { \
+            Py_XDECREF(_code); \
             return _PyStatus_ERR("errmap insertion problem."); \
+        } \
         Py_DECREF(_code); \
     } while (0)
 


### PR DESCRIPTION
(cherry picked from commit ed1007c0d74e658d1e6c9b51b12ce7501eb8cbf9)


<!-- issue-number: [bpo-42425](https://bugs.python.org/issue42425) -->
https://bugs.python.org/issue42425
<!-- /issue-number -->
