### PR TITLE
bpo-42827: Fix crash on SyntaxError in multiline expressions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -209,6 +209,9 @@ class ExceptionTests(unittest.TestCase):
         check('x = "a', 1, 7)
         check('lambda x: x = 2', 1, 1)
         check('f{a + b + c}', 1, 2)
+        check('[file for str(file) in []\n])', 1, 11)
+        check('[\nfile\nfor str(file)\nin\n[]\n]', 3, 5)
+        check('[file for\n str(file) in []]', 2, 2)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-06-17-06-37.bpo-42827.jtRR0D.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-06-17-06-37.bpo-42827.jtRR0D.rst
@@ -1,0 +1,2 @@
+Fix a crash when working out the error line of a :exc:`SyntaxError` in some
+multi-line expressions.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -435,8 +435,8 @@ _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
     }
 
     if (!error_line) {
-        // PyErr_ProgramTextObject returned NULL, so we're not parsing from a file
-        assert(p->tok->fp == NULL || p->tok->fp == stdin);
+        // PyErr_ProgramTextObject returned NULL, so it either failed or we're
+        // not parsing from a file
         if (p->tok->lineno == lineno) {
             Py_ssize_t size = p->tok->inp - p->tok->buf;
             error_line = PyUnicode_DecodeUTF8(p->tok->buf, size, "replace");

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -381,7 +381,7 @@ _PyPegen_raise_error(Parser *p, PyObject *errtype, const char *errmsg, ...)
 }
 
 static PyObject *
-get_error_line(Parser *p, int lineno)
+get_error_line(Parser *p, Py_ssize_t lineno)
 {
     char *cur_line = p->tok->fp == NULL ? p->tok->str : p->tok->stdin_content;
     for (int i = 0; i < lineno - 1; i++) {

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -383,7 +383,7 @@ _PyPegen_raise_error(Parser *p, PyObject *errtype, const char *errmsg, ...)
 static PyObject *
 get_error_line(Parser *p, Py_ssize_t lineno)
 {
-    // If p->tok->fp == NULL, the we're parsing from a string, which means that
+    // If p->tok->fp == NULL, then we're parsing from a string, which means that
     // the whole source is stored in p->tok->str. If not, then we're parsing
     // from the REPL, so the source lines of the current (multi-line) statement
     // are stored in p->tok->stdin_content

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -380,7 +380,7 @@ _PyPegen_raise_error(Parser *p, PyObject *errtype, const char *errmsg, ...)
     return NULL;
 }
 
-PyObject *
+static PyObject *
 get_error_line(Parser *p, int lineno)
 {
     char *cur_line = p->tok->fp == NULL ? p->tok->str : p->tok->stdin_content;

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -435,8 +435,8 @@ _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
     }
 
     if (!error_line) {
-        // PyErr_ProgramTextObject returned NULL, so it either failed or we're
-        // not parsing from a file
+        // PyErr_ProgramTextObject was not called or returned NULL, in which case
+        // we are either parsing from a file or it unexpectedly failed
         if (p->tok->lineno == lineno) {
             Py_ssize_t size = p->tok->inp - p->tok->buf;
             error_line = PyUnicode_DecodeUTF8(p->tok->buf, size, "replace");

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -865,8 +865,7 @@ tok_nextc(struct tok_state *tok)
                         tok->done = E_NOMEM;
                         return EOF;
                     }
-                    strcpy(tok->stdin_content, translated);
-                    tok->stdin_content[strlen(translated)] = 0;
+                    sprintf(tok->stdin_content, "%s", translated);
                 }
                 else {
                     char *new_str = PyMem_Malloc(strlen(tok->stdin_content) + strlen(translated) + 1);

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -817,6 +817,8 @@ PyTokenizer_Free(struct tok_state *tok)
         PyMem_Free(tok->buf);
     if (tok->input)
         PyMem_Free(tok->input);
+    if (tok->stdin_content)
+        PyMem_Free(tok->stdin_content);
     PyMem_Free(tok);
 }
 

--- a/Parser/tokenizer.h
+++ b/Parser/tokenizer.h
@@ -37,6 +37,7 @@ struct tok_state {
     int atbol;          /* Nonzero if at begin of new line */
     int pendin;         /* Pending indents (if > 0) or dedents (if < 0) */
     const char *prompt, *nextprompt;          /* For interactive prompting */
+    char *stdin_content;
     int lineno;         /* Current line number */
     int first_lineno;   /* First line of a single line or multi line string
                            expression (cf. issue 16806) */


### PR DESCRIPTION
When trying to extract the error line for the error message there
are two distinct cases:
1. The input comes from a file, which means that we can extract the
   error line by using `PyErr_ProgramTextObject` and which we already
   do.
2. The input does not come from a file, at which point we need to get
   the source code from the tokenizer:
   * If the tokenizer's current line number is the same with the line
     of the error, we get the line from `tok->buf` and we're ready.
   * Else, we can extract the error line from the source code in the
     following two ways:
     * If the input comes from a string we have all the input
       in `tok->str` and we can extract the error line from it.
     * If the input comes from stdin, i.e. the interactive prompt, we
       do not have access to the previous line. That's why a new
       field `tok->stdin_content` is added which holds the whole input for the
       current (multiline) statement or expression. We can then extract the
       error line from `tok->stdin_content` like we do in the string case above.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42827](https://bugs.python.org/issue42827) -->
https://bugs.python.org/issue42827
<!-- /issue-number -->
