### PR TITLE
bpo-42323: Fix math.nextafter() on AIX

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3474,10 +3474,10 @@ math_nextafter_impl(PyObject *module, double x, double y)
         return PyFloat_FromDouble(y);
     }
     if (Py_IS_NAN(x)) {
-        return x;
+        return PyFloat_FromDouble(x);
     }
     if (Py_IS_NAN(y)) {
-        return y;
+        return PyFloat_FromDouble(y);
     }
 #endif
     return PyFloat_FromDouble(nextafter(x, y));


### PR DESCRIPTION
math_nextafter_impl() must return a Python object, not a C double.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42323](https://bugs.python.org/issue42323) -->
https://bugs.python.org/issue42323
<!-- /issue-number -->
