### PR TITLE
bpo-43176: Fix processing of empty dataclasses

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -851,7 +851,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
         # Only process classes that have been processed by our
         # decorator.  That is, they have a _FIELDS attribute.
         base_fields = getattr(b, _FIELDS, None)
-        if base_fields:
+        if base_fields is not None:
             has_dataclass_bases = True
             for f in base_fields.values():
                 fields[f.name] = f

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2594,6 +2594,30 @@ class TestFrozen(unittest.TestCase):
         self.assertEqual(d.i, 0)
         self.assertEqual(d.j, 10)
 
+    def test_inherit_nonfrozen_from_empty_frozen(self):
+        @dataclass(frozen=True)
+        class C:
+            pass
+
+        with self.assertRaisesRegex(TypeError,
+                                    'cannot inherit non-frozen dataclass from a frozen one'):
+            @dataclass
+            class D(C):
+                j: int
+
+    def test_inherit_nonfrozen_from_empty_(self):
+        @dataclass
+        class C:
+            pass
+
+        @dataclass
+        class D(C):
+            j: int
+
+        d = D(3)
+        self.assertEqual(d.j, 3)
+        self.assertIsInstance(d, C)
+
     # Test both ways: with an intermediate normal (non-dataclass)
     #  class and without an intermediate class.
     def test_inherit_nonfrozen_from_frozen(self):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2605,7 +2605,7 @@ class TestFrozen(unittest.TestCase):
             class D(C):
                 j: int
 
-    def test_inherit_nonfrozen_from_empty_(self):
+    def test_inherit_nonfrozen_from_empty(self):
         @dataclass
         class C:
             pass

--- a/Misc/NEWS.d/next/Library/2021-02-09-07-24-29.bpo-43176.bocNQn.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-09-07-24-29.bpo-43176.bocNQn.rst
@@ -1,0 +1,1 @@
+Fixed processing of empty dataclasses.


### PR DESCRIPTION
When a dataclass inherits from an empty base, all immutability checks are omitted. This PR fixes this and adds tests for it.

<!-- issue-number: [bpo-43176](https://bugs.python.org/issue43176) -->
https://bugs.python.org/issue43176
<!-- /issue-number -->

Automerge-Triggered-By: GH:ericvsmith