### PR TITLE
bpo-42837: Account for deferred evaluation of yields in symbol tables.

### DIFF
--- a/Include/symtable.h
+++ b/Include/symtable.h
@@ -65,6 +65,7 @@ typedef struct _symtable_entry {
     int ste_opt_lineno;      /* lineno of last exec or import * */
     int ste_opt_col_offset;  /* offset of last exec or import * */
     struct symtable *ste_table;
+    int ste_in_annotation;
 } PySTEntryObject;
 
 PyAPI_DATA(PyTypeObject) PySTEntry_Type;

--- a/Lib/test/test_annotations.py
+++ b/Lib/test/test_annotations.py
@@ -223,6 +223,12 @@ class PostponedAnnotationsTestCase(unittest.TestCase):
         self.assertAnnotationEqual("('inf', 1e1000, 'infxxx', 1e1000j)", expected=f"('inf', {inf}, 'infxxx', {infj})")
         self.assertAnnotationEqual("(1e1000, (1e1000j,))", expected=f"({inf}, ({infj},))")
 
+    def test_yield_in_local_annotation(self):
+        def f():
+            x: (yield None)
+        def g():
+            yield
+        self.assertIs(type(f()), type(g()))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-06-10-01-09.bpo-42837.SgBANO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-06-10-01-09.bpo-42837.SgBANO.rst
@@ -1,0 +1,2 @@
+The symbol table now understands that 'yield' in an annotation is deferred
+and does not make the enclosing scope a generator.


### PR DESCRIPTION
Fix the symbol table to reflect current behavior.
This may be a temporary fix depending on the outcome of https://bugs.python.org/issue42737

<!-- issue-number: [bpo-42837](https://bugs.python.org/issue42837) -->
https://bugs.python.org/issue42837
<!-- /issue-number -->
