### PR TITLE
bpo-42988: Improve pydoc web server security

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2283,7 +2283,7 @@ def apropos(key):
 
 # As of 2021, a secret with this number of bytes is secure. Update in the future
 # if necessary.
-SECRET_URL_TOKEN = secrets.token_urlsafe(80)
+SECRET_URL_TOKEN = secrets.token_urlsafe(64)
 
 def _start_server(urlhandler, hostname, port):
     """Start an HTTP server thread on a specific port.
@@ -2663,11 +2663,12 @@ def _url_handler(url, content_type="text/html"):
             title, content = html_error(complete_url, exc)
         return html.page(title, content)
 
+    if url.startswith('/'):
+        url = url[1:]
     # Make sure the secret token is inside before doing any URL operations.
-    left, sep, right = url.partition(SECRET_URL_TOKEN)
-    if not sep:
+    if not secrets.compare_digest(url[:len(SECRET_URL_TOKEN)], SECRET_URL_TOKEN):
         raise ValueError(f'Invalid secret token for {url}')
-    url = right
+    url = url[len(SECRET_URL_TOKEN):]
     if url.startswith('/'):
         url = url[1:]
     if content_type == 'text/css':
@@ -2698,6 +2699,7 @@ def browse(port=0, *, open_browser=True, hostname='localhost'):
             webbrowser.open(serverthread.url)
         try:
             print('Server ready at', serverthread.url)
+            print("Note: This URL is unique to you. Please don't share it.")
             print(server_help_msg)
             while serverthread.serving:
                 cmd = input('server> ')

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2281,9 +2281,9 @@ def apropos(key):
 
 # --------------------------------------- enhanced Web browser interface
 
-# As of 2021, 128 byte secret is secure. Update in future if
-# necessary.
-SECRET_URL_TOKEN = secrets.token_urlsafe(128)
+# As of 2021, a secret with this number of bytes is secure. Update in the future
+# if necessary.
+SECRET_URL_TOKEN = secrets.token_urlsafe(80)
 
 def _start_server(urlhandler, hostname, port):
     """Start an HTTP server thread on a specific port.
@@ -2790,10 +2790,6 @@ def cli():
                 hostname = val
 
         if start_server:
-            warnings.warn("WARNING: The web server is accessible by other users "
-                          "on this computer. This will potentially make all "
-                          "content accessible by you visible to anyone else "
-                          "sharing the machine.", category=RuntimeWarning)
             browse(port, hostname=hostname, open_browser=open_browser)
             return
 

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2780,7 +2780,7 @@ def cli():
 
         if start_server:
             warnings.warn("WARNING: The web server is accessible by other users "
-                          "on this machine. This will potentially make all "
+                          "on this computer. This will potentially make all "
                           "content accessible by you visible to anyone else "
                           "sharing the machine.", category=RuntimeWarning)
             browse(port, hostname=hostname, open_browser=open_browser)

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2454,14 +2454,13 @@ def _url_handler(url, content_type="text/html"):
             css_link = (
                 '<link rel="stylesheet" type="text/css" href="%s">' %
                 css_path)
-            favicon_link = f'{SECRET_URL_TOKEN}/favicon.ico'
             return '''\
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html><head><title>Pydoc: %s</title>
-<link rel="shortcut icon" href="%s" type="image/x-icon"/>
+<link rel="shortcut icon" href="./favicon.ico" type="image/x-icon"/>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 %s</head><body bgcolor="#f0f0f8">%s<div style="clear:both;padding-top:.5em;">%s</div>
-</body></html>''' % (title, favicon_link, css_link, html_navbar(), contents)
+</body></html>''' % (title, css_link, html_navbar(), contents)
 
 
 
@@ -2664,6 +2663,7 @@ def _url_handler(url, content_type="text/html"):
             title, content = html_error(complete_url, exc)
         return html.page(title, content)
 
+    # Make sure the secret token is inside before doing any URL operations.
     left, sep, right = url.partition(SECRET_URL_TOKEN)
     if not sep:
         raise ValueError(f'Invalid secret token for {url}')

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2666,7 +2666,7 @@ def _url_handler(url, content_type="text/html"):
 
     left, sep, right = url.partition(SECRET_URL_TOKEN)
     if not sep:
-        raise TypeError(f'Invalid secret token for {url}')
+        raise ValueError(f'Invalid secret token for {url}')
     url = right
     if url.startswith('/'):
         url = url[1:]

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2456,8 +2456,6 @@ def _url_handler(url, content_type="text/html"):
 %s</head><body bgcolor="#f0f0f8">%s<div style="clear:both;padding-top:.5em;">%s</div>
 </body></html>''' % (title, css_link, html_navbar(), contents)
 
-        def filelink(self, url, path):
-            return '<a href="getfile?key=%s">%s</a>' % (url, path)
 
 
     html = _HTMLDoc()
@@ -2543,19 +2541,6 @@ def _url_handler(url, content_type="text/html"):
         contents = heading + html.bigsection(
             'key = %s' % key, '#ffffff', '#ee77aa', '<br>'.join(results))
         return 'Search Results', contents
-
-    def html_getfile(path):
-        """Get and display a source file listing safely."""
-        path = urllib.parse.unquote(path)
-        with tokenize.open(path) as fp:
-            lines = html.escape(fp.read())
-        body = '<pre>%s</pre>' % lines
-        heading = html.heading(
-            '<big><big><strong>File Listing</strong></big></big>',
-            '#ffffff', '#7799ee')
-        contents = heading + html.bigsection(
-            'File: %s' % path, '#ffffff', '#ee77aa', body)
-        return 'getfile %s' % path, contents
 
     def html_topics():
         """Index of topic texts available."""
@@ -2648,8 +2633,6 @@ def _url_handler(url, content_type="text/html"):
                 op, _, url = url.partition('=')
                 if op == "search?key":
                     title, content = html_search(url)
-                elif op == "getfile?key":
-                    title, content = html_getfile(url)
                 elif op == "topic?key":
                     # try topics first, then objects.
                     try:
@@ -2796,6 +2779,10 @@ def cli():
                 hostname = val
 
         if start_server:
+            warnings.warn("WARNING: The web server is accessible by other users "
+                          "on this machine. This will potentially make all "
+                          "content accessible by you visible to anyone else "
+                          "sharing the machine.", category=RuntimeWarning)
             browse(port, hostname=hostname, open_browser=open_browser)
             return
 

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1374,17 +1374,12 @@ class PydocUrlHandlerTest(PydocBaseTest):
             ("topic?key=def", "Pydoc: KEYWORD def"),
             ("topic?key=STRINGS", "Pydoc: TOPIC STRINGS"),
             ("foobar", "Pydoc: Error - foobar"),
-            ("getfile?key=foobar", "Pydoc: Error - getfile?key=foobar"),
             ]
 
         with self.restrict_walk_packages():
             for url, title in requests:
                 self.call_url_handler(url, title)
 
-            path = string.__file__
-            title = "Pydoc: getfile " + path
-            url = "getfile?key=" + path
-            self.call_url_handler(url, title)
 
 
 class TestHelper(unittest.TestCase):

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1356,8 +1356,8 @@ class PydocUrlHandlerTest(PydocBaseTest):
 
     def test_content_type_err(self):
         f = pydoc._url_handler
-        self.assertRaises(TypeError, f, 'A', '')
-        self.assertRaises(TypeError, f, 'B', 'foobar')
+        self.assertRaises(TypeError, f, f'{pydoc.SECRET_URL_TOKEN}/A', '')
+        self.assertRaises(TypeError, f, f'{pydoc.SECRET_URL_TOKEN}/B', 'foobar')
 
     def test_url_requests(self):
         # Test for the correct title in the html pages returned.
@@ -1379,8 +1379,15 @@ class PydocUrlHandlerTest(PydocBaseTest):
 
         with self.restrict_walk_packages():
             for url, title in requests:
-                self.call_url_handler(f"{pydoc.SECRET_URL_TOKEN}/{url}", title)
-
+                with self.subTest(url):
+                    self.call_url_handler(f"{pydoc.SECRET_URL_TOKEN}/{url}",
+                                          title)
+        # These should all fail without a token, see bpo-42988.
+        with self.restrict_walk_packages():
+            for url, title in requests:
+                with self.subTest(f"{url} should raise error without token"):
+                    with self.assertRaises(ValueError):
+                        self.call_url_handler(f"{url}", title)
 
 
 class TestHelper(unittest.TestCase):

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -973,7 +973,8 @@ class PydocImportTest(PydocBaseTest):
                 with self.assertRaisesRegex(ValueError, "ouch"):
                     import test_error_package  # Sanity check
 
-                text = self.call_url_handler("search?key=test_error_package",
+                text = self.call_url_handler(f"{pydoc.SECRET_URL_TOKEN}/search"
+                                             f"?key=test_error_package",
                     "Pydoc: Search Results")
                 found = ('<a href="test_error_package.html">'
                     'test_error_package</a>')
@@ -1378,7 +1379,7 @@ class PydocUrlHandlerTest(PydocBaseTest):
 
         with self.restrict_walk_packages():
             for url, title in requests:
-                self.call_url_handler(url, title)
+                self.call_url_handler(f"{pydoc.SECRET_URL_TOKEN}/{url}", title)
 
 
 

--- a/Misc/NEWS.d/next/Security/2021-01-22-00-54-24.bpo-42988.-i_qxd.rst
+++ b/Misc/NEWS.d/next/Security/2021-01-22-00-54-24.bpo-42988.-i_qxd.rst
@@ -1,4 +1,4 @@
 Removed ``html_getfile`` function from :mod:`pydoc` since it allowed reading
 an arbitrary file location.  Also use a unique token only available to the
-current user to prevent other users on the same computer from accessing the 
+current user to prevent other users on the same computer from accessing the
 :mod:`pydoc` Web server.

--- a/Misc/NEWS.d/next/Security/2021-01-22-00-54-24.bpo-42988.-i_qxd.rst
+++ b/Misc/NEWS.d/next/Security/2021-01-22-00-54-24.bpo-42988.-i_qxd.rst
@@ -1,0 +1,5 @@
+Removed ``html_getfile`` function from :mod:`pydoc` since it allowed reading
+an arbitrary file location.  Also added a warning to discourage users from
+using :mod:`pydoc`\ 's Web server because it potentially allows other users
+on the same computer to access any files accessible by the user who started the
+Web server.

--- a/Misc/NEWS.d/next/Security/2021-01-22-00-54-24.bpo-42988.-i_qxd.rst
+++ b/Misc/NEWS.d/next/Security/2021-01-22-00-54-24.bpo-42988.-i_qxd.rst
@@ -1,5 +1,4 @@
 Removed ``html_getfile`` function from :mod:`pydoc` since it allowed reading
-an arbitrary file location.  Also added a warning to discourage users from
-using :mod:`pydoc`\ 's Web server because it potentially allows other users
-on the same computer to access any files accessible by the user who started the
-Web server.
+an arbitrary file location.  Also use a unique token only available to the
+current user to prevent other users on the same computer from accessing the 
+:mod:`pydoc` Web server.


### PR DESCRIPTION
- Remove html_getfile.
- Use locally generated secret to prevent other users from accessing a running web server.

EDIT: Honestly I'm not sure if we need to remove html_getfile now that there's a token to validate the user.

<!-- issue-number: [bpo-42988](https://bugs.python.org/issue42988) -->
https://bugs.python.org/issue42988
<!-- /issue-number -->
