### PR TITLE
closes bpo-43278: remove unnecessary leading '\n' from COMPILER when build with GCC/Clang

### DIFF
--- a/Misc/NEWS.d/next/C API/2021-02-21-15-30-38.bpo-43278.DMPaWH.rst
+++ b/Misc/NEWS.d/next/C API/2021-02-21-15-30-38.bpo-43278.DMPaWH.rst
@@ -1,0 +1,1 @@
+remove unnecessary leading '\n' for unify 'welcome message' behave across different compilers.

--- a/Misc/NEWS.d/next/C API/2021-02-21-15-30-38.bpo-43278.DMPaWH.rst
+++ b/Misc/NEWS.d/next/C API/2021-02-21-15-30-38.bpo-43278.DMPaWH.rst
@@ -1,1 +1,1 @@
-remove unnecessary leading '\n' for unify 'welcome message' behave across different compilers.
+Always put compiler and system information on the first line of the REPL welcome message.

--- a/Python/getcompiler.c
+++ b/Python/getcompiler.c
@@ -8,9 +8,9 @@
 // Note the __clang__ conditional has to come before the __GNUC__ one because
 // clang pretends to be GCC.
 #if defined(__clang__)
-#define COMPILER "\n[Clang " __clang_version__ "]"
+#define COMPILER "[Clang " __clang_version__ "]"
 #elif defined(__GNUC__)
-#define COMPILER "\n[GCC " __VERSION__ "]"
+#define COMPILER "[GCC " __VERSION__ "]"
 // Generic fallbacks.
 #elif defined(__cplusplus)
 #define COMPILER "[C++]"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43278](https://bugs.python.org/issue43278) -->
https://bugs.python.org/issue43278
<!-- /issue-number -->

Automerge-Triggered-By: GH:benjaminp