### PR TITLE
bpo-42619: Arm64 build on macos10.15

### DIFF
--- a/Misc/NEWS.d/next/macOS/2021-01-10-11-04-33.bpo-42619._jWi3B.rst
+++ b/Misc/NEWS.d/next/macOS/2021-01-10-11-04-33.bpo-42619._jWi3B.rst
@@ -1,0 +1,3 @@
+Detect if the compiler supports building for arm64 when running on macOS
+10.15. This enables building "universal2" extensions on macOS 10.15 when
+Xcode 12.2 is installed.


### PR DESCRIPTION
Probe if the compiler supports arm64 when running on macOS 10.15. This enables building "universal2" extensions on a 10.15 system with a recent enough compiler.

<!-- issue-number: [bpo-42619](https://bugs.python.org/issue42619) -->
https://bugs.python.org/issue42619
<!-- /issue-number -->
