### PR TITLE
[3.9] bpo-42384: pdb: correctly populate sys.path[0] (GH-23338)

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1686,8 +1686,9 @@ def main():
 
     sys.argv[:] = args      # Hide "pdb.py" and pdb options from argument list
 
-    # Replace pdb's dir with script's dir in front of module search path.
     if not run_as_module:
+        mainpyfile = os.path.realpath(mainpyfile)
+        # Replace pdb's dir with script's dir in front of module search path.
         sys.path[0] = os.path.dirname(mainpyfile)
 
     # Note on saving/restoring sys.argv: it's a good idea when sys.argv was

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1670,14 +1670,14 @@ def bœr():
         """)
         commands = 'c\nq'
 
-        with os_helper.temp_cwd() as cwd:
+        with support.temp_cwd() as cwd:
             expected = f'(Pdb) sys.path[0] is {os.path.realpath(cwd)}'
 
             stdout, stderr = self.run_pdb_script(script, commands)
 
             self.assertEqual(stdout.split('\n')[2].rstrip('\r'), expected)
 
-    @os_helper.skip_unless_symlink
+    @support.skip_unless_symlink
     def test_issue42384_symlink(self):
         '''When running `python foo.py` sys.path[0] resolves symlinks. `python -m pdb foo.py` should behave the same'''
         script = textwrap.dedent("""
@@ -1686,7 +1686,7 @@ def bœr():
         """)
         commands = 'c\nq'
 
-        with os_helper.temp_cwd() as cwd:
+        with support.temp_cwd() as cwd:
             cwd = os.path.realpath(cwd)
             dir_one = os.path.join(cwd, 'dir_one')
             dir_two = os.path.join(cwd, 'dir_two')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1661,6 +1661,48 @@ def bœr():
             '(Pdb) ',
         ])
 
+
+    def test_issue42384(self):
+        '''When running `python foo.py` sys.path[0] is an absolute path. `python -m pdb foo.py` should behave the same'''
+        script = textwrap.dedent("""
+            import sys
+            print('sys.path[0] is', sys.path[0])
+        """)
+        commands = 'c\nq'
+
+        with os_helper.temp_cwd() as cwd:
+            expected = f'(Pdb) sys.path[0] is {os.path.realpath(cwd)}'
+
+            stdout, stderr = self.run_pdb_script(script, commands)
+
+            self.assertEqual(stdout.split('\n')[2].rstrip('\r'), expected)
+
+    @os_helper.skip_unless_symlink
+    def test_issue42384_symlink(self):
+        '''When running `python foo.py` sys.path[0] resolves symlinks. `python -m pdb foo.py` should behave the same'''
+        script = textwrap.dedent("""
+            import sys
+            print('sys.path[0] is', sys.path[0])
+        """)
+        commands = 'c\nq'
+
+        with os_helper.temp_cwd() as cwd:
+            cwd = os.path.realpath(cwd)
+            dir_one = os.path.join(cwd, 'dir_one')
+            dir_two = os.path.join(cwd, 'dir_two')
+            expected = f'(Pdb) sys.path[0] is {dir_one}'
+
+            os.mkdir(dir_one)
+            with open(os.path.join(dir_one, 'foo.py'), 'w') as f:
+                f.write(script)
+            os.mkdir(dir_two)
+            os.symlink(os.path.join(dir_one, 'foo.py'), os.path.join(dir_two, 'foo.py'))
+
+            stdout, stderr = self._run_pdb([os.path.join('dir_two', 'foo.py')], commands)
+
+            self.assertEqual(stdout.split('\n')[2].rstrip('\r'), expected)
+
+
 def load_tests(*args):
     from test import test_pdb
     suites = [

--- a/Misc/NEWS.d/next/Library/2020-11-17-14-32-39.bpo-42384.1ZnQSn.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-17-14-32-39.bpo-42384.1ZnQSn.rst
@@ -1,0 +1,1 @@
+Make pdb populate sys.path[0] exactly the same as regular python execution.


### PR DESCRIPTION
#24290 was an attempt to backport #23338 to 3.9. It failed due to tests. This is an updated PR that fixes the failing tests.

Co-authored-by: Miss Islington (bot) <mariatta.wijaya+miss-islington@gmail.com>

<!-- issue-number: [bpo-42384](https://bugs.python.org/issue42384) -->
https://bugs.python.org/issue42384
<!-- /issue-number -->
