### PR TITLE
DOC: re discourage single char class

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -263,8 +263,7 @@ The special characters are:
    right. When one pattern completely matches, that branch is accepted. This means
    that once *A* matches, *B* will not be tested further, even if it would
    produce a longer overall match.  In other words, the ``'|'`` operator is never
-   greedy.  To match a literal ``'|'``, use ``\|``, or enclose it inside a
-   character class, as in ``[|]``.
+   greedy.  To match a literal ``'|'``, use ``\|``.
 
 .. index::
    single: () (parentheses); in regular expressions
@@ -274,7 +273,7 @@ The special characters are:
    start and end of a group; the contents of a group can be retrieved after a match
    has been performed, and can be matched later in the string with the ``\number``
    special sequence, described below.  To match the literals ``'('`` or ``')'``,
-   use ``\(`` or ``\)``, or enclose them inside a character class: ``[(]``, ``[)]``.
+   use ``\(`` or ``\)``.
 
 .. index:: single: (?; in regular expressions
 


### PR DESCRIPTION
* this seemed simple enough not to justify a cognate issue,
but it is a regex matter, so maybe it will need one...

* there are a few cases in the `re` module documentation
that suggest "indirectly" escaping single metacharacters
by placing them in a character class; i.e., `[|]` as a viable
alternative to `\|`

* in general, this is likely best to avoid because you can
incur the overhead of a character class with none of the
benefits of a multi-character character class

* this is specifically discussed in the more detailed
reference cited by the `re` module docs; in particular,
see Chapter 6 of:
Friedl, Jeffrey. Mastering Regular Expressions. 3rd ed.,
O’Reilly Media, 2009.

* on the topic of using classes to escape metacharacters, which is
slightly more justified than single (non-meta)character classes,
the author notes `...it's probably because the
author didn't know about escaping...` 
While that may be a little harsh,
avoiding the overhead still makes sense to me.

* the docs already cover the fact that most metacharacters
are deactivated inside character classes, so that general information
is still presented to the user clearly, but now without explicitly
suggesting that the mechanism be used for single (meta)characters

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
