### PR TITLE
bpo-42877: add the 'compact' param to TracebackException's __init__

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -217,10 +217,10 @@ capture data for later printing in a lightweight fashion.
    Capture an exception for later rendering. *limit*, *lookup_lines* and
    *capture_locals* are as for the :class:`StackSummary` class.
 
-   If *compact* is true, only data that is required for :method:`format`
-   is saved in the class attributes. In particular, the ``__context__`` field
-   is calculated only if ``__cause__`` is ``None`` and ``__suppress_context__``
-   is false.
+   If *compact* is true, only data that is required by :class:`TracebackException`'s
+   ``format`` method is saved in the class attributes. In particular, the
+   ``__context__`` field is calculated only if ``__cause__`` is ``None`` and
+   ``__suppress_context__`` is false.
 
    Note that when locals are captured, they are also shown in the traceback.
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -212,10 +212,15 @@ The module also defines the following classes:
 :class:`TracebackException` objects are created from actual exceptions to
 capture data for later printing in a lightweight fashion.
 
-.. class:: TracebackException(exc_type, exc_value, exc_traceback, *, limit=None, lookup_lines=True, capture_locals=False)
+.. class:: TracebackException(exc_type, exc_value, exc_traceback, *, limit=None, lookup_lines=True, capture_locals=False, compact=False)
 
    Capture an exception for later rendering. *limit*, *lookup_lines* and
    *capture_locals* are as for the :class:`StackSummary` class.
+
+   If *compact* is true, only data that is required for :method:`format`
+   is saved in the class attributes. In particular, the ``__context__`` field
+   is calculated only if ``__cause__`` is ``None`` and ``__suppress_context__``
+   is false.
 
    Note that when locals are captured, they are also shown in the traceback.
 
@@ -293,6 +298,9 @@ capture data for later printing in a lightweight fashion.
 
       The message indicating which exception occurred is always the last
       string in the output.
+
+   .. versionchanged:: 3.10
+      Added the *compact* parameter.
 
 
 :class:`StackSummary` Objects

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1173,6 +1173,46 @@ class TestTracebackException(unittest.TestCase):
         self.assertIn(
             "RecursionError: maximum recursion depth exceeded", res[-1])
 
+    def test_compact_with_cause(self):
+        try:
+            try:
+                1/0
+            finally:
+                cause = Exception("cause")
+                raise Exception("uh oh") from cause
+        except Exception:
+            exc_info = sys.exc_info()
+            exc = traceback.TracebackException(*exc_info, compact=True)
+            expected_stack = traceback.StackSummary.extract(
+                traceback.walk_tb(exc_info[2]))
+        exc_cause = traceback.TracebackException(Exception, cause, None)
+        self.assertEqual(exc_cause, exc.__cause__)
+        self.assertEqual(None, exc.__context__)
+        self.assertEqual(True, exc.__suppress_context__)
+        self.assertEqual(expected_stack, exc.stack)
+        self.assertEqual(exc_info[0], exc.exc_type)
+        self.assertEqual(str(exc_info[1]), str(exc))
+
+    def test_compact_no_cause(self):
+        try:
+            try:
+                1/0
+            finally:
+                exc_info_context = sys.exc_info()
+                exc_context = traceback.TracebackException(*exc_info_context)
+                raise Exception("uh oh")
+        except Exception:
+            exc_info = sys.exc_info()
+            exc = traceback.TracebackException(*exc_info, compact=True)
+            expected_stack = traceback.StackSummary.extract(
+                traceback.walk_tb(exc_info[2]))
+        self.assertEqual(None, exc.__cause__)
+        self.assertEqual(exc_context, exc.__context__)
+        self.assertEqual(False, exc.__suppress_context__)
+        self.assertEqual(expected_stack, exc.stack)
+        self.assertEqual(exc_info[0], exc.exc_type)
+        self.assertEqual(str(exc_info[1]), str(exc))
+
     def test_no_refs_to_exception_and_traceback_objects(self):
         try:
             1/0

--- a/Misc/NEWS.d/next/Library/2021-01-13-12-55-41.bpo-42877.Fi1zEG.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-13-12-55-41.bpo-42877.Fi1zEG.rst
@@ -1,0 +1,4 @@
+Added the ``compact`` parameter to the constructor of
+:class:`traceback.TracebackException` to reduce time and memory
+for use cases that only need to call :func:`TracebackException.format`
+and :func:`TracebackException.format_exception_only`.


### PR DESCRIPTION
…re is __cause__

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42877](https://bugs.python.org/issue42877) -->
https://bugs.python.org/issue42877
<!-- /issue-number -->
