### PR TITLE
bpo-43040: Fix randrange() is very slow if the range is a power of 2.

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -240,10 +240,10 @@ class Random(_random.Random):
     def _randbelow_with_getrandbits(self, n):
         "Return a random int in the range [0,n).  Returns 0 if n==0."
 
-        if not n:
+        if n <= 1:
             return 0
         getrandbits = self.getrandbits
-        k = n.bit_length()  # don't use (n-1) here because n can be 1
+        k = (n-1).bit_length()
         r = getrandbits(k)  # 0 <= r < 2**k
         while r >= n:
             r = getrandbits(k)
@@ -261,7 +261,7 @@ class Random(_random.Random):
                 "enough bits to choose from a population range this large.\n"
                 "To remove the range limitation, add a getrandbits() method.")
             return _floor(random() * n)
-        if n == 0:
+        if n <= 1:
             return 0
         rem = maxsize % n
         limit = (maxsize - rem) / maxsize   # int(limit * maxsize) % n == 0

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -238,7 +238,7 @@ class Random(_random.Random):
                 break
 
     def _randbelow_with_getrandbits(self, n):
-        "Return a random int in the range [0,n).  Returns 0 if n==0."
+        "Return a random int in the range [0,n).  Returns 0 if n<=1."
 
         if n <= 1:
             return 0
@@ -250,7 +250,7 @@ class Random(_random.Random):
         return r
 
     def _randbelow_without_getrandbits(self, n, maxsize=1<<BPF):
-        """Return a random int in the range [0,n).  Returns 0 if n==0.
+        """Return a random int in the range [0,n).  Returns 0 if n<=1.
 
         The implementation does not use getrandbits, but only random.
         """

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -240,7 +240,7 @@ class Random(_random.Random):
     def _randbelow_with_getrandbits(self, n):
         "Return a random int in the range [0,n).  Returns 0 if n==0."
 
-        if n <= 1:
+        if not n:
             return 0
         getrandbits = self.getrandbits
         k = (n-1).bit_length()
@@ -261,7 +261,7 @@ class Random(_random.Random):
                 "enough bits to choose from a population range this large.\n"
                 "To remove the range limitation, add a getrandbits() method.")
             return _floor(random() * n)
-        if n <= 1:
+        if not n:
             return 0
         rem = maxsize % n
         limit = (maxsize - rem) / maxsize   # int(limit * maxsize) % n == 0

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -238,7 +238,7 @@ class Random(_random.Random):
                 break
 
     def _randbelow_with_getrandbits(self, n):
-        "Return a random int in the range [0,n).  Returns 0 if n<=1."
+        "Return a random int in the range [0,n).  Returns 0 if n==0."
 
         if n <= 1:
             return 0
@@ -250,7 +250,7 @@ class Random(_random.Random):
         return r
 
     def _randbelow_without_getrandbits(self, n, maxsize=1<<BPF):
-        """Return a random int in the range [0,n).  Returns 0 if n<=1.
+        """Return a random int in the range [0,n).  Returns 0 if n==0.
 
         The implementation does not use getrandbits, but only random.
         """

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -947,22 +947,22 @@ merged E into F
  A->F B->B C->C D->D E->F F->F G->G H->H I->I J->J K->B L->L M->M
 merged D into C
  A->F B->B C->C D->C E->F F->F G->G H->H I->I J->J K->B L->L M->M
-merged M into C
- A->F B->B C->C D->C E->F F->F G->G H->H I->I J->J K->B L->L M->C
-merged J into B
- A->F B->B C->C D->C E->F F->F G->G H->H I->I J->B K->B L->L M->C
+merged M into B
+ A->F B->B C->C D->C E->F F->F G->G H->H I->I J->J K->B L->L M->B
+merged H into G
+ A->F B->B C->C D->C E->F F->F G->G H->G I->I J->J K->B L->L M->B
 merged B into C
- A->F B->C C->C D->C E->F F->F G->G H->H I->I J->C K->C L->L M->C
-merged F into G
- A->G B->C C->C D->C E->G F->G G->G H->H I->I J->C K->C L->L M->C
-merged L into C
- A->G B->C C->C D->C E->G F->G G->G H->H I->I J->C K->C L->C M->C
-merged G into I
- A->I B->C C->C D->C E->I F->I G->I H->H I->I J->C K->C L->C M->C
-merged I into H
- A->H B->C C->C D->C E->H F->H G->H H->H I->H J->C K->C L->C M->C
-merged C into H
- A->H B->H C->H D->H E->H F->H G->H H->H I->H J->H K->H L->H M->H
+ A->F B->C C->C D->C E->F F->F G->G H->G I->I J->J K->C L->L M->C
+merged C into G
+ A->F B->G C->G D->G E->F F->F G->G H->G I->I J->J K->G L->L M->G
+merged G into J
+ A->F B->J C->J D->J E->F F->F G->J H->J I->I J->J K->J L->L M->J
+merged J into F
+ A->F B->F C->F D->F E->F F->F G->F H->F I->I J->F K->F L->L M->F
+merged L into F
+ A->F B->F C->F D->F E->F F->F G->F H->F I->I J->F K->F L->F M->F
+merged I into F
+ A->F B->F C->F D->F E->F F->F G->F H->F I->F J->F K->F L->F M->F
 
 """
 # Emacs turd '

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -791,7 +791,7 @@ class MersenneTwister_TestBasicOps(TestBasicOps, unittest.TestCase):
         # If randrange uses getrandbits, it should pick getrandbits(100)
         # when called with a 100-bits stop argument.
         self.assertEqual(self.gen.randrange(2**99),
-                         97904845777343510404718956115)
+                         18676683263079172811175005779)
 
     def test_randbelow_logic(self, _log=log, int=int):
         # check bitcount transition points:  2**i and 2**(i+1)-1

--- a/Misc/NEWS.d/next/Library/2021-01-28-03-38-28.bpo-43040.m-C7LJ.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-28-03-38-28.bpo-43040.m-C7LJ.rst
@@ -1,0 +1,1 @@
+Optimize ``randrange()`` (and anything that uses it like ``randint()``) when the range is a power of 2 so ``getrandbits()`` is only called once, and only for as many bits as are needed. This reduces the number of random bits consumed, changing the repeatability of random data using a fixed seed.


### PR DESCRIPTION
Make _randbelow_with_getrandbits() get the number of bits needed for (n-1), not n, since we only return values <=n. When n is a power of 2, this reduces the number of bits needed by 1, and also means getrandbits() is not called repeatedly (on average 2x as many times as needed) until the returned value is <n.

Make  _randbelow_without_getrandbits() handling of n==0 consistent with _randbelow_with_getrandbits() by using `if not n:` instead of `if n==0:`.

Update test_random.py and test_generators.py to reflect changes to the random repeatability introduced by this optimization.

<!-- issue-number: [bpo-43040](https://bugs.python.org/issue43040) -->
https://bugs.python.org/issue43040
<!-- /issue-number -->
