### PR TITLE
bpo-43174: Windows: Use /utf-8 compiler option.

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-02-10-14-11-53.bpo-43174.F9zwXQ.rst
+++ b/Misc/NEWS.d/next/Build/2021-02-10-14-11-53.bpo-43174.F9zwXQ.rst
@@ -1,1 +1,1 @@
-Windows build now uses ``/utf8`` compiler option.
+Windows build now uses ``/utf-8`` compiler option.

--- a/Misc/NEWS.d/next/Build/2021-02-10-14-11-53.bpo-43174.F9zwXQ.rst
+++ b/Misc/NEWS.d/next/Build/2021-02-10-14-11-53.bpo-43174.F9zwXQ.rst
@@ -1,0 +1,1 @@
+Windows build now uses ``/utf8`` compiler option.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -55,6 +55,9 @@
     <ClCompile Condition="$(ICCBuild) == 'true'">
       <FloatingPointModel>Strict</FloatingPointModel>
     </ClCompile>
+    <ClCompile>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -46,6 +46,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">OnlyExplicitInline</InlineFunctionExpansion>
       <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ClCompile Condition="$(Configuration) == 'Debug'">
       <Optimization>Disabled</Optimization>
@@ -54,9 +55,6 @@
     </ClCompile>
     <ClCompile Condition="$(ICCBuild) == 'true'">
       <FloatingPointModel>Strict</FloatingPointModel>
-    </ClCompile>
-    <ClCompile>
-      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION


<!-- issue-number: [bpo-43174](https://bugs.python.org/issue43174) -->
https://bugs.python.org/issue43174
<!-- /issue-number -->
