### PR TITLE
bpo-43108: Fix a reference leak in the curses module

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-02-02-20-23-31.bpo-43108.lqcCZ6.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-02-20-23-31.bpo-43108.lqcCZ6.rst
@@ -1,0 +1,1 @@
+Fixed a reference leak in the :mod:`curses` module. Patch by Pablo Galindo

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -388,6 +388,7 @@ PyCurses_ConvertToString(PyCursesWindowObject *win, PyObject *obj,
         *bytes = obj;
         /* check for embedded null bytes */
         if (PyBytes_AsStringAndSize(*bytes, &str, NULL) < 0) {
+            Py_DECREF(obj);
             return 0;
         }
         return 1;
@@ -828,8 +829,9 @@ _curses_window_addstr_impl(PyCursesWindowObject *self, int group_left_1,
 #else
     strtype = PyCurses_ConvertToString(self, str, &bytesobj, NULL);
 #endif
-    if (strtype == 0)
+    if (strtype == 0) {
         return NULL;
+    }
     if (use_attr) {
         attr_old = getattrs(self->win);
         (void)wattrset(self->win,attr);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43108](https://bugs.python.org/issue43108) -->
https://bugs.python.org/issue43108
<!-- /issue-number -->
