### PR TITLE
bpo-43311: under building Python with --with-experimental-isolated-subinterpreters, PyInterpreterState_New use thread-specific data tstate before key create .

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-25-08-39-42.bpo-43311.Ivv5Pe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-25-08-39-42.bpo-43311.Ivv5Pe.rst
@@ -1,0 +1,1 @@
+Fix :func:`PyInterpreterState_New` use thread-specific data tstate before key create .  Patch by Junyi Xie.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -563,6 +563,13 @@ pycore_init_runtime(_PyRuntimeState *runtime,
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
+    
+    struct _gilstate_runtime_state *gilstate = &runtime->gilstate;
+
+    if (PyThread_tss_create(&gilstate->autoTSSkey) != 0) {
+        return _PyStatus_NO_MEMORY();
+    }
+    
     return _PyStatus_OK();
 }
 


### PR DESCRIPTION
PyInterpreterState_New call and use `PyThreadState *tstate = _PyThreadState_GET();`

`_PyRuntime.gilstate.autoTSSkey`  has to be initialized before `pthread_getspecific()` or `pthread_setspecific()` can be used.

> Note that the key has to be initialized before pthread_getspecific() or pthread_setspecific() can be used. The pthread_key_create() call could either be explicitly made in a module initialization routine, or it can be done implicitly by the first call to a module as in this example. Any attempt to use the key before it is initialized is a programming error, making the code below incorrect.https://linux.die.net/man/3/pthread_key_create

_PyRuntime.gilstate.autoTSSkey create in `_PyGILState_Init`. PyInterpreterState_New called before `_PyGILState_Init`.

use xcode to debug cpython
`_PyRuntime.gilstate.autoTSSkey` create
<img width="253" alt="截屏2021-02-25 下午4 26 52" src="https://user-images.githubusercontent.com/22233256/109124775-47459e80-7786-11eb-9fe5-cc3c634cfcc8.png">


`_PyRuntime.gilstate.autoTSSkey` first use 
<img width="244" alt="截屏2021-02-25 下午4 26 18" src="https://user-images.githubusercontent.com/22233256/109124714-32690b00-7786-11eb-9aad-6b8643e9657d.png">

to slove this problem, wo can create `autoTSSkey` after init runtime 
<img width="549" alt="截屏2021-02-25 下午4 37 34" src="https://user-images.githubusercontent.com/22233256/109126032-c4bdde80-7787-11eb-8aa3-ebf8e168a2c6.png">


<!-- issue-number: [bpo-43311](https://bugs.python.org/issue43311) -->
https://bugs.python.org/issue43311
<!-- /issue-number -->
