### PR TITLE
bpo-43013: Fix old tkinter module names in idlelib

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -18,8 +18,8 @@ from tkinter import (Toplevel, Listbox, Scale, Canvas,
                      HORIZONTAL, VERTICAL, ANCHOR, ACTIVE, END)
 from tkinter.ttk import (Frame, LabelFrame, Button, Checkbutton, Entry, Label,
                          OptionMenu, Notebook, Radiobutton, Scrollbar, Style)
-import tkinter.colorchooser as tkColorChooser
-import tkinter.font as tkFont
+from tkinter import colorchooser
+import tkinter.font as tkfont
 from tkinter import messagebox
 
 from idlelib.config import idleConf, ConfigChanges
@@ -609,7 +609,7 @@ class FontPage(Frame):
         font_bold  = configured_font[2]=='bold'
 
         # Set sorted no-duplicate editor font selection list and font_name.
-        fonts = sorted(set(tkFont.families(self)))
+        fonts = sorted(set(tkfont.families(self)))
         for font in fonts:
             self.fontlist.insert(END, font)
         self.font_name.set(font_name)
@@ -663,7 +663,7 @@ class FontPage(Frame):
         Updates font_sample and highlight page highlight_sample.
         """
         font_name = self.font_name.get()
-        font_weight = tkFont.BOLD if self.font_bold.get() else tkFont.NORMAL
+        font_weight = tkfont.BOLD if self.font_bold.get() else tkfont.NORMAL
         new_font = (font_name, self.font_size.get(), font_weight)
         self.font_sample['font'] = new_font
         self.highlight_sample['font'] = new_font
@@ -1100,7 +1100,7 @@ class HighPage(Frame):
         target = self.highlight_target.get()
         prev_color = self.style.lookup(self.frame_color_set['style'],
                                        'background')
-        rgbTuplet, color_string = tkColorChooser.askcolor(
+        rgbTuplet, color_string = colorchooser.askcolor(
                 parent=self, title='Pick new color for : '+target,
                 initialcolor=prev_color)
         if color_string and (color_string != prev_color):

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -12,7 +12,7 @@ import webbrowser
 from tkinter import *
 from tkinter.font import Font
 from tkinter.ttk import Scrollbar
-import tkinter.simpledialog as tkSimpleDialog
+from tkinter import simpledialog
 import tkinter.messagebox as tkMessageBox
 
 from idlelib.config import idleConf
@@ -295,8 +295,8 @@ class EditorWindow:
             window.register_callback(self.postwindowsmenu)
 
         # Some abstractions so IDLE extensions are cross-IDE
+        self.askinteger = simpledialog.askinteger
         self.askyesno = tkMessageBox.askyesno
-        self.askinteger = tkSimpleDialog.askinteger
         self.showerror = tkMessageBox.showerror
 
         # Add pseudoevents for former extension fixed keys.

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -13,7 +13,7 @@ from tkinter import *
 from tkinter.font import Font
 from tkinter.ttk import Scrollbar
 from tkinter import simpledialog
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 
 from idlelib.config import idleConf
 from idlelib import configdialog
@@ -296,8 +296,8 @@ class EditorWindow:
 
         # Some abstractions so IDLE extensions are cross-IDE
         self.askinteger = simpledialog.askinteger
-        self.askyesno = tkMessageBox.askyesno
-        self.showerror = tkMessageBox.showerror
+        self.askyesno = messagebox.askyesno
+        self.showerror = messagebox.showerror
 
         # Add pseudoevents for former extension fixed keys.
         # (This probably needs to be done once in the process.)
@@ -596,7 +596,7 @@ class EditorWindow:
             try:
                 os.startfile(self.help_url)
             except OSError as why:
-                tkMessageBox.showerror(title='Document Start Failure',
+                messagebox.showerror(title='Document Start Failure',
                     message=str(why), parent=self.text)
         else:
             webbrowser.open(self.help_url)
@@ -927,7 +927,7 @@ class EditorWindow:
                 try:
                     os.startfile(helpfile)
                 except OSError as why:
-                    tkMessageBox.showerror(title='Document Start Failure',
+                    messagebox.showerror(title='Document Start Failure',
                         message=str(why), parent=self.text)
             else:
                 webbrowser.open(helpfile)
@@ -963,7 +963,7 @@ class EditorWindow:
             except OSError as err:
                 if not getattr(self.root, "recentfiles_message", False):
                     self.root.recentfiles_message = True
-                    tkMessageBox.showwarning(title='IDLE Warning',
+                    messagebox.showwarning(title='IDLE Warning',
                         message="Cannot save Recent Files list to disk.\n"
                                 f"  {err}\n"
                                 "Select OK to continue.",

--- a/Lib/idlelib/filelist.py
+++ b/Lib/idlelib/filelist.py
@@ -1,7 +1,7 @@
 "idlelib.filelist"
 
 import os
-from tkinter import messagebox as tkMessageBox
+from tkinter import messagebox
 
 
 class FileList:
@@ -20,7 +20,7 @@ class FileList:
         filename = self.canonize(filename)
         if os.path.isdir(filename):
             # This can happen when bad filename is passed on command line:
-            tkMessageBox.showerror(
+            messagebox.showerror(
                 "File Error",
                 "%r is a directory." % (filename,),
                 master=self.root)
@@ -88,7 +88,7 @@ class FileList:
         if newkey in self.dict:
             conflict = self.dict[newkey]
             self.inversedict[conflict] = None
-            tkMessageBox.showerror(
+            messagebox.showerror(
                 "Name Conflict",
                 "You now have multiple edit windows open for %r" % (filename,),
                 master=self.root)

--- a/Lib/idlelib/idle_test/mock_tk.py
+++ b/Lib/idlelib/idle_test/mock_tk.py
@@ -59,27 +59,26 @@ class Mbox_func:
 class Mbox:
     """Mock for tkinter.messagebox with an Mbox_func for each function.
 
-    This module was 'tkMessageBox' in 2.x; hence the 'import as' in  3.x.
     Example usage in test_module.py for testing functions in module.py:
     ---
 from idlelib.idle_test.mock_tk import Mbox
 import module
 
-orig_mbox = module.tkMessageBox
+orig_mbox = module.messagebox
 showerror = Mbox.showerror  # example, for attribute access in test methods
 
 class Test(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        module.tkMessageBox = Mbox
+        module.messagebox = Mbox
 
     @classmethod
     def tearDownClass(cls):
-        module.tkMessageBox = orig_mbox
+        module.messagebox = orig_mbox
     ---
     For 'ask' functions, set func.result return value before calling the method
-    that uses the message function. When tkMessageBox functions are the
+    that uses the message function. When messagebox functions are the
     only gui alls in a method, this replacement makes the method gui-free,
     """
     askokcancel = Mbox_func()     # True or False

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -423,7 +423,7 @@ class HighPageTest(unittest.TestCase):
     def test_color(self):
         d = self.page
         d.on_new_color_set = Func()
-        # self.color is only set in get_color through ColorChooser.
+        # self.color is only set in get_color through colorchooser.
         d.color.set('green')
         self.assertEqual(d.on_new_color_set.called, 1)
         del d.on_new_color_set
@@ -540,8 +540,8 @@ class HighPageTest(unittest.TestCase):
     def test_get_color(self):
         eq = self.assertEqual
         d = self.page
-        orig_chooser = configdialog.tkColorChooser.askcolor
-        chooser = configdialog.tkColorChooser.askcolor = Func()
+        orig_chooser = configdialog.colorchooser.askcolor
+        chooser = configdialog.colorchooser.askcolor = Func()
         gntn = d.get_new_theme_name = Func()
 
         d.highlight_target.set('Editor Breakpoint')
@@ -582,7 +582,7 @@ class HighPageTest(unittest.TestCase):
         eq(d.color.get(), '#de0000')
 
         del d.get_new_theme_name
-        configdialog.tkColorChooser.askcolor = orig_chooser
+        configdialog.colorchooser.askcolor = orig_chooser
 
     def test_on_new_color_set(self):
         d = self.page

--- a/Lib/idlelib/idle_test/test_replace.py
+++ b/Lib/idlelib/idle_test/test_replace.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 from idlelib.idle_test.mock_tk import Mbox
 import idlelib.searchengine as se
 
-orig_mbox = se.tkMessageBox
+orig_mbox = se.messagebox
 showerror = Mbox.showerror
 
 
@@ -20,7 +20,7 @@ class ReplaceDialogTest(unittest.TestCase):
     def setUpClass(cls):
         cls.root = Tk()
         cls.root.withdraw()
-        se.tkMessageBox = Mbox
+        se.messagebox = Mbox
         cls.engine = se.SearchEngine(cls.root)
         cls.dialog = ReplaceDialog(cls.root, cls.engine)
         cls.dialog.bell = lambda: None
@@ -32,7 +32,7 @@ class ReplaceDialogTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        se.tkMessageBox = orig_mbox
+        se.messagebox = orig_mbox
         del cls.text, cls.dialog, cls.engine
         cls.root.destroy()
         del cls.root

--- a/Lib/idlelib/idle_test/test_searchengine.py
+++ b/Lib/idlelib/idle_test/test_searchengine.py
@@ -4,7 +4,7 @@ from idlelib import searchengine as se
 import unittest
 # from test.support import requires
 from tkinter import  BooleanVar, StringVar, TclError  # ,Tk, Text
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 from idlelib.idle_test.mock_tk import Var, Mbox
 from idlelib.idle_test.mock_tk import Text as mockText
 import re
@@ -19,13 +19,13 @@ def setUpModule():
     # Replace s-e module tkinter imports other than non-gui TclError.
     se.BooleanVar = Var
     se.StringVar = Var
-    se.tkMessageBox = Mbox
+    se.messagebox = Mbox
 
 def tearDownModule():
     # Restore 'just in case', though other tests should also replace.
     se.BooleanVar = BooleanVar
     se.StringVar = StringVar
-    se.tkMessageBox = tkMessageBox
+    se.messagebox = messagebox
 
 
 class Mock:

--- a/Lib/idlelib/idle_test/test_squeezer.py
+++ b/Lib/idlelib/idle_test/test_squeezer.py
@@ -396,7 +396,7 @@ class ExpandingButtonTest(unittest.TestCase):
         expandingbutton.base_text = expandingbutton.text
 
         # Patch the message box module to always return False.
-        with patch('idlelib.squeezer.tkMessageBox') as mock_msgbox:
+        with patch('idlelib.squeezer.messagebox') as mock_msgbox:
             mock_msgbox.askokcancel.return_value = False
             mock_msgbox.askyesno.return_value = False
             # Trigger the expand event.
@@ -407,7 +407,7 @@ class ExpandingButtonTest(unittest.TestCase):
         self.assertEqual(expandingbutton.text.get('1.0', 'end-1c'), '')
 
         # Patch the message box module to always return True.
-        with patch('idlelib.squeezer.tkMessageBox') as mock_msgbox:
+        with patch('idlelib.squeezer.messagebox') as mock_msgbox:
             mock_msgbox.askokcancel.return_value = True
             mock_msgbox.askyesno.return_value = True
             # Trigger the expand event.

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -6,7 +6,7 @@ import tempfile
 import tokenize
 
 from tkinter import filedialog
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 from tkinter.simpledialog import askstring
 
 import idlelib
@@ -147,10 +147,10 @@ class IOBinding:
                     eol_convention = f.newlines
                     converted = True
         except OSError as err:
-            tkMessageBox.showerror("I/O Error", str(err), parent=self.text)
+            messagebox.showerror("I/O Error", str(err), parent=self.text)
             return False
         except UnicodeDecodeError:
-            tkMessageBox.showerror("Decoding Error",
+            messagebox.showerror("Decoding Error",
                                    "File %s\nFailed to Decode" % filename,
                                    parent=self.text)
             return False
@@ -159,7 +159,7 @@ class IOBinding:
             # If the file does not contain line separators, it is None.
             # If the file contains mixed line separators, it is a tuple.
             if eol_convention is not None:
-                tkMessageBox.showwarning("Mixed Newlines",
+                messagebox.showwarning("Mixed Newlines",
                                          "Mixed newlines detected.\n"
                                          "The file will be changed on save.",
                                          parent=self.text)
@@ -187,10 +187,10 @@ class IOBinding:
             return "yes"
         message = "Do you want to save %s before closing?" % (
             self.filename or "this untitled document")
-        confirm = tkMessageBox.askyesnocancel(
+        confirm = messagebox.askyesnocancel(
                   title="Save On Close",
                   message=message,
-                  default=tkMessageBox.YES,
+                  default=messagebox.YES,
                   parent=self.text)
         if confirm:
             reply = "yes"
@@ -249,7 +249,7 @@ class IOBinding:
                 os.fsync(f.fileno())
             return True
         except OSError as msg:
-            tkMessageBox.showerror("I/O Error", str(msg),
+            messagebox.showerror("I/O Error", str(msg),
                                    parent=self.text)
             return False
 
@@ -286,7 +286,7 @@ class IOBinding:
             failed = str(err)
         except UnicodeEncodeError:
             failed = "Invalid encoding '%s'" % enc
-        tkMessageBox.showerror(
+        messagebox.showerror(
             "I/O Error",
             "%s.\nSaving as UTF-8" % failed,
             parent=self.text)
@@ -295,10 +295,10 @@ class IOBinding:
         return chars.encode('utf-8-sig')
 
     def print_window(self, event):
-        confirm = tkMessageBox.askokcancel(
+        confirm = messagebox.askokcancel(
                   title="Print",
                   message="Print to Default Printer",
-                  default=tkMessageBox.OK,
+                  default=messagebox.OK,
                   parent=self.text)
         if not confirm:
             self.text.focus_set()
@@ -336,10 +336,10 @@ class IOBinding:
                          status + output
             if output:
                 output = "Printing command: %s\n" % repr(command) + output
-                tkMessageBox.showerror("Print status", output, parent=self.text)
+                messagebox.showerror("Print status", output, parent=self.text)
         else:  #no printing for this platform
             message = "Printing is not enabled for this platform: %s" % platform
-            tkMessageBox.showinfo("Print status", message, parent=self.text)
+            messagebox.showinfo("Print status", message, parent=self.text)
         if tempfilename:
             os.unlink(tempfilename)
         return "break"

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import tokenize
 
-import tkinter.filedialog as tkFileDialog
+from tkinter import filedialog
 import tkinter.messagebox as tkMessageBox
 from tkinter.simpledialog import askstring
 
@@ -358,7 +358,7 @@ class IOBinding:
     def askopenfile(self):
         dir, base = self.defaultfilename("open")
         if not self.opendialog:
-            self.opendialog = tkFileDialog.Open(parent=self.text,
+            self.opendialog = filedialog.Open(parent=self.text,
                                                 filetypes=self.filetypes)
         filename = self.opendialog.show(initialdir=dir, initialfile=base)
         return filename
@@ -378,7 +378,7 @@ class IOBinding:
     def asksavefile(self):
         dir, base = self.defaultfilename("save")
         if not self.savedialog:
-            self.savedialog = tkFileDialog.SaveAs(
+            self.savedialog = filedialog.SaveAs(
                     parent=self.text,
                     filetypes=self.filetypes,
                     defaultextension=self.defaultextension)

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -21,13 +21,13 @@ if sys.platform == 'win32':
     except (ImportError, AttributeError, OSError):
         pass
 
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 if TkVersion < 8.5:
     root = Tk()  # otherwise create root in main
     root.withdraw()
     from idlelib.run import fix_scaling
     fix_scaling(root)
-    tkMessageBox.showerror("Idle Cannot Start",
+    messagebox.showerror("Idle Cannot Start",
             "Idle requires tcl/tk 8.5+, not %s." % TkVersion,
             parent=root)
     raise SystemExit(1)
@@ -261,7 +261,7 @@ class PyShellEditorWindow(EditorWindow):
         except OSError as err:
             if not getattr(self.root, "breakpoint_error_displayed", False):
                 self.root.breakpoint_error_displayed = True
-                tkMessageBox.showerror(title='IDLE Error',
+                messagebox.showerror(title='IDLE Error',
                     message='Unable to update breakpoint list:\n%s'
                         % str(err),
                     parent=self.text)
@@ -771,7 +771,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
                 exec(code, self.locals)
         except SystemExit:
             if not self.tkconsole.closing:
-                if tkMessageBox.askyesno(
+                if messagebox.askyesno(
                     "Exit?",
                     "Do you want to exit altogether?",
                     default="yes",
@@ -805,7 +805,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
         return self.tkconsole.stderr.write(s)
 
     def display_port_binding_error(self):
-        tkMessageBox.showerror(
+        messagebox.showerror(
             "Port Binding Error",
             "IDLE can't bind to a TCP/IP port, which is necessary to "
             "communicate with its Python execution server.  This might be "
@@ -816,7 +816,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
             parent=self.tkconsole.text)
 
     def display_no_subprocess_error(self):
-        tkMessageBox.showerror(
+        messagebox.showerror(
             "Subprocess Connection Error",
             "IDLE's subprocess didn't make connection.\n"
             "See the 'Startup failure' section of the IDLE doc, online at\n"
@@ -824,7 +824,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
             parent=self.tkconsole.text)
 
     def display_executing_dialog(self):
-        tkMessageBox.showerror(
+        messagebox.showerror(
             "Already executing",
             "The Python Shell window is already executing a command; "
             "please wait until it is finished.",
@@ -945,7 +945,7 @@ class PyShell(OutputWindow):
 
     def toggle_debugger(self, event=None):
         if self.executing:
-            tkMessageBox.showerror("Don't debug now",
+            messagebox.showerror("Don't debug now",
                 "You can only toggle the debugger when idle",
                 parent=self.text)
             self.set_debugger_indicator()
@@ -1003,7 +1003,7 @@ class PyShell(OutputWindow):
     def close(self):
         "Extend EditorWindow.close()"
         if self.executing:
-            response = tkMessageBox.askokcancel(
+            response = messagebox.askokcancel(
                 "Kill?",
                 "Your program is still running!\n Do you want to kill it?",
                 default="ok",
@@ -1254,7 +1254,7 @@ class PyShell(OutputWindow):
         try:
             sys.last_traceback
         except:
-            tkMessageBox.showerror("No stack trace",
+            messagebox.showerror("No stack trace",
                 "There is no stack trace yet.\n"
                 "(sys.last_traceback is not defined)",
                 parent=self.text)

--- a/Lib/idlelib/runscript.py
+++ b/Lib/idlelib/runscript.py
@@ -14,7 +14,7 @@ import tabnanny
 import time
 import tokenize
 
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 
 from idlelib.config import idleConf
 from idlelib import macosx
@@ -195,15 +195,15 @@ class ScriptBinding:
 
     def ask_save_dialog(self):
         msg = "Source Must Be Saved\n" + 5*' ' + "OK to Save?"
-        confirm = tkMessageBox.askokcancel(title="Save Before Run or Check",
+        confirm = messagebox.askokcancel(title="Save Before Run or Check",
                                            message=msg,
-                                           default=tkMessageBox.OK,
+                                           default=messagebox.OK,
                                            parent=self.editwin.text)
         return confirm
 
     def errorbox(self, title, message):
         # XXX This should really be a function of EditorWindow...
-        tkMessageBox.showerror(title, message, parent=self.editwin.text)
+        messagebox.showerror(title, message, parent=self.editwin.text)
         self.editwin.text.focus_set()
         self.perf = time.perf_counter()
 

--- a/Lib/idlelib/searchengine.py
+++ b/Lib/idlelib/searchengine.py
@@ -2,7 +2,7 @@
 import re
 
 from tkinter import StringVar, BooleanVar, TclError
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 
 def get(root):
     '''Return the singleton SearchEngine instance for the process.
@@ -96,7 +96,7 @@ class SearchEngine:
             msg = msg + "\nPattern: " + str(pat)
         if col is not None:
             msg = msg + "\nOffset: " + str(col)
-        tkMessageBox.showerror("Regular expression error",
+        messagebox.showerror("Regular expression error",
                                msg, master=self.root)
 
     def search_text(self, text, prog=None, ok=0):

--- a/Lib/idlelib/squeezer.py
+++ b/Lib/idlelib/squeezer.py
@@ -17,7 +17,7 @@ messages and their tracebacks.
 import re
 
 import tkinter as tk
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 
 from idlelib.config import idleConf
 from idlelib.textview import view_text
@@ -147,7 +147,7 @@ class ExpandingButton(tk.Button):
         if self.is_dangerous is None:
             self.set_is_dangerous()
         if self.is_dangerous:
-            confirm = tkMessageBox.askokcancel(
+            confirm = messagebox.askokcancel(
                 title="Expand huge output?",
                 message="\n\n".join([
                     "The squeezed output is very long: %d lines, %d chars.",
@@ -155,7 +155,7 @@ class ExpandingButton(tk.Button):
                     "It is recommended to view or copy the output instead.",
                     "Really expand?"
                 ]) % (self.numoflines, len(self.s)),
-                default=tkMessageBox.CANCEL,
+                default=messagebox.CANCEL,
                 parent=self.text)
             if not confirm:
                 return "break"


### PR DESCRIPTION
Lowercase 'tkColorChooser', 'tkFileDialog', 'tkSimpleDialog', and
'tkMessageBox' and remove 'tk'.  Just lowercase 'tkFont' as 'font'
is already used.  Adjust imports.

2nd update patch for this issue.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43013](https://bugs.python.org/issue43013) -->
https://bugs.python.org/issue43013
<!-- /issue-number -->
