### PR TITLE
Lib: tempfile: Handle macos tempdir

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -46,6 +46,7 @@ from random import Random as _Random
 import sys as _sys
 import types as _types
 import weakref as _weakref
+import platform as _platform
 import _thread
 _allocate_lock = _thread.allocate_lock
 
@@ -276,7 +277,7 @@ tempdir = None
 
 def gettempdir():
     """Accessor for tempfile.tempdir."""
-    if platform.system() == 'Darwin':
+    if _platform.system() == 'Darwin':
         return '/tmp'
     global tempdir
     if tempdir is None:

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -276,6 +276,8 @@ tempdir = None
 
 def gettempdir():
     """Accessor for tempfile.tempdir."""
+    if platform.system() == 'Darwin':
+        return '/tmp'
     global tempdir
     if tempdir is None:
         _once_lock.acquire()


### PR DESCRIPTION
Function `tempfile.gettempdir()` will return something like `/var/folders/nj/269977hs0_96bttwj2gs_jhhp48z54/T` in macos. so, its better to return `/tmp`.