### PR TITLE
[WIP] bpo-42856: Add --with-wheel-pkg-dir=PATH configure option

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -599,6 +599,18 @@ Build Changes
   don't build nor install test modules.
   (Contributed by Xavier de Gaye, Thomas Petazzoni and Peixing Xin in :issue:`27640`.)
 
+* Add ``--with-wheel-pkg-dir=PATH`` option to ./configure. If specified, the
+  :mod:`ensurepip` module also looks for wheel packages in this directory, and
+  picks the most recent versions in :mod:`ensurepip._bundled` and the specified
+  directory.
+
+  Some Linux distribution packaging policies recommand against bundling
+  dependencies. For example, Fedora installs wheel packages in the
+  ``/usr/share/python-wheels/`` directory and don't install the
+  ``ensurepip._bundled`` package.
+
+  (Contributed by Victor Stinner in :issue:`42856`.)
+
 
 C API Changes
 =============

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -1,12 +1,9 @@
 import collections
 import os.path
-import re
-import runpy
 import subprocess
 import sys
 import sysconfig
 import tempfile
-from importlib import resources
 
 
 

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -5,19 +5,87 @@ import os
 import os.path
 import contextlib
 import sys
+import tempfile
 
 import ensurepip
 import ensurepip._uninstall
 
 
-class TestEnsurePipVersion(unittest.TestCase):
+def clear_caches():
+    ensurepip._PACKAGES = None
 
-    def test_returns_version(self):
-        self.assertEqual(ensurepip._PIP_VERSION, ensurepip.version())
+
+class TestPackages(unittest.TestCase):
+    def setUp(self):
+        clear_caches()
+
+    def tearDown(self):
+        clear_caches()
+
+    def touch(self, directory, filename):
+        fullname = os.path.join(directory, filename)
+        open(fullname, "wb").close()
+
+    def test_version(self):
+        # Test version()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.touch(tmpdir, "pip-20.2.2-py2.py3-none-any.whl")
+            with unittest.mock.patch.object(ensurepip,
+                                            '_get_package_search_paths',
+                                            return_value=[tmpdir]):
+                self.assertEqual(ensurepip.version(), '20.2.2')
+
+    def test_find_packages_no_dir(self):
+        # Test _find_packages() with no directories
+        with tempfile.TemporaryDirectory() as tmpdir:
+            packages = ensurepip._find_packages([tmpdir])
+        self.assertIsNone(packages['pip'].version)
+        self.assertIsNone(packages['setuptools'].version)
+
+    def test_find_packages_one_dir(self):
+        # Test _find_packages() with one directory
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.touch(tmpdir, "setuptools-49.1.3-py3-none-any.whl")
+            self.touch(tmpdir, "pip-20.2.2-py2.py3-none-any.whl")
+            # not used, make sure that it's ignored
+            self.touch(tmpdir, "wheel-0.34.2-py2.py3-none-any.whl")
+
+            packages = ensurepip._find_packages([tmpdir])
+
+            self.assertEqual(packages['pip'].version, (20, 2, 2))
+            self.assertEqual(packages['setuptools'].version, (49, 1, 3))
+            self.assertNotIn('wheel', packages)
+
+            with unittest.mock.patch.object(ensurepip,
+                                            '_get_package_search_paths',
+                                            return_value=[tmpdir]):
+                self.assertEqual(ensurepip.version(), '20.2.2')
+
+    def test_find_packages_two_dirs(self):
+        # Test _find_packages() with two directories
+        with tempfile.TemporaryDirectory() as tmpdir1:
+            self.touch(tmpdir1, "setuptools-49.1.3-py3-none-any.whl")
+            self.touch(tmpdir1, "pip-20.2.2-py2.py3-none-any.whl")
+            with tempfile.TemporaryDirectory() as tmpdir2:
+                self.touch(tmpdir2, "setuptools-47.1.0-py3-none-any.whl")
+                self.touch(tmpdir2, "pip-20.2.3-py2.py3-none-any.whl")
+
+                packages = ensurepip._find_packages([tmpdir1, tmpdir2])
+
+        self.assertEqual(packages['pip'].version, (20, 2, 3))
+        self.assertEqual(packages['pip'].filename,
+                         os.path.join(tmpdir2, "pip-20.2.3-py2.py3-none-any.whl"))
+        self.assertEqual(packages['setuptools'].version, (49, 1, 3))
+        self.assertEqual(packages['setuptools'].filename,
+                         os.path.join(tmpdir1, "setuptools-49.1.3-py3-none-any.whl"))
+        self.assertNotIn('wheel', packages)
+
 
 class EnsurepipMixin:
 
     def setUp(self):
+        clear_caches()
+
         run_pip_patch = unittest.mock.patch("ensurepip._run_pip")
         self.run_pip = run_pip_patch.start()
         self.run_pip.return_value = 0
@@ -31,6 +99,9 @@ class EnsurepipMixin:
         patched_os.devnull = real_devnull
         patched_os.path = os.path
         self.os_environ = patched_os.environ = os.environ.copy()
+
+    def tearDown(self):
+        clear_caches()
 
 
 class TestBootstrap(EnsurepipMixin, unittest.TestCase):
@@ -147,7 +218,7 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
         self.assertEqual(self.os_environ["PIP_CONFIG_FILE"], os.devnull)
 
 @contextlib.contextmanager
-def fake_pip(version=ensurepip._PIP_VERSION):
+def fake_pip(version=ensurepip.version()):
     if version is None:
         pip = None
     else:
@@ -243,8 +314,6 @@ class TestUninstall(EnsurepipMixin, unittest.TestCase):
 
 # Basic testing of the main functions and their argument parsing
 
-EXPECTED_VERSION_OUTPUT = "pip " + ensurepip._PIP_VERSION
-
 class TestBootstrappingMainFunction(EnsurepipMixin, unittest.TestCase):
 
     def test_bootstrap_version(self):
@@ -252,7 +321,7 @@ class TestBootstrappingMainFunction(EnsurepipMixin, unittest.TestCase):
             with self.assertRaises(SystemExit):
                 ensurepip._main(["--version"])
         result = stdout.getvalue().strip()
-        self.assertEqual(result, EXPECTED_VERSION_OUTPUT)
+        self.assertEqual(result, "pip " + ensurepip.version())
         self.assertFalse(self.run_pip.called)
 
     def test_basic_bootstrapping(self):
@@ -283,7 +352,7 @@ class TestUninstallationMainFunction(EnsurepipMixin, unittest.TestCase):
             with self.assertRaises(SystemExit):
                 ensurepip._uninstall._main(["--version"])
         result = stdout.getvalue().strip()
-        self.assertEqual(result, EXPECTED_VERSION_OUTPUT)
+        self.assertEqual(result, "pip " + ensurepip.version())
         self.assertFalse(self.run_pip.called)
 
     def test_basic_uninstall(self):

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -146,6 +146,8 @@ CONFINCLUDEDIR=	$(exec_prefix)/include
 PLATLIBDIR=	@PLATLIBDIR@
 SCRIPTDIR=	$(prefix)/$(PLATLIBDIR)
 ABIFLAGS=	@ABIFLAGS@
+# Variable used by ensurepip
+WHEEL_PKG_DIR=	@WHEEL_PKG_DIR@
 
 # Detailed destination directories
 BINLIBDEST=	@BINLIBDEST@

--- a/Misc/NEWS.d/next/Build/2021-01-07-12-51-38.bpo-42856.n3cMHV.rst
+++ b/Misc/NEWS.d/next/Build/2021-01-07-12-51-38.bpo-42856.n3cMHV.rst
@@ -1,0 +1,9 @@
+Add ``--with-wheel-pkg-dir=PATH`` option to ./configure. If specified, the
+:mod:`ensurepip` module also looks for wheel packages in this directory, and
+picks the most recent versions in :mod:`ensurepip._bundled` and the
+specified directory.
+
+Some Linux distribution packaging policies recommand against bundling
+dependencies. For example, Fedora installs wheel packages in the
+``/usr/share/python-wheels/`` directory and don't install the
+``ensurepip._bundled`` package.

--- a/configure
+++ b/configure
@@ -630,6 +630,7 @@ OPENSSL_INCLUDES
 ENSUREPIP
 SRCDIRS
 THREADHEADERS
+WHEEL_PKG_DIR
 LIBPL
 PY_ENABLE_SHARED
 PLATLIBDIR
@@ -847,6 +848,7 @@ with_libm
 with_libc
 enable_big_digits
 with_platlibdir
+with_wheel_pkg_dir
 with_computed_gotos
 with_ensurepip
 with_openssl
@@ -1576,6 +1578,9 @@ Optional Packages:
                           system-dependent)
   --with-platlibdir=DIRNAME
                           Python library directory name (default is "lib")
+  --with-wheel-pkg-dir=PATH
+                          Directory of wheel packages used by ensurepip
+                          (default: none)
   --with-computed-gotos   enable computed gotos in evaluation loop (enabled by
                           default on supported compilers)
   --with-ensurepip[=install|upgrade|no]
@@ -15490,6 +15495,29 @@ if test x$PLATFORM_TRIPLET = x; then
   LIBPL='$(prefix)'"/${PLATLIBDIR}/python${VERSION}/config-${LDVERSION}"
 else
   LIBPL='$(prefix)'"/${PLATLIBDIR}/python${VERSION}/config-${LDVERSION}-${PLATFORM_TRIPLET}"
+fi
+
+
+# Check for --with-wheel-pkg-dir=PATH
+
+WHEEL_PKG_DIR=""
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-wheel-pkg-dir" >&5
+$as_echo_n "checking for --with-wheel-pkg-dir... " >&6; }
+
+# Check whether --with-wheel-pkg-dir was given.
+if test "${with_wheel_pkg_dir+set}" = set; then :
+  withval=$with_wheel_pkg_dir;
+if test -n "$withval"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+  WHEEL_PKG_DIR="$withval"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4838,6 +4838,22 @@ else
 fi
 AC_SUBST(LIBPL)
 
+# Check for --with-wheel-pkg-dir=PATH
+AC_SUBST(WHEEL_PKG_DIR)
+WHEEL_PKG_DIR=""
+AC_MSG_CHECKING(for --with-wheel-pkg-dir)
+AC_ARG_WITH(wheel-pkg-dir,
+            AS_HELP_STRING([--with-wheel-pkg-dir=PATH],
+            [Directory of wheel packages used by ensurepip (default: none)]),
+[
+if test -n "$withval"; then
+  AC_MSG_RESULT(yes)
+  WHEEL_PKG_DIR="$withval"
+else
+  AC_MSG_RESULT(no)
+fi],
+[AC_MSG_RESULT(no)])
+
 # Check whether right shifting a negative integer extends the sign bit
 # or fills with zeros (like the Cray J90, according to Tim Peters).
 AC_MSG_CHECKING(whether right shift extends the sign bit)


### PR DESCRIPTION
Add --with-wheel-pkg-dir=PATH option to ./configure. If specified,
the :mod:`ensurepip` module also looks for wheel packages in this
directory, and picks the most recent versions in ensurepip._bundled
and the specified directory.

Some Linux distribution packaging policies recommand against bundling
dependencies. For example, Fedora installs wheel packages in the
/usr/share/python-wheels/ directory and don't install the
ensurepip._bundled package.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42856](https://bugs.python.org/issue42856) -->
https://bugs.python.org/issue42856
<!-- /issue-number -->
