### PR TITLE
Fix dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
     labels:
       - "skip issue"
       - "skip news"
-    target_branch:
-      - "master"
-      - "3.9"
-      - "3.8"


### PR DESCRIPTION
The `target-branch` field doesn't seem to support array.
Since it defaults to the default branch anyway, we should just remove the `target-branch` field from the config.
