### PR TITLE
bpo-42966: argparse: customizable help formatter

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2132,7 +2132,7 @@ Custom help format
    an instantiated object is passed to the :class:`ArgumentParser` constructor,
    not a class type.
 
-   Selection of help format is done by setting either passing keyword arguments 
+   Selection of help format is done by setting either passing keyword arguments
    to the constructor or setting attributes of the instantiated
    :class:`CustomHelpFormat` object, before passing it to the
    :class:`ArgumentParser` constructor::

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2116,7 +2116,10 @@ remaining unparsed argument strings.
 Custom help format
 ^^^^^^^^^^^^^^^^^^
 
-.. class:: CustomHelpFormat()
+.. class:: CustomHelpFormat(indent_increment=2, max_help_position=24,
+                            width=None, raw_description=False,
+                            raw_text=False, arg_defaults=False,
+                            metavar_type=False, **kwargs)
 
    A :class:`CustomHelpFormat` object can be passed as formatter_class_ parameter
    to the :class:`ArgumentParser` constructor instead of a formatter class.
@@ -2129,7 +2132,8 @@ Custom help format
    an instantiated object is passed to the :class:`ArgumentParser` constructor,
    not a class type.
 
-   Selection of help format is done by setting attributes of the instantiated
+   Selection of help format is done by setting either passing keyword arguments 
+   to the constructor or setting attributes of the instantiated
    :class:`CustomHelpFormat` object, before passing it to the
    :class:`ArgumentParser` constructor::
 
@@ -2149,7 +2153,7 @@ Custom help format
          -h, --help  show this help message and exit
          --foo FOO   FOO! (default: 42)
 
-   Attributes or :class:`CustomHelpFormat` are:
+   Keyword arguments and attributes of the :class:`CustomHelpFormat` class are:
 
    * indent_increment - Sets number of spaces added for each indentation level.
      The default is two spaces per indentation level.
@@ -2173,6 +2177,8 @@ Custom help format
    * metavar_type - Setting this attribute to ``True`` enabled using the name of the
      type_ argument passed to :meth:`ArgumentParser.add_argument` function as the
      display name, as with :class:`MetavarTypeHelpFormatter`.
+
+   Unknown keyword arguments passed to the class constructor are ignored.
 
    .. versionadded:: 3.10
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2158,19 +2158,19 @@ Custom help format
      block. The default is 24.
 
    * width - Set width of the terminal for line-wrapping. In most cases it's best
-     to leave this attribute `None` to allow argparse determine the width
+     to leave this attribute ``None`` to allow argparse determine the width
      automatically.
 
-   * raw_description - Setting `raw_description` to `True` disables formatting of 
+   * raw_description - Setting ``raw_description`` to ``True`` disables formatting of
      parser description_ and epilog_, as with :class:`RawDescriptionHelpFormatter`.
 
-   * raw_text - Setting this attribute to `True` disables formatting of parameters
+   * raw_text - Setting this attribute to ``True`` disables formatting of parameters
      help text, as with :class:`RawTextHelpFormatter`.
 
-   * arg_defaults - Setting this attribute to `True` adds information about default
+   * arg_defaults - Setting this attribute to ``True`` adds information about default
      values, as with :class:`ArgumentDefaultsHelpFormatter`.
 
-   * metavar_type - Setting this attribute to `True` enabled using the name of the
+   * metavar_type - Setting this attribute to ``True`` enabled using the name of the
      type_ argument passed to :meth:`ArgumentParser.add_argument` function as the
      display name, as with :class:`MetavarTypeHelpFormatter`.
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2152,27 +2152,27 @@ Custom help format
    Attributes or :class:`CustomHelpFormat` are:
 
    * indent_increment - Sets number of spaces added for each indentation level.
-   The default is two spaces per indentation level.
+     The default is two spaces per indentation level.
 
    * max_help_position - Sets maximum indentation of the parameters description
-   block. The default is 24.
+     block. The default is 24.
 
    * width - Set width of the terminal for line-wrapping. In most cases it's best
-   to leave this attribute `None` to allow argparse determine the width
-   automatically.
+     to leave this attribute `None` to allow argparse determine the width
+     automatically.
 
    * raw_description - Setting `raw_description` to `True` disables formatting of 
-   parser description_ and epilog_, as with :class:`RawDescriptionHelpFormatter`.
+     parser description_ and epilog_, as with :class:`RawDescriptionHelpFormatter`.
 
    * raw_text - Setting this attribute to `True` disables formatting of parameters
-   help text, as with :class:`RawTextHelpFormatter`.
+     help text, as with :class:`RawTextHelpFormatter`.
 
    * arg_defaults - Setting this attribute to `True` adds information about default
-   values, as with :class:`ArgumentDefaultsHelpFormatter`.
+     values, as with :class:`ArgumentDefaultsHelpFormatter`.
 
    * metavar_type - Setting this attribute to `True` enabled using the name of the
-   type_ argument passed to :meth:`ArgumentParser.add_argument` function as the
-   display name, as with :class:`MetavarTypeHelpFormatter`.
+     type_ argument passed to :meth:`ArgumentParser.add_argument` function as the
+     display name, as with :class:`MetavarTypeHelpFormatter`.
 
    .. versionadded:: 3.10
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2155,7 +2155,7 @@ Custom help format
    The default is two spaces per indentation level.
 
    * max_help_position - Sets maximum indentation of the parameters description
-   column. The default is calculated automatically from the terminal width.
+   block. The default is 24.
 
    * width - Set width of the terminal for line-wrapping. In most cases it's best
    to leave this attribute `None` to allow argparse determine the width

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -376,8 +376,8 @@ formatter_class
 ^^^^^^^^^^^^^^^
 
 :class:`ArgumentParser` objects allow the help formatting to be customized by
-specifying an alternate formatting class.  Currently, there are four such
-classes:
+specifying an alternate formatting class or a :class:`CustomHelpFormat` object.
+Currently, there are alternate formatting classes:
 
 .. class:: RawDescriptionHelpFormatter
            RawTextHelpFormatter
@@ -2111,6 +2111,71 @@ containing the populated namespace and the list of remaining argument strings.
 remaining unparsed argument strings.
 
 .. versionadded:: 3.7
+
+
+Custom help format
+^^^^^^^^^^^^^^^^^^
+
+.. class:: CustomHelpFormat()
+
+   A :class:`CustomHelpFormat` object can be passed as formatter_class_ parameter
+   to the :class:`ArgumentParser` constructor instead of a formatter class.
+   Using custom help format object allows to easy mix behavior or several
+   formatter classes and also provides easy way to modify some basic format
+   properties, such as indentation.
+
+   In contrast to alternate formatting classes, such as the
+   :class:`RawTextHelpFormatter` class, in case of :class:`CustomHelpFormat`,
+   an instantiated object is passed to the :class:`ArgumentParser` constructor,
+   not a class type.
+
+   Selection of help format is done by setting attributes of the instantiated
+   :class:`CustomHelpFormat` object, before passing it to the
+   :class:`ArgumentParser` constructor::
+
+      >>> my_format = argparse.CustomHelpFormat()
+      >>> my_format.indent_increment = 4
+      >>> my_format.arg_defaults = True
+      >>> parser = argparse.ArgumentParser(prog='PROG', formatter_class=my_format)
+      >>> parser.add_argument('--foo', type=int, default=42, help='FOO!')
+      >>> parser.add_argument('bar', nargs='*', default=[1, 2, 3], help='BAR!')
+      >>> parser.print_help()
+      usage: PROG [-h] [--foo FOO] [bar ...]
+
+      positional arguments:
+         bar         BAR! (default: [1, 2, 3])
+
+      options:
+         -h, --help  show this help message and exit
+         --foo FOO   FOO! (default: 42)
+
+   Attributes or :class:`CustomHelpFormat` are:
+
+   * indent_increment - Sets number of spaces added for each indentation level.
+   The default is two spaces per indentation level.
+
+   * max_help_position - Sets maximum indentation of the parameters description
+   column. The default is calculated automatically from the terminal width.
+
+   * width - Set width of the terminal for line-wrapping. In most cases it's best
+   to leave this attribute `None` to allow argparse determine the width
+   automatically.
+
+   * raw_description - Setting `raw_description` to `True` disables formatting of 
+   parser description_ and epilog_, as with :class:`RawDescriptionHelpFormatter`.
+
+   * raw_text - Setting this attribute to `True` disables formatting of parameters
+   help text, as with :class:`RawTextHelpFormatter`.
+
+   * arg_defaults - Setting this attribute to `True` adds information about default
+   values, as with :class:`ArgumentDefaultsHelpFormatter`.
+
+   * metavar_type - Setting this attribute to `True` enabled using the name of the
+   type_ argument passed to :meth:`ArgumentParser.add_argument` function as the
+   display name, as with :class:`MetavarTypeHelpFormatter`.
+
+   .. versionadded:: 3.10
+
 
 .. _upgrading-optparse-code:
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -377,7 +377,7 @@ formatter_class
 
 :class:`ArgumentParser` objects allow the help formatting to be customized by
 specifying an alternate formatting class or a :class:`CustomHelpFormat` object.
-Currently, there are alternate formatting classes:
+Currently, there are four alternate formatting classes:
 
 .. class:: RawDescriptionHelpFormatter
            RawTextHelpFormatter

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2116,9 +2116,9 @@ remaining unparsed argument strings.
 Custom help format
 ^^^^^^^^^^^^^^^^^^
 
-.. class:: CustomHelpFormat(indent_increment=2, max_help_position=24,
-                            width=None, raw_description=False,
-                            raw_text=False, arg_defaults=False,
+.. class:: CustomHelpFormat(indent_increment=2, max_help_position=24, \
+                            width=None, raw_description=False, \
+                            raw_text=False, arg_defaults=False, \
                             metavar_type=False, **kwargs)
 
    A :class:`CustomHelpFormat` object can be passed as formatter_class_ parameter

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -756,14 +756,22 @@ class _CustomizableHelpFormatter(RawTextHelpFormatter,
 class CustomHelpFormat:
     """Customizable help formatter factory."""
 
-    def __init__(self):
-        self.indent_increment = 2
-        self.max_help_position = 24
-        self.width = None
-        self.raw_description = False
-        self.raw_text = False
-        self.arg_defaults = False
-        self.metavar_type = False
+    def __init__(self, *,
+                 indent_increment=2,
+                 max_help_position=24,
+                 width=None,
+                 raw_description=False,
+                 raw_text=False,
+                 arg_defaults=False,
+                 metavar_type=False,
+                 **kwargs):
+        self.indent_increment = indent_increment
+        self.max_help_position = max_help_position
+        self.width = width
+        self.raw_description = raw_description
+        self.raw_text = raw_text
+        self.arg_defaults = arg_defaults
+        self.metavar_type = metavar_type
 
     def __call__(self, prog):
         return _CustomizableHelpFormatter(prog=prog,

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4129,6 +4129,32 @@ class TestHelpTupleMetavar(HelpTestCase):
     version = ''
 
 
+class TestHelpCustomIndent(HelpTestCase):
+    """Test that no errors occur if no help is specified"""
+
+    cust_format = argparse.CustomHelpFormat()
+    cust_format.indent_increment = 4
+    parser_signature = Sig(prog='PROG', formatter_class=cust_format)
+    argument_signatures = [
+        Sig('--foo'),
+        Sig('spam'),
+    ]
+    argument_group_signatures = []
+    usage = '''\
+        usage: PROG [-h] [--foo FOO] spam
+        '''
+    help = usage + '''\
+
+        positional arguments:
+            spam
+
+        options:
+            -h, --help  show this help message and exit
+            --foo FOO
+        '''
+    version = ''
+
+
 class TestHelpRawText(HelpTestCase):
     """Test the RawTextHelpFormatter"""
 
@@ -4176,6 +4202,21 @@ class TestHelpRawText(HelpTestCase):
           --bar BAR   bar help
         '''
     version = ''
+
+
+class TestCustomHelpRawText(TestHelpRawText):
+    """Test the CustomHelpFormat with raw_text"""
+    # Argument signatures and expected output inherited from TestHelpRawText
+
+    cust_format = argparse.CustomHelpFormat()
+    cust_format.raw_text = True
+    cust_format.raw_description = True
+    parser_signature = Sig(
+        prog='PROG', formatter_class=cust_format,
+        description='Keep the formatting\n'
+                    '    exactly as it is written\n'
+                    '\n'
+                    'here\n')
 
 
 class TestHelpRawDescription(HelpTestCase):
@@ -4226,6 +4267,21 @@ class TestHelpRawDescription(HelpTestCase):
     version = ''
 
 
+class TestCustomHelpRawDescription(TestHelpRawDescription):
+    """Test the CustomHelpFormat with raw_description"""
+    # Argument signatures and expected output inherited from
+    # TestHelpRawDescription
+
+    cust_format = argparse.CustomHelpFormat()
+    cust_format.raw_description = True
+    parser_signature = Sig(
+        prog='PROG', formatter_class=cust_format,
+        description='Keep the formatting\n'
+                    '    exactly as it is written\n'
+                    '\n'
+                    'here\n')
+
+
 class TestHelpArgumentDefaults(HelpTestCase):
     """Test the ArgumentDefaultsHelpFormatter"""
 
@@ -4265,6 +4321,19 @@ class TestHelpArgumentDefaults(HelpTestCase):
           --baz BAZ   baz help (default: 42)
         '''
     version = ''
+
+
+class TestCustomHelpArgumentDefaults(TestHelpArgumentDefaults):
+    """Test the CustomHelpFormat with arg_defaults"""
+    # Argument signatures and expected output inherited from
+    # TestHelpArgumentDefaults
+
+    cust_format = argparse.CustomHelpFormat()
+    cust_format.arg_defaults = True
+    parser_signature = Sig(
+        prog='PROG', formatter_class=cust_format,
+        description='description')
+
 
 class TestHelpVersionAction(HelpTestCase):
     """Test the default help for the version action"""
@@ -4340,6 +4409,7 @@ class TestHelpSubparsersOrdering(HelpTestCase):
         0.1
         '''
 
+
 class TestHelpSubparsersWithHelpOrdering(HelpTestCase):
     """Test ordering of subcommands in help matches the code"""
     parser_signature = Sig(prog='PROG',
@@ -4382,7 +4452,6 @@ class TestHelpSubparsersWithHelpOrdering(HelpTestCase):
         '''
 
 
-
 class TestHelpMetavarTypeFormatter(HelpTestCase):
 
     def custom_type(string):
@@ -4411,6 +4480,85 @@ class TestHelpMetavarTypeFormatter(HelpTestCase):
         '''
     version = ''
 
+
+class TestCustomHelpMetavarTypeFormatter(TestHelpMetavarTypeFormatter):
+    """Test the CustomHelpFormat with arg_defaults"""
+    # Argument signatures and expected output inherited from
+    # TestHelpMetavarTypeFormatter
+
+    cust_format = argparse.CustomHelpFormat()
+    cust_format.metavar_type = True
+    parser_signature = Sig(
+        prog='PROG', formatter_class=cust_format,
+        description='description')
+
+
+class TestCustomHelpAll(TestHelpMetavarTypeFormatter):
+    """Test the CustomHelpFormat with all options on"""
+
+    def custom_type(string):
+        return string
+
+    cust_format = argparse.CustomHelpFormat()
+    cust_format.indent_increment = 4
+    cust_format.width = 100
+    cust_format.raw_text = True
+    cust_format.raw_description = True
+    cust_format.arg_defaults = True
+    cust_format.metavar_type = True
+
+    parser_signature = Sig(
+        prog='PROG', formatter_class=cust_format,
+        description='Keep the formatting\n'
+                    '    exactly as it is written\n'
+                    '\n'
+                    'here\n')
+
+    argument_signatures = [
+        Sig('-b', type=custom_type),
+        Sig('-c', type=float, metavar='SOME FLOAT'),
+        Sig('--foo', type=int, help='foo help - oh and by the way, %(default)s'),
+        Sig('--baz', action='store_true', help='    baz help should also\n'
+                                               'appear as given here'),
+        Sig('spam', type=str, help='spam help'),
+        Sig('badger', type=str, nargs='?', default='wooden', help='badger help')
+    ]
+    argument_group_signatures = [
+        (Sig('title', description='    This text\n'
+                                  '  should be indented\n'
+                                  '    exactly like it is here\n'),
+         [Sig('--foz', type=int, default=42, help='foz help')]),
+    ]
+    usage = '''\
+        usage: PROG [-h] [-b custom_type] [-c SOME FLOAT] [--foo int] [--baz] [--foz int] str [str]
+        '''
+    help = usage + '''\
+
+        Keep the formatting
+            exactly as it is written
+
+        here
+
+        positional arguments:
+            str             spam help
+            str             badger help (default: wooden)
+
+        options:
+            -h, --help      show this help message and exit
+            -b custom_type
+            -c SOME FLOAT
+            --foo int       foo help - oh and by the way, None
+            --baz               baz help should also
+                            appear as given here (default: False)
+
+        title:
+                This text
+              should be indented
+                exactly like it is here
+
+            --foz int       foz help (default: 42)
+        '''
+    version = ''
 
 # =====================================
 # Optional/Positional constructor tests

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4499,14 +4499,10 @@ class TestCustomHelpAll(TestHelpMetavarTypeFormatter):
     def custom_type(string):
         return string
 
-    cust_format = argparse.CustomHelpFormat()
-    cust_format.indent_increment = 4
-    cust_format.width = 100
-    cust_format.raw_text = True
-    cust_format.raw_description = True
-    cust_format.arg_defaults = True
-    cust_format.metavar_type = True
-
+    cust_format = argparse.CustomHelpFormat(indent_increment=4, width=100,
+                                            raw_text=True, raw_description=True,
+                                            arg_defaults=True,
+                                            metavar_type=True)
     parser_signature = Sig(
         prog='PROG', formatter_class=cust_format,
         description='Keep the formatting\n'

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4130,7 +4130,7 @@ class TestHelpTupleMetavar(HelpTestCase):
 
 
 class TestHelpCustomIndent(HelpTestCase):
-    """Test that no errors occur if no help is specified"""
+    """Test CustomHelpFormat with changed indent_increment"""
 
     cust_format = argparse.CustomHelpFormat()
     cust_format.indent_increment = 4

--- a/Misc/NEWS.d/next/Library/2021-01-29-19-50-14.bpo-42966.nviBnq.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-29-19-50-14.bpo-42966.nviBnq.rst
@@ -1,0 +1,1 @@
+Added :class:`argparse.CustomHelpFormat` to :mod:`argparse` for easy basic customization of help text format.


### PR DESCRIPTION
Added public CustomHelpFormat class and private _CustomizableHelpFormatter to provide accessible API for basic help format customizations.

This PR doesn't introduce any new formatting customization, just adds more accessible API for existing alternative help formatter classes and for changing basic HelpFormatter parameters (indentation), with possibility to extend it for future formatter classes.


<!-- issue-number: [bpo-42966](https://bugs.python.org/issue42966) -->
https://bugs.python.org/issue42966
<!-- /issue-number -->
