### PR TITLE
bpo-43207: InspectLoader.is_package is not an abstract method

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -612,7 +612,7 @@ ABC hierarchy::
 
     .. method:: is_package(fullname)
 
-        An abstract method to return a true value if the module is a package, a
+        An optional method to return a true value if the module is a package, a
         false value otherwise. :exc:`ImportError` is raised if the
         :term:`loader` cannot find the module.
 


### PR DESCRIPTION
Making the description of `InspectLoader.is_package` aligned with the current implementation.

<!-- issue-number: [bpo-43207](https://bugs.python.org/issue43207) -->
https://bugs.python.org/issue43207
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco