### PR TITLE
bpo-31904: add library search path by wr-cc in add_cross_compiling_paths()

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-01-11-23-26-00.bpo-31904.ty8f3h.rst
+++ b/Misc/NEWS.d/next/Build/2021-01-11-23-26-00.bpo-31904.ty8f3h.rst
@@ -1,0 +1,1 @@
+Add library search path by wr-cc in add_cross_compiling_paths() for VxWorks.

--- a/setup.py
+++ b/setup.py
@@ -703,6 +703,9 @@ class PyBuildExt(build_ext):
             if ret:
                 return
             with open(tmpfile) as fp:
+                # Parse paths in libraries line. The line is like:
+                # On Linux, "libraries: = path1:path2:path3"
+                # On Windows, "libraries: = path1;path2;path3"
                 for line in fp:
                     if not line.startswith("libraries"):
                         continue

--- a/setup.py
+++ b/setup.py
@@ -740,7 +740,7 @@ class PyBuildExt(build_ext):
             os.unlink(tmpfile)
 
         if VXWORKS:
-            add_wrcc_search_dirs()
+            self.add_wrcc_search_dirs()
 
     def add_ldflags_cppflags(self):
         # Add paths specified in the environment variables LDFLAGS and


### PR DESCRIPTION
VxWorks has a compiler driver utility called wr-cc which wraps gcc or clang compiler. The call of sysconfig.get_config_var('CC') on building machine returns "wr-cc" for VxWorks cross compiling. "wr-cc --print-search-dirs" will add VSB specific path for library searching. Building extension modules will need these paths. So adding them in add_cross_compiling_paths().

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
