### PR TITLE
bpo-43316:  gzip: CLI uses non-zero return code on error.

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -583,8 +583,7 @@ def main():
                 g = sys.stdout.buffer
             else:
                 if arg[-3:] != ".gz":
-                    print("filename doesn't end in .gz:", repr(arg))
-                    continue
+                    sys.exit("filename doesn't end in .gz:", repr(arg))
                 f = open(arg, "rb")
                 g = builtins.open(arg[:-3], "wb")
         else:

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -774,10 +774,10 @@ class TestCommandLine(unittest.TestCase):
         self.assertEqual(err, b'')
 
     def test_decompress_infile_outfile_error(self):
-        rc, out, err = assert_python_ok('-m', 'gzip', '-d', 'thisisatest.out')
-        self.assertIn(b"filename doesn't end in .gz:", out)
-        self.assertEqual(rc, 0)
-        self.assertEqual(err, b'')
+        rc, out, err = assert_python_failure('-m', 'gzip', '-d', 'thisisatest.out')
+        self.assertIn(b"filename doesn't end in .gz:", err)
+        self.assertEqual(rc, 1)
+        self.assertEqual(out, b'')
 
     @create_and_remove_directory(TEMPDIR)
     def test_compress_stdin_outfile(self):

--- a/Misc/NEWS.d/next/Library/2021-02-25-09-44-36.bpo-43316.k9Gyqn.rst
+++ b/Misc/NEWS.d/next/Library/2021-02-25-09-44-36.bpo-43316.k9Gyqn.rst
@@ -1,0 +1,3 @@
+The ``python -m gzip`` command line application now properly fails when
+detecting an unsupported extension. It exits with a non-zero exit code and
+prints an error message to stderr.


### PR DESCRIPTION
Exit code is now 1 instead of 0. A message is printed to stderr instead of stdout. This is
the proper behaviour for a tool that can be used in scripts.

In my opinion this change should be backported to all currently supported versions of python. Exiting with 0 upon error is not acceptable behaviour for a tool. Luckily, I think the backport will be quite easy and I am happy to do it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43316](https://bugs.python.org/issue43316) -->
https://bugs.python.org/issue43316
<!-- /issue-number -->
