### PR TITLE
bpo-43084: Return bool instead of int from curses.window.enclose()

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -915,6 +915,9 @@ the following methods and attributes:
    determining what subset of the screen windows enclose the location of a mouse
    event.
 
+   .. versionchanged:: 3.10
+      Previously it returned ``1`` or ``0`` instead of ``True`` or ``False``.
+
 
 .. attribute:: window.encoding
 

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -548,13 +548,12 @@ class TestCurses(unittest.TestCase):
     @requires_curses_window_meth('enclose')
     def test_enclose(self):
         win = curses.newwin(5, 15, 2, 5)
-        # TODO: Return bool instead of 1/0
-        self.assertTrue(win.enclose(2, 5))
-        self.assertFalse(win.enclose(1, 5))
-        self.assertFalse(win.enclose(2, 4))
-        self.assertTrue(win.enclose(6, 19))
-        self.assertFalse(win.enclose(7, 19))
-        self.assertFalse(win.enclose(6, 20))
+        self.assertIs(win.enclose(2, 5), True)
+        self.assertIs(win.enclose(1, 5), False)
+        self.assertIs(win.enclose(2, 4), False)
+        self.assertIs(win.enclose(6, 19), True)
+        self.assertIs(win.enclose(7, 19), False)
+        self.assertIs(win.enclose(6, 20), False)
 
     def test_putwin(self):
         win = curses.newwin(5, 12, 1, 2)

--- a/Misc/NEWS.d/next/Library/2021-01-31-17-31-13.bpo-43084.i8nLpK.rst
+++ b/Misc/NEWS.d/next/Library/2021-01-31-17-31-13.bpo-43084.i8nLpK.rst
@@ -1,0 +1,2 @@
+:func:`curses.window.enclose` returns now ``True`` or ``False`` (as was
+documented) instead of ``1`` or ``0``.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1341,7 +1341,7 @@ _curses_window_echochar_impl(PyCursesWindowObject *self, PyObject *ch,
 
 #ifdef NCURSES_MOUSE_VERSION
 /*[clinic input]
-_curses.window.enclose -> long
+_curses.window.enclose
 
     y: int
         Y-coordinate.
@@ -1352,11 +1352,11 @@ _curses.window.enclose -> long
 Return True if the screen-relative coordinates are enclosed by the window.
 [clinic start generated code]*/
 
-static long
+static PyObject *
 _curses_window_enclose_impl(PyCursesWindowObject *self, int y, int x)
-/*[clinic end generated code: output=5251c961cbe3df63 input=dfe1d9d4d05d8642]*/
+/*[clinic end generated code: output=8679beef50502648 input=4fd3355d723f7bc9]*/
 {
-    return wenclose(self->win, y, x);
+    return PyBool_FromLong(wenclose(self->win, y, x));
 }
 #endif
 

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -689,7 +689,7 @@ PyDoc_STRVAR(_curses_window_enclose__doc__,
 #define _CURSES_WINDOW_ENCLOSE_METHODDEF    \
     {"enclose", (PyCFunction)(void(*)(void))_curses_window_enclose, METH_FASTCALL, _curses_window_enclose__doc__},
 
-static long
+static PyObject *
 _curses_window_enclose_impl(PyCursesWindowObject *self, int y, int x);
 
 static PyObject *
@@ -698,7 +698,6 @@ _curses_window_enclose(PyCursesWindowObject *self, PyObject *const *args, Py_ssi
     PyObject *return_value = NULL;
     int y;
     int x;
-    long _return_value;
 
     if (!_PyArg_CheckPositional("enclose", nargs, 2, 2)) {
         goto exit;
@@ -711,11 +710,7 @@ _curses_window_enclose(PyCursesWindowObject *self, PyObject *const *args, Py_ssi
     if (x == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    _return_value = _curses_window_enclose_impl(self, y, x);
-    if ((_return_value == -1) && PyErr_Occurred()) {
-        goto exit;
-    }
-    return_value = PyLong_FromLong(_return_value);
+    return_value = _curses_window_enclose_impl(self, y, x);
 
 exit:
     return return_value;
@@ -4289,4 +4284,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=ae6559aa61200289 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9efc9943a3ac3741 input=a9049054013a1b77]*/


### PR DESCRIPTION


<!-- issue-number: [bpo-43084](https://bugs.python.org/issue43084) -->
https://bugs.python.org/issue43084
<!-- /issue-number -->
