### PR TITLE
bpo-42973: argparse: mixing optional and positional

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -754,7 +754,7 @@ this:
 
 .. code-block:: shell-session
 
-   $ python fruits.py --color green apple pear kiwi --color brown banana
+   $ python fruits.py --color green apple pear kiwi --color yellow banana
    green apple
    plain pear
    plain kiwi

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -183,10 +183,6 @@ ArgumentParser objects
    * exit_on_error_ - Determines whether or not ArgumentParser exits with
      error info when an error occurs. (default: ``True``)
 
-   * greedy_ - Allows positional arguments with ``nargs='*'`` to consume
-     multiple groups of command-line arguments, interspersed with optional
-     arguments. (default: ``False``)
-
    .. versionchanged:: 3.5
       *allow_abbrev* parameter was added.
 
@@ -196,9 +192,6 @@ ArgumentParser objects
 
    .. versionchanged:: 3.9
       *exit_on_error* parameter was added.
-
-   .. versionchanged:: 3.10
-      *greedy* parameter was added.
 
 The following sections describe how each of these are used.
 
@@ -683,86 +676,6 @@ If the user would like catch errors manually, the feature can be enable by setti
 .. versionadded:: 3.9
 
 
-greedy
-^^^^^^
-
-
-By default, positional argument with ``nargs='*'`` will only consume one group
-of command-line arguments, up to first encountered optional argument::
-
-   >>> parser = argparse.ArgumentParser()
-   >>> parser.add_argument('--foo', action='store_true')
-   >>> parser.add_argument('bar', nargs='*')
-   >>> parser.parse_args('arg1 arg2 --foo arg3 arg4'.split())
-   usage: [-h] [--foo] [bar ...]
-   : error: unrecognized arguments: arg3 arg4
-
-In some cases it may be desirable to collect unspecified number of positional
-arguments and still allow to intersperse them with optional arguments. This can
-be achieved by setting ``greedy`` to ``True``::
-
-   >>> parser = argparse.ArgumentParser(greedy=True)
-   >>> parser.add_argument('--foo', action='store_true')
-   >>> parser.add_argument('bar', nargs='*', action='extend')
-   >>> parser.parse_args('arg1 arg2 --foo arg3 arg4'.split())
-   Namespace(foo=True, bar=['arg1', 'arg2', 'arg3', 'arg4'])
-
-Note that since action associated with the positional argument is executed for
-each consecutive group of command-line arguments, using default ``store`` action
-will likely not give expected results - it would just contain the last group of
-arguments (``arg3`` and  ``arg4`` in the example above).
-
-Conversely, here is an example which requires ``greedy`` not set::
-
-   >>> parser = argparse.ArgumentParser()
-   >>> parser.add_argument('foo', nargs='*')
-   >>> parser.add_argument('last')
-   >>> parser.parse_args('first second third'.split())
-   Namespace(foo=['first', 'second'], last='third')
-
-If ``greedy`` was set in the example above, argument parsing would always fail,
-because argument ``last`` could never match command-line argument.
-As a rule, if ``greedy`` is set, positional argument with ``nargs='*'``, if
-present, must be the last positional argument.
-
-Example below combines ``greedy`` with custom :ref:`Action class<action-classes>`
-to allow providing additional properties for each positional argument::
-
-   import argparse
-
-   DEFAULT_COLOR="plain"
-
-   class AddFruitAction(argparse.Action):
-      def __call__(self, parser, namespace, values, option_string=None):
-         for fruit in values:
-            namespace.fruits.append({'name': fruit, 'color': namespace.color})
-            namespace.color = DEFAULT_COLOR
-
-   def show_fruits(fruits):
-      for fruit in fruits:
-         print(f"{fruit['color']} {fruit['name']}")
-
-   parser = argparse.ArgumentParser(greedy=True)
-   parser.add_argument('--color', default=DEFAULT_COLOR)
-   parser.add_argument('fruits', nargs='*', action=AddFruitAction, default=[])
-   args = parser.parse_args()
-   show_fruits(args.fruits)
-
-
-If the code above was saved to file ``fruits.py``, it could be executed like
-this:
-
-.. code-block:: shell-session
-
-   $ python fruits.py --color green apple pear kiwi --color yellow banana
-   green apple
-   plain pear
-   plain kiwi
-   yellow banana
-
-.. versionadded:: 3.10
-
-
 The add_argument() method
 -------------------------
 
@@ -1048,6 +961,28 @@ values are:
      >>> parser.parse_args([])
      usage: PROG [-h] foo [foo ...]
      PROG: error: the following arguments are required: foo
+
+.. index:: single: **; in argparse module
+
+* ``'**'``. This value is only valid for positional arguments. Like ``'*'``,
+  all command-line args are gathered into a list. In contrast to ``'*'``,
+  all arguments are consumed, even if they are interspersed with optional
+  arguments. For example::
+
+     >>> parser = argparse.ArgumentParser()
+     >>> parser.add_argument('--foo', action='store_true')
+     >>> parser.add_argument('bar', nargs='**', action='extend')
+     >>> parser.parse_args('arg1 arg2 --foo arg3 arg4'.split())
+     Namespace(foo=True, bar=['arg1', 'arg2', 'arg3', 'arg4'])
+
+  Note that the ``action`` associated with the positional argument is executed
+  for each group of command-line args separated by optional args, so using the
+  default ``'store'`` action will not give expected results. In the example
+  above, if ``action`` was ``'store'``, ``bar`` in the returned namespace would
+  be just ``['args3', 'args4']``. Positional argument with ``nargs='**'``, if
+  preset, must be the last positional argument.
+
+  .. versionadded:: 3.10
 
 If the ``nargs`` keyword argument is not provided, the number of arguments consumed
 is determined by the action_.  Generally this means a single command-line argument

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -142,8 +142,7 @@ ArgumentParser objects
                           formatter_class=argparse.HelpFormatter, \
                           prefix_chars='-', fromfile_prefix_chars=None, \
                           argument_default=None, conflict_handler='error', \
-                          add_help=True, allow_abbrev=True, exit_on_error=True, \
-                          greedy=False)
+                          add_help=True, allow_abbrev=True, exit_on_error=True)
 
    Create a new :class:`ArgumentParser` object. All parameters should be passed
    as keyword arguments. Each parameter has its own more detailed description

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1697,7 +1697,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                  add_help=True,
                  allow_abbrev=True,
                  exit_on_error=True,
-                 greedy_star=False):
+                 greedy=False):
 
         superinit = super(ArgumentParser, self).__init__
         superinit(description=description,
@@ -1717,7 +1717,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         self.add_help = add_help
         self.allow_abbrev = allow_abbrev
         self.exit_on_error = exit_on_error
-        self.greedy_star = greedy_star
+        self.greedy = greedy
 
         add_group = self.add_argument_group
         self._positionals = add_group(_('positional arguments'))
@@ -2021,8 +2021,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 args = arg_strings[start_index: start_index + arg_count]
                 start_index += arg_count
                 take_action(action, args)
-                # positional action is '*', never remove it from list
-                if not self.greedy_star or action.nargs != ZERO_OR_MORE:
+                # if greedy is on and positional action nargs is '*',
+                # never remove it from actions list
+                if not self.greedy or action.nargs != ZERO_OR_MORE:
                     action_index += 1
 
             # slice off the Positionals that we just parsed and return the

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5022,9 +5022,9 @@ class TestParseKnownArgs(TestCase):
         self.assertEqual(NS(first=['arg1', 'arg2'], second='arg3'), args)
 
     def test_greedy(self):
-        parser = argparse.ArgumentParser(greedy=True)
+        parser = argparse.ArgumentParser()
         parser.add_argument('--foo', action='store')
-        parser.add_argument('first', nargs='*', action='extend')
+        parser.add_argument('first', nargs='**', action='extend')
 
         argv = ['arg1', 'arg2', '--foo', 'bar', 'arg3', 'arg4']
         args = parser.parse_args(argv)

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5012,6 +5012,25 @@ class TestParseKnownArgs(TestCase):
         self.assertEqual(NS(v=3, spam=True, badger="B"), args)
         self.assertEqual(["C", "--foo", "4"], extras)
 
+    def test_nongreedy(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('first', nargs='*', action='extend')
+        parser.add_argument('second')
+
+        argv = ['arg1', 'arg2', 'arg3']
+        args = parser.parse_args(argv)
+        self.assertEqual(NS(first=['arg1', 'arg2'], second='arg3'), args)
+
+    def test_greedy(self):
+        parser = argparse.ArgumentParser(greedy=True)
+        parser.add_argument('--foo', action='store')
+        parser.add_argument('first', nargs='*', action='extend')
+
+        argv = ['arg1', 'arg2', '--foo', 'bar', 'arg3', 'arg4']
+        args = parser.parse_args(argv)
+        self.assertEqual(NS(foo='bar',
+                            first=['arg1', 'arg2', 'arg3', 'arg4']), args)
+
 # ===========================
 # parse_intermixed_args tests
 # ===========================

--- a/Misc/NEWS.d/next/Library/2021-01-25-20-17-18.bpo-42973._HL64W.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-25-20-17-18.bpo-42973._HL64W.rst
@@ -1,1 +1,0 @@
-Added new parameter ``greedy`` to :class:`ArgumentParser` constructor which allows positional arguments with ``nargs='*'`` to match positional arguments interspersed with optional arguments.

--- a/Misc/NEWS.d/next/Library/2021-01-25-20-17-18.bpo-42973._HL64W.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-25-20-17-18.bpo-42973._HL64W.rst
@@ -1,0 +1,1 @@
+Added new parameter ``greedy`` to :class:`ArgumentParser` constructor which allows positional arguments with ``nargs='*'`` to match positional arguments interspersed with optional arguments.

--- a/Misc/NEWS.d/next/Library/2021-01-27-11-16-30.bpo-42973.sHk-kI.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-27-11-16-30.bpo-42973.sHk-kI.rst
@@ -1,0 +1,1 @@
+New possible value ``'**'`` for ``nargs`` parameter of :func:`ArgumentParser.add_argument` in :mod:`argparse`.


### PR DESCRIPTION
argparse: allow positional parameter with nargs='*' to match more than once without reordering parameters.
Restoration of old patch from [bpo-14191](https://bugs.python.org/issue14191).

https://bugs.python.org/issue42973

Copy of #24259 which I unwittingly closed by renaming the branch.


<!-- issue-number: [bpo-42973](https://bugs.python.org/issue42973) -->
https://bugs.python.org/issue42973
<!-- /issue-number -->
<!-- gh-issue-number: gh-87139 -->
* Issue: gh-87139
<!-- /gh-issue-number -->
