### PR TITLE
[3.8] bpo-40052: Fix alignment issue in PyVectorcall_Function() (GH-23999)

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -82,14 +82,14 @@ _PyVectorcall_Function(PyObject *callable)
 {
     PyTypeObject *tp = Py_TYPE(callable);
     Py_ssize_t offset = tp->tp_vectorcall_offset;
-    vectorcallfunc *ptr;
+    vectorcallfunc ptr;
     if (!PyType_HasFeature(tp, _Py_TPFLAGS_HAVE_VECTORCALL)) {
         return NULL;
     }
     assert(PyCallable_Check(callable));
     assert(offset > 0);
-    ptr = (vectorcallfunc*)(((char *)callable) + offset);
-    return *ptr;
+    memcpy(&ptr, (char *) callable + offset, sizeof(ptr));
+    return ptr;
 }
 
 /* Call the callable object 'callable' with the "vectorcall" calling

--- a/Misc/NEWS.d/next/C API/2020-03-24-09-27-10.bpo-40052.27P2KG.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-24-09-27-10.bpo-40052.27P2KG.rst
@@ -1,0 +1,2 @@
+Fix an alignment build warning/error in function ``PyVectorcall_Function()``.
+Patch by Andreas Schneider, Antoine Pitrou and Petr Viktorin.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -175,13 +175,14 @@ PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
 {
     /* get vectorcallfunc as in _PyVectorcall_Function, but without
      * the _Py_TPFLAGS_HAVE_VECTORCALL check */
+    vectorcallfunc func;
     Py_ssize_t offset = Py_TYPE(callable)->tp_vectorcall_offset;
     if (offset <= 0) {
         PyErr_Format(PyExc_TypeError, "'%.200s' object does not support vectorcall",
                      Py_TYPE(callable)->tp_name);
         return NULL;
     }
-    vectorcallfunc func = *(vectorcallfunc *)(((char *)callable) + offset);
+    memcpy(&func, (char *) callable + offset, sizeof(func));
     if (func == NULL) {
         PyErr_Format(PyExc_TypeError, "'%.200s' object does not support vectorcall",
                      Py_TYPE(callable)->tp_name);


### PR DESCRIPTION

```
In file included from /usr/include/python3.8/Python.h:147:
In file included from /usr/include/python3.8/abstract.h:837:
/usr/include/python3.8/cpython/abstract.h:91:11: error: cast from 'char *' to 'vectorcallfunc *'
(aka 'struct _object *(**)(struct _object *, struct _object *const *, unsigned long, struct _object *)')
increases required alignment from 1 to 8 [-Werror,-Wcast-align]

    ptr = (vectorcallfunc*)(((char *)callable) + offset);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
Co-authored-by: Petr Viktorin <encukou@gmail.com>
Co-Authored-By: Andreas Schneider <asn@cryptomilk.org>
Co-Authored-By: Antoine Pitrou <antoine@python.org>.
(cherry picked from commit 056c08211b402b4dbc1530a9de9d00ad5309909f)


<!-- issue-number: [bpo-40052](https://bugs.python.org/issue40052) -->
https://bugs.python.org/issue40052
<!-- /issue-number -->
