### PR TITLE
bpo-42958: Align docstring and filecmp.cmp() for shallow compare

### DIFF
--- a/Doc/library/filecmp.rst
+++ b/Doc/library/filecmp.rst
@@ -22,8 +22,13 @@ The :mod:`filecmp` module defines the following functions:
    Compare the files named *f1* and *f2*, returning ``True`` if they seem equal,
    ``False`` otherwise.
 
-   If *shallow* is true, files with identical :func:`os.stat` signatures are
-   taken to be equal.  Otherwise, the contents of the files are compared.
+   If *shallow* is true, files with identical :func:`os.stat` signatures (file
+   type, size and modification time) are taken to be equal.
+
+   If the files have a different size ``False`` will be returned.
+
+   Comparisons with ``shallow=False`` or different signatures imply that the
+   contents of the files are compared.
 
    Note that no external programs are called from this function, giving it
    portability and efficiency.

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -36,7 +36,13 @@ def cmp(f1, f2, shallow=True):
 
     f2 -- Second file name
 
-    shallow -- Just check stat signature (do not read the files).
+    shallow -- Check file signatures instead of contents, the
+               signature contains the file its mode, size and
+               mtime.
+               If the size differs, the files are considerd to be
+               different.
+               If other parts of the signature indicate that the files
+               differ, a deep compare is performed.
                defaults to True.
 
     Return value:

--- a/Misc/NEWS.d/next/Library/2021-01-21-20-03-34.bpo-42958.I8nNWP.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-21-20-03-34.bpo-42958.I8nNWP.rst
@@ -1,0 +1,1 @@
+Clarify filecmp.cmp() docstring and documentation


### PR DESCRIPTION


<!-- issue-number: [bpo-42958](https://bugs.python.org/issue42958) -->
https://bugs.python.org/issue42958
<!-- /issue-number -->
