### PR TITLE
bpo-43052: Make dyld search work with SYSTEM_VERSION_COMPAT=1

### DIFF
--- a/Misc/NEWS.d/next/macOS/2021-01-28-06-44-47.bpo-43052.NoLlgY.rst
+++ b/Misc/NEWS.d/next/macOS/2021-01-28-06-44-47.bpo-43052.NoLlgY.rst
@@ -1,0 +1,1 @@
+`_dyld_shared_cache_contains_path` now works with SYSTEM_VERSION_COMPAT=1

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1449,7 +1449,7 @@ static PyObject *py_dyld_shared_cache_contains_path(PyObject *self, PyObject *ar
      PyObject *name, *name2;
      char *name_str;
 
-     if (__builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)) {
+     if (__builtin_available(macOS 10.16, iOS 14.0, tvOS 14.0, watchOS 7.0, *)) {
          int r;
 
          if (!PyArg_ParseTuple(args, "O", &name))

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -82,7 +82,7 @@
 #  define HAVE_SYMLINKAT_RUNTIME __builtin_available(macOS 10.10, iOS 8.0, *)
 #  define HAVE_FUTIMENS_RUNTIME __builtin_available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
 #  define HAVE_UTIMENSAT_RUNTIME __builtin_available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
-#  define HAVE_PWRITEV_RUNTIME __builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+#  define HAVE_PWRITEV_RUNTIME __builtin_available(macOS 10.16, tvOS 14.0, watchOS 7.0, *)
 
 #  define HAVE_POSIX_SPAWN_SETSID_RUNTIME __builtin_available(macOS 10.15, *)
 


### PR DESCRIPTION
In macOS Big Sur, if the executable was compiled with `MACOSX_DEPLOYMENT_TARGET=10.15`
or below, then SYSTEM_VERSION_COMPAT=1 is the default which means that Big Sur
reports itself as 10.16 which means that `__builtin_available(macOS 11.0)` will not be triggered.

This can be observed by using the python 3.9.1 universal2 installer and using it on
x86_64 Big Sur or with Rossetta 2 on arm64 Big Sur. (Not an issue with native arm64
as that part is compiled with `MACOSX_DEPLOYMENT_TARGET=11.0`)

cc @ronaldoussoren 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43052](https://bugs.python.org/issue43052) -->
https://bugs.python.org/issue43052
<!-- /issue-number -->
