### PR TITLE
bpo-43200: Fix a link to shutil.copy() in the shutil module docs

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -443,8 +443,9 @@ Directory and files operations
 Platform-dependent efficient copy operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting from Python 3.8 all functions involving a file copy (:func:`copyfile`,
-:func:`copy`, :func:`copy2`, :func:`copytree`, and :func:`move`) may use
+Starting from Python 3.8, all functions involving a file copy
+(:func:`~shutil.copyfile`, :func:`~shutil.copy`, :func:`~shutil.copy2`,
+:func:`~shutil.copytree`, and :func:`~shutil.move`) may use
 platform-specific "fast-copy" syscalls in order to copy the file more
 efficiently (see :issue:`33671`).
 "fast-copy" means that the copying operation occurs within the kernel, avoiding

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -444,8 +444,8 @@ Platform-dependent efficient copy operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting from Python 3.8, all functions involving a file copy
-(:func:`~shutil.copyfile`, :func:`~shutil.copy`, :func:`~shutil.copy2`,
-:func:`~shutil.copytree`, and :func:`~shutil.move`) may use
+(:func:`copyfile`, :func:`~shutil.copy`, :func:`copy2`,
+:func:`copytree`, and :func:`move`) may use
 platform-specific "fast-copy" syscalls in order to copy the file more
 efficiently (see :issue:`33671`).
 "fast-copy" means that the copying operation occurs within the kernel, avoiding


### PR DESCRIPTION
A link generated for the copy() function was linking to the copy
module.  It should link to the shutil.copy() function instead.

Use reST markup to ensure the other functions in the sentence also
link to shutil functions.


<!-- issue-number: [bpo-43200](https://bugs.python.org/issue43200) -->
https://bugs.python.org/issue43200
<!-- /issue-number -->
