### PR TITLE
bpo-42971: Add errno.EQFULL (macOS)

### DIFF
--- a/Doc/library/errno.rst
+++ b/Doc/library/errno.rst
@@ -640,3 +640,5 @@ defined by the module.  The specific list of defined symbols is available as
 .. data:: EQFULL
 
    Interface output queue is full
+   
+   .. versionadded:: 3.11

--- a/Doc/library/errno.rst
+++ b/Doc/library/errno.rst
@@ -640,5 +640,5 @@ defined by the module.  The specific list of defined symbols is available as
 .. data:: EQFULL
 
    Interface output queue is full
-   
+
    .. versionadded:: 3.11

--- a/Doc/library/errno.rst
+++ b/Doc/library/errno.rst
@@ -637,3 +637,6 @@ defined by the module.  The specific list of defined symbols is available as
 
    Quota exceeded
 
+.. data:: EQFULL
+
+   Interface output queue is full

--- a/Misc/NEWS.d/next/Library/2021-02-02-20-11-14.bpo-42971.OpVoFu.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-02-20-11-14.bpo-42971.OpVoFu.rst
@@ -1,0 +1,2 @@
+Add definition of ``errno.EQFULL`` for platforms that define this constant
+(such as macOS).

--- a/Modules/errnomodule.c
+++ b/Modules/errnomodule.c
@@ -920,6 +920,9 @@ errno_exec(PyObject *module)
 #ifdef ESHLIBVERS
     add_errcode("ESHLIBVERS", ESHLIBVERS, "Shared library version mismatch");
 #endif
+#ifdef EQFULL
+    add_errcode("EQFULL", EQFULL, "Interface output queue is full");
+#endif
 
     Py_DECREF(error_dict);
     return 0;


### PR DESCRIPTION
This adds a definition for errno.EQFULL for platforms where that errno is used such as macOS.

<!-- issue-number: [bpo-42971](https://bugs.python.org/issue42971) -->
https://bugs.python.org/issue42971
<!-- /issue-number -->
