### PR TITLE
bpo-41824: Add versionadded for typing.ForwardRef docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1949,6 +1949,8 @@ Introspection helpers
    For example, ``list["SomeClass"]`` is implicitly transformed into
    ``list[ForwardRef("SomeClass")]``.  This class should not be instantiated by
    a user, but may be used by introspection tools.
+   
+   .. versionadded:: 3.7.4
 
 Constant
 --------

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1949,7 +1949,7 @@ Introspection helpers
    For example, ``list["SomeClass"]`` is implicitly transformed into
    ``list[ForwardRef("SomeClass")]``.  This class should not be instantiated by
    a user, but may be used by introspection tools.
-   
+
    .. versionadded:: 3.7.4
 
 Constant


### PR DESCRIPTION
``typing.ForwardRef`` officially became part of the documented public API in GH-14216 (19 Jun 2019). I'm interpolating a little and guessing it landed in Python 3.7.4 according to PEP 537's schedule https://www.python.org/dev/peps/pep-0537/#id3.

<!-- issue-number: [bpo-41824](https://bugs.python.org/issue41824) -->
https://bugs.python.org/issue41824
<!-- /issue-number -->
