### PR TITLE
added doc about *iterables in concurrent.futures.Executor.map

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -46,7 +46,7 @@ Executor Objects
          takes only one argument like `fn(x)`, then *iterables* can be passed
          in like `map(fn, [x1, x2, ...])`. If *fn* takes multiple arguments like
          `fn(x, y)`, then *iterables* can be passed in like `map(fn,
-         *zip*([(x1, x2), (y1, y2), ...])` using the `*zip(*)` trick, which is
+         *zip(*[(x1, x2), (y1, y2), ...])` using the `*zip(*)` trick, which is
          needed because `*iterables` will get zipped again inside `map`.
 
        * *func* is executed asynchronously and several calls to

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -43,9 +43,11 @@ Executor Objects
        Similar to :func:`map(func, *iterables) <map>` except:
 
        * the *iterables* are collected immediately rather than lazily; If *fn*
-         takes only one argument like `fn(x)`, then *iterables* can be simply
-         like `[x1, x2, ...]`. If *fn* takes multiple arguments like `fn(x,
-         y)`, the iterables can be formatted as `[(x1, x2), (y1, y2), ...]`.
+         takes only one argument like `fn(x)`, then *iterables* can be passed
+         in like `map(fn, [x1, x2, ...])`. If *fn* takes multiple arguments like
+         `fn(x, y)`, then *iterables* can be passed in like `map(fn,
+         *zip*([(x1, x2), (y1, y2), ...])` using the `*zip(*)` trick, which is
+         needed because `*iterables` will get zipped again inside `map`.
 
        * *func* is executed asynchronously and several calls to
          *func* may be made concurrently.

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -42,7 +42,10 @@ Executor Objects
 
        Similar to :func:`map(func, *iterables) <map>` except:
 
-       * the *iterables* are collected immediately rather than lazily;
+       * the *iterables* are collected immediately rather than lazily; If *fn*
+         takes only one argument like `fn(x)`, then *iterables* can be simply
+         like `[x1, x2, ...]`. If *fn* takes multiple arguments like `fn(x,
+         y)`, the iterables can be formatted as `[(x1, x2), (y1, y2), ...]`.
 
        * *func* is executed asynchronously and several calls to
          *func* may be made concurrently.

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -567,10 +567,6 @@ class Executor(object):
         Args:
             fn: A callable that will take as many arguments as there are
                 passed iterables.
-            *iterables: An iterable of arguments to fn. If fn takes only one
-                argument like fn(x), then iterables can be simply like [x1, x2,
-                ...]. If fn takes multiple arguments like fn(x, y), the
-                iterables can be formatted as [(x1, x2), (y1, y2), ...].
             timeout: The maximum number of seconds to wait. If None, then there
                 is no limit on the wait time.
             chunksize: The size of the chunks the iterable will be broken into

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -567,6 +567,10 @@ class Executor(object):
         Args:
             fn: A callable that will take as many arguments as there are
                 passed iterables.
+            *iterables: An iterable of arguments to fn. If fn takes only one
+                argument like fn(x), then iterables can be simply like [x1, x2,
+                ...]. If fn takes multiple arguments like fn(x, y), the
+                iterables can be formatted as [(x1, x2), (y1, y2), ...].
             timeout: The maximum number of seconds to wait. If None, then there
                 is no limit on the wait time.
             chunksize: The size of the chunks the iterable will be broken into


### PR DESCRIPTION
I thought this is a nice trick for mapping a function that takes multiple arguments, and perhaps worth documented more explicitly.

ref: https://skeptric.com/multiprocesing-future/