### PR TITLE
Fix minor typo in the rest format in the enum docs

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -1364,7 +1364,7 @@ The code sample::
     True
 
 There is a new boundary mechanism that controls how out-of-range / invalid
-bits are handled: ``STRICT``, ``CONFORM``, ``EJECT`', and ``KEEP``:
+bits are handled: ``STRICT``, ``CONFORM``, ``EJECT``, and ``KEEP``:
 
   * STRICT --> raises an exception when presented with invalid values
   * CONFORM --> discards any invalid bits


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
