### PR TITLE
bpo-43125: Fix: return expected type (str), not original value (bytes) in email/base64mime.py::body_encode

### DIFF
--- a/Lib/email/base64mime.py
+++ b/Lib/email/base64mime.py
@@ -84,7 +84,7 @@ def body_encode(s, maxlinelen=76, eol=NL):
     in an email.
     """
     if not s:
-        return s
+        return ""
 
     encvec = []
     max_unencoded = maxlinelen * 3 // 4

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -4261,7 +4261,7 @@ class TestBase64(unittest.TestCase):
 
     def test_encode(self):
         eq = self.assertEqual
-        eq(base64mime.body_encode(b''), '')  # bpo-43125
+        eq(base64mime.body_encode(b''), '')
         eq(base64mime.body_encode(b'hello'), 'aGVsbG8=\n')
         # Test the binary flag
         eq(base64mime.body_encode(b'hello\n'), 'aGVsbG8K\n')

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -4261,7 +4261,7 @@ class TestBase64(unittest.TestCase):
 
     def test_encode(self):
         eq = self.assertEqual
-        eq(base64mime.body_encode(b''), '')  # empty bytes ? empty string !
+        eq(base64mime.body_encode(b''), '')  # bpo-43125
         eq(base64mime.body_encode(b'hello'), 'aGVsbG8=\n')
         # Test the binary flag
         eq(base64mime.body_encode(b'hello\n'), 'aGVsbG8K\n')

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -4261,7 +4261,7 @@ class TestBase64(unittest.TestCase):
 
     def test_encode(self):
         eq = self.assertEqual
-        eq(base64mime.body_encode(b''), b'')
+        eq(base64mime.body_encode(b''), '')  # empty bytes ? empty string !
         eq(base64mime.body_encode(b'hello'), 'aGVsbG8=\n')
         # Test the binary flag
         eq(base64mime.body_encode(b'hello\n'), 'aGVsbG8K\n')
@@ -4290,7 +4290,6 @@ eHh4eCB4eHh4IA==\r
         # Test the charset option
         eq(he('hello', charset='iso-8859-2'), '=?iso-8859-2?b?aGVsbG8=?=')
         eq(he('hello\nworld'), '=?iso-8859-1?b?aGVsbG8Kd29ybGQ=?=')
-
 
 
 class TestQuopri(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2021-02-07-19-13-30.bpo-43125.AqNoMa.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-07-19-13-30.bpo-43125.AqNoMa.rst
@@ -1,0 +1,1 @@
+Fix: return expected type (str), not original value (bytes) in Lib/email/base64mime.py

--- a/Misc/NEWS.d/next/Library/2021-02-07-19-13-30.bpo-43125.AqNoMa.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-07-19-13-30.bpo-43125.AqNoMa.rst
@@ -1,1 +1,1 @@
-Fix: return expected type (str), not original value (bytes) in Lib/email/base64mime.py
+Return empty string if base64mime.body_encode receive empty bytes


### PR DESCRIPTION
All in title.

the utility function `Lib/email/base64mime.py::body_encode` :

```
def body_encode(s, maxlinelen=76, eol=NL):
```

returns its given input if this one evaluates to False. This is bad. given the expected input is bytes but the expected output is str. ( `return EMPTYSTRING.join(encvec)` ). 

The fix looks obvious: return an empty string instead of the original object (whatever type it might be).


<!-- issue-number: [bpo-43125](https://bugs.python.org/issue43125) -->
https://bugs.python.org/issue43125
<!-- /issue-number -->
