### PR TITLE
bpo-42960: resources module, adding RLIMIT_KQUEUES constant from FreeBSD

### DIFF
--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -257,7 +257,7 @@ platform.
 
 .. data:: RLIMIT_KQUEUES
 
-   The maximum number of kqueues created by this user id.
+   The maximum number of kqueues this user id is allowed to create.
 
    .. availability:: FreeBSD 11 or later.
 

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -255,6 +255,14 @@ platform.
 
    .. versionadded:: 3.4
 
+.. data:: RLIMIT_KQUEUES
+
+   The maximum number of kqueues created by this user id.
+
+   .. availability:: FreeBSD 11 or later.
+
+   .. versionadded:: 3.10
+
 Resource Usage
 --------------
 

--- a/Misc/NEWS.d/next/Library/2021-01-18-21-07-20.bpo-42960.a7Dote.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-18-21-07-20.bpo-42960.a7Dote.rst
@@ -1,0 +1,1 @@
+Adds :data:`resource.RLIMIT_KQUEUES` constant from FreeBSD to the :mod:`resource` module.

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -480,6 +480,10 @@ resource_exec(PyObject *module)
     ADD_INT(module, RLIMIT_NPTS);
 #endif
 
+#ifdef RLIMIT_KQUEUES
+    ADD_INT(module, RLIMIT_KQUEUES);
+#endif
+
     PyObject *v;
     if (sizeof(RLIM_INFINITY) > sizeof(long)) {
         v = PyLong_FromLongLong((long long) RLIM_INFINITY);


### PR DESCRIPTION


<!-- issue-number: [bpo-42960](https://bugs.python.org/issue42960) -->
https://bugs.python.org/issue42960
<!-- /issue-number -->
