### PR TITLE
bpo-43316: gzip: Fix sys.exit() usage.

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -583,7 +583,7 @@ def main():
                 g = sys.stdout.buffer
             else:
                 if arg[-3:] != ".gz":
-                    sys.exit("filename doesn't end in .gz:", repr(arg))
+                    sys.exit(f"filename doesn't end in .gz: {arg!r}")
                 f = open(arg, "rb")
                 g = builtins.open(arg[:-3], "wb")
         else:

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -775,7 +775,7 @@ class TestCommandLine(unittest.TestCase):
 
     def test_decompress_infile_outfile_error(self):
         rc, out, err = assert_python_failure('-m', 'gzip', '-d', 'thisisatest.out')
-        self.assertIn(b"filename doesn't end in .gz:", err)
+        self.assertEqual(b"filename doesn't end in .gz: 'thisisatest.out'", err.strip())
         self.assertEqual(rc, 1)
         self.assertEqual(out, b'')
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43316](https://bugs.python.org/issue43316) -->
https://bugs.python.org/issue43316
<!-- /issue-number -->
