### PR TITLE
bpo-42827: Fix crash when determining the error location of multi-line expressions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -209,6 +209,7 @@ class ExceptionTests(unittest.TestCase):
         check('x = "a', 1, 7)
         check('lambda x: x = 2', 1, 1)
         check('f{a + b + c}', 1, 2)
+        check('[file for str(file) in []\n])', 1, 11)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-05-01-30-58.bpo-42827.FQBB7w.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-05-01-30-58.bpo-42827.FQBB7w.rst
@@ -1,0 +1,2 @@
+Fix a crash when determining the error location of some multiline
+expressions. Patch by Pablo Galindo.


### PR DESCRIPTION
…

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42827](https://bugs.python.org/issue42827) -->
https://bugs.python.org/issue42827
<!-- /issue-number -->
