### PR TITLE
Fix a typo in a deprecation warning

### DIFF
--- a/Lib/distutils/__init__.py
+++ b/Lib/distutils/__init__.py
@@ -13,7 +13,7 @@ import warnings
 
 __version__ = sys.version[:sys.version.index(' ')]
 
-warnings.warn("The distutils package deprecated and slated for "
+warnings.warn("The distutils package is deprecated and slated for "
               "removal in Python 3.12. Use setuptools or check "
               "PEP 632 for potential alternatives",
               DeprecationWarning)


### PR DESCRIPTION
There was a minor typo in the warning message in `Lib/distutils/__init__.py`.