### PR TITLE
bpo-43243: Add ability to mark abstract base classes as strict

### DIFF
--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -68,6 +68,8 @@ except ImportError:
     from _py_abc import ABCMeta, get_cache_token
     ABCMeta.__module__ = 'abc'
 else:
+    from _py_abc import _abc_strict_init
+
     class ABCMeta(type):
         """Metaclass for defining Abstract Base Classes (ABCs).
 
@@ -81,9 +83,10 @@ else:
         implementations defined by the registering ABC be callable (not
         even via super()).
         """
-        def __new__(mcls, name, bases, namespace, **kwargs):
+        def __new__(mcls, name, bases, namespace, *, strict=False, **kwargs):
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
             _abc_init(cls)
+            _abc_strict_init(cls, strict)
             return cls
 
         def register(cls, subclass):

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -650,12 +650,63 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             class Receiver(ReceivesClassKwargs, abc_ABC, x=1, y=2, z=3):
                 pass
             self.assertEqual(saved_kwargs, dict(x=1, y=2, z=3))
-    return TestLegacyAPI, TestABC, TestABCWithInitSubclass
 
-TestLegacyAPI_Py, TestABC_Py, TestABCWithInitSubclass_Py = test_factory(abc.ABCMeta,
-                                                                        abc.get_cache_token)
-TestLegacyAPI_C, TestABC_C, TestABCWithInitSubclass_C = test_factory(_py_abc.ABCMeta,
-                                                                     _py_abc.get_cache_token)
+
+    class TestStrictABC(unittest.TestCase):
+        def test_subclass_strict_cls(self):
+            class A(metaclass=abc_ABCMeta, strict=True):
+                @abc.abstractmethod
+                def foo(self):
+                    pass
+
+            with self.assertRaisesRegex(
+                    TypeError,
+                    "^Can't create class B with unimplemented strict abstract method foo$",
+            ):
+                class B(A):
+                    pass
+
+        def test_make_subcls_strict(self):
+            class A(metaclass=abc_ABCMeta):
+                @abc.abstractmethod
+                def foo(self):
+                    pass
+
+            class B(A, strict=True):
+                pass
+
+            with self.assertRaisesRegex(
+                    TypeError,
+                    "^Can't create class C with unimplemented strict abstract method foo$",
+            ):
+                class C(B):
+                    pass
+
+        def test_inherit_from_strict_and_nonstrict_cls(self):
+            class A(metaclass=abc_ABCMeta):
+                @abc.abstractmethod
+                def foo(self):
+                    pass
+
+            class B(metaclass=abc_ABCMeta, strict=True):
+                @abc.abstractmethod
+                def bar(self):
+                    pass
+
+            with self.assertRaisesRegex(
+                    TypeError,
+                    "^Can't create class C with unimplemented strict abstract method bar$",
+            ):
+                class C(B):
+                    pass
+
+    return TestLegacyAPI, TestABC, TestABCWithInitSubclass, TestStrictABC
+
+
+TestLegacyAPI_Py, TestABC_Py, TestABCWithInitSubclass_Py, TestStrictABC_Py = test_factory(abc.ABCMeta,
+                                                                                          abc.get_cache_token)
+TestLegacyAPI_C, TestABC_C, TestABCWithInitSubclass_C, TestStrictABC_C = test_factory(_py_abc.ABCMeta,
+                                                                                      _py_abc.get_cache_token)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2021-02-17-19-29-35.bpo-43243.gNHRca.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-17-19-29-35.bpo-43243.gNHRca.rst
@@ -1,0 +1,2 @@
+Add ability to mark abstract base classes as strict. Patch provided by Yurii
+Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43243](https://bugs.python.org/issue43243) -->
https://bugs.python.org/issue43243
<!-- /issue-number -->
