### PR TITLE
bpo-42856: Add --with-wheel-pkg-dir=PATH configure option

### DIFF
--- a/Doc/library/ensurepip.rst
+++ b/Doc/library/ensurepip.rst
@@ -48,7 +48,7 @@ The simplest possible invocation is::
 
 This invocation will install ``pip`` if it is not already installed,
 but otherwise does nothing. To ensure the installed version of ``pip``
-is at least as recent as the one bundled with ``ensurepip``, pass the
+is at least as recent as the one available in ``ensurepip``, pass the
 ``--upgrade`` option::
 
     python -m ensurepip --upgrade
@@ -86,7 +86,7 @@ Module API
 
 .. function:: version()
 
-   Returns a string specifying the bundled version of pip that will be
+   Returns a string specifying the available version of pip that will be
    installed when bootstrapping an environment.
 
 .. function:: bootstrap(root=None, upgrade=False, user=False, \
@@ -100,7 +100,7 @@ Module API
    for the current environment.
 
    *upgrade* indicates whether or not to upgrade an existing installation
-   of an earlier version of ``pip`` to the bundled version.
+   of an earlier version of ``pip`` to the available version.
 
    *user* indicates whether to use the user scheme rather than installing
    globally.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -617,6 +617,18 @@ Build Changes
   don't build nor install test modules.
   (Contributed by Xavier de Gaye, Thomas Petazzoni and Peixing Xin in :issue:`27640`.)
 
+* Add ``--with-wheel-pkg-dir=PATH`` option to the ``./configure`` script. If
+  specified, the :mod:`ensurepip` module looks for ``setuptools`` and ``pip``
+  wheel packages in this directory: if both are present, these wheel packages
+  are used instead of ensurepip bundled wheel packages.
+
+  Some Linux distribution packaging policies recommend against bundling
+  dependencies. For example, Fedora installs wheel packages in the
+  ``/usr/share/python-wheels/`` directory and don't install the
+  ``ensurepip._bundled`` package.
+
+  (Contributed by Victor Stinner in :issue:`42856`.)
+
 
 C API Changes
 =============

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -1,19 +1,68 @@
-import unittest
-import unittest.mock
-import test.support
+import contextlib
 import os
 import os.path
-import contextlib
 import sys
+import tempfile
+import test.support
+import unittest
+import unittest.mock
 
 import ensurepip
 import ensurepip._uninstall
 
 
-class TestEnsurePipVersion(unittest.TestCase):
+class TestPackages(unittest.TestCase):
+    def touch(self, directory, filename):
+        fullname = os.path.join(directory, filename)
+        open(fullname, "wb").close()
 
-    def test_returns_version(self):
-        self.assertEqual(ensurepip._PIP_VERSION, ensurepip.version())
+    def test_version(self):
+        # Test version()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.touch(tmpdir, "pip-1.2.3b1-py2.py3-none-any.whl")
+            self.touch(tmpdir, "setuptools-49.1.3-py3-none-any.whl")
+            with (unittest.mock.patch.object(ensurepip, '_PACKAGES', None),
+                  unittest.mock.patch.object(ensurepip, '_WHEEL_PKG_DIR', tmpdir)):
+                self.assertEqual(ensurepip.version(), '1.2.3b1')
+
+    def test_get_packages_no_dir(self):
+        # Test _get_packages() without a wheel package directory
+        with (unittest.mock.patch.object(ensurepip, '_PACKAGES', None),
+              unittest.mock.patch.object(ensurepip, '_WHEEL_PKG_DIR', None)):
+            packages = ensurepip._get_packages()
+
+            # when bundled wheel packages are used, we get _PIP_VERSION
+            self.assertEqual(ensurepip._PIP_VERSION, ensurepip.version())
+
+        # use bundled wheel packages
+        self.assertIsNotNone(packages['pip'].wheel_name)
+        self.assertIsNotNone(packages['setuptools'].wheel_name)
+
+    def test_get_packages_with_dir(self):
+        # Test _get_packages() with a wheel package directory
+        setuptools_filename = "setuptools-49.1.3-py3-none-any.whl"
+        pip_filename = "pip-20.2.2-py2.py3-none-any.whl"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.touch(tmpdir, setuptools_filename)
+            self.touch(tmpdir, pip_filename)
+            # not used, make sure that it's ignored
+            self.touch(tmpdir, "wheel-0.34.2-py2.py3-none-any.whl")
+
+            with (unittest.mock.patch.object(ensurepip, '_PACKAGES', None),
+                  unittest.mock.patch.object(ensurepip, '_WHEEL_PKG_DIR', tmpdir)):
+                packages = ensurepip._get_packages()
+
+            self.assertEqual(packages['setuptools'].version, '49.1.3')
+            self.assertEqual(packages['setuptools'].wheel_path,
+                             os.path.join(tmpdir, setuptools_filename))
+            self.assertEqual(packages['pip'].version, '20.2.2')
+            self.assertEqual(packages['pip'].wheel_path,
+                             os.path.join(tmpdir, pip_filename))
+
+            # wheel package is ignored
+            self.assertEqual(sorted(packages), ['pip', 'setuptools'])
+
 
 class EnsurepipMixin:
 
@@ -27,6 +76,8 @@ class EnsurepipMixin:
         real_devnull = os.devnull
         os_patch = unittest.mock.patch("ensurepip.os")
         patched_os = os_patch.start()
+        # But expose os.listdir() used by _find_packages()
+        patched_os.listdir = os.listdir
         self.addCleanup(os_patch.stop)
         patched_os.devnull = real_devnull
         patched_os.path = os.path
@@ -147,7 +198,7 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
         self.assertEqual(self.os_environ["PIP_CONFIG_FILE"], os.devnull)
 
 @contextlib.contextmanager
-def fake_pip(version=ensurepip._PIP_VERSION):
+def fake_pip(version=ensurepip.version()):
     if version is None:
         pip = None
     else:
@@ -243,7 +294,7 @@ class TestUninstall(EnsurepipMixin, unittest.TestCase):
 
 # Basic testing of the main functions and their argument parsing
 
-EXPECTED_VERSION_OUTPUT = "pip " + ensurepip._PIP_VERSION
+EXPECTED_VERSION_OUTPUT = "pip " + ensurepip.version()
 
 class TestBootstrappingMainFunction(EnsurepipMixin, unittest.TestCase):
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -146,6 +146,8 @@ CONFINCLUDEDIR=	$(exec_prefix)/include
 PLATLIBDIR=	@PLATLIBDIR@
 SCRIPTDIR=	$(prefix)/$(PLATLIBDIR)
 ABIFLAGS=	@ABIFLAGS@
+# Variable used by ensurepip
+WHEEL_PKG_DIR=	@WHEEL_PKG_DIR@
 
 # Detailed destination directories
 BINLIBDEST=	@BINLIBDEST@

--- a/Misc/NEWS.d/next/Build/2021-01-07-12-51-38.bpo-42856.n3cMHV.rst
+++ b/Misc/NEWS.d/next/Build/2021-01-07-12-51-38.bpo-42856.n3cMHV.rst
@@ -1,0 +1,9 @@
+Add ``--with-wheel-pkg-dir=PATH`` option to the ``./configure`` script. If
+specified, the :mod:`ensurepip` module looks for ``setuptools`` and ``pip``
+wheel packages in this directory: if both are present, these wheel packages are
+used instead of ensurepip bundled wheel packages.
+
+Some Linux distribution packaging policies recommend against bundling
+dependencies. For example, Fedora installs wheel packages in the
+``/usr/share/python-wheels/`` directory and don't install the
+``ensurepip._bundled`` package.

--- a/configure
+++ b/configure
@@ -630,6 +630,7 @@ OPENSSL_INCLUDES
 ENSUREPIP
 SRCDIRS
 THREADHEADERS
+WHEEL_PKG_DIR
 LIBPL
 PY_ENABLE_SHARED
 PLATLIBDIR
@@ -847,6 +848,7 @@ with_libm
 with_libc
 enable_big_digits
 with_platlibdir
+with_wheel_pkg_dir
 with_computed_gotos
 with_ensurepip
 with_openssl
@@ -1576,6 +1578,9 @@ Optional Packages:
                           system-dependent)
   --with-platlibdir=DIRNAME
                           Python library directory name (default is "lib")
+  --with-wheel-pkg-dir=PATH
+                          Directory of wheel packages used by ensurepip
+                          (default: none)
   --with-computed-gotos   enable computed gotos in evaluation loop (enabled by
                           default on supported compilers)
   --with-ensurepip[=install|upgrade|no]
@@ -15490,6 +15495,29 @@ if test x$PLATFORM_TRIPLET = x; then
   LIBPL='$(prefix)'"/${PLATLIBDIR}/python${VERSION}/config-${LDVERSION}"
 else
   LIBPL='$(prefix)'"/${PLATLIBDIR}/python${VERSION}/config-${LDVERSION}-${PLATFORM_TRIPLET}"
+fi
+
+
+# Check for --with-wheel-pkg-dir=PATH
+
+WHEEL_PKG_DIR=""
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-wheel-pkg-dir" >&5
+$as_echo_n "checking for --with-wheel-pkg-dir... " >&6; }
+
+# Check whether --with-wheel-pkg-dir was given.
+if test "${with_wheel_pkg_dir+set}" = set; then :
+  withval=$with_wheel_pkg_dir;
+if test -n "$withval"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+  WHEEL_PKG_DIR="$withval"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4838,6 +4838,22 @@ else
 fi
 AC_SUBST(LIBPL)
 
+# Check for --with-wheel-pkg-dir=PATH
+AC_SUBST(WHEEL_PKG_DIR)
+WHEEL_PKG_DIR=""
+AC_MSG_CHECKING(for --with-wheel-pkg-dir)
+AC_ARG_WITH(wheel-pkg-dir,
+            AS_HELP_STRING([--with-wheel-pkg-dir=PATH],
+            [Directory of wheel packages used by ensurepip (default: none)]),
+[
+if test -n "$withval"; then
+  AC_MSG_RESULT(yes)
+  WHEEL_PKG_DIR="$withval"
+else
+  AC_MSG_RESULT(no)
+fi],
+[AC_MSG_RESULT(no)])
+
 # Check whether right shifting a negative integer extends the sign bit
 # or fills with zeros (like the Cray J90, according to Tim Peters).
 AC_MSG_CHECKING(whether right shift extends the sign bit)


### PR DESCRIPTION
Add --with-wheel-pkg-dir=PATH option to the ./configure script. If
specified, the ensurepip module looks for setuptools and pip wheel
packages in this directory: if both are present, these wheel packages
are used instead of ensurepip bundled wheel packages.

Some Linux distribution packaging policies recommand against bundling
dependencies. For example, Fedora installs wheel packages in the
/usr/share/python-wheels/ directory and don't install the
ensurepip._bundled package.

ensurepip: Remove unused runpy import.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42856](https://bugs.python.org/issue42856) -->
https://bugs.python.org/issue42856
<!-- /issue-number -->
