### PR TITLE
Fix link to sqlite3 enable_shared_cache documentation

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -644,7 +644,7 @@ Deprecated
 * The undocumented built-in function ``sqlite3.enable_shared_cache`` is now
   deprecated, scheduled for removal in Python 3.12.  Its use is strongly
   discouraged by the SQLite3 documentation.  See `the SQLite3 docs
-  <https://sqlite.org/c3ref/enable_shared_cache.html/>`_ for more details.
+  <https://sqlite.org/c3ref/enable_shared_cache.html>`_ for more details.
   If shared cache must be used, open the database in URI mode using the
   ``cache=shared`` query parameter.
   (Contributed by Erlend E. Aasland in :issue:`24464`.)


### PR DESCRIPTION
Currently the link 404's, removing the slash fixes this.