### PR TITLE
bpo-43172: readline now passes its tests when built against libedit

### DIFF
--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -258,7 +258,9 @@ with a custom completer, a different set of word delimiters should be set.
    Get the beginning or ending index of the completion scope.
    These indexes are the *start* and *end* arguments passed to the
    :c:data:`rl_attempted_completion_function` callback of the
-   underlying library.
+   underlying library.  The values may be different in the same
+   input editing scenario based on the underlying C readline implemtation.
+   Ex: libedit is known to behave differently than libreadline.
 
 
 .. function:: set_completer_delims(string)

--- a/Misc/NEWS.d/next/Library/2021-02-10-06-00-53.bpo-43172.ZMCJni.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-10-06-00-53.bpo-43172.ZMCJni.rst
@@ -1,0 +1,4 @@
+The readline module now passes its tests when built directly against
+libedit. Existing irreconcilable API differences remain in
+:func:`readline.get_begidx` and :func:`readline.get_endidx` behavior based
+on libreadline vs libedit use.

--- a/Modules/clinic/readline.c.h
+++ b/Modules/clinic/readline.c.h
@@ -384,7 +384,7 @@ PyDoc_STRVAR(readline_remove_history_item__doc__,
 "remove_history_item($module, pos, /)\n"
 "--\n"
 "\n"
-"Remove history item given by its position.");
+"Remove history item given by its zero-based position.");
 
 #define READLINE_REMOVE_HISTORY_ITEM_METHODDEF    \
     {"remove_history_item", (PyCFunction)readline_remove_history_item, METH_O, readline_remove_history_item__doc__},
@@ -412,7 +412,9 @@ PyDoc_STRVAR(readline_replace_history_item__doc__,
 "replace_history_item($module, pos, line, /)\n"
 "--\n"
 "\n"
-"Replaces history item given by its position with contents of line.");
+"Replaces history item given by its position with contents of line.\n"
+"\n"
+"pos is zero-based.");
 
 #define READLINE_REPLACE_HISTORY_ITEM_METHODDEF    \
     {"replace_history_item", (PyCFunction)(void(*)(void))readline_replace_history_item, METH_FASTCALL, readline_replace_history_item__doc__},
@@ -563,7 +565,7 @@ PyDoc_STRVAR(readline_get_history_item__doc__,
 "get_history_item($module, index, /)\n"
 "--\n"
 "\n"
-"Return the current contents of history item at index.");
+"Return the current contents of history item at one-based index.");
 
 #define READLINE_GET_HISTORY_ITEM_METHODDEF    \
     {"get_history_item", (PyCFunction)readline_get_history_item, METH_O, readline_get_history_item__doc__},
@@ -683,4 +685,4 @@ readline_redisplay(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef READLINE_CLEAR_HISTORY_METHODDEF
     #define READLINE_CLEAR_HISTORY_METHODDEF
 #endif /* !defined(READLINE_CLEAR_HISTORY_METHODDEF) */
-/*[clinic end generated code: output=cb44f391ccbfb565 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f7d390113b27989f input=a9049054013a1b77]*/

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -594,8 +594,7 @@ readline.remove_history_item
     pos as entry_number: int
     /
 
-Remove history item given by its position.
-pos is zero-based.
+Remove history item given by its zero-based position.
 [clinic start generated code]*/
 
 static PyObject *
@@ -629,6 +628,7 @@ readline.replace_history_item
     /
 
 Replaces history item given by its position with contents of line.
+
 pos is zero-based.
 [clinic start generated code]*/
 
@@ -792,8 +792,7 @@ readline.get_history_item
     index as idx: int
     /
 
-Return the current contents of history item at index.
-index is one-based.
+Return the current contents of history item at one-based index.
 [clinic start generated code]*/
 
 static PyObject *

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -599,7 +599,7 @@ Remove history item given by its zero-based position.
 
 static PyObject *
 readline_remove_history_item_impl(PyObject *module, int entry_number)
-/*[clinic end generated code: output=ab114f029208c7e8 input=c8520ac3da50224e]*/
+/*[clinic end generated code: output=ab114f029208c7e8 input=f248beb720ff1838]*/
 {
     HIST_ENTRY *entry;
 
@@ -635,7 +635,7 @@ pos is zero-based.
 static PyObject *
 readline_replace_history_item_impl(PyObject *module, int entry_number,
                                    PyObject *line)
-/*[clinic end generated code: output=f8cec2770ca125eb input=b7ccef0780ae041b]*/
+/*[clinic end generated code: output=f8cec2770ca125eb input=368bb66fe5ee5222]*/
 {
     PyObject *encoded;
     HIST_ENTRY *old_entry;
@@ -797,7 +797,7 @@ Return the current contents of history item at one-based index.
 
 static PyObject *
 readline_get_history_item_impl(PyObject *module, int idx)
-/*[clinic end generated code: output=83d3e53ea5f34b3d input=63fff0c3c4323269]*/
+/*[clinic end generated code: output=83d3e53ea5f34b3d input=8adf5c80e6c7ff2b]*/
 {
     HIST_ENTRY *hist_ent;
 


### PR DESCRIPTION
Existing irreconcilable API differences remain in readline.get_begidx and readline.get_endidx behavior based on libreadline vs libedit use.


<!-- issue-number: [bpo-43172](https://bugs.python.org/issue43172) -->
https://bugs.python.org/issue43172
<!-- /issue-number -->
