### PR TITLE
bpo-33065: Fix problem debugging user classes with __repr__ method

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,8 @@ Released on 2021-10-04?
 ======================================
 
 
+bpo-33065: Fix problem debugging user classes with __repr__ method.
+
 bpo-32631: Finish zzdummy example extension module: make menu entries
 work; add docstrings and tests with 100% coverage.
 

--- a/Lib/idlelib/debugger_r.py
+++ b/Lib/idlelib/debugger_r.py
@@ -19,7 +19,7 @@ arguments and return values that cannot be transported through the RPC
 barrier, in particular frame and traceback objects.
 
 """
-
+import reprlib
 import types
 from idlelib import debugger
 
@@ -170,7 +170,7 @@ class IdbAdapter:
     def dict_item(self, did, key):
         dict = dicttable[did]
         value = dict[key]
-        value = repr(value) ### can't pickle module 'builtins'
+        value = reprlib.repr(value) ### can't pickle module 'builtins'
         return value
 
 #----------end class IdbAdapter----------
@@ -390,4 +390,4 @@ def restart_subprocess_debugger(rpcclt):
 
 if __name__ == "__main__":
     from unittest import main
-    main('idlelib.idle_test.test_debugger', verbosity=2, exit=False)
+    main('idlelib.idle_test.test_debugger_r', verbosity=2, exit=False)

--- a/Lib/idlelib/idle_test/test_debugger_r.py
+++ b/Lib/idlelib/idle_test/test_debugger_r.py
@@ -25,5 +25,19 @@ class Test(unittest.TestCase):
 # Classes GUIProxy, IdbAdapter, FrameProxy, CodeProxy, DictProxy,
 # GUIAdapter, IdbProxy plus 7 module functions.
 
+class IdbAdapterTest(unittest.TestCase):
+
+    def test_dict_item_noattr(self):  # Issue 33065.
+
+        class BinData:
+            def __repr__(self):
+                return self.length
+
+        debugger_r.dicttable[0] = {'BinData': BinData()}
+        idb = debugger_r.IdbAdapter(None)
+        self.assertTrue(idb.dict_item(0, 'BinData'))
+        debugger_r.dicttable.clear()
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Misc/NEWS.d/next/IDLE/2021-01-10-01-25-43.bpo-33065.zmyHYJ.rst
+++ b/Misc/NEWS.d/next/IDLE/2021-01-10-01-25-43.bpo-33065.zmyHYJ.rst
@@ -1,0 +1,1 @@
+Fix problem debugging user classes with __repr__ method.


### PR DESCRIPTION
If __repr__ uses instance attributes, as normal, and one steps
through the __init__ method, debugger may try to get repr before
the instance attributes exist.  reprlib.repr handles the error.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33065](https://bugs.python.org/issue33065) -->
https://bugs.python.org/issue33065
<!-- /issue-number -->
