### PR TITLE
Fix compiler warnings in MSVC for winreg.c

### DIFF
--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -680,7 +680,7 @@ _Py_COMP_DIAG_POP
                     assert(size > 0);
                     len = PyUnicode_AsWideChar(t, P, size);
                     assert(len >= 0);
-                    assert(len < size);
+                    assert((unsigned)len < size);
                     size -= (DWORD)len + 1;
                     P += len + 1;
                 }


### PR DESCRIPTION
During compilation, I get a warning:
``1>\Documents\GitHub\cpython\PC\winreg.c(683,21): warning C4018: '<': signed/unsigned mismatch``.
Caused by the line ``assert(len < size);`` because ``len`` is type ``Py_ssize_t`` (signed) and ``size`` is type ``DWORD`` (unsigned).

We can cast len to ``unsigned`` safely to silence the warning (which is what the compiler already does implicitly), because there is already a check for ``assert(len >= 0);`` above.