### PR TITLE
Add a warning block around the get_referrers() documentation

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -136,10 +136,10 @@ The :mod:`gc` module provides the following functions:
    before calling :func:`get_referrers`.
 
    .. warning::
-       Care must be taken when using objects returned by :func:`get_referrers` because
-       some of them could still be under construction and hence in a temporarily
-       invalid state. Avoid using :func:`get_referrers` for any purpose other than
-       debugging.
+      Care must be taken when using objects returned by :func:`get_referrers` because
+      some of them could still be under construction and hence in a temporarily
+      invalid state. Avoid using :func:`get_referrers` for any purpose other than
+      debugging.
 
 
 .. function:: get_referents(*objs)

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -135,10 +135,11 @@ The :mod:`gc` module provides the following functions:
    resulting referrers.  To get only currently live objects, call :func:`collect`
    before calling :func:`get_referrers`.
 
-   Care must be taken when using objects returned by :func:`get_referrers` because
-   some of them could still be under construction and hence in a temporarily
-   invalid state. Avoid using :func:`get_referrers` for any purpose other than
-   debugging.
+   .. warning::
+       Care must be taken when using objects returned by :func:`get_referrers` because
+       some of them could still be under construction and hence in a temporarily
+       invalid state. Avoid using :func:`get_referrers` for any purpose other than
+       debugging.
 
 
 .. function:: get_referents(*objs)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
