### PR TITLE
bpo-43144: Mark unicodedata's test_normalization as requiring network

### DIFF
--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -320,6 +320,7 @@ class NormalizationTest(unittest.TestCase):
         data = [int(x, 16) for x in data.split(" ")]
         return "".join([chr(x) for x in data])
 
+    @requires_resource('network')
     def test_normalization(self):
         TESTDATAFILE = "NormalizationTest.txt"
         TESTDATAURL = f"http://www.pythontest.net/unicode/{unicodedata.unidata_version}/{TESTDATAFILE}"


### PR DESCRIPTION
This test is missing a requires network despite the fact that it uses `open_urlresource` which can cause failures on systems that aren't actually connected to the network.

Converted from a bpo patch to a github pull request on behalf of Arkadiusz.

<!-- issue-number: [bpo-43144](https://bugs.python.org/issue43144) -->
https://bugs.python.org/issue43144
<!-- /issue-number -->
