### PR TITLE
bpo-43121: Fix incorrect SyntaxError message for missing comma

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -694,7 +694,7 @@ invalid_primary:
 invalid_comprehension:
     | ('[' | '(' | '{') a=starred_expression for_if_clauses {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "iterable unpacking cannot be used in comprehension") }
-    | ('[' | '{') a=star_named_expression ',' [star_named_expressions] {
+    | ('[' | '{') a=star_named_expression ',' [star_named_expressions] for_if_clauses {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "did you forget parentheses around the comprehension target?") }
 invalid_dict_comprehension:
     | '{' a='**' bitwise_or for_if_clauses '}' {

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -246,9 +246,24 @@ SyntaxError: did you forget parentheses around the comprehension target?
 Traceback (most recent call last):
 SyntaxError: did you forget parentheses around the comprehension target?
 
->>> {x,y: None for x,y in range(100)}
+# Missing commas in non comprehension do not produce special
+# error messages
+
+>>> [1, 2 3]
 Traceback (most recent call last):
-SyntaxError: did you forget parentheses around the comprehension target?
+SyntaxError: invalid syntax
+
+>>> {1, 2 3}
+Traceback (most recent call last):
+SyntaxError: invalid syntax
+
+>>> {1:2, 2:5 3:12}
+Traceback (most recent call last):
+SyntaxError: invalid syntax
+
+>>> (1, 2 3)
+Traceback (most recent call last):
+SyntaxError: invalid syntax
 
 From compiler_complex_args():
 

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -246,8 +246,9 @@ SyntaxError: did you forget parentheses around the comprehension target?
 Traceback (most recent call last):
 SyntaxError: did you forget parentheses around the comprehension target?
 
-# Missing commas in non comprehension do not produce special
-# error messages
+# Missing commas in literals collections should not
+# produce special error messages regarding missing
+# parentheses
 
 >>> [1, 2 3]
 Traceback (most recent call last):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-03-22-33-05.bpo-43121.jqcViq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-03-22-33-05.bpo-43121.jqcViq.rst
@@ -1,0 +1,2 @@
+Fixed an incorrect :exc:`SyntaxError` message for missing comma in literals.
+Patch by Pablo Galindo.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -15217,7 +15217,7 @@ invalid_primary_rule(Parser *p)
 
 // invalid_comprehension:
 //     | ('[' | '(' | '{') starred_expression for_if_clauses
-//     | ('[' | '{') star_named_expression ',' star_named_expressions?
+//     | ('[' | '{') star_named_expression ',' star_named_expressions? for_if_clauses
 static void *
 invalid_comprehension_rule(Parser *p)
 {
@@ -15258,17 +15258,18 @@ invalid_comprehension_rule(Parser *p)
         D(fprintf(stderr, "%*c%s invalid_comprehension[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('[' | '(' | '{') starred_expression for_if_clauses"));
     }
-    { // ('[' | '{') star_named_expression ',' star_named_expressions?
+    { // ('[' | '{') star_named_expression ',' star_named_expressions? for_if_clauses
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> invalid_comprehension[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('[' | '{') star_named_expression ',' star_named_expressions?"));
+        D(fprintf(stderr, "%*c> invalid_comprehension[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "('[' | '{') star_named_expression ',' star_named_expressions? for_if_clauses"));
         Token * _literal;
         void *_opt_var;
         UNUSED(_opt_var); // Silence compiler warnings
         void *_tmp_132_var;
         expr_ty a;
+        asdl_comprehension_seq* for_if_clauses_var;
         if (
             (_tmp_132_var = _tmp_132_rule(p))  // '[' | '{'
             &&
@@ -15277,9 +15278,11 @@ invalid_comprehension_rule(Parser *p)
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
             &&
             (_opt_var = star_named_expressions_rule(p), 1)  // star_named_expressions?
+            &&
+            (for_if_clauses_var = for_if_clauses_rule(p))  // for_if_clauses
         )
         {
-            D(fprintf(stderr, "%*c+ invalid_comprehension[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "('[' | '{') star_named_expression ',' star_named_expressions?"));
+            D(fprintf(stderr, "%*c+ invalid_comprehension[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "('[' | '{') star_named_expression ',' star_named_expressions? for_if_clauses"));
             _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "did you forget parentheses around the comprehension target?" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -15290,7 +15293,7 @@ invalid_comprehension_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s invalid_comprehension[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('[' | '{') star_named_expression ',' star_named_expressions?"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('[' | '{') star_named_expression ',' star_named_expressions? for_if_clauses"));
     }
     _res = NULL;
   done:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43121](https://bugs.python.org/issue43121) -->
https://bugs.python.org/issue43121
<!-- /issue-number -->
