### PR TITLE
Remove all links to mingw.org

### DIFF
--- a/Doc/install/index.rst
+++ b/Doc/install/index.rst
@@ -1071,8 +1071,7 @@ normal libraries do.
 .. [#] This also means you could replace all existing COFF-libraries with OMF-libraries
    of the same name.
 
-.. [#] Check https://www.sourceware.org/cygwin/ and http://www.mingw.org/ for more
-   information
+.. [#] Check https://www.sourceware.org/cygwin/ for more information
 
 .. [#] Then you have no POSIX emulation available, but you also don't need
    :file:`cygwin1.dll`.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1149,8 +1149,6 @@ For extension modules, consult :ref:`building-on-windows`.
       MinGW gcc under Windows" or "Installing Python extension with distutils
       and without Microsoft Visual C++" by Sébastien Sauvage, 2003
 
-   `MingW -- Python extensions <http://www.mingw.org/wiki/FAQ#toc14>`_
-
 
 Other Platforms
 ===============


### PR DESCRIPTION
This lease on this domain has lapsed. This not only makes these dead links, but a potential attack vector for readers of python.org as the domain can be obtained by an untrustworthy party.


I considered redirecting these links to http://mingw-w64.org/ which is a maintained fork of mingw, but beyond my unfamiliarity with the exact level of compatibility, at the time of this PR that site had an expired cert and so is not much of a vulnerability fix.

Automerge-Triggered-By: GH:Mariatta