### PR TITLE
Fix wrong calls in text_fixers.py for 2to3

### DIFF
--- a/Lib/lib2to3/tests/test_fixers.py
+++ b/Lib/lib2to3/tests/test_fixers.py
@@ -3036,7 +3036,7 @@ class Test_map(FixerTestCase):
     fixer = "map"
 
     def check(self, b, a):
-        self.unchanged("from future_builtins import map; " + b, a)
+        self.unchanged("from future_builtins import map; " + b)
         super(Test_map, self).check(b, a)
 
     def test_prefix_preservation(self):
@@ -3160,7 +3160,7 @@ class Test_zip(FixerTestCase):
     fixer = "zip"
 
     def check(self, b, a):
-        self.unchanged("from future_builtins import zip; " + b, a)
+        self.unchanged("from future_builtins import zip; " + b)
         super(Test_zip, self).check(b, a)
 
     def test_zip_basic(self):


### PR DESCRIPTION
I happened to find a trivial bug in 2to3 tests: the second argument for `self.unchanged` should not be provided.