### PR TITLE
bpo-43225: [DOC] Add missing value returned by methods on cookiejar

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -494,7 +494,7 @@ and ``".168.1.2"``, 192.168.1.2 is blocked, but 193.168.1.2 is not.
 
 .. method:: DefaultCookiePolicy.is_blocked(domain)
 
-   Return ``True`` whether *domain* is on the blocklist for setting or receiving
+   Return ``True`` if *domain* is on the blocklist for setting or receiving
    cookies.
 
 
@@ -767,4 +767,3 @@ returned::
    cj = CookieJar(policy)
    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
    r = opener.open("http://example.com/")
-

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -510,7 +510,7 @@ and ``".168.1.2"``, 192.168.1.2 is blocked, but 193.168.1.2 is not.
 
 .. method:: DefaultCookiePolicy.is_not_allowed(domain)
 
-   Return ``True`` whether *domain* is not on the allowlist for setting or receiving
+   Return ``True`` if *domain* is not on the allowlist for setting or receiving
    cookies.
 
 :class:`DefaultCookiePolicy` instances have the following attributes, which are

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -494,7 +494,8 @@ and ``".168.1.2"``, 192.168.1.2 is blocked, but 193.168.1.2 is not.
 
 .. method:: DefaultCookiePolicy.is_blocked(domain)
 
-   Return whether *domain* is on the blocklist for setting or receiving cookies.
+   Return ``True`` whether *domain* is on the blocklist for setting or receiving
+   cookies.
 
 
 .. method:: DefaultCookiePolicy.allowed_domains()
@@ -509,7 +510,7 @@ and ``".168.1.2"``, 192.168.1.2 is blocked, but 193.168.1.2 is not.
 
 .. method:: DefaultCookiePolicy.is_not_allowed(domain)
 
-   Return whether *domain* is not on the allowlist for setting or receiving
+   Return ``True`` whether *domain* is not on the allowlist for setting or receiving
    cookies.
 
 :class:`DefaultCookiePolicy` instances have the following attributes, which are


### PR DESCRIPTION
Documentation say that return something but don't specific with what
value is return, and that can be confuse. This patch add that information.



<!-- issue-number: [bpo-43225](https://bugs.python.org/issue43225) -->
https://bugs.python.org/issue43225
<!-- /issue-number -->
