### PR TITLE
bpo-33809: add the TracebackException.print() method

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -299,6 +299,13 @@ capture data for later printing in a lightweight fashion.
       The message indicating which exception occurred is always the last
       string in the output.
 
+   .. method::  print(*, file=None, chain=True)
+
+      Print to *file* the exception information as returned by
+      ``self.format(chain=chain)``.
+
+      .. versionadded:: 3.10
+
    .. versionchanged:: 3.10
       Added the *compact* parameter.
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -273,7 +273,7 @@ capture data for later printing in a lightweight fashion.
 
    .. method::  print(*, file=None, chain=True)
 
-      Print to *file* the exception information as returned by :meth:`format`.
+      Print to *file* (default sys.stderr) the exception information returned by :meth:`format`.
 
       .. versionadded:: 3.11
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -304,7 +304,7 @@ capture data for later printing in a lightweight fashion.
       Print to *file* the exception information as returned by
       ``self.format(chain=chain)``.
 
-      .. versionadded:: 3.10
+      .. versionadded:: 3.11
 
    .. versionchanged:: 3.10
       Added the *compact* parameter.

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -271,6 +271,13 @@ capture data for later printing in a lightweight fashion.
 
       Note that when locals are captured, they are also shown in the traceback.
 
+   .. method::  print(*, file=None, chain=True)
+
+      Print to *file* the exception information as returned by
+      ``self.format(chain=chain)``.
+
+      .. versionadded:: 3.11
+
    .. method:: format(*, chain=True)
 
       Format the exception.
@@ -298,13 +305,6 @@ capture data for later printing in a lightweight fashion.
 
       The message indicating which exception occurred is always the last
       string in the output.
-
-   .. method::  print(*, file=None, chain=True)
-
-      Print to *file* the exception information as returned by
-      ``self.format(chain=chain)``.
-
-      .. versionadded:: 3.11
 
    .. versionchanged:: 3.10
       Added the *compact* parameter.

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -273,7 +273,8 @@ capture data for later printing in a lightweight fashion.
 
    .. method::  print(*, file=None, chain=True)
 
-      Print to *file* (default sys.stderr) the exception information returned by :meth:`format`.
+      Print to *file* (default ``sys.stderr``) the exception information returned by
+      :meth:`format`.
 
       .. versionadded:: 3.11
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -273,8 +273,7 @@ capture data for later printing in a lightweight fashion.
 
    .. method::  print(*, file=None, chain=True)
 
-      Print to *file* the exception information as returned by
-      ``self.format(chain=chain)``.
+      Print to *file* the exception information as returned by :meth:`format`.
 
       .. versionadded:: 3.11
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1378,6 +1378,23 @@ class TestTracebackException(unittest.TestCase):
         exc = traceback.TracebackException(Exception, Exception("haven"), None)
         self.assertEqual(list(exc.format()), ["Exception: haven\n"])
 
+    def test_print(self):
+        def f():
+            x = 12
+            try:
+                x/0
+            except Exception:
+                return sys.exc_info()
+        exc = traceback.TracebackException(*f(), capture_locals=True)
+        output = StringIO()
+        exc.print(file=output)
+        self.assertEqual(
+            output.getvalue().split('\n')[-4:],
+            ['    x/0',
+             '    x = 12',
+             'ZeroDivisionError: division by zero',
+             ''])
+
 
 class MiscTest(unittest.TestCase):
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -668,7 +668,7 @@ class TracebackException:
             yield from exc.format_exception_only()
 
     def print(self, *, file=None, chain=True):
-        """Print the result of self.format(chain=chain) to to 'file'."""
+        """Print the result of self.format(chain=chain) to 'file'."""
         if file is None:
             file = sys.stderr
         for line in self.format(chain=chain):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -111,11 +111,8 @@ def print_exception(exc, /, value=_sentinel, tb=_sentinel, limit=None, \
     position of the error.
     """
     value, tb = _parse_value_tb(exc, value, tb)
-    if file is None:
-        file = sys.stderr
     te = TracebackException(type(value), value, tb, limit=limit, compact=True)
-    for line in te.format(chain=chain):
-        print(line, file=file, end="")
+    te.print(file=file, chain=chain)
 
 
 def format_exception(exc, /, value=_sentinel, tb=_sentinel, limit=None, \
@@ -669,3 +666,10 @@ class TracebackException:
                 yield 'Traceback (most recent call last):\n'
                 yield from exc.stack.format()
             yield from exc.format_exception_only()
+
+    def print(self, *, file=None, chain=True):
+        """Print the result of self.format(chain=chain) to to 'file'."""
+        if file is None:
+            file = sys.stderr
+        for line in self.format(chain=chain):
+            print(line, file=file, end="")

--- a/Misc/NEWS.d/next/Library/2021-01-16-18-36-00.bpo-33809.BiMK6V.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-16-18-36-00.bpo-33809.BiMK6V.rst
@@ -1,0 +1,2 @@
+Add the :meth:`traceback.TracebackException.print` method which prints
+the formatted exception information.


### PR DESCRIPTION
Move the content of the module-level traceback.print_exception() into a new print() method on TracebackException so that people can do

TracebackException(exc, various configuration options ... ).print()


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33809](https://bugs.python.org/issue33809) -->
https://bugs.python.org/issue33809
<!-- /issue-number -->
