### PR TITLE
bpo-43030: Fixed a compiler warning in Py_UNICODE_ISSPACE with signed wchar_t

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -22,7 +22,7 @@
 
  */
 #define Py_UNICODE_ISSPACE(ch) \
-    ((ch) < 128U ? _Py_ascii_whitespace[(ch)] : _PyUnicode_IsWhitespace(ch))
+    ((Py_UCS4)(ch) < 128U ? _Py_ascii_whitespace[(ch)] : _PyUnicode_IsWhitespace(ch))
 
 #define Py_UNICODE_ISLOWER(ch) _PyUnicode_IsLowercase(ch)
 #define Py_UNICODE_ISUPPER(ch) _PyUnicode_IsUppercase(ch)

--- a/Misc/NEWS.d/next/C API/2021-01-27-10-27-47.bpo-43030.loDcD_.rst
+++ b/Misc/NEWS.d/next/C API/2021-01-27-10-27-47.bpo-43030.loDcD_.rst
@@ -1,0 +1,2 @@
+Fixed a compiler warning in :c:func:`Py_UNICODE_ISSPACE()` on platforms with
+signed ``wchar_t``.


### PR DESCRIPTION


<!-- issue-number: [bpo-43030](https://bugs.python.org/issue43030) -->
https://bugs.python.org/issue43030
<!-- /issue-number -->
