### PR TITLE
bpo-42827: Fix crash when storing error line of multi-line expressions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -209,6 +209,7 @@ class ExceptionTests(unittest.TestCase):
         check('x = "a', 1, 7)
         check('lambda x: x = 2', 1, 1)
         check('f{a + b + c}', 1, 2)
+        check('[file for str(file) in []\n])', 1, 11)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -416,8 +416,14 @@ _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
     }
 
     if (!error_line) {
-        Py_ssize_t size = p->tok->inp - p->tok->buf;
-        error_line = PyUnicode_DecodeUTF8(p->tok->buf, size, "replace");
+        if (p->tok->lineno == lineno) {
+            Py_ssize_t size = p->tok->inp - p->tok->buf;
+            error_line = PyUnicode_DecodeUTF8(p->tok->buf, size, "replace");
+        }
+        else {
+            assert(p->tok->lineno == lineno + 1);
+            error_line = PyUnicode_DecodeUTF8(p->tok->previous_line, strlen(p->tok->previous_line), "replace");
+        }
         if (!error_line) {
             goto error;
         }

--- a/Parser/tokenizer.h
+++ b/Parser/tokenizer.h
@@ -53,6 +53,8 @@ struct tok_state {
     int read_coding_spec;       /* whether 'coding:...' has been read  */
     char *encoding;         /* Source encoding. */
     int cont_line;          /* whether we are in a continuation line. */
+    char *previous_line;  /* previous line of input, needed by the parser
+                             in order to be able to correctly point to errors */
     const char* line_start;     /* pointer to start of current line */
     const char* multi_line_start; /* pointer to start of first line of
                                      a single line or multi line string


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42827](https://bugs.python.org/issue42827) -->
https://bugs.python.org/issue42827
<!-- /issue-number -->
