### PR TITLE
bpo-15108: Prevent accessing the result tuple from Python in PySequence_Tuple

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-12-00-56-06.bpo-15108.KKSAxV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-12-00-56-06.bpo-15108.KKSAxV.rst
@@ -1,0 +1,3 @@
+Fixed an issue that could cause a crash when accessing an incomplete tuple
+when collecting an iterable into a :class:`tuple` using :c:func:`PySequence_Tuple`.
+Patch by Pablo Galindo.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-15108](https://bugs.python.org/issue15108) -->
https://bugs.python.org/issue15108
<!-- /issue-number -->
