### PR TITLE
bpo-43288: Fix test_importlib test to correctly skip

### DIFF
--- a/Lib/test/test_importlib/fixtures.py
+++ b/Lib/test/test_importlib/fixtures.py
@@ -5,6 +5,7 @@ import pathlib
 import tempfile
 import textwrap
 import contextlib
+import unittest
 
 from test.support.os_helper import FS_NONASCII
 from typing import Dict, Union
@@ -218,6 +219,9 @@ class LocalPackage:
         self.addCleanup(self.fixtures.close)
         self.fixtures.enter_context(tempdir_as_cwd())
         build_files(self.files)
+
+    def skip(self, reason):
+        raise unittest.SkipTest(reason)
 
 
 def build_files(file_defs, prefix=pathlib.Path()):

--- a/Misc/NEWS.d/next/Tests/2021-02-21-11-11-53.bpo-43288.LfTvL-.rst
+++ b/Misc/NEWS.d/next/Tests/2021-02-21-11-11-53.bpo-43288.LfTvL-.rst
@@ -1,0 +1,2 @@
+Fix test_importlib to correctly skip Unicode file tests if the fileystem
+does not support them.


### PR DESCRIPTION
Fix test_importlib to correctly skip Unicode file tests if the fileystem does not support them.


<!-- issue-number: [bpo-43288](https://bugs.python.org/issue43288) -->
https://bugs.python.org/issue43288
<!-- /issue-number -->
