### PR TITLE
[3.7] bpo-43293: Doc: move note about GIL to top of threading module (GH-24622)

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -21,6 +21,18 @@ level :mod:`_thread` module.  See also the :mod:`queue` module.
    supported by this module.
 
 
+.. impl-detail::
+
+   In CPython, due to the :term:`Global Interpreter Lock`, only one thread
+   can execute Python code at once (even though certain performance-oriented
+   libraries might overcome this limitation).
+   If you want your application to make better use of the computational
+   resources of multi-core machines, you are advised to use
+   :mod:`multiprocessing` or :class:`concurrent.futures.ProcessPoolExecutor`.
+   However, threading is still an appropriate model if you want to run
+   multiple I/O-bound tasks simultaneously.
+
+
 This module defines the following functions:
 
 
@@ -321,18 +333,6 @@ since it is impossible to detect the termination of alien threads.
 
       Old getter/setter API for :attr:`~Thread.daemon`; use it directly as a
       property instead.
-
-
-.. impl-detail::
-
-   In CPython, due to the :term:`Global Interpreter Lock`, only one thread
-   can execute Python code at once (even though certain performance-oriented
-   libraries might overcome this limitation).
-   If you want your application to make better use of the computational
-   resources of multi-core machines, you are advised to use
-   :mod:`multiprocessing` or :class:`concurrent.futures.ProcessPoolExecutor`.
-   However, threading is still an appropriate model if you want to run
-   multiple I/O-bound tasks simultaneously.
 
 
 .. _lock-objects:


### PR DESCRIPTION
The note about the GIL was buried pretty deep in the threading documentation,
and this made it hard for first time users to discover why their attempts
at using threading to parallelize their application did not work.

In this commit, the note is moved to the top of the module documentation for
visibility.
(cherry picked from commit 32181be6081f6c70a1e0bd0540050805c8e88e83)

Co-authored-by: Guanzhong Chen <quantum2048@gmail.com>

<!-- issue-number: [bpo-43293](https://bugs.python.org/issue43293) -->
https://bugs.python.org/issue43293
<!-- /issue-number -->
