### PR TITLE
[3.9] bpo-41604: Don't decrement the reference count of the previous user_ptr when set_panel_usertpr fails (GH-21933).

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-08-21-15-24-14.bpo-41604.rTXleO.rst
+++ b/Misc/NEWS.d/next/Library/2020-08-21-15-24-14.bpo-41604.rTXleO.rst
@@ -1,0 +1,2 @@
+Don't decrement the reference count of the previous user_ptr when
+set_panel_userptr fails.

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -440,7 +440,9 @@ _curses_panel_panel_set_userptr(PyCursesPanelObject *self, PyObject *obj)
         /* In case of an ncurses error, decref the new object again */
         Py_DECREF(obj);
     }
-    Py_XDECREF(oldobj);
+    else {
+        Py_XDECREF(oldobj);
+    }
     return PyCursesCheckERR(rc, "set_panel_userptr");
 }
 


### PR DESCRIPTION
(cherry picked from commit 3243e8a4b4b4cf321f9b28335d565742a34b1976)

Co-authored-by: Anonymous Maarten <madebr@users.noreply.github.com>


<!-- issue-number: [bpo-41604](https://bugs.python.org/issue41604) -->
https://bugs.python.org/issue41604
<!-- /issue-number -->
