### PR TITLE
bpo-43194: Add JFXX as jpeg marker to imghdr.py

### DIFF
--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -36,7 +36,7 @@ tests = []
 
 def test_jpeg(h, f):
     """JPEG data in JFIF or Exif format"""
-    if h[6:10] in (b'JFIF', b'Exif'):
+    if h[6:10] in (b'JFIF', b'Exif', b'JFXX'):
         return 'jpeg'
 
 tests.append(test_jpeg)


### PR DESCRIPTION
Add support for JFIF extension APP0 marker ("JFXX" Header) in imghdr.

<!-- issue-number: [bpo-43194](https://bugs.python.org/issue43194) -->
https://bugs.python.org/issue43194
<!-- /issue-number -->
