### PR TITLE
bpo-43290: Remove pre SQLite 3.5.3 support code from pysqlite_step()

### DIFF
--- a/Modules/_sqlite/util.c
+++ b/Modules/_sqlite/util.c
@@ -29,7 +29,6 @@ int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection)
     int rc;
 
     Py_BEGIN_ALLOW_THREADS
-    /* returns SQLITE_MISUSE if called with a NULL argument */
     rc = sqlite3_step(statement);
     Py_END_ALLOW_THREADS
 

--- a/Modules/_sqlite/util.c
+++ b/Modules/_sqlite/util.c
@@ -28,15 +28,10 @@ int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection)
 {
     int rc;
 
-    if (statement == NULL) {
-        /* this is a workaround for SQLite 3.5 and later. it now apparently
-         * returns NULL for "no-operation" statements */
-        rc = SQLITE_OK;
-    } else {
-        Py_BEGIN_ALLOW_THREADS
-        rc = sqlite3_step(statement);
-        Py_END_ALLOW_THREADS
-    }
+    Py_BEGIN_ALLOW_THREADS
+    /* returns SQLITE_MISUSE if called with a NULL argument */
+    rc = sqlite3_step(statement);
+    Py_END_ALLOW_THREADS
 
     return rc;
 }


### PR DESCRIPTION
From the SQLite 3.5.3 changelog:
- sqlite3_step() returns SQLITE_MISUSE instead of crashing when called
  with a NULL parameter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43290](https://bugs.python.org/issue43290) -->
https://bugs.python.org/issue43290
<!-- /issue-number -->
