### PR TITLE
bpo-43087: Fix error in ctypes "Incomplete Types" doc

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -919,9 +919,9 @@ Let's try it. We create two instances of ``cell``, and let them point to each
 other, and finally follow the pointer chain a few times::
 
    >>> c1 = cell()
-   >>> c1.name = "foo"
+   >>> c1.name = b"foo"
    >>> c2 = cell()
-   >>> c2.name = "bar"
+   >>> c2.name = b"bar"
    >>> c1.next = pointer(c2)
    >>> c2.next = pointer(c1)
    >>> p = c1


### PR DESCRIPTION
The previous "Fundamental data types" section says a c_char_p must be bytes (or None).


<!-- issue-number: [bpo-43087](https://bugs.python.org/issue43087) -->
https://bugs.python.org/issue43087
<!-- /issue-number -->
