### PR TITLE
 bpo-43013: Update idlelib code to 3.x 

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -46,7 +46,7 @@ def _sphinx_version():
     return release
 
 
-class EditorWindow(object):
+class EditorWindow:
     from idlelib.percolator import Percolator
     from idlelib.colorizer import ColorDelegator, color_config
     from idlelib.undo import UndoDelegator
@@ -1546,7 +1546,7 @@ def get_line_indent(line, tabwidth):
     return m.end(), len(m.group().expandtabs(tabwidth))
 
 
-class IndentSearcher(object):
+class IndentSearcher:
 
     # .run() chews over the Text widget, looking for a block opener
     # and the stmt following it.  Returns a pair,

--- a/Lib/idlelib/idle_test/test_autocomplete.py
+++ b/Lib/idlelib/idle_test/test_autocomplete.py
@@ -195,7 +195,7 @@ class AutoCompleteTest(unittest.TestCase):
         self.assertFalse(acp.open_completions(ac.TAB))
         self.text.delete('1.0', 'end')
 
-    class dummy_acw():
+    class dummy_acw:
         __init__ = Func()
         show_window = Func(result=False)
         hide_window = Func()

--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -10,7 +10,7 @@ from idlelib.idle_test.mock_tk import Text
 
 
 # Test Class TC is used in multiple get_argspec test methods
-class TC():
+class TC:
     'doc'
     tip = "(ai=None, *b)"
     def __init__(self, ai=None, *b): 'doc'
@@ -268,7 +268,7 @@ class Get_entityTest(unittest.TestCase):
 # open_calltip is about half the code; the others are fairly trivial.
 # The default mocks are what are needed for open_calltip.
 
-class mock_Shell():
+class mock_Shell:
     "Return mock sufficient to pass to hyperparser."
     def __init__(self, text):
         text.tag_prevrange = Mock(return_value=None)

--- a/Lib/idlelib/idle_test/test_codecontext.py
+++ b/Lib/idlelib/idle_test/test_codecontext.py
@@ -20,7 +20,7 @@ testcfg = {
 }
 code_sample = """\
 
-class C1():
+class C1:
     # Class comment.
     def __init__(self, a, b):
         self.a = a
@@ -178,29 +178,29 @@ class CodeContextTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             gc(1, stopline=0)
 
-        eq(gc(3), ([(2, 0, 'class C1():', 'class')], 0))
+        eq(gc(3), ([(2, 0, 'class C1:', 'class')], 0))
 
         # Don't return comment.
-        eq(gc(4), ([(2, 0, 'class C1():', 'class')], 0))
+        eq(gc(4), ([(2, 0, 'class C1:', 'class')], 0))
 
         # Two indentation levels and no comment.
-        eq(gc(5), ([(2, 0, 'class C1():', 'class'),
+        eq(gc(5), ([(2, 0, 'class C1:', 'class'),
                     (4, 4, '    def __init__(self, a, b):', 'def')], 0))
 
         # Only one 'def' is returned, not both at the same indent level.
-        eq(gc(10), ([(2, 0, 'class C1():', 'class'),
+        eq(gc(10), ([(2, 0, 'class C1:', 'class'),
                      (7, 4, '    def compare(self):', 'def'),
                      (8, 8, '        if a > b:', 'if')], 0))
 
         # With 'elif', also show the 'if' even though it's at the same level.
-        eq(gc(11), ([(2, 0, 'class C1():', 'class'),
+        eq(gc(11), ([(2, 0, 'class C1:', 'class'),
                      (7, 4, '    def compare(self):', 'def'),
                      (8, 8, '        if a > b:', 'if'),
                      (10, 8, '        elif a < b:', 'elif')], 0))
 
         # Set stop_line to not go back to first line in source code.
         # Return includes stop_line.
-        eq(gc(11, stopline=2), ([(2, 0, 'class C1():', 'class'),
+        eq(gc(11, stopline=2), ([(2, 0, 'class C1:', 'class'),
                                  (7, 4, '    def compare(self):', 'def'),
                                  (8, 8, '        if a > b:', 'if'),
                                  (10, 8, '        elif a < b:', 'elif')], 0))
@@ -240,37 +240,37 @@ class CodeContextTest(unittest.TestCase):
         # Scroll down to line 2.
         cc.text.yview(2)
         cc.update_code_context()
-        eq(cc.info, [(0, -1, '', False), (2, 0, 'class C1():', 'class')])
+        eq(cc.info, [(0, -1, '', False), (2, 0, 'class C1:', 'class')])
         eq(cc.topvisible, 3)
-        eq(cc.context.get('1.0', 'end-1c'), 'class C1():')
+        eq(cc.context.get('1.0', 'end-1c'), 'class C1:')
 
         # Scroll down to line 3.  Since it's a comment, nothing changes.
         cc.text.yview(3)
         cc.update_code_context()
-        eq(cc.info, [(0, -1, '', False), (2, 0, 'class C1():', 'class')])
+        eq(cc.info, [(0, -1, '', False), (2, 0, 'class C1:', 'class')])
         eq(cc.topvisible, 4)
-        eq(cc.context.get('1.0', 'end-1c'), 'class C1():')
+        eq(cc.context.get('1.0', 'end-1c'), 'class C1:')
 
         # Scroll down to line 4.
         cc.text.yview(4)
         cc.update_code_context()
         eq(cc.info, [(0, -1, '', False),
-                     (2, 0, 'class C1():', 'class'),
+                     (2, 0, 'class C1:', 'class'),
                      (4, 4, '    def __init__(self, a, b):', 'def')])
         eq(cc.topvisible, 5)
-        eq(cc.context.get('1.0', 'end-1c'), 'class C1():\n'
+        eq(cc.context.get('1.0', 'end-1c'), 'class C1:\n'
                                             '    def __init__(self, a, b):')
 
         # Scroll down to line 11.  Last 'def' is removed.
         cc.text.yview(11)
         cc.update_code_context()
         eq(cc.info, [(0, -1, '', False),
-                     (2, 0, 'class C1():', 'class'),
+                     (2, 0, 'class C1:', 'class'),
                      (7, 4, '    def compare(self):', 'def'),
                      (8, 8, '        if a > b:', 'if'),
                      (10, 8, '        elif a < b:', 'elif')])
         eq(cc.topvisible, 12)
-        eq(cc.context.get('1.0', 'end-1c'), 'class C1():\n'
+        eq(cc.context.get('1.0', 'end-1c'), 'class C1:\n'
                                             '    def compare(self):\n'
                                             '        if a > b:\n'
                                             '        elif a < b:')
@@ -279,12 +279,12 @@ class CodeContextTest(unittest.TestCase):
         cc.update_code_context()
         cc.context_depth = 1
         eq(cc.info, [(0, -1, '', False),
-                     (2, 0, 'class C1():', 'class'),
+                     (2, 0, 'class C1:', 'class'),
                      (7, 4, '    def compare(self):', 'def'),
                      (8, 8, '        if a > b:', 'if'),
                      (10, 8, '        elif a < b:', 'elif')])
         eq(cc.topvisible, 12)
-        eq(cc.context.get('1.0', 'end-1c'), 'class C1():\n'
+        eq(cc.context.get('1.0', 'end-1c'), 'class C1:\n'
                                             '    def compare(self):\n'
                                             '        if a > b:\n'
                                             '        elif a < b:')
@@ -293,7 +293,7 @@ class CodeContextTest(unittest.TestCase):
         cc.text.yview(5)
         cc.update_code_context()
         eq(cc.info, [(0, -1, '', False),
-                     (2, 0, 'class C1():', 'class'),
+                     (2, 0, 'class C1:', 'class'),
                      (4, 4, '    def __init__(self, a, b):', 'def')])
         eq(cc.topvisible, 6)
         # context_depth is 1.
@@ -440,7 +440,7 @@ class HelperFunctionText(unittest.TestCase):
         # Line 1 is not a BLOCKOPENER.
         eq(gli(lines[0]), (codecontext.INFINITY, '', False))
         # Line 2 is a BLOCKOPENER without an indent.
-        eq(gli(lines[1]), (0, 'class C1():', 'class'))
+        eq(gli(lines[1]), (0, 'class C1:', 'class'))
         # Line 3 is not a BLOCKOPENER and does not return the indent level.
         eq(gli(lines[2]), (codecontext.INFINITY, '    # Class comment.', False))
         # Line 4 is a BLOCKOPENER and is indented.

--- a/Lib/idlelib/idle_test/test_format.py
+++ b/Lib/idlelib/idle_test/test_format.py
@@ -418,7 +418,7 @@ class FormatRegionTest(unittest.TestCase):
 
     code_sample = """\
 # WS line needed for test.
-class C1():
+class C1:
     # Class comment.
     def __init__(self, a, b):
         self.a = a

--- a/Lib/idlelib/idle_test/test_help_about.py
+++ b/Lib/idlelib/idle_test/test_help_about.py
@@ -134,7 +134,7 @@ class CloseTest(unittest.TestCase):
             self.dialog.winfo_class()
 
 
-class Dummy_about_dialog():
+class Dummy_about_dialog:
     # Dummy class for testing file display functions.
     idle_credits = About.show_idle_credits
     idle_readme = About.show_readme

--- a/Lib/idlelib/idle_test/test_pyparse.py
+++ b/Lib/idlelib/idle_test/test_pyparse.py
@@ -73,11 +73,12 @@ class PyParseTest(unittest.TestCase):
 
         # Split def across lines.
         setcode('"""This is a module docstring"""\n'
-                'class C():\n'
+                'class C:\n'
                 '    def __init__(self, a,\n'
                 '                 b=True):\n'
                 '        pass\n'
                 )
+        pos0, pos = 33, 42  # Start of 'class...', '    def' lines.
 
         # Passing no value or non-callable should fail (issue 32989).
         with self.assertRaises(TypeError):
@@ -91,40 +92,41 @@ class PyParseTest(unittest.TestCase):
 
         # Make all text look like it's not in a string.  This means that it
         # found a good start position.
-        eq(start(char_in_string_false), 44)
+        eq(start(char_in_string_false), pos)
 
         # If the beginning of the def line is not in a string, then it
         # returns that as the index.
-        eq(start(is_char_in_string=lambda index: index > 44), 44)
+        eq(start(is_char_in_string=lambda index: index > pos), pos)
         # If the beginning of the def line is in a string, then it
         # looks for a previous index.
-        eq(start(is_char_in_string=lambda index: index >= 44), 33)
+        eq(start(is_char_in_string=lambda index: index >= pos), pos0)
         # If everything before the 'def' is in a string, then returns None.
         # The non-continuation def line returns 44 (see below).
-        eq(start(is_char_in_string=lambda index: index < 44), None)
+        eq(start(is_char_in_string=lambda index: index < pos), None)
 
         # Code without extra line break in def line - mostly returns the same
         # values.
         setcode('"""This is a module docstring"""\n'
-                'class C():\n'
+                'class C:\n'
                 '    def __init__(self, a, b=True):\n'
                 '        pass\n'
-                )
-        eq(start(char_in_string_false), 44)
-        eq(start(is_char_in_string=lambda index: index > 44), 44)
-        eq(start(is_char_in_string=lambda index: index >= 44), 33)
+                )  # Does not affect class, def positions.
+        eq(start(char_in_string_false), pos)
+        eq(start(is_char_in_string=lambda index: index > pos), pos)
+        eq(start(is_char_in_string=lambda index: index >= pos), pos0)
         # When the def line isn't split, this returns which doesn't match the
         # split line test.
-        eq(start(is_char_in_string=lambda index: index < 44), 44)
+        eq(start(is_char_in_string=lambda index: index < pos), pos)
 
     def test_set_lo(self):
         code = (
                 '"""This is a module docstring"""\n'
-                'class C():\n'
+                'class C:\n'
                 '    def __init__(self, a,\n'
                 '                 b=True):\n'
                 '        pass\n'
                 )
+        pos = 42
         p = self.parser
         p.set_code(code)
 
@@ -137,8 +139,8 @@ class PyParseTest(unittest.TestCase):
         self.assertEqual(p.code, code)
 
         # An index that is preceded by a newline.
-        p.set_lo(44)
-        self.assertEqual(p.code, code[44:])
+        p.set_lo(pos)
+        self.assertEqual(p.code, code[pos:])
 
     def test_study1(self):
         eq = self.assertEqual

--- a/Lib/idlelib/rpc.py
+++ b/Lib/idlelib/rpc.py
@@ -125,7 +125,7 @@ request_queue = queue.Queue(0)
 response_queue = queue.Queue(0)
 
 
-class SocketIO(object):
+class SocketIO:
 
     nextseq = 0
 
@@ -486,7 +486,7 @@ class SocketIO(object):
 
 #----------------- end class SocketIO --------------------
 
-class RemoteObject(object):
+class RemoteObject:
     # Token mix-in class
     pass
 
@@ -497,7 +497,7 @@ def remoteref(obj):
     return RemoteProxy(oid)
 
 
-class RemoteProxy(object):
+class RemoteProxy:
 
     def __init__(self, oid):
         self.oid = oid
@@ -547,7 +547,7 @@ class RPCClient(SocketIO):
         return RPCProxy(self, oid)
 
 
-class RPCProxy(object):
+class RPCProxy:
 
     __methods = None
     __attributes = None
@@ -596,7 +596,7 @@ def _getattributes(obj, attributes):
             attributes[name] = 1
 
 
-class MethodProxy(object):
+class MethodProxy:
 
     def __init__(self, sockio, oid, name):
         self.sockio = sockio

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -538,7 +538,7 @@ class MyHandler(rpc.RPCHandler):
         thread.interrupt_main()
 
 
-class Executive(object):
+class Executive:
 
     def __init__(self, rpchandler):
         self.rpchandler = rpchandler

--- a/Lib/idlelib/tooltip.py
+++ b/Lib/idlelib/tooltip.py
@@ -7,7 +7,7 @@ This includes:
 from tkinter import *
 
 
-class TooltipBase(object):
+class TooltipBase:
     """abstract base class for tooltips"""
 
     def __init__(self, anchor_widget):


### PR DESCRIPTION
Remove 9 remaining '(object)' occurrences in class headers in idlelib
and 25 '()' occurrences in idlelib.idle_test class headers.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43013](https://bugs.python.org/issue43013) -->
https://bugs.python.org/issue43013
<!-- /issue-number -->
