### PR TITLE
gh-87465: Make pyclbr.readmodule_ex() not die on module w/o __spec__

### DIFF
--- a/Lib/pyclbr.py
+++ b/Lib/pyclbr.py
@@ -164,7 +164,10 @@ def _readmodule(module, path, inpackage=None):
         search_path = path
     else:
         search_path = path + sys.path
-    spec = importlib.util._find_spec_from_path(fullmodule, search_path)
+    try: spec = importlib.util._find_spec_from_path(fullmodule, search_path)
+    except ValueError:
+        # ValueError: __main__.__spec__ is None / is not set
+        spec = None
     if spec is None:
         raise ModuleNotFoundError(f"no module named {fullmodule!r}", name=fullmodule)
     _modules[fullmodule] = tree


### PR DESCRIPTION
pyclbr.readmodule_ex() should not die when traversing
an "import __main__" statement or an import of another
module without __spec__ attribute.

https://bugs.python.org/issue43299


<!-- issue-number: [bpo-43299](https://bugs.python.org/issue43299) -->
https://bugs.python.org/issue43299
<!-- /issue-number -->

<!-- gh-issue-number: gh-87465 -->
* Issue: gh-87465
<!-- /gh-issue-number -->
