### PR TITLE
bpo-42866: Fix refleak in CJK getcodec()

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-01-08-10-57-21.bpo-42866.Y1DnrO.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-08-10-57-21.bpo-42866.Y1DnrO.rst
@@ -1,0 +1,2 @@
+Fix a reference leak in the ``getcodec()`` function of CJK codecs. Patch by
+Victor Stinner.

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -291,6 +291,7 @@ getcodec(PyObject *self, PyObject *encoding)
 
     r = PyObject_CallOneArg(cofunc, codecobj);
     Py_DECREF(codecobj);
+    Py_DECREF(cofunc);
 
     return r;
 }


### PR DESCRIPTION
Fix a reference leak in the getcodec() function of CJK codecs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42866](https://bugs.python.org/issue42866) -->
https://bugs.python.org/issue42866
<!-- /issue-number -->
