### PR TITLE
bpo-42846: Convert CJK codec extensions to multiphase init

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-01-07-23-31-17.bpo-42846.kukDjw.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-07-23-31-17.bpo-42846.kukDjw.rst
@@ -1,0 +1,3 @@
+Convert the 6 CJK codec extension modules (_codecs_cn, _codecs_hk,
+_codecs_iso2022, _codecs_jp, _codecs_kr and _codecs_tw) to the multiphase
+initialization API (:pep:`489`). Patch by Victor Stinner.

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -410,7 +410,6 @@ static PyModuleDef_Slot _cjk_slots[] = {
     static struct PyModuleDef _cjk_module = {                           \
         PyModuleDef_HEAD_INIT,                                          \
         .m_name = "_codecs_"#loc,                                       \
-        NULL,                                                           \
         .m_size = 0,                                                    \
         .m_methods = _cjk_methods,                                      \
         .m_slots = _cjk_slots,                                          \

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -303,12 +303,17 @@ register_maps(PyObject *module)
 
     for (h = mapping_list; h->charset[0] != '\0'; h++) {
         char mhname[256] = "__map_";
-        int r;
         strcpy(mhname + sizeof("__map_") - 1, h->charset);
-        r = PyModule_AddObject(module, mhname,
-                        PyCapsule_New((void *)h, PyMultibyteCodec_CAPSULE_NAME, NULL));
-        if (r == -1)
+
+        PyObject *capsule = PyCapsule_New((void *)h,
+                                          PyMultibyteCodec_CAPSULE_NAME, NULL);
+        if (capsule == NULL) {
             return -1;
+        }
+        if (PyModule_AddObject(module, mhname, capsule) < 0) {
+            Py_DECREF(capsule);
+            return -1;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Convert the 6 CJK codec extension modules (_codecs_cn, _codecs_hk,
_codecs_iso2022, _codecs_jp, _codecs_kr and _codecs_tw) to the
multiphase initialization API (PEP 489).

Remove getmultibytecodec() local cache: always import
_multibytecodec. It should be uncommon to get a codec. For example,
this function is only called once per CJK codec module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42846](https://bugs.python.org/issue42846) -->
https://bugs.python.org/issue42846
<!-- /issue-number -->
