### PR TITLE
bpo-38250: [Enum] single-bit flags are canonical

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -638,12 +638,22 @@ IntFlag
 The next variation of :class:`Enum` provided, :class:`IntFlag`, is also based
 on :class:`int`.  The difference being :class:`IntFlag` members can be combined
 using the bitwise operators (&, \|, ^, ~) and the result is still an
-:class:`IntFlag` member.  However, as the name implies, :class:`IntFlag`
+:class:`IntFlag` member, if possible.  However, as the name implies, :class:`IntFlag`
 members also subclass :class:`int` and can be used wherever an :class:`int` is
-used.  Any operation on an :class:`IntFlag` member besides the bit-wise
-operations will lose the :class:`IntFlag` membership.
+used.
+
+.. note::
+
+    Any operation on an :class:`IntFlag` member besides the bit-wise operations will
+    lose the :class:`IntFlag` membership.
+
+.. note::
+
+    Bit-wise operations that result in invalid :class:`IntFlag` values will lose the
+    :class:`IntFlag` membership.
 
 .. versionadded:: 3.6
+.. versionchanged:: 3.10
 
 Sample :class:`IntFlag` class::
 
@@ -671,21 +681,41 @@ It is also possible to name the combinations::
     >>> Perm.RWX
     <Perm.RWX: 7>
     >>> ~Perm.RWX
-    <Perm.-8: -8>
+    <Perm: 0>
+    >>> Perm(7)
+    <Perm.RWX: 7>
+
+.. note::
+
+    Named combinations are considered aliases.  Aliases do not show up during
+    iteration, but can be returned from by-value lookups.
+
+.. versionchanged:: 3.10
 
 Another important difference between :class:`IntFlag` and :class:`Enum` is that
 if no flags are set (the value is 0), its boolean evaluation is :data:`False`::
 
     >>> Perm.R & Perm.X
-    <Perm.0: 0>
+    <Perm: 0>
     >>> bool(Perm.R & Perm.X)
     False
 
 Because :class:`IntFlag` members are also subclasses of :class:`int` they can
-be combined with them::
+be combined with them (but may lose :class:`IntFlag` membership::
+
+    >>> Perm.X | 4
+    <Perm.R|X: 5>
 
     >>> Perm.X | 8
-    <Perm.8|X: 9>
+    9
+
+.. note::
+
+    The negation operator, ``~``, always returns an :class:`IntFlag` member with a
+    positive number::
+
+    >>> ~Perm.X
+    <Perm.R|W: 6>
 
 :class:`IntFlag` members can also be iterated over::
 
@@ -717,7 +747,7 @@ flags being set, the boolean evaluation is :data:`False`::
     ...     GREEN = auto()
     ...
     >>> Color.RED & Color.GREEN
-    <Color.0: 0>
+    <Color: 0>
     >>> bool(Color.RED & Color.GREEN)
     False
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1175,6 +1175,14 @@ Supported ``_sunder_`` names
   :class:`auto` to get an appropriate value for an enum member; may be
   overridden
 
+    .. note::
+
+    For standard :class:`Enum` classes the next value chosen is the last value seen
+    incremented by one.
+
+    For :class:`Flag`-type classes the next value chosen will be the next highest
+    power-of-two, regardless of the last value seen.
+
 .. versionadded:: 3.6 ``_missing_``, ``_order_``, ``_generate_next_value_``
 .. versionadded:: 3.7 ``_ignore_``
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1175,7 +1175,7 @@ Supported ``_sunder_`` names
   :class:`auto` to get an appropriate value for an enum member; may be
   overridden
 
-    .. note::
+.. note::
 
     For standard :class:`Enum` classes the next value chosen is the last value seen
     incremented by one.

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -782,7 +782,7 @@ value::
 
     >>> purple = Color.RED | Color.BLUE
     >>> list(purple)
-    [<Color.BLUE: 2>, <Color.RED: 1>]
+    [<Color.RED: 1>, <Color.BLUE: 2>]
 
 .. versionadded:: 3.10
 
@@ -1212,7 +1212,7 @@ Private names are not converted to Enum members, but remain normal attributes.
 :class:`Enum` members are instances of their :class:`Enum` class, and are
 normally accessed as ``EnumClass.member``.  In Python versions ``3.5`` to
 ``3.9`` you could access members from other members -- this practice was
-discourages, and in ``3.10`` :class:`Enum` has returned to not allowing it::
+discouraged, and in ``3.10`` :class:`Enum` has returned to not allowing it::
 
     >>> class FieldTypes(Enum):
     ...     name = 0
@@ -1287,7 +1287,7 @@ are comprised of a single bit::
     >>> Color(3)
     <Color.YELLOW: 3>
     >>> Color(7)
-    <Color.BLUE|GREEN|RED: 7>
+    <Color.RED|GREEN|BLUE: 7>
 
 ``StrEnum`` and :meth:`str.__str__`
 """""""""""""""""""""""""""""""""""
@@ -1311,14 +1311,14 @@ The code sample::
     ...     BLUE = 4
     ...     PURPLE = RED | BLUE
     ...     WHITE = RED | GREEN | BLUE
-    ... 
+    ...
 
 - single-bit flags are canonical
 - multi-bit and zero-bit flags are aliases
 - only canonical flags are returned during iteration::
 
     >>> list(Color.WHITE)
-    [<Color.BLUE: 4>, <Color.GREEN: 2>, <Color.RED: 1>]
+    [<Color.RED: 1>, <Color.GREEN: 2>, <Color.BLUE: 4>]
 
 - negating a flag or flag set returns a new flag/flag set with the
   corresponding positive integer value::
@@ -1332,7 +1332,7 @@ The code sample::
 - names of pseudo-flags are constructed from their members' names::
 
     >>> (Color.RED | Color.GREEN).name
-    'GREEN|RED'
+    'RED|GREEN'
 
 - multi-bit flags, aka aliases, can be returned from operations::
 
@@ -1361,8 +1361,8 @@ bits are handled: ``STRICT``, ``CONFORM``, ``EJECT`', and ``KEEP``:
   * EJECT --> lose Flag status and become a normal int with the given value
   * KEEP --> keep the extra bits
            - keeps Flag status and extra bits
-           - they don't show up in iteration
-           - they do show up in repr() and str()
+           - extra bits do not show up in iteration
+           - extra bits do show up in repr() and str()
 
 The default for Flag is ``STRICT``, the default for ``IntFlag`` is ``DISCARD``,
 and the default for ``_convert_`` is ``KEEP`` (see ``ssl.Options`` for an

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -715,8 +715,8 @@ be combined with them (but may lose :class:`IntFlag` membership::
     The negation operator, ``~``, always returns an :class:`IntFlag` member with a
     positive value::
 
-    >>> ~Perm.X
-    <Perm.R|W: 6>
+        >>> (~Perm.X).value == (Perm.R|Perm.W).value == 6
+        True
 
 :class:`IntFlag` members can also be iterated over::
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1198,7 +1198,9 @@ and raise an error if the two do not match::
     ...
     Traceback (most recent call last):
     ...
-    TypeError: member order does not match _order_
+    TypeError: member order does not match _order_:
+    ['RED', 'BLUE', 'GREEN']
+    ['RED', 'GREEN', 'BLUE']
 
 .. note::
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -522,10 +522,6 @@ class EnumMeta(type):
             if enum_class._boundary_ is not KEEP:
                 # missed_bits = multi_bit_total & ~single_bit_total
                 missed = list(_iter_bits_lsb(multi_bit_total & ~single_bit_total))
-                # while missed_bits:
-                #     i = 2 ** (missed_bits.bit_length() - 1)
-                #     missed.append(i)
-                #     missed_bits &= ~i
                 if missed:
                     raise TypeError(
                             'invalid Flag %r -- missing values: %s'
@@ -1113,10 +1109,8 @@ class Flag(Enum, boundary=STRICT):
         """
         Extract all members from the value in definition (i.e. increasing value) order.
         """
-        for val in _iter_bits_lsb(value):
-            member = cls._value2member_map_.get(val)
-            if member is not None:
-                yield member
+        for val in _iter_bits_lsb(value & cls._flag_mask_):
+            yield cls._value2member_map_.get(val)
 
     _iter_member_ = _iter_member_by_value_
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -514,10 +514,8 @@ class EnumMeta(type):
             enum_class._flag_mask_ = single_bit_total
             #
             # set correct __iter__
-            inverted = ~enum_class(0)
-            if list(enum_class) != list(inverted):
-                if '|' in inverted._name_:
-                    enum_class._value2member_map_.pop(inverted._value_, None)
+            member_list = [m._value_ for m in enum_class]
+            if member_list != sorted(member_list):
                 enum_class._iter_member_ = enum_class._iter_member_by_def_
         #
         return enum_class

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -673,7 +673,7 @@ class EnumMeta(type):
         # special processing needed for names?
         if isinstance(names, str):
             names = names.replace(',', ' ').split()
-        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str)):
+        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str):
             original_names, names = names, []
             last_values = []
             for count, name in enumerate(original_names):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1131,9 +1131,6 @@ class Flag(Enum, boundary=STRICT):
         if not hasattr(pseudo_member, 'value'):
             pseudo_member._value_ = value
         if member_value:
-            # pseudo_member._name_ = '|'.join([m._name_ for m in members])
-            # if unknown:
-            #     pseudo_member._name_ += '|0x%x' % unknown
             pseudo_member._name_ = '|'.join([
                 m._name_ for m in cls._iter_member_(member_value)
                 ])

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -124,7 +124,6 @@ class auto:
     """
     value = _auto_null
 
-
 class property(DynamicClassAttribute):
     """
     This is a descriptor, used to define attributes that act differently
@@ -139,10 +138,7 @@ class property(DynamicClassAttribute):
             try:
                 return ownerclass._member_map_[self.name]
             except KeyError:
-                raise AttributeError(
-                        '%s: no attribute %r'
-                        % (ownerclass.__name__, self.name)
-                        )
+                raise AttributeError('%r not found in %r' % (self.name, ownerclass.__name__))	
         else:
             if self.fget is None:
                 raise AttributeError(
@@ -154,19 +150,13 @@ class property(DynamicClassAttribute):
 
     def __set__(self, instance, value):
         if self.fset is None:
-            raise AttributeError(
-                    "%s: cannot set attribute %r"
-                    % (self.clsname, self.name)
-                    )
+            raise AttributeError("%s: cannot set attribute %r" % (self.clsname, self.name))	
         else:
             return self.fset(instance, value)
 
     def __delete__(self, instance):
         if self.fdel is None:
-            raise AttributeError(
-                    "%s: cannot delete attribute %r"
-                    % (self.clsname, self.name)
-                    )
+            raise AttributeError("%s: cannot delete attribute %r" % (self.clsname, self.name))
         else:
             return self.fdel(instance)
 
@@ -254,8 +244,8 @@ class _proto_member:
             redirect = property()
             redirect.__set_name__(enum_class, member_name)
             if descriptor and need_override:
-                # previous enum.property found, but some other inherited
-                # attribute is in the way; copy fget, fset, fdel to this one
+                # previous enum.property found, but some other inherited attribute
+                # is in the way; copy fget, fset, fdel to this one
                 redirect.fget = descriptor.fget
                 redirect.fset = descriptor.fset
                 redirect.fdel = descriptor.fdel
@@ -304,17 +294,14 @@ class _EnumDict(dict):
                     '_iter_member_', '_iter_member_by_value_', '_iter_member_by_def_',
                     ):
                 raise ValueError(
-                        '_sunder_ names, such as %r, are reserved for future'
-                        ' Enum use'
+                        '_sunder_ names, such as %r, are reserved for future Enum use'
                         % (key, )
                         )
             if key == '_generate_next_value_':
                 # check if members already defined as auto()
                 if self._auto_called:
                     raise TypeError(
-                            "_generate_next_value_ must be defined before"
-                            " members"
-                            )
+                            "_generate_next_value_ must be defined before members")
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':
                 if isinstance(value, str):
@@ -343,7 +330,10 @@ class _EnumDict(dict):
             if isinstance(value, auto):
                 if value.value == _auto_null:
                     value.value = self._generate_next_value(
-                            key, 1, len(self._member_names), self._last_values[:],
+                            key,
+                            1,
+                            len(self._member_names),
+                            self._last_values[:],
                             )
                     self._auto_called = True
                 value = value.value
@@ -366,7 +356,6 @@ class EnumMeta(type):
     """
     Metaclass for Enum
     """
-
     @classmethod
     def __prepare__(metacls, cls, bases, **kwds):
         # check that previous enum members do not exist
@@ -425,7 +414,7 @@ class EnumMeta(type):
                 flag_mask |= value
             classdict[name] = _proto_member(value)
         #
-        # house-keeping structures
+        # house keeping structures
         classdict['_member_names_'] = []
         classdict['_member_map_'] = {}
         classdict['_value2member_map_'] = {}
@@ -464,9 +453,8 @@ class EnumMeta(type):
             exc = None
             enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
         except RuntimeError as e:
-            # any exceptions raised by member.__new__ will get converted to
-            # a RuntimeError, so get that original exception back and raise
-            # it instead
+            # any exceptions raised by member.__new__ will get converted to a
+            # RuntimeError, so get that original exception back and raise it instead
             exc = e.__cause__ or e
         if exc is not None:
             raise exc
@@ -544,12 +532,7 @@ class EnumMeta(type):
         """
         return True
 
-    def __call__(
-                cls, value, names=None,
-                *,
-                module=None, qualname=None, type=None,
-                start=1, boundary=None,
-        ):
+    def __call__(cls, value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None):
         """
         Either returns an existing member, or creates a new enum class.
 
@@ -562,8 +545,7 @@ class EnumMeta(type):
         `value` will be the name of the new class.
 
         `names` should be either a string of white-space/comma delimited names
-        (values will start at `start`), or an iterator/mapping of name, value
-        pairs.
+        (values will start at `start`), or an iterator/mapping of name, value pairs.
 
         `module` should be set to the module this class is being created in;
         if it is not set, an attempt to find that module will be made, but if
@@ -671,12 +653,7 @@ class EnumMeta(type):
             raise AttributeError('Cannot reassign members.')
         super().__setattr__(name, value)
 
-    def _create_(
-                cls, class_name, names,
-                *,
-                module=None, qualname=None, type=None,
-                start=1, boundary=None,
-        ):
+    def _create_(cls, class_name, names, *, module=None, qualname=None, type=None, start=1, boundary=None):
         """
         Convenience method to create a new Enum class.
 
@@ -684,8 +661,7 @@ class EnumMeta(type):
 
         * A string containing member names, separated either with spaces or
           commas.  Values are incremented by 1 from `start`.
-        * An iterable of member names.  Values are incremented by 1 from
-          `start`.
+        * An iterable of member names.  Values are incremented by 1 from `start`.
         * An iterable of (member name, value) pairs.
         * A mapping of member name -> value pairs.
         """
@@ -697,20 +673,14 @@ class EnumMeta(type):
         # special processing needed for names?
         if isinstance(names, str):
             names = names.replace(',', ' ').split()
-        if (
-                isinstance(names, (tuple, list))
-                and names
-                and isinstance(names[0], str)
-            ):
+        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str)):
             original_names, names = names, []
             last_values = []
             for count, name in enumerate(original_names):
-                value = first_enum._generate_next_value_(
-                        name, start, count, last_values[:]
-                        )
+                value = first_enum._generate_next_value_(name, start, count, last_values[:])
                 last_values.append(value)
                 names.append((name, value))
-        #
+
         # Here, names is either an iterable of (name, value) or a mapping.
         for item in names:
             if isinstance(item, str):
@@ -718,7 +688,7 @@ class EnumMeta(type):
             else:
                 member_name, member_value = item
             classdict[member_name] = member_value
-        #
+
         # TODO: replace the frame hack if a blessed way to know the calling
         # module is ever developed
         if module is None:
@@ -732,11 +702,8 @@ class EnumMeta(type):
             classdict['__module__'] = module
         if qualname is not None:
             classdict['__qualname__'] = qualname
-        #
-        return metacls.__new__(
-                metacls, class_name, bases, classdict,
-                boundary=boundary,
-                )
+
+        return metacls.__new__(metacls, class_name, bases, classdict, boundary=boundary)
 
     def _convert_(cls, name, module, filter, source=None, boundary=None):
         """
@@ -791,7 +758,7 @@ class EnumMeta(type):
         """
         if not bases:
             return object, Enum
-        #
+
         def _find_data_type(bases):
             data_types = []
             for chain in bases:
@@ -811,15 +778,12 @@ class EnumMeta(type):
                     else:
                         candidate = base
             if len(data_types) > 1:
-                raise TypeError(
-                        '%r: too many data types: %r'
-                        % (class_name, data_types)
-                        )
+                raise TypeError('%r: too many data types: %r' % (class_name, data_types))
             elif data_types:
                 return data_types[0]
             else:
                 return None
-        #
+
         # ensure final parent class is an Enum derivative, find any concrete
         # data type, and check that Enum has no members
         first_enum = bases[-1]
@@ -844,10 +808,10 @@ class EnumMeta(type):
         # by the user; also check earlier enum classes in case a __new__ was
         # saved as __new_member__
         __new__ = classdict.get('__new__', None)
-        #
+
         # should __new__ be saved as __new_member__ later?
         save_new = __new__ is not None
-        #
+
         if __new__ is None:
             # check all possibles for __new_member__ before falling back to
             # __new__
@@ -866,7 +830,7 @@ class EnumMeta(type):
                     break
             else:
                 __new__ = object.__new__
-        #
+
         # if a non-object.__new__ is used then whatever value/tuple was
         # assigned to the enum member name will be passed to __new__ and to the
         # new enum member's __init__
@@ -918,15 +882,11 @@ class Enum(metaclass=EnumMeta):
             ):
             return result
         else:
-            ve_exc = ValueError(
-                    "%r is not a valid %s" % (value, cls.__qualname__)
-                    )
+            ve_exc = ValueError("%r is not a valid %s" % (value, cls.__qualname__))
             if result is None and exc is None:
                 raise ve_exc
             elif exc is None:
-                exc = TypeError(
-                        'error in %s._missing_: returned %r instead of None'
-                        ' or a valid member'
+                exc = TypeError('error in %s._missing_: returned %r instead of None or a valid member'
                         % (cls.__name__, result)
                         )
             if not isinstance(exc, ValueError):
@@ -980,7 +940,7 @@ class Enum(metaclass=EnumMeta):
         # mixed-in Enums should use the mixed-in type's __format__, otherwise
         # we can get strange results with the Enum name showing up instead of
         # the value
-        #
+
         # pure Enum branch, or branch with __str__ explicitly overridden
         str_overridden = type(self).__str__ not in (Enum.__str__, Flag.__str__)
         if self._member_type_ is object or str_overridden:
@@ -1030,25 +990,19 @@ class StrEnum(str, Enum):
 
     def __new__(cls, *values):
         if len(values) > 3:
-            raise TypeError(
-                    'too many arguments for str(): %r' % (values, )
-                    )
+            raise TypeError('too many arguments for str(): %r' % (values, ))
         if len(values) == 1:
             # it must be a string
             if not isinstance(values[0], str):
                 raise TypeError('%r is not a string' % (values[0], ))
-        if len(values) >= 2:
+        if len(values) > 1:
             # check that encoding argument is a string
             if not isinstance(values[1], str):
-                raise TypeError(
-                        'encoding must be a string, not %r' % (values[1], )
-                        )
-        if len(values) == 3:
-            # check that errors argument is a string
-            if not isinstance(values[2], str):
-                raise TypeError(
-                        'errors must be a string, not %r' % (values[2], )
-                        )
+                raise TypeError('encoding must be a string, not %r' % (values[1], ))
+            if len(values) > 2:
+                # check that errors argument is a string
+                if not isinstance(values[2], str):
+                    raise TypeError('errors must be a string, not %r' % (values[2], ))
         value = str(*values)
         member = str.__new__(cls, value)
         member._value_ = value

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -138,22 +138,30 @@ class property(DynamicClassAttribute):
             try:
                 return ownerclass._member_map_[self.name]
             except KeyError:
-                raise AttributeError('%r not found in %r' % (self.name, ownerclass.__name__))
+                raise AttributeError(
+                        '%s: no attribute %r' % (ownerclass.__name__, self.name)
+                        )
         else:
             if self.fget is None:
-                raise AttributeError('%s: cannot read attribute %r' % (ownerclass.__name__, self.name))
+                raise AttributeError(
+                        '%s: no attribute %r' % (ownerclass.__name__, self.name)
+                        )
             else:
                 return self.fget(instance)
 
     def __set__(self, instance, value):
         if self.fset is None:
-            raise AttributeError("%s: cannot set attribute %r" % (self.clsname, self.name))
+            raise AttributeError(
+                    "%s: cannot set attribute %r" % (self.clsname, self.name)
+                    )
         else:
             return self.fset(instance, value)
 
     def __delete__(self, instance):
         if self.fdel is None:
-            raise AttributeError("%s: cannot delete attribute %r" % (self.clsname, self.name))
+            raise AttributeError(
+                    "%s: cannot delete attribute %r" % (self.clsname, self.name)
+                    )
         else:
             return self.fdel(instance)
 
@@ -331,10 +339,7 @@ class _EnumDict(dict):
             if isinstance(value, auto):
                 if value.value == _auto_null:
                     value.value = self._generate_next_value(
-                            key,
-                            1,
-                            len(self._member_names),
-                            self._last_values[:],
+                            key, 1, len(self._member_names), self._last_values[:],
                             )
                     self._auto_called = True
                 value = value.value
@@ -357,6 +362,7 @@ class EnumMeta(type):
     """
     Metaclass for Enum
     """
+
     @classmethod
     def __prepare__(metacls, cls, bases, **kwds):
         # check that previous enum members do not exist
@@ -415,7 +421,7 @@ class EnumMeta(type):
                 flag_mask |= value
             classdict[name] = _proto_member(value)
         #
-        # house keeping structures
+        # house-keeping structures
         classdict['_member_names_'] = []
         classdict['_member_map_'] = {}
         classdict['_value2member_map_'] = {}
@@ -873,6 +879,7 @@ class Enum(metaclass=EnumMeta):
 
     Derive from this class to define new enumerations.
     """
+
     def __new__(cls, value):
         # all enum instances are actually created during class construction
         # without calling this method; this method is called by the metaclass'
@@ -1021,14 +1028,14 @@ class StrEnum(str, Enum):
             # it must be a string
             if not isinstance(values[0], str):
                 raise TypeError('%r is not a string' % (values[0], ))
-        if len(values) > 1:
+        if len(values) >= 2:
             # check that encoding argument is a string
             if not isinstance(values[1], str):
                 raise TypeError('encoding must be a string, not %r' % (values[1], ))
-            if len(values) > 2:
-                # check that errors argument is a string
-                if not isinstance(values[2], str):
-                    raise TypeError('errors must be a string, not %r' % (values[2], ))
+        if len(values) == 3:
+            # check that errors argument is a string
+            if not isinstance(values[2], str):
+                raise TypeError('errors must be a string, not %r' % (values[2]))
         value = str(*values)
         member = str.__new__(cls, value)
         member._value_ = value

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -138,19 +138,16 @@ class property(DynamicClassAttribute):
             try:
                 return ownerclass._member_map_[self.name]
             except KeyError:
-                raise AttributeError('%r not found in %r' % (self.name, ownerclass.__name__))	
+                raise AttributeError('%r not found in %r' % (self.name, ownerclass.__name__))
         else:
             if self.fget is None:
-                raise AttributeError(
-                        '%s: no attribute %r'
-                        % (ownerclass.__name__, self.name)
-                        )
+                raise AttributeError('%s: cannot read attribute %r' % (ownerclass.__name__, self.name))
             else:
                 return self.fget(instance)
 
     def __set__(self, instance, value):
         if self.fset is None:
-            raise AttributeError("%s: cannot set attribute %r" % (self.clsname, self.name))	
+            raise AttributeError("%s: cannot set attribute %r" % (self.clsname, self.name))
         else:
             return self.fset(instance, value)
 
@@ -581,10 +578,7 @@ class EnumMeta(type):
         # nicer error message when someone tries to delete an attribute
         # (see issue19025).
         if attr in cls._member_map_:
-            raise AttributeError(
-                    "%s: cannot delete Enum member %r."
-                    % (cls.__name__, attr)
-                    )
+            raise AttributeError("%s: cannot delete Enum member %r." % (cls.__name__, attr))
         super().__delattr__(attr)
 
     def __dir__(self):
@@ -669,7 +663,7 @@ class EnumMeta(type):
         bases = (cls, ) if type is None else (type, cls)
         _, first_enum = cls._get_mixins_(cls, bases)
         classdict = metacls.__prepare__(class_name, bases)
-        #
+
         # special processing needed for names?
         if isinstance(names, str):
             names = names.replace(',', ' ').split()
@@ -847,7 +841,6 @@ class Enum(metaclass=EnumMeta):
 
     Derive from this class to define new enumerations.
     """
-
     def __new__(cls, value):
         # all enum instances are actually created during class construction
         # without calling this method; this method is called by the metaclass'
@@ -886,7 +879,8 @@ class Enum(metaclass=EnumMeta):
             if result is None and exc is None:
                 raise ve_exc
             elif exc is None:
-                exc = TypeError('error in %s._missing_: returned %r instead of None or a valid member'
+                exc = TypeError(
+                        'error in %s._missing_: returned %r instead of None or a valid member'
                         % (cls.__name__, result)
                         )
             if not isinstance(exc, ValueError):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -176,10 +176,10 @@ class property(DynamicClassAttribute):
             try:
                 return ownerclass._member_map_[self.name]
             except KeyError:
-                raise AttributeError('%r not found in %r' % (self.name, ownerclass.__name__))
+                raise AttributeError('%s: no attribute %r' % (ownerclass.__name__, self.name))
         else:
             if self.fget is None:
-                raise AttributeError('%s: cannot read attribute %r' % (ownerclass.__name__, self.name))
+                raise AttributeError('%s: no attribute %r' % (ownerclass.__name__, self.name))
             else:
                 return self.fget(instance)
 
@@ -1161,13 +1161,21 @@ class Flag(Enum, boundary=STRICT):
             raise TypeError(
                 "unsupported operand type(s) for 'in': '%s' and '%s'" % (
                     type(other).__qualname__, self.__class__.__qualname__))
+        if other._value_ == 0 or self._value_ == 0:
+            return False
         return other._value_ & self._value_ == other._value_
 
     def __iter__(self):
         """
         Returns flags in decreasing value order.
         """
-        return (m for m in reversed(self.__class__) if m._value_ & self._value_)
+        return (
+                m
+                for m in sorted(
+                    self.__class__, key=lambda m: m._value_, reverse=True
+                    )
+                if m._value_ & self._value_
+                )
 
     def __len__(self):
         return _bit_count(self._value_)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -75,8 +75,10 @@ def _bits(num):
     while num:
         digits.insert(0, num&1)
         num >>= 1
+    if len(digits) < 4:
+        digits = ([0, 0, 0, 0] + digits)[-4:]
     if negative:
-        result = '0b1' + (''.join(['10'[d] for d in digits]).lstrip('0'))
+        result = '0b1' + (''.join(['10'[d] for d in digits]))
     else:
         result = '0b0' + ''.join(str(d) for d in digits)
     return result

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -297,8 +297,7 @@ class _EnumDict(dict):
             if key == '_generate_next_value_':
                 # check if members already defined as auto()
                 if self._auto_called:
-                    raise TypeError(
-                            "_generate_next_value_ must be defined before members")
+                    raise TypeError("_generate_next_value_ must be defined before members")
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':
                 if isinstance(value, str):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -100,7 +100,8 @@ def _bit_count(num):
 
     * The C Programming Language 2nd Ed., Kernighan & Ritchie, 1988.
 
-    This works because each subtraction "borrows" from the lowest 1-bit. For example:
+    This works because each subtraction "borrows" from the lowest 1-bit. For
+    example:
 
           loop pass 1     loop pass 2
           -----------     -----------
@@ -110,8 +111,8 @@ def _bit_count(num):
              & 101000        & 100000
              = 100000        =      0
 
-    It is an excellent technique for Python, since the size of the integer need not
-    be determined beforehand.
+    It is an excellent technique for Python, since the size of the integer need
+    not be determined beforehand.
 
     (from https://wiki.python.org/moin/BitManipulation)
     """
@@ -166,22 +167,34 @@ class property(DynamicClassAttribute):
             try:
                 return ownerclass._member_map_[self.name]
             except KeyError:
-                raise AttributeError('%s: no attribute %r' % (ownerclass.__name__, self.name))
+                raise AttributeError(
+                        '%s: no attribute %r'
+                        % (ownerclass.__name__, self.name)
+                        )
         else:
             if self.fget is None:
-                raise AttributeError('%s: no attribute %r' % (ownerclass.__name__, self.name))
+                raise AttributeError(
+                        '%s: no attribute %r'
+                        % (ownerclass.__name__, self.name)
+                        )
             else:
                 return self.fget(instance)
 
     def __set__(self, instance, value):
         if self.fset is None:
-            raise AttributeError("%s: cannot set attribute %r" % (self.clsname, self.name))
+            raise AttributeError(
+                    "%s: cannot set attribute %r"
+                    % (self.clsname, self.name)
+                    )
         else:
             return self.fset(instance, value)
 
     def __delete__(self, instance):
         if self.fdel is None:
-            raise AttributeError("%s: cannot delete attribute %r" % (self.clsname, self.name))
+            raise AttributeError(
+                    "%s: cannot delete attribute %r"
+                    % (self.clsname, self.name)
+                    )
         else:
             return self.fdel(instance)
 
@@ -234,12 +247,19 @@ class _proto_member:
                 enum_member = canonical_member
                 break
         else:
-            # this could still be an alias if the value is multi-bit and the class
-            # is a flag class
-            if Flag is None or not issubclass(enum_class, Flag):
+            # this could still be an alias if the value is multi-bit and the
+            # class is a flag class
+            if (
+                    Flag is None
+                    or not issubclass(enum_class, Flag)
+                ):
                 # no other instances found, record this member in _member_names_
                 enum_class._member_names_.append(member_name)
-            elif Flag is not None and issubclass(enum_class, Flag) and _is_single_bit(value):
+            elif (
+                    Flag is not None
+                    and issubclass(enum_class, Flag)
+                    and _is_single_bit(value)
+                ):
                 # no other instances found, record this member in _member_names_
                 enum_class._member_names_.append(member_name)
         # get redirect in place before adding to _member_map_
@@ -261,8 +281,8 @@ class _proto_member:
             redirect = property()
             redirect.__set_name__(enum_class, member_name)
             if descriptor and need_override:
-                # previous enum.property found, but some other inherited attribute
-                # is in the way; copy fget, fset, fdel to this one
+                # previous enum.property found, but some other inherited
+                # attribute is in the way; copy fget, fset, fdel to this one
                 redirect.fget = descriptor.fget
                 redirect.fset = descriptor.fset
                 redirect.fdel = descriptor.fdel
@@ -310,13 +330,17 @@ class _EnumDict(dict):
                     '_generate_next_value_', '_missing_', '_ignore_',
                     ):
                 raise ValueError(
-                        '_sunder_ names, such as %r, are reserved for future Enum use'
+                        '_sunder_ names, such as %r, are reserved for future'
+                        ' Enum use'
                         % (key, )
                         )
             if key == '_generate_next_value_':
                 # check if members already defined as auto()
                 if self._auto_called:
-                    raise TypeError("_generate_next_value_ must be defined before members")
+                    raise TypeError(
+                            "_generate_next_value_ must be defined before"
+                            " members"
+                            )
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':
                 if isinstance(value, str):
@@ -371,6 +395,7 @@ class EnumMeta(type):
     """
     Metaclass for Enum
     """
+
     @classmethod
     def __prepare__(metacls, cls, bases, **kwds):
         # check that previous enum members do not exist
@@ -436,7 +461,10 @@ class EnumMeta(type):
         classdict['_member_type_'] = member_type
         #
         # Flag structures (will be removed if final class is not a Flag
-        classdict['_boundary_'] = boundary or getattr(first_enum, '_boundary_', None)
+        classdict['_boundary_'] = (
+                boundary
+                or getattr(first_enum, '_boundary_', None)
+                )
         classdict['_flag_mask_'] = flag_mask
         classdict['_all_bits_'] = 2 ** ((flag_mask).bit_length()) - 1
         classdict['_inverted_'] = None
@@ -465,8 +493,9 @@ class EnumMeta(type):
             exc = None
             enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
         except RuntimeError as e:
-            # any exceptions raised by member.__new__ will get converted to a
-            # RuntimeError, so get that original exception back and raise it instead
+            # any exceptions raised by member.__new__ will get converted to
+            # a RuntimeError, so get that original exception back and raise
+            # it instead
             exc = e.__cause__ or e
         if exc is not None:
             raise exc
@@ -501,7 +530,10 @@ class EnumMeta(type):
                 raise TypeError('member order does not match _order_')
         #
         # remove Flag structures if final class is not a Flag
-        if Flag is None and cls != 'Flag' or Flag is not None and not issubclass(enum_class, Flag):
+        if (
+                Flag is None and cls != 'Flag'
+                or Flag is not None and not issubclass(enum_class, Flag)
+            ):
             delattr(enum_class, '_boundary_')
             delattr(enum_class, '_flag_mask_')
             delattr(enum_class, '_all_bits_')
@@ -524,7 +556,10 @@ class EnumMeta(type):
                     missed.append(i)
                     missed_bits &= ~i
                 if missed:
-                    raise TypeError('invalid Flag %r -- missing values: %s' % (cls, ', '.join((str(i) for i in missed))))
+                    raise TypeError(
+                            'invalid Flag %r -- missing values: %s'
+                            % (cls, ', '.join((str(i) for i in missed)))
+                            )
             enum_class._flag_mask_ = single_bit_total
         #
         return enum_class
@@ -553,7 +588,8 @@ class EnumMeta(type):
         `value` will be the name of the new class.
 
         `names` should be either a string of white-space/comma delimited names
-        (values will start at `start`), or an iterator/mapping of name, value pairs.
+        (values will start at `start`), or an iterator/mapping of name, value
+        pairs.
 
         `module` should be set to the module this class is being created in;
         if it is not set, an attempt to find that module will be made, but if
@@ -589,7 +625,10 @@ class EnumMeta(type):
         # nicer error message when someone tries to delete an attribute
         # (see issue19025).
         if attr in cls._member_map_:
-            raise AttributeError("%s: cannot delete Enum member %r." % (cls.__name__, attr))
+            raise AttributeError(
+                    "%s: cannot delete Enum member %r."
+                    % (cls.__name__, attr)
+                    )
         super().__delattr__(attr)
 
     def __dir__(self):
@@ -671,7 +710,8 @@ class EnumMeta(type):
 
         * A string containing member names, separated either with spaces or
           commas.  Values are incremented by 1 from `start`.
-        * An iterable of member names.  Values are incremented by 1 from `start`.
+        * An iterable of member names.  Values are incremented by 1 from
+          `start`.
         * An iterable of (member name, value) pairs.
         * A mapping of member name -> value pairs.
         """
@@ -679,18 +719,24 @@ class EnumMeta(type):
         bases = (cls, ) if type is None else (type, cls)
         _, first_enum = cls._get_mixins_(cls, bases)
         classdict = metacls.__prepare__(class_name, bases)
-
+        #
         # special processing needed for names?
         if isinstance(names, str):
             names = names.replace(',', ' ').split()
-        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str):
+        if (
+                isinstance(names, (tuple, list))
+                and names
+                and isinstance(names[0], str)
+            ):
             original_names, names = names, []
             last_values = []
             for count, name in enumerate(original_names):
-                value = first_enum._generate_next_value_(name, start, count, last_values[:])
+                value = first_enum._generate_next_value_(
+                        name, start, count, last_values[:]
+                        )
                 last_values.append(value)
                 names.append((name, value))
-
+        #
         # Here, names is either an iterable of (name, value) or a mapping.
         for item in names:
             if isinstance(item, str):
@@ -698,7 +744,7 @@ class EnumMeta(type):
             else:
                 member_name, member_value = item
             classdict[member_name] = member_value
-
+        #
         # TODO: replace the frame hack if a blessed way to know the calling
         # module is ever developed
         if module is None:
@@ -712,7 +758,7 @@ class EnumMeta(type):
             classdict['__module__'] = module
         if qualname is not None:
             classdict['__qualname__'] = qualname
-
+        #
         return metacls.__new__(
                 metacls, class_name, bases, classdict,
                 boundary=boundary,
@@ -771,7 +817,7 @@ class EnumMeta(type):
         """
         if not bases:
             return object, Enum
-
+        #
         def _find_data_type(bases):
             data_types = []
             for chain in bases:
@@ -791,12 +837,15 @@ class EnumMeta(type):
                     else:
                         candidate = base
             if len(data_types) > 1:
-                raise TypeError('%r: too many data types: %r' % (class_name, data_types))
+                raise TypeError(
+                        '%r: too many data types: %r'
+                        % (class_name, data_types)
+                        )
             elif data_types:
                 return data_types[0]
             else:
                 return None
-
+        #
         # ensure final parent class is an Enum derivative, find any concrete
         # data type, and check that Enum has no members
         first_enum = bases[-1]
@@ -821,10 +870,10 @@ class EnumMeta(type):
         # by the user; also check earlier enum classes in case a __new__ was
         # saved as __new_member__
         __new__ = classdict.get('__new__', None)
-
+        #
         # should __new__ be saved as __new_member__ later?
         save_new = __new__ is not None
-
+        #
         if __new__ is None:
             # check all possibles for __new_member__ before falling back to
             # __new__
@@ -843,7 +892,7 @@ class EnumMeta(type):
                     break
             else:
                 __new__ = object.__new__
-
+        #
         # if a non-object.__new__ is used then whatever value/tuple was
         # assigned to the enum member name will be passed to __new__ and to the
         # new enum member's __init__
@@ -895,12 +944,15 @@ class Enum(metaclass=EnumMeta):
             ):
             return result
         else:
-            ve_exc = ValueError("%r is not a valid %s" % (value, cls.__qualname__))
+            ve_exc = ValueError(
+                    "%r is not a valid %s" % (value, cls.__qualname__)
+                    )
             if result is None and exc is None:
                 raise ve_exc
             elif exc is None:
                 exc = TypeError(
-                        'error in %s._missing_: returned %r instead of None or a valid member'
+                        'error in %s._missing_: returned %r instead of None'
+                        ' or a valid member'
                         % (cls.__name__, result)
                         )
             if not isinstance(exc, ValueError):
@@ -954,7 +1006,7 @@ class Enum(metaclass=EnumMeta):
         # mixed-in Enums should use the mixed-in type's __format__, otherwise
         # we can get strange results with the Enum name showing up instead of
         # the value
-
+        #
         # pure Enum branch, or branch with __str__ explicitly overridden
         str_overridden = type(self).__str__ not in (Enum.__str__, Flag.__str__)
         if self._member_type_ is object or str_overridden:
@@ -1004,19 +1056,25 @@ class StrEnum(str, Enum):
 
     def __new__(cls, *values):
         if len(values) > 3:
-            raise TypeError('too many arguments for str(): %r' % (values, ))
+            raise TypeError(
+                    'too many arguments for str(): %r' % (values, )
+                    )
         if len(values) == 1:
             # it must be a string
             if not isinstance(values[0], str):
                 raise TypeError('%r is not a string' % (values[0], ))
-        if len(values) > 1:
+        if len(values) >= 2:
             # check that encoding argument is a string
             if not isinstance(values[1], str):
-                raise TypeError('encoding must be a string, not %r' % (values[1], ))
-            if len(values) > 2:
-                # check that errors argument is a string
-                if not isinstance(values[2], str):
-                    raise TypeError('errors must be a string, not %r' % (values[2], ))
+                raise TypeError(
+                        'encoding must be a string, not %r' % (values[1], )
+                        )
+        if len(values) == 3:
+            # check that errors argument is a string
+            if not isinstance(values[2], str):
+                raise TypeError(
+                        'errors must be a string, not %r' % (values[2], )
+                        )
         value = str(*values)
         member = str.__new__(cls, value)
         member._value_ = value
@@ -1078,10 +1136,13 @@ class Flag(Enum, boundary=STRICT):
         Create a composite member iff value contains only members.
         """
         if not isinstance(value, int):
-            raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
+            raise ValueError(
+                    "%r is not a valid %s" % (value, cls.__qualname__)
+                    )
         # check boundaries
         # - value must be in range (e.g. -16 <-> +15, i.e. ~15 <-> 15)
-        # - value must not include any skipped flags (e.g. if bit 2 is not defined, then 0d10 is invalid)
+        # - value must not include any skipped flags (e.g. if bit 2 is not
+        #   defined, then 0d10 is invalid)
         neg_value = None
         if (
                 not ~cls._all_bits_ <= value <= cls._all_bits_
@@ -1089,9 +1150,16 @@ class Flag(Enum, boundary=STRICT):
             ):
             if cls._boundary_ is STRICT:
                 invalid_as_bits = _bits(value)
-                length = max(len(invalid_as_bits), cls._flag_mask_.bit_length())
-                valid_as_bits = ('0' * length + _bits(cls._flag_mask_))[-length:]
-                invalid_as_bits = ('01'[value<0] * length + invalid_as_bits)[-length:]
+                length = max(
+                        len(invalid_as_bits),
+                        cls._flag_mask_.bit_length()
+                        )
+                valid_as_bits = (
+                        ('0' * length + _bits(cls._flag_mask_))[-length:]
+                        )
+                invalid_as_bits = (
+                        ('01'[value<0] * length + invalid_as_bits)[-length:]
+                        )
                 raise ValueError(
                         "%s: invalid value: %r\n    given %s\n  allowed %s" % (
                             cls.__name__,
@@ -1105,9 +1173,14 @@ class Flag(Enum, boundary=STRICT):
                 return value
             elif cls._boundary_ is KEEP:
                 if value < 0:
-                    value = max(cls._all_bits_+1, 2**(value.bit_length())) + value
+                    value = (
+                            max(cls._all_bits_+1, 2**(value.bit_length()))
+                            + value
+                            )
             else:
-                raise ValueError('unknown flag boundary: %r' % (cls._boundary_, ))
+                raise ValueError(
+                        'unknown flag boundary: %r' % (cls._boundary_, )
+                        )
         if value < 0:
             neg_value = value
             value = cls._all_bits_ + 1 + value

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1304,7 +1304,7 @@ def _decompose(flag, value):
                 continue
             if multi._value_ & value == multi._value_:
                 members.append(multi)
-                value ^= multi._value_            
+                value ^= multi._value_
     if negative:
         members = [m for m in flag if m not in members]
         if value:
@@ -1316,4 +1316,3 @@ def _power_of_two(value):
     if value < 1:
         return False
     return value == 2 ** _high_bit(value)
-

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -533,7 +533,7 @@ class EnumMeta(type):
             inverted = ~enum_class(0)
             if list(enum_class) != list(inverted):
                 if '|' in inverted._name_:
-                    del enum_class._value2member_map_[inverted._value_]
+                    enum_class._value2member_map_.pop(inverted._value_, None)
                 enum_class._iter_member_ = enum_class._iter_member_by_def_
         #
         return enum_class

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -142,7 +142,7 @@ __all__ = [
 
 __version__ = "2.2.1"
 
-class RegexFlag(enum.IntFlag):
+class RegexFlag(enum.IntFlag, boundary=enum.KEEP):
     ASCII = A = sre_compile.SRE_FLAG_ASCII # assume ascii "locale"
     IGNORECASE = I = sre_compile.SRE_FLAG_IGNORECASE # ignore case
     LOCALE = L = sre_compile.SRE_FLAG_LOCALE # assume current 8-bit locale
@@ -155,26 +155,17 @@ class RegexFlag(enum.IntFlag):
     DEBUG = sre_compile.SRE_FLAG_DEBUG # dump pattern after compilation
 
     def __repr__(self):
-        if self._name_ is not None:
-            return f're.{self._name_}'
-        value = self._value_
-        members = []
-        negative = value < 0
-        if negative:
-            value = ~value
-        for m in self.__class__:
-            if value & m._value_:
-                value &= ~m._value_
-                members.append(f're.{m._name_}')
-        if value:
-            members.append(hex(value))
-        res = '|'.join(members)
-        if negative:
-            if len(members) > 1:
-                res = f'~({res})'
-            else:
-                res = f'~{res}'
+        res = ''
+        if self._name_:
+            member_names = self._name_.split('|')
+            constant = None
+            if member_names[-1].startswith('0x'):
+                constant = member_names.pop()
+            res = 're.' + '|re.'.join(member_names)
+            if constant:
+                res += '|%s' % constant
         return res
+
     __str__ = object.__str__
 
 globals().update(RegexFlag.__members__)

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2544,6 +2544,7 @@ class TestFlag(unittest.TestCase):
 
     def test_member_iter(self):
         Color = self.Color
+        self.assertEqual(list(Color.BLACK), [])
         self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
         self.assertEqual(list(Color.BLUE), [Color.BLUE])
         self.assertEqual(list(Color.GREEN), [Color.GREEN])
@@ -3090,6 +3091,7 @@ class TestIntFlag(unittest.TestCase):
 
     def test_member_iter(self):
         Color = self.Color
+        self.assertEqual(list(Color.BLACK), [])
         self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
         self.assertEqual(list(Color.BLUE), [Color.BLUE])
         self.assertEqual(list(Color.GREEN), [Color.GREEN])

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -15,13 +15,13 @@ from test.support import ALWAYS_EQ
 from test.support import threading_helper
 from datetime import timedelta
 
-# def load_tests(loader, tests, ignore):
-#     tests.addTests(doctest.DocTestSuite(enum))
-#     tests.addTests(doctest.DocFileSuite(
-#             '../../Doc/library/enum.rst',
-#             optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
-#             ))
-#     return tests
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(enum))
+    tests.addTests(doctest.DocFileSuite(
+            '../../Doc/library/enum.rst',
+            optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
+            ))
+    return tests
 
 # for pickle tests
 try:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2300,9 +2300,9 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(str(Open.WO), 'Open.WO')
         self.assertEqual(str(Open.AC), 'Open.AC')
         self.assertEqual(str(Open.RO | Open.CE), 'Open.CE')
-        self.assertEqual(str(Open.WO | Open.CE), 'Open.CE|WO')
-        self.assertEqual(str(~Open.RO), 'Open.CE|RW|WO')
-        self.assertEqual(str(~Open.WO), 'Open.CE|RW')
+        self.assertEqual(str(Open.WO | Open.CE), 'Open.WO|CE')
+        self.assertEqual(str(~Open.RO), 'Open.WO|RW|CE')
+        self.assertEqual(str(~Open.WO), 'Open.RW|CE')
         self.assertEqual(str(~Open.AC), 'Open.CE')
         self.assertEqual(str(~Open.CE), 'Open.AC')
         self.assertEqual(str(~(Open.RO | Open.CE)), 'Open.AC')
@@ -2328,9 +2328,9 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(repr(Open.WO), '<Open.WO: 1>')
         self.assertEqual(repr(Open.AC), '<Open.AC: 3>')
         self.assertEqual(repr(Open.RO | Open.CE), '<Open.CE: 524288>')
-        self.assertEqual(repr(Open.WO | Open.CE), '<Open.CE|WO: 524289>')
-        self.assertEqual(repr(~Open.RO), '<Open.CE|RW|WO: 524291>')
-        self.assertEqual(repr(~Open.WO), '<Open.CE|RW: 524290>')
+        self.assertEqual(repr(Open.WO | Open.CE), '<Open.WO|CE: 524289>')
+        self.assertEqual(repr(~Open.RO), '<Open.WO|RW|CE: 524291>')
+        self.assertEqual(repr(~Open.WO), '<Open.RW|CE: 524290>')
         self.assertEqual(repr(~Open.AC), '<Open.CE: 524288>')
         self.assertEqual(repr(~Open.CE), '<Open.AC: 3>')
         self.assertEqual(repr(~(Open.RO | Open.CE)), '<Open.AC: 3>')
@@ -2566,11 +2566,11 @@ class TestFlag(unittest.TestCase):
     def test_member_iter(self):
         Color = self.Color
         self.assertEqual(list(Color.BLACK), [])
-        self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
+        self.assertEqual(list(Color.PURPLE), [Color.RED, Color.BLUE])
         self.assertEqual(list(Color.BLUE), [Color.BLUE])
         self.assertEqual(list(Color.GREEN), [Color.GREEN])
-        self.assertEqual(list(Color.WHITE), [Color.BLUE, Color.GREEN, Color.RED])
-        self.assertEqual(list(Color.WHITE), [Color.BLUE, Color.GREEN, Color.RED])
+        self.assertEqual(list(Color.WHITE), [Color.RED, Color.GREEN, Color.BLUE])
+        self.assertEqual(list(Color.WHITE), [Color.RED, Color.GREEN, Color.BLUE])
 
     def test_member_length(self):
         self.assertEqual(self.Color.__len__(self.Color.BLACK), 0)
@@ -2613,7 +2613,7 @@ class TestFlag(unittest.TestCase):
         self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
 
     def test_bizarre(self):
-        with self.assertRaisesRegex(TypeError, "invalid Flag 'Bizarre' -- missing values: 2, 1"):
+        with self.assertRaisesRegex(TypeError, "invalid Flag 'Bizarre' -- missing values: 1, 2"):
             class Bizarre(Flag):
                 b = 3
                 c = 4
@@ -2741,9 +2741,9 @@ class TestIntFlag(unittest.TestCase):
     """Tests of the IntFlags."""
 
     class Perm(IntFlag):
-        X = 1 << 0
-        W = 1 << 1
         R = 1 << 2
+        W = 1 << 1
+        X = 1 << 0
 
     class Open(IntFlag):
         RO = 0
@@ -2807,10 +2807,10 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(str(Open.WO), 'Open.WO')
         self.assertEqual(str(Open.AC), 'Open.AC')
         self.assertEqual(str(Open.RO | Open.CE), 'Open.CE')
-        self.assertEqual(str(Open.WO | Open.CE), 'Open.CE|WO')
+        self.assertEqual(str(Open.WO | Open.CE), 'Open.WO|CE')
         self.assertEqual(str(Open(4)), '4')
-        self.assertEqual(str(~Open.RO), 'Open.CE|RW|WO')
-        self.assertEqual(str(~Open.WO), 'Open.CE|RW')
+        self.assertEqual(str(~Open.RO), 'Open.WO|RW|CE')
+        self.assertEqual(str(~Open.WO), 'Open.RW|CE')
         self.assertEqual(str(~Open.AC), 'Open.CE')
         self.assertEqual(str(~Open.CE), 'Open.AC')
         self.assertEqual(str(~(Open.RO | Open.CE)), 'Open.AC')
@@ -2818,7 +2818,7 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(str(Open(~4)), '-5')
 
         Skip = self.Skip
-        self.assertEqual(str(Skip(~4)), 'Skip.EIGHTH|SECOND|FIRST')
+        self.assertEqual(str(Skip(~4)), 'Skip.FIRST|SECOND|EIGHTH')
 
     def test_repr(self):
         Perm = self.Perm
@@ -2844,17 +2844,17 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(repr(Open.WO), '<Open.WO: 1>')
         self.assertEqual(repr(Open.AC), '<Open.AC: 3>')
         self.assertEqual(repr(Open.RO | Open.CE), '<Open.CE: 524288>')
-        self.assertEqual(repr(Open.WO | Open.CE), '<Open.CE|WO: 524289>')
+        self.assertEqual(repr(Open.WO | Open.CE), '<Open.WO|CE: 524289>')
         self.assertEqual(repr(Open(4)), '4')
-        self.assertEqual(repr(~Open.RO), '<Open.CE|RW|WO: 524291>')
-        self.assertEqual(repr(~Open.WO), '<Open.CE|RW: 524290>')
+        self.assertEqual(repr(~Open.RO), '<Open.WO|RW|CE: 524291>')
+        self.assertEqual(repr(~Open.WO), '<Open.RW|CE: 524290>')
         self.assertEqual(repr(~Open.AC), '<Open.CE: 524288>')
         self.assertEqual(repr(~(Open.RO | Open.CE)), '<Open.AC: 3>')
         self.assertEqual(repr(~(Open.WO | Open.CE)), '<Open.RW: 2>')
         self.assertEqual(repr(Open(~4)), '-5')
 
         Skip = self.Skip
-        self.assertEqual(repr(Skip(~4)), '<Skip.EIGHTH|SECOND|FIRST: 11>')
+        self.assertEqual(repr(Skip(~4)), '<Skip.FIRST|SECOND|EIGHTH: 11>')
 
     def test_format(self):
         Perm = self.Perm
@@ -3128,10 +3128,10 @@ class TestIntFlag(unittest.TestCase):
     def test_member_iter(self):
         Color = self.Color
         self.assertEqual(list(Color.BLACK), [])
-        self.assertEqual(list(Color.PURPLE), [Color.BLUE, Color.RED])
+        self.assertEqual(list(Color.PURPLE), [Color.RED, Color.BLUE])
         self.assertEqual(list(Color.BLUE), [Color.BLUE])
         self.assertEqual(list(Color.GREEN), [Color.GREEN])
-        self.assertEqual(list(Color.WHITE), [Color.BLUE, Color.GREEN, Color.RED])
+        self.assertEqual(list(Color.WHITE), [Color.RED, Color.GREEN, Color.BLUE])
 
     def test_member_length(self):
         self.assertEqual(self.Color.__len__(self.Color.BLACK), 0)
@@ -3158,7 +3158,7 @@ class TestIntFlag(unittest.TestCase):
             self.assertEqual(bool(f.value), bool(f))
 
     def test_bizarre(self):
-        with self.assertRaisesRegex(TypeError, "invalid Flag 'Bizarre' -- missing values: 2, 1"):
+        with self.assertRaisesRegex(TypeError, "invalid Flag 'Bizarre' -- missing values: 1, 2"):
             class Bizarre(IntFlag):
                 b = 3
                 c = 4
@@ -3466,7 +3466,7 @@ class TestStdLib(unittest.TestCase):
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
-        support.check__all__(self, enum)
+        support.check__all__(self, enum, not_exported={'bin'})
 
 
 # These are unordered here on purpose to ensure that declaration order

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2578,6 +2578,24 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(self.Color.__len__(self.Color.PURPLE), 2)
         self.assertEqual(self.Color.__len__(self.Color.BLANCO), 3)
 
+    def test_number_reset_and_order_cleanup(self):
+        class Confused(Flag):
+            _settings_ = AutoValue
+            _order_ = 'ONE TWO FOUR DOS EIGHT SIXTEEN'
+            ONE = auto()
+            TWO = auto()
+            FOUR = auto()
+            DOS = 2
+            EIGHT = auto()
+            SIXTEEN = auto()
+        self.assertEqual(
+                list(Confused),
+                [Confused.ONE, Confused.TWO, Confused.FOUR, Confused.EIGHT, Confused.SIXTEEN])
+        self.assertIs(Confused.TWO, Confused.DOS)
+        self.assertEqual(Confused.DOS._value_, 2)
+        self.assertEqual(Confused.EIGHT._value_, 8)
+        self.assertEqual(Confused.SIXTEEN._value_, 16)
+
     def test_aliases(self):
         Color = self.Color
         self.assertEqual(Color(1).name, 'RED')

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2404,22 +2404,23 @@ class TestFlag(unittest.TestCase):
         class Iron(Flag, boundary=STRICT):
             ONE = 1
             TWO = 2
-            FOUR = 4
+            EIGHT = 8
         #
         class Water(Flag, boundary=CONFORM):
             ONE = 1
             TWO = 2
-            FOUR = 4
+            EIGHT = 8
         #
         class Space(Flag, boundary=EJECT):
             ONE = 1
             TWO = 2
-            FOUR = 4
+            EIGHT = 8
         #
-        self.assertRaisesRegex(ValueError, 'invalid value: 11', Iron, 11)
-        self.assertIs(Water(11), Water.ONE|Water.TWO)
-        self.assertEqual(Space(11), 11)
-        self.assertTrue(type(Space(11)) is int)
+        self.assertRaisesRegex(ValueError, 'invalid value: 7', Iron, 7)
+        self.assertIs(Water(7), Water.ONE|Water.TWO)
+        self.assertIs(Water(~9), Water.TWO)
+        self.assertEqual(Space(7), 7)
+        self.assertTrue(type(Space(7)) is int)
 
     def test_iter(self):
         Color = self.Color
@@ -2924,25 +2925,26 @@ class TestIntFlag(unittest.TestCase):
         self.assertIs((Open.WO|Open.CE) & ~Open.WO, Open.CE)
 
     def test_boundary(self):
-        class Iron(Flag, boundary=STRICT):
+        class Iron(IntFlag, boundary=STRICT):
             ONE = 1
             TWO = 2
-            FOUR = 4
+            EIGHT = 8
         #
-        class Water(Flag, boundary=CONFORM):
+        class Water(IntFlag, boundary=CONFORM):
             ONE = 1
             TWO = 2
-            FOUR = 4
+            EIGHT = 8
         #
-        class Space(Flag, boundary=EJECT):
+        class Space(IntFlag, boundary=EJECT):
             ONE = 1
             TWO = 2
-            FOUR = 4
+            EIGHT = 8
         #
-        self.assertRaisesRegex(ValueError, 'invalid value: 11', Iron, 11)
-        self.assertIs(Water(11), Water.ONE|Water.TWO)
-        self.assertEqual(Space(11), 11)
-        self.assertTrue(type(Space(11)) is int)
+        self.assertRaisesRegex(ValueError, 'invalid value: 5', Iron, 5)
+        self.assertIs(Water(7), Water.ONE|Water.TWO)
+        self.assertIs(Water(~9), Water.TWO)
+        self.assertEqual(Space(7), 7)
+        self.assertTrue(type(Space(7)) is int)
 
     def test_iter(self):
         Color = self.Color

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2135,7 +2135,30 @@ class TestEnum(unittest.TestCase):
                 one = '1'
                 two = b'2', 'ascii', 9
 
-
+    def test_missing_value_error(self):
+        with self.assertRaisesRegex(TypeError, "_value_ not set in __new__"):
+            class Combined(str, Enum):
+                #
+                def __new__(cls, value, sequence):
+                    enum = str.__new__(cls, value)
+                    if '(' in value:
+                        fis_name, segment = value.split('(', 1)
+                        segment = segment.strip(' )')
+                    else:
+                        fis_name = value
+                        segment = None
+                    enum.fis_name = fis_name
+                    enum.segment = segment
+                    enum.sequence = sequence
+                    return enum
+                #
+                def __repr__(self):
+                    return "<%s.%s>" % (self.__class__.__name__, self._name_)
+                #
+                key_type      = 'An$(1,2)', 0
+                company_id    = 'An$(3,2)', 1
+                code          = 'An$(5,1)', 2
+                description   = 'Bn$',      3
 
     @unittest.skipUnless(
             sys.version_info[:2] == (3, 9),
@@ -2580,7 +2603,6 @@ class TestFlag(unittest.TestCase):
 
     def test_number_reset_and_order_cleanup(self):
         class Confused(Flag):
-            _settings_ = AutoValue
             _order_ = 'ONE TWO FOUR DOS EIGHT SIXTEEN'
             ONE = auto()
             TWO = auto()

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -15,13 +15,13 @@ from test.support import ALWAYS_EQ
 from test.support import threading_helper
 from datetime import timedelta
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(enum))
-    tests.addTests(doctest.DocFileSuite(
-            '../../Doc/library/enum.rst',
-            optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
-            ))
-    return tests
+# def load_tests(loader, tests, ignore):
+#     tests.addTests(doctest.DocTestSuite(enum))
+#     tests.addTests(doctest.DocFileSuite(
+#             '../../Doc/library/enum.rst',
+#             optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
+#             ))
+#     return tests
 
 # for pickle tests
 try:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2279,12 +2279,12 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(str(Perm.X), 'Perm.X')
         self.assertEqual(str(Perm.R | Perm.W), 'Perm.R|W')
         self.assertEqual(str(Perm.R | Perm.W | Perm.X), 'Perm.R|W|X')
-        self.assertEqual(str(Perm(0)), 'Perm.0')
+        self.assertEqual(str(Perm(0)), 'Perm(0)')
         self.assertEqual(str(~Perm.R), 'Perm.W|X')
         self.assertEqual(str(~Perm.W), 'Perm.R|X')
         self.assertEqual(str(~Perm.X), 'Perm.R|W')
         self.assertEqual(str(~(Perm.R | Perm.W)), 'Perm.X')
-        self.assertEqual(str(~(Perm.R | Perm.W | Perm.X)), 'Perm.0')
+        self.assertEqual(str(~(Perm.R | Perm.W | Perm.X)), 'Perm(0)')
         self.assertEqual(str(Perm(~0)), 'Perm.R|W|X')
 
         Open = self.Open
@@ -2421,6 +2421,11 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(Space(11), 11)
         self.assertTrue(type(Space(11)) is int)
 
+    def test_iter(self):
+        Color = self.Color
+        Open = self.Open
+        self.assertEqual(list(Color), [Color.RED, Color.GREEN, Color.BLUE])
+        self.assertEqual(list(Open), [Open.WO, Open.RW, Open.CE])
 
     def test_programatic_function_string(self):
         Perm = Flag('Perm', 'R W X')
@@ -2762,13 +2767,13 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(str(Perm.R | Perm.W), 'Perm.R|W')
         self.assertEqual(str(Perm.R | Perm.W | Perm.X), 'Perm.R|W|X')
         self.assertEqual(str(Perm.R | 8), '12')
-        self.assertEqual(str(Perm(0)), 'Perm.0')
+        self.assertEqual(str(Perm(0)), 'Perm(0)')
         self.assertEqual(str(Perm(8)), '8')
         self.assertEqual(str(~Perm.R), 'Perm.W|X')
         self.assertEqual(str(~Perm.W), 'Perm.R|X')
         self.assertEqual(str(~Perm.X), 'Perm.R|W')
         self.assertEqual(str(~(Perm.R | Perm.W)), 'Perm.X')
-        self.assertEqual(str(~(Perm.R | Perm.W | Perm.X)), 'Perm.0')
+        self.assertEqual(str(~(Perm.R | Perm.W | Perm.X)), 'Perm(0)')
         self.assertEqual(str(~(Perm.R | 8)), '-13')
         self.assertEqual(str(Perm(~0)), 'Perm.R|W|X')
         self.assertEqual(str(Perm(~8)), '-9')
@@ -2937,6 +2942,12 @@ class TestIntFlag(unittest.TestCase):
         self.assertIs(Water(11), Water.ONE|Water.TWO)
         self.assertEqual(Space(11), 11)
         self.assertTrue(type(Space(11)) is int)
+
+    def test_iter(self):
+        Color = self.Color
+        Open = self.Open
+        self.assertEqual(list(Color), [Color.RED, Color.GREEN, Color.BLUE])
+        self.assertEqual(list(Open), [Open.WO, Open.RW, Open.CE])
 
     def test_programatic_function_string(self):
         Perm = IntFlag('Perm', 'R W X')
@@ -3256,7 +3267,7 @@ expected_help_output_with_docs = """\
 Help on class Color in module %s:
 
 class Color(enum.Enum)
- |  Color(value, names=None, *, module=None, qualname=None, type=None, start=1)
+ |  Color(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)
  |\x20\x20
  |  An enumeration.
  |\x20\x20

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1,4 +1,5 @@
 import enum
+import doctest
 import inspect
 import pydoc
 import sys
@@ -14,6 +15,13 @@ from test.support import ALWAYS_EQ
 from test.support import threading_helper
 from datetime import timedelta
 
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(enum))
+    tests.addTests(doctest.DocFileSuite(
+            '../../Doc/library/enum.rst',
+            optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
+            ))
+    return tests
 
 # for pickle tests
 try:

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2173,14 +2173,16 @@ class PatternReprTests(unittest.TestCase):
     def test_flags_repr(self):
         self.assertEqual(repr(re.I), "re.IGNORECASE")
         self.assertEqual(repr(re.I|re.S|re.X),
-                         "re.IGNORECASE|re.DOTALL|re.VERBOSE")
+                         "re.VERBOSE|re.DOTALL|re.IGNORECASE")
         self.assertEqual(repr(re.I|re.S|re.X|(1<<20)),
-                         "re.IGNORECASE|re.DOTALL|re.VERBOSE|0x100000")
-        self.assertEqual(repr(~re.I), "~re.IGNORECASE")
+                         "re.VERBOSE|re.DOTALL|re.IGNORECASE|0x100000")
+        self.assertEqual(
+                repr(~re.I),
+                "re.ASCII|re.DEBUG|re.VERBOSE|re.UNICODE|re.DOTALL|re.MULTILINE|re.LOCALE|re.TEMPLATE")
         self.assertEqual(repr(~(re.I|re.S|re.X)),
-                         "~(re.IGNORECASE|re.DOTALL|re.VERBOSE)")
+                         "re.ASCII|re.DEBUG|re.UNICODE|re.MULTILINE|re.LOCALE|re.TEMPLATE")
         self.assertEqual(repr(~(re.I|re.S|re.X|(1<<20))),
-                         "~(re.IGNORECASE|re.DOTALL|re.VERBOSE|0x100000)")
+                         "re.ASCII|re.DEBUG|re.UNICODE|re.MULTILINE|re.LOCALE|re.TEMPLATE|0xffe00")
 
 
 class ImplementationTest(unittest.TestCase):

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2173,16 +2173,16 @@ class PatternReprTests(unittest.TestCase):
     def test_flags_repr(self):
         self.assertEqual(repr(re.I), "re.IGNORECASE")
         self.assertEqual(repr(re.I|re.S|re.X),
-                         "re.VERBOSE|re.DOTALL|re.IGNORECASE")
+                         "re.IGNORECASE|re.DOTALL|re.VERBOSE")
         self.assertEqual(repr(re.I|re.S|re.X|(1<<20)),
-                         "re.VERBOSE|re.DOTALL|re.IGNORECASE|0x100000")
+                         "re.IGNORECASE|re.DOTALL|re.VERBOSE|0x100000")
         self.assertEqual(
                 repr(~re.I),
-                "re.ASCII|re.DEBUG|re.VERBOSE|re.UNICODE|re.DOTALL|re.MULTILINE|re.LOCALE|re.TEMPLATE")
+                "re.ASCII|re.LOCALE|re.UNICODE|re.MULTILINE|re.DOTALL|re.VERBOSE|re.TEMPLATE|re.DEBUG")
         self.assertEqual(repr(~(re.I|re.S|re.X)),
-                         "re.ASCII|re.DEBUG|re.UNICODE|re.MULTILINE|re.LOCALE|re.TEMPLATE")
+                         "re.ASCII|re.LOCALE|re.UNICODE|re.MULTILINE|re.TEMPLATE|re.DEBUG")
         self.assertEqual(repr(~(re.I|re.S|re.X|(1<<20))),
-                         "re.ASCII|re.DEBUG|re.UNICODE|re.MULTILINE|re.LOCALE|re.TEMPLATE|0xffe00")
+                         "re.ASCII|re.LOCALE|re.UNICODE|re.MULTILINE|re.TEMPLATE|re.DEBUG|0xffe00")
 
 
 class ImplementationTest(unittest.TestCase):

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -155,7 +155,7 @@ class DynamicClassAttribute:
     class's __getattr__ method; this is done by raising AttributeError.
 
     This allows one to have properties active on an instance, and have virtual
-    attributes on the class with the same name (see Enum for an example).
+    attributes on the class with the same name.
 
     """
     def __init__(self, fget=None, fset=None, fdel=None, doc=None):

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -155,7 +155,12 @@ class DynamicClassAttribute:
     class's __getattr__ method; this is done by raising AttributeError.
 
     This allows one to have properties active on an instance, and have virtual
-    attributes on the class with the same name.
+    attributes on the class with the same name.  (Enum used this between Python
+    versions 3.4 - 3.9 .)
+
+    Subclass from this to use a different method of accessing virtual atributes
+    and still be treated properly by the inspect module. (Enum uses this since
+    Python 3.10 .)
 
     """
     def __init__(self, fget=None, fset=None, fdel=None, doc=None):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -141,6 +141,7 @@ Stefan Behnel
 Reimer Behrends
 Ben Bell
 Thomas Bellman
+John Belmonte
 Alexander “Саша” Belopolsky
 Eli Bendersky
 Nikhil Benesch

--- a/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
@@ -1,0 +1,12 @@
+[Enum] Flags consisting of a single bit are now considered canonical, and
+will be the only flags returned from listing and iterating over a Flag class
+or a Flag member.  Multi-bit flags are considered aliases; they will be
+returned from lookups and operations that result in their value.
+
+For example:
+
+>>> class Color(Flag):     ...     BLACK = 0     ...     RED = 1     ...
+GREEN = 2     ...     BLUE = 4     ...     WHITE = 7     ...     >>>
+list(Color)     [<Color.RED: 1>, <Color.GREEN: 2>, <Color.BLUE: 4>]     >>>
+Color(7)     <Color.WHITE: 7>     >>> Color.RED | Color.GREEN | Color.BLUE
+<Color.WHITE: 7>     >>> Color.RED & Color.GREEN     <Color.BLACK: 0>

--- a/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
@@ -2,21 +2,3 @@
 will be the only flags returned from listing and iterating over a Flag class
 or a Flag member.  Multi-bit flags are considered aliases; they will be
 returned from lookups and operations that result in their value.
-
-For example:
-
-    >>> class Color(Flag):
-    ...     BLACK = 0
-    ...     RED = 1
-    ...     GREEN = 2
-    ...     BLUE = 4
-    ...     WHITE = 7
-    ...
-    >>> list(Color)
-    [<Color.RED: 1>, <Color.GREEN: 2>, <Color.BLUE: 4>]
-    >>> Color(7)
-    <Color.WHITE: 7>
-    >>> Color.RED | Color.GREEN | Color.BLUE
-    <Color.WHITE: 7>
-    >>> Color.RED & Color.GREEN
-    <Color.BLACK: 0>

--- a/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
@@ -5,8 +5,18 @@ returned from lookups and operations that result in their value.
 
 For example:
 
->>> class Color(Flag):     ...     BLACK = 0     ...     RED = 1     ...
-GREEN = 2     ...     BLUE = 4     ...     WHITE = 7     ...     >>>
-list(Color)     [<Color.RED: 1>, <Color.GREEN: 2>, <Color.BLUE: 4>]     >>>
-Color(7)     <Color.WHITE: 7>     >>> Color.RED | Color.GREEN | Color.BLUE
-<Color.WHITE: 7>     >>> Color.RED & Color.GREEN     <Color.BLACK: 0>
+    >>> class Color(Flag):
+    ...     BLACK = 0
+    ...     RED = 1
+    ...     GREEN = 2
+    ...     BLUE = 4
+    ...     WHITE = 7
+    ...
+    >>> list(Color)
+    [<Color.RED: 1>, <Color.GREEN: 2>, <Color.BLUE: 4>]
+    >>> Color(7)
+    <Color.WHITE: 7>
+    >>> Color.RED | Color.GREEN | Color.BLUE
+    <Color.WHITE: 7>
+    >>> Color.RED & Color.GREEN
+    <Color.BLACK: 0>

--- a/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-14-15-07-16.bpo-38250.1fvhOk.rst
@@ -2,3 +2,4 @@
 will be the only flags returned from listing and iterating over a Flag class
 or a Flag member.  Multi-bit flags are considered aliases; they will be
 returned from lookups and operations that result in their value.
+Iteration for both Flag and Flag members is in definition order.


### PR DESCRIPTION
Flag members are now divided by one-bit verses multi-bit, with multi-bit
being treated as aliases.  Iterating over a flag only returns the
contained single-bit flags.

Iterating, `repr()`, and `str()` show members in definition order.

When constructing combined-member flags, any extra integer values are either discarded (`CONFORM`), turned into `int`s (`EJECT`) or treated as errors (`STRICT`).  Flag classes can specify which of those three behaviors is desired:

    >>> class Test(Flag, boundary=CONFORM):
    ...     ONE = 1
    ...     TWO = 2
    ...
    >>> Test(5)
    <Test.ONE: 1>

Besides the three above behaviors, there is also `KEEP`, which should not be used unless necessary -- for example, `_convert_` specifies `KEEP` as there are flag sets in the stdlib that are incomplete and/or inconsistent (e.g. `ssl.Options`).  `KEEP` will, as the name suggests, keep all bits; however, iterating over a flag with extra bits will only return the canonical flags contained, not the extra bits.

<!-- issue-number: [bpo-38250](https://bugs.python.org/issue38250) -->
https://bugs.python.org/issue38250
<!-- /issue-number -->
