### PR TITLE
bpo-42903: optimize lru_cache for functions with no arguments

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-01-11-23-33-46.bpo-42903.zy_Bcc.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-11-23-33-46.bpo-42903.zy_Bcc.rst
@@ -1,0 +1,1 @@
+Optimize lru_cache for functions with no arguments.


### PR DESCRIPTION


<!-- issue-number: [bpo-42903](https://bugs.python.org/issue42903) -->
https://bugs.python.org/issue42903
<!-- /issue-number -->
