### PR TITLE
bpo-42986: Fix parser crash when reporting syntax errors in f-string with newlines

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -212,7 +212,6 @@ class ExceptionTests(unittest.TestCase):
         check('[file for str(file) in []\n])', 1, 11)
         check('[\nfile\nfor str(file)\nin\n[]\n]', 3, 5)
         check('[file for\n str(file) in []]', 2, 2)
-        check('"\n\nf\'{.}\'"' , 1, 1)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -212,6 +212,7 @@ class ExceptionTests(unittest.TestCase):
         check('[file for str(file) in []\n])', 1, 11)
         check('[\nfile\nfor str(file)\nin\n[]\n]', 3, 5)
         check('[file for\n str(file) in []]', 2, 2)
+        check('"\n\nf\'{.}\'"' , 1, 1)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -664,6 +664,9 @@ x = (
         self.assertAllRaise(SyntaxError, 'unterminated string literal',
                             ["f'{\n}'",
                              ])
+    def test_newlines_before_syntax_error(self):
+        self.assertAllRaise(SyntaxError, "invalid syntax",
+                ["f'{.}'", "\nf'{.}'", "\n\nf'{.}'"])
 
     def test_backslashes_in_string_part(self):
         self.assertEqual(f'\t', '\t')

--- a/Misc/NEWS.d/next/Core and Builtins/2021-01-20-23-44-15.bpo-42986.sWoaGf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-01-20-23-44-15.bpo-42986.sWoaGf.rst
@@ -1,0 +1,2 @@
+Fix parser crash when reporting syntax errors in f-string with newlines.
+Patch by Pablo Galindo.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -454,7 +454,7 @@ _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
            does not physically exist */
         assert(p->tok->fp == NULL || p->tok->fp == stdin || p->tok->done == E_EOF);
 
-        if (p->tok->lineno == lineno) {
+        if (p->tok->lineno <= lineno) {
             Py_ssize_t size = p->tok->inp - p->tok->buf;
             error_line = PyUnicode_DecodeUTF8(p->tok->buf, size, "replace");
         }


### PR DESCRIPTION


<!-- issue-number: [bpo-42986](https://bugs.python.org/issue42986) -->
https://bugs.python.org/issue42986
<!-- /issue-number -->
