### PR TITLE
bpo-43268: Replace _PyThreadState_GET() with _PyInterpreterState_GET()

### DIFF
--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -14,13 +14,10 @@ extern "C" {
 // Don't call this function but _PyLong_GetZero() and _PyLong_GetOne()
 static inline PyObject* __PyLong_GetSmallInt_internal(int value)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-#ifdef Py_DEBUG
-    _Py_EnsureTstateNotNULL(tstate);
-#endif
+    PyInterpreterState *interp = _PyInterpreterState_GET();
     assert(-_PY_NSMALLNEGINTS <= value && value < _PY_NSMALLPOSINTS);
     size_t index = _PY_NSMALLNEGINTS + value;
-    PyObject *obj = (PyObject*)tstate->interp->small_ints[index];
+    PyObject *obj = (PyObject*)interp->small_ints[index];
     // _PyLong_GetZero() and _PyLong_GetOne() must not be called
     // before _PyLong_Init() nor after _PyLong_Fini()
     assert(obj != NULL);

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -8,9 +8,9 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_gc.h"         // _PyObject_GC_IS_TRACKED()
-#include "pycore_interp.h"     // PyInterpreterState.gc
-#include "pycore_pystate.h"    // _PyThreadState_GET()
+#include "pycore_gc.h"            // _PyObject_GC_IS_TRACKED()
+#include "pycore_interp.h"        // PyInterpreterState.gc
+#include "pycore_pystate.h"       // _PyInterpreterState_GET()
 
 PyAPI_FUNC(int) _PyType_CheckConsistency(PyTypeObject *type);
 PyAPI_FUNC(int) _PyDict_CheckConsistency(PyObject *mp, int check_content);
@@ -85,8 +85,8 @@ static inline void _PyObject_GC_TRACK(
                           "object is in generation which is garbage collected",
                           filename, lineno, __func__);
 
-    PyThreadState *tstate = _PyThreadState_GET();
-    PyGC_Head *generation0 = tstate->interp->gc.generation0;
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    PyGC_Head *generation0 = interp->gc.generation0;
     PyGC_Head *last = (PyGC_Head*)(generation0->_gc_prev);
     _PyGCHead_SET_NEXT(last, gc);
     _PyGCHead_SET_PREV(gc, last);

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "pycore_initconfig.h"    // _PyStatus_ERR
 #include "pycore_pyerrors.h"      // _Py_DumpExtensionModules
+#include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads
 #include <signal.h>
 #include <object.h>
@@ -208,7 +209,7 @@ faulthandler_get_fileno(PyObject **file_ptr)
 static PyThreadState*
 get_thread_state(void)
 {
-    PyThreadState *tstate = _PyThreadState_UncheckedGet();
+    PyThreadState *tstate = _PyThreadState_GET();
     if (tstate == NULL) {
         /* just in case but very unlikely... */
         PyErr_SetString(PyExc_RuntimeError,


### PR DESCRIPTION
Replace _PyThreadState_GET() with _PyInterpreterState_GET() in
functions which only need the current interpreter, but don't need the
current Python thread state.

Replace also _PyThreadState_UncheckedGet() with _PyThreadState_GET()
in faulthandler.c, since _PyThreadState_UncheckedGet() is just an
alias to _PyThreadState_GET() in practice.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43268](https://bugs.python.org/issue43268) -->
https://bugs.python.org/issue43268
<!-- /issue-number -->
