### PR TITLE
bpo-38250: [Enum] only include .rst test if file available

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -16,14 +16,14 @@ from test.support import ALWAYS_EQ
 from test.support import threading_helper
 from datetime import timedelta
 
-if os.path.exists('../../Doc/library/enum.rst'):
-    def load_tests(loader, tests, ignore):
-        tests.addTests(doctest.DocTestSuite(enum))
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(enum))
+    if os.path.exists('../../Doc/library/enum.rst'):
         tests.addTests(doctest.DocFileSuite(
                 '../../Doc/library/enum.rst',
                 optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
                 ))
-        return tests
+    return tests
 
 # for pickle tests
 try:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1,6 +1,7 @@
 import enum
 import doctest
 import inspect
+import os
 import pydoc
 import sys
 import unittest
@@ -15,13 +16,14 @@ from test.support import ALWAYS_EQ
 from test.support import threading_helper
 from datetime import timedelta
 
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(enum))
-    tests.addTests(doctest.DocFileSuite(
-            '../../Doc/library/enum.rst',
-            optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
-            ))
-    return tests
+if os.path.exists('../../Doc/library/enum.rst'):
+    def load_tests(loader, tests, ignore):
+        tests.addTests(doctest.DocTestSuite(enum))
+        tests.addTests(doctest.DocFileSuite(
+                '../../Doc/library/enum.rst',
+                optionflags=doctest.ELLIPSIS|doctest.NORMALIZE_WHITESPACE,
+                ))
+        return tests
 
 # for pickle tests
 try:


### PR DESCRIPTION
In order to ensure the ReST documentation is up to date for Enum,
use doctest to check it -- but only if the .rst files have not
been stripped.

<!-- issue-number: [bpo-38250](https://bugs.python.org/issue38250) -->
https://bugs.python.org/issue38250
<!-- /issue-number -->
