### PR TITLE
bpo-43254: Fix broken *snprintf() man page links

### DIFF
--- a/Doc/c-api/conversion.rst
+++ b/Doc/c-api/conversion.rst
@@ -11,14 +11,14 @@ Functions for number conversion and formatted string output.
 .. c:function:: int PyOS_snprintf(char *str, size_t size,  const char *format, ...)
 
    Output not more than *size* bytes to *str* according to the format string
-   *format* and the extra arguments. See the Unix man page :manpage:`snprintf(2)`.
+   *format* and the extra arguments. See the Unix man page :manpage:`snprintf(3)`.
 
 
 .. c:function:: int PyOS_vsnprintf(char *str, size_t size, const char *format, va_list va)
 
    Output not more than *size* bytes to *str* according to the format string
    *format* and the variable argument list *va*. Unix man page
-   :manpage:`vsnprintf(2)`.
+   :manpage:`vsnprintf(3)`.
 
 :c:func:`PyOS_snprintf` and :c:func:`PyOS_vsnprintf` wrap the Standard C library
 functions :c:func:`snprintf` and :c:func:`vsnprintf`. Their purpose is to


### PR DESCRIPTION
Both `snprintf` and `vsnprintf` belong to man section 3 (library functions), not section 2 (system calls).

Affected doc page: https://docs.python.org/3.10/c-api/conversion.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43254](https://bugs.python.org/issue43254) -->
https://bugs.python.org/issue43254
<!-- /issue-number -->
