### PR TITLE
[3.8] [3.9] bpo-42681: Fix test_curses failures related to color pairs (GH-24089) (GH-24113)

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2592,13 +2592,18 @@ _curses_color_content_impl(PyObject *module, short color_number)
     PyCursesInitialised;
     PyCursesInitialisedColor;
 
-    if (color_content(color_number, &r, &g, &b) != ERR)
-        return Py_BuildValue("(iii)", r, g, b);
-    else {
-        PyErr_SetString(PyCursesError,
-                        "Argument 1 was out of range. Check value of COLORS.");
+    if (color_content(color_number, &r, &g, &b) == ERR) {
+        if (color_number >= COLORS) {
+            PyErr_SetString(PyCursesError,
+                            "Argument 1 was out of range. Check value of COLORS.");
+        }
+        else {
+            PyErr_SetString(PyCursesError, "color_content() returned ERR");
+        }
         return NULL;
     }
+
+    return Py_BuildValue("(iii)", r, g, b);
 }
 
 /*[clinic input]
@@ -3617,9 +3622,14 @@ _curses_pair_content_impl(PyObject *module, short pair_number)
     PyCursesInitialised;
     PyCursesInitialisedColor;
 
-    if (pair_content(pair_number, &f, &b)==ERR) {
-        PyErr_SetString(PyCursesError,
-                        "Argument 1 was out of range. (0..COLOR_PAIRS-1)");
+    if (pair_content(pair_number, &f, &b) == ERR) {
+        if (pair_number >= COLOR_PAIRS) {
+            PyErr_SetString(PyCursesError,
+                            "Argument 1 was out of range. (0..COLOR_PAIRS-1)");
+        }
+        else {
+            PyErr_SetString(PyCursesError, "pair_content() returned ERR");
+        }
         return NULL;
     }
 


### PR DESCRIPTION
On ncurses 6.1 pair numbers are limited by SHORT_MAX-1.

Improve error reporting and tests for color functions.
(cherry picked from commit 59f9b4e4509be67494f3d45489fa55523175ff69)
(cherry picked from commit 9b3a53a8264d4c469a3f3d8c037e74c010be3e5c)


<!-- issue-number: [bpo-42681](https://bugs.python.org/issue42681) -->
https://bugs.python.org/issue42681
<!-- /issue-number -->
