### PR TITLE
bpo-43059: sqlite3: Remove reference to legacy external sqlite3 repository

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -100,10 +100,6 @@ This example uses the iterator form::
 
 .. seealso::
 
-   https://github.com/ghaering/pysqlite
-      The pysqlite web page -- sqlite3 is developed externally under the name
-      "pysqlite".
-
    https://www.sqlite.org
       The SQLite web page; the documentation describes the syntax and the
       available data types for the supported SQL dialect.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
As discussed in [issue43059](https://bugs.python.org/issue43059), the link to the external sqlite3 repository is probably obsolete and can be removed.

<!-- issue-number: [bpo-43059](https://bugs.python.org/issue43059) -->
https://bugs.python.org/issue43059
<!-- /issue-number -->
