### PR TITLE
bpo-42934: use TracebackException's new compact param in unittest.Tes…

### DIFF
--- a/Lib/unittest/result.py
+++ b/Lib/unittest/result.py
@@ -183,7 +183,8 @@ class TestResult(object):
         else:
             length = None
         tb_e = traceback.TracebackException(
-            exctype, value, tb, limit=length, capture_locals=self.tb_locals)
+            exctype, value, tb,
+            limit=length, capture_locals=self.tb_locals, compact=True)
         msgLines = list(tb_e.format())
 
         if self.buffer:

--- a/Misc/NEWS.d/next/Library/2021-01-15-11-48-00.bpo-42934.ILKoOI.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-15-11-48-00.bpo-42934.ILKoOI.rst
@@ -1,0 +1,3 @@
+Use :class:`~traceback.TracebackException`'s new ``compact`` param in
+:class:`~unittest.TestResult` to reduce time and memory consumed by
+traceback formatting.


### PR DESCRIPTION
…tResult

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42934](https://bugs.python.org/issue42934) -->
https://bugs.python.org/issue42934
<!-- /issue-number -->
