### PR TITLE
Add a clarification for the object-domain allocators regarding pointer validity

### DIFF
--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -272,6 +272,12 @@ The following function sets, modeled after the ANSI C standard, but specifying
 behavior when requesting zero bytes, are available for allocating and releasing
 memory from the Python heap.
 
+.. note::
+    There is no guarantee that the memory returned by these allocators can be
+    succesfully casted to a Python object when intercepting the allocating
+    functions in this domain by the methods described in
+    the :ref:`Customize Memory Allocators <customize-memory-allocators>` section.
+
 The :ref:`default object allocator <default-memory-allocators>` uses the
 :ref:`pymalloc memory allocator <pymalloc>`.
 
@@ -353,6 +359,7 @@ Legend:
 * ``pymalloc``: :ref:`pymalloc memory allocator <pymalloc>`
 * "+ debug": with debug hooks installed by :c:func:`PyMem_SetupDebugHooks`
 
+.. _customize-memory-allocators:
 
 Customize Memory Allocators
 ===========================


### PR DESCRIPTION


Automerge-Triggered-By: GH:pablogsal