### PR TITLE
gh-87326: Add extend_const action to argparse

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -842,6 +842,21 @@ how the command-line arguments should be handled. The supplied actions are:
 
   .. versionadded:: 3.8
 
+* ``'extend_const'`` - This stores a list, and extends each argument value to the list.
+  The ``'extend_const'`` action is typically useful when you want to provide an alias
+  that is the combination of multiple other arguments. For example::
+
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument('--str', dest='types', action='append_const', const=str)
+    >>> parser.add_argument('--int', dest='types', action='append_const', const=int)
+    >>> parser.add_argument('--both', dest='types', action='extend_const', const=(str, int))
+    >>> parser.parse_args('--str --int'.split())
+    Namespace(types=[<class 'str'>, <class 'int'>])
+    >>> parser.parse_args('--both'.split())
+    Namespace(types=[<class 'str'>, <class 'int'>])
+
+  .. versionadded:: TBA
+
 You may also specify an arbitrary action by passing an Action subclass or
 other object that implements the same interface. The ``BooleanOptionalAction``
 is available in ``argparse`` and adds support for boolean actions such as

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -138,8 +138,9 @@ class _AttributeHolder(object):
 def _copy_items(items):
     if items is None:
         return []
-    # The copy module is used only in the 'append' and 'append_const'
-    # actions, and it is needed only when the default value isn't a list.
+    # The copy module is used in the 'append', 'append_const', 'extend', and
+    # 'extend_const' actions, and it is needed only when the default value
+    # isn't a list.
     # Delay its import for speeding up the common case.
     if type(items) is list:
         return items[:]

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1219,6 +1219,13 @@ class _ExtendAction(_AppendAction):
         items.extend(values)
         setattr(namespace, self.dest, items)
 
+class _ExtendConstAction(_AppendConstAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest, None)
+        items = _copy_items(items)
+        items.extend(self.const)
+        setattr(namespace, self.dest, items)
+
 # ==============
 # Type classes
 # ==============
@@ -1328,6 +1335,7 @@ class _ActionsContainer(object):
         self.register('action', 'version', _VersionAction)
         self.register('action', 'parsers', _SubParsersAction)
         self.register('action', 'extend', _ExtendAction)
+        self.register('action', 'extend_const', _ExtendConstAction)
 
         # raise an exception if the conflict handler is invalid
         self._get_handler()

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -774,6 +774,34 @@ class TestOptionalsActionAppendConstWithDefault(ParserTestCase):
         ('-b -cx -b -cyz', NS(b=['X', Exception, 'x', Exception, 'yz'])),
     ]
 
+class TestOptionalsActionExtendConst(ParserTestCase):
+    """Tests the extend_const action for an Optional"""
+
+    argument_signatures = [
+        Sig('-b', action='extend_const', const=[Exception, Exception]),
+        Sig('-c', action='extend', dest='b'),
+    ]
+    failures = ['a', '-c', 'a -c', '-bx', '-b x']
+    successes = [
+        ('', NS(b=None)),
+        ('-b', NS(b=[Exception, Exception])),
+        ('-b -cx -b -cyz', NS(b=[Exception, Exception, 'x', Exception, Exception, 'y', 'z'])),
+    ]
+
+class TestOptionalsActionExtendConstWithDefault(ParserTestCase):
+    """Tests the extend_const action for an Optional"""
+
+    argument_signatures = [
+        Sig('-b', action='extend_const', const=[Exception, Exception], default=['X']),
+        Sig('-c', action='extend', dest='b'),
+    ]
+    failures = ['a', '-c', 'a -c', '-bx', '-b x']
+    successes = [
+        ('', NS(b=['X'])),
+        ('-b', NS(b=['X', Exception, Exception])),
+        ('-b -cx -b -cyz', NS(b=['X', Exception, Exception, 'x', Exception, Exception, 'y', 'z'])),
+    ]
+
 
 class TestOptionalsActionCount(ParserTestCase):
     """Tests the count action for an Optional"""

--- a/Misc/NEWS.d/next/Library/2021-02-08-04-23-43.bpo-43160.7Uni_P.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-08-04-23-43.bpo-43160.7Uni_P.rst
@@ -1,0 +1,1 @@
+Add ``extend_const`` action to argparse.


### PR DESCRIPTION
This adds a new action, `extend_const`, which mimics `append_const` except it extends the argument dest instead of appending. This is useful for using a single argument to add multiple items to the destination.

I added tests that were red before adding the implementation, and are green now. I also added docs. I haven't contributed to CPython before and am following https://devguide.python.org/, but please let me know if I missed something.

<!-- issue-number: [bpo-43160](https://bugs.python.org/issue43160) -->
https://bugs.python.org/issue43160
<!-- /issue-number -->

<!-- gh-issue-number: gh-87326 -->
* Issue: gh-87326
<!-- /gh-issue-number -->
