### PR TITLE
bpo-43033: Fix the handling of PyObject_SetAttrString() in _zoneinfo.c

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2525,7 +2525,11 @@ zoneinfo_init_subclass(PyTypeObject *cls, PyObject *args, PyObject **kwargs)
         return NULL;
     }
 
-    PyObject_SetAttrString((PyObject *)cls, "_weak_cache", weak_cache);
+    if (PyObject_SetAttrString((PyObject *)cls, "_weak_cache",
+                               weak_cache) < 0) {
+        Py_DECREF(weak_cache);
+        return NULL;
+    }
     Py_DECREF(weak_cache);
     Py_RETURN_NONE;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-43033](https://bugs.python.org/issue43033) -->
https://bugs.python.org/issue43033
<!-- /issue-number -->
