### PR TITLE
bpo-24650: Use full term "generator function" in yield expressions docs

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -422,7 +422,7 @@ Yield expressions
 The yield expression is used when defining a :term:`generator` function
 or an :term:`asynchronous generator` function and
 thus can only be used in the body of a function definition.  Using a yield
-expression in a function's body causes that function to be a generator,
+expression in a function's body causes that function to be a generator function,
 and using it in an :keyword:`async def` function's body causes that
 coroutine function to be an asynchronous generator. For example::
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -424,7 +424,7 @@ or an :term:`asynchronous generator` function and
 thus can only be used in the body of a function definition.  Using a yield
 expression in a function's body causes that function to be a generator function,
 and using it in an :keyword:`async def` function's body causes that
-coroutine function to be an asynchronous generator. For example::
+coroutine function to be an asynchronous generator function. For example::
 
     def gen():  # defines a generator function
         yield 123


### PR DESCRIPTION
https://bugs.python.org/issue24650

Throughout the section "Yield expressions" there is consistent use of "generator function" in all instances except this one, perhaps because the word "function" appears earlier in the sentence.

From [glossary](https://docs.python.org/3.5/glossary.html#term-generator):

> **generator**
> A function which returns a generator iterator. It looks like a normal function except that it contains yield expressions for producing a series of values usable in a for-loop or that can be retrieved one at a time with the next() function.
> 
> Usually refers to a generator function, but may refer to a generator iterator in some contexts. In cases where the intended meaning isn’t clear, using the full terms avoids ambiguity.

I agree with the ticket author that using the full term here would avoid ambiguity. The only other use of the short term "generator" is in this sentence:

> When a generator function is called, it returns an iterator known as a generator.

From this usage it would be understandable to draw the incorrect conclusion that generator (short term) == generator iterator.

<!-- issue-number: [bpo-24650](https://bugs.python.org/issue24650) -->
https://bugs.python.org/issue24650
<!-- /issue-number -->
