### PR TITLE
bpo-43031: Set a timeout when running tests in PGO build

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-01-26-14-48-40.bpo-43031.44nK9U.rst
+++ b/Misc/NEWS.d/next/Build/2021-01-26-14-48-40.bpo-43031.44nK9U.rst
@@ -1,0 +1,2 @@
+Pass ``--timeout=$(TESTTIMEOUT)`` option to the default profile task
+``./python -m test --pgo`` command.

--- a/configure
+++ b/configure
@@ -6532,7 +6532,7 @@ fi
 $as_echo_n "checking PROFILE_TASK... " >&6; }
 if test -z "$PROFILE_TASK"
 then
-	PROFILE_TASK='-m test --pgo'
+	PROFILE_TASK='-m test --pgo --timeout=$(TESTTIMEOUT)'
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PROFILE_TASK" >&5
 $as_echo "$PROFILE_TASK" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1325,7 +1325,7 @@ AC_ARG_VAR(PROFILE_TASK, Python args for PGO generation task)
 AC_MSG_CHECKING(PROFILE_TASK)
 if test -z "$PROFILE_TASK"
 then
-	PROFILE_TASK='-m test --pgo'
+	PROFILE_TASK='-m test --pgo --timeout=$(TESTTIMEOUT)'
 fi
 AC_MSG_RESULT($PROFILE_TASK)
 


### PR DESCRIPTION
Pass --timeout=$(TESTTIMEOUT) option to the default profile task
"./python -m test --pgo" command.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43031](https://bugs.python.org/issue43031) -->
https://bugs.python.org/issue43031
<!-- /issue-number -->
