### PR TITLE
[doc] Add mention to pow in operator.pow

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -174,6 +174,8 @@ The mathematical and bitwise operations are the most numerous:
 
    Return ``a ** b``, for *a* and *b* numbers.
 
+   Consider using :func:`pow`.
+
 
 .. function:: rshift(a, b)
               __rshift__(a, b)


### PR DESCRIPTION
The pow built-in is the only case where an operator is immediately available without having to import from operator.

Mention it as it's probably what the user needs.