### PR TITLE
bpo-42780: fix set_inheritable() for O_PATH file descriptors on Linux

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3881,6 +3881,27 @@ class FDInheritanceTests(unittest.TestCase):
         self.assertEqual(fcntl.fcntl(fd, fcntl.F_GETFD) & fcntl.FD_CLOEXEC,
                          0)
 
+    @unittest.skipUnless(hasattr(os, 'O_PATH'), "need os.O_PATH")
+    def test_get_set_inheritable_o_path(self):
+        fd = os.open(__file__, os.O_PATH)
+        self.addCleanup(os.close, fd)
+        self.assertEqual(os.get_inheritable(fd), False)
+
+        os.set_inheritable(fd, True)
+        self.assertEqual(os.get_inheritable(fd), True)
+
+        os.set_inheritable(fd, False)
+        self.assertEqual(os.get_inheritable(fd), False)
+
+    def test_get_set_inheritable_badf(self):
+        with self.assertRaises(OSError) as ctx:
+            os.set_inheritable(-1, True)
+        self.assertEqual(ctx.exception.errno, errno.EBADF)
+
+        with self.assertRaises(OSError) as ctx:
+            os.set_inheritable(-1, False)
+        self.assertEqual(ctx.exception.errno, errno.EBADF)
+
     def test_open(self):
         fd = os.open(__file__, os.O_RDONLY)
         self.addCleanup(os.close, fd)

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3894,12 +3894,14 @@ class FDInheritanceTests(unittest.TestCase):
         self.assertEqual(os.get_inheritable(fd), False)
 
     def test_get_set_inheritable_badf(self):
+        fd = os_helper.make_bad_fd()
+
         with self.assertRaises(OSError) as ctx:
-            os.set_inheritable(-1, True)
+            os.set_inheritable(fd, True)
         self.assertEqual(ctx.exception.errno, errno.EBADF)
 
         with self.assertRaises(OSError) as ctx:
-            os.set_inheritable(-1, False)
+            os.set_inheritable(fd, False)
         self.assertEqual(ctx.exception.errno, errno.EBADF)
 
     def test_open(self):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3897,6 +3897,10 @@ class FDInheritanceTests(unittest.TestCase):
         fd = os_helper.make_bad_fd()
 
         with self.assertRaises(OSError) as ctx:
+            os.get_inheritable(fd)
+        self.assertEqual(ctx.exception.errno, errno.EBADF)
+
+        with self.assertRaises(OSError) as ctx:
             os.set_inheritable(fd, True)
         self.assertEqual(ctx.exception.errno, errno.EBADF)
 

--- a/Misc/NEWS.d/next/Library/2021-01-08-15-49-20.bpo-42780.rtqi6B.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-08-15-49-20.bpo-42780.rtqi6B.rst
@@ -1,0 +1,1 @@
+Fix os.set_inheritable() for O_PATH file descriptors on Linux.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1234,6 +1234,13 @@ set_inheritable(int fd, int inheritable, int raise, int *atomic_flag_works)
             return 0;
         }
 
+#ifdef __linux__
+        if (errno == EBADF) {
+            // On Linux, ioctl(FIOCLEX) will fail with EBADF for O_PATH file descriptors
+            // Fall through to the fcntl() path
+        }
+        else
+#endif
         if (errno != ENOTTY && errno != EACCES) {
             if (raise)
                 PyErr_SetFromErrno(PyExc_OSError);


### PR DESCRIPTION
`ioctl()` doesn't work on `O_PATH` file descriptors on Linux, which breaks `os.set_inheritable()` since it uses `ioctl(FIOCLEX)`/`ioctl(FIONCLEX)` on Linux. This patch fixes that.

<!-- issue-number: [bpo-42780](https://bugs.python.org/issue42780) -->
https://bugs.python.org/issue42780
<!-- /issue-number -->
