### PR TITLE
bpo-42851: [Enum] remove brittle __init_subclass__ support

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -9,14 +9,6 @@ __all__ = [
         ]
 
 
-class _NoInitSubclass:
-    """
-    temporary base class to suppress calling __init_subclass__
-    """
-    @classmethod
-    def __init_subclass__(cls, **kwds):
-        pass
-
 def _is_descriptor(obj):
     """
     Returns True if obj is a descriptor, False otherwise.
@@ -227,22 +219,7 @@ class EnumMeta(type):
         if '__doc__' not in classdict:
             classdict['__doc__'] = 'An enumeration.'
 
-        # postpone calling __init_subclass__
-        if '__init_subclass__' in classdict and classdict['__init_subclass__'] is None:
-            raise TypeError('%s.__init_subclass__ cannot be None')
-        # remove current __init_subclass__ so previous one can be found with getattr
-        new_init_subclass = classdict.pop('__init_subclass__', None)
-        # create our new Enum type
-        if bases:
-            bases = (_NoInitSubclass, ) + bases
-            enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
-            enum_class.__bases__ = enum_class.__bases__[1:] #or (object, )
-        else:
-            enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
-        old_init_subclass = getattr(enum_class, '__init_subclass__', None)
-        # and restore the new one (if there was one)
-        if new_init_subclass is not None:
-            enum_class.__init_subclass__ = classmethod(new_init_subclass)
+        enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
         enum_class._member_names_ = []               # names in definition order
         enum_class._member_map_ = {}                 # name->value map
         enum_class._member_type_ = member_type
@@ -354,9 +331,6 @@ class EnumMeta(type):
             if _order_ != enum_class._member_names_:
                 raise TypeError('member order does not match _order_')
 
-        # finally, call parents' __init_subclass__
-        if Enum is not None and old_init_subclass is not None:
-            old_init_subclass(**kwds)
         return enum_class
 
     def __bool__(self):
@@ -733,9 +707,6 @@ class Enum(metaclass=EnumMeta):
                 pass
         else:
             return start
-
-    def __init_subclass__(cls, **kwds):
-        super().__init_subclass__(**kwds)
 
     @classmethod
     def _missing_(cls, value):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2119,52 +2119,7 @@ class TestEnum(unittest.TestCase):
                 one = '1'
                 two = b'2', 'ascii', 9
                 
-    def test_init_subclass_calling(self):
-        class MyEnum(Enum):
-            def __init_subclass__(cls, **kwds):
-                super(MyEnum, cls).__init_subclass__(**kwds)
-                self.assertFalse(cls.__dict__.get('_test', False))
-                cls._test1 = 'MyEnum'
-        #
-        class TheirEnum(MyEnum):
-            def __init_subclass__(cls, **kwds):
-                super().__init_subclass__(**kwds)
-                cls._test2 = 'TheirEnum'
-        class WhoseEnum(TheirEnum):
-            def __init_subclass__(cls, **kwds):
-                pass
-        class NoEnum(WhoseEnum):
-            ONE = 1
-        self.assertEqual(TheirEnum.__dict__['_test1'], 'MyEnum')
-        self.assertEqual(WhoseEnum.__dict__['_test1'], 'MyEnum')
-        self.assertEqual(WhoseEnum.__dict__['_test2'], 'TheirEnum')
-        self.assertFalse(NoEnum.__dict__.get('_test1', False))
-        self.assertFalse(NoEnum.__dict__.get('_test2', False))
-        #
-        class OurEnum(MyEnum):
-            def __init_subclass__(cls, **kwds):
-                cls._test2 = 'OurEnum'
-        class WhereEnum(OurEnum):
-            def __init_subclass__(cls, **kwds):
-                pass
-        class NeverEnum(WhereEnum):
-            ONE = 'one'
-        self.assertEqual(OurEnum.__dict__['_test1'], 'MyEnum')
-        self.assertFalse(WhereEnum.__dict__.get('_test1', False))
-        self.assertEqual(WhereEnum.__dict__['_test2'], 'OurEnum')
-        self.assertFalse(NeverEnum.__dict__.get('_test1', False))
-        self.assertFalse(NeverEnum.__dict__.get('_test2', False))
 
-    def test_init_subclass_parameter(self):
-        class multiEnum(Enum):
-            def __init_subclass__(cls, multi):
-                for member in cls:
-                    member._as_parameter_ = multi * member.value
-        class E(multiEnum, multi=3):
-            A = 1
-            B = 2
-        self.assertEqual(E.A._as_parameter_, 3)
-        self.assertEqual(E.B._as_parameter_, 6)
 
     @unittest.skipUnless(
             sys.version_info[:2] == (3, 9),

--- a/Misc/NEWS.d/next/Library/2021-01-07-11-44-22.bpo-42851.uyQFyd.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-07-11-44-22.bpo-42851.uyQFyd.rst
@@ -1,0 +1,1 @@
+remove __init_subclass__ support for Enum members


### PR DESCRIPTION
Solution to support calls to `__init_subclass__` with members defined is too brittle and breaks with certain mixins.

<!-- issue-number: [bpo-42851](https://bugs.python.org/issue42851) -->
https://bugs.python.org/issue42851
<!-- /issue-number -->
