### PR TITLE
bpo-42925: Mark instructions at end of class scope as artificial.

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -956,6 +956,24 @@ class TraceTestCase(unittest.TestCase):
              (2, 'line'),
              (2, 'return')])
 
+    def test_implicit_return_in_class(self):
+
+        def func():
+            class A:
+                if 3 < 9:
+                    a = 1
+                else:
+                    a = 2
+
+        self.run_and_compare(func,
+            [(0, 'call'),
+             (1, 'line'),
+             (1, 'call'),
+             (1, 'line'),
+             (2, 'line'),
+             (3, 'line'),
+             (3, 'return'),
+             (1, 'return')])
 
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2371,6 +2371,8 @@ compiler_class(struct compiler *c, stmt_ty s)
             compiler_exit_scope(c);
             return 0;
         }
+        /* The following code is artificial */
+        c->u->u_lineno = -1;
         /* Return __classcell__ if it is referenced, otherwise return None */
         if (c->u->u_ste->ste_needs_class_closure) {
             /* Store __classcell__ into class namespace & return it */


### PR DESCRIPTION
Mark the code at the end of a class body as artificial.

Skipping news as this part of cleaning up PEP 626


<!-- issue-number: [bpo-42925](https://bugs.python.org/issue42925) -->
https://bugs.python.org/issue42925
<!-- /issue-number -->
