### PR TITLE
[3.9] Minor improvements to the convolve() recipe (GH-24012)

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -774,9 +774,9 @@ which incur interpreter overhead.
        # convolve(data, [0.25, 0.25, 0.25, 0.25]) --> Moving average (blur)
        # convolve(data, [1, -1]) --> 1st finite difference (1st derivative)
        # convolve(data, [1, -2, 1]) --> 2nd finite difference (2nd derivative)
-       kernel = list(reversed(kernel))
+       kernel = tuple(kernel)[::-1]
        n = len(kernel)
-       window = collections.deque([0] * n, maxlen=n)
+       window = collections.deque([0], maxlen=n) * n
        for x in chain(signal, repeat(0, n-1)):
            window.append(x)
            yield sum(map(operator.mul, kernel, window))

--- a/Doc/tools/susp-ignored.csv
+++ b/Doc/tools/susp-ignored.csv
@@ -171,6 +171,7 @@ library/ipaddress,,:db00,2001:db00::0/ffff:ff00::
 library/ipaddress,,::,2001:db00::0/ffff:ff00::
 library/itertools,,:step,elements from seq[start:stop:step]
 library/itertools,,:stop,elements from seq[start:stop:step]
+library/itertools,,::,kernel = tuple(kernel)[::-1]
 library/logging.handlers,,:port,host:port
 library/mmap,,:i2,obj[i1:i2]
 library/multiprocessing,,`,# Add more tasks using `put()`


### PR DESCRIPTION
* Minor improvement to speed and space efficiency for the convolve() recipe
* Don't require convolve's kernel to be a sequence.
(cherry picked from commit f421bfce80730cb0ff5cbe14727ac30cf0462eed)


Co-authored-by: Raymond Hettinger <rhettinger@users.noreply.github.com>