### PR TITLE
bpo-42911: Addition chains

### DIFF
--- a/Include/internal/pycore_bitutils.h
+++ b/Include/internal/pycore_bitutils.h
@@ -155,17 +155,18 @@ _Py_bit_length(unsigned long x)
         return 0;
     }
 #else
-    const int BIT_LENGTH_TABLE[32] = {
-        0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4,
-        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
-    };
-    int msb = 0;
-    while (x >= 32) {
-        msb += 6;
-        x >>= 6;
+    static const uint8_t lengths[16] = { 0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4 };
+    int result = 0;
+    if (x >= 1 << 16) {
+        result += 16; x >>= 16;
     }
-    msb += BIT_LENGTH_TABLE[x];
-    return msb;
+    if (x >= 1 << 8) {
+        result += 8; x >>= 8;
+    }
+    if (x >= 1 << 4) {
+        result += 4; x >>= 4;
+    }
+    return result + lengths[x];
 #endif
 }
 

--- a/Lib/test/test_pow.py
+++ b/Lib/test/test_pow.py
@@ -144,6 +144,29 @@ class PowTest(unittest.TestCase):
                         with self.assertRaises(ValueError):
                             pow(a, -1001, m)
 
+    def test_fermat(self, base=3):
+        # use Fermat's theorem to test very high powers for the addition chains
+        prime = 10 ** 17 - 3
+        for length in range(60, 1000):
+            for prefix in range(8, 16):
+                n = prefix << length - 4 | getrandbits(length - 4)
+                self.assertEqual(pow(base, n, prime),
+                                 pow(base, n % (prime-1), prime))
+
+    def test_heuristic(self):
+        # test all cases of the heuristic addition chain optimizer
+        prime = 10 ** 17 - 3
+        for n in range(1 << 8):
+            self.assertEqual(2 ** n, 1 << n)
+        for length in range(8,61):
+            for ones in range(length - 3):
+                pattern = (1 << ones) - 1
+                for prefix in range(8, 16):
+                    n = prefix << length - 4 | pattern
+                    m = getrandbits(length - 1)
+                    self.assertEqual(
+                        pow(2, n, prime),
+                        pow(2, m, prime) * pow(2, n-m, prime) % prime)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_pow.py
+++ b/Lib/test/test_pow.py
@@ -1,5 +1,6 @@
 import math
 import unittest
+from random import getrandbits
 
 class PowTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-13-11-01-52.bpo-42911.jg3FIk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-13-11-01-52.bpo-42911.jg3FIk.rst
@@ -1,0 +1,4 @@
+Integer exponents used a hard boundary between binary exponentation for short exponents, and "fiveary" (actually 32-ary) exponentiation for very long exponents.
+This patch fills in the gap for moderately long exponents, making a smooth transistion. Addition chains with dynamic windows are used to even make smaller exponentiations faster, and very long exponents will still gain a bit.
+Total speedup varies from 2 % to 15% if your exponent is midrange.
+Speed test code and long explanation of the method is coming up Real Soon.

--- a/Misc/additionchains.txt
+++ b/Misc/additionchains.txt
@@ -116,6 +116,37 @@ appeared just because a certain point in the routine never was reached, while I
 knew from the research that it actually would occur.
 So, if you are still interested, here's the code.
 - Jurjen Bos, januari 2021
+
+Here are some rough measurements to give you an idea (times in us, measured with Python 3.8):
+Bitsize     old     new     %
+  16 (1):   0.99    0.73   -26
+  32 (1):   1.88    1.25   -34
+  48 (1):   2.13    1.75   -18
+  64 (1):   2.79    2.14   -23
+  80 (1):   3.39    2.62   -22
+  96 (1):   4.56    3.35   -26
+ 111 (1):   4.88    3.73   -23
+ 127 (1):   5.40    4.31   -20
+ 143 (1):   5.96    4.75   -20
+ 159 (1):   6.69    5.12   -23
+ 175 (1):   6.88    5.64   -18
+ 191 (1):   7.75    6.32   -18
+ 207 (1):   7.69    6.59   -24
+ 222 (1):   9.77    7.17   -26
+ 238 (1):   9.32    7.61   -18
+ 254 (5):   9.64    8.23   -14
+ 270 (5):   9.67    8.58   -11
+ 286 (5):  10.53    9.33   -11
+ 302 (5):  11.50    9.55   -17
+ 317 (5):  11.69   10.24   -12
+
+Some comments about these numbers:
+The savings with the very short exponents (16 and 32) are mainly because the old code
+multiplies a lot of 1*1 during the computation.
+The savings between 80 and 200 bits is where the addition chains really shine, because
+the old code uses the binary method still.
+From 250 bits one, the old code uses the fiveary method, but there is still plenty of
+room for my chunkSize 6 to win from that.
 """
 
 import re
@@ -634,6 +665,19 @@ def showOverview2(margin=.01, ws=30, lengths=None, prefixes=None):
             totalLoss += loss/samples
         if len(prefixes) != 1: print()
     return totalLoss
+    
+def speedMeasurement(multiplies=10**8):
+    from timeit import repeat
+    print("size    time (us)")
+    for p in range(10, 210, 10):
+        n = 3 ** p
+        length = n.bit_length()
+        number = multiplies // length
+        t = min(repeat('pow(7, n, 100)',
+                       'n=%d'%n,
+                       repeat=7,
+                       number=number)) / number * 1e6
+        print(f"{length:4d} ({'15'[length>=240]}): {t:6.2f}")
 
 # extended tests ---------------------------------------------------
 __test__ = {

--- a/Misc/additionchains.txt
+++ b/Misc/additionchains.txt
@@ -1,0 +1,713 @@
+#!python3
+"""Investigation of how useful it is to optimize Python powers.
+(I am talking about integer-to-integer powers here, that are implemented
+by repeated multiplications.)
+In Python 3.9 and earlier, there were two algorithms:
+- the binary method which is the regular "left to right" method of powering.
+- the "fiveary" method, which is actually 32-are, which precomputes the powers
+  zero through 31 and than scans the exponent 5 bits at a time.
+There is a hard boundary of quite a large number of bits, where there is a
+switch from one method to another.
+
+But we can do better than that. First some exaplanation.
+
+Both methods use the same basic algorithm:
+- Start with a small power that is equal to the first few bits of the exponent
+- square this number repeatedly, and at the apppropriate time, do a single
+  multiplication
+In the binary case, a multiplication could occur at every squaring.
+In the fiveary case, a multiplication was considered every five squarings.
+
+I investigated if this can be improved upon by generalizing the fiveary method:
+- using different bases than just 2 and 32, to make a smooth transition
+- making computation of the table more efficient
+- vary the base not only on the length of the number, but also on other
+  characteristics to make it more efficient for smaller numbers
+  Actually, the first number where this happens is 15.
+
+So, first I wrote a routine that does this "generalized fiveary method" that
+uses a given "chunkSize" indicate how many bits are use at one time.
+Below you find a Python routine called otfR (for historic reasons) that
+calculates the number of squarings and multiplications, implicitly defining
+the algorithm.
+This routine uses the following optimizations:
+- the table only contains odd entries, since an even entry can be handled
+  simply by doing the multiplication at an earlier time
+- table entries are not computed if not needed
+- at the beginning of the number, you can recongnise the bit patterns 10
+  because you'll have to do a squaring anyway to fill the table
+- also, if a number starts with 1001, and the chunksize is 3, it is
+  advantageous to compute the start from table entry 111 and the square, so you
+  start one bit ahead.
+- No muliplication will be done at all if there are zeros in the exponent
+
+The result of this is that the binary method (corresponding to chunkSize 1)
+is no longer needed, since chunkSize 2 does never use more multiplies than
+chunkSize 1. Also, using the same 32 entry table of the fiveary method,
+we can go up to chunk size 6 instead of 5. And finally, since the zeros in
+the number are skipped, chunkSize n corresponds to chunkSize n+1 of the old
+method, so chunkSize 4 is as fast as the fiveary method, and we effectively
+are now up to chunksize 7!
+
+Now, the question remains what is the best chunkSize to use.
+Here we call numberLength the number of bits in the exponent, as given by
+Python's exponent.bit_length().
+
+The naive computation is as follows:
+- it takes 1 << chunkSize multiplications to construct the table (one for
+  computing the square, the rest for computing powers)
+  3, 5, ..., (1 << chunkSize) - 1
+- once the table is ready, there is a multplication for every chunkSize + 1
+  squarings
+- there are numberLength - chunkSize squarings, plus one for constructing
+  the table.
+Average number of operations (cs=chunkSize, nl=numberLength):
+              Multiplies          Squarings   Total
+Table         (1<<cs)-1           1           1<<cs
+First cs bits 0                   0           0
+Rest          (nl-cs)/(cs+1)      nl-cs       (nl+1)/(cs+1)-1
+Total         (1<<cs)+(nl-cs)/... nl-cs+1     (cs+2)*((nl+1)/(cs+1)-1)+(1<<cs)
+[nlcs stands for numberLength-chunkSize]
+
+From these numbers, you can simply compute the numberLength ranges where a given chunk size
+is optimal:
+chunkSize    min #mults   max #mults
+2            0     0      35   48
+3           35   34.3    140  179.2
+4          140  179.2    450  551.2
+5          450  551.2   1296 1538.2 
+6         1296 1538.3   -
+
+But you would be mistaken, since the other optimizations in the routine influence
+matters a lot.
+Some numbers are happy with a small chunkSize (two powers for example), while
+other are much more efficient is the chunkSize is bigger (like numbers with
+many ones in their pattern).
+I found that if you ignored that, the performance would suffer even for quite
+small numbers. So I wanted to optimize for that, too.
+After a lot of experimentation and days of number crunching, I found that there
+are two parameters, that are relatively easy to compute, that give an good indication
+on the optimal chunk size. I order of effect:
+- the initial bits of the number (I chose to use four bits): the prefix
+- the pairs in the number that are two bits apart: (n&n>>2).bit_length()
+- the length of the number
+There are also other parameters, but these turned out to be good. The routine 
+calculating this is called good_chunksize below.
+But of course, for very long number even calculating these pairs is complicated.
+Fortunately,the bit pattern doesn't make much of a difference for longer numbers,
+so I chose not to compute the bit pattern if it didn't fit in 60 bits.
+The routine fastChunksize below does that.
+
+The routine goodChunksize performs an algorithm to choose a good chunkSize in
+the three dimensional space of the three parameters.
+The Python code below explores that space, so you can see for yourself how well I did.
+I ended up with an algorithm that is partly table based, but the really
+complicated shapes consist of 8 simple curves indexed by prefix.
+The other routines below were used to construct these curves.
+
+And finally, I had to convert all that to C, and debug it.
+There were two challenges:
+- getting the reference counts right (of course)
+- making sure the fastChunksize algorithm is actually implemented.
+For that latter problem, I started with extendeding test_pow to find all
+little corner cases, so that all places in the code would be touched. Then I checked
+if all cases were indeed touched. That was quite useful, as I found that most bugs
+appeared just because a certain point in the routine never was reached, while I
+knew from the research that it actually would occur.
+So, if you are still interested, here's the code.
+- Jurjen Bos, januari 2021
+"""
+
+import re
+from collections import namedtuple, defaultdict, Counter
+from random import randrange, getrandbits, sample
+from operator import methodcaller, itemgetter, add
+from itertools import chain, product,islice
+from functools import partial
+
+# number of multiplications, squares and "empty" squares (of 1)
+_Mults = namedtuple("_Mults", "squares mults empty chunkSize")
+class Mults(namedtuple("Mults", "squares mults empty chunkSize")):
+    """Make sensible ordering in Mults"""
+    def __int__(self): return self.mults + self.squares
+    def __eq__(self, other): return int(self) == int(other)
+    def __lt__(self, other): return int(self) < int(other)
+    def __gt__(self, other): return int(self) > int(other)
+    def __le__(self, other): return int(self) <= int(other)
+    def __ge__(self, other): return int(self) >= int(other)
+    def __ne__(self, other): return int(self) != int(other)
+
+# auxiliary functions ----------------------------------------
+def digits(n, chunkSize=30):
+    """Split n into 'big digits' of chunkSize bits each
+    >>> digits(10000, 3)
+    [0, 2, 4, 3, 2]
+    """
+    mask = (1 << chunkSize) - 1
+    return [n >> i & mask
+            for i in range(0, n.bit_length(), chunkSize)]
+
+def hamming(n):
+    return bin(n).count('1')
+
+# original functions ----------------------------------------
+def mul_bin(n, ws=30):
+    """Compute number of multiplications using basic binary method
+    As close to python code as possible
+    counts squares, multiplications, empty squares
+    >>> mul_bin(10000, 8)
+    Mults(squares=13, mults=5, empty=3, chunkSize=None)
+    """
+    oneSquares = squares = mults = 0
+    resultPower = 0
+    for digit in reversed(digits(n, ws)):
+        for bitPos in range(ws - 1, -1, -1):
+            if resultPower: squares += 1
+            else: oneSquares += 1
+            resultPower *= 2
+            if digit >> bitPos & 1:
+                mults += 1
+                resultPower += 1
+    if resultPower != n: raise AssertionError
+    return Mults(squares, mults, oneSquares, None)
+
+def est_mul_bin(n, ws=30):
+    """Compute counts of mul_bin directly
+    >>> est_mul_bin(10000, 8)
+    Mults(squares=13, mults=5, empty=3, chunkSize=None)
+    """
+    if not n: return Mults(0, 0, 0, None)
+    bl = n.bit_length()
+    return Mults(bl - 1, hamming(n), -bl % ws + 1, None)
+
+def mulP(n, ws=30, chunkSize=5):
+    """Compute number of multiplications with chunkSize bits at a time
+    As close to python code as possible
+    counts squares, multiplications, empty squares
+    >>> mulP(10000, 8, 4)
+    Mults(squares=13, mults=17, empty=4, chunkSize=4)
+    """
+    # make table
+    if ws % chunkSize: raise AssertionError
+    mask = (1 << chunkSize) - 1
+    oneSquares, squares, mults = 0, 1, (1 << chunkSize) - 2
+    resultPower = 0
+    for digit in reversed(digits(n, ws)):
+        for bitPos in range(ws - chunkSize, -chunkSize, -chunkSize):
+            if resultPower: squares += chunkSize
+            else: oneSquares += chunkSize
+            resultPower <<= chunkSize
+            d = digit >> bitPos & mask
+            if d:
+                mults += 1
+                resultPower += d
+    if resultPower != n: raise AssertionError
+    return Mults(squares, mults, oneSquares, chunkSize)
+
+def est_mulP(n, ws=30, chunkSize=5):
+    """Compute counts of mulP directly
+    >>> est_mulP(10000, 8, 4)
+    Mults(squares=13, mults=17, empty=4, chunkSize=4)
+    """
+    if not n: return Mults(1, (1 << chunkSize) - 2, 0, chunkSize)
+    bl = n.bit_length()
+    dg = digits(n, chunkSize)
+    return Mults((len(dg) - 1) * chunkSize + 1,
+                 sum(map(bool, dg)) + (1 << chunkSize) - 2,
+                 (chunkSize - 1 - len(dg) * chunkSize) % ws + 1,
+                 chunkSize)
+
+# proposed function --------------------------------------------
+def otfR(n, ws=30, chunkSize=2, special=False):
+    """On the fly powering.
+    Using a table of powers, this routine multplies multiple bits
+    at a time.
+    Optimizations:
+      - only store odd numbers in the table, and search for the locations to
+        apply the power.
+      - do not compute table entries until needed
+      - use the square that is needed to construct the table where useful
+      - special case for numbers that start with 1001
+    Results:
+    chunkSize = 2 is never worse than binary (!)
+    chunkSize = 3 costs at most 1 (8% of numbers <100, 1.4% under a million)
+    The best value for the chunkSize parameter is computed by otfR_good
+    >>> otfR(27, 8, 2)
+    Mults(squares=4, mults=2, empty=0, chunkSize=2)
+    """
+    if n < 2: return Mults(0, 0, 0, chunkSize)
+    squares, mults, maxTable = 1, 0, 1
+    def tableFetch(p):
+        nonlocal maxTable, mults
+        assert p & 1
+        while maxTable < p:
+            mults += 1
+            maxTable += 2
+    resultPower = 0
+    myDigits = list(digits(n, ws))
+    if len(myDigits) > 1:
+        myDigits[-2] |= myDigits[-1] << ws
+        del myDigits[-1]
+    for digit in reversed(myDigits):
+        resultShift = ws
+        while digit:
+            # compute active position
+            bitPos = max(digit.bit_length(), chunkSize) - chunkSize
+            head = digit >> bitPos
+            if not resultPower:
+                # start here: first part of first digit
+                if head == 2:
+                    pass # from variable
+                elif head == 4 and bitPos > 1 and digit >> bitPos - 1 == 9:
+                    # head can be extended to 9 (we know chunkSize==3 now)
+                    bitPos -= 1
+                    head = 9
+                    tableFetch(head)
+                else:
+                    # make digit >> bitPos odd by moving to the left
+                    bitPos += (head ^ head - 1).bit_length() - 1
+                    head = digit >> bitPos
+                    if head == 1 and bitPos and digit >> bitPos - 1 == 2:
+                        # we can move to the right for free from the square
+                        bitPos -= 1
+                        head = 2
+                    else:
+                        tableFetch(head)
+            else:
+                # make digit >> bitPos odd
+                bitPos += (head ^ head - 1).bit_length() - 1
+                head = digit >> bitPos
+                # shift to bitPos, multiply with table entry
+                squares += resultShift - bitPos
+                resultPower <<= resultShift - bitPos
+                tableFetch(head)
+                mults += 1
+            resultShift = bitPos
+            resultPower += head
+            # remove chunk
+            digit &= (1 << resultShift) - 1
+        squares += resultShift
+        resultPower <<= resultShift
+    if resultPower != n: raise AssertionError
+    return Mults(squares, mults, 0, chunkSize)
+
+def goodChunksize(n):
+    """Determine a very good chunk size for n,
+    under the assumption that we have the comfort of having all the bits of n.
+    This condition will be removed below in "fastChunksize".
+    Roughly, using chunk size n costs 1<<n-1 multiplications to build the table
+    and n+2 multiplications per n+1 bits of exponent.
+    It is easy to verify that the crossover points are roughly:
+    2-3: 2*3*4 = 24 bits
+    3-4: 4*4*5 = 80 bits
+    4-5: 8*5*6 = 240 bits
+    5-6: 16*6*7 = 672 bits
+    If fact, for shorter numbers it depends heavily on the first few bits of
+    the exponent. So we look at the first four, and use this to make a better
+    guess. This saves a fraction of a multiplication on average, which still
+    makes it worth the effort spendind a few instructions.
+    """
+    # let's do the easy to see cases first
+    length = n.bit_length()
+    if length < 5: return 2
+    # first four bits of n to optimize the boundaries
+    prefix = n >> length - 4
+    if length > 100:
+        if length > [647, 669, 657, 671, 647, 670, 657, 671][prefix - 8]: return 6
+        if length > [197, 230, 215, 230, 197, 230, 214, 231][prefix - 8]: return 5
+        return 4
+    # now n has between 8 and 100 bits
+    # the optimal chunksize depends heavily on bit pattern subtleties in n
+    # we use the two values below to get an idea on the best approach
+    if length < 8:
+        return [2, 2, 3, 3, 2, 2, 3, 2][prefix - 8]
+    # number of times there are two ones with distance 2 apart in n
+    # note this is at least 1 for prefix 10,11,13,14 and at least two for 15
+    h2 = hamming(n & n >> 2)
+    # with these two numbers, we can combine a value for chunksize
+    # that is (in average) a fraction of a multiplication from optimal
+    # for lengths up to 17, it is optimal
+    if prefix == 8 or prefix == 12:
+        if length <= 14: return 2
+        if length > 83: return 4
+        return 2 if h2 < 4 + 25 // (length - 14) else 3
+    if prefix == 9:
+        # this is the most complicated one
+        if h2 < (31 - length) // 8: return 2
+        if length >= 60: return 4
+        if h2 < 3 + 110 // (64 - length) >> 1: return 4
+        return 3
+    if prefix == 10:
+        return 3 if length + h2 < 105 else 4
+    if prefix == 11:
+        # return 3 if length < 46 else 4
+        # there's a very complicated region around 45 to be handled here
+        return 3 if length + (h2 - 18) ** 2 // 19 < 50 else 4
+        # this saves .08 multiplications for numbers of 46 bits
+    if prefix == 13:
+        if length <= 14 or h2 < 9 + 40 // (length - 14) >> 1:
+            return 2
+        return 3 if length < 28 else 4
+    if prefix == 14:
+        return 3 if length < 84 else 4
+    if prefix == 15:
+        # the complicated region around 57 bits costs about .01 multiplication:
+        # we leave that since there's no benefit anymore
+        return 2 if h2 < 4 else (3 if length + h2 < 71 else 4)
+    raise ValueError
+
+def fastChunksize(n):
+    """Determine a very good chunk size for n,
+    but don't look further than the first two digits of n.
+    Roughly, using chunk size n costs 1<<n-1 multiplications to build the table
+    and n+2 multiplications per n+1 bits of exponent.
+    It is easy to verify that the crossover points are roughly:
+    2-3: 2*3*4 = 24 bits
+    3-4: 4*4*5 = 80 bits
+    4-5: 8*5*6 = 240 bits
+    5-6: 16*6*7 = 672 bits
+    If fact, for shorter numbers it depends heavily on the first few bits of
+    the exponent. So we look at the first four, and use this to make a better
+    guess. This saves a fraction of a multiplication on average, which still
+    makes it worth the effort spending a few instructions.
+    """
+    # let's do the easy to see cases first
+    length = n.bit_length()
+    if length <= 4: return 2
+    # first four bits of n to optimize the boundaries
+    prefix = n >> length - 4
+    # very short numbers
+    if length < 8:
+        return [2, 2, 3, 3, 2, 2, 3, 2][prefix - 8]
+    if length > 60:
+    # we don't want to compute h2 for such long numbers
+        # for odd prefix we don't need 3
+        if length < 84 and ~prefix & 1: return 3
+        if length < [198, 231, 216, 231, 198, 231, 215, 232][prefix - 8]: return 4
+        # in the C code we compare length >> 2
+        if length < [648, 670, 658, 672, 648, 671, 658, 672][prefix - 8]: return 5
+        return 6
+    # now n has between 8 and 60 bits
+    # the optimal chunksize depends heavily on bit pattern subtleties in n
+    # we use the h2 below to get an idea on the best approach
+    # number of times there are two ones with distance 2 apart in n
+    # note this is at least 1 for prefix 10,11,13,14 and at least two for 15
+    h2 = hamming(n & n >> 2) if length <= 60 else length // 4
+    # with length  prefix and h2, we can combine a value for chunksize
+    # that is (in average) a fraction of a multiplication from optimal
+    # for lengths up to 17, it is optimal
+    if prefix == 8 or prefix == 12:
+        if length <= 14: return 2
+        return 2 if h2 < 4 + 25 // (length - 14) else 3
+    if prefix == 9:
+        # this is the most complicated one
+        if h2 < (31 - length) // 8: return 2
+        if h2 < 3 + 110 // (64 - length) >> 1: return 4
+        return 3
+    if prefix == 10 or prefix == 14:
+        return 3
+    if prefix == 11:
+        # return 3 if length < 46 else 4
+        # there's a very complicated region around 45 to be handled here
+        return 3 if length + (h2 - 18) ** 2 // 19 < 50 else 4
+        # this saves .08 multiplications for numbers of 46 bits
+    if prefix == 13:
+        if length <= 14 or h2 < 9 + 40 // (length - 14) >> 1: return 2
+        return 3 if length < 28 else 4
+    if prefix == 15:
+        # the complicated region around 57 bits costs about .01 multiplication:
+        # we leave that since there's no benefit anymore
+        return 2 if h2 < 4 else (3 if length + h2 < 71 else 4)
+    raise ValueError
+
+goodChunksize = fastChunksize
+
+def otfR_good(n, ws=30):
+    """This optimal choice for chunk size gives pretty nice results.
+    Here's a comparison with respect to optimal parameter choice.
+    Method  Up to 10**3   10**4    10**5     10**6      10**7       10**8
+    Binary        12910  178226  2283954  27836418  327657410  3780229378
+    Optimal       11032  154298  1970878  23957755  282553573
+    Good          11039  154553  1974797  24024764  283496827  3254408073
+    Difference   -14.5%  -13.3%   -13.5%    -13.7%     -13.5%      -13.9%
+    """
+    return otfR(n, 32, goodChunksize(n))
+
+# analytic stuff -------------------------------------------
+def otfR_optimal(n, ws=30):
+    return min((otfR(n, ws, k) for k in range(2, 6)), key=int)
+
+def chooseBigChunk():
+    """Give statistical information for very big numbers
+    Apparently, we get something like this:
+    - 30: what otfR_good says
+    30-70: 4 appears to work nicely for prefixes 13, 9, 11, 15 too
+    70-250: most prefer 4, some 5
+    250-: all numbers use 5
+    750: all numbers use 66
+    """
+    for p in range(100):
+        if p % 10 == 0:
+            print("length  8  9 10 11 12 13 14 15   h2")
+        length = int(20 * 1.05 ** p)
+        n = getrandbits(length - 1) | 1 << length - 1
+        mults = [int(otfR(n, 30, k)) for k in range(2, 7)]
+        opt = min(mults)
+        opts = [i for i,m in enumerate(mults, start=2) if m==opt]
+        prefix = n >> length - 4
+        mask = (1 << length) - 1
+        h2 = hamming(mask & n & n >> 2)
+        print(f"{length:4d}:", "   " * (prefix - 8),
+            str(min(opts))+str(max(opts)), "   " * (15 - prefix), h2)
+
+def showSummary(m=9):
+    """Print the text in the header of otfR_good
+    """
+    print(end="Method To  ")
+    print(*(" " * (d-2) + f"10**{d:d}" for d in range(3, m)))
+    binary = [sum(int(est_mul_bin(n, 30)) for n in range(10 ** d))
+              for d in range(3, m)]
+    print(end="Binary     ")
+    print(*(f"{binary[d-3]:{d+3}d}" for d in range(3, m)))
+    optimal = [sum(int(otfR_optimal(n, 30)) for n in range(10 ** d))
+              for d in range(3, m-1)]
+    print(end="Optimal    ")
+    print(*(f"{optimal[d-3]:{d+3}d}" for d in range(3, m-1)))
+    good = [sum(int(otfR_good(n, 30)) for n in range(10 ** d))
+              for d in range(3, m)]
+    print(end="Good       ")
+    print(*(f"{good[d-3]:{d+3}d}" for d in range(3, m)))
+    print(end="Difference ")
+    print(*(f"{(good[d-3]-binary[d-3])/binary[d-3]:{d+3}.1%}"
+            for d in range(3, m)))
+
+# If you look at the output of this routine, you see the patterns
+# that allow to guess the optimal chunk size
+# for more, see showOverviewOutput.txt
+def showOverview(margin=.01, ws=30, lengths=None, prefixes=None, verbose=False):
+    """Shows a very concise overview of te best choices to make for
+    the otfR parameter.
+    Parameters: accuracy margin (take e.g. .001 for high accuracy (slow!)
+    ws: word size of Python's integers
+    lengths: iterable of bit lengths: default 6 to 100 in increasing steps
+    prefixs: iterable of prefixes: default is all
+    Lines are like this:
+    [22,9:2<1;3>4]24 4 4 4 4 34 3 s 3 3 3 3 3 3 3 3 3
+      | |  |   |  ^ choices for chunkSize for h2=0 and up that give value
+      | |  |   |    that uses almost optimal multiplications
+      | |  |   |    e.g. 34 means that for h2=5, both s and 4 are almost optimal
+      | |  |   ^ if h2>4, you can safely use s (! means: use always)
+      | |  ^ if h2<1, you can safely use 2
+      | ^ prefix (first four bits of number in hex)
+      ^ length of number in bits
+    If the line is near optimal for 2 (prefix 89cd) or 3 (prefix abef)
+    irrespective of h2, is it omitted.
+    Also notice the wordsize artifacts for numbers just above 30, 60.
+    Lower margin is more accurate, but slower of course
+    """
+    samplesize = int(1 / margin**2)
+    if prefixes is None: prefixes = range(8, 16)
+    if lengths is None: lengths = chain(
+            range(6,35),
+            range(35, 65, 2),
+            range(65, 100, 5))
+    for length in lengths:
+        for prefix in prefixes:
+            m2 = defaultdict(int)
+            m3 = defaultdict(int)
+            m4 = defaultdict(int)
+            m5 = defaultdict(int)
+            ns = range(prefix << length-4, prefix+1 << length-4)
+            if samplesize >> length - 4: pass
+            elif length < 30: ns = sample(ns, samplesize)
+            else: ns = islice(iter(
+                lambda:getrandbits(length-4)|prefix<<length-4,
+                None),samplesize)
+            for n in ns:
+                h2 = hamming(n&n>>2)
+                m2[h2] += int(otfR(n,ws,2))
+                m3[h2] += int(otfR(n,ws,3))
+                m4[h2] += int(otfR(n,ws,4))
+                m5[h2] += int(otfR(n,ws,5))
+            line = []
+            irrelevant = sum(m2.values()) * margin
+            for k in range(max(m2)+1):
+                m = m2[k],m3[k],m4[k],m5[k]
+                b = min(m) * (margin + 1)
+                line.append((''.join(
+                    str(i)
+                    for i,v in enumerate(m, start=2)
+                    if irrelevant <= v <= b)) or '-')
+            if not verbose:
+                prediction = str((prefix >> 1 & 1) + 2)
+                if all(prediction in w or w=='-' for w in line): continue
+            while line[-1] == '-': del line[-1]
+            head = ""
+            try:
+                non2 = min(i
+                           for i,w in enumerate(line)
+                           if "2" not in w and w != '-')
+                head += f"2<{non2}"
+            except ValueError: head += "2!"
+            try:
+                hi3 = max(i
+                          for i,w in enumerate(line)
+                          if "3" not in w and w != '-')
+                head += f";3>{hi3}"
+            except ValueError: head += ";3!"
+            try:
+                hi4 = max(i
+                          for i,w in enumerate(line)
+                          if "4" not in w and w != '-')
+                if hi4 < len(line) - 1: head += f";4>{hi4}"
+            except ValueError: head += ";4!"
+            line = ']' + ' '.join(line)
+            if prefix == 9: line = line.replace("3", "s")
+            print(f"[{length},{prefix:x}:" + head + line)
+        print()
+        #if length>15: input("?")
+
+def showOverview2(margin=.01, ws=30, lengths=None, prefixes=None):
+    """Checks out if goodChunksize works.
+    Parameters: accuracy margin (take e.g. .001 for high accuracy (slow!)
+    ws: word size of Python's integers
+    lengths: iterable of bit lengths: default 6 to 100 in increasing steps
+    prefixs: iterable of prefixes: default is all
+    [22,9:0.100]24 4 4 4 4 s4 s s s s s s s s s s s
+      ^ ^  ^    ^ choices for chunkSize for h2=0 and up that give value
+      | |  |      that uses almost optimal multiplications
+      | |  |      e.g. 34 means that for h2=5, both s and 4 are almost optimal
+      | |  ^  number of multiplications lost per call to goodChunksize
+      | ^ prefix (first four bits of number in hex)
+      ^ length of number in bits
+    """
+    if prefixes is None: prefixes = range(8, 16)
+    if lengths is None: lengths = chain(
+            range(6,35),
+            range(35, 65, 2),
+            range(65, 100, 5))
+    totalLoss = 0
+    samplesize = int(1 / margin**2)
+    for length in lengths:
+        for prefix in prefixes:
+            m2 = defaultdict(int)
+            m3 = defaultdict(int)
+            m4 = defaultdict(int)
+            m5 = defaultdict(int)
+            m6 = defaultdict(int)
+            choice = {}
+            ns = range(prefix << length-4, prefix+1 << length-4)
+            if samplesize >> length - 4: pass
+            elif length < 30: ns = sample(ns, samplesize)
+            else: ns = islice(iter(
+                lambda:getrandbits(length-4)|prefix<<length-4,
+                None),samplesize)
+            samples = 0
+            for n in ns:
+                samples += 1
+                h2 = hamming(n&n>>2)
+                m2[h2] += int(otfR(n,ws,2))
+                m3[h2] += int(otfR(n,ws,3))
+                m4[h2] += int(otfR(n,ws,4))
+                m5[h2] += int(otfR(n,ws,5))
+                m6[h2] += int(otfR(n,ws,6))
+                if h2 not in choice: choice[h2] = goodChunksize(n)
+            line = []
+            irrelevant = sum(m2.values()) * margin
+            loss = 0
+            for k in range(max(m2)+1):
+                m = m2[k],m3[k],m4[k],m5[k],m6[k]
+                b = min(m) * (margin + 1)
+                line.append((''.join(
+                    str(i)
+                    for i,v in enumerate(m, start=2)
+                    if irrelevant <= v <= b)) or '-')
+                if k in choice:
+                    loss += m[choice[k] - 2] - min(m)
+            while line and line[-1] == '-': del line[-1]
+            if line[:3] == ['-', '-', '-']:
+                firstNonDash = 0
+                while line[firstNonDash] == '-': firstNonDash += 1
+                line[:firstNonDash] = [str(firstNonDash) + '*-']
+            line = ']' + ' '.join(line)
+            print(f"[{length},{prefix:x}:{loss/samples:.3f}"  + line)
+            totalLoss += loss/samples
+        if len(prefixes) != 1: print()
+    return totalLoss
+
+# extended tests ---------------------------------------------------
+__test__ = {
+'mul_bin_small': '''
+    >>> for i in range(256):
+    ...   if est_mul_bin(i,4) != mul_bin(i, 4):
+    ...      print(i, est_mul_bin(i,4), mul_bin(i, 4))
+''',
+'mul_bin_big': '''
+    >>> for b in range(8, 100):
+    ...   r = getrandbits(b)
+    ...   if est_mul_bin(r, 15) != mul_bin(r, 15):
+    ...      print(i, est_mul_bin(i,15), mul_bin(i, 15))
+    ...   if est_mul_bin(r, 30) != mul_bin(r, 30):
+    ...      print(i, est_mul_bin(i,30), mul_bin(i, 30))
+''',
+'mulP_small': '''
+    >>> for i in range(256):
+    ...   if est_mulP(i,4,2) != mulP(i, 4, 2):
+    ...      print(i, est_mulP(i,4, 2), mulP(i, 4, 2))
+''',
+'mulP_big': '''
+    >>> for b in range(8, 100):
+    ...   r = getrandbits(b)
+    ...   if est_mulP(r, 15, 3) != mulP(r, 15, 3):
+    ...      print(b, est_mulP(r, 15, 3), mulP(r, 15, 3))
+    ...   if est_mulP(r, 30, 5) != mulP(r, 30, 5):
+    ...      print(b, est_mulP(r, 30, 5), mulP(r, 30, 5))
+''',
+'otfR_small': '''
+    >>> otfR(0x1b, 15, 2)
+    Mults(squares=4, mults=2, empty=0, chunkSize=2)
+    >>> otfR(0x27, 15, 3)
+    Mults(squares=3, mults=5, empty=0, chunkSize=3)
+    >>> otfR(0x73, 15, 3)
+    Mults(squares=5, mults=4, empty=0, chunkSize=3)
+    >>> for i in range(10):
+    ...    print (i, otfR(i, 8, 2 + i % 2))   #doctest:   +REPORT_NDIFF
+    0 Mults(squares=0, mults=0, empty=0, chunkSize=2)
+    1 Mults(squares=0, mults=0, empty=0, chunkSize=3)
+    2 Mults(squares=1, mults=0, empty=0, chunkSize=2)
+    3 Mults(squares=1, mults=1, empty=0, chunkSize=3)
+    4 Mults(squares=2, mults=0, empty=0, chunkSize=2)
+    5 Mults(squares=1, mults=2, empty=0, chunkSize=3)
+    6 Mults(squares=2, mults=1, empty=0, chunkSize=2)
+    7 Mults(squares=1, mults=3, empty=0, chunkSize=3)
+    8 Mults(squares=3, mults=0, empty=0, chunkSize=2)
+    9 Mults(squares=3, mults=1, empty=0, chunkSize=3)
+''',
+'quality': '''
+    >>> sum(int(est_mulP(n, 30, 5)) for n in range(1024))
+    38688
+    >>> sum(int(est_mulJ(n, 30, 5)) for n in range(1024))
+    21934
+    >>> sum(int(est_mulP(n, 30, 3)) for n in range(1024))
+    17832
+    >>> sum(int(est_mulP(n, 30, 2)) for n in range(1024))
+    14424
+    >>> sum(int(est_mul_bin(n, 30)) for n in range(1024))
+    13314
+    >>> sum(int(est_mulJ(n, 30, 3)) for n in range(1024))
+    12482
+    >>> sum(int(est_mulJ(n, 30, 2)) for n in range(1024))
+    11724
+    >>> sum(int(otfR(n, 30, 3)) for n in range(1024))
+    11581
+    >>> sum(int(otfR(n, 30, 2)) for n in range(1024))
+    11578
+    >>> sum(int(otfR(n, 30, 2)) > int(est_mul_bin(n, 30)) for n in range(1024))
+    0
+''',
+}
+
+if __name__ == "__main__":
+    import doctest
+    print(doctest.testmod())
+

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4225,7 +4225,7 @@ prepare_pow(PyLongObject* n, uint64_t* firstDigits, Py_ssize_t* restOfDigits)
         switch (upperBits >> (bitLength - 4)) {
         case 8:
         case 12:
-            if (bitLength < 14 || hamming2 < 4 + 25 / (bitLength - 14))
+            if (bitLength <= 14 || hamming2 < 4 + 25 / (bitLength - 14))
                 return 2;
             break;
         case 9:
@@ -4568,6 +4568,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
                 goto Error;
             Py_DECREF(a);
             a = temp;
+            temp = NULL;
         }
 
         /* Reduce base by modulus in some cases:
@@ -4609,10 +4610,10 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     Py_CLEAR(z);
     /* fall through */
   Done:
+    assert(temp == NULL);
     Py_DECREF(a);
     Py_DECREF(b);
     Py_XDECREF(c);
-    Py_XDECREF(temp);
     return (PyObject *)z;
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -26,7 +26,7 @@ int _Py_bit_length64(uint64_t x) {
     return _Py_bit_length((unsigned long)x);
 }
 
-int _Py_bit_count(unsigned long x) {
+int _Py_bitcount(unsigned long x) {
 #define o33333333333 0xDB6DB6DB
 #define o11111111111 0x49249249
 #define o30303030303 0xC30C30C3
@@ -39,7 +39,7 @@ int _Py_bit_count(unsigned long x) {
 }
 
 int _Py_bit_count64(uint64_t x) {
-    return _Py_bit_count(x >> 32) + _Py_bit_count((unsigned long)x);
+    return _Py_popcount32(x >> 32) + _Py_popcount32((unsigned long)x);
 }
 
 #ifndef NSMALLPOSINTS

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4342,18 +4342,19 @@ PyLongObject* addition_chain(
     if (!currentDigit)
         return (PyLongObject*)PyLong_FromLong(1L);
 
-    // Prepare the table
+    // Prepare the table by storing a in table[0]
+    / table[0] could be the result of the call
     // since a can be > c, it must be reduced
     if (c != NULL) {
         if (l_divmod(a, c, NULL, &temp) < 0)
             goto Error;
-        table[0] = temp;
-        temp = NULL;
     }
-    // Make sure we have a long in the table, because it could be copied
-    temp = (PyLongObject*)long_long(a);
-    if (temp == NULL)
-        goto Error;
+    else {
+        // Make sure we have a long in the table, because it could be something int-like
+        temp = (PyLongObject*)long_long(a);
+        if (temp == NULL)
+            goto Error;
+    }
     table[0] = temp;
     temp = NULL;
     tableSize = 0;
@@ -4361,7 +4362,7 @@ PyLongObject* addition_chain(
     // Skip the computation of aSquared for exponent 1
     // because it isn't used
     if (restOfDigits || (currentDigit > 1))
-        MULTMODC(a, a, aSquared);
+        MULTMODC(table[0], table[0], aSquared);
 
     // The loop does this
     // Find a power of at most chunkSize bits that is odd

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -31,12 +31,8 @@ int _Py_bit_count64(uint64_t x) {
     return _Py_popcount32(x >> 32) + _Py_popcount32((unsigned long)x);
 }
 
-#ifndef NSMALLPOSINTS
-#define NSMALLPOSINTS           257
-#endif
-#ifndef NSMALLNEGINTS
-#define NSMALLNEGINTS           5
-#endif
+#define NSMALLNEGINTS           _PY_NSMALLNEGINTS
+#define NSMALLPOSINTS           _PY_NSMALLPOSINTS
 
 _Py_IDENTIFIER(little);
 _Py_IDENTIFIER(big);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3978,7 +3978,7 @@ long_mod(PyObject *a, PyObject *b)
 
     if (Py_ABS(Py_SIZE(a)) == 1 && Py_ABS(Py_SIZE(b)) == 1) {
         return fast_mod((PyLongObject*)a, (PyLongObject*)b);
-    }
+    }b
 
     if (l_divmod((PyLongObject*)a, (PyLongObject*)b, NULL, &mod) < 0)
         mod = NULL;
@@ -4350,10 +4350,12 @@ PyLongObject* addition_chain(
         table[0] = temp;
         temp = NULL;
     }
-    else {
-        table[0] = (PyLongObject*)a;
-    }
-    Py_INCREF(table[0]);
+    // Make sure we have a long in the table, because it could be copied
+    temp = (PyLongObject*)long_long(a);
+    if (temp == NULL)
+        goto Error;
+    table[0] = temp;
+    temp = NULL;
     tableSize = 0;
 
     // Skip the computation of aSquared for exponent 1

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4343,7 +4343,7 @@ PyLongObject* addition_chain(
         return (PyLongObject*)PyLong_FromLong(1L);
 
     // Prepare the table by storing a in table[0]
-    / table[0] could be the result of the call
+    // table[0] could be the result of the call
     // since a can be > c, it must be reduced
     if (c != NULL) {
         if (l_divmod(a, c, NULL, &temp) < 0)

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -20,8 +20,34 @@ class int "PyObject *" "&PyLong_Type"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=ec0275e3422a36e3]*/
 
-#define NSMALLNEGINTS           _PY_NSMALLNEGINTS
-#define NSMALLPOSINTS           _PY_NSMALLPOSINTS
+int _Py_bit_length64(uint64_t x) {
+    if (x >= (uint64_t)1 << 32)
+        return 32 + _Py_bit_length(x >> 32);
+    return _Py_bit_length((unsigned long)x);
+}
+
+int _Py_bit_count(unsigned long x) {
+#define o33333333333 0xDB6DB6DB
+#define o11111111111 0x49249249
+#define o30303030303 0xC30C30C3
+    // count bits in groups of three (octal: 0o
+    x = x - ((x >> 1) & o33333333333) - ((x >> 2) & o11111111111);
+    // combine groups to groups of six
+    x = ((x >> 3) & o30303030303) + (x & o30303030303);
+    // add groups together
+    return x % 63;
+}
+
+int _Py_bit_count64(uint64_t x) {
+    return _Py_bit_count(x >> 32) + _Py_bit_count((unsigned long)x);
+}
+
+#ifndef NSMALLPOSINTS
+#define NSMALLPOSINTS           257
+#endif
+#ifndef NSMALLNEGINTS
+#define NSMALLNEGINTS           5
+#endif
 
 _Py_IDENTIFIER(little);
 _Py_IDENTIFIER(big);
@@ -80,13 +106,6 @@ _PyLong_Negate(PyLongObject **x_p)
  */
 #define KARATSUBA_CUTOFF 70
 #define KARATSUBA_SQUARE_CUTOFF (2 * KARATSUBA_CUTOFF)
-
-/* For exponentiation, use the binary left-to-right algorithm
- * unless the exponent contains more than FIVEARY_CUTOFF digits.
- * In that case, do 5 bits at a time.  The potential drawback is that
- * a table of 2**5 intermediate results is computed.
- */
-#define FIVEARY_CUTOFF 8
 
 #define SIGCHECK(PyTryBlock)                    \
     do {                                        \
@@ -4091,6 +4110,370 @@ long_invmod(PyLongObject *a, PyLongObject *n)
     return NULL;
 }
 
+/* Perform a modular reduction, X = X % c, but leave X alone if c
+ * is NULL.
+ */
+#define REDUCEMODC(X)                                       \
+    do {                                                \
+        if (c != NULL) {                                \
+            if (l_divmod(X, c, NULL, &temp) < 0)        \
+                goto Error;                             \
+            Py_XDECREF(X);                              \
+            X = temp;                                   \
+            temp = NULL;                                \
+        }                                               \
+    } while(0)
+
+ /* Multiply two values, then reduce the result:
+    result = X*Y % c.  If c is NULL, skip the mod. */
+#define MULTMODC(X, Y, result)                      \
+    do {                                        \
+        temp = (PyLongObject *)long_mul(X, Y);  \
+        if (temp == NULL)                       \
+            goto Error;                         \
+        Py_XDECREF(result);                     \
+        result = temp;                          \
+        temp = NULL;                            \
+        REDUCEMODC(result);                         \
+    } while(0)
+
+/* Generate entries in the table to make sure the proper one is there
+ * uses square and c
+ */
+#define ENSURE_TABLE_ENTRY(chunk)                                          \
+    do {                                                                \
+        while(tableSize < chunk / 2) {                                  \
+            MULTMODC(aSquared, table[tableSize], table[tableSize + 1]); \
+            tableSize++;                                                \
+        }                                                               \
+    } while (0);
+
+
+/* The routine prepare_pow gives chooses a chunksize
+ * that produces a number of multiplications very close to optimal for
+ * the addition chain routine
+ * This piece of horrible black belt voodoo magic code produces
+ * the best chunksize value to use for exponentiations.
+ * The problem is that the best way to produce a power (i.e. generate
+ * an addition chain) depends on subtle properties of the number.
+ * It is the result of a few days of computations to find a good heuristic
+ * and optimize the parameters.
+ * Comparison of the number of multiplies:
+ *    Method  Up to 10**3   10**4    10**5     10**6      10**7       10**8
+ *    Binary        12910  178226  2283954  27836418  327657410  3780229378
+ *    Optimal       11032  154298  1970878  23957755  282553573  <too slow to count>
+ *    Good          11039  154553  1974797  24024764  283496827  3254408073
+ *    Difference   -14.5%  -13.3%   -13.5%    -13.7%     -13.5%      -13.9%
+ * where:
+ *    Binary = binary method
+ *    Optimal = the best parameter for the routine below
+ *    Good = what the routine below returns
+ *    Difference = with respect to binary (HAC Algorithm 14.79)
+*/
+
+// Number of Python digits that fit in an ulong
+#define DIGITS_IN_ULONG (60 / PYLONG_BITS_IN_DIGIT)
+
+ /* Compute for the power routine:
+  * - The first up to 60 bits of the exponent
+  * - the number of extra digits to be expected
+  * - a heuristics based good value for chunksize
+  * n is a PyLong that is >0
+  */
+
+// Heuristic constants. See expHeuristics.txt
+static const unsigned char CHUNKSIZES5TO7[8] = {
+    2, 3, 2, 3, 2, 3, 2, 2 };
+static const unsigned char LENGTHSFOR4[8] = {
+    198, 231, 216, 231, 198, 231, 215, 232 };
+static const unsigned short LENGHTSFOR5DIV4[8] = {
+    648 >> 2, 670 >> 2, 658 >> 2, 672 >> 2,
+    648 >> 2, 671 >> 2, 658 >> 2, 672 >> 2 };
+
+inline static int
+prepare_pow(PyLongObject* n, uint64_t* firstDigits, Py_ssize_t* restOfDigits)
+{
+    // local copy of *firstDigits
+    uint64_t upperBits;
+    // number of Python digits in the exponent
+    Py_ssize_t numberOfDigits = Py_SIZE(n);
+
+    // Handle the common case of numbers of at most 7 bits
+    if (numberOfDigits == 0) {
+        digit nValue = n->ob_digit[0];
+        *firstDigits = nValue;
+        *restOfDigits = 0;
+        if (nValue < 16)
+            return 2;
+        // since the digit is now at least four bits, we can compute the prefix
+        int bitLength = bit_length_digit(nValue);
+        int prefix = nValue >> (bitLength - 4);
+        return CHUNKSIZES5TO7[prefix - 8];
+    }
+
+    /* Handle numbers of up to 60 bits
+     * this is the most complicated case
+     * because the pattern in the bits really matters
+     * This code is all heuristic; all is does is return 2, 3 or 4
+     * A wrong result wouldn't break the code, just make it slower
+     */
+    if (numberOfDigits < DIGITS_IN_ULONG) {
+        *firstDigits = upperBits = PyLong_AsUnsignedLongLong((PyObject*)n);
+        *restOfDigits = 0;
+        int bitLength = _Py_bit_length64(upperBits);
+        // we use this value to get insight in the bit pattern
+        int hamming2 = _Py_bit_count64(upperBits & upperBits >> 2);
+        // distinguish the prefixes
+        // find reasons for choosing chunksize 2 or 4 instead of the default 3
+        switch (upperBits >> (bitLength - 4)) {
+        case 8:
+        case 12:
+            if (bitLength < 14 || hamming2 < 4 + 25 / (bitLength - 14))
+                return 2;
+            break;
+        case 9:
+            if (hamming2 < (31 - bitLength) / 8)
+                return 2;
+            if (hamming2 < (3 + (110 / (64 - bitLength) >> 1)))
+                return 4;
+            break;
+        case 11:
+            if (bitLength + (hamming2 - 18) * (hamming2 - 18) / 19 > 49)
+                return 4;
+            break;
+        case 13:
+            if ((bitLength <= 14) || hamming2 < ((9 + 40 / (bitLength - 14)) >> 1))
+                return 2;
+            if (bitLength > 27)
+                return 4;
+            break;
+        case 15:
+            if (hamming2 < 4)
+                return 2;
+            if (bitLength + hamming2 > 70)
+                return 4;
+            break;
+        }
+        return 3;
+    }
+
+    // Now the number is longer than 60 bits
+    // Get the most significant bits in firstDigits
+    upperBits = 0;
+    for (int i = 1; i <= DIGITS_IN_ULONG; i++) {
+        upperBits <<= PYLONG_BITS_IN_DIGIT;
+        upperBits += n->ob_digit[numberOfDigits - i];
+    }
+    *firstDigits = upperBits;
+    *restOfDigits = numberOfDigits - DIGITS_IN_ULONG;
+    // bit length of the upper bits for the prefix
+    int upperBitLength = _Py_bit_length64(upperBits);
+    uint8_t prefix = (uint8_t)(upperBits >> (upperBitLength - 4));
+    Py_ssize_t numberOfBits = upperBitLength + PYLONG_BITS_IN_DIGIT * numberOfDigits;
+    // Now return the heuristic value for the chunk size
+    // LENGHTSFOR3 would be [84, 0, 84, 0, 84, 0, 84, 0], but this is faster
+    if ((numberOfBits < 84) && !(prefix & 1))
+        return 3;
+    if (numberOfBits < LENGTHSFOR4[prefix - 8])
+        return 4;
+    if ((numberOfBits >> 2) < LENGHTSFOR5DIV4[prefix - 8])
+        return 5;
+    return 6;
+}
+
+// table for the addition chain routine to help find bit patterns
+// for chunk sizes 2 through 4 (last row is for 5 and 6)
+// tell how much bitPos needs to be corrected given digit >> bitPos
+static const signed char CHUNKJUMPTABLE[5][16] = {
+    //0  01  10  11 100 101 110 111 1000 1001 1010 1011 1100 1101 1110 1111
+    {-4, -3,  1,  0,  2,  2,  1,  1,   3,   3,   3,   3,   2,   2,   2,   2},
+    {-4, -3, -2, -2,  2,  0,  1,  0,   3,   3,   1,   1,   2,   2,   1,   1},
+    {-4, -3, -2, -2, -1, -1, -1, -1,   3,   0,   1,   0,   2,   0,   1,   0},
+    { 4,  0,  1,  0,  2,  0,  1,  0,   3,   0,   1,   0,   2,   0,   1,   0}
+};
+
+/* Addition chain generator for the exponent function 
+ * Compute power using an addition chain generator which is an optimized
+ * and generalized version of the "5-ary" method from HAC 14.82
+ * (which is actually 32-ary).
+ * http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf
+ * Parameter: the chunk size, which is the number of bits of the exponent
+ * processed per step.
+ * computes result = pow(a, b, c)
+ * assumes b >= 0
+ * gererates a new reference
+ *
+ * Differences with the HAC method:
+ *    The table contains only odd entries saving 50% on building time
+ *    zeroes in the exponent are skipped
+ *    Upper entries in the table are computed on-the-fly
+ *  Roughly, using chunk size n costs 1<<n-1 multiplications to build the table
+ *  and n+2 multiplications per n+1 bits of exponent.
+ *  It is easy to verify that the crossover points are roughly:
+ *  2-3: 2*3*4 = 24 bits
+ *  3-4: 4*4*5 = 80 bits
+ *  4-5: 8*5*6 = 240 bits
+ *  5-6: 16*6*7 = 672 bits
+ */
+
+static inline
+PyLongObject* addition_chain(
+    PyLongObject* a, PyLongObject* b, PyLongObject* c)
+{
+    /* If the exponent is large enough, table is
+     * precomputed so that table[i] == a**i % c for i in range(32).
+     * Size of table is 1 << chunksize - 1
+     * Table entry i corresponds to a ** (2 * i + 1)
+     */
+    PyLongObject* result = 0;
+    PyLongObject* table[32] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
+    // index of last full entry in table
+    int tableSize;
+    // if the exponent is larger than 1, we store the square here
+    PyLongObject* aSquared = 0;
+    // for digit loop: value of current digit, and number to digits to process then
+    uint64_t currentDigit = 0;
+    Py_ssize_t restOfDigits = 0;
+    int chunkSize;
+    PyLongObject* temp = NULL;
+
+    // Determine the optimal chunk size, first digit, number of rest
+    chunkSize = prepare_pow(b, &currentDigit, &restOfDigits);
+
+    // handle 0th power
+    if (!currentDigit)
+        return (PyLongObject*)PyLong_FromLong(1L);
+
+    // Prepare the table
+    table[0] = (PyLongObject*)a;
+    tableSize = 0;
+    Py_INCREF(a);
+
+    // Skip the computation of aSquared for exponent 1
+    // because it isn't used
+    if (restOfDigits || (currentDigit > 1))
+        MULTMODC(a, a, aSquared);
+
+    // The loop does this
+    // Find a power of at most chunkSize bits that is odd
+    // Look up in the table (generating it if needed)
+    // From then on, repeatedly square the result
+    // and multiply with as high as possible table entries
+    // taking into account that there are only odd entries
+    // squaresToDo keeps the number of squares before getting a new digit
+    // bitPosition keeps the location of the least significant bit of the chunk
+    int bitPosition = _Py_bit_length64(currentDigit); 
+    int squaresToDo = 0;
+
+    // loop over the digits
+    // Note: the actual initalisation of result is in the middle of this loop!
+    while (1) {
+        // at this point, bitPosition is >= currentDigit.bit_length()
+        assert(currentDigit >> bitPosition == 0);
+        while (currentDigit) {
+            if (chunkSize <= 4) {
+                // adjust bitPosition jumping by four using table
+                signed char delta = -4;
+                do {
+                    bitPosition += delta;
+                    if (bitPosition < 0) {
+                        // overshoot. This means that currentDigits has fewer bits than chunkSize
+                        // fortunately, our table can be used to fix it
+                        // put that value in delta, since it will be added anyway
+                        bitPosition = 0;
+                        if (currentDigit == 1)
+                            delta = 0;
+                        else
+                            delta = CHUNKJUMPTABLE[0][currentDigit];
+                        break;
+                    }
+                    // determine new jump size
+                    delta = CHUNKJUMPTABLE[chunkSize - 2][currentDigit >> bitPosition];
+                } while (delta < 0);
+                bitPosition += delta;
+            }
+            else {
+                // adjust bitPosition in one step
+                bitPosition = _Py_bit_length64(currentDigit);
+                if (bitPosition < chunkSize)
+                    bitPosition = 0;
+                else
+                    bitPosition -= chunkSize;
+                bitPosition += CHUNKJUMPTABLE[3][(currentDigit >> bitPosition) & 0xf];
+                // since we only checked 4 bits
+                // value 2 is still possible if chunkSize = 6
+                if (currentDigit >> bitPosition == 2)
+                    bitPosition++;
+            }
+
+            uint8_t chunk;
+            // get the chunk
+            chunk = (uint8_t)(currentDigit >> bitPosition);
+            // chunk is just right at this point thanks to the table
+            assert(chunk & 1);
+            if (result) {
+                // square until we are the proper position, then multiply
+                while (squaresToDo > bitPosition) {
+                    MULTMODC(result, result, result);
+                    squaresToDo -= 1;
+                }
+                ENSURE_TABLE_ENTRY(chunk);
+                MULTMODC(result, table[chunk / 2], result);
+            }
+            else {
+                // Result gets initialized at this point, from a known value
+                // let's see if we can squeeze out a few more bits by using 2 or 9
+                if (bitPosition && chunk == 1) {
+                    bitPosition--;
+                    chunk = 2;
+                    assert(currentDigit >> bitPosition == chunk);
+                    result = aSquared;
+                }
+                else if (bitPosition > 3 && currentDigit >> (bitPosition - 4) == 9) {
+                    bitPosition -= 3;
+                    chunk = 9;
+                    assert(currentDigit >> bitPosition == chunk);
+                    ENSURE_TABLE_ENTRY(chunk);
+                    result = table[chunk / 2];
+                } else {
+                    ENSURE_TABLE_ENTRY(chunk);
+                    result = table[chunk / 2];
+                }
+                // start the computation from here
+                Py_INCREF(result);
+                squaresToDo = bitPosition;
+            }
+            // now all bits up to bitPosition are processed
+            currentDigit &= ((uint64_t)1 << bitPosition) - 1;
+            // set bitPosition to get the maximum chunkk
+            bitPosition = squaresToDo;
+        }
+        // current digit has to ones anymore, but we may have to square a few times
+        while (squaresToDo) {
+            MULTMODC(result, result, result);
+            squaresToDo -= 1;
+        }
+        // fetch new digit, or stop
+        if (restOfDigits) {
+            currentDigit = b->ob_digit[--restOfDigits];
+            bitPosition = squaresToDo = PYLONG_BITS_IN_DIGIT;
+        }
+        else
+            break;
+    }
+    goto Done;
+Error:
+    Py_CLEAR(result);
+    /* fall through */
+Done:
+    // Clean up, make sure we leave no pointers to dead objects
+    Py_CLEAR(aSquared);
+    for (int i = 0; i < 32 && table[i]; i++)
+        Py_CLEAR(table[i]);
+    return result;
+}
+
 
 /* pow(v, w, x) */
 static PyObject *
@@ -4100,14 +4483,8 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     int negativeOutput = 0;  /* if x<0 return negative output */
 
     PyLongObject *z = NULL;  /* accumulated result */
-    Py_ssize_t i, j, k;             /* counters */
     PyLongObject *temp = NULL;
 
-    /* 5-ary values.  If the exponent is large enough, table is
-     * precomputed so that table[i] == a**i % c for i in range(32).
-     */
-    PyLongObject *table[32] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                               0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
     /* a, b, c = v, w, x */
     CHECK_BINOP(v, w);
@@ -4208,70 +4585,10 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     /* At this point a, b, and c are guaranteed non-negative UNLESS
        c is NULL, in which case a may be negative. */
 
-    z = (PyLongObject *)PyLong_FromLong(1L);
+    z = addition_chain(a, b, c);
+
     if (z == NULL)
         goto Error;
-
-    /* Perform a modular reduction, X = X % c, but leave X alone if c
-     * is NULL.
-     */
-#define REDUCE(X)                                       \
-    do {                                                \
-        if (c != NULL) {                                \
-            if (l_divmod(X, c, NULL, &temp) < 0)        \
-                goto Error;                             \
-            Py_XDECREF(X);                              \
-            X = temp;                                   \
-            temp = NULL;                                \
-        }                                               \
-    } while(0)
-
-    /* Multiply two values, then reduce the result:
-       result = X*Y % c.  If c is NULL, skip the mod. */
-#define MULT(X, Y, result)                      \
-    do {                                        \
-        temp = (PyLongObject *)long_mul(X, Y);  \
-        if (temp == NULL)                       \
-            goto Error;                         \
-        Py_XDECREF(result);                     \
-        result = temp;                          \
-        temp = NULL;                            \
-        REDUCE(result);                         \
-    } while(0)
-
-    if (Py_SIZE(b) <= FIVEARY_CUTOFF) {
-        /* Left-to-right binary exponentiation (HAC Algorithm 14.79) */
-        /* http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf    */
-        for (i = Py_SIZE(b) - 1; i >= 0; --i) {
-            digit bi = b->ob_digit[i];
-
-            for (j = (digit)1 << (PyLong_SHIFT-1); j != 0; j >>= 1) {
-                MULT(z, z, z);
-                if (bi & j)
-                    MULT(z, a, z);
-            }
-        }
-    }
-    else {
-        /* Left-to-right 5-ary exponentiation (HAC Algorithm 14.82) */
-        Py_INCREF(z);           /* still holds 1L */
-        table[0] = z;
-        for (i = 1; i < 32; ++i)
-            MULT(table[i-1], a, table[i]);
-
-        for (i = Py_SIZE(b) - 1; i >= 0; --i) {
-            const digit bi = b->ob_digit[i];
-
-            for (j = PyLong_SHIFT - 5; j >= 0; j -= 5) {
-                const int index = (bi >> j) & 0x1f;
-                for (k = 0; k < 5; ++k)
-                    MULT(z, z, z);
-                if (index)
-                    MULT(z, table[index], z);
-            }
-        }
-    }
-
     if (negativeOutput && (Py_SIZE(z) != 0)) {
         temp = (PyLongObject *)long_sub(z, c);
         if (temp == NULL)
@@ -4286,10 +4603,6 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
     Py_CLEAR(z);
     /* fall through */
   Done:
-    if (Py_SIZE(b) > FIVEARY_CUTOFF) {
-        for (i = 0; i < 32; ++i)
-            Py_XDECREF(table[i]);
-    }
     Py_DECREF(a);
     Py_DECREF(b);
     Py_XDECREF(c);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -20,22 +20,11 @@ class int "PyObject *" "&PyLong_Type"
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=ec0275e3422a36e3]*/
 
+// These routine would be more happy in bitutils
 int _Py_bit_length64(uint64_t x) {
     if (x >= (uint64_t)1 << 32)
         return 32 + _Py_bit_length(x >> 32);
     return _Py_bit_length((unsigned long)x);
-}
-
-int _Py_bitcount(unsigned long x) {
-#define o33333333333 0xDB6DB6DB
-#define o11111111111 0x49249249
-#define o30303030303 0xC30C30C3
-    // count bits in groups of three (octal: 0o
-    x = x - ((x >> 1) & o33333333333) - ((x >> 2) & o11111111111);
-    // combine groups to groups of six
-    x = ((x >> 3) & o30303030303) + (x & o30303030303);
-    // add groups together
-    return x % 63;
 }
 
 int _Py_bit_count64(uint64_t x) {
@@ -4110,8 +4099,10 @@ long_invmod(PyLongObject *a, PyLongObject *n)
     return NULL;
 }
 
+// Beginning of addition chain code
 /* Perform a modular reduction, X = X % c, but leave X alone if c
  * is NULL.
+ * This routine is used both in long_pow and in addition_chain
  */
 #define REDUCEMODC(X)                                       \
     do {                                                \
@@ -4138,7 +4129,8 @@ long_invmod(PyLongObject *a, PyLongObject *n)
     } while(0)
 
 /* Generate entries in the table to make sure the proper one is there
- * uses square and c
+ * uses aSquare and c
+ * Used in addition_chain
  */
 #define ENSURE_TABLE_ENTRY(chunk)                                          \
     do {                                                                \
@@ -4151,7 +4143,7 @@ long_invmod(PyLongObject *a, PyLongObject *n)
 
 /* The routine prepare_pow gives chooses a chunksize
  * that produces a number of multiplications very close to optimal for
- * the addition chain routine
+ * the addition chain routine.
  * This piece of horrible black belt voodoo magic code produces
  * the best chunksize value to use for exponentiations.
  * The problem is that the best way to produce a power (i.e. generate
@@ -4169,6 +4161,7 @@ long_invmod(PyLongObject *a, PyLongObject *n)
  *    Optimal = the best parameter for the routine below
  *    Good = what the routine below returns
  *    Difference = with respect to binary (HAC Algorithm 14.79)
+ * Full explanation how I did this is in Misc/additionchain.txt
 */
 
 // Number of Python digits that fit in an ulong
@@ -4176,12 +4169,11 @@ long_invmod(PyLongObject *a, PyLongObject *n)
 
  /* Compute for the power routine:
   * - The first up to 60 bits of the exponent
-  * - the number of extra digits to be expected
+  * - the number of extra digits following these
   * - a heuristics based good value for chunksize
-  * n is a PyLong that is >0
+  * n is a PyLong that is >0, borrowed reference
   */
 
-// Heuristic constants. See expHeuristics.txt
 static const unsigned char CHUNKSIZES5TO7[8] = {
     2, 3, 2, 3, 2, 3, 2, 2 };
 static const unsigned char LENGTHSFOR4[8] = {
@@ -4199,16 +4191,21 @@ prepare_pow(PyLongObject* n, uint64_t* firstDigits, Py_ssize_t* restOfDigits)
     Py_ssize_t numberOfDigits = Py_SIZE(n);
 
     // Handle the common case of numbers of at most 7 bits
-    if (numberOfDigits == 0) {
+    if (numberOfDigits <= 1) {
         digit nValue = n->ob_digit[0];
         *firstDigits = nValue;
         *restOfDigits = 0;
         if (nValue < 16)
+            // four bits or less
             return 2;
-        // since the digit is now at least four bits, we can compute the prefix
-        int bitLength = bit_length_digit(nValue);
-        int prefix = nValue >> (bitLength - 4);
-        return CHUNKSIZES5TO7[prefix - 8];
+        if (nValue < 128) {
+            // seven bits or less
+            // since the digit is now at least four bits,
+            // we can compute the prefix
+            int bitLength = bit_length_digit(nValue);
+            int prefix = nValue >> (bitLength - 4);
+            return CHUNKSIZES5TO7[prefix - 8];
+        }
     }
 
     /* Handle numbers of up to 60 bits
@@ -4217,7 +4214,7 @@ prepare_pow(PyLongObject* n, uint64_t* firstDigits, Py_ssize_t* restOfDigits)
      * This code is all heuristic; all is does is return 2, 3 or 4
      * A wrong result wouldn't break the code, just make it slower
      */
-    if (numberOfDigits < DIGITS_IN_ULONG) {
+    if (numberOfDigits <= DIGITS_IN_ULONG) {
         *firstDigits = upperBits = PyLong_AsUnsignedLongLong((PyObject*)n);
         *restOfDigits = 0;
         int bitLength = _Py_bit_length64(upperBits);
@@ -4269,7 +4266,7 @@ prepare_pow(PyLongObject* n, uint64_t* firstDigits, Py_ssize_t* restOfDigits)
     // bit length of the upper bits for the prefix
     int upperBitLength = _Py_bit_length64(upperBits);
     uint8_t prefix = (uint8_t)(upperBits >> (upperBitLength - 4));
-    Py_ssize_t numberOfBits = upperBitLength + PYLONG_BITS_IN_DIGIT * numberOfDigits;
+    Py_ssize_t numberOfBits = upperBitLength + PYLONG_BITS_IN_DIGIT * *restOfDigits;
     // Now return the heuristic value for the chunk size
     // LENGHTSFOR3 would be [84, 0, 84, 0, 84, 0, 84, 0], but this is faster
     if ((numberOfBits < 84) && !(prefix & 1))
@@ -4282,7 +4279,7 @@ prepare_pow(PyLongObject* n, uint64_t* firstDigits, Py_ssize_t* restOfDigits)
 }
 
 // table for the addition chain routine to help find bit patterns
-// for chunk sizes 2 through 4 (last row is for 5 and 6)
+// for chunk sizes 2 through 4 (last row is for clipping zeros)
 // tell how much bitPos needs to be corrected given digit >> bitPos
 static const signed char CHUNKJUMPTABLE[5][16] = {
     //0  01  10  11 100 101 110 111 1000 1001 1010 1011 1100 1101 1110 1111
@@ -4301,7 +4298,7 @@ static const signed char CHUNKJUMPTABLE[5][16] = {
  * processed per step.
  * computes result = pow(a, b, c)
  * assumes b >= 0
- * gererates a new reference
+ * used borrowed reference to a, b, c
  *
  * Differences with the HAC method:
  *    The table contains only odd entries saving 50% on building time
@@ -4346,9 +4343,18 @@ PyLongObject* addition_chain(
         return (PyLongObject*)PyLong_FromLong(1L);
 
     // Prepare the table
-    table[0] = (PyLongObject*)a;
+    // since a can be > c, it must be reduced
+    if (c != NULL) {
+        if (l_divmod(a, c, NULL, &temp) < 0)
+            goto Error;
+        table[0] = temp;
+        temp = NULL;
+    }
+    else {
+        table[0] = (PyLongObject*)a;
+    }
+    Py_INCREF(table[0]);
     tableSize = 0;
-    Py_INCREF(a);
 
     // Skip the computation of aSquared for exponent 1
     // because it isn't used
@@ -4385,7 +4391,7 @@ PyLongObject* addition_chain(
                         if (currentDigit == 1)
                             delta = 0;
                         else
-                            delta = CHUNKJUMPTABLE[0][currentDigit];
+                            delta = CHUNKJUMPTABLE[3][currentDigit];
                         break;
                     }
                     // determine new jump size
@@ -4430,13 +4436,14 @@ PyLongObject* addition_chain(
                     assert(currentDigit >> bitPosition == chunk);
                     result = aSquared;
                 }
-                else if (bitPosition > 3 && currentDigit >> (bitPosition - 4) == 9) {
-                    bitPosition -= 3;
-                    chunk = 9;
-                    assert(currentDigit >> bitPosition == chunk);
-                    ENSURE_TABLE_ENTRY(chunk);
-                    result = table[chunk / 2];
-                } else {
+                else {
+                    // fetch from table, but first see if it is useful
+                    // to compute one extra entry...
+                    if (bitPosition > 3 && currentDigit >> (bitPosition - 4) == 9) {
+                        bitPosition -= 3;
+                        chunk = 9;
+                        assert(currentDigit >> bitPosition == chunk);
+                    }
                     ENSURE_TABLE_ENTRY(chunk);
                     result = table[chunk / 2];
                 }
@@ -4446,7 +4453,7 @@ PyLongObject* addition_chain(
             }
             // now all bits up to bitPosition are processed
             currentDigit &= ((uint64_t)1 << bitPosition) - 1;
-            // set bitPosition to get the maximum chunkk
+            // set bitPosition to get the maximum chunk
             bitPosition = squaresToDo;
         }
         // current digit has to ones anymore, but we may have to square a few times
@@ -4467,13 +4474,11 @@ Error:
     Py_CLEAR(result);
     /* fall through */
 Done:
-    // Clean up, make sure we leave no pointers to dead objects
     Py_CLEAR(aSquared);
     for (int i = 0; i < 32 && table[i]; i++)
         Py_CLEAR(table[i]);
     return result;
 }
-
 
 /* pow(v, w, x) */
 static PyObject *

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4130,8 +4130,8 @@ long_invmod(PyLongObject *a, PyLongObject *n)
  */
 #define ENSURE_TABLE_ENTRY(chunk)                                          \
     do {                                                                \
-        while(tableSize < chunk / 2) {                                  \
-            MULTMODC(aSquared, table[tableSize], table[tableSize + 1]); \
+        while(tableSize <= chunk / 2) {                                  \
+            MULTMODC(aSquared, table[tableSize - 1], table[tableSize]); \
             tableSize++;                                                \
         }                                                               \
     } while (0);
@@ -4322,7 +4322,7 @@ PyLongObject* addition_chain(
     PyLongObject* table[32] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
                                 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
     // index of last full entry in table
-    int tableSize;
+    int tableSize = 0;
     // if the exponent is larger than 1, we store the square here
     PyLongObject* aSquared = 0;
     // for digit loop: value of current digit, and number to digits to process then
@@ -4353,7 +4353,7 @@ PyLongObject* addition_chain(
     }
     table[0] = temp;
     temp = NULL;
-    tableSize = 0;
+    tableSize = 1;
 
     // Skip the computation of aSquared for exponent 1
     // because it isn't used
@@ -4474,8 +4474,8 @@ Error:
     /* fall through */
 Done:
     Py_CLEAR(aSquared);
-    // Yes the table is tableSize + 1 entries, I know
-    for (int i = 0; i <= tableSize; i++)
+    // Yes the table is tableSize entries, I know
+    for (int i = 0; i < tableSize; i++)
         Py_CLEAR(table[i]);
     return result;
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4467,10 +4467,11 @@ Error:
     Py_CLEAR(result);
     /* fall through */
 Done:
-    // Clean up, make sure we leave no pointers to dead objects
-    Py_CLEAR(aSquared);
-    for (int i = 0; i < 32 && table[i]; i++)
-        Py_CLEAR(table[i]);
+    Py_XDECREF(aSquared);
+    Py_XDECREF(temp);
+    // Yes the table is tableSize + 1 entries, I know
+    for (int i = 0; i <= tableSize; i++)
+        Py_DECREF(table[i]);
     return result;
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4351,7 +4351,7 @@ PyLongObject* addition_chain(
     }
     else {
         // Make sure we have a long in the table, because it could be something int-like
-        temp = (PyLongObject*)long_long(a);
+        temp = (PyLongObject*)long_long((PyObject*)a);
         if (temp == NULL)
             goto Error;
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3978,7 +3978,7 @@ long_mod(PyObject *a, PyObject *b)
 
     if (Py_ABS(Py_SIZE(a)) == 1 && Py_ABS(Py_SIZE(b)) == 1) {
         return fast_mod((PyLongObject*)a, (PyLongObject*)b);
-    }b
+    }
 
     if (l_divmod((PyLongObject*)a, (PyLongObject*)b, NULL, &mod) < 0)
         mod = NULL;


### PR DESCRIPTION
I put the code that I can only test with 3.8 here, to see actually works in 3.10.
Short description: speeding up pow(int,int) especially for exponents with between 20 and 500 bits (until the fiveary method kicks in) , but is also saves time outside this range.
Speedup is between 2 % (for very high exponents) to 15% (for exponents of a few hundred bits).
And, I speeded up _Py_bit_length for generic processors just because I could :-)


<!-- issue-number: [bpo-42911](https://bugs.python.org/issue42911) -->
https://bugs.python.org/issue42911
<!-- /issue-number -->
