### PR TITLE
bpo-42800: add audit hooks for f_code and tb_frame

### DIFF
--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -314,8 +314,6 @@ class object, and get the doc string using its :attr:`__doc__` attribute.
 As with the :c:member:`~PyTypeObject.tp_methods` table, a sentinel entry with a :attr:`name` value
 of ``NULL`` is required.
 
-.. version
-
 .. XXX Descriptors need to be explained in more detail somewhere, but not here.
 
    Descriptor objects have two handler functions which correspond to the

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -292,7 +292,7 @@ combined using bitwise-OR.
 |                           | reading.                                     |
 +---------------------------+----------------------------------------------+
 
-.. version-changed:: 3.10
+.. versionchanged:: 3.10
    :const:`RESTRICTED`, :const:`READ_RESTRICTED` and :const:`WRITE_RESTRICTED`
    are deprecated. However, :const:`READ_RESTRICTED` is an alias for
    :const:`AUDIT_READ`, so fields that specify either :const:`RESTRICTED` or

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -287,15 +287,23 @@ combined using bitwise-OR.
 +===========================+==============================================+
 | :const:`READONLY`         | Never writable.                              |
 +---------------------------+----------------------------------------------+
-| :const:`AUDIT_READ`       | Emit a :pep:`578` ``object.__getattr__``     |
-|                           | audit event before read.                     |
+| :const:`AUDIT_READ`       | Emit an ``object.__getattr__``               |
+|                           | :ref:`audit events <audit-events>` before    |
+|                           | reading.                                     |
 +---------------------------+----------------------------------------------+
+
+.. version-changed:: 3.10
+   :const:`RESTRICTED`, :const:`READ_RESTRICTED` and :const:`WRITE_RESTRICTED`
+   are deprecated. However, :const:`READ_RESTRICTED` is an alias for
+   :const:`AUDIT_READ`, so fields that specify either :const:`RESTRICTED` or
+   :const:`READ_RESTRICTED` will also raise an audit event.
 
 .. index::
    single: READONLY
    single: READ_RESTRICTED
    single: WRITE_RESTRICTED
    single: RESTRICTED
+   single: AUDIT_READ
 
 An interesting advantage of using the :c:member:`~PyTypeObject.tp_members` table to build
 descriptors that are used at runtime is that any attribute defined this way can
@@ -305,6 +313,8 @@ class object, and get the doc string using its :attr:`__doc__` attribute.
 
 As with the :c:member:`~PyTypeObject.tp_methods` table, a sentinel entry with a :attr:`name` value
 of ``NULL`` is required.
+
+.. version
 
 .. XXX Descriptors need to be explained in more detail somewhere, but not here.
 

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -287,11 +287,8 @@ combined using bitwise-OR.
 +===========================+==============================================+
 | :const:`READONLY`         | Never writable.                              |
 +---------------------------+----------------------------------------------+
-| :const:`READ_RESTRICTED`  | Not readable in restricted mode.             |
-+---------------------------+----------------------------------------------+
-| :const:`WRITE_RESTRICTED` | Not writable in restricted mode.             |
-+---------------------------+----------------------------------------------+
-| :const:`RESTRICTED`       | Not readable or writable in restricted mode. |
+| :const:`AUDIT_READ`       | Emit a :pep:`578` ``object.__getattr__``     |
+|                           | audit event before read.                     |
 +---------------------------+----------------------------------------------+
 
 .. index::

--- a/Doc/library/audit_events.rst
+++ b/Doc/library/audit_events.rst
@@ -7,7 +7,7 @@ Audit events table
 
 This table contains all events raised by :func:`sys.audit` or
 :c:func:`PySys_Audit` calls throughout the CPython runtime and the
-standard library.  These calls were added in 3.8.0 or later.
+standard library.  These calls were added in 3.8.0 or later (see :pep:`578`).
 
 See :func:`sys.addaudithook` and :c:func:`PySys_AddAuditHook` for
 information on handling these events.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5206,6 +5206,9 @@ environment.  Code objects are returned by the built-in :func:`compile` function
 and can be extracted from function objects through their :attr:`__code__`
 attribute. See also the :mod:`code` module.
 
+Accessing ``__code__`` raises an :ref:`auditing event <auditing>`
+``object.__getattr__`` with arguments ``obj`` and ``"__code__"``.
+
 .. index::
    builtin: exec
    builtin: eval

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1005,6 +1005,9 @@ Internal types
       :attr:`f_lasti` gives the precise instruction (this is an index into the
       bytecode string of the code object).
 
+      Accessing ``f_code`` raises an :ref:`auditing event <auditing>`
+      ``object.__getattr__`` with arguments ``obj`` and ``"f_code"``.
+
       .. index::
          single: f_trace (frame attribute)
          single: f_trace_lines (frame attribute)
@@ -1088,6 +1091,9 @@ Internal types
       line number of its frame object if the exception occurred in a
       :keyword:`try` statement with no matching except clause or with a
       finally clause.
+
+      Accessing ``tb_frame`` raises an :ref:`auditing event <auditing>`
+      ``object.__getattr__`` with arguments ``obj`` and ``"tb_frame"``.
 
       .. index::
          single: tb_next (traceback attribute)

--- a/Include/structmember.h
+++ b/Include/structmember.h
@@ -62,6 +62,7 @@ typedef struct PyMemberDef {
 #define PY_WRITE_RESTRICTED 4
 #define RESTRICTED          (READ_RESTRICTED | PY_WRITE_RESTRICTED)
 
+#define AUDIT_READ          READ_RESTRICTED
 
 /* Current API, use this */
 PyAPI_FUNC(PyObject *) PyMember_GetOne(const char *, struct PyMemberDef *);

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -718,6 +718,7 @@ Kevan Heydon
 Wouter van Heyst
 Kelsey Hightower
 Jason Hildebrand
+Ryan Hileman
 Aaron Hill
 Joel Hillacre
 Richie Hindle

--- a/Misc/NEWS.d/next/Security/2021-01-09-17-07-36.bpo-42800._dtZvW.rst
+++ b/Misc/NEWS.d/next/Security/2021-01-09-17-07-36.bpo-42800._dtZvW.rst
@@ -1,0 +1,1 @@
+Audit hooks are now fired for frame.f_code, traceback.tb_frame, and generator code/frame attribute access.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -164,7 +164,7 @@ member_get(PyMemberDescrObject *descr, PyObject *obj, PyObject *type)
     if (descr_check((PyDescrObject *)descr, obj, &res))
         return res;
 
-    if (descr->d_member->flags & READ_RESTRICTED) {
+    if (descr->d_member->flags & AUDIT_READ) {
         if (PySys_Audit("object.__getattr__", "Os",
             obj ? obj : Py_None, descr->d_member->name) < 0) {
             return NULL;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -13,7 +13,7 @@
 
 static PyMemberDef frame_memberlist[] = {
     {"f_back",          T_OBJECT,       OFF(f_back),      READONLY},
-    {"f_code",          T_OBJECT,       OFF(f_code),      READONLY},
+    {"f_code",          T_OBJECT,       OFF(f_code),      READONLY|AUDIT_READ},
     {"f_builtins",      T_OBJECT,       OFF(f_builtins),  READONLY},
     {"f_globals",       T_OBJECT,       OFF(f_globals),   READONLY},
     {"f_lasti",         T_INT,          OFF(f_lasti),     READONLY},

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -756,8 +756,8 @@ static PyGetSetDef gen_getsetlist[] = {
 };
 
 static PyMemberDef gen_memberlist[] = {
-    {"gi_frame",     T_OBJECT, offsetof(PyGenObject, gi_frame),    READONLY},
-    {"gi_code",      T_OBJECT, offsetof(PyGenObject, gi_code),     READONLY},
+    {"gi_frame",     T_OBJECT, offsetof(PyGenObject, gi_frame),    READONLY|AUDIT_READ},
+    {"gi_code",      T_OBJECT, offsetof(PyGenObject, gi_code),     READONLY|AUDIT_READ},
     {NULL}      /* Sentinel */
 };
 
@@ -993,8 +993,8 @@ static PyGetSetDef coro_getsetlist[] = {
 };
 
 static PyMemberDef coro_memberlist[] = {
-    {"cr_frame",     T_OBJECT, offsetof(PyCoroObject, cr_frame),    READONLY},
-    {"cr_code",      T_OBJECT, offsetof(PyCoroObject, cr_code),     READONLY},
+    {"cr_frame",     T_OBJECT, offsetof(PyCoroObject, cr_frame),    READONLY|AUDIT_READ},
+    {"cr_code",      T_OBJECT, offsetof(PyCoroObject, cr_code),     READONLY|AUDIT_READ},
     {"cr_origin",    T_OBJECT, offsetof(PyCoroObject, cr_origin),   READONLY},
     {NULL}      /* Sentinel */
 };
@@ -1375,10 +1375,10 @@ static PyGetSetDef async_gen_getsetlist[] = {
 };
 
 static PyMemberDef async_gen_memberlist[] = {
-    {"ag_frame",   T_OBJECT, offsetof(PyAsyncGenObject, ag_frame),   READONLY},
+    {"ag_frame",   T_OBJECT, offsetof(PyAsyncGenObject, ag_frame),   READONLY|AUDIT_READ},
     {"ag_running", T_BOOL,   offsetof(PyAsyncGenObject, ag_running_async),
         READONLY},
-    {"ag_code",    T_OBJECT, offsetof(PyAsyncGenObject, ag_code),    READONLY},
+    {"ag_code",    T_OBJECT, offsetof(PyAsyncGenObject, ag_code),    READONLY|AUDIT_READ},
     {NULL}      /* Sentinel */
 };
 

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -147,7 +147,7 @@ static PyMethodDef tb_methods[] = {
 };
 
 static PyMemberDef tb_memberlist[] = {
-    {"tb_frame",        T_OBJECT,       OFF(tb_frame),  READONLY},
+    {"tb_frame",        T_OBJECT,       OFF(tb_frame),  READONLY|AUDIT_READ},
     {"tb_lasti",        T_INT,          OFF(tb_lasti),  READONLY},
     {"tb_lineno",       T_INT,          OFF(tb_lineno), READONLY},
     {NULL}      /* Sentinel */


### PR DESCRIPTION
* Accessing the following attributes will now fire PEP 578 style
  audit hooks as `("object.__getattr__", obj, name)`:
  * `PyTracebackObject: tb_frame`
  * `PyFrameObject: f_code`
  * `PyGenObject: gi_code, gi_frame`
  * `PyCoroObject: cr_code, cr_frame`
  * `PyAsyncGenObject: ag_code, ag_frame`

* Document audit hooks for `tb_frame`, `f_code`, and `__code__`
* Add an `AUDIT_READ` attribute flag aliased to `READ_RESTRICTED`.
* Update obsolete `RESTRICTED` flag documentation.

<!-- issue-number: [bpo-42800](https://bugs.python.org/issue42800) -->
https://bugs.python.org/issue42800
<!-- /issue-number -->
