### PR TITLE
bpo-42504: Ensure that get_config_var('MACOSX_DEPLOYMENT_TARGET') is a string

### DIFF
--- a/Lib/distutils/spawn.py
+++ b/Lib/distutils/spawn.py
@@ -54,8 +54,8 @@ def spawn(cmd, search_path=1, verbose=0, dry_run=0):
         global _cfg_target, _cfg_target_split
         if _cfg_target is None:
             from distutils import sysconfig
-            _cfg_target = str(sysconfig.get_config_var(
-                                  'MACOSX_DEPLOYMENT_TARGET') or '')
+            _cfg_target = sysconfig.get_config_var(
+                                  'MACOSX_DEPLOYMENT_TARGET') or ''
             if _cfg_target:
                 _cfg_target_split = [int(x) for x in _cfg_target.split('.')]
         if _cfg_target:

--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -456,7 +456,7 @@ class BuildExtTestCase(TempdirManager,
         deptarget = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
         if deptarget:
             # increment the minor version number (i.e. 10.6 -> 10.7)
-            deptarget = [int(x) for x in str(deptarget).split('.')]
+            deptarget = [int(x) for x in deptarget.split('.')]
             deptarget[-1] += 1
             deptarget = '.'.join(str(i) for i in deptarget)
             self._try_compile_deployment_target('<', deptarget)
@@ -489,7 +489,7 @@ class BuildExtTestCase(TempdirManager,
 
         # get the deployment target that the interpreter was built with
         target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
-        target = tuple(map(int, str(target).split('.')[0:2]))
+        target = tuple(map(int, target.split('.')[0:2]))
         # format the target value as defined in the Apple
         # Availability Macros.  We can't use the macro names since
         # at least one value we test with will not exist yet.

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -18,6 +18,11 @@ __all__ = [
     'parse_config_h',
 ]
 
+# Keys for get_config_var() that are never converted to Python integers.
+_ALLWAYS_STR = {
+    'MACOSX_DEPLOYMENT_TARGET',
+}
+
 _INSTALL_SCHEMES = {
     'posix_prefix': {
         'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
@@ -252,6 +257,9 @@ def _parse_makefile(filename, vars=None):
                 notdone[n] = v
             else:
                 try:
+                    if n in _ALLWAYS_STR: 
+                        raise ValueError
+
                     v = int(v)
                 except ValueError:
                     # insert literal `$'
@@ -310,6 +318,8 @@ def _parse_makefile(filename, vars=None):
                         notdone[name] = value
                     else:
                         try:
+                            if name in _ALLWAYS_STR: 
+                                raise ValueError
                             value = int(value)
                         except ValueError:
                             done[name] = value.strip()
@@ -472,6 +482,8 @@ def parse_config_h(fp, vars=None):
         if m:
             n, v = m.group(1, 2)
             try:
+                if n in _ALLWAYS_STR: 
+                    raise ValueError
                 v = int(v)
             except ValueError:
                 pass

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 # Keys for get_config_var() that are never converted to Python integers.
-_ALLWAYS_STR = {
+_ALWAYS_STR = {
     'MACOSX_DEPLOYMENT_TARGET',
 }
 
@@ -257,7 +257,7 @@ def _parse_makefile(filename, vars=None):
                 notdone[n] = v
             else:
                 try:
-                    if n in _ALLWAYS_STR: 
+                    if n in _ALWAYS_STR:
                         raise ValueError
 
                     v = int(v)
@@ -318,7 +318,7 @@ def _parse_makefile(filename, vars=None):
                         notdone[name] = value
                     else:
                         try:
-                            if name in _ALLWAYS_STR: 
+                            if name in _ALWAYS_STR:
                                 raise ValueError
                             value = int(value)
                         except ValueError:
@@ -482,7 +482,7 @@ def parse_config_h(fp, vars=None):
         if m:
             n, v = m.group(1, 2)
             try:
-                if n in _ALLWAYS_STR: 
+                if n in _ALWAYS_STR:
                     raise ValueError
                 v = int(v)
             except ValueError:

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1071,7 +1071,7 @@ class PosixTester(unittest.TestCase):
         if sys.platform == 'darwin':
             import sysconfig
             dt = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') or '10.0'
-            if tuple(int(n) for n in str(dt).split('.')[0:2]) < (10, 6):
+            if tuple(int(n) for n in dt.split('.')[0:2]) < (10, 6):
                 raise unittest.SkipTest("getgroups(2) is broken prior to 10.6")
 
         # 'id -G' and 'os.getgroups()' should return the same

--- a/Misc/NEWS.d/next/macOS/2021-01-26-14-36-11.bpo-42504.ZxWt71.rst
+++ b/Misc/NEWS.d/next/macOS/2021-01-26-14-36-11.bpo-42504.ZxWt71.rst
@@ -1,0 +1,3 @@
+Ensure that the value of
+sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') is always a string,
+even in when the value is parsable as an integer.

--- a/setup.py
+++ b/setup.py
@@ -1072,7 +1072,7 @@ class PyBuildExt(build_ext):
             os_release = int(os.uname()[2].split('.')[0])
             dep_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
             if (dep_target and
-                    (tuple(int(n) for n in str(dep_target).split('.')[0:2])
+                    (tuple(int(n) for n in dep_target.split('.')[0:2])
                         < (10, 5) ) ):
                 os_release = 8
             if os_release < 9:


### PR DESCRIPTION
This PR adds a way to ensure that the result of sysconfig.get_config_var() is always a string, even if the value can be interpreted as string (EDIT: as int) and uses that mechanism for MACOSX_DEPLOYMENT_TARGET.

This ensures that ``sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')`` is a string regardless of how Python was configured, both for consistency and for compatibility with older versions.


<!-- issue-number: [bpo-42504](https://bugs.python.org/issue42504) -->
https://bugs.python.org/issue42504
<!-- /issue-number -->
