### PR TITLE
bpo-42899: Only eliminate jumps to successor block if jump is unconditional.

### DIFF
--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -354,6 +354,22 @@ class BoolTest(unittest.TestCase):
         self.assertIs(type(False.real), int)
         self.assertIs(type(False.imag), int)
 
+    def test_bool_called_at_least_once(self):
+        class X:
+            def __init__(self):
+                self.count = 0
+            def __bool__(self):
+                self.count += 1
+                return True
+
+        def f(x):
+            if x or True:
+                pass
+
+        x = X()
+        f(x)
+        self.assertGreaterEqual(x.count, 1)
+
 def test_main():
     support.run_unittest(BoolTest)
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6586,27 +6586,14 @@ optimize_cfg(struct assembler *a, PyObject *consts)
     for (basicblock *b = a->a_entry; b != NULL; b = b->b_next) {
         if (b->b_iused > 0) {
             struct instr *b_last_instr = &b->b_instr[b->b_iused - 1];
-            if (b_last_instr->i_opcode == POP_JUMP_IF_FALSE ||
-                b_last_instr->i_opcode == POP_JUMP_IF_TRUE ||
-                b_last_instr->i_opcode == JUMP_ABSOLUTE ||
+            if (b_last_instr->i_opcode == JUMP_ABSOLUTE ||
                 b_last_instr->i_opcode == JUMP_FORWARD) {
                 if (b_last_instr->i_target == b->b_next) {
                     assert(b->b_next->b_iused);
                     b->b_nofallthrough = 0;
-                    switch(b_last_instr->i_opcode) {
-                        case POP_JUMP_IF_FALSE:
-                        case POP_JUMP_IF_TRUE:
-                            b_last_instr->i_opcode = POP_TOP;
-                            b_last_instr->i_target = NULL;
-                            b_last_instr->i_oparg = 0;
-                            break;
-                        case JUMP_ABSOLUTE:
-                        case JUMP_FORWARD:
-                            b_last_instr->i_opcode = NOP;
-                            clean_basic_block(b, -1);
-                            maybe_empty_blocks = 1;
-                            break;
-                    }
+                    b_last_instr->i_opcode = NOP;
+                    clean_basic_block(b, -1);
+                    maybe_empty_blocks = 1;
                 }
             }
         }


### PR DESCRIPTION
Prevents elimination of sole test of value in statements like:
```python
   if x or True: ...
```

Skipping NEWS as this reverts behavior to that of 3.9 and earlier alphas.

<!-- issue-number: [bpo-42899](https://bugs.python.org/issue42899) -->
https://bugs.python.org/issue42899
<!-- /issue-number -->
