### PR TITLE
gh-87146: Add GnuStyleLongOptionsHelpFormatter

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -383,6 +383,7 @@ classes:
            RawTextHelpFormatter
            ArgumentDefaultsHelpFormatter
            MetavarTypeHelpFormatter
+           GnuStyleLongOptionsHelpFormatter
 
 :class:`RawDescriptionHelpFormatter` and :class:`RawTextHelpFormatter` give
 more control over how textual descriptions are displayed.
@@ -476,6 +477,22 @@ as the regular formatter does)::
    options:
      -h, --help  show this help message and exit
      --foo int
+
+:class:`GnuStyleLongOptionsHelpFormatter` inserts '=' in between long options
+and their arguments, rather than a space::
+
+   >>> parser = argparse.ArgumentParser(
+   ...     prog='PROG',
+   ...     formatter_class=argparse.GnuStyleLongOptionsHelpFormatter)
+   >>> parser.add_argument('--foo')
+   >>> parser.print_help()
+   usage: PROG [-h] [--foo=FOO]
+
+   options:
+     -h, --help  show this help message and exit
+     --foo=FOO
+
+.. versionadded:: 3.10
 
 
 prefix_chars

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -376,7 +376,7 @@ formatter_class
 ^^^^^^^^^^^^^^^
 
 :class:`ArgumentParser` objects allow the help formatting to be customized by
-specifying an alternate formatting class.  Currently, there are four such
+specifying an alternate formatting class.  Currently, there are five such
 classes:
 
 .. class:: RawDescriptionHelpFormatter

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -74,6 +74,7 @@ __all__ = [
     'RawDescriptionHelpFormatter',
     'RawTextHelpFormatter',
     'MetavarTypeHelpFormatter',
+    'GnuStyleLongOptionsHelpFormatter',
     'Namespace',
     'Action',
     'ONE_OR_MORE',
@@ -462,7 +463,7 @@ class HelpFormatter(object):
                 else:
                     default = self._get_default_metavar_for_optional(action)
                     args_string = self._format_args(action, default)
-                    part = '%s %s' % (option_string, args_string)
+                    part = self._format_option_with_args(option_string, args_string)
 
                 # make it look optional if it's not required or in a group
                 if not action.required and action not in group_actions:
@@ -564,9 +565,12 @@ class HelpFormatter(object):
                 default = self._get_default_metavar_for_optional(action)
                 args_string = self._format_args(action, default)
                 for option_string in action.option_strings:
-                    parts.append('%s %s' % (option_string, args_string))
+                    parts.append(self._format_option_with_args(option_string, args_string))
 
             return ', '.join(parts)
+
+    def _format_option_with_args(self, option_string, args_string):
+        return '%s %s' % (option_string, args_string)
 
     def _metavar_formatter(self, action, default_metavar):
         if action.metavar is not None:
@@ -700,7 +704,7 @@ class ArgumentDefaultsHelpFormatter(HelpFormatter):
 
 class MetavarTypeHelpFormatter(HelpFormatter):
     """Help message formatter which uses the argument 'type' as the default
-    metavar value (instead of the argument 'dest')
+    metavar value (instead of the argument 'dest').
 
     Only the name of this class is considered a public API. All the methods
     provided by the class are considered an implementation detail.
@@ -711,6 +715,20 @@ class MetavarTypeHelpFormatter(HelpFormatter):
 
     def _get_default_metavar_for_positional(self, action):
         return action.type.__name__
+
+
+class GnuStyleLongOptionsHelpFormatter(HelpFormatter):
+    """Help message formatter which uses the GNU-style long option format
+    (with '=' in between options and arguments) in help messages.
+
+    Only the name of this class is considered a public API. All the methods
+    provided by the class are considered an implementation detail.
+    """
+
+    def _format_option_with_args(self, option_string, args_string):
+        if option_string.startswith('--'):
+            return '%s=%s' % (option_string, args_string)
+        return '%s %s' % (option_string, args_string)
 
 
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4412,6 +4412,47 @@ class TestHelpMetavarTypeFormatter(HelpTestCase):
     version = ''
 
 
+class TestHelpGnuStyleLongOptions(HelpTestCase):
+    """Test the GnuStyleLongOptionsHelpFormatter"""
+
+    parser_signature = Sig(
+        prog='PROG', formatter_class=argparse.GnuStyleLongOptionsHelpFormatter,
+        description='description')
+
+    argument_signatures = [
+        Sig('--foo', help='with argument'),
+        Sig('--bar', action='store_true', help='no argument'),
+        Sig('-z', '--baz', help='both short and long'),
+        Sig('spam', help='positional'),
+    ]
+    argument_group_signatures = [
+        (Sig('title', description='a group'),
+         [Sig('--turtle', type=int, default=42, help='option in group')]),
+    ]
+    usage = '''\
+        usage: PROG [-h] [--foo=FOO] [--bar] [-z BAZ] [--turtle=TURTLE] spam
+        '''
+    help = usage + '''\
+
+        description
+
+        positional arguments:
+          spam               positional
+
+        options:
+          -h, --help         show this help message and exit
+          --foo=FOO          with argument
+          --bar              no argument
+          -z BAZ, --baz=BAZ  both short and long
+
+        title:
+          a group
+
+          --turtle=TURTLE    option in group
+        '''
+    version = ''
+
+
 # =====================================
 # Optional/Positional constructor tests
 # =====================================

--- a/Misc/NEWS.d/next/Library/2021-01-21-06-17-52.bpo-42980.Mcifcp.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-21-06-17-52.bpo-42980.Mcifcp.rst
@@ -1,0 +1,1 @@
+Added a new help formatter for argparse that prints the help message using GNU-style long options (with '=' in between the option and the argument for options that take arguments).


### PR DESCRIPTION
    Add a new help formatter for argparse that prints long options
    in a style consistent with GNU getopt long options.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42980](https://bugs.python.org/issue42980) -->
https://bugs.python.org/issue42980
<!-- /issue-number -->

<!-- gh-issue-number: gh-87146 -->
* Issue: gh-87146
<!-- /gh-issue-number -->
