### PR TITLE
bpo-43317: Use io.DEFAULT_BUFFER_SIZE instead of arbitrary number in gzip module

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -596,7 +596,7 @@ def main():
                 f = builtins.open(arg, "rb")
                 g = open(arg + ".gz", "wb")
         while True:
-            chunk = f.read(1024)
+            chunk = f.read(io.DEFAULT_BUFFER_SIZE)
             if not chunk:
                 break
             g.write(chunk)

--- a/Misc/NEWS.d/next/Library/2021-02-25-09-08-55.bpo-43317.qrOOpB.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-25-09-08-55.bpo-43317.qrOOpB.rst
@@ -1,0 +1,3 @@
+Set the chunk size for the ``gzip`` module main function to
+io.DEFAULT_BUFFER_SIZE. This is slightly faster than the 1024 bytes constant
+that was used previously.


### PR DESCRIPTION
This improves the performance slightly, while also using a constant that is shared across the python code base.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43317](https://bugs.python.org/issue43317) -->
https://bugs.python.org/issue43317
<!-- /issue-number -->
