### PR TITLE
bpo-42874: Remove grep -qE options for Solaris 10 compatibility

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-01-12-10-06-50.bpo-42874.XKK61g.rst
+++ b/Misc/NEWS.d/next/Build/2021-01-12-10-06-50.bpo-42874.XKK61g.rst
@@ -1,0 +1,3 @@
+Removed the grep -q and -E flags in the tzpath validation section of the
+configure script to better accomodate users of some platforms (specifically
+Solaris 10).

--- a/configure
+++ b/configure
@@ -10252,7 +10252,7 @@ validate_tzpath() {
     fi
 
     # Bad paths are those that don't start with /
-        if ( echo $1 | grep -qE '(^|:)([^/]|$)' ); then
+        if ( echo $1 | grep '\(^\|:\)\([^/]\|$\)' > /dev/null); then
         as_fn_error $? "--with-tzpath must contain only absolute paths, not $1" "$LINENO" 5
         return 1;
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -2980,7 +2980,7 @@ validate_tzpath() {
 
     # Bad paths are those that don't start with /
     dnl quadrigraphs "@<:@" and "@:>@" produce "[" and "]" in the output
-    if ( echo $1 | grep -qE '(^|:)(@<:@^/@:>@|$)' ); then
+    if ( echo $1 | grep '\(^\|:\)\(@<:@^/@:>@\|$\)' > /dev/null); then
         AC_MSG_ERROR([--with-tzpath must contain only absolute paths, not $1])
         return 1;
     fi


### PR DESCRIPTION
According to [bpo-42874](https://bugs.python.org/issue42874), some versions of grep do not support the `-q` and `-E` options. Although both options are used elsewhere in the configure script, this particular bit of validation can be achieved without them,
so there's no real harm in using a grep call with no flags.

Would be good to get some people taking advantage of the `--with-tzpath` arguments in the wild to try this out.. Local testing seems to indicate that this does the same thing, but I don't know that we have any buildbots using this option. Maybe @pablogsal?

[bpo-42874](https://bugs.python.org/issue42874): https://bugs.python.org/issue42874


<!-- issue-number: [bpo-42874](https://bugs.python.org/issue42874) -->
https://bugs.python.org/issue42874
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal