### PR TITLE
bpo-43231: Correctly calculate the curses color pair limit when checking for it

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -930,7 +930,7 @@ class TestCurses(unittest.TestCase):
             # range may be restricted, so we need to check if the limit is still
             # correct
             try:
-                curses.init_pair(pair_limit, 0, 0)
+                curses.init_pair(pair_limit - 1, 0, 0)
             except ValueError:
                 pair_limit = curses.COLOR_PAIRS
         return pair_limit


### PR DESCRIPTION


<!-- issue-number: [bpo-43231](https://bugs.python.org/issue43231) -->
https://bugs.python.org/issue43231
<!-- /issue-number -->
