### PR TITLE
bpo-27820: Fix AUTH LOGIN logic in smtplib.SMTP

### DIFF
--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -1094,7 +1094,7 @@ class SMTPSimTests(unittest.TestCase):
 
     def testAUTH_BUGGY(self):
         self.serv.add_feature("AUTH BUGGY")
-        
+
         def auth_buggy(challenge=None):
             self.assertEqual(b"BuGgYbUgGy", challenge)
             return "\0"

--- a/Misc/NEWS.d/next/Library/2021-03-10-14-07-44.bpo-27820.Wwdy-r.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-10-14-07-44.bpo-27820.Wwdy-r.rst
@@ -1,0 +1,8 @@
+Fixed long-standing bug of smtplib.SMTP where doing AUTH LOGIN with
+initial_response_ok=False will fail.
+
+The cause is that SMTP.auth_login _always_ returns a password if provided
+with a challenge string, thus non-compliant with the standard for AUTH
+LOGIN.
+
+Also fixes bug with the test for smtpd.


### PR DESCRIPTION
Previously, `smtplib.SMTP.auth_login` responded with username if challenge is not given, and _always_ responded with password if challenge is given. This causes auth failure when `initial_response_ok=False`.

The standard for AUTH LOGIN specifies that clients should simply respond with base64-encoded username on first challenge, and with base64-encoded password on second challenge, disregarding the actual contents of the challenges themselves.

Suitable test cases have been added to `test_smtplib.py` + a fix for a long-standing bug in `test_smtplib.py` where setting `initial_response_ok=False` will always result in "Internal Confusion" error.


<!-- issue-number: [bpo-27820](https://bugs.python.org/issue27820) -->
https://bugs.python.org/issue27820
<!-- /issue-number -->
