### PR TITLE
bpo-42882: Fix compiler warnings in MSVC

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -56,7 +56,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
     _Py_AuditHookEntry *audit_hook_head = runtime->audit_hook_head;
     // bpo-42882: Preserve next_index value if Py_Initialize()/Py_Finalize()
     // is called multiple times.
-    int64_t unicode_next_index = runtime->unicode_ids.next_index;
+    Py_ssize_t unicode_next_index = runtime->unicode_ids.next_index;
 
     memset(runtime, 0, sizeof(*runtime));
 


### PR DESCRIPTION
In MSVC, I get warnings during compilation:
 ``1>\Documents\GitHub\cpython\Python\pystate.c(96,57): warning C4244: '=': conversion from 'int64_t' to 'Py_ssize_t', possible loss of data``.
It seems that ``runtime->unicode_ids.next_index`` is type Py_ssize_t, not int64_t. 

This was introduced in 44bf57aca627bd11a08b12fe4e4b6a0e1d268862 which only exists in 3.10, so no backport required.

cc @vstinner 

<!-- issue-number: [bpo-42882](https://bugs.python.org/issue42882) -->
https://bugs.python.org/issue42882
<!-- /issue-number -->
