### PR TITLE
bpo-42833: make digest algorithms case insensitive

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import hashlib_helper
 from test.support import os_helper
 from test.support import socket_helper
 from test.support import warnings_helper
@@ -1875,6 +1876,14 @@ class MiscTests(unittest.TestCase):
             str(exc.exception),
             "Unsupported digest authentication algorithm 'invalid'"
         )
+
+    @hashlib_helper.requires_hashdigest('sha1')
+    def test_lowercase_algorithm(self):
+        handler = AbstractDigestAuthHandler()
+        # make sure both algorithms are equivalent
+        self.assertEqual(
+            handler.get_algorithm_impls('sha')[0]("TEST"),
+            handler.get_algorithm_impls('SHA')[0]("TEST"))
 
 
 class RequestTests(unittest.TestCase):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1206,10 +1206,13 @@ class AbstractDigestAuthHandler:
         return base
 
     def get_algorithm_impls(self, algorithm):
+        # as per https://tools.ietf.org/html/rfc3230#section-4.1.1
+        # algorithm is case insensitive
+        upper_algorithm = algorithm.upper()
         # lambdas assume digest modules are imported at the top level
-        if algorithm == 'MD5':
+        if upper_algorithm == 'MD5':
             H = lambda x: hashlib.md5(x.encode("ascii")).hexdigest()
-        elif algorithm == 'SHA':
+        elif upper_algorithm == 'SHA':
             H = lambda x: hashlib.sha1(x.encode("ascii")).hexdigest()
         # XXX MD5-sess
         else:

--- a/Misc/NEWS.d/next/Library/2021-01-05-16-58-10.bpo-42833.EIcmpu.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-05-16-58-10.bpo-42833.EIcmpu.rst
@@ -1,0 +1,1 @@
+urllib2 digest algorithm selection is now case insensitive


### PR DESCRIPTION
as per https://tools.ietf.org/html/rfc3230#section-4.1.1
digest names shall be case insensitive


<!-- issue-number: [bpo-42833](https://bugs.python.org/issue42833) -->
https://bugs.python.org/issue42833
<!-- /issue-number -->
