### PR TITLE
[3.9] bpo-43272: Fix old parser test failures for backported grammar constructs

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -374,10 +374,10 @@ x = (
         # check the call
         call = middle.value
         self.assertEqual(type(call), ast.Call)
-        self.assertEqual(call.lineno, 5)
-        self.assertEqual(call.end_lineno, 5)
-        self.assertEqual(call.col_offset, 27)
-        self.assertEqual(call.end_col_offset, 31)
+        self.assertEqual(call.lineno, 4 if use_old_parser() else 5)
+        self.assertEqual(call.end_lineno, 4 if use_old_parser() else 5)
+        self.assertEqual(call.col_offset, 13 if use_old_parser() else 27)
+        self.assertEqual(call.end_col_offset, 17 if use_old_parser() else 31)
         # check the second wat
         self.assertEqual(type(wat2), ast.Constant)
         self.assertEqual(wat2.lineno, 4)

--- a/Lib/test/test_named_expressions.py
+++ b/Lib/test/test_named_expressions.py
@@ -1,4 +1,5 @@
 import unittest
+from test.support import use_old_parser
 
 GLOBAL_VAR = None
 
@@ -167,6 +168,7 @@ class NamedExpressionInvalidTest(unittest.TestCase):
                 with self.assertRaisesRegex(SyntaxError, msg):
                     exec(f"lambda: {code}", {}) # Function scope
 
+    @unittest.skipIf(use_old_parser(), "Old parser does not support walruses in set comprehensions")
     def test_named_expression_invalid_rebinding_set_comprehension_iteration_variable(self):
         cases = [
             ("Local reuse", 'i', "{i := 0 for i in range(5)}"),
@@ -199,6 +201,7 @@ class NamedExpressionInvalidTest(unittest.TestCase):
                 with self.assertRaisesRegex(SyntaxError, msg):
                     exec(f"lambda: {code}", {}) # Function scope
 
+    @unittest.skipIf(use_old_parser(), "Old parser does not support walruses in set comprehensions")
     def test_named_expression_invalid_set_comprehension_iterable_expression(self):
         cases = [
             ("Top level", "{i for i in (i := range(5))}"),

--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -1,5 +1,7 @@
 # Tests for extended unpacking, starred expressions.
 
+from test.support import use_old_parser
+
 doctests = """
 
 Unpack tuple
@@ -346,6 +348,26 @@ Now some general starred expressions (all fail).
       ...
     SyntaxError: can't use starred expression here
 
+Some size constraints (all fail.)
+
+    >>> s = ", ".join("a%d" % i for i in range(1<<8)) + ", *rest = range(1<<8 + 1)"
+    >>> compile(s, 'test', 'exec') # doctest:+ELLIPSIS
+    Traceback (most recent call last):
+     ...
+    SyntaxError: too many expressions in star-unpacking assignment
+
+    >>> s = ", ".join("a%d" % i for i in range(1<<8 + 1)) + ", *rest = range(1<<8 + 2)"
+    >>> compile(s, 'test', 'exec') # doctest:+ELLIPSIS
+    Traceback (most recent call last):
+     ...
+    SyntaxError: too many expressions in star-unpacking assignment
+
+(there is an additional limit, on the number of expressions after the
+'*rest', but it's 1<<24 and testing it takes too much memory.)
+
+"""
+
+new_parser_doctests = """\
     >>> (*x),y = 1, 2 # doctest:+ELLIPSIS
     Traceback (most recent call last):
       ...
@@ -370,27 +392,12 @@ Now some general starred expressions (all fail).
     Traceback (most recent call last):
       ...
     SyntaxError: can't use starred expression here
-
-Some size constraints (all fail.)
-
-    >>> s = ", ".join("a%d" % i for i in range(1<<8)) + ", *rest = range(1<<8 + 1)"
-    >>> compile(s, 'test', 'exec') # doctest:+ELLIPSIS
-    Traceback (most recent call last):
-     ...
-    SyntaxError: too many expressions in star-unpacking assignment
-
-    >>> s = ", ".join("a%d" % i for i in range(1<<8 + 1)) + ", *rest = range(1<<8 + 2)"
-    >>> compile(s, 'test', 'exec') # doctest:+ELLIPSIS
-    Traceback (most recent call last):
-     ...
-    SyntaxError: too many expressions in star-unpacking assignment
-
-(there is an additional limit, on the number of expressions after the
-'*rest', but it's 1<<24 and testing it takes too much memory.)
-
 """
 
-__test__ = {'doctests' : doctests}
+if use_old_parser():
+    __test__ = {'doctests' : doctests}
+else:
+    __test__ = {'doctests' : doctests + new_parser_doctests}
 
 def test_main(verbose=False):
     from test import support


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43272](https://bugs.python.org/issue43272) -->
https://bugs.python.org/issue43272
<!-- /issue-number -->
