### PR TITLE
bpo-42979: Use _Py_CheckSlotResult() to check slots result

### DIFF
--- a/Misc/NEWS.d/next/C API/2021-01-28-01-11-59.bpo-42979.JrGkrm.rst
+++ b/Misc/NEWS.d/next/C API/2021-01-28-01-11-59.bpo-42979.JrGkrm.rst
@@ -1,0 +1,5 @@
+When Python is built in debug mode (with C assertions), calling a type slot
+like ``sq_length`` (``__len__()`` in Python) now fails with a fatal error if
+the slot succeeded with an exception set, or failed with no exception set. The
+error message contains the slot, the type name, and the current exception (if
+an exception is set). Patch by Victor Stinner.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1736,6 +1736,11 @@ bytearray_extend(PyByteArrayObject *self, PyObject *iterable_of_ints)
     }
     Py_DECREF(it);
 
+    if (PyErr_Occurred()) {
+        Py_DECREF(bytearray_obj);
+        return NULL;
+    }
+
     /* Resize down to exact size. */
     if (PyByteArray_Resize((PyObject *)bytearray_obj, len) < 0) {
         Py_DECREF(bytearray_obj);
@@ -1748,10 +1753,7 @@ bytearray_extend(PyByteArrayObject *self, PyObject *iterable_of_ints)
     }
     Py_DECREF(bytearray_obj);
 
-    if (PyErr_Occurred()) {
-        return NULL;
-    }
-
+    assert(!PyErr_Occurred());
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
When Python is built in debug mode (with C assertions), calling a
type slot like sq_length (__len__() in Python) now fails with a fatal
error if the slot succeeded with an exception set, or failed with no
exception set.

* Check the result of all slots using _Py_CheckSlotResult().
* No longer pass op_name to ternary_op() in release mode.
* Replace operator with dunder Python method name in error messages.
  For example, replace "*" with "__mul__".
* Fix compiler_exit_scope() when an exception is set.
* Fix bytearray.extend() when an exception is set: don't call
  bytearray_setslice() with an exception set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42979](https://bugs.python.org/issue42979) -->
https://bugs.python.org/issue42979
<!-- /issue-number -->
