### PR TITLE
bpo-30077: Add aifc/sowt pseudo-compression

### DIFF
--- a/Lib/aifc.py
+++ b/Lib/aifc.py
@@ -461,7 +461,7 @@ class Aifc_read:
             self._adpcmstate = None
         data, self._adpcmstate = audioop.adpcm2lin(data, 2, self._adpcmstate)
         return data
-    
+
     def _sowt2lin(self, data):
         import audioop
         return audioop.byteswap(data, 2)

--- a/Lib/aifc.py
+++ b/Lib/aifc.py
@@ -461,6 +461,10 @@ class Aifc_read:
             self._adpcmstate = None
         data, self._adpcmstate = audioop.adpcm2lin(data, 2, self._adpcmstate)
         return data
+    
+    def _sowt2lin(self, data):
+        import audioop
+        return audioop.byteswap(data, 2)
 
     def _read_comm_chunk(self, chunk):
         self._nchannels = _read_short(chunk)
@@ -497,6 +501,8 @@ class Aifc_read:
                     self._convert = self._ulaw2lin
                 elif self._comptype in (b'alaw', b'ALAW'):
                     self._convert = self._alaw2lin
+                elif self._comptype in (b'sowt', b'SOWT'):
+                    self._convert = self._sowt2lin
                 else:
                     raise Error('unsupported compression type')
                 self._sampwidth = 2
@@ -659,7 +665,7 @@ class Aifc_write:
         if self._nframeswritten:
             raise Error('cannot change parameters after starting to write')
         if comptype not in (b'NONE', b'ulaw', b'ULAW',
-                            b'alaw', b'ALAW', b'G722'):
+                            b'alaw', b'ALAW', b'G722', b'sowt', b'SOWT'):
             raise Error('unsupported compression type')
         self._comptype = comptype
         self._compname = compname
@@ -680,7 +686,7 @@ class Aifc_write:
         if self._nframeswritten:
             raise Error('cannot change parameters after starting to write')
         if comptype not in (b'NONE', b'ulaw', b'ULAW',
-                            b'alaw', b'ALAW', b'G722'):
+                            b'alaw', b'ALAW', b'G722', b'sowt', b'SOWT'):
             raise Error('unsupported compression type')
         self.setnchannels(nchannels)
         self.setsampwidth(sampwidth)
@@ -778,14 +784,21 @@ class Aifc_write:
         data, self._adpcmstate = audioop.lin2adpcm(data, 2, self._adpcmstate)
         return data
 
+    def _lin2sowt(self, data):
+        import audioop
+        return audioop.byteswap(data, 2)
+
     def _ensure_header_written(self, datasize):
         if not self._nframeswritten:
-            if self._comptype in (b'ULAW', b'ulaw', b'ALAW', b'alaw', b'G722'):
+            if self._comptype in (b'ULAW', b'ulaw',
+                b'ALAW', b'alaw', b'G722',
+                b'sowt', b'SOWT'):
                 if not self._sampwidth:
                     self._sampwidth = 2
                 if self._sampwidth != 2:
                     raise Error('sample width must be 2 when compressing '
-                                'with ulaw/ULAW, alaw/ALAW or G7.22 (ADPCM)')
+                                'with ulaw/ULAW, alaw/ALAW, sowt/SOWT '
+                                'or G7.22 (ADPCM)')
             if not self._nchannels:
                 raise Error('# channels not specified')
             if not self._sampwidth:
@@ -801,6 +814,8 @@ class Aifc_write:
             self._convert = self._lin2ulaw
         elif self._comptype in (b'alaw', b'ALAW'):
             self._convert = self._lin2alaw
+        elif self._comptype in (b'sowt', b'SOWT'):
+            self._convert = self._lin2sowt
 
     def _write_header(self, initlength):
         if self._aifc and self._comptype != b'NONE':

--- a/Misc/NEWS.d/next/Library/2021-02-04-23-16-03.bpo-30077.v6TqAi.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-04-23-16-03.bpo-30077.v6TqAi.rst
@@ -1,0 +1,1 @@
+Added support for Apple's aifc/sowt pseudo-compression


### PR DESCRIPTION
Add support for Apple's proprietary [SOWT](https://en.wikipedia.org/wiki/Audio_Interchange_File_Format#AIFF_on_Mac_OS_X) AIFF extension.

<!-- issue-number: [bpo-30077](https://bugs.python.org/issue30077) -->
https://bugs.python.org/issue30077
<!-- /issue-number -->
