### PR TITLE
[doc] Fix addCleanupClass  -> addClassCleanup typo

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1498,7 +1498,7 @@ Test cases
       after :meth:`setUpClass` if :meth:`setUpClass` raises an exception.
 
       It is responsible for calling all the cleanup functions added by
-      :meth:`addCleanupClass`. If you need cleanup functions to be called
+      :meth:`addClassCleanup`. If you need cleanup functions to be called
       *prior* to :meth:`tearDownClass` then you can call
       :meth:`doCleanupsClass` yourself.
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1500,9 +1500,9 @@ Test cases
       It is responsible for calling all the cleanup functions added by
       :meth:`addClassCleanup`. If you need cleanup functions to be called
       *prior* to :meth:`tearDownClass` then you can call
-      :meth:`doCleanupsClass` yourself.
+      :meth:`doClassCleanups` yourself.
 
-      :meth:`doCleanupsClass` pops methods off the stack of cleanup
+      :meth:`doClassCleanups` pops methods off the stack of cleanup
       functions one at a time, so it can be called at any time.
 
       .. versionadded:: 3.8


### PR DESCRIPTION
Fix addCleanupClass  -> addCleanupClass typo in https://docs.python.org/3/library/unittest.html#unittest.TestCase.doClassCleanups