### PR TITLE
bpo-43011: Fix DeprecationWarnings in test_ctypes

### DIFF
--- a/Lib/ctypes/test/test_parameters.py
+++ b/Lib/ctypes/test/test_parameters.py
@@ -240,8 +240,8 @@ class SimpleTypesTestCase(unittest.TestCase):
         self.assertEqual(repr(c_double.from_param(1.5)), "<cparam 'd' (1.5)>")
         self.assertEqual(repr(c_double.from_param(1e300)), "<cparam 'd' (1e+300)>")
         self.assertRegex(repr(c_longdouble.from_param(1.5)), r"^<cparam ('d' \(1.5\)|'g' at 0x[A-Fa-f0-9]+)>$")
-        self.assertRegex(repr(c_char_p.from_param(b'hihi')), "^<cparam 'z' \(0x[A-Fa-f0-9]+\)>$")
-        self.assertRegex(repr(c_wchar_p.from_param('hihi')), "^<cparam 'Z' \(0x[A-Fa-f0-9]+\)>$")
+        self.assertRegex(repr(c_char_p.from_param(b'hihi')), r"^<cparam 'z' \(0x[A-Fa-f0-9]+\)>$")
+        self.assertRegex(repr(c_wchar_p.from_param('hihi')), r"^<cparam 'Z' \(0x[A-Fa-f0-9]+\)>$")
         self.assertRegex(repr(c_void_p.from_param(0x12)), r"^<cparam 'P' \(0x0*12\)>$")
 
 ################################################################


### PR DESCRIPTION
These warnings were introduced in 916610ef90a0d0761f08747f7b0905541f0977c7.

<!-- issue-number: [bpo-43011](https://bugs.python.org/issue43011) -->
https://bugs.python.org/issue43011
<!-- /issue-number -->
