### PR TITLE
gh-86013: Update "Install launcher for all users" win installer option

### DIFF
--- a/Tools/msi/bundle/Default.wxl
+++ b/Tools/msi/bundle/Default.wxl
@@ -86,7 +86,7 @@ Select Customize to review current options.</String>
   <String Id="ShortPrependPathLabel">Add &amp;Python [ShortVersion] to PATH</String>
   <String Id="InstallAllUsersLabel">Install for &amp;all users</String>
   <String Id="InstallLauncherAllUsersLabel">for &amp;all users (requires elevation)</String>
-  <String Id="ShortInstallLauncherAllUsersLabel">Install &amp;launcher for all users (recommended)</String>
+  <String Id="ShortInstallLauncherAllUsersLabel">Install py.exe &amp;launcher for all users (recommended)</String>
   <String Id="PrecompileLabel">&amp;Precompile standard library</String>
   <String Id="Include_symbolsLabel">Download debugging &amp;symbols</String>
   <String Id="Include_debugLabel">Download debu&amp;g binaries (requires VS 2017 or later)</String>


### PR DESCRIPTION
The "Install launcher for all users" option on the front page of
the installer now reads "Install py.exe launcher for all users".

<!-- issue-number: [bpo-41847](https://bugs.python.org/issue41847) -->
https://bugs.python.org/issue41847
<!-- /issue-number -->


<!-- gh-issue-number: gh-86013 -->
* Issue: gh-86013
<!-- /gh-issue-number -->
