### PR TITLE
bpo-43152: Update assert statement to remove unused warning

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4744,7 +4744,7 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
         Py_DECREF(defaults);
         return NULL;
     }
-#ifdef Py_DEBUG
+#ifndef NDEBUG
     PyCodeObject *code = (PyCodeObject *)_co;
     assert ((code->co_flags & (CO_NEWLOCALS | CO_OPTIMIZED)) == 0);
 #endif

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4744,8 +4744,10 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
         Py_DECREF(defaults);
         return NULL;
     }
+#ifdef Py_DEBUG
     PyCodeObject *code = (PyCodeObject *)_co;
     assert ((code->co_flags & (CO_NEWLOCALS | CO_OPTIMIZED)) == 0);
+#endif
     if (locals == NULL) {
         locals = globals;
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4744,10 +4744,7 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
         Py_DECREF(defaults);
         return NULL;
     }
-#ifndef NDEBUG
-    PyCodeObject *code = (PyCodeObject *)_co;
-    assert ((code->co_flags & (CO_NEWLOCALS | CO_OPTIMIZED)) == 0);
-#endif
+    assert ((((PyCodeObject *)_co)->co_flags & (CO_NEWLOCALS | CO_OPTIMIZED)) == 0);
     if (locals == NULL) {
         locals = globals;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

```
Python/ceval.c:4747:19: warning: unused variable 'code' [-Wunused-variable]
    PyCodeObject *code = (PyCodeObject *)_co;
```

<!-- issue-number: [bpo-43152](https://bugs.python.org/issue43152) -->
https://bugs.python.org/issue43152
<!-- /issue-number -->
