### PR TITLE
bpo-42195: Disallow isinstance/issubclass for subclasses of genericaliases in Union

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -737,6 +737,16 @@ class TypesTests(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError):
             list[int] | list[bt]
 
+        union_ga = (int | list[str], int | collections.abc.Callable[..., str],
+                    int | d)
+        # Raise error when isinstance(type, type | genericalias)
+        for type_ in union_ga:
+            with self.subTest(f"check isinstance/issubclass is invalid for {type_}"):
+                with self.assertRaises(TypeError):
+                    isinstance(list, type_)
+                with self.assertRaises(TypeError):
+                    issubclass(list, type_)
+
     def test_ellipsis_type(self):
         self.assertIsInstance(Ellipsis, types.EllipsisType)
 

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -34,7 +34,7 @@ is_generic_alias_in_args(PyObject *args) {
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     for (Py_ssize_t iarg = 0; iarg < nargs; iarg++) {
         PyObject *arg = PyTuple_GET_ITEM(args, iarg);
-        if (Py_TYPE(arg) == &Py_GenericAliasType) {
+        if (PyObject_TypeCheck(arg, &Py_GenericAliasType)) {
             return 0;
         }
     }


### PR DESCRIPTION
Previously this didn't raise an error. Now it will:
```python
from collections.abc import Callable
isinstance(int, list | Callable[..., str])
```
Also added tests in Union since there were previously none for stuff like ``isinstance(list, list | list[int])`` either.

Backport to 3.9 not required.

<!-- issue-number: [bpo-42195](https://bugs.python.org/issue42195) -->
https://bugs.python.org/issue42195
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum