### PR TITLE
unittest lib: raise an error if delta is negative in assertAlmostEqual

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -864,8 +864,12 @@ class TestCase(object):
         if first == second:
             # shortcut
             return
-        if delta is not None and places is not None:
-            raise TypeError("specify delta or places not both")
+
+        if delta is not None:
+            if delta < 0:
+                raise ValueError("delta cannot be negative")
+            if places is not None:
+                raise TypeError("specify delta or places not both")
 
         diff = abs(first - second)
         if delta is not None:


### PR DESCRIPTION
Hello,

right now it is allowed to pass negative delta as argument, however _diff_ is always non-negative `diff = abs(first - second)`. All following checks will always lead to fail which probably is not what user expected


please skip news and skip issue
