### PR TITLE
[3.8] bpo-41824: Fix indentation issue in ForwardRef docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1020,6 +1020,8 @@ The module defines the following classes, functions and decorators:
    ``List[ForwardRef("SomeClass")]``.  This class should not be instantiated by
    a user, but may be used by introspection tools.
 
+  .. versionadded:: 3.7.4
+
 .. function:: NewType(name, tp)
 
    A helper function to indicate a distinct type to a typechecker,

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1020,7 +1020,7 @@ The module defines the following classes, functions and decorators:
    ``List[ForwardRef("SomeClass")]``.  This class should not be instantiated by
    a user, but may be used by introspection tools.
 
-  .. versionadded:: 3.7.4
+   .. versionadded:: 3.7.4
 
 .. function:: NewType(name, tp)
 


### PR DESCRIPTION
Introduced by c8a48c6d0417cc8f256a40142962825febdc2e20.

<!-- issue-number: [bpo-41824](https://bugs.python.org/issue41824) -->
https://bugs.python.org/issue41824
<!-- /issue-number -->
