### PR TITLE
bpo-43049: Use io.IncrementalNewlineDecoder for doctest newline conversion

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -102,7 +102,7 @@ import re
 import sys
 import traceback
 import unittest
-from io import StringIO
+from io import StringIO, IncrementalNewlineDecoder
 from collections import namedtuple
 
 TestResults = namedtuple('TestResults', 'failed attempted')
@@ -212,11 +212,8 @@ def _normalize_module(module, depth=2):
         raise TypeError("Expected a module, string, or None")
 
 def _newline_convert(data):
-    # We have two cases to cover and we need to make sure we do
-    # them in the right order
-    for newline in ('\r\n', '\r'):
-        data = data.replace(newline, '\n')
-    return data
+    # The IO module provides a handy decoder for universal newline conversion
+    return IncrementalNewlineDecoder(None, True).decode(data, True)
 
 def _load_testfile(filename, package, module_relative, encoding):
     if module_relative:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


This PR is a follow-up to PR #17385 for [bpo-1812](https://bugs.python.org/issue1812) (now merged). During discussion on that issue the suggestion was made to investigate whether any resources already provided by the io module might be available to do the newline conversion in doctest that was corrected in that PR. It turns out there is: the io.IncrementalNewlineDecoder object does exactly the conversion that is needed. This PR implements using that object in place of the custom newline conversion that was done in the previous PR. The only change is in the relevant code in the doctest module.


<!-- issue-number: [bpo-43049](https://bugs.python.org/issue43049) -->
https://bugs.python.org/issue43049
<!-- /issue-number -->
