### PR TITLE
bpo-43283: Add IDLE doc paragraph about print speed

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -733,7 +733,7 @@ for each argument, each separator, the newline are sent separately.
 For development, this is usually not a problem, but if one wants to
 print faster in IDLE, format and join together everything one wants
 displayed together and then print a single string.  Both format strings
-and ``separator.join`` can help combine fields and lines.
+and :meth:`str.join` can help combine fields and lines.
 
 IDLE's standard stream replacements are not inherited by subprocesses
 created in the execution process, whether directly by user code or by

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -726,6 +726,15 @@ with objects that get input from and send output to the Shell window.
 The original values stored in ``sys.__stdin__``, ``sys.__stdout__``, and
 ``sys.__stderr__`` are not touched, but may be ``None``.
 
+Sending print output from one process to a text widget in another is
+slower than printing to a system terminal in the same process.
+This has the most effect when printing multiple arguments, as the string
+for each argument, each separator, the newline are sent separately.
+For development, this is usually not a problem, but if one wants to
+print faster in IDLE, format and join together everything one wants
+displayed together and then print a single string.  Both format strings
+and ``separator.join`` can help combine fields and lines.
+
 IDLE's standard stream replacements are not inherited by subprocesses
 created in the execution process, whether directly by user code or by
 modules such as multiprocessing.  If such subprocess use ``input`` from

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,10 @@ Released on 2021-10-04?
 ======================================
 
 
+bpo-43283: Document why printing to IDLE's Shell is often slower than
+printing to a system terminal and that it can be made faster by
+pre-formatting a single string before printing.
+
 bpo-23544: Disable Debug=>Stack Viewer when user code is running or
 Debugger is active, to prevent hang or crash.  Patch by Zackery Spytz.
 

--- a/Lib/idlelib/help.html
+++ b/Lib/idlelib/help.html
@@ -679,6 +679,14 @@ process, it replaces <code class="docutils literal notranslate"><span class="pre
 with objects that get input from and send output to the Shell window.
 The original values stored in <code class="docutils literal notranslate"><span class="pre">sys.__stdin__</span></code>, <code class="docutils literal notranslate"><span class="pre">sys.__stdout__</span></code>, and
 <code class="docutils literal notranslate"><span class="pre">sys.__stderr__</span></code> are not touched, but may be <code class="docutils literal notranslate"><span class="pre">None</span></code>.</p>
+<p>Sending print output from one process to a text widget in another is
+slower than printing to a system terminal in the same process.
+This has the most effect when printing multiple arguments, as the string
+for each argument, each separator, the newline are sent separately.
+For development, this is usually not a problem, but if one wants to
+print faster in IDLE, format and join together everything one wants
+displayed together and then print a single string.  Both format strings
+and <a class="reference internal" href="stdtypes.html#str.join" title="str.join"><code class="xref py py-meth docutils literal notranslate"><span class="pre">str.join()</span></code></a> can help combine fields and lines.</p>
 <p>IDLE’s standard stream replacements are not inherited by subprocesses
 created in the execution process, whether directly by user code or by
 modules such as multiprocessing.  If such subprocess use <code class="docutils literal notranslate"><span class="pre">input</span></code> from
@@ -982,7 +990,7 @@ also used for testing.</p>
 <br />
     <br />
 
-    Last updated on Feb 21, 2021.
+    Last updated on Feb 23, 2021.
     <a href="https://docs.python.org/3/bugs.html">Found a bug</a>?
     <br />
 

--- a/Misc/NEWS.d/next/IDLE/2021-02-21-16-30-10.bpo-43283.DLBwYn.rst
+++ b/Misc/NEWS.d/next/IDLE/2021-02-21-16-30-10.bpo-43283.DLBwYn.rst
@@ -1,0 +1,3 @@
+Document why printing to IDLE's Shell is often slower than printing to a
+system terminal and that it can be made faster by pre-formatting a single
+string before printing.


### PR DESCRIPTION
Printing to IDLE's Shell is often slower than printing to a system
terminal, but it can be made faster by pre-formatting a single
string before printing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43283](https://bugs.python.org/issue43283) -->
https://bugs.python.org/issue43283
<!-- /issue-number -->
