### PR TITLE
bpo-42819: disable Readline bracketed paste

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1459,6 +1459,7 @@ Mark Roddy
 Kevin Rodgers
 Sean Rodman
 Giampaolo Rodola
+Dustin Rodrigues
 Mauro S. M. Rodrigues
 Elson Rodriguez
 Adi Roiban

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
@@ -1,0 +1,3 @@
+Prevents bracketed paste from being enabled in the interactive interpreter,
+even if it's set in the inputrc or is enabled by default (eg GNU Readline
+8.1). Patch by Dustin Rodrigues.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
@@ -1,7 +1,9 @@
-Explicitly disable bracketed paste in the interactive interpreter, even if it's
-set in the inputrc, is enabled by default (eg GNU Readline 8.1), or a user calls
-``readline.read_init_file()``. The Python REPL has not implemented bracketed
-paste support so this prevents Readline defaults or global user configuration
-from causing unexpected behavior within Python. It can still be explicitly
-enabled by calling ``readline.parse_and_bind("set enable-bracketed-paste on")``.
-Patch by Dustin Rodrigues.
+:mod:`readline`: Explicitly disable bracketed paste in the interactive 
+interpreter, even if it's set in the inputrc, is enabled by default (eg GNU
+Readline 8.1), or a user calls ``readline.read_init_file()``. The Python REPL
+has not implemented bracketed paste support. Also, bracketed mode writes the
+`"\x1b[?2004h"` escape sequence into stdout which causes test failures in
+applications that don't support it. It can still be explicitly enabled by
+calling ``readline.parse_and_bind("set enable-bracketed-paste on")``. This
+should be removed if bracketed paste mode is implemented (bpo-39820). Patch by
+Dustin Rodrigues.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
@@ -2,8 +2,7 @@
 interpreter, even if it's set in the inputrc, is enabled by default (eg GNU
 Readline 8.1), or a user calls ``readline.read_init_file()``. The Python REPL
 has not implemented bracketed paste support. Also, bracketed mode writes the
-`"\x1b[?2004h"` escape sequence into stdout which causes test failures in
+``"\x1b[?2004h"`` escape sequence into stdout which causes test failures in
 applications that don't support it. It can still be explicitly enabled by
-calling ``readline.parse_and_bind("set enable-bracketed-paste on")``. This
-should be removed if bracketed paste mode is implemented (bpo-39820). Patch by
+calling ``readline.parse_and_bind("set enable-bracketed-paste on")``. Patch by
 Dustin Rodrigues.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
@@ -1,4 +1,4 @@
-:mod:`readline`: Explicitly disable bracketed paste in the interactive 
+:mod:`readline`: Explicitly disable bracketed paste in the interactive
 interpreter, even if it's set in the inputrc, is enabled by default (eg GNU
 Readline 8.1), or a user calls ``readline.read_init_file()``. The Python REPL
 has not implemented bracketed paste support. Also, bracketed mode writes the

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
@@ -1,3 +1,7 @@
-Prevents bracketed paste from being enabled in the interactive interpreter,
-even if it's set in the inputrc or is enabled by default (eg GNU Readline
-8.1). Patch by Dustin Rodrigues.
+Explicitly disable bracketed paste in the interactive interpreter, even if it's
+set in the inputrc or is enabled by default (eg GNU Readline 8.1). The Python
+REPL has not implemented bracketed paste support so this prevents Readline
+defaults or global user configuration from causing unexpected behavior within
+Python. It can still be explicitly enabled by calling
+``readline.parse_and_bind("set enable-bracketed-paste on")``. Patch by Dustin
+Rodrigues.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-04-23-54-34.bpo-42819.4KO6wU.rst
@@ -1,7 +1,7 @@
 Explicitly disable bracketed paste in the interactive interpreter, even if it's
-set in the inputrc or is enabled by default (eg GNU Readline 8.1). The Python
-REPL has not implemented bracketed paste support so this prevents Readline
-defaults or global user configuration from causing unexpected behavior within
-Python. It can still be explicitly enabled by calling
-``readline.parse_and_bind("set enable-bracketed-paste on")``. Patch by Dustin
-Rodrigues.
+set in the inputrc, is enabled by default (eg GNU Readline 8.1), or a user calls
+``readline.read_init_file()``. The Python REPL has not implemented bracketed
+paste support so this prevents Readline defaults or global user configuration
+from causing unexpected behavior within Python. It can still be explicitly
+enabled by calling ``readline.parse_and_bind("set enable-bracketed-paste on")``.
+Patch by Dustin Rodrigues.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -212,6 +212,9 @@ readline_read_init_file_impl(PyObject *module, PyObject *filename_obj)
         errno = rl_read_init_file(NULL);
     if (errno)
         return PyErr_SetFromErrno(PyExc_OSError);
+    if (!using_libedit_emulation) {
+        rl_variable_bind ("enable-bracketed-paste", "off");
+    }
     Py_RETURN_NONE;
 }
 
@@ -1240,6 +1243,10 @@ setup_readline(readlinestate *mod_state)
         rl_read_init_file(NULL);
     else
         rl_initialize();
+
+    if (!using_libedit_emulation) {
+        rl_variable_bind ("enable-bracketed-paste", "off");
+    }
 
     RESTORE_LOCALE(saved_locale)
     return 0;

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -154,11 +154,11 @@ decode(const char *s)
 /*
 Explicitly disable bracketed paste in the interactive interpreter, even if it's
 set in the inputrc, is enabled by default (eg GNU Readline 8.1), or a user calls
-``readline.read_init_file()``. The Python REPL has not implemented bracketed
-paste support. Also, bracketed mode writes the `"\x1b[?2004h"` escape sequence
+readline.read_init_file(). The Python REPL has not implemented bracketed
+paste support. Also, bracketed mode writes the "\x1b[?2004h" escape sequence
 into stdout which causes test failures in applications that don't support it.
-It can still be explicitly enabled by calling ``readline.parse_and_bind("set
-enable-bracketed-paste on")``. See bpo-42819 for more details.
+It can still be explicitly enabled by calling readline.parse_and_bind("set
+enable-bracketed-paste on"). See bpo-42819 for more details.
 
 This should be removed if bracketed paste mode is implemented (bpo-39820).
 */

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -152,13 +152,15 @@ decode(const char *s)
 
 
 /*
-   Explicitly disable bracketed paste mode. This is called both during module
-   initialization and after reading the init file. Even if the version of
-   Readline enables it by default or a user has it set, the Python REPL doesn't
-   support bracketed paste and it injects escape sequences which cause test
-   failures. This keeps the behavior consistent with user expectations for the
-   Python REPL when pasting multi-line strings. See bpo-42819 for more details.
-   This should be removed if bracketed paste mode is implemented (bpo-39820).
+Explicitly disable bracketed paste in the interactive interpreter, even if it's
+set in the inputrc, is enabled by default (eg GNU Readline 8.1), or a user calls
+``readline.read_init_file()``. The Python REPL has not implemented bracketed
+paste support. Also, bracketed mode writes the `"\x1b[?2004h"` escape sequence
+into stdout which causes test failures in applications that don't support it.
+It can still be explicitly enabled by calling ``readline.parse_and_bind("set
+enable-bracketed-paste on")``. See bpo-42819 for more details.
+
+This should be removed if bracketed paste mode is implemented (bpo-39820).
 */
 
 static void


### PR DESCRIPTION
This prevents bracketed paste from being enabled in the interactive interpreter so that paste works as expected.

<!-- issue-number: [bpo-42819](https://bugs.python.org/issue42819) -->
https://bugs.python.org/issue42819
<!-- /issue-number -->
