### PR TITLE
Fix various ParamSpec errors in typing

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -695,10 +695,10 @@ These can be used as types in annotations using ``[]``, each having a unique syn
 
       from collections.abc import Callable
       from threading import Lock
-      from typing import Any, Concatenate, ParamSpec
+      from typing import Any, Concatenate, ParamSpec, TypeVar
 
       P = ParamSpec('P')
-      R = ParamSpec('R')
+      R = TypeVar('R')
 
       # Use this lock to ensure that only one thread is executing a function
       # at any time.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1000,7 +1000,7 @@ These are not used in annotations. They are building blocks for creating generic
     for the type variable must be a subclass of the boundary type,
     see :pep:`484`.
 
-.. class:: ParamSpec(name, *, bound=None, covariant=False, contravariant=False)
+.. class:: ParamSpec(name, bound=None, covariant=False, contravariant=False)
 
    Parameter specification variable.  A specialized version of
    :class:`type variables <TypeVar>`.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1000,7 +1000,7 @@ These are not used in annotations. They are building blocks for creating generic
     for the type variable must be a subclass of the boundary type,
     see :pep:`484`.
 
-.. class:: ParamSpec(name, bound=None, covariant=False, contravariant=False)
+.. class:: ParamSpec(name, *, bound=None, covariant=False, contravariant=False)
 
    Parameter specification variable.  A specialized version of
    :class:`type variables <TypeVar>`.

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -779,7 +779,7 @@ class ParamSpec(_Final, _Immutable, _TypeVarLike, _root=True):
     args = object()
     kwargs = object()
 
-    def __init__(self, name, bound=None, covariant=False, contravariant=False):
+    def __init__(self, name, *, bound=None, covariant=False, contravariant=False):
         self.__name__ = name
         super().__init__(bound, covariant, contravariant)
         try:


### PR DESCRIPTION
1. ParamSpec -> TypeVar for ``typing.Concatenate``
2. ParamSpec's call signature should align with its documentation.
Noticed in GH-24169

Automerge-Triggered-By: GH:gvanrossum