### PR TITLE
bpo-43260: io: Prevent large data remains in textio buffer.

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-02-20-12-15-29.bpo-43260.6znAas.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-20-12-15-29.bpo-43260.6znAas.rst
@@ -1,0 +1,2 @@
+Fix TextIOWrapper can not flush internal buffer forever after very large
+text is written.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1646,7 +1646,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     if (self->encodefunc != NULL) {
         if (PyUnicode_IS_ASCII(text) &&
                 // See bpo-43260
-                PyUnicode_GET_LENGTH(text) < self->chunk_size &&
+                PyUnicode_GET_LENGTH(text) <= self->chunk_size &&
                 is_asciicompat_encoding(self->encodefunc)) {
             b = text;
             Py_INCREF(b);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1684,9 +1684,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         self->pending_bytes = b;
     }
     else if (self->pending_bytes_count + bytes_len > self->chunk_size) {
-        // bpo-43260: If `b` is very large, leaving it in pending_bytes may
-        // cause MemoryError and we can not recover from it forever.
-        // So do not leave the large data in pending_bytes buffer.
+        // Prevent to concatinate more than chunk_size data.
         if (_textiowrapper_writeflush(self) < 0) {
             Py_DECREF(b);
             return NULL;

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1678,8 +1678,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     // bpo-43260: If `b` is large, leaving it in pending_bytes may cause
     // MemoryError and we can not recover from it forever.
     // So do not leave the large data in pending_bytes buffer.
-    // 1MiB is just a heuristics.
-    if (bytes_len > 1024*1024) {
+    if (bytes_len > self->chunk_size) {
         if (_textiowrapper_writeflush(self)) {
             Py_DECREF(b);
             return NULL;

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1684,7 +1684,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         self->pending_bytes = b;
     }
     else if (self->pending_bytes_count + bytes_len > self->chunk_size) {
-        // Prevent to concatinate more than chunk_size data.
+        // Prevent to concatenate more than chunk_size data.
         if (_textiowrapper_writeflush(self) < 0) {
             Py_DECREF(b);
             return NULL;


### PR DESCRIPTION
When very large data remains in TextIOWrapper, it can not flush the internal
buffer forever because of MemoryError.

<!-- issue-number: [bpo-43260](https://bugs.python.org/issue43260) -->
[bpo-43260](https://bugs.python.org/issue43260)
<!-- /issue-number -->
