### PR TITLE
bpo-42990: Introduce 'frame constructor' struct to simplify API for PyEval_CodeEval and friends

### DIFF
--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -72,7 +72,7 @@ PyAPI_FUNC(PyFrameObject *) PyFrame_New(PyThreadState *, PyCodeObject *,
 
 /* only internal use */
 PyFrameObject* _PyFrame_New_NoTrack(PyThreadState *, PyCodeObject *,
-                                    PyObject *, PyObject *);
+                                    PyObject *, PyObject *, PyObject *);
 
 
 /* The rest of the interface is specific for frame objects */
@@ -92,3 +92,5 @@ PyAPI_FUNC(void) PyFrame_FastToLocals(PyFrameObject *);
 PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
+
+PyObject *_PyEval_BuiltinsFromGlobals(PyObject *globals);

--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -7,6 +7,18 @@
 extern "C" {
 #endif
 
+
+typedef struct {
+    PyObject *globals;
+    PyObject *builtins;
+    PyObject *name;
+    PyObject *qualname;
+    PyObject *code;        /* A code object, the __code__ attribute */
+    PyObject *defaults;    /* NULL or a tuple */
+    PyObject *kwdefaults;  /* NULL or a dict */
+    PyObject *closure;     /* NULL or a tuple of cell objects */
+} PyFrameConstructor;
+
 /* Function objects and code objects should not be confused with each other:
  *
  * Function objects are created by the execution of the 'def' statement.
@@ -20,18 +32,12 @@ extern "C" {
 
 typedef struct {
     PyObject_HEAD
-    PyObject *func_code;        /* A code object, the __code__ attribute */
-    PyObject *func_globals;     /* A dictionary (other mappings won't do) */
-    PyObject *func_defaults;    /* NULL or a tuple */
-    PyObject *func_kwdefaults;  /* NULL or a dict */
-    PyObject *func_closure;     /* NULL or a tuple of cell objects */
+    PyFrameConstructor func_descr;  /* Frame descriptor fields for this function */
     PyObject *func_doc;         /* The __doc__ attribute, can be anything */
-    PyObject *func_name;        /* The __name__ attribute, a string object */
     PyObject *func_dict;        /* The __dict__ attribute, a dict or NULL */
     PyObject *func_weakreflist; /* List of weak references */
     PyObject *func_module;      /* The __module__ attribute, can be anything */
     PyObject *func_annotations; /* Annotations, a dict or NULL */
-    PyObject *func_qualname;    /* The qualified name */
     vectorcallfunc vectorcall;
 
     /* Invariant:
@@ -70,17 +76,17 @@ PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyFunction_GET_CODE(func) \
-        (((PyFunctionObject *)func) -> func_code)
+        (((PyFunctionObject *)func) -> func_descr.code)
 #define PyFunction_GET_GLOBALS(func) \
-        (((PyFunctionObject *)func) -> func_globals)
+        (((PyFunctionObject *)func) -> func_descr.globals)
 #define PyFunction_GET_MODULE(func) \
         (((PyFunctionObject *)func) -> func_module)
 #define PyFunction_GET_DEFAULTS(func) \
-        (((PyFunctionObject *)func) -> func_defaults)
+        (((PyFunctionObject *)func) -> func_descr.defaults)
 #define PyFunction_GET_KW_DEFAULTS(func) \
-        (((PyFunctionObject *)func) -> func_kwdefaults)
+        (((PyFunctionObject *)func) -> func_descr.kwdefaults)
 #define PyFunction_GET_CLOSURE(func) \
-        (((PyFunctionObject *)func) -> func_closure)
+        (((PyFunctionObject *)func) -> func_descr.closure)
 #define PyFunction_GET_ANNOTATIONS(func) \
         (((PyFunctionObject *)func) -> func_annotations)
 

--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -19,7 +19,7 @@ extern "C" {
     PyObject *PREFIX ## closure;     /* NULL or a tuple of cell objects */
 
 typedef struct {
-    COMMON_FIELDS()
+    COMMON_FIELDS(fc_)
 } PyFrameConstructor;
 
 /* Function objects and code objects should not be confused with each other:

--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -32,7 +32,21 @@ typedef struct {
 
 typedef struct {
     PyObject_HEAD
-    PyFrameConstructor func_descr;  /* Frame descriptor fields for this function */
+    union {
+        PyFrameConstructor func_descr;  /* Frame descriptor fields for this function */
+        /* This struct is for backward compatibility of code using the old func_* fields;
+         Note that the order of fields must match PyFrameConstructor *exactly*. */
+        struct {
+            PyObject *func_globals;
+            PyObject *func_builtins;
+            PyObject *func_name;
+            PyObject *func_qualname;
+            PyObject *func_code;
+            PyObject *func_defaults;
+            PyObject *func_kwdefaults;
+            PyObject *func_closure;
+        };
+    };
     PyObject *func_doc;         /* The __doc__ attribute, can be anything */
     PyObject *func_dict;        /* The __dict__ attribute, a dict or NULL */
     PyObject *func_weakreflist; /* List of weak references */
@@ -76,17 +90,17 @@ PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyFunction_GET_CODE(func) \
-        (((PyFunctionObject *)func) -> func_descr.code)
+        (((PyFunctionObject *)func) -> func_code)
 #define PyFunction_GET_GLOBALS(func) \
-        (((PyFunctionObject *)func) -> func_descr.globals)
+        (((PyFunctionObject *)func) -> func_globals)
 #define PyFunction_GET_MODULE(func) \
         (((PyFunctionObject *)func) -> func_module)
 #define PyFunction_GET_DEFAULTS(func) \
-        (((PyFunctionObject *)func) -> func_descr.defaults)
+        (((PyFunctionObject *)func) -> func_defaults)
 #define PyFunction_GET_KW_DEFAULTS(func) \
-        (((PyFunctionObject *)func) -> func_descr.kwdefaults)
+        (((PyFunctionObject *)func) -> func_kwdefaults)
 #define PyFunction_GET_CLOSURE(func) \
-        (((PyFunctionObject *)func) -> func_descr.closure)
+        (((PyFunctionObject *)func) -> func_closure)
 #define PyFunction_GET_ANNOTATIONS(func) \
         (((PyFunctionObject *)func) -> func_annotations)
 

--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -8,15 +8,18 @@ extern "C" {
 #endif
 
 
+#define COMMON_FIELDS(PREFIX) \
+    PyObject *PREFIX ## globals; \
+    PyObject *PREFIX ## builtins; \
+    PyObject *PREFIX ## name; \
+    PyObject *PREFIX ## qualname; \
+    PyObject *PREFIX ## code;        /* A code object, the __code__ attribute */ \
+    PyObject *PREFIX ## defaults;    /* NULL or a tuple */ \
+    PyObject *PREFIX ## kwdefaults;  /* NULL or a dict */ \
+    PyObject *PREFIX ## closure;     /* NULL or a tuple of cell objects */
+
 typedef struct {
-    PyObject *globals;
-    PyObject *builtins;
-    PyObject *name;
-    PyObject *qualname;
-    PyObject *code;        /* A code object, the __code__ attribute */
-    PyObject *defaults;    /* NULL or a tuple */
-    PyObject *kwdefaults;  /* NULL or a dict */
-    PyObject *closure;     /* NULL or a tuple of cell objects */
+    COMMON_FIELDS()
 } PyFrameConstructor;
 
 /* Function objects and code objects should not be confused with each other:
@@ -32,21 +35,7 @@ typedef struct {
 
 typedef struct {
     PyObject_HEAD
-    union {
-        PyFrameConstructor func_descr;  /* Frame descriptor fields for this function */
-        /* This struct is for backward compatibility of code using the old func_* fields;
-         Note that the order of fields must match PyFrameConstructor *exactly*. */
-        struct {
-            PyObject *func_globals;
-            PyObject *func_builtins;
-            PyObject *func_name;
-            PyObject *func_qualname;
-            PyObject *func_code;
-            PyObject *func_defaults;
-            PyObject *func_kwdefaults;
-            PyObject *func_closure;
-        };
-    };
+    COMMON_FIELDS(func_)
     PyObject *func_doc;         /* The __doc__ attribute, can be anything */
     PyObject *func_dict;        /* The __dict__ attribute, a dict or NULL */
     PyObject *func_weakreflist; /* List of weak references */
@@ -103,6 +92,9 @@ PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
         (((PyFunctionObject *)func) -> func_closure)
 #define PyFunction_GET_ANNOTATIONS(func) \
         (((PyFunctionObject *)func) -> func_annotations)
+
+#define PyFunction_AS_FRAME_CONSTRUCTOR(func) \
+        ((PyFrameConstructor *)&((PyFunctionObject *)(func))->func_globals)
 
 /* The classmethod and staticmethod types lives here, too */
 PyAPI_DATA(PyTypeObject) PyClassMethod_Type;

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -42,13 +42,10 @@ _PyEval_EvalFrame(PyThreadState *tstate, PyFrameObject *f, int throwflag)
 
 extern PyObject *_PyEval_EvalCode(
     PyThreadState *tstate,
-    PyObject *_co, PyObject *globals, PyObject *locals,
+    PyFrameConstructor *desc, PyObject *locals,
     PyObject *const *args, Py_ssize_t argcount,
     PyObject *const *kwnames, PyObject *const *kwargs,
-    Py_ssize_t kwcount, int kwstep,
-    PyObject *const *defs, Py_ssize_t defcount,
-    PyObject *kwdefs, PyObject *closure,
-    PyObject *name, PyObject *qualname);
+    Py_ssize_t kwcount, int kwstep);
 
 #ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
 extern int _PyEval_ThreadsInitialized(PyInterpreterState *interp);

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1275,7 +1275,7 @@ class SizeofTest(unittest.TestCase):
         check(x, vsize('4Pi2c4P3ic' + CO_MAXBLOCKS*'3i' + 'P' + extras*'P'))
         # function
         def func(): pass
-        check(func, size('13P'))
+        check(func, size('14P'))
         class c():
             @staticmethod
             def foo():

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -316,7 +316,7 @@ function_code_fastcall(PyThreadState *tstate, PyCodeObject *co,
        _PyFrame_New_NoTrack() that doesn't take locals, but does
        take builtins without sanity checking them.
        */
-    PyFrameObject *f = _PyFrame_New_NoTrack(tstate, co, func->func_descr.globals, func->func_descr.builtins, NULL);
+    PyFrameObject *f = _PyFrame_New_NoTrack(tstate, co, func->func_globals, func->func_builtins, NULL);
     if (f == NULL) {
         return NULL;
     }
@@ -377,7 +377,7 @@ _PyFunction_Vectorcall(PyObject *func, PyObject* const* stack,
     }
 
     return _PyEval_EvalCode(tstate,
-                &((PyFunctionObject *)func)->func_descr, (PyObject *)NULL,
+                PyFunction_AS_FRAME_CONSTRUCTOR(func), (PyObject *)NULL,
                 stack, nargs,
                 nkwargs ? _PyTuple_ITEMS(kwnames) : NULL,
                 stack + nargs,

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -307,16 +307,16 @@ PyCFunction_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
 static PyObject* _Py_HOT_FUNCTION
 function_code_fastcall(PyThreadState *tstate, PyCodeObject *co,
                        PyObject *const *args, Py_ssize_t nargs,
-                       PyObject *globals)
+                       PyFunctionObject *func)
 {
     assert(tstate != NULL);
-    assert(globals != NULL);
+    assert(func != NULL);
 
     /* XXX Perhaps we should create a specialized
        _PyFrame_New_NoTrack() that doesn't take locals, but does
        take builtins without sanity checking them.
        */
-    PyFrameObject *f = _PyFrame_New_NoTrack(tstate, co, globals, NULL);
+    PyFrameObject *f = _PyFrame_New_NoTrack(tstate, co, func->func_descr.globals, func->func_descr.builtins, NULL);
     if (f == NULL) {
         return NULL;
     }
@@ -357,14 +357,13 @@ _PyFunction_Vectorcall(PyObject *func, PyObject* const* stack,
 
     PyThreadState *tstate = _PyThreadState_GET();
     PyCodeObject *co = (PyCodeObject *)PyFunction_GET_CODE(func);
-    PyObject *globals = PyFunction_GET_GLOBALS(func);
     PyObject *argdefs = PyFunction_GET_DEFAULTS(func);
 
     if (co->co_kwonlyargcount == 0 && nkwargs == 0 &&
         (co->co_flags & ~PyCF_MASK) == (CO_OPTIMIZED | CO_NEWLOCALS | CO_NOFREE))
     {
         if (argdefs == NULL && co->co_argcount == nargs) {
-            return function_code_fastcall(tstate, co, stack, nargs, globals);
+            return function_code_fastcall(tstate, co, stack, nargs, (PyFunctionObject *)func);
         }
         else if (nargs == 0 && argdefs != NULL
                  && co->co_argcount == PyTuple_GET_SIZE(argdefs)) {
@@ -373,34 +372,16 @@ _PyFunction_Vectorcall(PyObject *func, PyObject* const* stack,
             stack = _PyTuple_ITEMS(argdefs);
             return function_code_fastcall(tstate, co,
                                           stack, PyTuple_GET_SIZE(argdefs),
-                                          globals);
+                                          (PyFunctionObject *)func);
         }
     }
 
-    PyObject *kwdefs = PyFunction_GET_KW_DEFAULTS(func);
-    PyObject *closure = PyFunction_GET_CLOSURE(func);
-    PyObject *name = ((PyFunctionObject *)func) -> func_name;
-    PyObject *qualname = ((PyFunctionObject *)func) -> func_qualname;
-
-    PyObject **d;
-    Py_ssize_t nd;
-    if (argdefs != NULL) {
-        d = _PyTuple_ITEMS(argdefs);
-        nd = PyTuple_GET_SIZE(argdefs);
-        assert(nd <= INT_MAX);
-    }
-    else {
-        d = NULL;
-        nd = 0;
-    }
     return _PyEval_EvalCode(tstate,
-                (PyObject*)co, globals, (PyObject *)NULL,
+                &((PyFunctionObject *)func)->func_descr, (PyObject *)NULL,
                 stack, nargs,
                 nkwargs ? _PyTuple_ITEMS(kwnames) : NULL,
                 stack + nargs,
-                nkwargs, 1,
-                d, (int)nd, kwdefs,
-                closure, name, qualname);
+                nkwargs, 1);
 }
 
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -3,6 +3,7 @@
 
 #include "Python.h"
 #include "pycore_object.h"
+#include "frameobject.h"
 #include "code.h"
 #include "structmember.h"         // PyMemberDef
 
@@ -39,14 +40,20 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
 
     op->func_weakreflist = NULL;
     Py_INCREF(code);
-    op->func_code = code;
+    op->func_descr.code = code;
+    assert(globals != NULL);
     Py_INCREF(globals);
-    op->func_globals = globals;
-    op->func_name = ((PyCodeObject *)code)->co_name;
-    Py_INCREF(op->func_name);
-    op->func_defaults = NULL; /* No default arguments */
-    op->func_kwdefaults = NULL; /* No keyword only defaults */
-    op->func_closure = NULL;
+    op->func_descr.globals = globals;
+    PyObject *builtins = _PyEval_BuiltinsFromGlobals(globals);
+    if (builtins == NULL) {
+        return NULL;
+    }
+    op->func_descr.builtins = builtins;
+    op->func_descr.name = ((PyCodeObject *)code)->co_name;
+    Py_INCREF(op->func_descr.name);
+    op->func_descr.defaults = NULL; /* No default arguments */
+    op->func_descr.kwdefaults = NULL; /* No keyword only defaults */
+    op->func_descr.closure = NULL;
     op->vectorcall = _PyFunction_Vectorcall;
     op->func_module = module;
 
@@ -65,10 +72,10 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
     op->func_annotations = NULL;
 
     if (qualname)
-        op->func_qualname = qualname;
+        op->func_descr.qualname = qualname;
     else
-        op->func_qualname = op->func_name;
-    Py_INCREF(op->func_qualname);
+        op->func_descr.qualname = op->func_descr.name;
+    Py_INCREF(op->func_descr.qualname);
 
     _PyObject_GC_TRACK(op);
     return (PyObject *)op;
@@ -87,7 +94,7 @@ PyFunction_GetCode(PyObject *op)
         PyErr_BadInternalCall();
         return NULL;
     }
-    return ((PyFunctionObject *) op) -> func_code;
+    return ((PyFunctionObject *) op) -> func_descr.code;
 }
 
 PyObject *
@@ -97,7 +104,7 @@ PyFunction_GetGlobals(PyObject *op)
         PyErr_BadInternalCall();
         return NULL;
     }
-    return ((PyFunctionObject *) op) -> func_globals;
+    return ((PyFunctionObject *) op) -> func_descr.globals;
 }
 
 PyObject *
@@ -117,7 +124,7 @@ PyFunction_GetDefaults(PyObject *op)
         PyErr_BadInternalCall();
         return NULL;
     }
-    return ((PyFunctionObject *) op) -> func_defaults;
+    return ((PyFunctionObject *) op) -> func_descr.defaults;
 }
 
 int
@@ -136,7 +143,7 @@ PyFunction_SetDefaults(PyObject *op, PyObject *defaults)
         PyErr_SetString(PyExc_SystemError, "non-tuple default args");
         return -1;
     }
-    Py_XSETREF(((PyFunctionObject *)op)->func_defaults, defaults);
+    Py_XSETREF(((PyFunctionObject *)op)->func_descr.defaults, defaults);
     return 0;
 }
 
@@ -147,7 +154,7 @@ PyFunction_GetKwDefaults(PyObject *op)
         PyErr_BadInternalCall();
         return NULL;
     }
-    return ((PyFunctionObject *) op) -> func_kwdefaults;
+    return ((PyFunctionObject *) op) -> func_descr.kwdefaults;
 }
 
 int
@@ -167,7 +174,7 @@ PyFunction_SetKwDefaults(PyObject *op, PyObject *defaults)
                         "non-dict keyword only default args");
         return -1;
     }
-    Py_XSETREF(((PyFunctionObject *)op)->func_kwdefaults, defaults);
+    Py_XSETREF(((PyFunctionObject *)op)->func_descr.kwdefaults, defaults);
     return 0;
 }
 
@@ -178,7 +185,7 @@ PyFunction_GetClosure(PyObject *op)
         PyErr_BadInternalCall();
         return NULL;
     }
-    return ((PyFunctionObject *) op) -> func_closure;
+    return ((PyFunctionObject *) op) -> func_descr.closure;
 }
 
 int
@@ -199,7 +206,7 @@ PyFunction_SetClosure(PyObject *op, PyObject *closure)
                      Py_TYPE(closure)->tp_name);
         return -1;
     }
-    Py_XSETREF(((PyFunctionObject *)op)->func_closure, closure);
+    Py_XSETREF(((PyFunctionObject *)op)->func_descr.closure, closure);
     return 0;
 }
 
@@ -239,9 +246,8 @@ PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
 #define OFF(x) offsetof(PyFunctionObject, x)
 
 static PyMemberDef func_memberlist[] = {
-    {"__closure__",   T_OBJECT,     OFF(func_closure), READONLY},
     {"__doc__",       T_OBJECT,     OFF(func_doc), 0},
-    {"__globals__",   T_OBJECT,     OFF(func_globals), READONLY},
+    {"__globals__",   T_OBJECT,     OFF(func_descr.globals), READONLY},
     {"__module__",    T_OBJECT,     OFF(func_module), 0},
     {NULL}  /* Sentinel */
 };
@@ -253,8 +259,21 @@ func_get_code(PyFunctionObject *op, void *Py_UNUSED(ignored))
         return NULL;
     }
 
-    Py_INCREF(op->func_code);
-    return op->func_code;
+    Py_INCREF(op->func_descr.code);
+    return op->func_descr.code;
+}
+
+static PyObject *
+func_get_closure(PyFunctionObject *op, void *Py_UNUSED(ignored))
+{
+    if (PySys_Audit("object.__getattr__", "Os", op, "__closure__") < 0) {
+        return NULL;
+    }
+    if (op->func_descr.closure == NULL) {
+        Py_RETURN_NONE;
+    }
+    Py_INCREF(op->func_descr.closure);
+    return op->func_descr.closure;
 }
 
 static int
@@ -276,26 +295,26 @@ func_set_code(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignored))
     }
 
     nfree = PyCode_GetNumFree((PyCodeObject *)value);
-    nclosure = (op->func_closure == NULL ? 0 :
-            PyTuple_GET_SIZE(op->func_closure));
+    nclosure = (op->func_descr.closure == NULL ? 0 :
+            PyTuple_GET_SIZE(op->func_descr.closure));
     if (nclosure != nfree) {
         PyErr_Format(PyExc_ValueError,
                      "%U() requires a code object with %zd free vars,"
                      " not %zd",
-                     op->func_name,
+                     op->func_descr.name,
                      nclosure, nfree);
         return -1;
     }
     Py_INCREF(value);
-    Py_XSETREF(op->func_code, value);
+    Py_XSETREF(op->func_descr.code, value);
     return 0;
 }
 
 static PyObject *
 func_get_name(PyFunctionObject *op, void *Py_UNUSED(ignored))
 {
-    Py_INCREF(op->func_name);
-    return op->func_name;
+    Py_INCREF(op->func_descr.name);
+    return op->func_descr.name;
 }
 
 static int
@@ -309,15 +328,15 @@ func_set_name(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignored))
         return -1;
     }
     Py_INCREF(value);
-    Py_XSETREF(op->func_name, value);
+    Py_XSETREF(op->func_descr.name, value);
     return 0;
 }
 
 static PyObject *
 func_get_qualname(PyFunctionObject *op, void *Py_UNUSED(ignored))
 {
-    Py_INCREF(op->func_qualname);
-    return op->func_qualname;
+    Py_INCREF(op->func_descr.qualname);
+    return op->func_descr.qualname;
 }
 
 static int
@@ -331,7 +350,7 @@ func_set_qualname(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignored
         return -1;
     }
     Py_INCREF(value);
-    Py_XSETREF(op->func_qualname, value);
+    Py_XSETREF(op->func_descr.qualname, value);
     return 0;
 }
 
@@ -341,11 +360,11 @@ func_get_defaults(PyFunctionObject *op, void *Py_UNUSED(ignored))
     if (PySys_Audit("object.__getattr__", "Os", op, "__defaults__") < 0) {
         return NULL;
     }
-    if (op->func_defaults == NULL) {
+    if (op->func_descr.defaults == NULL) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(op->func_defaults);
-    return op->func_defaults;
+    Py_INCREF(op->func_descr.defaults);
+    return op->func_descr.defaults;
 }
 
 static int
@@ -371,7 +390,7 @@ func_set_defaults(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignored
     }
 
     Py_XINCREF(value);
-    Py_XSETREF(op->func_defaults, value);
+    Py_XSETREF(op->func_descr.defaults, value);
     return 0;
 }
 
@@ -382,11 +401,11 @@ func_get_kwdefaults(PyFunctionObject *op, void *Py_UNUSED(ignored))
                     op, "__kwdefaults__") < 0) {
         return NULL;
     }
-    if (op->func_kwdefaults == NULL) {
+    if (op->func_descr.kwdefaults == NULL) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(op->func_kwdefaults);
-    return op->func_kwdefaults;
+    Py_INCREF(op->func_descr.kwdefaults);
+    return op->func_descr.kwdefaults;
 }
 
 static int
@@ -412,7 +431,7 @@ func_set_kwdefaults(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(ignor
     }
 
     Py_XINCREF(value);
-    Py_XSETREF(op->func_kwdefaults, value);
+    Py_XSETREF(op->func_descr.kwdefaults, value);
     return 0;
 }
 
@@ -466,6 +485,7 @@ func_set_annotations(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(igno
 }
 
 static PyGetSetDef func_getsetlist[] = {
+    {"__closure__", (getter)func_get_closure, NULL},
     {"__code__", (getter)func_get_code, (setter)func_set_code},
     {"__defaults__", (getter)func_get_defaults,
      (setter)func_set_defaults},
@@ -573,15 +593,15 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
 
     if (name != Py_None) {
         Py_INCREF(name);
-        Py_SETREF(newfunc->func_name, name);
+        Py_SETREF(newfunc->func_descr.name, name);
     }
     if (defaults != Py_None) {
         Py_INCREF(defaults);
-        newfunc->func_defaults  = defaults;
+        newfunc->func_descr.defaults  = defaults;
     }
     if (closure != Py_None) {
         Py_INCREF(closure);
-        newfunc->func_closure = closure;
+        newfunc->func_descr.closure = closure;
     }
 
     return (PyObject *)newfunc;
@@ -590,17 +610,18 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
 static int
 func_clear(PyFunctionObject *op)
 {
-    Py_CLEAR(op->func_code);
-    Py_CLEAR(op->func_globals);
+    Py_CLEAR(op->func_descr.code);
+    Py_CLEAR(op->func_descr.globals);
+    Py_CLEAR(op->func_descr.builtins);
+    Py_CLEAR(op->func_descr.name);
+    Py_CLEAR(op->func_descr.qualname);
     Py_CLEAR(op->func_module);
-    Py_CLEAR(op->func_name);
-    Py_CLEAR(op->func_defaults);
-    Py_CLEAR(op->func_kwdefaults);
+    Py_CLEAR(op->func_descr.defaults);
+    Py_CLEAR(op->func_descr.kwdefaults);
     Py_CLEAR(op->func_doc);
     Py_CLEAR(op->func_dict);
-    Py_CLEAR(op->func_closure);
+    Py_CLEAR(op->func_descr.closure);
     Py_CLEAR(op->func_annotations);
-    Py_CLEAR(op->func_qualname);
     return 0;
 }
 
@@ -619,23 +640,24 @@ static PyObject*
 func_repr(PyFunctionObject *op)
 {
     return PyUnicode_FromFormat("<function %U at %p>",
-                               op->func_qualname, op);
+                               op->func_descr.qualname, op);
 }
 
 static int
 func_traverse(PyFunctionObject *f, visitproc visit, void *arg)
 {
-    Py_VISIT(f->func_code);
-    Py_VISIT(f->func_globals);
+    Py_VISIT(f->func_descr.code);
+    Py_VISIT(f->func_descr.globals);
+    Py_VISIT(f->func_descr.builtins);
     Py_VISIT(f->func_module);
-    Py_VISIT(f->func_defaults);
-    Py_VISIT(f->func_kwdefaults);
+    Py_VISIT(f->func_descr.defaults);
+    Py_VISIT(f->func_descr.kwdefaults);
     Py_VISIT(f->func_doc);
-    Py_VISIT(f->func_name);
+    Py_VISIT(f->func_descr.name);
     Py_VISIT(f->func_dict);
-    Py_VISIT(f->func_closure);
+    Py_VISIT(f->func_descr.closure);
     Py_VISIT(f->func_annotations);
-    Py_VISIT(f->func_qualname);
+    Py_VISIT(f->func_descr.qualname);
     return 0;
 }
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -246,6 +246,7 @@ PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
 #define OFF(x) offsetof(PyFunctionObject, x)
 
 static PyMemberDef func_memberlist[] = {
+    {"__closure__",   T_OBJECT,     OFF(func_descr.closure), READONLY},
     {"__doc__",       T_OBJECT,     OFF(func_doc), 0},
     {"__globals__",   T_OBJECT,     OFF(func_descr.globals), READONLY},
     {"__module__",    T_OBJECT,     OFF(func_module), 0},
@@ -261,19 +262,6 @@ func_get_code(PyFunctionObject *op, void *Py_UNUSED(ignored))
 
     Py_INCREF(op->func_descr.code);
     return op->func_descr.code;
-}
-
-static PyObject *
-func_get_closure(PyFunctionObject *op, void *Py_UNUSED(ignored))
-{
-    if (PySys_Audit("object.__getattr__", "Os", op, "__closure__") < 0) {
-        return NULL;
-    }
-    if (op->func_descr.closure == NULL) {
-        Py_RETURN_NONE;
-    }
-    Py_INCREF(op->func_descr.closure);
-    return op->func_descr.closure;
 }
 
 static int
@@ -485,7 +473,6 @@ func_set_annotations(PyFunctionObject *op, PyObject *value, void *Py_UNUSED(igno
 }
 
 static PyGetSetDef func_getsetlist[] = {
-    {"__closure__", (getter)func_get_closure, NULL},
     {"__code__", (getter)func_get_code, (setter)func_set_code},
     {"__defaults__", (getter)func_get_defaults,
      (setter)func_set_defaults},

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4627,7 +4627,7 @@ fail: /* Jump here from prelude on failure */
     return retval;
 }
 
-/* Lageacy API */
+/* Legacy API */
 PyObject *
 _PyEval_EvalCodeWithName(PyObject *_co, PyObject *globals, PyObject *locals,
            PyObject *const *args, Py_ssize_t argcount,
@@ -4666,7 +4666,7 @@ _PyEval_EvalCodeWithName(PyObject *_co, PyObject *globals, PyObject *locals,
     return res;
 }
 
-/* Lageacy API */
+/* Legacy API */
 PyObject *
 PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
                   PyObject *const *args, int argcount,

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3888,7 +3888,7 @@ main_loop:
 
             if (oparg & 0x08) {
                 assert(PyTuple_CheckExact(TOP()));
-                func->func_descr.closure = POP();
+                func->func_closure = POP();
             }
             if (oparg & 0x04) {
                 assert(PyTuple_CheckExact(TOP()));
@@ -3896,11 +3896,11 @@ main_loop:
             }
             if (oparg & 0x02) {
                 assert(PyDict_CheckExact(TOP()));
-                func->func_descr.kwdefaults = POP();
+                func->func_kwdefaults = POP();
             }
             if (oparg & 0x01) {
                 assert(PyTuple_CheckExact(TOP()));
-                func->func_descr.defaults = POP();
+                func->func_defaults = POP();
             }
 
             PUSH((PyObject *)func);
@@ -5276,7 +5276,7 @@ PyEval_GetFuncName(PyObject *func)
     if (PyMethod_Check(func))
         return PyEval_GetFuncName(PyMethod_GET_FUNCTION(func));
     else if (PyFunction_Check(func))
-        return PyUnicode_AsUTF8(((PyFunctionObject*)func)->func_descr.name);
+        return PyUnicode_AsUTF8(((PyFunctionObject*)func)->func_name);
     else if (PyCFunction_Check(func))
         return ((PyCFunctionObject*)func)->m_ml->ml_name;
     else


### PR DESCRIPTION
Rather than pass the contents of a `PyFunctionObject` as 8 different parameters, this PR passes a pointer to a struct, and embeds that struct in `PyFunctionObject`.

Only saves a few lines of code, but should enable more refactorings in `_PyFunction_Vectorcall` and similar functions.


<!-- issue-number: [bpo-42990](https://bugs.python.org/issue42990) -->
https://bugs.python.org/issue42990
<!-- /issue-number -->
