### PR TITLE
bpo-42888: Remove PyThread_exit_thread() calls from top-level thread …

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-01-21-18-03-09.bpo-42888.0oAR2x.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-21-18-03-09.bpo-42888.0oAR2x.rst
@@ -1,0 +1,4 @@
+Remove calls of :c:func:`PyThread_exit_thread()` from top-level thread
+functions, thereby avoiding a runtime dependency on ``libgcc_s.so`` and
+associated issues with lazy-loading it via ``dlopen()`` in typical scenarios
+on glibc-based Linux systems.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4512,8 +4512,6 @@ temporary_c_thread(void *data)
     PyGILState_Release(state);
 
     PyThread_release_lock(test_c_thread->exit_event);
-
-    PyThread_exit_thread();
 }
 
 static PyObject *

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1087,8 +1087,6 @@ thread_run(void *boot_raw)
     tstate->interp->num_threads--;
     PyThreadState_Clear(tstate);
     _PyThreadState_DeleteCurrent(tstate);
-
-    PyThread_exit_thread();
 }
 
 static PyObject *

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -241,8 +241,6 @@ static void bpo20891_thread(void *lockp)
     PyGILState_Release(state);
 
     PyThread_release_lock(lock);
-
-    PyThread_exit_thread();
 }
 
 static int test_bpo20891(void)

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -160,6 +160,13 @@ PyThread__init_thread(void)
  * Thread support.
  */
 
+static void
+_pythread_at_thread_exit(void)
+{
+    dprintf(("%lu: _pythread_at_thread_exit called\n",
+            PyThread_get_thread_ident()));
+}
+
 typedef struct {
     void (*func)(void*);
     void *arg;
@@ -175,6 +182,7 @@ bootstrap(void *call)
     void *arg = obj->arg;
     HeapFree(GetProcessHeap(), 0, obj);
     func(arg);
+    _pythread_at_thread_exit();
     return 0;
 }
 
@@ -254,7 +262,7 @@ PyThread_get_thread_native_id(void)
 void _Py_NO_RETURN
 PyThread_exit_thread(void)
 {
-    dprintf(("%lu: PyThread_exit_thread called\n", PyThread_get_thread_ident()));
+    _pythread_at_thread_exit();
     if (!initialized)
         exit(0);
     _endthreadex(0);

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -218,6 +218,12 @@ PyThread__init_thread(void)
  * Thread support.
  */
 
+static void
+_pythread_at_thread_exit(void)
+{
+    dprintf(("_pythread_at_thread_exit called\n"));
+}
+
 /* bpo-33015: pythread_callback struct and pythread_wrapper() cast
    "void func(void *)" to "void* func(void *)": always return NULL.
 
@@ -238,6 +244,7 @@ pythread_wrapper(void *arg)
     PyMem_RawFree(arg);
 
     func(func_arg);
+    _pythread_at_thread_exit();
     return NULL;
 }
 
@@ -359,7 +366,7 @@ PyThread_get_thread_native_id(void)
 void _Py_NO_RETURN
 PyThread_exit_thread(void)
 {
-    dprintf(("PyThread_exit_thread called\n"));
+    _pythread_at_thread_exit();
     if (!initialized)
         exit(0);
     pthread_exit(0);


### PR DESCRIPTION
…functions

PyThread_exit_thread() uses pthread_exit() on POSIX systems. In glibc,
pthread_exit() is implemented in terms of pthread_cancel(), requiring
the stack unwinder implemented in libgcc. Further, in dynamically
linked applications, calls of pthread_exit() in source code do not
make libgcc_s.so a startup dependency: instead, it's lazily loaded
by glibc via dlopen() when pthread_exit() is called the first time[1].
All of this makes otherwise finely working CPython fail in multithreaded
applications on thread exit if dlopen() fails for any reason.

While providing libgcc_s.so is the reponsibility of the user
(or their package manager), this hidden dependency has been
the source of countless frustrations(e.g. [2]) and, further,
dlopen() may fail for other reasons([3]). But most calls
to PyThread_exit_thread() in CPython are useless because they're done
from the top-level thread function and hence are equivalent
to simply returning. So remove all such calls, thereby avoiding
the glibc cancellation machinery.

The only exception are calls in take_gil() (Python/ceval_gil.h)
which serve as a safety net for daemon threads attempting
to acquire the GIL after Py_Finalize(). Unless a better model for
daemon threads is devised or support for them is removed,
those calls have to be preserved since we need to terminate
the thread right now without touching any interpreter state.

Of course, since PyThread_exit_thread() is a public API,
any extension module can still call it and trip over the same issue.

[1] https://sourceware.org/legacy-ml/libc-help/2014-07/msg00000.html
[2] https://stackoverflow.com/questions/64797838/libgcc-s-so-1-must-be-installed-for-pthread-cancel-to-work
[3] https://www.sourceware.org/bugzilla/show_bug.cgi?id=13119

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42888](https://bugs.python.org/issue42888) -->
https://bugs.python.org/issue42888
<!-- /issue-number -->
