### PR TITLE
bpo-43166 Disable ceval.c optimisations for Windows debug builds

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -180,7 +180,7 @@ typedef int Py_ssize_clean_t;
  */
 
 #if defined(_MSC_VER)
-#  if defined(PY_LOCAL_AGGRESSIVE)
+#  if defined(PY_LOCAL_AGGRESSIVE) && !defined(Py_DEBUG)
    /* enable more aggressive optimization for visual studio */
 #  pragma optimize("agtw", on)
 #endif

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -181,8 +181,8 @@ typedef int Py_ssize_clean_t;
 
 #if defined(_MSC_VER)
 #  if defined(PY_LOCAL_AGGRESSIVE) && !defined(Py_DEBUG)
-   /* enable more aggressive optimization for visual studio */
-#  pragma optimize("agtw", on)
+   /* enable more aggressive optimization for MSVC */
+#  pragma optimize("gt", on)
 #endif
    /* ignore warnings if the compiler decides not to inline a function */
 #  pragma warning(disable: 4710)


### PR DESCRIPTION
This ensures that ceval.c can be debugged.

<!-- issue-number: [bpo-43166](https://bugs.python.org/issue43166) -->
https://bugs.python.org/issue43166
<!-- /issue-number -->
