### PR TITLE
bpo-42811: Update importlib.utils.resolve_name() docs to use __spec__.parent

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1476,7 +1476,7 @@ an :term:`importer`.
 
    If  **name** has no leading dots, then **name** is simply returned. This
    allows for usage such as
-   ``importlib.util.resolve_name('sys', __spec__)`` without doing a
+   ``importlib.util.resolve_name('sys', __spec__.parent)`` without doing a
    check to see if the **package** argument is needed.
 
    :exc:`ImportError` is raised if **name** is a relative module name but

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1476,7 +1476,7 @@ an :term:`importer`.
 
    If  **name** has no leading dots, then **name** is simply returned. This
    allows for usage such as
-   ``importlib.util.resolve_name('sys', __package__)`` without doing a
+   ``importlib.util.resolve_name('sys', __spec__)`` without doing a
    check to see if the **package** argument is needed.
 
    :exc:`ImportError` is raised if **name** is a relative module name but

--- a/Misc/NEWS.d/next/Documentation/2021-01-04-22-14-22.bpo-42811.HY2beA.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-01-04-22-14-22.bpo-42811.HY2beA.rst
@@ -1,0 +1,2 @@
+Updated importlib.utils.resolve_name doc to use __spec__ instead of
+__package__

--- a/Misc/NEWS.d/next/Documentation/2021-01-04-22-14-22.bpo-42811.HY2beA.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-01-04-22-14-22.bpo-42811.HY2beA.rst
@@ -1,2 +1,2 @@
-Updated importlib.utils.resolve_name doc to use __spec__ instead of
-__package__
+Updated importlib.utils.resolve_name() doc to use __spec__.parent
+instead of __package__. (Thanks Yair Frid.)


### PR DESCRIPTION
<!-- issue-number: [bpo-42811](https://bugs.python.org/issue42811) -->
https://bugs.python.org/issue42811
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon