### PR TITLE
bpo-41818: Close file descriptors in test_openpty

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -176,54 +176,53 @@ class PtyTest(unittest.TestCase):
             # " An optional feature could not be imported " ... ?
             raise unittest.SkipTest("Pseudo-terminals (seemingly) not functional.")
 
+        # closing master_fd can raise a SIGHUP if the process is
+        # the session leader: we installed a SIGHUP signal handler
+        # to ignore this signal.
+        self.addCleanup(os.close, master_fd)
+        self.addCleanup(os.close, slave_fd)
+
+        self.assertTrue(os.isatty(slave_fd), "slave_fd is not a tty")
+
+        if mode:
+            self.assertEqual(tty.tcgetattr(slave_fd), mode,
+                             "openpty() failed to set slave termios")
+        if new_stdin_winsz:
+            self.assertEqual(_get_term_winsz(slave_fd), new_stdin_winsz,
+                             "openpty() failed to set slave window size")
+
+        # Solaris requires reading the fd before anything is returned.
+        # My guess is that since we open and close the slave fd
+        # in master_open(), we need to read the EOF.
+        #
+        # NOTE: the above comment is from an older version of the test;
+        # master_open() is not being used anymore.
+
+        # Ensure the fd is non-blocking in case there's nothing to read.
+        blocking = os.get_blocking(master_fd)
         try:
-            self.assertTrue(os.isatty(slave_fd), "slave_fd is not a tty")
-
-            if mode:
-                self.assertEqual(tty.tcgetattr(slave_fd), mode,
-                                "openpty() failed to set slave termios")
-            if new_stdin_winsz:
-                self.assertEqual(_get_term_winsz(slave_fd), new_stdin_winsz,
-                                "openpty() failed to set slave window size")
-
-            # Solaris requires reading the fd before anything is returned.
-            # My guess is that since we open and close the slave fd
-            # in master_open(), we need to read the EOF.
-            #
-            # NOTE: the above comment is from an older version of the test;
-            # master_open() is not being used anymore.
-
-            # Ensure the fd is non-blocking in case there's nothing to read.
-            blocking = os.get_blocking(master_fd)
+            os.set_blocking(master_fd, False)
             try:
-                os.set_blocking(master_fd, False)
-                try:
-                    s1 = os.read(master_fd, 1024)
-                    self.assertEqual(b'', s1)
-                except OSError as e:
-                    if e.errno != errno.EAGAIN:
-                        raise
-            finally:
-                # Restore the original flags.
-                os.set_blocking(master_fd, blocking)
-
-            debug("Writing to slave_fd")
-            os.write(slave_fd, TEST_STRING_1)
-            s1 = _readline(master_fd)
-            self.assertEqual(b'I wish to buy a fish license.\n',
-                            normalize_output(s1))
-
-            debug("Writing chunked output")
-            os.write(slave_fd, TEST_STRING_2[:5])
-            os.write(slave_fd, TEST_STRING_2[5:])
-            s2 = _readline(master_fd)
-            self.assertEqual(b'For my pet fish, Eric.\n', normalize_output(s2))
+                s1 = os.read(master_fd, 1024)
+                self.assertEqual(b'', s1)
+            except OSError as e:
+                if e.errno != errno.EAGAIN:
+                    raise
         finally:
-            os.close(slave_fd)
-            # closing master_fd can raise a SIGHUP if the process is
-            # the session leader: we installed a SIGHUP signal handler
-            # to ignore this signal.
-            os.close(master_fd)
+            # Restore the original flags.
+            os.set_blocking(master_fd, blocking)
+
+        debug("Writing to slave_fd")
+        os.write(slave_fd, TEST_STRING_1)
+        s1 = _readline(master_fd)
+        self.assertEqual(b'I wish to buy a fish license.\n',
+                         normalize_output(s1))
+
+        debug("Writing chunked output")
+        os.write(slave_fd, TEST_STRING_2[:5])
+        os.write(slave_fd, TEST_STRING_2[5:])
+        s2 = _readline(master_fd)
+        self.assertEqual(b'For my pet fish, Eric.\n', normalize_output(s2))
 
     def test_fork(self):
         debug("calling pty.fork()")


### PR DESCRIPTION
When stdin is a TTY, the test added in commit c13d89955d9a2942c6355d6839d7096323244136 
is expected to fail. However, when it failed, it did not close
its file descriptors. This is flagged by the refleak tests (but
only when stdin is a TTY, which doesn't seem to be the case on CI).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41818](https://bugs.python.org/issue41818) -->
https://bugs.python.org/issue41818
<!-- /issue-number -->
