### PR TITLE
bpo-40170: Convert PyIter_Check macro to a function

### DIFF
--- a/Doc/c-api/iter.rst
+++ b/Doc/c-api/iter.rst
@@ -9,8 +9,8 @@ There are two functions specifically for working with iterators.
 
 .. c:function:: int PyIter_Check(PyObject *o)
 
-   Return true if the object *o* supports the iterator protocol.  This
-   function always succeeds.
+   Return non-zero if the object *o* supports the iterator protocol, and ``0``
+   otherwise.  This function always succeeds.
 
 
 .. c:function:: PyObject* PyIter_Next(PyObject *o)

--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -324,7 +324,7 @@ PyAPI_FUNC(PyObject *) PyObject_Format(PyObject *obj,
    returns itself. */
 PyAPI_FUNC(PyObject *) PyObject_GetIter(PyObject *);
 
-/* Returns 1 if the object 'obj' provides iterator protocols, and 0 otherwise.
+/* Returns non-zero if the object 'obj' provides iterator protocols, and 0 otherwise.
 
    This function always succeeds. */
 PyAPI_FUNC(int) PyIter_Check(PyObject *);

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -325,10 +325,6 @@ PyAPI_FUNC(int) PyBuffer_FillInfo(Py_buffer *view, PyObject *o, void *buf,
 /* Releases a Py_buffer obtained from getbuffer ParseTuple's "s*". */
 PyAPI_FUNC(void) PyBuffer_Release(Py_buffer *view);
 
-/* ==== Iterators ================================================ */
-
-PyAPI_FUNC(int) PyIter_Check(PyObject *);
-
 /* === Sequence protocol ================================================ */
 
 /* Assume tp_as_sequence and sq_item exist and that 'i' does not

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -327,9 +327,7 @@ PyAPI_FUNC(void) PyBuffer_Release(Py_buffer *view);
 
 /* ==== Iterators ================================================ */
 
-#define PyIter_Check(obj) \
-    (Py_TYPE(obj)->tp_iternext != NULL && \
-     Py_TYPE(obj)->tp_iternext != &_PyObject_NextNotImplemented)
+PyAPI_FUNC(int) PyIter_Check(PyObject *);
 
 /* === Sequence protocol ================================================ */
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-15-15-06-43.bpo-40170.ZYeSii.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-15-15-06-43.bpo-40170.ZYeSii.rst
@@ -1,3 +1,3 @@
-:c:func:`PyIter_Check` macro is now a function, in order to hide implementation
+:c:func:`PyIter_Check` is now always declared as a function, in order to hide implementation
 details. The macro accessed :c:member:`PyTypeObject.tp_iternext` directly.
 Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-15-15-06-43.bpo-40170.ZYeSii.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-15-15-06-43.bpo-40170.ZYeSii.rst
@@ -1,0 +1,3 @@
+:c:func:`PyIter_Check` macro is now a function, in order to hide implementation
+details. The macro accessed :c:member:`PyTypeObject.tp_iternext` directly.
+Patch by Erlend E. Aasland.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2732,12 +2732,12 @@ PyObject_GetIter(PyObject *o)
     }
 }
 
-#undef PyIter_Check
-
-int PyIter_Check(PyObject *obj)
+int
+PyIter_Check(PyObject *obj)
 {
-    return Py_TYPE(obj)->tp_iternext != NULL &&
-           Py_TYPE(obj)->tp_iternext != &_PyObject_NextNotImplemented;
+    PyTypeObject *tp = Py_TYPE(obj);
+    return tp->tp_iternext != NULL &&
+           tp->tp_iternext != &_PyObject_NextNotImplemented;
 }
 
 /* Return next item.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2736,8 +2736,8 @@ int
 PyIter_Check(PyObject *obj)
 {
     PyTypeObject *tp = Py_TYPE(obj);
-    return tp->tp_iternext != NULL &&
-           tp->tp_iternext != &_PyObject_NextNotImplemented;
+    return (tp->tp_iternext != NULL &&
+            tp->tp_iternext != &_PyObject_NextNotImplemented);
 }
 
 /* Return next item.


### PR DESCRIPTION
The macro accessed the `PyTypeObject.tp_iternext` member directly.
"Swap" macro variant with the function in order to hide implementation details.
(A function already existed, but it was not exposed.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
