### PR TITLE
Issue 42844: Turtle Module -- "onclick" arguments enchancement

### DIFF
--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -603,7 +603,7 @@ class TurtleScreenBase(object):
 ##    def _dot(self, pos, size, color):
 ##        """may be implemented for some other graphics toolkit"""
 
-    def _onclick(self, item, fun, num=1, add=None):
+    def _onclick(self, item, fun, num=1, add=None, funArguments={}):
         """Bind fun to mouse-click event on turtle.
         fun must be a function with two arguments, the coordinates
         of the clicked point on the canvas.
@@ -615,7 +615,8 @@ class TurtleScreenBase(object):
             def eventfun(event):
                 x, y = (self.cv.canvasx(event.x)/self.xscale,
                         -self.cv.canvasy(event.y)/self.yscale)
-                fun(x, y)
+                # unpack keyword arguments into function and execute
+                fun(x, y, **funArguments)
             self.cv.tag_bind(item, "<Button-%s>" % num, eventfun, add)
 
     def _onrelease(self, item, fun, num=1, add=None):
@@ -1354,6 +1355,7 @@ class TurtleScreen(TurtleScreenBase):
         fun -- a function with two arguments, the coordinates of the
                clicked point on the canvas.
         btn -- the number of the mouse-button, defaults to 1
+
 
         Example (for a TurtleScreen instance named screen)
 
@@ -3521,7 +3523,7 @@ class RawTurtle(TPen, TNavigator):
         """
         return self.screen.delay(delay)
 
-    def onclick(self, fun, btn=1, add=None):
+    def onclick(self, fun, btn=1, add=None, funArguments={}):
         """Bind fun to mouse-click event on this turtle on canvas.
 
         Arguments:
@@ -3530,6 +3532,21 @@ class RawTurtle(TPen, TNavigator):
         btn --  number of the mouse-button defaults to 1 (left mouse button).
         add --  True or False. If True, new binding will be added, otherwise
                 it will replace a former binding.
+        funArguments -- A dictionary of keyword arguments to be passed into the function 
+        
+        Example for passing in arguments into the function being called on click
+        >>> def remove_turtle(x, y, t):
+        ...     t.hide()
+        ...     print(f"Removed turtle ({t}) from the screen")
+        ...     
+        >>> 
+        >>> turtles = [turtle.Turtle() for i in range(1,10)]
+        >>> for turtle in turtles:
+        ...     t.onclick(remove_turtle, funArguments={"t":turtle})
+        ...     
+        >>> 
+
+
 
         Example for the anonymous turtle, i. e. the procedural way:
 
@@ -3539,7 +3556,7 @@ class RawTurtle(TPen, TNavigator):
         >>> onclick(turn)  # Now clicking into the turtle will turn it.
         >>> onclick(None)  # event-binding will be removed
         """
-        self.screen._onclick(self.turtle._item, fun, btn, add)
+        self.screen._onclick(self.turtle._item, fun, btn, add, funArguments)
         self._update()
 
     def onrelease(self, fun, btn=1, add=None):


### PR DESCRIPTION
# (issue 42844) Turtle Module  -- "onclick" arguments enchancement 

[bpo-42844](https://bugs.python.org/issue42844) 

https://bugs.python.org/issue42844


I have created an enhancement in the Turtle module. When a programmer wants to have an action performed after clicking on a Turtle object, the programmer is currently unable to supply any arguments into the method that is run when "on_clicked" which is extremely limiting, especially to beginners who are looking to modify multiple objects on the screen at one time, such as in a game. I have modified the implementation of the “on_clicked” method to be able to provide keyword arguments into the method through a dictionary that is later unpacked into the target method. Attached to my post on the Python Bugs page is an example of the benefits of this enhancement to the turtle module.

This is my first pull request to Python, or on any large project for that matter. Please let me know if I need to make any changes to my PR/formatting for the PR. I tried to read everything in the documentation about this process but it is likely I made a mistake somewhere!