### PR TITLE
bpo-43268: _Py_IsMainInterpreter() now expects interp

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -22,11 +22,11 @@ _Py_IsMainThread(void)
 
 
 static inline int
-_Py_IsMainInterpreter(PyThreadState* tstate)
+_Py_IsMainInterpreter(PyInterpreterState *interp)
 {
     /* Use directly _PyRuntime rather than tstate->interp->runtime, since
        this function is used in performance critical code path (ceval) */
-    return (tstate->interp == _PyRuntime.interpreters.main);
+    return (interp == _PyRuntime.interpreters.main);
 }
 
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5719,7 +5719,7 @@ _PyLong_Init(PyThreadState *tstate)
         tstate->interp->small_ints[i] = v;
     }
 
-    if (_Py_IsMainInterpreter(tstate)) {
+    if (_Py_IsMainInterpreter(tstate->interp)) {
         /* initialize int_info */
         if (Int_InfoType.tp_name == NULL) {
             if (PyStructSequence_InitType2(&Int_InfoType, &int_info_desc) < 0) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -286,7 +286,7 @@ void
 _PyType_Fini(PyThreadState *tstate)
 {
     _PyType_ClearCache(&tstate->interp->type_cache);
-    if (_Py_IsMainInterpreter(tstate)) {
+    if (_Py_IsMainInterpreter(tstate->interp)) {
         clear_slotdefs();
     }
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15701,7 +15701,7 @@ _PyUnicode_Init(PyThreadState *tstate)
         return _PyStatus_NO_MEMORY();
     }
 
-    if (_Py_IsMainInterpreter(tstate)) {
+    if (_Py_IsMainInterpreter(tstate->interp)) {
         /* initialize the linebreak bloom filter */
         bloom_linebreak = make_bloom_mask(
             PyUnicode_2BYTE_KIND, linebreak,

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -298,7 +298,7 @@ PyStatus
 _PyEval_InitGIL(PyThreadState *tstate)
 {
 #ifndef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
-    if (!_Py_IsMainInterpreter(tstate)) {
+    if (!_Py_IsMainInterpreter(tstate->interp)) {
         /* Currently, the GIL is shared by all interpreters,
            and only the main interpreter is responsible to create
            and destroy it. */
@@ -326,7 +326,7 @@ void
 _PyEval_FiniGIL(PyThreadState *tstate)
 {
 #ifndef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
-    if (!_Py_IsMainInterpreter(tstate)) {
+    if (!_Py_IsMainInterpreter(tstate->interp)) {
         /* Currently, the GIL is shared by all interpreters,
            and only the main interpreter is responsible to create
            and destroy it. */

--- a/Python/context.c
+++ b/Python/context.c
@@ -1302,7 +1302,7 @@ _PyContext_ClearFreeList(PyThreadState *tstate)
 void
 _PyContext_Fini(PyThreadState *tstate)
 {
-    if (_Py_IsMainInterpreter(tstate)) {
+    if (_Py_IsMainInterpreter(tstate->interp)) {
         Py_CLEAR(_token_missing);
     }
     _PyContext_ClearFreeList(tstate);

--- a/Python/import.c
+++ b/Python/import.c
@@ -441,7 +441,7 @@ _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
         return -1;
     }
 
-    if (_Py_IsMainInterpreter(tstate)) {
+    if (_Py_IsMainInterpreter(tstate->interp)) {
         if (def->m_size == -1) {
             if (def->m_base.m_copy) {
                 /* Somebody already imported the module,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -430,7 +430,7 @@ interpreter_update_config(PyThreadState *tstate, int only_update_path_config)
         }
     }
 
-    if (_Py_IsMainInterpreter(tstate)) {
+    if (_Py_IsMainInterpreter(tstate->interp)) {
         PyStatus status = _PyConfig_WritePathConfig(config);
         if (_PyStatus_EXCEPTION(status)) {
             _PyErr_SetFromPyStatus(status);
@@ -627,7 +627,7 @@ static PyStatus
 pycore_init_types(PyThreadState *tstate)
 {
     PyStatus status;
-    int is_main_interp = _Py_IsMainInterpreter(tstate);
+    int is_main_interp = _Py_IsMainInterpreter(tstate->interp);
 
     status = _PyGC_Init(tstate);
     if (_PyStatus_EXCEPTION(status)) {
@@ -1003,7 +1003,7 @@ init_interp_main(PyThreadState *tstate)
     assert(!_PyErr_Occurred(tstate));
 
     PyStatus status;
-    int is_main_interp = _Py_IsMainInterpreter(tstate);
+    int is_main_interp = _Py_IsMainInterpreter(tstate->interp);
     PyInterpreterState *interp = tstate->interp;
     const PyConfig *config = _PyInterpreterState_GetConfig(interp);
 
@@ -1597,7 +1597,7 @@ finalize_interp_types(PyThreadState *tstate)
 static void
 finalize_interp_clear(PyThreadState *tstate)
 {
-    int is_main_interp = _Py_IsMainInterpreter(tstate);
+    int is_main_interp = _Py_IsMainInterpreter(tstate->interp);
 
     /* Clear interpreter state and all thread states */
     _PyInterpreterState_Clear(tstate);
@@ -1622,7 +1622,7 @@ finalize_interp_clear(PyThreadState *tstate)
 static void
 finalize_interp_delete(PyThreadState *tstate)
 {
-    if (_Py_IsMainInterpreter(tstate)) {
+    if (_Py_IsMainInterpreter(tstate->interp)) {
         /* Cleanup auto-thread-state */
         _PyGILState_Fini(tstate);
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1327,7 +1327,7 @@ PyThreadState_IsCurrent(PyThreadState *tstate)
 PyStatus
 _PyGILState_Init(PyThreadState *tstate)
 {
-    if (!_Py_IsMainInterpreter(tstate)) {
+    if (!_Py_IsMainInterpreter(tstate->interp)) {
         /* Currently, PyGILState is shared by all interpreters. The main
          * interpreter is responsible to initialize it. */
         return _PyStatus_OK();


### PR DESCRIPTION
The _Py_IsMainInterpreter() function now expects interp rather than
tstate.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43268](https://bugs.python.org/issue43268) -->
https://bugs.python.org/issue43268
<!-- /issue-number -->
