### PR TITLE
bpo-43224: Initial implementation of PEP 646 in typing.py

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -40,10 +40,11 @@ from queue import Queue, SimpleQueue
 from weakref import WeakSet, ReferenceType, ref
 import typing
 
-from typing import TypeVar
+from typing import TypeVar, TypeVarTuple
 T = TypeVar('T')
 K = TypeVar('K')
 V = TypeVar('V')
+Ts = TypeVarTuple('Ts)')
 
 class BaseTest(unittest.TestCase):
     """Test basics."""
@@ -170,7 +171,7 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(a.__args__, (int,))
         self.assertEqual(a.__parameters__, ())
 
-    def test_parameters(self):
+    def test_parameters_typevar(self):
         from typing import List, Dict, Callable
         D0 = dict[str, int]
         self.assertEqual(D0.__args__, (str, int))
@@ -187,6 +188,34 @@ class BaseTest(unittest.TestCase):
         D2b = dict[T, T]
         self.assertEqual(D2b.__args__, (T, T))
         self.assertEqual(D2b.__parameters__, (T,))
+        L0 = list[str]
+        self.assertEqual(L0.__args__, (str,))
+        self.assertEqual(L0.__parameters__, ())
+        L1 = list[T]
+        self.assertEqual(L1.__args__, (T,))
+        self.assertEqual(L1.__parameters__, (T,))
+        L2 = list[list[T]]
+        self.assertEqual(L2.__args__, (list[T],))
+        self.assertEqual(L2.__parameters__, (T,))
+        L3 = list[List[T]]
+        self.assertEqual(L3.__args__, (List[T],))
+        self.assertEqual(L3.__parameters__, (T,))
+        L4a = list[Dict[K, V]]
+        self.assertEqual(L4a.__args__, (Dict[K, V],))
+        self.assertEqual(L4a.__parameters__, (K, V))
+        L4b = list[Dict[T, int]]
+        self.assertEqual(L4b.__args__, (Dict[T, int],))
+        self.assertEqual(L4b.__parameters__, (T,))
+        L5 = list[Callable[[K, V], K]]
+        self.assertEqual(L5.__args__, (Callable[[K, V], K],))
+        self.assertEqual(L5.__parameters__, (K, V))
+
+    def test_parameters_typevartuple(self):
+        from typing import List, Dict, Callable
+        T0 = tuple[*Ts]
+        self.assertEqual(T0.__args__, (Ts._unpacked,))
+        self.assertEqual(T0.__parameters__, (T,))
+
         L0 = list[str]
         self.assertEqual(L0.__args__, (str,))
         self.assertEqual(L0.__parameters__, ())
@@ -390,6 +419,10 @@ class BaseTest(unittest.TestCase):
             C1 = Callable[typing.Concatenate[int, P], int]
             self.assertEqual(repr(C1), "collections.abc.Callable"
                                        "[typing.Concatenate[int, ~P], int]")
+
+        with self.subTest("Testing TypeVarTuple uses"):
+            Ts = typing.TypeVarTuple('Ts')
+            tuple[*Ts]
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -375,7 +375,12 @@ class TypeVarTupleTests(BaseTestCase):
         with self.assertRaises(TypeError):
             C[int]
 
+    def test_args_and_parameters(self):
+        Ts = TypeVarTuple('Ts')
 
+        t = Tuple[*Ts]
+        self.assertEqual(t.__args__, (Ts._unpacked,))
+        self.assertEqual(t.__parameters__, (Ts,))
 
 
 class UnionTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -241,7 +241,9 @@ class TypeVarTupleTests(BaseTestCase):
     def test_basic_plain(self):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(Ts, Ts)
+        self.assertEqual(Unpack[Ts], Unpack[Ts])
         self.assertIsInstance(Ts, TypeVarTuple)
+        self.assertIsInstance(Unpack[Ts], _UnpackedTypeVarTuple)
 
     def test_repr(self):
         Ts = TypeVarTuple('Ts')
@@ -356,7 +358,6 @@ class TypeVarTupleTests(BaseTestCase):
     def test_class(self):
         Ts = TypeVarTuple('Ts')
 
-        class C(Generic[Unpack[Ts]]): pass
         class C(Generic[Unpack[Ts]]): pass
         C[int]
         C[int, str]

--- a/Misc/NEWS.d/next/Library/2021-02-14-17-22-52.bpo-43224.WDihrT.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-14-17-22-52.bpo-43224.WDihrT.rst
@@ -1,0 +1,1 @@
+Add support for PEP 646.


### PR DESCRIPTION
Currently this only supports the `Unpack[Ts]` form, but once the changes from PEP 637 are merged, `*Ts` also works with no extra changes.

I don't think this is finished yet - we need more tests, especially for aliases - but this is enough to begin discussion.

Notes:
* I've renamed `_TypeVarLike` to `_BoundVarianceMixin`, since `TypeVarTuple` doesn't support bounds or variance yet, and it would be confusing if `TypeVarTuple` wasn't a `_TypeVarLike`. I've created `_TypeVarTypes` as a replacement.
* I've renamed `_check_generic` to `_check_type_parameter_count` to make its purpose clearer, and overhauled its body to support `TypeVarTuple`s.
* In `_check_type_parameter_count`, I've removed the check on whether `cls` is a generic a) so that the function only does one thing, and b) because I couldn't see any way for the function to be called on a class which *wasn't* generic (and none of the tests fail, so *shrug*).

<!-- issue-number: [bpo-43224](https://bugs.python.org/issue43224) -->
https://bugs.python.org/issue43224
<!-- /issue-number -->
