### PR TITLE
bpo-42766 Fix 2 bugs in urllib.request.HTTPPasswordMgr.is_suburi

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -215,13 +215,22 @@ class RequestHdrsTests(unittest.TestCase):
 
         # is_suburi
 
-        self.assertTrue(is_suburi(reduce_uri('http://example.com'), reduce_uri('http://example.com/sub_dir')))
-        self.assertTrue(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://example.com/sub_dir/sub_dir')))
-        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir/sub_dir'), reduce_uri('http://example.com/sub_dir')))
-        self.assertFalse(is_suburi(reduce_uri('http://example.com/second_dir'), reduce_uri('http://example.com/first_dir/second_dir')))
-        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://example.com/sub')))
-        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://exmaple.com/sub_dir_diff')))
-        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir_diff'), reduce_uri('http://exmaple.com/sub_dir_second_diff')))
+        true = self.assertTrue
+        false = self.assertFalse
+        true(is_suburi(reduce_uri('http://example.com'),
+                       reduce_uri('http://example.com/sub_dir')))
+        true(is_suburi(reduce_uri('http://example.com/sub_dir'),
+                       reduce_uri('http://example.com/sub_dir/sub_dir')))
+        false(is_suburi(reduce_uri('http://example.com/sub_dir/sub_dir'),
+                        reduce_uri('http://example.com/sub_dir')))
+        false(is_suburi(reduce_uri('http://example.com/second_dir'),
+                        reduce_uri('http://example.com/first_dir/second_dir')))
+        false(is_suburi(reduce_uri('http://example.com/sub_dir'),
+                        reduce_uri('http://example.com/sub')))
+        false(is_suburi(reduce_uri('http://example.com/sub_dir'),
+                        reduce_uri('http://exmaple.com/sub_dir_diff')))
+        false(is_suburi(reduce_uri('http://example.com/sub_dir_diff'),
+                        reduce_uri('http://exmaple.com/sub_dir_second_diff')))
 
     def test_password_manager_default_port(self):
         """

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -145,6 +145,8 @@ class RequestHdrsTests(unittest.TestCase):
         mgr = urllib.request.HTTPPasswordMgr()
         add = mgr.add_password
         find_user_pass = mgr.find_user_password
+        is_suburi = mgr.is_suburi
+        reduce_uri = mgr.reduce_uri
 
         add("Some Realm", "http://example.com/", "joe", "password")
         add("Some Realm", "http://example.com/ni", "ni", "ni")
@@ -210,6 +212,15 @@ class RequestHdrsTests(unittest.TestCase):
                          ('4', 'd'))
         self.assertEqual(find_user_pass("Some Realm", "e.example.com:3128"),
                          ('5', 'e'))
+
+        # is_suburi
+
+        self.assertTrue(is_suburi(reduce_uri('http://example.com/'), reduce_uri('http://example.com/sub_dir')))
+        self.assertTrue(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://example.com/sub_dir/sub_dir')))
+        self.assertFalse(is_suburi(reduce_uri('http://example.com/second_dir'), reduce_uri('http://example.com/first_dir/second_dir')))
+        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://example.com/sub')))
+        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://exmaple.com/sub_dir_diff')))
+        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir_diff'), reduce_uri('http://exmaple.com/sub_dir_second_diff')))
 
     def test_password_manager_default_port(self):
         """

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -215,8 +215,9 @@ class RequestHdrsTests(unittest.TestCase):
 
         # is_suburi
 
-        self.assertTrue(is_suburi(reduce_uri('http://example.com/'), reduce_uri('http://example.com/sub_dir')))
+        self.assertTrue(is_suburi(reduce_uri('http://example.com'), reduce_uri('http://example.com/sub_dir')))
         self.assertTrue(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://example.com/sub_dir/sub_dir')))
+        self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir/sub_dir'), reduce_uri('http://example.com/sub_dir')))
         self.assertFalse(is_suburi(reduce_uri('http://example.com/second_dir'), reduce_uri('http://example.com/first_dir/second_dir')))
         self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://example.com/sub')))
         self.assertFalse(is_suburi(reduce_uri('http://example.com/sub_dir'), reduce_uri('http://exmaple.com/sub_dir_diff')))

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -881,7 +881,7 @@ class HTTPPasswordMgr:
         return authority, path
 
     def is_suburi(self, base, test):
-        """Check if test is below base in a URI tree (inclusive)
+        """Check if test is equal or below base in a URI tree
 
         Both args must be URIs in reduced form.
         """

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -853,6 +853,7 @@ class HTTPPasswordMgr:
             reduced_authuri = self.reduce_uri(authuri, default_port)
             for uris, authinfo in domains.items():
                 for uri in uris:
+                    print(uri, reduced_authuri)
                     if self.is_suburi(uri, reduced_authuri):
                         return authinfo
         return None, None
@@ -887,7 +888,7 @@ class HTTPPasswordMgr:
         """
         if base == test:
             return True
-        if base[0] != test[0] or len(test) > len(base):
+        if base[0] != test[0] or len(test[1]) < len(base[1]):
             return False
         common = posixpath.commonpath((base[1], test[1]))
         if len(common) == len(base[1]):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -853,7 +853,6 @@ class HTTPPasswordMgr:
             reduced_authuri = self.reduce_uri(authuri, default_port)
             for uris, authinfo in domains.items():
                 for uri in uris:
-                    print(uri, reduced_authuri)
                     if self.is_suburi(uri, reduced_authuri):
                         return authinfo
         return None, None

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -881,13 +881,13 @@ class HTTPPasswordMgr:
         return authority, path
 
     def is_suburi(self, base, test):
-        """Check if test is below base in a URI tree
+        """Check if test is below base in a URI tree (inclusive)
 
         Both args must be URIs in reduced form.
         """
         if base == test:
             return True
-        if base[0] != test[0]:
+        if base[0] != test[0] or len(test) > len(base):
             return False
         common = posixpath.commonpath((base[1], test[1]))
         if len(common) == len(base[1]):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -889,7 +889,7 @@ class HTTPPasswordMgr:
             return True
         if base[0] != test[0]:
             return False
-        common = posixpath.commonprefix((base[1], test[1]))
+        common = posixpath.commonpath((base[1], test[1]))
         if len(common) == len(base[1]):
             return True
         return False

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -552,6 +552,7 @@ Stefan Franke
 Martin Franklin
 Kent Frazier
 Bruce Frederiksen
+Yair Frid
 Jason Fried
 Robin Friedrich
 Bradley Froehle

--- a/Misc/NEWS.d/next/Library/2021-01-09-22-36-01.bpo-42766.6ybdUr.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-09-22-36-01.bpo-42766.6ybdUr.rst
@@ -1,0 +1,3 @@
+Fixed 2 bugs in urllib.request.HTTPPasswordMgr.is_suburi, added some tests
+for it. :func:`urllib.request.HTTPPasswordMgr.is_suburi`. Patch by Yair
+Frid.`


### PR DESCRIPTION
Change code in two places, noted in two issues, to match docstring, so
`is_suburi(reduce_uri('http://example.com/sub_dir/sub_dir'), reduce_uri('http://example.com/sub_dir'))` is false.

<!-- issue-number: [bpo-42766](https://bugs.python.org/issue42766) -->
https://bugs.python.org/issue42766
<!-- /issue-number -->

<!-- issue-number: [[bpo-42878](https://bugs.python.org/issue42878)](https://bugs.python.org/issue878) -->
https://bugs.python.org/issue42878
<!-- /issue-number -->
