### PR TITLE
bpo-42789: Enable using /dev/tty in test_curses.

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -85,7 +85,7 @@ class TestCurses(unittest.TestCase):
             else:
                 try:
                     # Try to open the terminal device.
-                    tmp = open('/xdev/tty', 'wb', buffering=0)
+                    tmp = open('/dev/tty', 'wb', buffering=0)
                 except OSError:
                     # As a fallback, use regular file to write control codes.
                     # Some functions (like savetty) will not work, but at


### PR DESCRIPTION
It was temporary disabled for debugging.


<!-- issue-number: [bpo-42789](https://bugs.python.org/issue42789) -->
https://bugs.python.org/issue42789
<!-- /issue-number -->
