### PR TITLE
bpo-42967: Don't treat semicolon as a separator in urllib.parse

### DIFF
--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -158,7 +158,7 @@ def parse(fp=None, environ=os.environ, keep_blank_values=0, strict_parsing=0,
     if environ['REQUEST_METHOD'] == 'POST':
         ctype, pdict = parse_header(environ['CONTENT_TYPE'])
         if ctype == 'multipart/form-data':
-            return parse_multipart(fp, pdict)
+            return parse_multipart(fp, pdict, semicolon_sep=semicolon_sep)
         elif ctype == 'application/x-www-form-urlencoded':
             clength = int(environ['CONTENT_LENGTH'])
             if maxlen and clength > maxlen:
@@ -185,7 +185,8 @@ def parse(fp=None, environ=os.environ, keep_blank_values=0, strict_parsing=0,
                                  encoding=encoding, semicolon_sep=semicolon_sep)
 
 
-def parse_multipart(fp, pdict, encoding="utf-8", errors="replace"):
+def parse_multipart(fp, pdict, encoding="utf-8", errors="replace",
+                    semicolon_sep=True):
     """Parse multipart input.
 
     Arguments:
@@ -209,7 +210,7 @@ def parse_multipart(fp, pdict, encoding="utf-8", errors="replace"):
     except KeyError:
         pass
     fs = FieldStorage(fp, headers=headers, encoding=encoding, errors=errors,
-        environ={'REQUEST_METHOD': 'POST'})
+        environ={'REQUEST_METHOD': 'POST'}, semicolon_sep=semicolon_sep)
     return {k: fs.getlist(k) for k in fs}
 
 def _parseparam(s):
@@ -605,7 +606,7 @@ class FieldStorage:
 
     FieldStorageClass = None
 
-    def read_multi(self, environ, keep_blank_values, strict_parsing, semicolon_sep):
+    def read_multi(self, environ, keep_blank_values, strict_parsing, semicolon_sep=True):
         """Internal: read a part that is itself multipart."""
         ib = self.innerboundary
         if not valid_boundary(ib):

--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -115,7 +115,8 @@ log = initlog           # The current logging function
 # 0 ==> unlimited input
 maxlen = 0
 
-def parse(fp=None, environ=os.environ, keep_blank_values=0, strict_parsing=0):
+def parse(fp=None, environ=os.environ, keep_blank_values=0, strict_parsing=0,
+          semicolon_sep=True):
     """Parse a query in the environment or from a file (default stdin)
 
         Arguments, all optional:
@@ -134,6 +135,9 @@ def parse(fp=None, environ=os.environ, keep_blank_values=0, strict_parsing=0):
         strict_parsing: flag indicating what to do with parsing errors.
             If false (the default), errors are silently ignored.
             If true, errors raise a ValueError exception.
+
+        semicolon_sep: flag indicating whether ``;`` should be treated as a
+            valid separator.
     """
     if fp is None:
         fp = sys.stdin
@@ -178,7 +182,7 @@ def parse(fp=None, environ=os.environ, keep_blank_values=0, strict_parsing=0):
             qs = ""
         environ['QUERY_STRING'] = qs    # XXX Shouldn't, really
     return urllib.parse.parse_qs(qs, keep_blank_values, strict_parsing,
-                                 encoding=encoding)
+                                 encoding=encoding, semicolon_sep=semicolon_sep)
 
 
 def parse_multipart(fp, pdict, encoding="utf-8", errors="replace"):

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -180,23 +180,23 @@ class UrlParseTestCase(unittest.TestCase):
     def test_qsl(self):
         for orig, expect in parse_qsl_test_cases:
             result = urllib.parse.parse_qsl(orig, keep_blank_values=True,
-                                            semicolon_sep=True)
+                                            separators=('&', ';'))
             self.assertEqual(result, expect, "Error parsing %r" % orig)
             expect_without_blanks = [v for v in expect if len(v[1])]
             result = urllib.parse.parse_qsl(orig, keep_blank_values=False,
-                                            semicolon_sep=True)
+                                            separators=('&', ';'))
             self.assertEqual(result, expect_without_blanks,
                             "Error parsing %r" % orig)
 
     def test_qs(self):
         for orig, expect in parse_qs_test_cases:
             result = urllib.parse.parse_qs(orig, keep_blank_values=True,
-                                           semicolon_sep=True)
+                                           separators=('&', ';'))
             self.assertEqual(result, expect, "Error parsing %r" % orig)
             expect_without_blanks = {v: expect[v]
                                      for v in expect if len(expect[v][0])}
             result = urllib.parse.parse_qs(orig, keep_blank_values=False,
-                                           semicolon_sep=True)
+                                           separators=('&', ';'))
             self.assertEqual(result, expect_without_blanks,
                             "Error parsing %r" % orig)
 
@@ -205,12 +205,12 @@ class UrlParseTestCase(unittest.TestCase):
         for orig, expect in parse_qsl_test_cases_semicolon:
             with self.subTest(f"Original: {orig!r}, Expected: {expect!r}"):
                 result = urllib.parse.parse_qsl(orig, keep_blank_values=True,
-                                                semicolon_sep=False)
+                                                separators=('&',))
                 self.assertEqual(result, expect,
                                 "Error parsing %r" % orig)
                 expect_without_blanks = [v for v in expect if len(v[1])]
                 result = urllib.parse.parse_qsl(orig, keep_blank_values=False,
-                                                semicolon_sep=False)
+                                                separators=('&',))
                 self.assertEqual(result, expect_without_blanks,
                                  "Error parsing %r" % orig)
 
@@ -219,12 +219,12 @@ class UrlParseTestCase(unittest.TestCase):
         for orig, expect in parse_qs_test_cases_semicolon:
             with self.subTest(f"Original: {orig!r}, Expected: {expect!r}"):
                 result = urllib.parse.parse_qs(orig, keep_blank_values=True,
-                                               semicolon_sep=False)
+                                               separators=('&',))
                 self.assertEqual(result, expect, "Error parsing %r" % orig)
                 expect_without_blanks = {v: expect[v]
                                          for v in expect if len(expect[v][0])}
                 result = urllib.parse.parse_qs(orig, keep_blank_values=False,
-                                               semicolon_sep=False)
+                                               separators=('&',))
                 self.assertEqual(result, expect_without_blanks,
                              "Error parsing %r" % orig)
 
@@ -964,7 +964,7 @@ class UrlParseTestCase(unittest.TestCase):
             urllib.parse.parse_qs('&'.join(['a=a']*11), max_num_fields=10)
         with self.assertRaises(ValueError):
             urllib.parse.parse_qs(';'.join(['a=a']*11), max_num_fields=10,
-                                  semicolon_sep=True)
+                                  separators=('&', ';'))
         urllib.parse.parse_qs('&'.join(['a=a']*10), max_num_fields=10)
 
     def test_urlencode_sequences(self):

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -203,7 +203,7 @@ class UrlParseTestCase(unittest.TestCase):
     def test_qsl_no_semicolon(self):
         # See bpo-42967 for more information.
         for orig, expect in parse_qsl_test_cases_semicolon:
-            with self.subTest(f"Original: {orig}, Expected: {expect}"):
+            with self.subTest(f"Original: {orig!r}, Expected: {expect!r}"):
                 result = urllib.parse.parse_qsl(orig, keep_blank_values=True,
                                                 semicolon_sep=False)
                 self.assertEqual(result, expect,
@@ -215,9 +215,9 @@ class UrlParseTestCase(unittest.TestCase):
                                  "Error parsing %r" % orig)
 
     def test_qs_no_semicolon(self):
-
+        # See bpo-42967 for more information.
         for orig, expect in parse_qs_test_cases_semicolon:
-            with self.subTest(f"Original: {orig}, Expected: {expect}"):
+            with self.subTest(f"Original: {orig!r}, Expected: {expect!r}"):
                 result = urllib.parse.parse_qs(orig, keep_blank_values=True,
                                                semicolon_sep=False)
                 self.assertEqual(result, expect, "Error parsing %r" % orig)

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -662,7 +662,8 @@ def unquote(string, encoding='utf-8', errors='replace'):
 
 
 def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
-             encoding='utf-8', errors='replace', max_num_fields=None):
+             encoding='utf-8', errors='replace', max_num_fields=None,
+             semicolon_sep=False):
     """Parse a query given as a string argument.
 
         Arguments:
@@ -686,12 +687,17 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
         max_num_fields: int. If set, then throws a ValueError if there
             are more than n fields read by parse_qsl().
 
+        semicolon_sep: flag indicating whether ``;`` should be treated as a
+            valid separator. Defaults to False due to recommendation by the W3C
+            (see https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#url-encoded-form-data)
+
         Returns a dictionary.
     """
     parsed_result = {}
     pairs = parse_qsl(qs, keep_blank_values, strict_parsing,
                       encoding=encoding, errors=errors,
-                      max_num_fields=max_num_fields)
+                      max_num_fields=max_num_fields,
+                      semicolon_sep=semicolon_sep)
     for name, value in pairs:
         if name in parsed_result:
             parsed_result[name].append(value)
@@ -701,7 +707,8 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
 
 
 def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
-              encoding='utf-8', errors='replace', max_num_fields=None):
+              encoding='utf-8', errors='replace', max_num_fields=None,
+              semicolon_sep=False):
     """Parse a query given as a string argument.
 
         Arguments:
@@ -724,6 +731,10 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         max_num_fields: int. If set, then throws a ValueError
             if there are more than n fields read by parse_qsl().
 
+        semicolon_sep: flag indicating whether ``;`` should be treated as a
+            valid separator. Defaults to False due to recommendation by the W3C
+            (see https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#url-encoded-form-data)
+
         Returns a list, as G-d intended.
     """
     qs, _coerce_result = _coerce_args(qs)
@@ -732,11 +743,18 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
     # is less than max_num_fields. This prevents a memory exhaustion DOS
     # attack via post bodies with many fields.
     if max_num_fields is not None:
-        num_fields = 1 + qs.count('&') + qs.count(';')
+        if semicolon_sep:
+            num_fields = 1 + qs.count('&') + qs.count(';')
+        else:
+            num_fields = 1 + qs.count('&')
         if max_num_fields < num_fields:
             raise ValueError('Max number of fields exceeded')
 
-    pairs = [s2 for s1 in qs.split('&') for s2 in s1.split(';')]
+    if semicolon_sep:
+        pairs = [s2 for s1 in qs.split('&') for s2 in s1.split(';')]
+    else:
+        pairs = [s for s in qs.split('&')]
+
     r = []
     for name_value in pairs:
         if not name_value and not strict_parsing:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -663,7 +663,7 @@ def unquote(string, encoding='utf-8', errors='replace'):
 
 def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
              encoding='utf-8', errors='replace', max_num_fields=None,
-             semicolon_sep=False):
+             semicolon_sep=True):
     """Parse a query given as a string argument.
 
         Arguments:
@@ -688,7 +688,7 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
             are more than n fields read by parse_qsl().
 
         semicolon_sep: flag indicating whether ``;`` should be treated as a
-            valid separator. Defaults to False due to recommendation by the W3C
+            valid separator. Recommended to set to False.
             (see https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#url-encoded-form-data)
 
         Returns a dictionary.
@@ -708,7 +708,7 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
 
 def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
               encoding='utf-8', errors='replace', max_num_fields=None,
-              semicolon_sep=False):
+              semicolon_sep=True):
     """Parse a query given as a string argument.
 
         Arguments:
@@ -732,7 +732,7 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             if there are more than n fields read by parse_qsl().
 
         semicolon_sep: flag indicating whether ``;`` should be treated as a
-            valid separator. Defaults to False due to recommendation by the W3C
+            valid separator. Recommended to set to False.
             (see https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#url-encoded-form-data)
 
         Returns a list, as G-d intended.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -613,6 +613,7 @@ Karan Goel
 Jeroen Van Goey
 Christoph Gohlke
 Tim Golden
+Adam Goldschmidt
 Yonatan Goldschmidt
 Mark Gollahon
 Mikhail Golubev


### PR DESCRIPTION
I wonder if this should be the default behaviour?

I'll update docs once we decide on that ^,

~TODO: Update Public API of FieldStorage, FieldStorage.read_multi, parse and parse_multipart.~

Co-Authored-By: Adam Goldschmidt adamgold7@gmail.com
<!-- issue-number: [bpo-42967](https://bugs.python.org/issue42967) -->
https://bugs.python.org/issue42967
<!-- /issue-number -->
