### PR TITLE
bpo-43258: Prevent needless allocation of sqlite3 aggregate context for empty queries

### DIFF
--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -429,6 +429,11 @@ class AggregateTests(unittest.TestCase):
         val = cur.fetchone()[0]
         self.assertEqual(val, 60)
 
+    def test_aggr_no_match(self):
+        cur = self.con.execute("select mysum(i) from (select 1 as i) where i == 0")
+        val = cur.fetchone()[0]
+        self.assertIsNone(val)
+
 class AuthorizerTests(unittest.TestCase):
     @staticmethod
     def authorizer_cb(action, arg1, arg2, dbname, source):

--- a/Misc/NEWS.d/next/Library/2021-02-18-23-30-52.bpo-43258.LeU-q8.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-18-23-30-52.bpo-43258.LeU-q8.rst
@@ -1,0 +1,2 @@
+Prevent needless allocation of :mod:`sqlite3` aggregate function context
+when no rows match an aggregate query. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -709,7 +709,11 @@ void _pysqlite_final_callback(sqlite3_context* context)
     threadstate = PyGILState_Ensure();
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, 0);
-    if (!*aggregate_instance) {
+    if (aggregate_instance == NULL) {
+        /* No rows matched the query; the step handler was never called. */
+        goto error;
+    }
+    else if (!*aggregate_instance) {
         /* this branch is executed if there was an exception in the aggregate's
          * __init__ */
 

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -708,7 +708,7 @@ void _pysqlite_final_callback(sqlite3_context* context)
 
     threadstate = PyGILState_Ensure();
 
-    aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
+    aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, 0);
     if (!*aggregate_instance) {
         /* this branch is executed if there was an exception in the aggregate's
          * __init__ */


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43258](https://bugs.python.org/issue43258) -->
https://bugs.python.org/issue43258
<!-- /issue-number -->
