### PR TITLE
bpo-42896 Allow for Solaris 11.4 crle output not containing ELF

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -251,6 +251,8 @@ elif os.name == "posix":
                     line = line.strip()
                     if line.startswith(b'Default Library Path (ELF):'):
                         paths = os.fsdecode(line).split()[4]
+                    elif line.startswith(b'Default Library Path:'):
+                        paths = os.fsdecode(line).split()[3]
 
             if not paths:
                 return None

--- a/Misc/NEWS.d/next/Library/2021-01-19-10-49-55.bpo-42896.emKDJ-.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-19-10-49-55.bpo-42896.emKDJ-.rst
@@ -1,0 +1,1 @@
+Allow for Solaris 11.4 crle output not containing ELF


### PR DESCRIPTION
# Pull Request title
bp0-42896: Allow for Solaris 11.4 crle output

The output of crle has changed with Solaris 11 and '(ELF)' has been removed from the 'Default Library Path' string


<!-- issue-number: [bpo-42896](https://bugs.python.org/issue42896) -->
https://bugs.python.org/issue42896
<!-- /issue-number -->
