### PR TITLE
bpo-42093: Tweak the what's new message about the new LOAD_ATTR opcode cache

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -426,9 +426,11 @@ Optimizations
   average.
   (Contributed by Victor Stinner in :issue:`41006`.)
 
-* The ``LOAD_ATTR`` instruction now uses new "per opcode cache" mechanism.
-  It is about 36% faster now.  (Contributed by Pablo Galindo and Yury Selivanov
-  in :issue:`42093`, based on ideas implemented originally in PyPy and MicroPython.)
+* The ``LOAD_ATTR`` instruction now uses new "per opcode cache" mechanism.  It
+  is about 36% faster now. This makes optimized ``LOAD_ATTR`` instructions the
+  current most performance attribute access method (faster than slots).
+  (Contributed by Pablo Galindo and Yury Selivanov in :issue:`42093`, based on
+  ideas implemented originally in PyPy and MicroPython.)
 
 * When building Python with ``--enable-optimizations`` now
   ``-fno-semantic-interposition`` is added to both the compile and link line.


### PR DESCRIPTION


<!-- issue-number: [bpo-42093](https://bugs.python.org/issue42093) -->
https://bugs.python.org/issue42093
<!-- /issue-number -->
