### PR TITLE
bpo-40810: Require SQLite 3.7.15

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -19,7 +19,7 @@ PostgreSQL or Oracle.
 
 The sqlite3 module was written by Gerhard Häring.  It provides a SQL interface
 compliant with the DB-API 2.0 specification described by :pep:`249`, and
-requires SQLite 3.7.3 or newer.
+requires SQLite 3.7.15 or newer.
 
 To use the module, you must first create a :class:`Connection` object that
 represents the database.  Here the data will be stored in the

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -577,13 +577,12 @@ CPython bytecode changes
 Build Changes
 =============
 
-
 * The C99 functions :c:func:`snprintf` and :c:func:`vsnprintf` are now required
   to build Python.
   (Contributed by Victor Stinner in :issue:`36020`.)
 
-* :mod:`sqlite3` requires SQLite 3.7.3 or higher.
-  (Contributed by Sergey Fedoseev and Erlend E. Aasland :issue:`40744`.)
+* :mod:`sqlite3` requires SQLite 3.7.15 or higher. (Contributed by Sergey Fedoseev
+  and Erlend E. Aasland :issue:`40744` and :issue:`40810`.)
 
 * The :mod:`atexit` module must now always be built as a built-in module.
   (Contributed by Victor Stinner in :issue:`42639`.)

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -172,10 +172,6 @@ class ConnectionTests(unittest.TestCase):
             cx.execute('create table test(id integer)')
 
     def CheckOpenUri(self):
-        if sqlite.sqlite_version_info < (3, 7, 7):
-            with self.assertRaises(sqlite.NotSupportedError):
-                sqlite.connect(':memory:', uri=True)
-            return
         self.addCleanup(unlink, TESTFN)
         with sqlite.connect(TESTFN) as cx:
             cx.execute('create table test(id integer)')

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -260,14 +260,6 @@ class TraceCallbackTests(unittest.TestCase):
         cur.execute(queries[0])
         con2.execute("create table bar(x)")
         cur.execute(queries[1])
-
-        # Extract from SQLite 3.7.15 changelog:
-        # Avoid invoking the sqlite3_trace() callback multiple times when a
-        # statement is automatically reprepared due to SQLITE_SCHEMA errors.
-        #
-        # See bpo-40810
-        if sqlite.sqlite_version_info < (3, 7, 15):
-            queries.append(queries[-1])
         self.assertEqual(traced_statements, queries)
 
 

--- a/Misc/NEWS.d/next/Library/2021-01-05-00-52-30.bpo-40810.JxQqPe.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-05-00-52-30.bpo-40810.JxQqPe.rst
@@ -1,0 +1,1 @@
+Require SQLite 3.7.15 or newer. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -29,8 +29,8 @@
 #include "microprotocols.h"
 #include "row.h"
 
-#if SQLITE_VERSION_NUMBER < 3007003
-#error "SQLite 3.7.3 or higher required"
+#if SQLITE_VERSION_NUMBER < 3007015
+#error "SQLite 3.7.15 or higher required"
 #endif
 
 #include "clinic/module.c.h"
@@ -365,8 +365,8 @@ PyMODINIT_FUNC PyInit__sqlite3(void)
 {
     PyObject *module;
 
-    if (sqlite3_libversion_number() < 3007003) {
-        PyErr_SetString(PyExc_ImportError, MODULE_NAME ": SQLite 3.7.3 or higher required");
+    if (sqlite3_libversion_number() < 3007015) {
+        PyErr_SetString(PyExc_ImportError, MODULE_NAME ": SQLite 3.7.15 or higher required");
         return NULL;
     }
 

--- a/Modules/_sqlite/util.h
+++ b/Modules/_sqlite/util.h
@@ -39,10 +39,4 @@ int _pysqlite_seterror(sqlite3* db, sqlite3_stmt* st);
 
 sqlite_int64 _pysqlite_long_as_int64(PyObject * value);
 
-#if SQLITE_VERSION_NUMBER >= 3007014
-#define SQLITE3_CLOSE sqlite3_close_v2
-#else
-#define SQLITE3_CLOSE sqlite3_close
-#endif
-
 #endif

--- a/setup.py
+++ b/setup.py
@@ -1444,8 +1444,7 @@ class PyBuildExt(build_ext):
                              ]
         if CROSS_COMPILING:
             sqlite_inc_paths = []
-        # We need to find >= sqlite version 3.7.3, for sqlite3_create_function_v2()
-        MIN_SQLITE_VERSION_NUMBER = (3, 7, 3)
+        MIN_SQLITE_VERSION_NUMBER = (3, 7, 15)  # Issue 40810
         MIN_SQLITE_VERSION = ".".join([str(x)
                                     for x in MIN_SQLITE_VERSION_NUMBER])
 


### PR DESCRIPTION
Remove code required to support SQLite pre 3.7.15.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40810](https://bugs.python.org/issue40810) -->
https://bugs.python.org/issue40810
<!-- /issue-number -->
