### PR TITLE
bpo-43146: fix None-handling in single-arg version of traceback.print…

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -235,6 +235,10 @@ class TracebackCases(unittest.TestCase):
     def test_exception_is_None(self):
         NONE_EXC_STRING = 'NoneType: None\n'
         excfile = StringIO()
+        traceback.print_exception(None, file=excfile)
+        self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
+
+        excfile = StringIO()
         traceback.print_exception(None, None, None, file=excfile)
         self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
 
@@ -243,6 +247,7 @@ class TracebackCases(unittest.TestCase):
         self.assertEqual(excfile.getvalue(), NONE_EXC_STRING)
 
         self.assertEqual(traceback.format_exc(None), NONE_EXC_STRING)
+        self.assertEqual(traceback.format_exception(None), [NONE_EXC_STRING])
         self.assertEqual(
             traceback.format_exception(None, None, None), [NONE_EXC_STRING])
         self.assertEqual(

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -91,7 +91,10 @@ def _parse_value_tb(exc, value, tb):
     if (value is _sentinel) != (tb is _sentinel):
         raise ValueError("Both or neither of value and tb must be given")
     if value is tb is _sentinel:
-        return exc, exc.__traceback__
+        if exc is not None:
+            return exc, exc.__traceback__
+        else:
+            return None, None
     return value, tb
 
 

--- a/Misc/NEWS.d/next/Library/2021-02-23-17-20-16.bpo-43146.JAFplg.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-23-17-20-16.bpo-43146.JAFplg.rst
@@ -1,0 +1,1 @@
+Handle None in single-arg versions of :func:`~traceback.print_exception` and :func:`~traceback.format_exception`.


### PR DESCRIPTION
…_exception() and traceback.format_exception()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43146](https://bugs.python.org/issue43146) -->
https://bugs.python.org/issue43146
<!-- /issue-number -->
