### PR TITLE
bpo-42924: Fix incorrect copy in bytearray_repeat

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1666,6 +1666,16 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         # Shouldn't raise an error
         self.assertEqual(list(it), [])
 
+    def test_repeat_after_setslice(self):
+        # bpo-42924: * used to copy from the wrong memory location
+        b = bytearray(b'abc')
+        b[:2] = b'x'
+        b1 = b * 1
+        b3 = b * 3
+        self.assertEqual(b1, b'xc')
+        self.assertEqual(b1, b)
+        self.assertEqual(b3, b'xcxcxc')
+
 
 class AssortedBytesTest(unittest.TestCase):
     #

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-13-14-06-01.bpo-42924._WS1Ok.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-13-14-06-01.bpo-42924._WS1Ok.rst
@@ -1,0 +1,2 @@
+Fix :c:func:`bytearray_repeat` incorrectly copying from data from
+``ob_bytes`` instead of ``ob_start``.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-13-14-06-01.bpo-42924._WS1Ok.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-13-14-06-01.bpo-42924._WS1Ok.rst
@@ -1,2 +1,1 @@
-Fix :c:func:`bytearray_repeat` incorrectly copying from data from
-``ob_bytes`` instead of ``ob_start``.
+Fix ``bytearray`` repetition incorrectly copying data from the start of the buffer, even if the data is offset within the buffer (e.g. after reassigning a slice at the start of the ``bytearray`` to a shorter byte string).

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -321,6 +321,7 @@ bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
     PyByteArrayObject *result;
     Py_ssize_t mysize;
     Py_ssize_t size;
+    char *buf;
 
     if (count < 0)
         count = 0;
@@ -329,13 +330,14 @@ bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
         return PyErr_NoMemory();
     size = mysize * count;
     result = (PyByteArrayObject *)PyByteArray_FromStringAndSize(NULL, size);
+    buf = PyByteArray_AS_STRING(self);
     if (result != NULL && size != 0) {
         if (mysize == 1)
-            memset(result->ob_bytes, self->ob_bytes[0], size);
+            memset(result->ob_bytes, buf[0], size);
         else {
             Py_ssize_t i;
             for (i = 0; i < count; i++)
-                memcpy(result->ob_bytes + i*mysize, self->ob_bytes, mysize);
+                memcpy(result->ob_bytes + i*mysize, buf, mysize);
         }
     }
     return (PyObject *)result;

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -321,7 +321,7 @@ bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
     PyByteArrayObject *result;
     Py_ssize_t mysize;
     Py_ssize_t size;
-    char *buf;
+    const char *buf;
 
     if (count < 0)
         count = 0;


### PR DESCRIPTION
This should fix [bpo-42924](https://bugs.python.org/issue42924).

Before, using the `*` operator to repeat a `bytearray` would copy data from the start of the internal buffer (`ob_bytes`) and not from the start of the actual data (`ob_start`). The assert in this example used to fail, now it should pass.

```python
ba = bytearray(b'0123456789abcdef')
ba[:10] = b'test'
assert bytes(ba) == bytes(ba * 1)
```

<!-- issue-number: [bpo-42924](https://bugs.python.org/issue42924) -->
https://bugs.python.org/issue42924
<!-- /issue-number -->
