### PR TITLE
bpo-41798: Allocate unicodedata CAPI on the heap

### DIFF
--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1502,8 +1502,9 @@ unicodedata_exec(PyObject *module)
         PyMem_Free(capi);
         return -1;
     }
-    if (PyModule_AddObject(module, "_ucnhash_CAPI", capsule) < 0) {
-        Py_DECREF(capsule);
+    int rc = PyModule_AddObjectRef(module, "_ucnhash_CAPI", capsule);
+    Py_DECREF(capsule);
+    if (rc < 0) {
         return -1;
     }
     return 0;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41798](https://bugs.python.org/issue41798) -->
https://bugs.python.org/issue41798
<!-- /issue-number -->
