### PR TITLE
bpo-42990: Refactor _PyFrame_New_NoTrack()

### DIFF
--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -61,9 +61,11 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject* PyFunction_GetModule(PyObject *op)
 
-   Return the *__module__* attribute of the function object *op*. This is normally
-   a string containing the module name, but can be set to any other object by
-   Python code.
+   Return a :term:`borrowed reference` to the *__module__* attribute of the
+   function object *op*. It can be *NULL*.
+
+   This is normally a string containing the module name, but can be set to any
+   other object by Python code.
 
 
 .. c:function:: PyObject* PyFunction_GetDefaults(PyObject *op)

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -92,5 +92,3 @@ PyAPI_FUNC(void) PyFrame_FastToLocals(PyFrameObject *);
 PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
-
-PyObject *_PyEval_BuiltinsFromGlobals(PyObject *globals);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -31,8 +31,11 @@ PyAPI_FUNC(void) _PyEval_SetCoroutineOriginTrackingDepth(
     PyThreadState *tstate,
     int new_depth);
 
-/* Private function */
 void _PyEval_Fini(void);
+
+
+extern PyObject *_PyEval_BuiltinsFromGlobals(PyObject *globals);
+
 
 static inline PyObject*
 _PyEval_EvalFrame(PyThreadState *tstate, PyFrameObject *f, int throwflag)

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -2,83 +2,90 @@
 /* Function object implementation */
 
 #include "Python.h"
-#include "pycore_object.h"
-#include "frameobject.h"
-#include "code.h"
+#include "pycore_ceval.h"         // _PyEval_BuiltinsFromGlobals()
+#include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "structmember.h"         // PyMemberDef
 
 PyObject *
 PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname)
 {
-    PyFunctionObject *op;
-    PyObject *doc, *consts, *module;
-    static PyObject *__name__ = NULL;
+    assert(globals != NULL);
+    assert(PyDict_Check(globals));
+    Py_INCREF(globals);
 
-    if (__name__ == NULL) {
-        __name__ = PyUnicode_InternFromString("__name__");
-        if (__name__ == NULL)
-            return NULL;
+    PyCodeObject *code_obj = (PyCodeObject *)code;
+    Py_INCREF(code_obj);
+
+    PyObject *name = code_obj->co_name;
+    assert(name != NULL);
+    Py_INCREF(name);
+    if (!qualname) {
+        qualname = name;
+    }
+    Py_INCREF(qualname);
+
+    PyObject *consts = code_obj->co_consts;
+    assert(PyTuple_Check(consts));
+    PyObject *doc;
+    if (PyTuple_Size(consts) >= 1) {
+        doc = PyTuple_GetItem(consts, 0);
+        if (!PyUnicode_Check(doc)) {
+            doc = Py_None;
+        }
+    }
+    else {
+        doc = Py_None;
+    }
+    Py_INCREF(doc);
+
+    // __module__: Use globals['__name__'] if it exists, or NULL.
+    _Py_IDENTIFIER(__name__);
+    PyObject *module = _PyDict_GetItemIdWithError(globals, &PyId___name__);
+    PyObject *builtins = NULL;
+    if (module == NULL && PyErr_Occurred()) {
+        goto error;
+    }
+    Py_XINCREF(module);
+
+    builtins = _PyEval_BuiltinsFromGlobals(globals);
+    if (builtins == NULL) {
+        goto error;
     }
 
-    /* __module__: If module name is in globals, use it.
-       Otherwise, use None. */
-    module = PyDict_GetItemWithError(globals, __name__);
-    if (module) {
-        Py_INCREF(module);
-    }
-    else if (PyErr_Occurred()) {
-        return NULL;
-    }
-
-    op = PyObject_GC_New(PyFunctionObject, &PyFunction_Type);
+    PyFunctionObject *op = PyObject_GC_New(PyFunctionObject, &PyFunction_Type);
     if (op == NULL) {
-        Py_XDECREF(module);
-        return NULL;
+        goto error;
     }
     /* Note: No failures from this point on, since func_dealloc() does not
        expect a partially-created object. */
 
-    op->func_weakreflist = NULL;
-    Py_INCREF(code);
-    op->func_code = code;
-    assert(globals != NULL);
-    Py_INCREF(globals);
     op->func_globals = globals;
-    PyObject *builtins = _PyEval_BuiltinsFromGlobals(globals);
-    if (builtins == NULL) {
-        return NULL;
-    }
     op->func_builtins = builtins;
-    op->func_name = ((PyCodeObject *)code)->co_name;
-    Py_INCREF(op->func_name);
-    op->func_defaults = NULL; /* No default arguments */
-    op->func_kwdefaults = NULL; /* No keyword only defaults */
+    op->func_name = name;
+    op->func_qualname = qualname;
+    op->func_code = (PyObject*)code_obj;
+    op->func_defaults = NULL;    // No default positional arguments
+    op->func_kwdefaults = NULL;  // No default keyword arguments
     op->func_closure = NULL;
-    op->vectorcall = _PyFunction_Vectorcall;
-    op->func_module = module;
-
-    consts = ((PyCodeObject *)code)->co_consts;
-    if (PyTuple_Size(consts) >= 1) {
-        doc = PyTuple_GetItem(consts, 0);
-        if (!PyUnicode_Check(doc))
-            doc = Py_None;
-    }
-    else
-        doc = Py_None;
-    Py_INCREF(doc);
     op->func_doc = doc;
-
     op->func_dict = NULL;
+    op->func_weakreflist = NULL;
+    op->func_module = module;
     op->func_annotations = NULL;
-
-    if (qualname)
-        op->func_qualname = qualname;
-    else
-        op->func_qualname = op->func_name;
-    Py_INCREF(op->func_qualname);
+    op->vectorcall = _PyFunction_Vectorcall;
 
     _PyObject_GC_TRACK(op);
     return (PyObject *)op;
+
+error:
+    Py_DECREF(globals);
+    Py_DECREF(code_obj);
+    Py_DECREF(name);
+    Py_DECREF(qualname);
+    Py_DECREF(doc);
+    Py_XDECREF(module);
+    Py_XDECREF(builtins);
+    return NULL;
 }
 
 PyObject *

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -908,7 +908,7 @@ PyEval_EvalCode(PyObject *co, PyObject *globals, PyObject *locals)
         .fc_closure = NULL
     };
     PyThreadState *tstate = PyThreadState_GET();
-    PyObject *res =_PyEval_Vector(tstate, &desc, locals, NULL, 0, NULL);
+    PyObject *res = _PyEval_Vector(tstate, &desc, locals, NULL, 0, NULL);
     Py_DECREF(builtins);
     return res;
 }
@@ -4800,8 +4800,8 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
     };
     PyThreadState *tstate = _PyThreadState_GET();
     res = _PyEval_Vector(tstate, &constr, locals,
-                                    allargs, argcount,
-                                    kwnames);
+                         allargs, argcount,
+                         kwnames);
     if (kwcount) {
         Py_DECREF(kwnames);
         PyMem_Free(newargs);


### PR DESCRIPTION
* Refactor _PyFrame_New_NoTrack() and PyFunction_NewWithQualName()
  code.
* PyFrame_New() checks for _PyEval_BuiltinsFromGlobals() failure.
* Fix a ref leak in _PyEval_BuiltinsFromGlobals() error path.
* Complete PyFunction_GetModule() documentation: it returns a
  borrowed reference and it can return NULL.
* Move _PyEval_BuiltinsFromGlobals() definition to the internal C
  API.
* PyFunction_NewWithQualName() uses _Py_IDENTIFIER() API for the
  "__name__" string to make it compatible with subinterpreters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42990](https://bugs.python.org/issue42990) -->
https://bugs.python.org/issue42990
<!-- /issue-number -->
