### PR TITLE
bpo-42392: Mention loop removal in whatsnew for 3.10

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -644,7 +644,7 @@ Changes in the Python API
   Maintaining backwards compatibility with 3.6 code is slightly trickier.
   Previous code using :mod:`asyncio` functions and classes, passing the loop
   explicitly and relying on special behavior will error on 3.10.  A possible
-  option is to guard the old call with a check for Python versions before 3.6
+  option is to guard the old call with a check for Python versions before 3.7
   and use the new call signature for newer versions.
 
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -564,7 +564,7 @@ Removed
 
   1. This simplifies the high-level API.
   2. The functions in the high-level API have been implicitly getting the
-     current thread's running event loop since Python 3.6.  There isn't a need to
+     current thread's running event loop since Python 3.7.  There isn't a need to
      pass the event loop to the API in most normal use cases.
   3. Event loop passing is error-prone especially when dealing with loops
      running in different threads.
@@ -628,7 +628,7 @@ Changes in the Python API
          await asyncio.sleep(1)
 
   If ``foo()`` was specifically designed *not* to run in the current thread's
-  running event loop (eg. running in another thread's event loop), consider
+  running event loop (e.g. running in another thread's event loop), consider
   using :func:`asyncio.run_coroutine_threadsafe` instead.
 
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -637,6 +637,7 @@ Changes in the Python API
      async def foo():
          loop = get_loop()
          ...
+
   Users can also store the result of :func:`asyncio.get_event_loop` should
   they wish to avoid the slight performance overhead of always calling the
   function.  Note that this requires additional thread safety and loop checks.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -558,9 +558,10 @@ Removed
   the :mod:`collections` module.
   (Contributed by Victor Stinner in :issue:`37324`.)
 
-* Removed the ``loop`` parameter of nearly all :mod:`asyncio` functions and
-  classes.  This parameter was marked for deprecation in Python 3.8.  See
-  `Changes in the Python API`_ for examples of how to replace existing code.
+* The ``loop`` parameter has been removed from most of :mod:`asyncio`
+  :doc:`high-level API <../library/asyncio-api-index>` following deprecation
+  in Python 3.8. See `Changes in the Python API`_ for the reasoning behind the
+  change, and examples of how to replace existing code.
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
   in :issue:`42392`.)
 
@@ -602,21 +603,32 @@ Changes in the Python API
   a 16-bit unsigned integer.
   (Contributed by Erlend E. Aasland in :issue:`42393`.)
 
-* The ``loop`` parameter to nearly all :mod:`asyncio` functions has been removed
-  following deprecation in Python 3.8. For example, a coroutine that currently
-  look like this::
+* The ``loop`` parameter has been removed from most of :mod:`asyncio`
+  :doc:`high-level API <../library/asyncio-api-index>` following deprecation
+  in Python 3.8. The motivation behind this change is multifold:
 
-     import asyncio
+  1. This simplifies the high-level API.
+  2. The functions in the high-level API have been implicitly getting the
+     current thread's running event loop since Python 3.6.  There isn't a need to
+     pass the event loop to the API in most normal use cases.
+  3. Event loop passing is error-prone especially when dealing with loops
+     running in different threads.
+
+  Note that the low-level API has **not** been affected.
+
+  A coroutine that currently look like this::
 
      async def foo(loop):
-         await asyncio.sleep(loop=loop)
+         await asyncio.sleep(1, loop=loop)
 
-  Can *usually* be replaced with this::
+  Should be replaced with this::
 
-     import asyncio
+     async def foo():
+         await asyncio.sleep(1)
 
-     async def foo(loop):
-         await asyncio.sleep()
+  If ``foo()`` was specifically designed *not* to run in the current thread's
+  running event loop (eg. running in another thread's event loop), consider
+  using :func:`asyncio.run_coroutine_threadsafe` instead.
 
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
   in :issue:`42392`.)

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -558,7 +558,7 @@ Removed
   the :mod:`collections` module.
   (Contributed by Victor Stinner in :issue:`37324`.)
 
-* The ``loop`` parameter has been removed from most of :mod:`asyncio`
+* The ``loop`` parameter has been removed from most of :mod:`asyncio`\ 's
   :doc:`high-level API <../library/asyncio-api-index>` following deprecation
   in Python 3.8. See `Changes in the Python API`_ for the reasoning behind the
   change, and examples of how to replace existing code.
@@ -603,7 +603,7 @@ Changes in the Python API
   a 16-bit unsigned integer.
   (Contributed by Erlend E. Aasland in :issue:`42393`.)
 
-* The ``loop`` parameter has been removed from most of :mod:`asyncio`
+* The ``loop`` parameter has been removed from most of :mod:`asyncio`\ 's
   :doc:`high-level API <../library/asyncio-api-index>` following deprecation
   in Python 3.8. The motivation behind this change is multifold:
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -560,8 +560,18 @@ Removed
 
 * The ``loop`` parameter has been removed from most of :mod:`asyncio`\ 's
   :doc:`high-level API <../library/asyncio-api-index>` following deprecation
-  in Python 3.8. See `Changes in the Python API`_ for the reasoning behind the
-  change, and examples of how to replace existing code.
+  in Python 3.8.  The motivation behind this change is multifold:
+
+  1. This simplifies the high-level API.
+  2. The functions in the high-level API have been implicitly getting the
+     current thread's running event loop since Python 3.6.  There isn't a need to
+     pass the event loop to the API in most normal use cases.
+  3. Event loop passing is error-prone especially when dealing with loops
+     running in different threads.
+
+  Note that the low-level API will still accept ``loop``.
+  See `Changes in the Python API`_ for examples of how to replace existing code.
+
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
   in :issue:`42392`.)
 
@@ -605,16 +615,7 @@ Changes in the Python API
 
 * The ``loop`` parameter has been removed from most of :mod:`asyncio`\ 's
   :doc:`high-level API <../library/asyncio-api-index>` following deprecation
-  in Python 3.8. The motivation behind this change is multifold:
-
-  1. This simplifies the high-level API.
-  2. The functions in the high-level API have been implicitly getting the
-     current thread's running event loop since Python 3.6.  There isn't a need to
-     pass the event loop to the API in most normal use cases.
-  3. Event loop passing is error-prone especially when dealing with loops
-     running in different threads.
-
-  Note that the low-level API has **not** been affected.
+  in Python 3.8.
 
   A coroutine that currently look like this::
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -602,45 +602,21 @@ Changes in the Python API
   a 16-bit unsigned integer.
   (Contributed by Erlend E. Aasland in :issue:`42393`.)
 
-* The ``loop`` parameter to nearly all :mod:`asyncio` functions has been
-  removed following deprecation in Python 3.8.  Users should instead get the
-  current event loop inside of coroutines preferrably via
-  :func:`asyncio.get_running_loop` (Python 3.7 and above) or
-  :func:`asyncio.get_event_loop`.  For example, a coroutine that currently look
-  like this::
+* The ``loop`` parameter to nearly all :mod:`asyncio` functions has been removed
+  following deprecation in Python 3.8. For example, a coroutine that currently
+  look like this::
+
+     import asyncio
 
      async def foo(loop):
-         ...
+         await asyncio.sleep(loop=loop)
 
-  Can be replaced with this::
-
-     import asyncio
-
-     async def foo():
-         # Note that this asserts the loop is already running.
-         loop = asyncio.get_running_loop()
-         ...
-
-  A minimal thread-safe version::
+  Can *usually* be replaced with this::
 
      import asyncio
-     import threading
 
-     lock = threading.Lock()
-
-     def get_loop():
-         global lock
-         with lock:
-             # Note that this asserts the loop is already running.
-             return asyncio.get_running_loop()
-
-     async def foo():
-         loop = get_loop()
-         ...
-
-  Users can also store the result of :func:`asyncio.get_event_loop` should
-  they wish to avoid the slight performance overhead of always calling the
-  function.  Note that this requires additional thread safety and loop checks.
+     async def foo(loop):
+         await asyncio.sleep()
 
   Maintaining backwards compatibility with 3.6 code is slightly trickier.
   Previous code using :mod:`asyncio` functions and classes, passing the loop

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -618,12 +618,6 @@ Changes in the Python API
      async def foo(loop):
          await asyncio.sleep()
 
-  Maintaining backwards compatibility with 3.6 code is slightly trickier.
-  Previous code using :mod:`asyncio` functions and classes, passing the loop
-  explicitly and relying on special behavior will error on 3.10.  A possible
-  option is to guard the old call with a check for Python versions before 3.7
-  and use the new call signature for newer versions.
-
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
   in :issue:`42392`.)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -605,8 +605,9 @@ Changes in the Python API
 * The ``loop`` parameter to nearly all :mod:`asyncio` functions has been
   removed following deprecation in Python 3.8.  Users should instead get the
   current event loop inside of coroutines preferrably via
-  :func:`asyncio.get_running_loop` or :func:`asyncio.get_event_loop`.  For
-  example, a coroutine that currently look like this::
+  :func:`asyncio.get_running_loop` (Python 3.7 and above) or
+  :func:`asyncio.get_event_loop`.  For example, a coroutine that currently look
+  like this::
 
      async def foo(loop):
          ...
@@ -639,6 +640,12 @@ Changes in the Python API
   Users can also store the result of :func:`asyncio.get_event_loop` should
   they wish to avoid the slight performance overhead of always calling the
   function.  Note that this requires additional thread safety and loop checks.
+
+  Maintaining backwards compatibility with 3.6 code is slightly trickier.
+  Previous code using :mod:`asyncio` functions and classes, passing the loop
+  explicitly and relying on special behavior will error on 3.10.  A possible
+  option is to guard the old call with a check for Python versions before 3.6
+  and use the new call signature for newer versions.
 
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
   in :issue:`42392`.)

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -558,6 +558,12 @@ Removed
   the :mod:`collections` module.
   (Contributed by Victor Stinner in :issue:`37324`.)
 
+* Removed the ``loop`` parameter of nearly all :mod:`asyncio` functions and
+  classes.  This parameter was marked for deprecation in Python 3.8.  See
+  `Changes in the Python API`_ for examples of how to replace existing code.
+  (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
+  in :issue:`42392`.)
+
 
 Porting to Python 3.10
 ======================
@@ -596,6 +602,46 @@ Changes in the Python API
   a 16-bit unsigned integer.
   (Contributed by Erlend E. Aasland in :issue:`42393`.)
 
+* The ``loop`` parameter to nearly all :mod:`asyncio` functions has been
+  removed following deprecation in Python 3.8.  Users should instead get the
+  current event loop inside of coroutines preferrably via
+  :func:`asyncio.get_running_loop` or :func:`asyncio.get_event_loop`.  For
+  example, a coroutine that currently look like this::
+
+     async def foo(loop):
+         ...
+
+  Can be replaced with this::
+
+     import asyncio
+
+     async def foo():
+         # Note that this asserts the loop is already running.
+         loop = asyncio.get_running_loop()
+         ...
+
+  A minimal thread-safe version::
+
+     import asyncio
+     import threading
+
+     lock = threading.Lock()
+
+     def get_loop():
+         global lock
+         with lock:
+             # Note that this asserts the loop is already running.
+             return asyncio.get_running_loop()
+
+     async def foo():
+         loop = get_loop()
+         ...
+  Users can also store the result of :func:`asyncio.get_event_loop` should
+  they wish to avoid the slight performance overhead of always calling the
+  function.  Note that this requires additional thread safety and loop checks.
+
+  (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
+  in :issue:`42392`.)
 
 CPython bytecode changes
 ========================


### PR DESCRIPTION
@vstinner [noticed on python-dev](https://mail.python.org/archives/list/python-dev@python.org/thread/O3T7SK3BGMFWMLCQXDODZJSBL42AUWTR/) that there is no what's new or porting entry for removal of asyncio ``loop`` parameter. 

This patch adds a basic guide.

Co-Authored-By: Kyle Stanley <aeros167@gmail.com>


<!-- issue-number: [bpo-42392](https://bugs.python.org/issue42392) -->
https://bugs.python.org/issue42392
<!-- /issue-number -->

Automerge-Triggered-By: GH:aeros