### PR TITLE
bpo-43295: Fix error handling of datetime.strptime format string '%z'

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -201,7 +201,7 @@ class TimeRE(dict):
             #XXX: Does 'Y' need to worry about having less or more than
             #     4 digits?
             'Y': r"(?P<Y>\d\d\d\d)",
-            'z': r"(?P<z>[+-]\d\d:?[0-5]\d(:?[0-5]\d(\.\d{1,6})?)?|Z)",
+            'z': r"(?P<z>[+-]\d\d:?[0-5]\d(:?[0-5]\d(\.\d{1,6})?)?|(?-i:Z))",
             'A': self.__seqToRE(self.locale_time.f_weekday, 'A'),
             'a': self.__seqToRE(self.locale_time.a_weekday, 'a'),
             'B': self.__seqToRE(self.locale_time.f_month[1:], 'B'),

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -2609,6 +2609,7 @@ class TestDateTime(TestDate):
 
         with self.assertRaises(ValueError): strptime("-2400", "%z")
         with self.assertRaises(ValueError): strptime("-000", "%z")
+        with self.assertRaises(ValueError): strptime("z", "%z")
 
     def test_strptime_single_digit(self):
         # bpo-34903: Check that single digit dates and times are allowed.

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -466,11 +466,6 @@ class StrptimeTests(unittest.TestCase):
                 time.strptime("Feb 29", "%b %d"),
                 time.strptime("Mar 1", "%b %d"))
 
-    def test_timezone_offset_cannot_parse_z(self):
-        # Check ValueError is raised when matching "z" (ordinary letter)
-        # with "%z" (timezone offset)
-        self.assertRaises(ValueError, _strptime._strptime_time, "z", "%z")
-
 class Strptime12AMPMTests(unittest.TestCase):
     """Test a _strptime regression in '%I %p' at 12 noon (12 PM)"""
 

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -466,6 +466,11 @@ class StrptimeTests(unittest.TestCase):
                 time.strptime("Feb 29", "%b %d"),
                 time.strptime("Mar 1", "%b %d"))
 
+    def test_timezone_offset_cannot_parse_z(self):
+        # Check ValueError is raised when matching "z" (ordinary letter)
+        # with "%z" (timezone offset)
+        self.assertRaises(ValueError, _strptime._strptime_time, "z", "%z")
+
 class Strptime12AMPMTests(unittest.TestCase):
     """Test a _strptime regression in '%I %p' at 12 noon (12 PM)"""
 

--- a/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
@@ -1,10 +1,2 @@
-Previously, datetime.strptime would match 'z' with the format string '%z'
-(for UTC offsets), throwing an IndexError by erroneously trying to parse 'z'
-as a timestamp. As a special case, '%z' matches the string 'Z' which is
-equivalent to the offset '+00:00', however this behavior is not defined for
-lowercase 'z'. This change ensures a ValueError is thrown when encountering
-the original example, as follows::
-
-    >>> from datetime import datetime
-    >>> datetime.strptime('z', '%z')
-    ValueError: time data 'z' does not match format '%z'
+Previously, :meth:`datetime.datetime.strptime` would fail with `IndexError` when the string `'z'`
+was found for the `%z` format specifier. This has been fixed to properly raise `ValueError` instead.

--- a/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
@@ -1,0 +1,9 @@
+Previously, datetime.strptime would match 'z' with the format string '%z'
+(for UTC offsets), throwing an IndexError by erroneously trying to parse 'z'
+as a timestamp. As a special case, '%z' matches the string 'Z' which is
+equivalent to the offset '+00:00', however this behavior is not defined for
+lowercase 'z'. This change ensures a ValueError is thrown when encountering
+the original example, as follows:
+
+>>> from datetime import datetime >>> datetime.strptime('z', '%z')
+ValueError: time data 'z' does not match format '%z'

--- a/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
@@ -3,8 +3,8 @@ Previously, datetime.strptime would match 'z' with the format string '%z'
 as a timestamp. As a special case, '%z' matches the string 'Z' which is
 equivalent to the offset '+00:00', however this behavior is not defined for
 lowercase 'z'. This change ensures a ValueError is thrown when encountering
-the original example, as follows:
+the original example, as follows::
 
->>> from datetime import datetime
->>> datetime.strptime('z', '%z')
-ValueError: time data 'z' does not match format '%z'
+    >>> from datetime import datetime
+    >>> datetime.strptime('z', '%z')
+    ValueError: time data 'z' does not match format '%z'

--- a/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
@@ -1,2 +1,2 @@
-Previously, :meth:`datetime.datetime.strptime` would fail with `IndexError` when the string `'z'`
-was found for the `%z` format specifier. This has been fixed to properly raise `ValueError` instead.
+:meth:`datetime.datetime.strptime` has been fixed to raise `ValueError`
+instead of `IndexError` when matching `'z'` with the `%z` format specifier.

--- a/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
@@ -5,5 +5,6 @@ equivalent to the offset '+00:00', however this behavior is not defined for
 lowercase 'z'. This change ensures a ValueError is thrown when encountering
 the original example, as follows:
 
->>> from datetime import datetime >>> datetime.strptime('z', '%z')
+>>> from datetime import datetime
+>>> datetime.strptime('z', '%z')
 ValueError: time data 'z' does not match format '%z'

--- a/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-22-22-54-40.bpo-43295.h_ffu7.rst
@@ -1,2 +1,2 @@
-:meth:`datetime.datetime.strptime` has been fixed to raise `ValueError`
-instead of `IndexError` when matching `'z'` with the `%z` format specifier.
+:meth:`datetime.datetime.strptime` now raises ``ValueError`` instead of
+``IndexError`` when matching ``'z'`` with the ``%z`` format specifier.


### PR DESCRIPTION
Previously, `datetime.strptime` would match `'z'` with the format string `'%z'` (for UTC offsets), throwing an `IndexError` by erroneously trying to parse `'z'` as a timestamp. As a special case, `'%z'` matches the string `'Z'` which is equivalent to the offset `'+00:00'`, however this behavior is not defined for lowercase `'z'`.

This change ensures a `ValueError` is thrown when encountering the original example, as follows:

```
>>> from datetime import datetime
>>> datetime.strptime('z', '%z')
ValueError: time data 'z' does not match format '%z'
```

<!-- issue-number: [bpo-43295](https://bugs.python.org/issue43295) -->
https://bugs.python.org/issue43295
<!-- /issue-number -->

Automerge-Triggered-By: GH:pganssle