### PR TITLE
Fix id of 'Internet Message Format' RFC in email doc

### DIFF
--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -23,7 +23,7 @@ policy :attr:`~email.policy.Compat32`.  If you are going to use another policy,
 you should be using the :class:`~email.message.EmailMessage` class instead.
 
 An email message consists of *headers* and a *payload*.  Headers must be
-:rfc:`5233` style names and values, where the field name and value are
+:rfc:`5322` style names and values, where the field name and value are
 separated by a colon.  The colon is not part of either the field name or the
 field value.  The payload may be a simple text message, or a binary object, or
 a structured sequence of sub-messages each with their own set of headers and

--- a/Doc/library/email.rst
+++ b/Doc/library/email.rst
@@ -16,7 +16,7 @@ The :mod:`email` package is a library for managing email messages.  It is
 specifically *not* designed to do any sending of email messages to SMTP
 (:rfc:`2821`), NNTP, or other servers; those are functions of modules such as
 :mod:`smtplib` and :mod:`nntplib`.  The :mod:`email` package attempts to be as
-RFC-compliant as possible, supporting :rfc:`5233` and :rfc:`6532`, as well as
+RFC-compliant as possible, supporting :rfc:`5322` and :rfc:`6532`, as well as
 such MIME-related RFCs as :rfc:`2045`, :rfc:`2046`, :rfc:`2047`, :rfc:`2183`,
 and :rfc:`2231`.
 


### PR DESCRIPTION
Previous ID (5233) refers to "Sieve Email Filtering: Subaddress
Extension". It seems that the actual reference should be "Internet
Message Format" RFC 5232 (https://tools.ietf.org/html/rfc5322).

(The typo probably comes from commit https://github.com/python/cpython/commit/29d1bc0842e5b086813aa7de4ab18f1c192d2291#diff-7728cd0eb5e471a8d52c0850e26560351f50ec6cb59d03bd5646bf492d80eb24 in which the ID of
this RFC got updated from the obsolete 2822.)