### PR TITLE
Remove comment about a private email.headerregistry

### DIFF
--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -2,10 +2,6 @@
 
 This module provides an implementation of the HeaderRegistry API.
 The implementation is designed to flexibly follow RFC5322 rules.
-
-Eventually HeaderRegistry will be a public API, but it isn't yet,
-and will probably change some before that happens.
-
 """
 from types import MappingProxyType
 


### PR DESCRIPTION
It's been public since 2012: ea9766897bf1d2ccf610ff9ce805acca7c4cce6f

(I'm assuming this is trivial enough to not need a bpo entry or news fragment)