### PR TITLE
bpo-42882: _PyRuntimeState_Init() leaves unicode next_index unchanged

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -51,6 +51,8 @@ typedef struct _Py_AuditHookEntry {
 
 struct _Py_unicode_runtime_ids {
     PyThread_type_lock lock;
+    // next_index value must be preserved when Py_Initialize()/Py_Finalize()
+    // is called multiple times: see _PyUnicode_FromId() implementation.
     Py_ssize_t next_index;
 };
 
@@ -107,6 +109,8 @@ typedef struct pyruntimestate {
 
     PyPreConfig preconfig;
 
+    // Audit values must be preserved when Py_Initialize()/Py_Finalize()
+    // is called multiple times.
     Py_OpenCodeHookFunction open_code_hook;
     void *open_code_userdata;
     _Py_AuditHookEntry *audit_hook_head;

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-11-17-58-52.bpo-42882.WfTdfg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-11-17-58-52.bpo-42882.WfTdfg.rst
@@ -1,0 +1,3 @@
+Fix the :c:func:`_PyUnicode_FromId` function (_Py_IDENTIFIER(var) API) when
+:c:func:`Py_Initialize` / :c:func:`Py_Finalize` is called multiple times:
+preserve ``_PyRuntime.unicode_ids.next_index`` value.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -54,6 +54,9 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
     void *open_code_hook = runtime->open_code_hook;
     void *open_code_userdata = runtime->open_code_userdata;
     _Py_AuditHookEntry *audit_hook_head = runtime->audit_hook_head;
+    // bpo-42882: Preserve next_index value if Py_Initialize()/Py_Finalize()
+    // is called multiple times.
+    int64_t unicode_next_index = runtime->unicode_ids.next_index;
 
     memset(runtime, 0, sizeof(*runtime));
 
@@ -90,7 +93,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
     if (runtime->unicode_ids.lock == NULL) {
         return _PyStatus_NO_MEMORY();
     }
-    runtime->unicode_ids.next_index = 0;
+    runtime->unicode_ids.next_index = unicode_next_index;
 
     return _PyStatus_OK();
 }


### PR DESCRIPTION
Fix the _PyUnicode_FromId() function (_Py_IDENTIFIER(var) API) when
Py_Initialize() / Py_Finalize() is called multiple times:
preserve _PyRuntime.unicode_ids.next_index value.

Use _PyRuntimeState_INIT macro instead memset(0) to reset
_PyRuntimeState members to zero.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42882](https://bugs.python.org/issue42882) -->
https://bugs.python.org/issue42882
<!-- /issue-number -->
