### PR TITLE
Update handlers.py to have a configurable message_separator_character

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -934,10 +934,9 @@ class SysLogHandler(logging.Handler):
         exception information is present, it is NOT sent to the server.
         """
         try:
-            msg = self.format(record)
+            msg = self.format(record) + message_separator_character
             if self.ident:
                 msg = self.ident + msg
-            msg += message_separator_character
 
             # We need to convert record level to lowercase, maybe this will
             # change in the future.

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -923,8 +923,8 @@ class SysLogHandler(logging.Handler):
         """
         return self.priority_map.get(levelName, "warning")
 
-    ident = ''          # prepended to all messages
-    append_nul = True   # some old syslog daemons expect a NUL terminator
+    ident = ''                             # prepended to all messages
+    message_separator_character = '\000'   # some old syslog daemons expect a NUL terminator
 
     def emit(self, record):
         """
@@ -937,8 +937,7 @@ class SysLogHandler(logging.Handler):
             msg = self.format(record)
             if self.ident:
                 msg = self.ident + msg
-            if self.append_nul:
-                msg += '\000'
+            msg += message_separator_character
 
             # We need to convert record level to lowercase, maybe this will
             # change in the future.


### PR DESCRIPTION
SyslogHandler, emit function add the nul_character to the message. This PR allows the user to choose what character to use to separate messages.
The functionality of `append_nul` that was a boolean variable stays the same since the user can override this value since it's a class attribute:
From the docs:
```
To enable easier handling of Syslog messages in the face of all these differing daemon behaviours, the appending of the NUL byte has been made configurable, through the use of a class-level attribute, append_nul. This defaults to True (preserving the existing behaviour) but can be set to False on a SysLogHandler instance in order for that instance to not append the NUL terminator.
```
So now this functionality is possible through setting:
```
message_separator_character = ''  # using the empty string
# instead of doing:
# append_nul = False
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
