### PR TITLE
bpo-43270: Remove private _PyErr_OCCURRED() macro

### DIFF
--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -30,12 +30,6 @@ PyAPI_FUNC(void) PyErr_SetExcInfo(PyObject *, PyObject *, PyObject *);
    macro is defined. */
 PyAPI_FUNC(void) _Py_NO_RETURN Py_FatalError(const char *message);
 
-#if defined(Py_DEBUG) || defined(Py_LIMITED_API)
-#define _PyErr_OCCURRED() PyErr_Occurred()
-#else
-#define _PyErr_OCCURRED() (PyThreadState_GET()->curexc_type)
-#endif
-
 /* Error testing and normalization */
 PyAPI_FUNC(int) PyErr_GivenExceptionMatches(PyObject *, PyObject *);
 PyAPI_FUNC(int) PyErr_ExceptionMatches(PyObject *);

--- a/Misc/NEWS.d/next/C API/2021-02-19-14-28-26.bpo-43270.UKx4XN.rst
+++ b/Misc/NEWS.d/next/C API/2021-02-19-14-28-26.bpo-43270.UKx4XN.rst
@@ -1,0 +1,2 @@
+Remove the private ``_PyErr_OCCURRED()`` macro: use the public
+:c:func:`PyErr_Occurred` function instead.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2750,7 +2750,7 @@ main_loop:
                                        (PyDictObject *)f->f_builtins,
                                        name);
                 if (v == NULL) {
-                    if (!_PyErr_OCCURRED()) {
+                    if (!_PyErr_Occurred(tstate)) {
                         /* _PyDict_LoadGlobal() returns NULL without raising
                          * an exception if the key doesn't exist */
                         format_exc_check_arg(tstate, PyExc_NameError,


### PR DESCRIPTION
Remove the private _PyErr_OCCURRED() macro: use the public
PyErr_Occurred() function instead.

CPython internals must use the internal _PyErr_Occurred(tstate)
function instead: it is the most efficient way to check if an
exception was raised.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43270](https://bugs.python.org/issue43270) -->
https://bugs.python.org/issue43270
<!-- /issue-number -->
