### PR TITLE
Remove full stop from bytes syntaxerror message

### DIFF
--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -250,7 +250,7 @@ _PyPegen_parsestr(Parser *p, int *bytesmode, int *rawmode, PyObject **result,
             if (Py_CHARMASK(*ch) >= 0x80) {
                 RAISE_SYNTAX_ERROR(
                                    "bytes can only contain ASCII "
-                                   "literal characters.");
+                                   "literal characters");
                 return -1;
             }
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Every other error I've seen raised by Python doesn't have a full stop at the end. This one appears to be an anomaly, so this PR removes the full stop to make it consistent with other errors.