### PR TITLE
Fix name of executable in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ This will install Python as ``python3``.
 
 You can pass many options to the configure script; run ``./configure --help``
 to find out more.  On macOS case-insensitive file systems and on Cygwin,
-the executable is called ``python.exe``; elsewhere it's just ``python``.
+the executable is called ``python3``; elsewhere it's just ``python``.
 
 Building a complete Python installation requires the use of various
 additional third-party libraries, depending on your build platform and


### PR DESCRIPTION
It is _definitely_ not called `python.exe` on macOS. Not sure about Cygwin, since I haven't used it. If someone could check it for me, that would be great.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
