### PR TITLE
bpo-42923: Dump extension modules on fatal error

### DIFF
--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -84,6 +84,8 @@ PyAPI_FUNC(PyObject *) _PyErr_FormatFromCauseTstate(
 
 PyAPI_FUNC(int) _PyErr_CheckSignalsTstate(PyThreadState *tstate);
 
+PyAPI_FUNC(void) _Py_DumpExtensionModules(int fd, PyInterpreterState *interp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -84,6 +84,12 @@ typedef struct PyModuleDef{
   freefunc m_free;
 } PyModuleDef;
 
+
+// Internal C API
+#ifdef Py_BUILD_CORE
+extern int _PyModule_IsExtension(PyObject *obj);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -556,6 +556,16 @@ class CAPITest(unittest.TestCase):
         self.assertIn('Fatal Python error: test_fatal_error: MESSAGE\n',
                       err)
 
+        match = re.search('^Extension modules:(.*)$', err, re.MULTILINE)
+        if not match:
+            self.fail(f"Cannot find 'Extension modules:' in {err!r}")
+        modules = set(match.group(1).strip().split(', '))
+        # Test _PyModule_IsExtension(): the list doesn't have to
+        # be exhaustive.
+        for name in ('sys', 'builtins', '_imp', '_thread', '_weakref',
+                     '_io', 'marshal', '_signal', '_abc', '_testcapi'):
+            self.assertIn(name, modules)
+
 
 class TestPendingCalls(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2021-01-13-12-15-13.bpo-42923.zBiNls.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-13-12-15-13.bpo-42923.zBiNls.rst
@@ -1,0 +1,2 @@
+The :c:func:`Py_FatalError` function and the :mod:`faulthandler` module now
+dump the list of extension modules on a fatal error.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "pycore_initconfig.h"    // _PyStatus_ERR
+#include "pycore_pyerrors.h"      // _Py_DumpExtensionModules
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads
 #include <signal.h>
 #include <object.h>
@@ -348,6 +349,8 @@ faulthandler_fatal_error(int signum)
 
     faulthandler_dump_traceback(fd, fatal_error.all_threads,
                                 fatal_error.interp);
+
+    _Py_DumpExtensionModules(fd, fatal_error.interp);
 
     errno = save_errno;
 #ifdef MS_WINDOWS

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -35,6 +35,19 @@ PyTypeObject PyModuleDef_Type = {
 };
 
 
+int
+_PyModule_IsExtension(PyObject *obj)
+{
+    if (!PyModule_Check(obj)) {
+        return 0;
+    }
+    PyModuleObject *module = (PyModuleObject*)obj;
+
+    struct PyModuleDef *def = module->md_def;
+    return (def != NULL && def->m_methods != NULL);
+}
+
+
 PyObject*
 PyModuleDef_Init(struct PyModuleDef* def)
 {


### PR DESCRIPTION
The Py_FatalError() function and the faulthandler module now dump the
list of extension modules on a fatal error.

* Add _Py_DumpExtensionModules() and _PyModule_IsExtension() internal
  functions.
* Pass stream to _Py_FatalError_DumpTracebacks() rather than
  hardcoding stderr.
* Move faulthandler._fatal_error() to _testcapi.fatal_error().
* Add test_capi.test_fatal_error() test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42923](https://bugs.python.org/issue42923) -->
https://bugs.python.org/issue42923
<!-- /issue-number -->
