### PR TITLE
bpo-43146: fix a recent (3.10) regression in handling None inputs to `tra…

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -232,6 +232,29 @@ class TracebackCases(unittest.TestCase):
         output = traceback.format_exception_only(Exception("projector"))
         self.assertEqual(output, ["Exception: projector\n"])
 
+    def test_exception_is_None(self):
+        NONE_EXC_STRING = 'NoneType: None\n'
+        excfile = StringIO()
+        traceback.print_exception(None, file=excfile)
+        self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
+
+        excfile = StringIO()
+        traceback.print_exception(None, None, None, file=excfile)
+        self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
+
+        excfile = StringIO()
+        traceback.print_exc(None, file=excfile)
+        self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
+
+        self.assertEqual(traceback.format_exc(None), NONE_EXC_STRING)
+        self.assertEqual(traceback.format_exception(None), [NONE_EXC_STRING])
+        self.assertEqual(
+            traceback.format_exception(None, None, None), [NONE_EXC_STRING])
+        self.assertEqual(
+            traceback.format_exception_only(None), [NONE_EXC_STRING])
+        self.assertEqual(
+            traceback.format_exception_only(None, None), [NONE_EXC_STRING])
+
 
 class TracebackFormatTests(unittest.TestCase):
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -235,10 +235,6 @@ class TracebackCases(unittest.TestCase):
     def test_exception_is_None(self):
         NONE_EXC_STRING = 'NoneType: None\n'
         excfile = StringIO()
-        traceback.print_exception(None, file=excfile)
-        self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
-
-        excfile = StringIO()
         traceback.print_exception(None, None, None, file=excfile)
         self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
 
@@ -247,7 +243,6 @@ class TracebackCases(unittest.TestCase):
         self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
 
         self.assertEqual(traceback.format_exc(None), NONE_EXC_STRING)
-        self.assertEqual(traceback.format_exception(None), [NONE_EXC_STRING])
         self.assertEqual(
             traceback.format_exception(None, None, None), [NONE_EXC_STRING])
         self.assertEqual(

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -91,7 +91,10 @@ def _parse_value_tb(exc, value, tb):
     if (value is _sentinel) != (tb is _sentinel):
         raise ValueError("Both or neither of value and tb must be given")
     if value is tb is _sentinel:
-        return exc, exc.__traceback__
+        if exc is not None:
+            return exc, exc.__traceback__
+        else:
+            return None, None
     return value, tb
 
 
@@ -528,7 +531,9 @@ class TracebackException:
                     cause = None
 
                 if compact:
-                    need_context = cause is None and not e.__suppress_context__
+                    need_context = (cause is None and
+                                    e is not None and
+                                    not e.__suppress_context__)
                 else:
                     need_context = True
                 if (e and e.__context__ is not None

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -91,10 +91,7 @@ def _parse_value_tb(exc, value, tb):
     if (value is _sentinel) != (tb is _sentinel):
         raise ValueError("Both or neither of value and tb must be given")
     if value is tb is _sentinel:
-        if exc is not None:
-            return exc, exc.__traceback__
-        else:
-            return None, None
+        return exc, exc.__traceback__
     return value, tb
 
 

--- a/Misc/NEWS.d/next/Library/2021-02-06-21-21-35.bpo-43146.MHtb2v.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-06-21-21-35.bpo-43146.MHtb2v.rst
@@ -1,1 +1,1 @@
-Fix two recent regressions in None argument handling in :mod:`~traceback` module functions.
+Fix recent regression in None argument handling in :mod:`~traceback` module functions.

--- a/Misc/NEWS.d/next/Library/2021-02-06-21-21-35.bpo-43146.MHtb2v.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-06-21-21-35.bpo-43146.MHtb2v.rst
@@ -1,0 +1,1 @@
+Fix two recent regressions in None argument handling in :mod:`~traceback` module functions.


### PR DESCRIPTION
…ceback` module methods

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43146](https://bugs.python.org/issue43146) -->
https://bugs.python.org/issue43146
<!-- /issue-number -->
