### PR TITLE
Add annotations to example of overload implementation

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1809,7 +1809,7 @@ Functions and decorators
       @overload
       def process(response: bytes) -> str:
           ...
-      def process(response):
+      def process(response: Union[None, int, bytes]) -> Union[None, tuple[int, str], str]:
           <actual implementation>
 
    See :pep:`484` for details and comparison with other typing semantics.


### PR DESCRIPTION
For the body of the implementation of an overloaded function to be type-checked it must be annotated. 
This updates the overloaded example to show this behaviour.
Similar to https://github.com/python/mypy/pull/3369

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
