### PR TITLE
bpo-42990: Add __builtins__ attribute to functions

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -95,6 +95,8 @@ attributes:
 |           | __globals__       | global namespace in which |
 |           |                   | this function was defined |
 +-----------+-------------------+---------------------------+
+|           | __builtins__      | builtins namespace        |
++-----------+-------------------+---------------------------+
 |           | __annotations__   | mapping of parameters     |
 |           |                   | names to annotations;     |
 |           |                   | ``"return"`` key is       |
@@ -250,6 +252,10 @@ attributes:
 .. versionchanged:: 3.7
 
    Add ``cr_origin`` attribute to coroutines.
+
+.. versionchanged:: 3.10
+
+   Add ``__builtins__`` attribute to functions.
 
 .. function:: getmembers(object[, predicate])
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -280,6 +280,11 @@ Other Language Changes
 * Assignment expressions can now be used unparenthesized within set literals
   and set comprehensions, as well as in sequence indexes (but not slices).
 
+* Functions have a new ``__builtins__`` attribute which is used to look for
+  builtin symbols when a function is executed, instead of looking into
+  ``__globals__['__builtins__']``.
+  (Contributed by Mark Shannon in :issue:`42990`.)
+
 
 New Modules
 ===========

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -682,9 +682,10 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(np.y, 2)
 
     def test_new_builtins_issue_43102(self):
-        self.assertEqual(
-            namedtuple('C', ()).__new__.__globals__['__builtins__'],
-            {})
+        obj = namedtuple('C', ())
+        new_func = obj.__new__
+        self.assertEqual(new_func.__globals__['__builtins__'], {})
+        self.assertEqual(new_func.__builtins__, {})
 
 
 ################################################################################

--- a/Lib/test/test_funcattrs.py
+++ b/Lib/test/test_funcattrs.py
@@ -73,6 +73,11 @@ class FunctionPropertiesTest(FuncAttrsTest):
         self.cannot_set_attr(self.b, '__globals__', 2,
                              (AttributeError, TypeError))
 
+    def test___builtins__(self):
+        self.assertIs(self.b.__builtins__, __builtins__)
+        self.cannot_set_attr(self.b, '__builtins__', 2,
+                             (AttributeError, TypeError))
+
     def test___closure__(self):
         a = 12
         def f(): print(a)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-17-19-02-21.bpo-42990.SKXHiI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-17-19-02-21.bpo-42990.SKXHiI.rst
@@ -1,0 +1,3 @@
+Functions have a new ``__builtins__`` attribute which is used to look for
+builtin symbols when a function is executed, instead of looking into
+``__globals__['__builtins__']``. Patch by Mark Shannon and Victor Stinner.

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -250,6 +250,7 @@ static PyMemberDef func_memberlist[] = {
     {"__doc__",       T_OBJECT,     OFF(func_doc), 0},
     {"__globals__",   T_OBJECT,     OFF(func_globals), READONLY},
     {"__module__",    T_OBJECT,     OFF(func_module), 0},
+    {"__builtins__",  T_OBJECT,     OFF(func_builtins), READONLY},
     {NULL}  /* Sentinel */
 };
 


### PR DESCRIPTION
Expose the new `PyFunctionObject.func_builtins` member in Python as a
new `__builtins__` attribute on functions.

Document also the behavior change in What's New in Python 3.10.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42990](https://bugs.python.org/issue42990) -->
https://bugs.python.org/issue42990
<!-- /issue-number -->
