### PR TITLE
bpo-42814: Fix undefined behavior in Objects/genericaliasobject.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-03-04-41-25.bpo-42814.sDvVbb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-03-04-41-25.bpo-42814.sDvVbb.rst
@@ -1,0 +1,1 @@
+Fix undefined behavior in ``Objects/genericaliasobject.c``.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -173,6 +173,7 @@ is_typing_name(PyObject *obj, int num, ...)
             break;
         }
     }
+    va_end(names);
     if (!hit) {
         return 0;
     }
@@ -184,7 +185,6 @@ is_typing_name(PyObject *obj, int num, ...)
         && _PyUnicode_EqualToASCIIString(module, "typing");
     Py_DECREF(module);
     
-    va_end(names);
     return res;
 }
 


### PR DESCRIPTION
In is_typing_name(), va_end() is not always called before the
function returns.  It is undefined behavior to call va_start()
without also calling va_end().

<!-- issue-number: [bpo-42814](https://bugs.python.org/issue42814) -->
https://bugs.python.org/issue42814
<!-- /issue-number -->
