### PR TITLE
bpo-40170: Convert PyDescr_IsData macro to C function

### DIFF
--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -32,8 +32,8 @@ found in the dictionary of type objects.
 
 .. c:function:: int PyDescr_IsData(PyObject *descr)
 
-   Return true if the descriptor objects *descr* describes a data attribute, or
-   false if it describes a method.  *descr* must be a descriptor object; there is
+   Return non-zero if the descriptor objects *descr* describes a data attribute, or
+   ``0`` if it describes a method.  *descr* must be a descriptor object; there is
    no error checking.
 
 

--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -93,7 +93,7 @@ PyAPI_FUNC(PyObject *) PyDescr_NewGetSet(PyTypeObject *,
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) PyDescr_NewWrapper(PyTypeObject *,
                                                 struct wrapperbase *, void *);
-#define PyDescr_IsData(d) (Py_TYPE(d)->tp_descr_set != NULL)
+PyAPI_FUNC(int) PyDescr_IsData(PyObject *);
 #endif
 
 PyAPI_FUNC(PyObject *) PyDictProxy_New(PyObject *);

--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -93,9 +93,6 @@ PyAPI_FUNC(PyObject *) PyDescr_NewGetSet(PyTypeObject *,
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) PyDescr_NewWrapper(PyTypeObject *,
                                                 struct wrapperbase *, void *);
-#endif
-
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030A0000
 PyAPI_FUNC(int) PyDescr_IsData(PyObject *);
 #endif
 

--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -93,6 +93,9 @@ PyAPI_FUNC(PyObject *) PyDescr_NewGetSet(PyTypeObject *,
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) PyDescr_NewWrapper(PyTypeObject *,
                                                 struct wrapperbase *, void *);
+#endif
+
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030A0000
 PyAPI_FUNC(int) PyDescr_IsData(PyObject *);
 #endif
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
@@ -1,3 +1,3 @@
 Convert :c:func:`PyDescr_IsData` macro to a function to hide implementation
 details: The macro accessed :c:member:`PyTypeObject.tp_descr_set` directly.
-The function is now a part of the limited C API. Patch by Erlend E. Aasland.
+Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
@@ -1,2 +1,3 @@
-Convert :c:func:`PyDescr_IsData` macro to function. Patch by Erlend E.
-Aasland.
+Convert :c:func:`PyDescr_IsData` macro to a function to hide implementation
+details: The macro accessed :c:member:`PyTypeObject.tp_descr_set` directly.
+Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
@@ -1,3 +1,3 @@
 Convert :c:func:`PyDescr_IsData` macro to a function to hide implementation
 details: The macro accessed :c:member:`PyTypeObject.tp_descr_set` directly.
-Patch by Erlend E. Aasland.
+The function is now a part of the limited C API. Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-15-13-41-14.bpo-40170.r2FAtl.rst
@@ -1,0 +1,2 @@
+Convert :c:func:`PyDescr_IsData` macro to function. Patch by Erlend E.
+Aasland.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -995,6 +995,11 @@ PyDescr_NewWrapper(PyTypeObject *type, struct wrapperbase *base, void *wrapped)
     return (PyObject *)descr;
 }
 
+int
+PyDescr_IsData(PyObject *ob)
+{
+    return Py_TYPE(ob)->tp_descr_set != NULL;
+}
 
 /* --- mappingproxy: read-only proxy for mappings --- */
 


### PR DESCRIPTION
The macro accessed the PyTypeObject.tp_descr_set member.
Reimplemented as a C function to hide implementation details.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
