### PR TITLE
[doc] Remove duplicated operator.itemgetter example

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -319,15 +319,12 @@ expect a function argument.
    method.  Dictionaries accept any hashable value.  Lists, tuples, and
    strings accept an index or a slice:
 
-      >>> itemgetter('name')({'name': 'tu', 'age': 18})
-      'tu'
       >>> itemgetter(1)('ABCDEFG')
       'B'
       >>> itemgetter(1,3,5)('ABCDEFG')
       ('B', 'D', 'F')
       >>> itemgetter(slice(2,None))('ABCDEFG')
       'CDEFG'
-
       >>> soldier = dict(rank='captain', name='dotterbart')
       >>> itemgetter('rank')(soldier)
       'captain'

--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -321,9 +321,9 @@ expect a function argument.
 
       >>> itemgetter(1)('ABCDEFG')
       'B'
-      >>> itemgetter(1,3,5)('ABCDEFG')
+      >>> itemgetter(1, 3, 5)('ABCDEFG')
       ('B', 'D', 'F')
-      >>> itemgetter(slice(2,None))('ABCDEFG')
+      >>> itemgetter(slice(2, None))('ABCDEFG')
       'CDEFG'
       >>> soldier = dict(rank='captain', name='dotterbart')
       >>> itemgetter('rank')(soldier)


### PR DESCRIPTION
Don't understand how we got here, but we have two examples for operator.itemgetter when used with dictionaries.

These are the PRs that added them:
https://github.com/python/cpython/pull/1280
https://github.com/python/cpython/pull/3431

Note that when each PR was created no example existed, yet they vary greatly on date.

Having two examples for the exact same use case is confusing. I'm preserving Raymond's example as it is clearer.

Also, fix markup by removing a blank line.