### PR TITLE
bpo-43002: Fix description of behaviour of an exception class in 'from' clause

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -591,10 +591,13 @@ instance, with its traceback set to its argument), like so::
            __context__ (exception attribute)
 
 The ``from`` clause is used for exception chaining: if given, the second
-*expression* must be another exception class or instance, which will then be
-attached to the raised exception as the :attr:`__cause__` attribute (which is
-writable).  If the raised exception is not handled, both exceptions will be
-printed::
+*expression* must be another exception class or instance. If the second
+expression is an exception instance, it will be attached to the raised
+exception as the :attr:`__cause__` attribute (which is writable). If the
+expression is an exception class, the class will be instantiated and the
+resulting exception instance will be attached to the raised exception as the
+:attr:`__cause__` attribute. If the raised exception is not handled, both
+exceptions will be printed::
 
    >>> try:
    ...     print(1 / 0)


### PR DESCRIPTION
In a `raise <expr> from <expr2>` statement, `<expr2>` is permitted to be an exception instance, an exception class, or `None`. The reference manual suggests that in the first two cases, the value of `<expr2>` is attached directly to the raise exception as the `__cause__`. But in the implementation, an exception *class* is first instantiated before being attached to the raised exception: https://github.com/python/cpython/blob/b745a6143ae79efe00aa46affe5ea31a06b0b532/Python/ceval.c#L4758-L4763

This PR fixes the documentation to match the implementation.



<!-- issue-number: [bpo-43002](https://bugs.python.org/issue43002) -->
https://bugs.python.org/issue43002
<!-- /issue-number -->
