### PR TITLE
[3.8] bpo-41837: Updated Windows installer to include OpenSSL 1.1.1i (GH-24125)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-01-05-20-36-40.bpo-41837.bmS7vB.rst
+++ b/Misc/NEWS.d/next/Windows/2021-01-05-20-36-40.bpo-41837.bmS7vB.rst
@@ -1,0 +1,1 @@
+Updated Windows installer to include OpenSSL 1.1.1i

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0-rc0-r1
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1g
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1i
 set libraries=%libraries%                                       sqlite-3.33.0.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
@@ -77,8 +77,13 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi
+<<<<<<< HEAD
 if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1g
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
+=======
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1i
+if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.10.0
+>>>>>>> afb7144378... bpo-41837: Updated Windows installer to include OpenSSL 1.1.1i (GH-24125)
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 
 for %%b in (%binaries%) do (

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -77,13 +77,8 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi
-<<<<<<< HEAD
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1g
-if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
-=======
 if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1i
-if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.10.0
->>>>>>> afb7144378... bpo-41837: Updated Windows installer to include OpenSSL 1.1.1i (GH-24125)
+if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 
 for %%b in (%binaries%) do (

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -62,8 +62,8 @@
     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
     <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
     <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1g\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1g\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.1i\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1i\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -165,7 +165,7 @@ _lzma
     Homepage:
         http://tukaani.org/xz/
 _ssl
-    Python wrapper for version 1.1.1c of the OpenSSL secure sockets
+    Python wrapper for version 1.1.1i of the OpenSSL secure sockets
     library, which is downloaded from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 


### PR DESCRIPTION


<!-- issue-number: [bpo-41837](https://bugs.python.org/issue41837) -->
https://bugs.python.org/issue41837
<!-- /issue-number -->
