### PR TITLE
bpo-42825: Enable /OPT:REF

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -73,6 +73,7 @@
       <LinkTimeCodeGeneration Condition="$(SupportPGO) and $(Configuration) == 'PGInstrument'">PGInstrument</LinkTimeCodeGeneration>
       <LinkTimeCodeGeneration Condition="$(SupportPGO) and $(Configuration) == 'PGUpdate'">PGUpdate</LinkTimeCodeGeneration>
       <AdditionalDependencies>advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions Condition="$(Configuration) != 'Debug'">/OPT:REF,NOICF %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Lib>
       <LinkTimeCodeGeneration Condition="$(Configuration) == 'Release'">true</LinkTimeCodeGeneration>


### PR DESCRIPTION
This PR enables the /OPT:REF linker optimization on Windows, allowing the linker to discard uncalled code.  This is analogous to --gc-sections for ld on linux, if you're familiar with that.  Basically the linker can determine that a function is never called and not include it in the final binary.

Note that I had to explicitly keep /OPT:ICF disabled because enabling Identical COMDAT Folding (ICF) causes test failures.  This is because Python310.dll depends on some identical things not folding together (such as wrap_binary_func and wrap_binary_func_l) as their addresses are compared to determine equality in some important places.  There are even helpful tests that verify COMDAT folding is disabled which helped me catch this 😊.

This could be backported to previous versions if desired, it should be simple and safe to do to whichever versions are deployed at scale in the wild, but I'll leave that to the community and maintainers to decide, I didn't want to go through the backport process.

Note: I am not sure how to build for PGO locally, but I think it's good to have this on for Configuration == PGInstrument and/or PGUpdate, so I used a Condition of "!= Debug".  This should be verified in the real build pipeline that does PGO, or let me know how I can do it locally.

In terms of the size savings, here's a few example binaries and then the total across all of them in the build output folder - all measurements were done for amd64 Release binaries.  It's over a 10% savings in the size of everything, and some binaries are considerably more than that.

Binary | Size before | Size after | Delta (%)
--------|-------------|------------|----------
py.exe | 1,024,000 | 735,744 | -288,256 (-28.2%)
python.exe | 93,696 | 91,136 | -2,560 (-2.7%)
python_uwp.exe | 225,792 | 140,288 | -85,504 (-37.9%)
python310.dll | 5,268,992 | 4,753,408 | -515,584 (-9.8%)
sqlite3.dll | 1,505,280 | 1,376,256 | -129,024 (-8.6%)
**Total of .exe/.dll/.pyd** | 21,632,408 |   19,278,744 | **-2,353,664 (-10.9%)**

<!-- issue-number: [bpo-42825](https://bugs.python.org/issue42825) -->
https://bugs.python.org/issue42825
<!-- /issue-number -->
