### PR TITLE
bpo-40455: Fix gcc10+ warning about writing into a section of offset 0

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -408,8 +408,8 @@ emit_pair(PyObject **bytes, int *offset, int a, int b)
         if (_PyBytes_Resize(bytes, len * 2) < 0)
             return 0;
     }
-    unsigned char *lnotab = (unsigned char *)
-                    PyBytes_AS_STRING(*bytes) + *offset;
+    unsigned char *lnotab = (unsigned char *) PyBytes_AS_STRING(*bytes);
+    lnotab += *offset;
     *lnotab++ = a;
     *lnotab++ = b;
     *offset += 2;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5577,9 +5577,8 @@ assemble_emit_linetable_pair(struct assembler *a, int bdelta, int ldelta)
         if (_PyBytes_Resize(&a->a_lnotab, len * 2) < 0)
             return 0;
     }
-    unsigned char *lnotab = (unsigned char *)
-                    PyBytes_AS_STRING(a->a_lnotab) + a->a_lnotab_off;
-
+    unsigned char *lnotab = (unsigned char *) PyBytes_AS_STRING(a->a_lnotab);
+    lnotab += a->a_lnotab_off;
     a->a_lnotab_off += 2;
     *lnotab++ = bdelta;
     *lnotab++ = ldelta;


### PR DESCRIPTION
This silences this warnings:

Objects/codeobject.c:414:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  414 |     *lnotab++ = b;

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40455](https://bugs.python.org/issue40455) -->
https://bugs.python.org/issue40455
<!-- /issue-number -->
