### PR TITLE
bpo-43268: Pass interp rather than tstate

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -23,7 +23,7 @@ PyAPI_FUNC(int) _PyEval_AddPendingCall(
     PyInterpreterState *interp,
     int (*func)(void *),
     void *arg);
-PyAPI_FUNC(void) _PyEval_SignalAsyncExc(PyThreadState *tstate);
+PyAPI_FUNC(void) _PyEval_SignalAsyncExc(PyInterpreterState *interp);
 #ifdef HAVE_FORK
 extern PyStatus _PyEval_ReInitThreads(PyThreadState *tstate);
 #endif
@@ -55,7 +55,7 @@ extern int _PyEval_ThreadsInitialized(PyInterpreterState *interp);
 extern int _PyEval_ThreadsInitialized(struct pyruntimestate *runtime);
 #endif
 extern PyStatus _PyEval_InitGIL(PyThreadState *tstate);
-extern void _PyEval_FiniGIL(PyThreadState *tstate);
+extern void _PyEval_FiniGIL(PyInterpreterState *interp);
 
 extern void _PyEval_ReleaseLock(PyThreadState *tstate);
 

--- a/Include/internal/pycore_context.h
+++ b/Include/internal/pycore_context.h
@@ -37,6 +37,6 @@ struct _pycontexttokenobject {
 
 
 int _PyContext_Init(void);
-void _PyContext_Fini(PyThreadState *tstate);
+void _PyContext_Fini(PyInterpreterState *interp);
 
 #endif /* !Py_INTERNAL_CONTEXT_H */

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -167,13 +167,13 @@ extern Py_ssize_t _PyGC_CollectNoFail(PyThreadState *tstate);
 
 
 // Functions to clear types free lists
-extern void _PyFrame_ClearFreeList(PyThreadState *tstate);
-extern void _PyTuple_ClearFreeList(PyThreadState *tstate);
-extern void _PyFloat_ClearFreeList(PyThreadState *tstate);
-extern void _PyList_ClearFreeList(PyThreadState *tstate);
-extern void _PyDict_ClearFreeList(PyThreadState *tstate);
-extern void _PyAsyncGen_ClearFreeLists(PyThreadState *tstate);
-extern void _PyContext_ClearFreeList(PyThreadState *tstate);
+extern void _PyFrame_ClearFreeList(PyInterpreterState *interp);
+extern void _PyTuple_ClearFreeList(PyInterpreterState *interp);
+extern void _PyFloat_ClearFreeList(PyInterpreterState *interp);
+extern void _PyList_ClearFreeList(PyInterpreterState *interp);
+extern void _PyDict_ClearFreeList(PyInterpreterState *interp);
+extern void _PyAsyncGen_ClearFreeLists(PyInterpreterState *interp);
+extern void _PyContext_ClearFreeList(PyInterpreterState *interp);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -31,21 +31,21 @@ PyAPI_FUNC(int) _Py_IsLocaleCoercionTarget(const char *ctype_loc);
 
 /* Various one-time initializers */
 
-extern PyStatus _PyUnicode_Init(PyThreadState *tstate);
-extern PyStatus _PyBytes_Init(PyThreadState *tstate);
+extern PyStatus _PyUnicode_Init(PyInterpreterState *interp);
+extern PyStatus _PyBytes_Init(PyInterpreterState *interp);
 extern int _PyStructSequence_Init(void);
-extern int _PyLong_Init(PyThreadState *tstate);
-extern PyStatus _PyTuple_Init(PyThreadState *tstate);
+extern int _PyLong_Init(PyInterpreterState *interp);
+extern PyStatus _PyTuple_Init(PyInterpreterState *interp);
 extern PyStatus _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
-extern PyObject * _PyBuiltin_Init(PyThreadState *tstate);
+extern PyObject * _PyBuiltin_Init(PyInterpreterState *interp);
 extern PyStatus _PySys_Create(
     PyThreadState *tstate,
     PyObject **sysmod_p);
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_UpdateConfig(PyThreadState *tstate);
-extern PyStatus _PyExc_Init(PyThreadState *tstate);
+extern PyStatus _PyExc_Init(PyInterpreterState *interp);
 extern PyStatus _PyErr_Init(void);
 extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);
 extern int _PyFloat_Init(void);
@@ -54,33 +54,33 @@ extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 extern PyStatus _PyTypes_Init(void);
 extern PyStatus _PyTypes_InitSlotDefs(void);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
-extern PyStatus _PyGC_Init(PyThreadState *tstate);
-extern PyStatus _PyAtExit_Init(PyThreadState *tstate);
+extern PyStatus _PyGC_Init(PyInterpreterState *interp);
+extern PyStatus _PyAtExit_Init(PyInterpreterState *interp);
 
 
 /* Various internal finalizers */
 
-extern void _PyFrame_Fini(PyThreadState *tstate);
-extern void _PyDict_Fini(PyThreadState *tstate);
-extern void _PyTuple_Fini(PyThreadState *tstate);
-extern void _PyList_Fini(PyThreadState *tstate);
-extern void _PyBytes_Fini(PyThreadState *tstate);
-extern void _PyFloat_Fini(PyThreadState *tstate);
-extern void _PySlice_Fini(PyThreadState *tstate);
-extern void _PyAsyncGen_Fini(PyThreadState *tstate);
+extern void _PyFrame_Fini(PyInterpreterState *interp);
+extern void _PyDict_Fini(PyInterpreterState *interp);
+extern void _PyTuple_Fini(PyInterpreterState *interp);
+extern void _PyList_Fini(PyInterpreterState *interp);
+extern void _PyBytes_Fini(PyInterpreterState *interp);
+extern void _PyFloat_Fini(PyInterpreterState *interp);
+extern void _PySlice_Fini(PyInterpreterState *interp);
+extern void _PyAsyncGen_Fini(PyInterpreterState *interp);
 
 extern int _PySignal_Init(int install_signal_handlers);
 extern void _PySignal_Fini(void);
 
-extern void _PyExc_Fini(PyThreadState *tstate);
+extern void _PyExc_Fini(PyInterpreterState *interp);
 extern void _PyImport_Fini(void);
 extern void _PyImport_Fini2(void);
-extern void _PyGC_Fini(PyThreadState *tstate);
-extern void _PyType_Fini(PyThreadState *tstate);
+extern void _PyGC_Fini(PyInterpreterState *interp);
+extern void _PyType_Fini(PyInterpreterState *interp);
 extern void _Py_HashRandomization_Fini(void);
-extern void _PyUnicode_Fini(PyThreadState *tstate);
-extern void _PyUnicode_ClearInterned(PyThreadState *tstate);
-extern void _PyLong_Fini(PyThreadState *tstate);
+extern void _PyUnicode_Fini(PyInterpreterState *interp);
+extern void _PyUnicode_ClearInterned(PyInterpreterState *interp);
+extern void _PyLong_Fini(PyInterpreterState *interp);
 extern void _PyFaulthandler_Fini(void);
 extern void _PyHash_Fini(void);
 extern void _PyTraceMalloc_Fini(void);
@@ -89,9 +89,9 @@ extern void _PyAST_Fini(PyInterpreterState *interp);
 extern void _PyAtExit_Fini(PyInterpreterState *interp);
 
 extern PyStatus _PyGILState_Init(PyThreadState *tstate);
-extern void _PyGILState_Fini(PyThreadState *tstate);
+extern void _PyGILState_Fini(PyInterpreterState *interp);
 
-PyAPI_FUNC(void) _PyGC_DumpShutdownStats(PyThreadState *tstate);
+PyAPI_FUNC(void) _PyGC_DumpShutdownStats(PyInterpreterState *interp);
 
 PyAPI_FUNC(PyStatus) _Py_PreInitializeFromPyArgv(
     const PyPreConfig *src_config,
@@ -111,7 +111,7 @@ PyAPI_FUNC(void) _PyErr_Display(PyObject *file, PyObject *exception,
 
 PyAPI_FUNC(void) _PyThreadState_DeleteCurrent(PyThreadState *tstate);
 
-extern void _PyAtExit_Call(PyThreadState *tstate);
+extern void _PyAtExit_Call(PyInterpreterState *interp);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_warnings.h
+++ b/Include/internal/pycore_warnings.h
@@ -17,7 +17,7 @@ struct _warnings_runtime_state {
     long filters_version;
 };
 
-extern int _PyWarnings_InitState(PyThreadState *tstate);
+extern int _PyWarnings_InitState(PyInterpreterState *interp);
 
 #ifdef __cplusplus
 }

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -52,9 +52,9 @@ atexit_cleanup(struct atexit_state *state)
 
 
 PyStatus
-_PyAtExit_Init(PyThreadState *tstate)
+_PyAtExit_Init(PyInterpreterState *interp)
 {
-    struct atexit_state *state = &tstate->interp->atexit;
+    struct atexit_state *state = &interp->atexit;
     // _PyAtExit_Init() must only be called once
     assert(state->callbacks == NULL);
 
@@ -109,9 +109,9 @@ atexit_callfuncs(struct atexit_state *state)
 
 
 void
-_PyAtExit_Call(PyThreadState *tstate)
+_PyAtExit_Call(PyInterpreterState *interp)
 {
-    struct atexit_state *state = &tstate->interp->atexit;
+    struct atexit_state *state = &interp->atexit;
     atexit_callfuncs(state);
 }
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -161,9 +161,9 @@ _PyGC_InitState(GCState *gcstate)
 
 
 PyStatus
-_PyGC_Init(PyThreadState *tstate)
+_PyGC_Init(PyInterpreterState *interp)
 {
-    GCState *gcstate = &tstate->interp->gc;
+    GCState *gcstate = &interp->gc;
 
     gcstate->garbage = PyList_New(0);
     if (gcstate->garbage == NULL) {
@@ -1036,15 +1036,15 @@ delete_garbage(PyThreadState *tstate, GCState *gcstate,
  * Clearing the free lists may give back memory to the OS earlier.
  */
 static void
-clear_freelists(PyThreadState *tstate)
+clear_freelists(PyInterpreterState *interp)
 {
-    _PyFrame_ClearFreeList(tstate);
-    _PyTuple_ClearFreeList(tstate);
-    _PyFloat_ClearFreeList(tstate);
-    _PyList_ClearFreeList(tstate);
-    _PyDict_ClearFreeList(tstate);
-    _PyAsyncGen_ClearFreeLists(tstate);
-    _PyContext_ClearFreeList(tstate);
+    _PyFrame_ClearFreeList(interp);
+    _PyTuple_ClearFreeList(interp);
+    _PyFloat_ClearFreeList(interp);
+    _PyList_ClearFreeList(interp);
+    _PyDict_ClearFreeList(interp);
+    _PyAsyncGen_ClearFreeLists(interp);
+    _PyContext_ClearFreeList(interp);
 }
 
 // Show stats for objects in each generations
@@ -1323,7 +1323,7 @@ gc_collect_main(PyThreadState *tstate, int generation,
     /* Clear free list only during the collection of the highest
      * generation */
     if (generation == NUM_GENERATIONS-1) {
-        clear_freelists(tstate);
+        clear_freelists(tstate->interp);
     }
 
     if (_PyErr_Occurred(tstate)) {
@@ -2092,9 +2092,9 @@ _PyGC_CollectNoFail(PyThreadState *tstate)
 }
 
 void
-_PyGC_DumpShutdownStats(PyThreadState *tstate)
+_PyGC_DumpShutdownStats(PyInterpreterState *interp)
 {
-    GCState *gcstate = &tstate->interp->gc;
+    GCState *gcstate = &interp->gc;
     if (!(gcstate->debug & DEBUG_SAVEALL)
         && gcstate->garbage != NULL && PyList_GET_SIZE(gcstate->garbage) > 0) {
         const char *message;
@@ -2129,9 +2129,9 @@ _PyGC_DumpShutdownStats(PyThreadState *tstate)
 }
 
 void
-_PyGC_Fini(PyThreadState *tstate)
+_PyGC_Fini(PyInterpreterState *interp)
 {
-    GCState *gcstate = &tstate->interp->gc;
+    GCState *gcstate = &interp->gc;
     Py_CLEAR(gcstate->garbage);
     Py_CLEAR(gcstate->callbacks);
 }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3063,9 +3063,9 @@ error:
 
 
 PyStatus
-_PyBytes_Init(PyThreadState *tstate)
+_PyBytes_Init(PyInterpreterState *interp)
 {
-    struct _Py_bytes_state *state = &tstate->interp->bytes;
+    struct _Py_bytes_state *state = &interp->bytes;
     if (bytes_create_empty_string_singleton(state) < 0) {
         return _PyStatus_NO_MEMORY();
     }
@@ -3074,9 +3074,9 @@ _PyBytes_Init(PyThreadState *tstate)
 
 
 void
-_PyBytes_Fini(PyThreadState *tstate)
+_PyBytes_Fini(PyInterpreterState *interp)
 {
-    struct _Py_bytes_state* state = &tstate->interp->bytes;
+    struct _Py_bytes_state* state = &interp->bytes;
     for (int i = 0; i < UCHAR_MAX + 1; i++) {
         Py_CLEAR(state->characters[i]);
     }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -260,9 +260,9 @@ get_dict_state(void)
 
 
 void
-_PyDict_ClearFreeList(PyThreadState *tstate)
+_PyDict_ClearFreeList(PyInterpreterState *interp)
 {
-    struct _Py_dict_state *state = &tstate->interp->dict_state;
+    struct _Py_dict_state *state = &interp->dict_state;
     while (state->numfree) {
         PyDictObject *op = state->free_list[--state->numfree];
         assert(PyDict_CheckExact(op));
@@ -275,11 +275,11 @@ _PyDict_ClearFreeList(PyThreadState *tstate)
 
 
 void
-_PyDict_Fini(PyThreadState *tstate)
+_PyDict_Fini(PyInterpreterState *interp)
 {
-    _PyDict_ClearFreeList(tstate);
+    _PyDict_ClearFreeList(interp);
 #ifdef Py_DEBUG
-    struct _Py_dict_state *state = get_dict_state();
+    struct _Py_dict_state *state = &interp->dict_state;
     state->numfree = -1;
     state->keys_numfree = -1;
 #endif

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2529,9 +2529,9 @@ SimpleExtendsException(PyExc_Warning, ResourceWarning,
 #endif /* MS_WINDOWS */
 
 PyStatus
-_PyExc_Init(PyThreadState *tstate)
+_PyExc_Init(PyInterpreterState *interp)
 {
-    struct _Py_exc_state *state = &tstate->interp->exc_state;
+    struct _Py_exc_state *state = &interp->exc_state;
 
 #define PRE_INIT(TYPE) \
     if (!(_PyExc_ ## TYPE.tp_flags & Py_TPFLAGS_READY)) { \
@@ -2766,9 +2766,9 @@ _PyBuiltins_AddExceptions(PyObject *bltinmod)
 }
 
 void
-_PyExc_Fini(PyThreadState *tstate)
+_PyExc_Fini(PyInterpreterState *interp)
 {
-    struct _Py_exc_state *state = &tstate->interp->exc_state;
+    struct _Py_exc_state *state = &interp->exc_state;
     free_preallocated_memerrors(state);
     Py_CLEAR(state->errnomap);
 }

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2026,9 +2026,9 @@ _PyFloat_Init(void)
 }
 
 void
-_PyFloat_ClearFreeList(PyThreadState *tstate)
+_PyFloat_ClearFreeList(PyInterpreterState *interp)
 {
-    struct _Py_float_state *state = &tstate->interp->float_state;
+    struct _Py_float_state *state = &interp->float_state;
     PyFloatObject *f = state->free_list;
     while (f != NULL) {
         PyFloatObject *next = (PyFloatObject*) Py_TYPE(f);
@@ -2040,11 +2040,11 @@ _PyFloat_ClearFreeList(PyThreadState *tstate)
 }
 
 void
-_PyFloat_Fini(PyThreadState *tstate)
+_PyFloat_Fini(PyInterpreterState *interp)
 {
-    _PyFloat_ClearFreeList(tstate);
+    _PyFloat_ClearFreeList(interp);
 #ifdef Py_DEBUG
-    struct _Py_float_state *state = &tstate->interp->float_state;
+    struct _Py_float_state *state = &interp->float_state;
     state->numfree = -1;
 #endif
 }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1109,9 +1109,9 @@ PyFrame_LocalsToFast(PyFrameObject *f, int clear)
 
 /* Clear out the free list */
 void
-_PyFrame_ClearFreeList(PyThreadState *tstate)
+_PyFrame_ClearFreeList(PyInterpreterState *interp)
 {
-    struct _Py_frame_state *state = &tstate->interp->frame;
+    struct _Py_frame_state *state = &interp->frame;
     while (state->free_list != NULL) {
         PyFrameObject *f = state->free_list;
         state->free_list = state->free_list->f_back;
@@ -1122,11 +1122,11 @@ _PyFrame_ClearFreeList(PyThreadState *tstate)
 }
 
 void
-_PyFrame_Fini(PyThreadState *tstate)
+_PyFrame_Fini(PyInterpreterState *interp)
 {
-    _PyFrame_ClearFreeList(tstate);
+    _PyFrame_ClearFreeList(interp);
 #ifdef Py_DEBUG
-    struct _Py_frame_state *state = &tstate->interp->frame;
+    struct _Py_frame_state *state = &interp->frame;
     state->numfree = -1;
 #endif
 }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1489,9 +1489,9 @@ PyAsyncGen_New(PyFrameObject *f, PyObject *name, PyObject *qualname)
 
 
 void
-_PyAsyncGen_ClearFreeLists(PyThreadState *tstate)
+_PyAsyncGen_ClearFreeLists(PyInterpreterState *interp)
 {
-    struct _Py_async_gen_state *state = &tstate->interp->async_gen;
+    struct _Py_async_gen_state *state = &interp->async_gen;
 
     while (state->value_numfree) {
         _PyAsyncGenWrappedValue *o;
@@ -1509,11 +1509,11 @@ _PyAsyncGen_ClearFreeLists(PyThreadState *tstate)
 }
 
 void
-_PyAsyncGen_Fini(PyThreadState *tstate)
+_PyAsyncGen_Fini(PyInterpreterState *interp)
 {
-    _PyAsyncGen_ClearFreeLists(tstate);
+    _PyAsyncGen_ClearFreeLists(interp);
 #ifdef Py_DEBUG
-    struct _Py_async_gen_state *state = &tstate->interp->async_gen;
+    struct _Py_async_gen_state *state = &interp->async_gen;
     state->value_numfree = -1;
     state->asend_numfree = -1;
 #endif

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -106,9 +106,9 @@ list_preallocate_exact(PyListObject *self, Py_ssize_t size)
 }
 
 void
-_PyList_ClearFreeList(PyThreadState *tstate)
+_PyList_ClearFreeList(PyInterpreterState *interp)
 {
-    struct _Py_list_state *state = &tstate->interp->list;
+    struct _Py_list_state *state = &interp->list;
     while (state->numfree) {
         PyListObject *op = state->free_list[--state->numfree];
         assert(PyList_CheckExact(op));
@@ -117,11 +117,11 @@ _PyList_ClearFreeList(PyThreadState *tstate)
 }
 
 void
-_PyList_Fini(PyThreadState *tstate)
+_PyList_Fini(PyInterpreterState *interp)
 {
-    _PyList_ClearFreeList(tstate);
+    _PyList_ClearFreeList(interp);
 #ifdef Py_DEBUG
-    struct _Py_list_state *state = &tstate->interp->list;
+    struct _Py_list_state *state = &interp->list;
     state->numfree = -1;
 #endif
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5702,7 +5702,7 @@ PyLong_GetInfo(void)
 }
 
 int
-_PyLong_Init(PyThreadState *tstate)
+_PyLong_Init(PyInterpreterState *interp)
 {
     for (Py_ssize_t i=0; i < NSMALLNEGINTS + NSMALLPOSINTS; i++) {
         sdigit ival = (sdigit)i - NSMALLNEGINTS;
@@ -5716,10 +5716,10 @@ _PyLong_Init(PyThreadState *tstate)
         Py_SET_SIZE(v, size);
         v->ob_digit[0] = (digit)abs(ival);
 
-        tstate->interp->small_ints[i] = v;
+        interp->small_ints[i] = v;
     }
 
-    if (_Py_IsMainInterpreter(tstate->interp)) {
+    if (_Py_IsMainInterpreter(interp)) {
         /* initialize int_info */
         if (Int_InfoType.tp_name == NULL) {
             if (PyStructSequence_InitType2(&Int_InfoType, &int_info_desc) < 0) {
@@ -5732,9 +5732,9 @@ _PyLong_Init(PyThreadState *tstate)
 }
 
 void
-_PyLong_Fini(PyThreadState *tstate)
+_PyLong_Fini(PyInterpreterState *interp)
 {
     for (Py_ssize_t i = 0; i < NSMALLNEGINTS + NSMALLPOSINTS; i++) {
-        Py_CLEAR(tstate->interp->small_ints[i]);
+        Py_CLEAR(interp->small_ints[i]);
     }
 }

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -97,9 +97,8 @@ PyObject _Py_EllipsisObject = {
 /* Slice object implementation */
 
 
-void _PySlice_Fini(PyThreadState *tstate)
+void _PySlice_Fini(PyInterpreterState *interp)
 {
-    PyInterpreterState *interp = tstate->interp;
     PySliceObject *obj = interp->slice_cache;
     if (obj != NULL) {
         interp->slice_cache = NULL;

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1007,10 +1007,10 @@ _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
 }
 
 void
-_PyTuple_ClearFreeList(PyThreadState *tstate)
+_PyTuple_ClearFreeList(PyInterpreterState *interp)
 {
 #if PyTuple_MAXSAVESIZE > 0
-    struct _Py_tuple_state *state = &tstate->interp->tuple;
+    struct _Py_tuple_state *state = &interp->tuple;
     for (Py_ssize_t i = 1; i < PyTuple_MAXSAVESIZE; i++) {
         PyTupleObject *p = state->free_list[i];
         state->free_list[i] = NULL;
@@ -1027,9 +1027,9 @@ _PyTuple_ClearFreeList(PyThreadState *tstate)
 
 
 PyStatus
-_PyTuple_Init(PyThreadState *tstate)
+_PyTuple_Init(PyInterpreterState *interp)
 {
-    struct _Py_tuple_state *state = &tstate->interp->tuple;
+    struct _Py_tuple_state *state = &interp->tuple;
     if (tuple_create_empty_tuple_singleton(state) < 0) {
         return _PyStatus_NO_MEMORY();
     }
@@ -1038,14 +1038,14 @@ _PyTuple_Init(PyThreadState *tstate)
 
 
 void
-_PyTuple_Fini(PyThreadState *tstate)
+_PyTuple_Fini(PyInterpreterState *interp)
 {
 #if PyTuple_MAXSAVESIZE > 0
-    struct _Py_tuple_state *state = &tstate->interp->tuple;
+    struct _Py_tuple_state *state = &interp->tuple;
     // The empty tuple singleton must not be tracked by the GC
     assert(!_PyObject_GC_IS_TRACKED(state->free_list[0]));
     Py_CLEAR(state->free_list[0]);
-    _PyTuple_ClearFreeList(tstate);
+    _PyTuple_ClearFreeList(interp);
 #ifdef Py_DEBUG
     state->numfree[0] = -1;
 #endif

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -283,10 +283,10 @@ PyType_ClearCache(void)
 
 
 void
-_PyType_Fini(PyThreadState *tstate)
+_PyType_Fini(PyInterpreterState *interp)
 {
-    _PyType_ClearCache(&tstate->interp->type_cache);
-    if (_Py_IsMainInterpreter(tstate->interp)) {
+    _PyType_ClearCache(&interp->type_cache);
+    if (_Py_IsMainInterpreter(interp)) {
         clear_slotdefs();
     }
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15682,7 +15682,7 @@ PyTypeObject PyUnicode_Type = {
 /* Initialize the Unicode implementation */
 
 PyStatus
-_PyUnicode_Init(PyThreadState *tstate)
+_PyUnicode_Init(PyInterpreterState *interp)
 {
     /* XXX - move this array to unicodectype.c ? */
     const Py_UCS2 linebreak[] = {
@@ -15696,12 +15696,12 @@ _PyUnicode_Init(PyThreadState *tstate)
         0x2029, /* PARAGRAPH SEPARATOR */
     };
 
-    struct _Py_unicode_state *state = &tstate->interp->unicode;
+    struct _Py_unicode_state *state = &interp->unicode;
     if (unicode_create_empty_string_singleton(state) < 0) {
         return _PyStatus_NO_MEMORY();
     }
 
-    if (_Py_IsMainInterpreter(tstate->interp)) {
+    if (_Py_IsMainInterpreter(interp)) {
         /* initialize the linebreak bloom filter */
         bloom_linebreak = make_bloom_mask(
             PyUnicode_2BYTE_KIND, linebreak,
@@ -15813,9 +15813,9 @@ PyUnicode_InternFromString(const char *cp)
 
 
 void
-_PyUnicode_ClearInterned(PyThreadState *tstate)
+_PyUnicode_ClearInterned(PyInterpreterState *interp)
 {
-    struct _Py_unicode_state *state = &tstate->interp->unicode;
+    struct _Py_unicode_state *state = &interp->unicode;
     if (state->interned == NULL) {
         return;
     }
@@ -16093,10 +16093,10 @@ error:
 
 
 static PyStatus
-init_stdio_encoding(PyThreadState *tstate)
+init_stdio_encoding(PyInterpreterState *interp)
 {
     /* Update the stdio encoding to the normalized Python codec name. */
-    PyConfig *config = (PyConfig*)_PyInterpreterState_GetConfig(tstate->interp);
+    PyConfig *config = (PyConfig*)_PyInterpreterState_GetConfig(interp);
     if (config_get_codec_name(&config->stdio_encoding) < 0) {
         return _PyStatus_ERR("failed to get the Python codec name "
                              "of the stdio encoding");
@@ -16189,7 +16189,7 @@ _PyUnicode_InitEncodings(PyThreadState *tstate)
         return status;
     }
 
-    return init_stdio_encoding(tstate);
+    return init_stdio_encoding(tstate->interp);
 }
 
 
@@ -16233,9 +16233,9 @@ _PyUnicode_EnableLegacyWindowsFSEncoding(void)
 
 
 void
-_PyUnicode_Fini(PyThreadState *tstate)
+_PyUnicode_Fini(PyInterpreterState *interp)
 {
-    struct _Py_unicode_state *state = &tstate->interp->unicode;
+    struct _Py_unicode_state *state = &interp->unicode;
 
     // _PyUnicode_ClearInterned() must be called before
     assert(state->interned == NULL);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -114,9 +114,9 @@ init_filters(void)
 
 /* Initialize the given warnings module state. */
 int
-_PyWarnings_InitState(PyThreadState *tstate)
+_PyWarnings_InitState(PyInterpreterState *interp)
 {
-    WarningsState *st = &tstate->interp->warnings;
+    WarningsState *st = &interp->warnings;
 
     if (st->filters == NULL) {
         st->filters = init_filters();

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2853,11 +2853,11 @@ static struct PyModuleDef builtinsmodule = {
 
 
 PyObject *
-_PyBuiltin_Init(PyThreadState *tstate)
+_PyBuiltin_Init(PyInterpreterState *interp)
 {
     PyObject *mod, *dict, *debug;
 
-    const PyConfig *config = _PyInterpreterState_GetConfig(tstate->interp);
+    const PyConfig *config = _PyInterpreterState_GetConfig(interp);
 
     if (PyType_Ready(&PyFilter_Type) < 0 ||
         PyType_Ready(&PyMap_Type) < 0 ||

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -318,7 +318,7 @@ _ready:
 
     /* Don't access tstate if the thread must exit */
     if (tstate->async_exc != NULL) {
-        _PyEval_SignalAsyncExc(tstate);
+        _PyEval_SignalAsyncExc(tstate->interp);
     }
 
     MUTEX_UNLOCK(gil->mutex);

--- a/Python/context.c
+++ b/Python/context.c
@@ -1287,9 +1287,9 @@ get_token_missing(void)
 
 
 void
-_PyContext_ClearFreeList(PyThreadState *tstate)
+_PyContext_ClearFreeList(PyInterpreterState *interp)
 {
-    struct _Py_context_state *state = &tstate->interp->context;
+    struct _Py_context_state *state = &interp->context;
     for (; state->numfree; state->numfree--) {
         PyContext *ctx = state->freelist;
         state->freelist = (PyContext *)ctx->ctx_weakreflist;
@@ -1300,14 +1300,14 @@ _PyContext_ClearFreeList(PyThreadState *tstate)
 
 
 void
-_PyContext_Fini(PyThreadState *tstate)
+_PyContext_Fini(PyInterpreterState *interp)
 {
-    if (_Py_IsMainInterpreter(tstate->interp)) {
+    if (_Py_IsMainInterpreter(interp)) {
         Py_CLEAR(_token_missing);
     }
-    _PyContext_ClearFreeList(tstate);
+    _PyContext_ClearFreeList(interp);
 #ifdef Py_DEBUG
-    struct _Py_context_state *state = &tstate->interp->context;
+    struct _Py_context_state *state = &interp->context;
     state->numfree = -1;
 #endif
     _PyHamt_Fini();

--- a/Python/import.c
+++ b/Python/import.c
@@ -301,16 +301,16 @@ _PyImport_GetModuleId(struct _Py_Identifier *nameid)
 int
 _PyImport_SetModule(PyObject *name, PyObject *m)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    PyObject *modules = tstate->interp->modules;
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    PyObject *modules = interp->modules;
     return PyObject_SetItem(modules, name, m);
 }
 
 int
 _PyImport_SetModuleString(const char *name, PyObject *m)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    PyObject *modules = tstate->interp->modules;
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    PyObject *modules = interp->modules;
     return PyMapping_SetItemString(modules, name, m);
 }
 
@@ -342,9 +342,8 @@ import_get_module(PyThreadState *tstate, PyObject *name)
 
 
 static int
-import_ensure_initialized(PyThreadState *tstate, PyObject *mod, PyObject *name)
+import_ensure_initialized(PyInterpreterState *interp, PyObject *mod, PyObject *name)
 {
-    PyInterpreterState *interp = tstate->interp;
     PyObject *spec;
 
     _Py_IDENTIFIER(_lock_unlock_module);
@@ -1530,7 +1529,7 @@ PyImport_GetModule(PyObject *name)
 
     mod = import_get_module(tstate, name);
     if (mod != NULL && mod != Py_None) {
-        if (import_ensure_initialized(tstate, mod, name) < 0) {
+        if (import_ensure_initialized(tstate->interp, mod, name) < 0) {
             Py_DECREF(mod);
             remove_importlib_frames(tstate);
             return NULL;
@@ -1594,7 +1593,7 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
     }
 
     if (mod != NULL && mod != Py_None) {
-        if (import_ensure_initialized(tstate, mod, name) < 0) {
+        if (import_ensure_initialized(tstate->interp, mod, name) < 0) {
             goto error;
         }
     }

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2909,8 +2909,8 @@ _Py_GetConfigsAsDict(void)
     Py_CLEAR(dict);
 
     /* pre config */
-    PyThreadState *tstate = _PyThreadState_GET();
-    const PyPreConfig *pre_config = &tstate->interp->runtime->preconfig;
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    const PyPreConfig *pre_config = &interp->runtime->preconfig;
     dict = _PyPreConfig_AsDict(pre_config);
     if (dict == NULL) {
         goto error;
@@ -2921,7 +2921,7 @@ _Py_GetConfigsAsDict(void)
     Py_CLEAR(dict);
 
     /* core config */
-    const PyConfig *config = _PyInterpreterState_GetConfig(tstate->interp);
+    const PyConfig *config = _PyInterpreterState_GetConfig(interp);
     dict = _PyConfig_AsDict(config);
     if (dict == NULL) {
         goto error;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -574,7 +574,7 @@ init_interp_create_gil(PyThreadState *tstate)
 
     /* finalize_interp_delete() comment explains why _PyEval_FiniGIL() is
        only called here. */
-    _PyEval_FiniGIL(tstate);
+    _PyEval_FiniGIL(tstate->interp);
 
     /* Auto-thread-state API */
     status = _PyGILState_Init(tstate);
@@ -624,12 +624,12 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
 
 
 static PyStatus
-pycore_init_types(PyThreadState *tstate)
+pycore_init_types(PyInterpreterState *interp)
 {
     PyStatus status;
-    int is_main_interp = _Py_IsMainInterpreter(tstate->interp);
+    int is_main_interp = _Py_IsMainInterpreter(interp);
 
-    status = _PyGC_Init(tstate);
+    status = _PyGC_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -637,7 +637,7 @@ pycore_init_types(PyThreadState *tstate)
     // Create the empty tuple singleton. It must be created before the first
     // PyType_Ready() call since PyType_Ready() creates tuples, for tp_bases
     // for example.
-    status = _PyTuple_Init(tstate);
+    status = _PyTuple_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -649,21 +649,21 @@ pycore_init_types(PyThreadState *tstate)
         }
     }
 
-    if (!_PyLong_Init(tstate)) {
+    if (!_PyLong_Init(interp)) {
         return _PyStatus_ERR("can't init longs");
     }
 
-    status = _PyUnicode_Init(tstate);
+    status = _PyUnicode_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
 
-    status = _PyBytes_Init(tstate);
+    status = _PyBytes_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
 
-    status = _PyExc_Init(tstate);
+    status = _PyExc_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -689,11 +689,11 @@ pycore_init_types(PyThreadState *tstate)
         }
     }
 
-    if (_PyWarnings_InitState(tstate) < 0) {
+    if (_PyWarnings_InitState(interp) < 0) {
         return _PyStatus_ERR("can't initialize warnings");
     }
 
-    status = _PyAtExit_Init(tstate);
+    status = _PyAtExit_Init(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -703,16 +703,13 @@ pycore_init_types(PyThreadState *tstate)
 
 
 static PyStatus
-pycore_init_builtins(PyThreadState *tstate)
+pycore_init_builtins(PyInterpreterState *interp)
 {
-    assert(!_PyErr_Occurred(tstate));
-
-    PyObject *bimod = _PyBuiltin_Init(tstate);
+    PyObject *bimod = _PyBuiltin_Init(interp);
     if (bimod == NULL) {
         goto error;
     }
 
-    PyInterpreterState *interp = tstate->interp;
     if (_PyImport_FixupBuiltin(bimod, "builtins", interp->modules) < 0) {
         goto error;
     }
@@ -743,8 +740,6 @@ pycore_init_builtins(PyThreadState *tstate)
     }
     interp->import_func = Py_NewRef(import_func);
 
-    assert(!_PyErr_Occurred(tstate));
-
     return _PyStatus_OK();
 
 error:
@@ -759,7 +754,7 @@ pycore_interp_init(PyThreadState *tstate)
     PyStatus status;
     PyObject *sysmod = NULL;
 
-    status = pycore_init_types(tstate);
+    status = pycore_init_types(tstate->interp);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;
     }
@@ -769,10 +764,14 @@ pycore_interp_init(PyThreadState *tstate)
         goto done;
     }
 
-    status = pycore_init_builtins(tstate);
+    assert(!_PyErr_Occurred(tstate));
+
+    status = pycore_init_builtins(tstate->interp);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;
     }
+
+    assert(!_PyErr_Occurred(tstate));
 
     const PyConfig *config = _PyInterpreterState_GetConfig(tstate->interp);
     if (config->_install_importlib) {
@@ -1464,7 +1463,7 @@ finalize_modules(PyThreadState *tstate)
 
     // Dump GC stats before it's too late, since it uses the warnings
     // machinery.
-    _PyGC_DumpShutdownStats(tstate);
+    _PyGC_DumpShutdownStats(interp);
 
     if (weaklist != NULL) {
         // Now, if there are any modules left alive, clear their globals to
@@ -1570,27 +1569,27 @@ flush_std_files(void)
 
 
 static void
-finalize_interp_types(PyThreadState *tstate)
+finalize_interp_types(PyInterpreterState *interp)
 {
-    _PyExc_Fini(tstate);
-    _PyFrame_Fini(tstate);
-    _PyAsyncGen_Fini(tstate);
-    _PyContext_Fini(tstate);
-    _PyType_Fini(tstate);
+    _PyExc_Fini(interp);
+    _PyFrame_Fini(interp);
+    _PyAsyncGen_Fini(interp);
+    _PyContext_Fini(interp);
+    _PyType_Fini(interp);
     // Call _PyUnicode_ClearInterned() before _PyDict_Fini() since it uses
     // a dict internally.
-    _PyUnicode_ClearInterned(tstate);
+    _PyUnicode_ClearInterned(interp);
 
-    _PyDict_Fini(tstate);
-    _PyList_Fini(tstate);
-    _PyTuple_Fini(tstate);
+    _PyDict_Fini(interp);
+    _PyList_Fini(interp);
+    _PyTuple_Fini(interp);
 
-    _PySlice_Fini(tstate);
+    _PySlice_Fini(interp);
 
-    _PyBytes_Fini(tstate);
-    _PyUnicode_Fini(tstate);
-    _PyFloat_Fini(tstate);
-    _PyLong_Fini(tstate);
+    _PyBytes_Fini(interp);
+    _PyUnicode_Fini(interp);
+    _PyFloat_Fini(interp);
+    _PyLong_Fini(interp);
 }
 
 
@@ -1615,16 +1614,16 @@ finalize_interp_clear(PyThreadState *tstate)
         _Py_ClearFileSystemEncoding();
     }
 
-    finalize_interp_types(tstate);
+    finalize_interp_types(tstate->interp);
 }
 
 
 static void
-finalize_interp_delete(PyThreadState *tstate)
+finalize_interp_delete(PyInterpreterState *interp)
 {
-    if (_Py_IsMainInterpreter(tstate->interp)) {
+    if (_Py_IsMainInterpreter(interp)) {
         /* Cleanup auto-thread-state */
-        _PyGILState_Fini(tstate);
+        _PyGILState_Fini(interp);
     }
 
     /* We can't call _PyEval_FiniGIL() here because destroying the GIL lock can
@@ -1633,7 +1632,7 @@ finalize_interp_delete(PyThreadState *tstate)
        created GIL, which ensures that Py_Initialize / Py_FinalizeEx can be
        called multiple times. */
 
-    PyInterpreterState_Delete(tstate->interp);
+    PyInterpreterState_Delete(interp);
 }
 
 
@@ -1666,7 +1665,7 @@ Py_FinalizeEx(void)
      * the threads created via Threading.
      */
 
-    _PyAtExit_Call(tstate);
+    _PyAtExit_Call(tstate->interp);
 
     /* Copy the core config, PyInterpreterState_Delete() free
        the core config memory */
@@ -1779,7 +1778,7 @@ Py_FinalizeEx(void)
 #endif /* Py_TRACE_REFS */
 
     finalize_interp_clear(tstate);
-    finalize_interp_delete(tstate);
+    finalize_interp_delete(tstate->interp);
 
 #ifdef Py_TRACE_REFS
     /* Display addresses (& refcnts) of all objects still alive.
@@ -1954,7 +1953,7 @@ Py_EndInterpreter(PyThreadState *tstate)
     // Wrap up existing "threading"-module-created, non-daemon threads.
     wait_for_thread_shutdown(tstate);
 
-    _PyAtExit_Call(tstate);
+    _PyAtExit_Call(tstate->interp);
 
     if (tstate != interp->tstate_head || tstate->next != NULL) {
         Py_FatalError("not the last thread");
@@ -1963,7 +1962,7 @@ Py_EndInterpreter(PyThreadState *tstate)
     finalize_modules(tstate);
 
     finalize_interp_clear(tstate);
-    finalize_interp_delete(tstate);
+    finalize_interp_delete(tstate->interp);
 }
 
 /* Add the __main__ module */

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -324,7 +324,7 @@ interpreter_clear(PyInterpreterState *interp, PyThreadState *tstate)
 
     /* Last garbage collection on this interpreter */
     _PyGC_CollectNoFail(tstate);
-    _PyGC_Fini(tstate);
+    _PyGC_Fini(interp);
 
     /* We don't clear sysdict and builtins until the end of this function.
        Because clearing other attributes can execute arbitrary Python code
@@ -1146,7 +1146,7 @@ PyThreadState_SetAsyncExc(unsigned long id, PyObject *exc)
         HEAD_UNLOCK(runtime);
 
         Py_XDECREF(old_exc);
-        _PyEval_SignalAsyncExc(tstate);
+        _PyEval_SignalAsyncExc(tstate->interp);
         return 1;
     }
     HEAD_UNLOCK(runtime);
@@ -1357,9 +1357,9 @@ _PyGILState_GetInterpreterStateUnsafe(void)
 }
 
 void
-_PyGILState_Fini(PyThreadState *tstate)
+_PyGILState_Fini(PyInterpreterState *interp)
 {
-    struct _gilstate_runtime_state *gilstate = &tstate->interp->runtime->gilstate;
+    struct _gilstate_runtime_state *gilstate = &interp->runtime->gilstate;
     PyThread_tss_delete(&gilstate->autoTSSkey);
     gilstate->autoInterpreterState = NULL;
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -86,9 +86,9 @@ _PySys_GetObjectId(_Py_Identifier *key)
 }
 
 static PyObject *
-_PySys_GetObject(PyThreadState *tstate, const char *name)
+_PySys_GetObject(PyInterpreterState *interp, const char *name)
 {
-    PyObject *sysdict = tstate->interp->sysdict;
+    PyObject *sysdict = interp->sysdict;
     if (sysdict == NULL) {
         return NULL;
     }
@@ -102,7 +102,7 @@ PySys_GetObject(const char *name)
 
     PyObject *exc_type, *exc_value, *exc_tb;
     _PyErr_Fetch(tstate, &exc_type, &exc_value, &exc_tb);
-    PyObject *value = _PySys_GetObject(tstate, name);
+    PyObject *value = _PySys_GetObject(tstate->interp, name);
     /* XXX Suppress a new exception if it was raised and restore
      * the old one. */
     _PyErr_Restore(tstate, exc_type, exc_value, exc_tb);
@@ -110,12 +110,12 @@ PySys_GetObject(const char *name)
 }
 
 static int
-sys_set_object(PyThreadState *tstate, PyObject *key, PyObject *v)
+sys_set_object(PyInterpreterState *interp, PyObject *key, PyObject *v)
 {
     if (key == NULL) {
         return -1;
     }
-    PyObject *sd = tstate->interp->sysdict;
+    PyObject *sd = interp->sysdict;
     if (v == NULL) {
         v = _PyDict_Pop(sd, key, Py_None);
         if (v == NULL) {
@@ -130,24 +130,24 @@ sys_set_object(PyThreadState *tstate, PyObject *key, PyObject *v)
 }
 
 static int
-sys_set_object_id(PyThreadState *tstate, _Py_Identifier *key, PyObject *v)
+sys_set_object_id(PyInterpreterState *interp, _Py_Identifier *key, PyObject *v)
 {
-    return sys_set_object(tstate, _PyUnicode_FromId(key), v);
+    return sys_set_object(interp, _PyUnicode_FromId(key), v);
 }
 
 int
 _PySys_SetObjectId(_Py_Identifier *key, PyObject *v)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    return sys_set_object_id(tstate, key, v);
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    return sys_set_object_id(interp, key, v);
 }
 
 static int
-sys_set_object_str(PyThreadState *tstate, const char *name, PyObject *v)
+sys_set_object_str(PyInterpreterState *interp, const char *name, PyObject *v)
 {
     PyObject *key = v ? PyUnicode_InternFromString(name)
                       : PyUnicode_FromString(name);
-    int r = sys_set_object(tstate, key, v);
+    int r = sys_set_object(interp, key, v);
     Py_XDECREF(key);
     return r;
 }
@@ -155,22 +155,21 @@ sys_set_object_str(PyThreadState *tstate, const char *name, PyObject *v)
 int
 PySys_SetObject(const char *name, PyObject *v)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    return sys_set_object_str(tstate, name, v);
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    return sys_set_object_str(interp, name, v);
 }
 
 
 static int
-should_audit(PyInterpreterState *is)
+should_audit(PyInterpreterState *interp)
 {
-    /* tstate->interp cannot be NULL, but test it just in case
-       for extra safety */
-    assert(is != NULL);
-    if (!is) {
+    /* interp must not be NULL, but test it just in case for extra safety */
+    assert(interp != NULL);
+    if (!interp) {
         return 0;
     }
-    return (is->runtime->audit_hook_head
-            || is->audit_hooks
+    return (interp->runtime->audit_hook_head
+            || interp->audit_hooks
             || PyDTrace_AUDIT_ENABLED());
 }
 
@@ -455,15 +454,15 @@ sys_addaudithook_impl(PyObject *module, PyObject *hook)
         return NULL;
     }
 
-    PyInterpreterState *is = tstate->interp;
-    if (is->audit_hooks == NULL) {
-        is->audit_hooks = PyList_New(0);
-        if (is->audit_hooks == NULL) {
+    PyInterpreterState *interp = tstate->interp;
+    if (interp->audit_hooks == NULL) {
+        interp->audit_hooks = PyList_New(0);
+        if (interp->audit_hooks == NULL) {
             return NULL;
         }
     }
 
-    if (PyList_Append(is->audit_hooks, hook) < 0) {
+    if (PyList_Append(interp->audit_hooks, hook) < 0) {
         return NULL;
     }
 
@@ -1613,8 +1612,8 @@ static PyObject *
 sys_setdlopenflags_impl(PyObject *module, int new_val)
 /*[clinic end generated code: output=ec918b7fe0a37281 input=4c838211e857a77f]*/
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    tstate->interp->dlopenflags = new_val;
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    interp->dlopenflags = new_val;
     Py_RETURN_NONE;
 }
 
@@ -1631,8 +1630,8 @@ static PyObject *
 sys_getdlopenflags_impl(PyObject *module)
 /*[clinic end generated code: output=e92cd1bc5005da6e input=dc4ea0899c53b4b6]*/
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    return PyLong_FromLong(tstate->interp->dlopenflags);
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    return PyLong_FromLong(interp->dlopenflags);
 }
 
 #endif  /* HAVE_DLOPEN */
@@ -2223,7 +2222,7 @@ get_warnoptions(PyThreadState *tstate)
         if (warnoptions == NULL) {
             return NULL;
         }
-        if (sys_set_object_id(tstate, &PyId_warnoptions, warnoptions)) {
+        if (sys_set_object_id(tstate->interp, &PyId_warnoptions, warnoptions)) {
             Py_DECREF(warnoptions);
             return NULL;
         }
@@ -2316,7 +2315,7 @@ get_xoptions(PyThreadState *tstate)
         if (xoptions == NULL) {
             return NULL;
         }
-        if (sys_set_object_id(tstate, &PyId__xoptions, xoptions)) {
+        if (sys_set_object_id(tstate->interp, &PyId__xoptions, xoptions)) {
             Py_DECREF(xoptions);
             return NULL;
         }
@@ -2517,9 +2516,8 @@ static PyStructSequence_Desc flags_desc = {
 };
 
 static int
-set_flags_from_config(PyObject *flags, PyThreadState *tstate)
+set_flags_from_config(PyInterpreterState *interp, PyObject *flags)
 {
-    PyInterpreterState *interp = tstate->interp;
     const PyPreConfig *preconfig = &interp->runtime->preconfig;
     const PyConfig *config = _PyInterpreterState_GetConfig(interp);
 
@@ -2560,14 +2558,14 @@ set_flags_from_config(PyObject *flags, PyThreadState *tstate)
 
 
 static PyObject*
-make_flags(PyThreadState *tstate)
+make_flags(PyInterpreterState *interp)
 {
     PyObject *flags = PyStructSequence_New(&FlagsType);
     if (flags == NULL) {
         return NULL;
     }
 
-    if (set_flags_from_config(flags, tstate) < 0) {
+    if (set_flags_from_config(interp, flags) < 0) {
         Py_DECREF(flags);
         return NULL;
     }
@@ -2825,7 +2823,7 @@ _PySys_InitCore(PyThreadState *tstate, PyObject *sysdict)
             goto type_init_failed;
         }
     }
-    SET_SYS("flags", make_flags(tstate));
+    SET_SYS("flags", make_flags(tstate->interp));
     /* prevent user from creating new instances */
     FlagsType.tp_init = NULL;
     FlagsType.tp_new = NULL;
@@ -2947,8 +2945,9 @@ sys_create_xoptions_dict(const PyConfig *config)
 int
 _PySys_UpdateConfig(PyThreadState *tstate)
 {
-    PyObject *sysdict = tstate->interp->sysdict;
-    const PyConfig *config = _PyInterpreterState_GetConfig(tstate->interp);
+    PyInterpreterState *interp = tstate->interp;
+    PyObject *sysdict = interp->sysdict;
+    const PyConfig *config = _PyInterpreterState_GetConfig(interp);
     int res;
 
 #define COPY_LIST(KEY, VALUE) \
@@ -2991,11 +2990,11 @@ _PySys_UpdateConfig(PyThreadState *tstate)
 #undef COPY_WSTR
 
     // sys.flags
-    PyObject *flags = _PySys_GetObject(tstate, "flags");  // borrowed ref
+    PyObject *flags = _PySys_GetObject(interp, "flags"); // borrowed ref
     if (flags == NULL) {
         return -1;
     }
-    if (set_flags_from_config(flags, tstate) < 0) {
+    if (set_flags_from_config(interp, flags) < 0) {
         return -1;
     }
 
@@ -3135,8 +3134,8 @@ PySys_SetPath(const wchar_t *path)
     PyObject *v;
     if ((v = makepathobject(path, DELIM)) == NULL)
         Py_FatalError("can't create sys.path");
-    PyThreadState *tstate = _PyThreadState_GET();
-    if (sys_set_object_id(tstate, &PyId_path, v) != 0) {
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    if (sys_set_object_id(interp, &PyId_path, v) != 0) {
         Py_FatalError("can't assign sys.path");
     }
     Py_DECREF(v);
@@ -3177,7 +3176,7 @@ PySys_SetArgvEx(int argc, wchar_t **argv, int updatepath)
     if (av == NULL) {
         Py_FatalError("no mem for sys.argv");
     }
-    if (sys_set_object_str(tstate, "argv", av) != 0) {
+    if (sys_set_object_str(tstate->interp, "argv", av) != 0) {
         Py_DECREF(av);
         Py_FatalError("can't assign sys.argv");
     }


### PR DESCRIPTION
Pass the current interpreter (interp) rather than the current Python
thread state (tstate) to internal functions which only use the
interpreter.

Modified functions:

* _PyXXX_Fini() and _PyXXX_ClearFreeList() functions
* _PyEval_SignalAsyncExc()
* make_pending_calls()
* _PySys_GetObject(), sys_set_object(), sys_set_object_id(), sys_set_object_str()
* should_audit(), set_flags_from_config(), make_flags()
* _PyAtExit_Call()
* init_stdio_encoding()
* etc.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43268](https://bugs.python.org/issue43268) -->
https://bugs.python.org/issue43268
<!-- /issue-number -->
