### PR TITLE
bpo-43178: Redundant method overrides in queue

### DIFF
--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -229,9 +229,6 @@ class PriorityQueue(Queue):
     def _init(self, maxsize):
         self.queue = []
 
-    def _qsize(self):
-        return len(self.queue)
-
     def _put(self, item):
         heappush(self.queue, item)
 
@@ -244,9 +241,6 @@ class LifoQueue(Queue):
 
     def _init(self, maxsize):
         self.queue = []
-
-    def _qsize(self):
-        return len(self.queue)
 
     def _put(self, item):
         self.queue.append(item)

--- a/Misc/NEWS.d/next/Library/2021-02-09-10-06-37.bpo-43178.Lbvvsz.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-09-10-06-37.bpo-43178.Lbvvsz.rst
@@ -1,1 +1,0 @@
-Removed redundant method definitions of _qsize in PriorityQueue and LIFOQueue. These methods already inherit the exact same implementation from their parent class, Queue, so these are not necessary

--- a/Misc/NEWS.d/next/Library/2021-02-09-10-06-37.bpo-43178.Lbvvsz.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-09-10-06-37.bpo-43178.Lbvvsz.rst
@@ -1,0 +1,1 @@
+Removed redundant method definitions of _qsize in PriorityQueue and LIFOQueue. These methods already inherit the exact same implementation from their parent class, Queue, so these are not necessary


### PR DESCRIPTION
Fixed redundant method definitions of _qsize.

<!-- issue-number: [bpo-43178](https://bugs.python.org/issue43178) -->
https://bugs.python.org/issue43178
<!-- /issue-number -->
