### PR TITLE
bpo-28146: Fix a confusing error message in str.format()

### DIFF
--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1225,8 +1225,11 @@ class UnicodeTest(string_tests.CommonTest,
                           0, 1, 2, 3, 4, 5, 6, 7)
 
         # string format spec errors
-        self.assertRaises(ValueError, "{0:-s}".format, '')
-        self.assertRaises(ValueError, format, "", "-")
+        sign_msg = "Sign not allowed in string format specifier"
+        self.assertRaisesRegex(ValueError, sign_msg, "{0:-s}".format, '')
+        self.assertRaisesRegex(ValueError, sign_msg, format, "", "-")
+        space_msg = "Space not allowed in string format specifier"
+        self.assertRaisesRegex(ValueError, space_msg, "{: }".format, '')
         self.assertRaises(ValueError, "{0:=s}".format, '')
 
         # Alternate formatting is not supported

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-13-19-34-41.bpo-28146.AZBBkH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-13-19-34-41.bpo-28146.AZBBkH.rst
@@ -1,1 +1,1 @@
-Fixed a confusing error message in :func:`str.format`.
+Fix a confusing error message in :func:`str.format`.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-13-19-34-41.bpo-28146.AZBBkH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-13-19-34-41.bpo-28146.AZBBkH.rst
@@ -1,0 +1,1 @@
+Fixed a confusing error message in :func:`str.format`.

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -773,8 +773,14 @@ format_string_internal(PyObject *value, const InternalFormatSpec *format,
 
     /* sign is not allowed on strings */
     if (format->sign != '\0') {
-        PyErr_SetString(PyExc_ValueError,
-                        "Sign not allowed in string format specifier");
+        if (format->sign == ' ') {
+            PyErr_SetString(PyExc_ValueError,
+                "Space not allowed in string format specifier");
+        }
+        else {
+            PyErr_SetString(PyExc_ValueError,
+                "Sign not allowed in string format specifier");
+        }
         goto done;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28146](https://bugs.python.org/issue28146) -->
https://bugs.python.org/issue28146
<!-- /issue-number -->

Automerge-Triggered-By: GH:pitrou