### PR TITLE
bpo-42361: Update macOS installer build to use Tcl/Tk 8.6.11

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -263,10 +263,10 @@ def library_recipes():
             tk_patches = ['tk868_on_10_8_10_9.patch']
 
         else:
-            tcl_tk_ver='8.6.10'
-            tcl_checksum='97c55573f8520bcab74e21bfd8d0aadc'
+            tcl_tk_ver='8.6.11'
+            tcl_checksum='8a4c004f48984a03a7747e9ba06e4da4'
 
-            tk_checksum='602a47ad9ecac7bf655ada729d140a94'
+            tk_checksum='c7ee71a2d05bba78dfffd76528dc17c6'
             tk_patches = [ ]
 
 

--- a/Misc/NEWS.d/next/macOS/2021-01-04-01-17-17.bpo-42361.eolZAi.rst
+++ b/Misc/NEWS.d/next/macOS/2021-01-04-01-17-17.bpo-42361.eolZAi.rst
@@ -1,0 +1,2 @@
+Update macOS installer build to use Tcl/Tk 8.6.11 (rc2, expected to be final
+release).


### PR DESCRIPTION
As of 2021-01-03, Tcl/Tk 8.6.11rc2 is expected to be the final release.


<!-- issue-number: [bpo-42361](https://bugs.python.org/issue42361) -->
https://bugs.python.org/issue42361
<!-- /issue-number -->
