### PR TITLE
bpo-43179: Drop 31/32-bit Linux s390 platform support

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -820,6 +820,12 @@ Build Changes
 
   (Contributed by Victor Stinner in :issue:`42856`.)
 
+* The discontinued 31/32-bit Linux s390 platform is no longer supported. The
+  31/32-bit IBM s390 architecture was discontinued in 1998 and superseded by
+  the 64-bit IBM s390x architecture. The 64-bit Linux s390x platform remains
+  supported.
+  (Contributed by Victor Stinner in :issue:`43179`.)
+
 
 C API Changes
 =============

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -382,7 +382,7 @@ class TestSysConfig(unittest.TestCase):
         import platform, re
         machine = platform.machine()
         suffix = sysconfig.get_config_var('EXT_SUFFIX')
-        if re.match('(aarch64|arm|mips|ppc|powerpc|s390|sparc)', machine):
+        if re.match('(aarch64|arm|mips|ppc|powerpc|s390x|sparc)', machine):
             self.assertTrue('linux' in suffix, suffix)
         if re.match('(i[3-6]86|x86_64)$', machine):
             if ctypes.sizeof(ctypes.c_char_p()) == 4:

--- a/Misc/NEWS.d/next/Build/2021-02-15-12-27-58.bpo-43179.iw-mBW.rst
+++ b/Misc/NEWS.d/next/Build/2021-02-15-12-27-58.bpo-43179.iw-mBW.rst
@@ -1,0 +1,4 @@
+The discontinued 31/32-bit Linux s390 platform is no longer supported. The
+31/32-bit IBM s390 architecture was discontinued in 1998 and superseded by the
+64-bit IBM s390x architecture. The 64-bit Linux s390x platform remains
+supported. Patch by Victor Stinner.

--- a/Modules/_ctypes/libffi_osx/ffi.c
+++ b/Modules/_ctypes/libffi_osx/ffi.c
@@ -161,8 +161,8 @@ ffi_prep_cif(
 	/* Perform a sanity check on the return type */
 	FFI_ASSERT_VALID_TYPE(cif->rtype);
 
-	/* x86-64 and s390 stack space allocation is handled in prep_machdep.  */
-#if !defined M68K && !defined __x86_64__ && !defined S390 && !defined PA
+	/* x86-64 and s390x stack space allocation is handled in prep_machdep.  */
+#if !defined M68K && !defined __x86_64__ && !defined PA
 	/* Make space for the return structure pointer */
 	if (cif->rtype->type == FFI_TYPE_STRUCT
 #ifdef SPARC
@@ -200,7 +200,7 @@ ffi_prep_cif(
 
 			bytes += STACK_ARG_SIZE((*ptr)->size);
 		}
-#elif !defined __x86_64__ && !defined S390 && !defined PA
+#elif !defined __x86_64__ && !defined PA
 #ifdef SPARC
 		if (((*ptr)->type == FFI_TYPE_STRUCT
 			&& ((*ptr)->size > 16 || cif->abi != FFI_V9))

--- a/configure
+++ b/configure
@@ -5310,8 +5310,6 @@ cat >> conftest.c <<EOF
         powerpc-linux-gnu
 # elif defined(__s390x__)
         s390x-linux-gnu
-# elif defined(__s390__)
-        s390-linux-gnu
 # elif defined(__sh__) && defined(__LITTLE_ENDIAN__)
         sh4-linux-gnu
 # elif defined(__sparc__) && defined(__arch64__)

--- a/configure.ac
+++ b/configure.ac
@@ -819,8 +819,6 @@ cat >> conftest.c <<EOF
         powerpc-linux-gnu
 # elif defined(__s390x__)
         s390x-linux-gnu
-# elif defined(__s390__)
-        s390-linux-gnu
 # elif defined(__sh__) && defined(__LITTLE_ENDIAN__)
         sh4-linux-gnu
 # elif defined(__sparc__) && defined(__arch64__)


### PR DESCRIPTION
The discontinued 32-bit Linux s390 platform is no longer supported.
The 32-bit IBM s390 architecture was discontinued in 1998 and
superseded by the 64-bit IBM s390x architecture. The 64-bit Linux
s390x platform remains supported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43179](https://bugs.python.org/issue43179) -->
https://bugs.python.org/issue43179
<!-- /issue-number -->
