### PR TITLE
bpo-42323: Fix math.nextafter() for AIX libc

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-01-20-12-10-47.bpo-42323.PONB8e.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-20-12-10-47.bpo-42323.PONB8e.rst
@@ -1,0 +1,1 @@
+Fix :func:`math.nextafter` for NaN on AIX.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3473,6 +3473,12 @@ math_nextafter_impl(PyObject *module, double x, double y)
            Bug fixed in bos.adt.libm 7.2.2.0 by APAR IV95512. */
         return PyFloat_FromDouble(y);
     }
+    if (Py_IS_NAN(x)) {
+        return x;
+    }
+    if (Py_IS_NAN(y)) {
+        return y;
+    }
 #endif
     return PyFloat_FromDouble(nextafter(x, y));
 }


### PR DESCRIPTION
Handle manually NaNs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42323](https://bugs.python.org/issue42323) -->
https://bugs.python.org/issue42323
<!-- /issue-number -->
