### PR TITLE
bpo-42978: Improve error message when 'self' is missing from the method definition

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -713,5 +713,66 @@ class TestErrorMessagesUseQualifiedName(unittest.TestCase):
             A().method_two_args("x", "y", x="oops")
 
 
+class NoSelfClass:
+    def foo():
+        pass
+
+    def foo1(x, y):
+        pass
+
+    def foo2(self, y):
+        pass
+
+    @classmethod
+    def clsmethod(x, y):
+        pass
+
+    @staticmethod
+    def stmethod(x, y):
+        pass
+
+
+@cpython_only
+class TestErrorMessagesInMethodsGiveHintAboutSelf(unittest.TestCase):
+    @contextlib.contextmanager
+    def check_raises_type_error(self, message):
+        with self.assertRaises(TypeError) as cm:
+            yield
+        self.assertEqual(str(cm.exception), message)
+
+
+    def test_method_with_missing_self_no_args(self):
+
+        msg = ("NoSelfClass.foo() takes 0 positional arguments but 1 was given. "
+               "Did you forget 'self' in the method definition?")
+        with self.check_raises_type_error(msg):
+            NoSelfClass().foo()
+
+    def test_method_with_missing_self_args(self):
+
+        msg = ("NoSelfClass.foo1() takes 2 positional arguments but 3 were given. "
+               "Did you forget 'self' in the method definition?")
+        with self.check_raises_type_error(msg):
+            NoSelfClass().foo1(1, 2)
+
+    def test_method_with_self_args(self):
+
+        msg = "NoSelfClass.foo2() takes 2 positional arguments but 3 were given"
+        with self.check_raises_type_error(msg):
+            NoSelfClass().foo2(1, 2)
+
+    def test_method_with_classmethod(self):
+
+        msg = "NoSelfClass.clsmethod() takes 2 positional arguments but 3 were given"
+        with self.check_raises_type_error(msg):
+            NoSelfClass().clsmethod(1, 2)
+
+    def test_method_with_staticmethod(self):
+
+        msg = "NoSelfClass.stmethod() takes 2 positional arguments but 3 were given"
+        with self.check_raises_type_error(msg):
+            NoSelfClass().stmethod(1, 2, 3)
+
+
 if __name__ == "__main__":
-    unittest.main()
+     unittest.main()

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -775,4 +775,4 @@ class TestErrorMessagesInMethodsGiveHintAboutSelf(unittest.TestCase):
 
 
 if __name__ == "__main__":
-     unittest.main()
+    unittest.main()

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -6008,7 +6008,9 @@ void Py_LeaveRecursiveCall(void)
     _Py_LeaveRecursiveCall_inline();
 }
 
-static void improve_missing_self_error(PyThreadState* tstate, PyCodeObject* co, Py_ssize_t nargs) {
+static void
+improve_missing_self_error(PyThreadState* tstate, PyCodeObject* co, Py_ssize_t nargs)
+{
 
     if (nargs + 1 != co->co_argcount) {
         return;


### PR DESCRIPTION
⚠️  I just opened the draft to discuss the approach,⚠️ 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42978](https://bugs.python.org/issue42978) -->
https://bugs.python.org/issue42978
<!-- /issue-number -->
