### PR TITLE
[3.8] bpo-41824: Add versionadded for typing.ForwardRef docs (GH-24224)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1020,6 +1020,8 @@ The module defines the following classes, functions and decorators:
    ``List[ForwardRef("SomeClass")]``.  This class should not be instantiated by
    a user, but may be used by introspection tools.
 
+  .. versionadded:: 3.7.4
+
 .. function:: NewType(name, tp)
 
    A helper function to indicate a distinct type to a typechecker,


### PR DESCRIPTION
(cherry picked from commit da21f7b6e1fd5bd3e78931a06c5eb694f6335233)

<!-- issue-number: [bpo-41824](https://bugs.python.org/issue41824) -->
https://bugs.python.org/issue41824
<!-- /issue-number -->
