### PR TITLE
bpo-43202: Immediately return code object in codeop._maybe_compile

### DIFF
--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -80,8 +80,7 @@ def _maybe_compile(compiler, source, filename, symbol):
     code1 = code2 = None
 
     try:
-        code = compiler(source, filename, symbol)
-        return code
+        return compiler(source, filename, symbol)
     except SyntaxError:
         pass
 

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -77,10 +77,11 @@ def _maybe_compile(compiler, source, filename, symbol):
             source = "pass"     # Replace it with a 'pass' statement
 
     err = err1 = err2 = None
-    code = code1 = code2 = None
+    code1 = code2 = None
 
     try:
         code = compiler(source, filename, symbol)
+        return code
     except SyntaxError:
         pass
 
@@ -100,8 +101,6 @@ def _maybe_compile(compiler, source, filename, symbol):
             err2 = e
 
     try:
-        if code:
-            return code
         if not code1 and _is_syntax_error(err1, err2):
             raise err1
     finally:


### PR DESCRIPTION
The code following is ignored when compile returns.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43202](https://bugs.python.org/issue43202) -->
https://bugs.python.org/issue43202
<!-- /issue-number -->
