### PR TITLE
bpo-40170: Always define PyExceptionClass_Name as a function

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -78,10 +78,6 @@ PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, Py
 
 PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
 
-/* */
-
-#define PyExceptionClass_Name(x)  (((PyTypeObject*)(x))->tp_name)
-
 /* Convenience functions */
 
 #ifdef MS_WINDOWS

--- a/Misc/NEWS.d/next/C API/2021-02-16-22-29-39.bpo-40170.ahHmOo.rst
+++ b/Misc/NEWS.d/next/C API/2021-02-16-22-29-39.bpo-40170.ahHmOo.rst
@@ -1,0 +1,3 @@
+:c:func:`PyExceptionClass_Name` is now always declared as a function, in
+order to hide implementation details. The macro accessed
+:c:member:`PyTypeObject.tp_name` directly.  Patch by Erlend E. Aasland.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -364,8 +364,6 @@ PyException_SetContext(PyObject *self, PyObject *context)
     Py_XSETREF(_PyBaseExceptionObject_cast(self)->context, context);
 }
 
-#undef PyExceptionClass_Name
-
 const char *
 PyExceptionClass_Name(PyObject *ob)
 {


### PR DESCRIPTION
Remove the macro variant, as it accessed `PyTypeObject.tp_name` directly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
