### PR TITLE
Fix a typo/error in a news entry (bidst_wheel -> bdist_wheel)

### DIFF
--- a/Misc/NEWS.d/3.10.0a5.rst
+++ b/Misc/NEWS.d/3.10.0a5.rst
@@ -386,7 +386,7 @@ initialization (:pep:`489`).  Patch by Erlend E. Aasland.
 .. section: Library
 
 The distutils ``bdist_wininst`` command deprecated in Python 3.8 has been
-removed. The distutils ``bidst_wheel`` command is now recommended to
+removed. The distutils ``bdist_wheel`` command is now recommended to
 distribute binary packages on Windows.
 
 ..


### PR DESCRIPTION
This error was fixed recently in `Doc/whatsnew/3.10.rst`.

Automerge-Triggered-By: GH:iritkatriel