### PR TITLE
bpo-43314: Remove pre SQLite 3.7.7 support code for SQLITE_OPEN_URI

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -102,21 +102,10 @@ pysqlite_connection_init(pysqlite_Connection *self, PyObject *args,
     Py_INCREF(&PyUnicode_Type);
     Py_XSETREF(self->text_factory, (PyObject*)&PyUnicode_Type);
 
-#ifdef SQLITE_OPEN_URI
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_open_v2(database, &self->db,
                          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE |
                          (uri ? SQLITE_OPEN_URI : 0), NULL);
-#else
-    if (uri) {
-        PyErr_SetString(pysqlite_NotSupportedError, "URIs not supported");
-        return -1;
-    }
-    Py_BEGIN_ALLOW_THREADS
-    /* No need to use sqlite3_open_v2 as sqlite3_open(filename, db) is the
-       same as sqlite3_open_v2(filename, db, SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE, NULL). */
-    rc = sqlite3_open(database, &self->db);
-#endif
     Py_END_ALLOW_THREADS
 
     Py_DECREF(database_obj);


### PR DESCRIPTION
SQLite 3.7.15 is required as by GH-24106. SQLITE_OPEN_URI was added in
SQLite 3.7.7.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43314](https://bugs.python.org/issue43314) -->
https://bugs.python.org/issue43314
<!-- /issue-number -->
