### PR TITLE
bpo-43318: Fix a bug where pdb does not always echo cleared breakpoints.

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -893,7 +893,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             except ValueError:
                 err = "Invalid line number (%s)" % arg
             else:
-                bplist = self.get_breaks(filename, lineno)
+                bplist = self.get_breaks(filename, lineno)[:]
                 err = self.clear_break(filename, lineno)
             if err:
                 self.error(err)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1350,6 +1350,7 @@ def test_pdb_issue_43318():
     3
     4
     """
+    
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1331,7 +1331,7 @@ def test_pdb_issue_43318():
     ...     print(2)
     ...     print(3)
     ...     print(4)
-
+    >>> reset_Breakpoint()
     >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
     ...     'break 3',
     ...     'clear <doctest test.test_pdb.test_pdb_issue_43318[0]>:3',
@@ -1341,9 +1341,9 @@ def test_pdb_issue_43318():
     > <doctest test.test_pdb.test_pdb_issue_43318[0]>(3)test_function()
     -> print(1)
     (Pdb) break 3
-    Breakpoint 6 at <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
+    Breakpoint 1 at <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
     (Pdb) clear <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
-    Deleted breakpoint 6 at <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
+    Deleted breakpoint 1 at <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
     (Pdb) continue
     1
     2

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1322,6 +1322,34 @@ def test_pdb_issue_20766():
     pdb 2: <built-in function default_int_handler>
     """
 
+def test_pdb_issue_43318():
+    """issue-43318:pdb can't output the prompt message when successfully clear breakpoints by filename:lineno
+
+    >>> def test_function():
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     print(1)
+    ...     print(2)
+    ...     print(3)
+    ...     print(4)
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'break 3',
+    ...     'clear <doctest test.test_pdb.test_pdb_issue_43318[0]>:3',
+    ...     'continue'
+    ... ]):
+    ...     test_function()
+    > <doctest test.test_pdb.test_pdb_issue_43318[0]>(3)test_function()
+    -> print(1)
+    (Pdb) break 3
+    Breakpoint 6 at <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
+    (Pdb) clear <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
+    Deleted breakpoint 6 at <doctest test.test_pdb.test_pdb_issue_43318[0]>:3
+    (Pdb) continue
+    1
+    2
+    3
+    4
+    """
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1350,7 +1350,7 @@ def test_pdb_issue_43318():
     3
     4
     """
-    
+
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1323,7 +1323,7 @@ def test_pdb_issue_20766():
     """
 
 def test_pdb_issue_43318():
-    """issue-43318:pdb can't output the prompt message when successfully clear breakpoints by filename:lineno
+    """echo breakpoints cleared with  filename:lineno
 
     >>> def test_function():
     ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1323,7 +1323,7 @@ def test_pdb_issue_20766():
     """
 
 def test_pdb_issue_43318():
-    """echo breakpoints cleared with  filename:lineno
+    """echo breakpoints cleared with filename:lineno
 
     >>> def test_function():
     ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()

--- a/Misc/NEWS.d/next/Library/2021-02-25-08-32-06.bpo-43318.bZJw6V.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-25-08-32-06.bpo-43318.bZJw6V.rst
@@ -1,1 +1,1 @@
-Fix the bug that pdb can't output prompt message when breakpoints are successfully cleared by "filename:lineno".
+Fix a bug where :mod:`pdb` does not always echo cleared breakpoints.

--- a/Misc/NEWS.d/next/Library/2021-02-25-08-32-06.bpo-43318.bZJw6V.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-25-08-32-06.bpo-43318.bZJw6V.rst
@@ -1,0 +1,1 @@
+Fix the bug that pdb can't output prompt message when breakpoints are successfully cleared by "filename:lineno".

--- a/Misc/NEWS.d/next/Library/2021-04-22-08-34-46.bpo-43318.Rztyvu.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-22-08-34-46.bpo-43318.Rztyvu.rst
@@ -1,0 +1,1 @@
+Fix pdb can't output prompt message when breakpoints are successfully cleared by (filename, lineno).

--- a/Misc/NEWS.d/next/Library/2021-04-22-08-34-46.bpo-43318.Rztyvu.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-22-08-34-46.bpo-43318.Rztyvu.rst
@@ -1,1 +1,0 @@
-Fix pdb can't output prompt message when breakpoints are successfully cleared by (filename, lineno).


### PR DESCRIPTION
https://bugs.python.org/issue43318

In Pdb, when successfully clear breakpoints, the Pdb should output a message:"Deleted XXX", but when breakpoints are cleared by filename:lineno, the message can't be output.

I think it's related to the following code.

```python
pdb.py:

def do_clear(self, arg):
    ...
  
    if ':' in arg:
        # Make sure it works for "clear C:\foo\bar.py:12"
        i = arg.rfind(':')
        filename = arg[:i]
        arg = arg[i+1:]
        try:
            lineno = int(arg)
        except ValueError:
            err = "Invalid line number (%s)" % arg
        else:
            bplist = self.get_breaks(filename, lineno)
            err = self.clear_break(filename, lineno)
        if err:
            self.error(err)
        else:
            for bp in bplist:
                self.message('Deleted %s' % bp)
        return
```
self.get_breaks is called to get the breakpoints to be deleted,  the result is in bplist. self.clear_break is called to delete the breakpoints in bplist. Each element in bplist is a reference to a Breakpoint object, so when all Breakpoint objects are removed, the bplist will become an empty list when self.clear_break is called, so pdb can't output the prompt message.

It can be simply fixed by following code:
```python
    bplist = self.get_breaks(filename, lineno)[:]
```

<!-- issue-number: [bpo-43318](https://bugs.python.org/issue43318) -->
https://bugs.python.org/issue43318
<!-- /issue-number -->
