### PR TITLE
bpo-40956: [regression] first argument in sqlite3.Connection.backup is mandatory

### DIFF
--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -17,9 +17,11 @@ class BackupTests(unittest.TestCase):
         self.assertEqual(result[0][0], 3)
         self.assertEqual(result[1][0], 4)
 
-    def test_bad_target_none(self):
+    def test_bad_target(self):
         with self.assertRaises(TypeError):
             self.cx.backup(None)
+        with self.assertRaises(TypeError):
+            self.cx.backup()
 
     def test_bad_target_filename(self):
         with self.assertRaises(TypeError):

--- a/Misc/NEWS.d/next/Library/2021-02-10-23-29-50.bpo-40956.LcAbwG.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-10-23-29-50.bpo-40956.LcAbwG.rst
@@ -1,0 +1,2 @@
+Fix segfault in ``sqlite3.Connection.backup`` if no argument was provided.
+The regression was introduced by GH-23838. Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Library/2021-02-10-23-29-50.bpo-40956.LcAbwG.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-10-23-29-50.bpo-40956.LcAbwG.rst
@@ -1,2 +1,3 @@
-Fix segfault in ``sqlite3.Connection.backup`` if no argument was provided.
-The regression was introduced by GH-23838. Patch by Erlend E. Aasland.
+Fix segfault in :meth:`sqlite3.Connection.backup` if no argument was
+provided. The regression was introduced by GH-23838. Patch by
+Erlend E. Aasland.

--- a/Modules/_sqlite/clinic/connection.c.h
+++ b/Modules/_sqlite/clinic/connection.c.h
@@ -519,8 +519,8 @@ pysqlite_connection_iterdump(pysqlite_Connection *self, PyObject *Py_UNUSED(igno
 }
 
 PyDoc_STRVAR(pysqlite_connection_backup__doc__,
-"backup($self, /, target=<unrepresentable>, *, pages=-1, progress=None,\n"
-"       name=\'main\', sleep=0.25)\n"
+"backup($self, /, target, *, pages=-1, progress=None, name=\'main\',\n"
+"       sleep=0.25)\n"
 "--\n"
 "\n"
 "Makes a backup of the database. Non-standard.");
@@ -541,31 +541,22 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *const *args, Py_
     static const char * const _keywords[] = {"target", "pages", "progress", "name", "sleep", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "backup", 0};
     PyObject *argsbuf[5];
-    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
-    pysqlite_Connection *target = NULL;
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
+    pysqlite_Connection *target;
     int pages = -1;
     PyObject *progress = Py_None;
     const char *name = "main";
     double sleep = 0.25;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 1, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
     if (!args) {
         goto exit;
     }
-    if (!noptargs) {
-        goto skip_optional_pos;
+    if (!PyObject_TypeCheck(args[0], pysqlite_ConnectionType)) {
+        _PyArg_BadArgument("backup", "argument 'target'", (pysqlite_ConnectionType)->tp_name, args[0]);
+        goto exit;
     }
-    if (args[0]) {
-        if (!PyObject_TypeCheck(args[0], pysqlite_ConnectionType)) {
-            _PyArg_BadArgument("backup", "argument 'target'", (pysqlite_ConnectionType)->tp_name, args[0]);
-            goto exit;
-        }
-        target = (pysqlite_Connection *)args[0];
-        if (!--noptargs) {
-            goto skip_optional_pos;
-        }
-    }
-skip_optional_pos:
+    target = (pysqlite_Connection *)args[0];
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
@@ -719,4 +710,4 @@ exit:
 #ifndef PYSQLITE_CONNECTION_LOAD_EXTENSION_METHODDEF
     #define PYSQLITE_CONNECTION_LOAD_EXTENSION_METHODDEF
 #endif /* !defined(PYSQLITE_CONNECTION_LOAD_EXTENSION_METHODDEF) */
-/*[clinic end generated code: output=7cb13d491a5970aa input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c1bf09db3bcd0105 input=a9049054013a1b77]*/

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1582,7 +1582,7 @@ finally:
 /*[clinic input]
 _sqlite3.Connection.backup as pysqlite_connection_backup
 
-    target: object(type='pysqlite_Connection *', subclass_of='pysqlite_ConnectionType') = NULL
+    target: object(type='pysqlite_Connection *', subclass_of='pysqlite_ConnectionType')
     *
     pages: int = -1
     progress: object = None
@@ -1597,7 +1597,7 @@ pysqlite_connection_backup_impl(pysqlite_Connection *self,
                                 pysqlite_Connection *target, int pages,
                                 PyObject *progress, const char *name,
                                 double sleep)
-/*[clinic end generated code: output=306a3e6a38c36334 input=2f3497ea530144b1]*/
+/*[clinic end generated code: output=306a3e6a38c36334 input=30ae45fc420bfd3b]*/
 {
     int rc;
     int callback_error = 0;


### PR DESCRIPTION
Regression introduced by GH-23838.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40956](https://bugs.python.org/issue40956) -->
https://bugs.python.org/issue40956
<!-- /issue-number -->
