### PR TITLE
bpo-42128: Add documentation for pattern matching (PEP 634)

### DIFF
--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -259,9 +259,8 @@ Why isn't there a switch or case statement in Python?
 -----------------------------------------------------
 
 You can do this easily enough with a sequence of ``if... elif... elif... else``.
-There have been some proposals for switch statement syntax, but there is no
-consensus (yet) on whether and how to do range tests.  See :pep:`275` for
-complete details and the current status.
+For literal values, or constants within a namespace, you can also use a 
+``match ... case`` statement.
 
 For cases where you need to choose from a very large number of possibilities,
 you can create a dictionary mapping case values to functions to call.  For

--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -259,7 +259,7 @@ Why isn't there a switch or case statement in Python?
 -----------------------------------------------------
 
 You can do this easily enough with a sequence of ``if... elif... elif... else``.
-For literal values, or constants within a namespace, you can also use a 
+For literal values, or constants within a namespace, you can also use a
 ``match ... case`` statement.
 
 For cases where you need to choose from a very large number of possibilities,

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -714,21 +714,21 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |                   |                                                          |
 |                          |                   | 3. if failure test ...                                   |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`as-patterns`       | ``pattern``       | 1. test ``patttern``                                     |
+| :ref:`as-patterns`       | ``pattern``       | 1. test ``pattern``                                     |
 |                          |  :keyword:`as`    |                                                          |
 |                          |  ``capture``      | 2. if success, bind name into                            |
 |                          |                   |    ``capture``                                           |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`literal-patterns`  | ``"literal"``     | for strings and numbers, test ``subject == x.y``         |
+| :ref:`literal-patterns`  | ``"literal"``     | for strings and numbers, test ``subject == "literal"``         |
 |                          |                   |                                                          |
 |                          |                   | otherwise, for singletons like ``None`` and :func:`bool`,|
-|                          |                   | test ``subject is x.y``                                  |
+|                          |                   | test ``subject is literal``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`capture-patterns`  | ``name``          | bind ``name = subject``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`wildcard-patterns` | ``_``             | ``pass``                                                 |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`value-patterns`    | ``x.y``           | test ``subject == "literal"``                            |
+| :ref:`value-patterns`    | ``x.y``           | test ``subject == x.y``                            |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`group-patterns`    | ``( pattern )``   | test ``pattern``                                         |
 +--------------------------+-------------------+----------------------------------------------------------+

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -719,15 +719,16 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |  ``capture``      | 2. if success, bind name into                            |
 |                          |                   |    ``capture``                                           |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`literal-patterns`  | ``"literal"``     | test ``subject == "literal"``                            |
+| :ref:`literal-patterns`  | ``"literal"``     | for strings and numbers, test ``subject == x.y``         |
+|                          |                   |                                                          |
+|                          |                   | otherwise, for singletons like ``None`` and :func:`bool`,|
+|                          |                   | test ``subject is x.y``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`capture-patterns`  | ``name``          | bind ``name = subject``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`wildcard-patterns` | ``_``             | ``pass``                                                 |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`value-patterns`    | ``x.y``           | For strings and numbers, test ``subject == x.y``         |
-|                          |                   | Otherwise, for singletons like ``None`` and :func:`bool`,|
-|                          |                   | test ``subject is x.y``                                  |
+| :ref:`value-patterns`    | ``x.y``           | test ``subject == "literal"``                            |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`group-patterns`    | ``( pattern )``   | test ``pattern``                                         |
 +--------------------------+-------------------+----------------------------------------------------------+
@@ -759,7 +760,8 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |                   | 4. test ``p2`` matches ``subject.name``                  |
 |                          |                   |                                                          |
 |                          |                   | 5. convert ``p1`` to a keyword pattern using             |
-|                          |                   |    ``K.__match_args__`` and repeat steps 2. and 3.       |
+|                          |                   |    ``K.__match_args__`` and repeat steps 2. to 4.        |
+|                          |                   |    using ``p1``                                          |
 +--------------------------+-------------------+----------------------------------------------------------+
 
 Note that this table purely for illustration purposes and **may not** reflect

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -535,9 +535,6 @@ The match statement is used for pattern matching.  Syntax:
                : | `named_expression`
    case_block: "case" `patterns` [`guard`] ':' `block`
 
-The rules ``star_named_expression``, ``star_named_expressions``,
-``named_expression`` and ``block`` are part of the
-:doc:`standard Python grammar <./grammar>`.
 
 Pattern matching takes a pattern as input (following ``case``) and a subject
 value (following ``match``).  The pattern (which may contain subpatterns) is
@@ -549,15 +546,6 @@ matched against the subject value.  The outcomes are:
   further discussed below.
 
 The ``match`` and ``case`` keywords are :ref:`soft keywords <soft_keywords>`.
-This means ``match`` and ``case`` have the following characteristics:
-
-* They are not reserved words in other grammatical contexts, including at the
-  start of a line if there is no colon where expected.
-
-* They are recognized as keywords when part of a match statement or case block
-  only.
-
-* They can be used in all other contexts as variable or argument names.
 
 .. seealso::
 
@@ -627,16 +615,7 @@ Guards
 
 A ``guard`` (which is part of the ``case``) must succeed for code inside
 the ``case`` block to execute.  It takes the form: :keyword:`if` followed by an
-expression.  Conceptually it's similar to a
-:ref:`conditional expression <if_expr>`.  An example guard::
-
-   >>> match 100:
-   ...    case x if x < 0:
-   ...        print(f'{x} is negative!')
-   ...    case x:
-   ...        print(f'{x} is non-negative!')
-   ...
-   100 is non-negative!
+expression.
 
 
 The logical flow of a ``case`` block with a ``guard`` follows:
@@ -734,12 +713,12 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`as_patterns`       | ``or_pattern``    | 1. test ``or_pattern``                                   |
 |                          |  :keyword:`as`    |                                                          |
-|                          |  ``capture``      | 2. if success, bind names in                             |
+|                          |  ``capture``      | 2. if success, bind name into                             |
 |                          |                   |    ``capture``                                           |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`literal_patterns`  | ``"literal"``     | test ``subject == "literal"``                            |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`capture_patterns`  | ``name``          | test ``name = subject``                                  |
+| :ref:`capture_patterns`  | ``name``          | bind ``name = subject``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`wildcard_patterns` | ``_``             | ``pass``                                                 |
 +--------------------------+-------------------+----------------------------------------------------------+

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -535,6 +535,10 @@ The match statement is used for pattern matching.  Syntax:
                : | `named_expression`
    case_block: "case" `patterns` [`guard`] ':' `block`
 
+The rules ``star_named_expression``, ``star_named_expressions``,
+``named_expression`` and ``block`` are part of the
+:doc:`standard Python grammar <./grammar>`.
+
 Pattern matching takes a pattern as input (following ``case``) and a subject
 value (following ``match``).  The pattern (which may contain subpatterns) is
 matched against the subject value.  The outcomes are:
@@ -553,18 +557,18 @@ This means ``match`` and ``case`` have the following characteristics:
 * They are recognized as keywords when part of a match statement or case block
   only.
 
-* They can be used in all other contexts as variable or argument names
+* They can be used in all other contexts as variable or argument names.
 
+.. seealso::
 
-The rules ``star_named_expression``, ``star_named_expressions``,
-``named_expression`` and ``block`` are part of the
-:doc:`standard Python grammar <./grammar>`.  While ``patterns`` is specified
-further below.
+   * :pep:`634` -- Structural Pattern Matching: Specification
+   * :pep:`636` -- Structural Pattern Matching: Tutorial
+
 
 Overview
 --------
 
-Here's an overview of the logical flow:
+Here's an overview of the logical flow of a match statement:
 
 #. The subject expression ``subject_expr`` is evaluated and a resulting subject
    value obtained.  If the subject expression contains a comma, a tuple is
@@ -666,7 +670,7 @@ Irrefutable Case Blocks
 
 .. index:: irrefutable case block, case block
 
-An irrefutable case block is a catch-all case block.  A match statement may have
+An irrefutable case block is a match-all case block.  A match statement may have
 at most one irrefutable case block, and it must be last.
 
 A case block is considered irrefutable if it has no guard and its pattern is
@@ -733,13 +737,13 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |  ``capture``      | 2. if success, bind names in                             |
 |                          |                   |    ``capture``                                           |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`literal_patterns`  | ``"literal"``     | ``subject == "literal"``                                 |
+| :ref:`literal_patterns`  | ``"literal"``     | test ``subject == "literal"``                            |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`capture_patterns`  | ``name``          | ``name = subject``                                       |
+| :ref:`capture_patterns`  | ``name``          | test ``name = subject``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`wildcard_patterns` | ``_``             | ``pass``                                                 |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`value_patterns`    | ``x.y``           | ``subject == x.y``                                       |
+| :ref:`value_patterns`    | ``x.y``           | test ``subject == x.y``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`group_patterns`    | ``( pattern )``   | test ``pattern``                                         |
 +--------------------------+-------------------+----------------------------------------------------------+
@@ -776,7 +780,7 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 
 Note that this table purely for illustration purposes and **may not** reflect
 the underlying implementation.  Furthermore, they do not cover all valid forms.
-Read the pattern's respective section to learn more.
+Read the pattern's respective sections to learn more.
 
 
 .. _or_patterns:
@@ -784,57 +788,51 @@ Read the pattern's respective section to learn more.
 OR Patterns
 ^^^^^^^^^^^
 
+An OR pattern is two or more patterns separated by vertical
+bars ``|``.  Syntax:
+
 .. productionlist:: python-grammar
    or_pattern: '|'.`closed_pattern`+
 
-``or_pattern``: An OR pattern is two or more patterns separated by vertical
-bars ``|``.  Only the final subpattern may be
-:ref:`irrefutable <irrefutable_case>`, and each subpattern
-must bind the same set of names to avoid ambiguity.
+Only the final subpattern may be :ref:`irrefutable <irrefutable_case>`, and each
+subpattern must bind the same set of names to avoid ambiguity.
 
 An OR pattern matches each of its subpatterns in turn to the subject value,
 until one succeeds.  The OR pattern is then considered successful.  Otherwise,
 if none of the subpatterns succeed, the OR pattern fails.
-
-
-..
-   @TODO: NOTE TO SELF: EVERYTHING ONWARDS FROM HERE IS A TODO.
-
 
 .. _as_patterns:
 
 AS Patterns
 ^^^^^^^^^^^
 
+An AS pattern matches an OR pattern on the left of the :keyword:`as`
+keyword against a subject.  Syntax:
+
 .. productionlist:: python-grammar
    as_pattern: `or_pattern` 'as' `capture_pattern`
 
-``as_pattern``: An AS pattern matches the OR pattern on the left of the as
-keyword against the subject.  If this fails, the AS pattern fails.
-Otherwise, the AS pattern binds the subject to the name on the right of the
-as keyword and succeeds.  Note that ``capture_pattern`` cannot be a a ``_``.
-
-
-
-The following belong to ``closed_pattern``:
+If the OR pattern fails, the AS pattern fails.  Otherwise, the AS pattern binds
+the subject to the name on the right of the as keyword and succeeds.
+``capture_pattern`` cannot be a a ``_``.
 
 .. _literal_patterns:
 
 Literal Patterns
 ^^^^^^^^^^^^^^^^
 
-``literal_pattern``: A literal pattern corresponds to most
+A literal pattern corresponds to most
 :ref:`literals <literals>` in Python.  Syntax:
 
 .. productionlist:: python-grammar
-  literal_pattern: signed_number
-                 : | signed_number '+' NUMBER
-                 : | signed_number '-' NUMBER
-                 : | strings
-                 : | 'None'
-                 : | 'True'
-                 : | 'False'
-                 : | signed_number: NUMBER | '-' NUMBER
+   literal_pattern: `signed_number`
+                  : | `signed_number` '+' NUMBER
+                  : | `signed_number` '-' NUMBER
+                  : | `strings`
+                  : | 'None'
+                  : | 'True'
+                  : | 'False'
+                  : | `signed_number`: NUMBER | '-' NUMBER
 
 The rule ``strings`` and the token ``NUMBER`` are defined in the
 :doc:`standard Python grammar <./grammar>`.  Triple-quoted strings are
@@ -850,11 +848,11 @@ on the left and an imaginary number on the right. E.g. ``3 + 4j``.
 Capture Patterns
 ^^^^^^^^^^^^^^^^
 
-``capture_pattern``: A capture pattern binds the subject value to the name.
+A capture pattern binds the subject value to a name.
 Syntax:
 
 .. productionlist:: python-grammar
-  capture_pattern: !"_" NAME
+   capture_pattern: !"_" NAME
 
 A single underscore ``_`` is not a capture pattern (this is what ``!"_"``
 expresses). And is instead treated as a :token:`wildcard_pattern`.
@@ -863,7 +861,7 @@ In a given pattern, a given name can only be bound once.  E.g.
 ``case x, x: ...`` is invalid while ``case [x] | x: ...`` is allowed.
 
 Capture patterns always succeed.  The binding follows scoping rules
-established by the assignment expression operator in :pep`572`, where the
+established by the assignment expression operator in :pep`572`; the
 name becomes a local variable in the closest containing function scope unless
 there's an applicable :keyword:`global` or :keyword:`nonlocal` statement.
 
@@ -872,24 +870,24 @@ there's an applicable :keyword:`global` or :keyword:`nonlocal` statement.
 Wildcard Patterns
 ^^^^^^^^^^^^^^^^^
 
-``wildcard_pattern``: A wildcard pattern always succeeds (matches anything)
+A wildcard pattern always succeeds (matches anything)
 and binds no name.  Syntax:
 
 .. productionlist:: python-grammar
-  wildcard_pattern: "_"
+   wildcard_pattern: "_"
 
 .. _value_patterns:
 
 Value Patterns
 ^^^^^^^^^^^^^^
 
-``value_pattern``: A value pattern corresponds to a named value in Python.
+A value pattern represents a named value in Python.
 Syntax:
 
 .. productionlist:: python-grammar
-  value_pattern: `attr`
-  attr: `name_or_attr` '.' NAME
-  name_or_attr: `attr` | NAME
+   value_pattern: `attr`
+   attr: `name_or_attr` '.' NAME
+   name_or_attr: `attr` | NAME
 
 The dotted name in the pattern is looked up using standard Python
 :ref:`name resolution rules <resolve_names>`.  The pattern succeeds if the
@@ -898,27 +896,30 @@ operator).
 
 .. note::
 
- If the same value occurs multiple times in the same match statement, the
- interpreter may cache the first value found and reuse it rather than repeat
- the same lookup.  This cache is strictly tied to a given execution of a
- given match statement.
+  If the same value occurs multiple times in the same match statement, the
+  interpreter may cache the first value found and reuse it rather than repeat
+  the same lookup.  This cache is strictly tied to a given execution of a
+  given match statement.
 
 .. _group_patterns:
 
 Group Patterns
 ^^^^^^^^^^^^^^
 
-``group_pattern``: TODO
+A group pattern allows users to add parentheses around patterns to
+emphasize the intended grouping.  Otherwise, it has no additional syntax.
+Syntax:
 
 .. productionlist:: python-grammar
-  group_pattern: '(' `pattern` ')'
+   group_pattern: '(' `pattern` ')'
 
 .. _sequence_patterns:
 
 Sequence Patterns
 ^^^^^^^^^^^^^^^^^
 
-``sequence_pattern``: TODO
+A sequence pattern contains a sequence of subpatterns.  The syntax is
+similar to the construction of a list or tuple.
 
 .. productionlist:: python-grammar
   sequence_pattern: '[' [`maybe_sequence_pattern`] ']'
@@ -928,26 +929,113 @@ Sequence Patterns
   maybe_star_pattern: `star_pattern` | `pattern`
   star_pattern: '*' (`capture_pattern` | `wildcard_pattern`)
 
+
+There is no difference if parentheses (``(...)``) or square brackets (``[...]``)
+are used for sequence patterns.
+
+.. note::
+   A single pattern enclosed in parentheses without a trailing comma
+   (e.g. ``(3 | 4)``) is a :ref:`group pattern <group_patterns>`.
+   While a single pattern enclosed in square brackets (e.g. ``[3 | 4]``) is
+   still a sequence pattern.
+
+At most one star subpattern may be in a sequence pattern.  The star subpattern
+may occur in any position. If no star subpattern is present, the sequence
+pattern is a fixed-length sequence pattern; otherwise it is a variable-length
+sequence pattern.
+
+The following is the logical flow for matching a sequence pattern against a
+subject value:
+
+#. If the subject value is not an instance of a
+   :class:`collections.abc.Sequence` the sequence pattern fails.
+
+#. If the subject value is an instance of ``str``, ``bytes`` or ``bytearray``
+   the sequence pattern fails.
+
+#. The subsequent steps depend on whether the sequence pattern is fixed or
+   variable-length.
+
+   If the sequence pattern is fixed-length:
+
+   #. If the length of the subject sequence is not equal to the number of
+      subpatterns, the sequence pattern fails
+
+   #. Subpatterns in the sequence pattern are matched to their corresponding
+      items in the subject sequence from left to right.  Matching stops as soon
+      as a subpattern fails.  If all subpatterns succeed in matching their
+      corresponding item, the sequence pattern succeeds.
+
+   Otherwise, if the sequence pattern is variable-length:
+
+   #. If the length of the subject sequence is less than the number of non-star
+      subpatterns, the sequence pattern fails.
+
+   #. The leading non-star subpatterns are matched to their corresponding items
+      as for fixed-length sequences.
+
+   #. If the previous step succeeds, the star subpattern matches a list formed
+      of the remaining subject items, excluding the remaining items
+      corresponding to non-star subpatterns following the star subpattern.
+
+   #. Remaining non-star subpatterns are matched to their corresponding subject
+      items, as for a fixed-length sequence.
+
+   .. note:: The length of the subject sequence is obtained via
+      :func:`len` (i.e. via the :meth:`__len__` protocol).  This length may be
+      cached by the interpreter in a similar manner as
+      :ref:`value patterns <value_patterns>`.
+
+
 .. _mapping_patterns:
 
 Mapping Patterns
 ^^^^^^^^^^^^^^^^
 
-``mapping_pattern``: TODO
+A mapping pattern contains one or more key-value patterns.  The syntax is
+similar to the construction of a dictionary.
+Syntax:
 
 .. productionlist:: python-grammar
-  mapping_pattern: '{' [`items_pattern`] '}'
-  items_pattern: ','.`key_value_pattern`+ ','?
-  key_value_pattern: (`literal_pattern` | `value_pattern`) ':' `pattern`
-                   : | `double_star_pattern`
-  double_star_pattern: '**' `capture_pattern`
+   mapping_pattern: '{' [`items_pattern`] '}'
+   items_pattern: ','.`key_value_pattern`+ ','?
+   key_value_pattern: (`literal_pattern` | `value_pattern`) ':' `pattern`
+                    : | `double_star_pattern`
+   double_star_pattern: '**' `capture_pattern`
+
+At most one double star pattern may be in a mapping pattern.  The double star
+pattern must be the last subpattern in the mapping pattern.
+
+Duplicate key values in mapping patterns are disallowed. (If all key patterns
+are literal patterns this is considered a syntax error; otherwise this is a
+runtime error and will raise :exc:`ValueError`.)
+
+The following is the logical flow for matching a mapping pattern against a
+subject value:
+
+#. If the subject value is not an instance of :class:`collections.abc.Mapping`,
+   the mapping pattern fails.
+
+#. If every key given in the mapping pattern is present in the subject mapping,
+   and the pattern for each key matches the corresponding item of the subject
+   mapping, the mapping pattern succeeds.
+
+#. If duplicate keys are detected in the mapping pattern, the pattern is
+   considered invalid and :exc:`ValueError` is raised.
+
+.. note:: Key-value pairs are matched using the two-argument form of the mapping
+   subject's ``get()`` method.  Matched key-value pairs must already be present
+   in the mapping, and not created on-the-fly via :meth:`__missing__` or
+   :meth:`__getitem__`.
+
 
 .. _class_patterns:
 
 Class Patterns
 ^^^^^^^^^^^^^^
 
-``class_pattern``: TODO
+A class pattern represents a class and its positional and keyword arguments
+(if any).  Syntax:
 
 .. productionlist:: python-grammar
   class_pattern: `name_or_attr` '(' [`pattern_arguments` ','?] ')'
@@ -957,54 +1045,86 @@ Class Patterns
   keyword_patterns: ','.`keyword_pattern`+
   keyword_pattern: NAME '=' `pattern`
 
+The same keyword should not be repeated in class patterns.
 
-Full Grammar
-------------
+The following is the logical flow for matching a mapping pattern against a
+subject value:
 
-.. productionlist:: python-grammar
-   patterns: open_sequence_pattern | pattern
-   pattern: as_pattern | or_pattern
-   as_pattern: or_pattern 'as' capture_pattern
-   or_pattern: '|'.closed_pattern+
-   closed_pattern: literal_pattern
-                 : | capture_pattern
-                 : | wildcard_pattern
-                 : | value_pattern
-                 : | group_pattern
-                 : | sequence_pattern
-                 : | mapping_pattern
-                 : | class_pattern
-   literal_pattern: signed_number !('+' | '-')
-                  : | signed_number '+' NUMBER
-                  : | signed_number '-' NUMBER
-                  : | strings
-                  : | 'None'
-                  : | 'True'
-                  : | 'False'
-   signed_number: NUMBER | '-' NUMBER
-   capture_pattern: !"_" NAME !('.' | '(' | '=')
-   wildcard_pattern: "_"
-   value_pattern: attr !('.' | '(' | '=')
-   attr: name_or_attr '.' NAME
-   name_or_attr: attr | NAME
-   group_pattern: '(' pattern ')'
-   sequence_pattern: '[' [maybe_sequence_pattern] ']'
-                   : | '(' [open_sequence_pattern] ')'
-   open_sequence_pattern: maybe_star_pattern ',' [maybe_sequence_pattern]
-   maybe_sequence_pattern: ','.maybe_star_pattern+ ','?
-   maybe_star_pattern: star_pattern | pattern
-   star_pattern: '*' (capture_pattern | wildcard_pattern)
-   mapping_pattern: '{' [items_pattern] '}'
-   items_pattern: ','.key_value_pattern+ ','?
-   key_value_pattern: | (literal_pattern | value_pattern) ':' pattern
-                    : | double_star_pattern
-   double_star_pattern: '**' capture_pattern
-   class_pattern: name_or_attr '(' [pattern_arguments ','?] ')'
-   pattern_arguments: positional_patterns [',' keyword_patterns]
-                    : | keyword_patterns
-   positional_patterns: ','.pattern+
-   keyword_patterns: ','.keyword_pattern+
-   keyword_pattern: NAME '=' pattern
+#. If ``name_or_attr`` is not an instance of the builtin :class:`type` , raise
+   :exc:`TypeError`.
+
+#. If the subject value is not an instance of ``name_or_attr`` (tested via
+   :func:`isinstance`), the class pattern fails.
+
+#. If no pattern arguments are present, the pattern succeeds.  Otherwise,
+   the subsequent steps depend on whether keyword or positional argument patterns
+   are present.
+
+   For a number of built-in types (specified below), a single positional
+   subpattern is accepted which will match the entire subject; for these types
+   no keyword patterns are accepted.
+
+   If only keyword patterns are present, they are processed as follows,
+   one by one:
+
+   I. The keyword is looked up as an attribute on the subject.
+
+      * If this raises an exception other than :exc:`AttributeError`, the
+        exception bubbles up.
+
+      * If this raises :exc:`AttributeError`, the class pattern has failed.
+
+      * Else, the subpattern associated with the keyword pattern is matched
+        against the subject's attribute value.  If this fails, the class
+        pattern fails; if this succeeds, the match proceeds to the next keyword.
+
+
+   II. If all keyword patterns succeed, the class pattern succeeds.
+
+   If any positional patterns are present, they are converted to keyword
+   patterns using the ``__match_args__`` attribute on the class
+   ``name_or_attr`` before matching:
+
+   I. The equivalent of getattr(cls, "__match_args__", ())) is called.
+
+      * If this raises an exception, the exception bubbles up.
+
+      * If the returned value is not a list or tuple, the conversion fails and
+        :exc:`TypeError` is raised.
+
+      * If there are more positional patterns than ``len(cls.__match_args__)``,
+        :exc:`TypeError` is raised.
+
+      * Otherwise, positional pattern ``i`` is converted to a keyword pattern
+        using ``__match_args__[i]`` as the keyword.  ``__match_args__[i]`` must
+        be a string; if not :exc:`TypeError` is raised.
+
+      * If there are duplicate keywords, :exc:`TypeError` is raised.
+
+   II. Once all positional patterns have been converted to keyword patterns,
+       the match proceeds as if there were only keyword patterns.
+
+   For the following built-in types the handling of positional subpatterns is
+   different:
+
+   * :class:`bool`
+   * :class:`bytearray`
+   * :class:`bytes`
+   * :class:`dict`
+   * :class:`float`
+   * :class:`frozenset`
+   * :class:`int`
+   * :class:`list`
+   * :class:`set`
+   * :class:`str`
+   * :class:`tuple`
+
+
+.. seealso::
+
+   * :pep:`634` -- Structural Pattern Matching: Specification
+   * :pep:`636` -- Structural Pattern Matching: Tutorial
+
 
 .. index::
    single: parameter; function definition

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1070,10 +1070,10 @@ subject value:
    II. If all keyword patterns succeed, the class pattern succeeds.
 
    If any positional patterns are present, they are converted to keyword
-   patterns using the ``__match_args__`` attribute on the class
+   patterns using the :data:`~class.__match_args__` attribute on the class
    ``name_or_attr`` before matching:
 
-   I. The equivalent of getattr(cls, "__match_args__", ())) is called.
+   I. The equivalent of ``getattr(cls, "__match_args__", ()))`` is called.
 
       * If this raises an exception, the exception bubbles up.
 
@@ -1088,6 +1088,8 @@ subject value:
         be a string; if not :exc:`TypeError` is raised.
 
       * If there are duplicate keywords, :exc:`TypeError` is raised.
+
+      .. seealso:: :ref:`class-pattern-matching`
 
    II. Once all positional patterns have been converted to keyword patterns,
        the match proceeds as if there were only keyword patterns.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -711,9 +711,9 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |                   |                                                          |
 |                          |                   | 3. if failure test ...                                   |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`as_patterns`       | ``or_pattern``    | 1. test ``or_pattern``                                   |
+| :ref:`as_patterns`       | ``pattern``       | 1. test ``patttern``                                     |
 |                          |  :keyword:`as`    |                                                          |
-|                          |  ``capture``      | 2. if success, bind name into                             |
+|                          |  ``capture``      | 2. if success, bind name into                            |
 |                          |                   |    ``capture``                                           |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`literal_patterns`  | ``"literal"``     | test ``subject == "literal"``                            |
@@ -722,7 +722,9 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`wildcard_patterns` | ``_``             | ``pass``                                                 |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`value_patterns`    | ``x.y``           | test ``subject == x.y``                                  |
+| :ref:`value_patterns`    | ``x.y``           | For strings and numbers, test ``subject == x.y``         |
+|                          |                   | Otherwise, for singletons like ``None`` and :func:`bool`,|
+|                          |                   | test ``subject is x.y``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`group_patterns`    | ``( pattern )``   | test ``pattern``                                         |
 +--------------------------+-------------------+----------------------------------------------------------+
@@ -854,6 +856,8 @@ and binds no name.  Syntax:
 
 .. productionlist:: python-grammar
    wildcard_pattern: "_"
+
+``_`` is a :ref:`soft keyword <soft_keywords>`.
 
 .. _value_patterns:
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -530,11 +530,14 @@ The :keyword:`!match` statement
 The match statement is used for pattern matching.  Syntax:
 
 .. productionlist:: python-grammar
-   match_stmt: "match" `subject_expr` ':' NEWLINE INDENT `case_block`+ DEDENT
-   subject_expr: `star_named_expression` ',' `star_named_expressions`?
+   match_stmt: 'match' `subject_expr` ":" NEWLINE INDENT `case_block`+ DEDENT
+   subject_expr: `star_named_expression` "," `star_named_expressions`?
                : | `named_expression`
-   case_block: "case" `patterns` [`guard`] ':' `block`
+   case_block: 'case' `patterns` [`guard`] ':' `block`
 
+.. note::
+   This section uses single quotes to denote
+   :ref:`soft keywords <soft-keywords>`.
 
 Pattern matching takes a pattern as input (following ``case``) and a subject
 value (following ``match``).  The pattern (which may contain subpatterns) is
@@ -545,7 +548,7 @@ matched against the subject value.  The outcomes are:
 * Possible binding of matched values to a name.  The prerequisites for this are
   further discussed below.
 
-The ``match`` and ``case`` keywords are :ref:`soft keywords <soft_keywords>`.
+The ``match`` and ``case`` keywords are :ref:`soft keywords <soft-keywords>`.
 
 .. seealso::
 
@@ -611,7 +614,7 @@ Guards
 .. index:: ! guard
 
 .. productionlist:: python-grammar
-   guard: 'if' `named_expression`
+   guard: "if" `named_expression`
 
 A ``guard`` (which is part of the ``case``) must succeed for code inside
 the ``case`` block to execute.  It takes the form: :keyword:`if` followed by an
@@ -657,13 +660,13 @@ irrefutable.  A pattern is considered irrefutable if we can prove from its
 syntax alone that it will always succeed.  The following patterns are
 irrefutable:
 
-* :ref:`as_patterns` whose left-hand side is irrefutable
+* :ref:`as-patterns` whose left-hand side is irrefutable
 
-* :ref:`or_patterns` containing at least one irrefutable pattern
+* :ref:`or-patterns` containing at least one irrefutable pattern
 
-* :ref:`capture_patterns`
+* :ref:`capture-patterns`
 
-* :ref:`wildcard_patterns`
+* :ref:`wildcard-patterns`
 
 * parenthesized irrefutable patterns
 
@@ -688,8 +691,8 @@ The top-level syntax for ``patterns`` is:
 .. productionlist:: python-grammar
    patterns: `open_sequence_pattern` | `pattern`
    pattern: `as_pattern` | `or_pattern`
-   as_pattern: `or_pattern` 'as' `capture_pattern`
-   or_pattern: '|'.`closed_pattern`+
+   as_pattern: `or_pattern` "as" `capture_pattern`
+   or_pattern: "|".`closed_pattern`+
    closed_pattern: | `literal_pattern`
                  : | `capture_pattern`
                  : | `wildcard_pattern`
@@ -705,30 +708,30 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 +--------------------------+-------------------+----------------------------------------------------------+
 | Pattern Type             | Pattern Form      | Logical behavior                                         |
 +==========================+===================+==========================================================+
-| :ref:`or_patterns`       | ``p1 | p2 | ...`` | 1. test ``p1``                                           |
+| :ref:`or-patterns`       | ``p1 | p2 | ...`` | 1. test ``p1``                                           |
 |                          |                   |                                                          |
 |                          |                   | 2. if failure, test ``p2``                               |
 |                          |                   |                                                          |
 |                          |                   | 3. if failure test ...                                   |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`as_patterns`       | ``pattern``       | 1. test ``patttern``                                     |
+| :ref:`as-patterns`       | ``pattern``       | 1. test ``patttern``                                     |
 |                          |  :keyword:`as`    |                                                          |
 |                          |  ``capture``      | 2. if success, bind name into                            |
 |                          |                   |    ``capture``                                           |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`literal_patterns`  | ``"literal"``     | test ``subject == "literal"``                            |
+| :ref:`literal-patterns`  | ``"literal"``     | test ``subject == "literal"``                            |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`capture_patterns`  | ``name``          | bind ``name = subject``                                  |
+| :ref:`capture-patterns`  | ``name``          | bind ``name = subject``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`wildcard_patterns` | ``_``             | ``pass``                                                 |
+| :ref:`wildcard-patterns` | ``_``             | ``pass``                                                 |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`value_patterns`    | ``x.y``           | For strings and numbers, test ``subject == x.y``         |
+| :ref:`value-patterns`    | ``x.y``           | For strings and numbers, test ``subject == x.y``         |
 |                          |                   | Otherwise, for singletons like ``None`` and :func:`bool`,|
 |                          |                   | test ``subject is x.y``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`group_patterns`    | ``( pattern )``   | test ``pattern``                                         |
+| :ref:`group-patterns`    | ``( pattern )``   | test ``pattern``                                         |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`sequence_patterns` | ``[p1, p2, ...]`` | 1. check ``isinstance(subject, collections.abc.Sequence``|
+| :ref:`sequence-patterns` | ``[p1, p2, ...]`` | 1. check ``isinstance(subject, collections.abc.Sequence``|
 |                          |                   |                                                          |
 |                          |                   | 2. check ``len(subject) == len(sequence_pattern)``       |
 |                          |                   |                                                          |
@@ -738,7 +741,7 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |                   |                                                          |
 |                          |                   | 5. repeat step 4. for subsequent patterns and indexes    |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`mapping_patterns`  | ``{p1: p2, ...}`` | 1. check ``isinstance(subject, collections.abc.Mapping)``|
+| :ref:`mapping-patterns`  | ``{p1: p2, ...}`` | 1. check ``isinstance(subject, collections.abc.Mapping)``|
 |                          |                   |                                                          |
 |                          |                   | 2. test ``p1 in subject``                                |
 |                          |                   |                                                          |
@@ -747,7 +750,7 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |                   | 4. repeat steps 2. and 3. for subsequent key and value   |
 |                          |                   |    patterns.                                             |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`class_patterns`    | ``K(p1, name=p2)``| 1. check ``isinstance(K, type)``                         |
+| :ref:`class-patterns`    | ``K(p1, name=p2)``| 1. check ``isinstance(K, type)``                         |
 |                          |                   |                                                          |
 |                          |                   | 2. check ``isinstance(subject, K)``                      |
 |                          |                   |                                                          |
@@ -764,7 +767,7 @@ the underlying implementation.  Furthermore, they do not cover all valid forms.
 Read the pattern's respective sections to learn more.
 
 
-.. _or_patterns:
+.. _or-patterns:
 
 OR Patterns
 ^^^^^^^^^^^
@@ -773,7 +776,7 @@ An OR pattern is two or more patterns separated by vertical
 bars ``|``.  Syntax:
 
 .. productionlist:: python-grammar
-   or_pattern: '|'.`closed_pattern`+
+   or_pattern: "|".`closed_pattern`+
 
 Only the final subpattern may be :ref:`irrefutable <irrefutable_case>`, and each
 subpattern must bind the same set of names to avoid ambiguity.
@@ -782,7 +785,7 @@ An OR pattern matches each of its subpatterns in turn to the subject value,
 until one succeeds.  The OR pattern is then considered successful.  Otherwise,
 if none of the subpatterns succeed, the OR pattern fails.
 
-.. _as_patterns:
+.. _as-patterns:
 
 AS Patterns
 ^^^^^^^^^^^
@@ -791,13 +794,13 @@ An AS pattern matches an OR pattern on the left of the :keyword:`as`
 keyword against a subject.  Syntax:
 
 .. productionlist:: python-grammar
-   as_pattern: `or_pattern` 'as' `capture_pattern`
+   as_pattern: `or_pattern` "as" `capture_pattern`
 
 If the OR pattern fails, the AS pattern fails.  Otherwise, the AS pattern binds
 the subject to the name on the right of the as keyword and succeeds.
 ``capture_pattern`` cannot be a a ``_``.
 
-.. _literal_patterns:
+.. _literal-patterns:
 
 Literal Patterns
 ^^^^^^^^^^^^^^^^
@@ -807,13 +810,13 @@ A literal pattern corresponds to most
 
 .. productionlist:: python-grammar
    literal_pattern: `signed_number`
-                  : | `signed_number` '+' NUMBER
-                  : | `signed_number` '-' NUMBER
+                  : | `signed_number` "+" NUMBER
+                  : | `signed_number` "-" NUMBER
                   : | `strings`
-                  : | 'None'
-                  : | 'True'
-                  : | 'False'
-                  : | `signed_number`: NUMBER | '-' NUMBER
+                  : | "None"
+                  : | "True"
+                  : | "False"
+                  : | `signed_number`: NUMBER | "-" NUMBER
 
 The rule ``strings`` and the token ``NUMBER`` are defined in the
 :doc:`standard Python grammar <./grammar>`.  Triple-quoted strings are
@@ -824,7 +827,7 @@ The forms ``signed_number '+' NUMBER`` and ``signed_number '-' NUMBER`` are
 for expressing :ref:`complex numbers <imaginary>`; they require a real number
 on the left and an imaginary number on the right. E.g. ``3 + 4j``.
 
-.. _capture_patterns:
+.. _capture-patterns:
 
 Capture Patterns
 ^^^^^^^^^^^^^^^^
@@ -833,9 +836,9 @@ A capture pattern binds the subject value to a name.
 Syntax:
 
 .. productionlist:: python-grammar
-   capture_pattern: !"_" NAME
+   capture_pattern: !'_' NAME
 
-A single underscore ``_`` is not a capture pattern (this is what ``!"_"``
+A single underscore ``_`` is not a capture pattern (this is what ``!'_'``
 expresses). And is instead treated as a :token:`wildcard_pattern`.
 
 In a given pattern, a given name can only be bound once.  E.g.
@@ -846,7 +849,7 @@ established by the assignment expression operator in :pep`572`; the
 name becomes a local variable in the closest containing function scope unless
 there's an applicable :keyword:`global` or :keyword:`nonlocal` statement.
 
-.. _wildcard_patterns:
+.. _wildcard-patterns:
 
 Wildcard Patterns
 ^^^^^^^^^^^^^^^^^
@@ -855,11 +858,11 @@ A wildcard pattern always succeeds (matches anything)
 and binds no name.  Syntax:
 
 .. productionlist:: python-grammar
-   wildcard_pattern: "_"
+   wildcard_pattern: '_'
 
-``_`` is a :ref:`soft keyword <soft_keywords>`.
+``_`` is a :ref:`soft keyword <soft-keywords>`.
 
-.. _value_patterns:
+.. _value-patterns:
 
 Value Patterns
 ^^^^^^^^^^^^^^
@@ -869,7 +872,7 @@ Syntax:
 
 .. productionlist:: python-grammar
    value_pattern: `attr`
-   attr: `name_or_attr` '.' NAME
+   attr: `name_or_attr` "." NAME
    name_or_attr: `attr` | NAME
 
 The dotted name in the pattern is looked up using standard Python
@@ -884,7 +887,7 @@ operator).
   the same lookup.  This cache is strictly tied to a given execution of a
   given match statement.
 
-.. _group_patterns:
+.. _group-patterns:
 
 Group Patterns
 ^^^^^^^^^^^^^^
@@ -896,7 +899,7 @@ Syntax:
 .. productionlist:: python-grammar
    group_pattern: '(' `pattern` ')'
 
-.. _sequence_patterns:
+.. _sequence-patterns:
 
 Sequence Patterns
 ^^^^^^^^^^^^^^^^^
@@ -905,12 +908,12 @@ A sequence pattern contains a sequence of subpatterns.  The syntax is
 similar to the construction of a list or tuple.
 
 .. productionlist:: python-grammar
-  sequence_pattern: '[' [`maybe_sequence_pattern`] ']'
-                  : | '(' [`open_sequence_pattern`] ')'
-  open_sequence_pattern: `maybe_star_pattern` ',' [`maybe_sequence_pattern`]
-  maybe_sequence_pattern: ','.`maybe_star_pattern`+ ','?
+  sequence_pattern: "[" [`maybe_sequence_pattern`] "]"
+                  : | "(" [`open_sequence_pattern`] ")"
+  open_sequence_pattern: `maybe_star_pattern` "," [`maybe_sequence_pattern`]
+  maybe_sequence_pattern: ",".`maybe_star_pattern`+ ","?
   maybe_star_pattern: `star_pattern` | `pattern`
-  star_pattern: '*' (`capture_pattern` | `wildcard_pattern`)
+  star_pattern: "*" (`capture_pattern` | `wildcard_pattern`)
 
 
 There is no difference if parentheses (``(...)``) or square brackets (``[...]``)
@@ -918,7 +921,7 @@ are used for sequence patterns.
 
 .. note::
    A single pattern enclosed in parentheses without a trailing comma
-   (e.g. ``(3 | 4)``) is a :ref:`group pattern <group_patterns>`.
+   (e.g. ``(3 | 4)``) is a :ref:`group pattern <group-patterns>`.
    While a single pattern enclosed in square brackets (e.g. ``[3 | 4]``) is
    still a sequence pattern.
 
@@ -967,10 +970,10 @@ subject value:
    .. note:: The length of the subject sequence is obtained via
       :func:`len` (i.e. via the :meth:`__len__` protocol).  This length may be
       cached by the interpreter in a similar manner as
-      :ref:`value patterns <value_patterns>`.
+      :ref:`value patterns <value-patterns>`.
 
 
-.. _mapping_patterns:
+.. _mapping-patterns:
 
 Mapping Patterns
 ^^^^^^^^^^^^^^^^
@@ -980,11 +983,11 @@ similar to the construction of a dictionary.
 Syntax:
 
 .. productionlist:: python-grammar
-   mapping_pattern: '{' [`items_pattern`] '}'
-   items_pattern: ','.`key_value_pattern`+ ','?
-   key_value_pattern: (`literal_pattern` | `value_pattern`) ':' `pattern`
+   mapping_pattern: "{" [`items_pattern`] "}"
+   items_pattern: ",".`key_value_pattern`+ ","?
+   key_value_pattern: (`literal_pattern` | `value_pattern`) ":" `pattern`
                     : | `double_star_pattern`
-   double_star_pattern: '**' `capture_pattern`
+   double_star_pattern: "**" `capture_pattern`
 
 At most one double star pattern may be in a mapping pattern.  The double star
 pattern must be the last subpattern in the mapping pattern.
@@ -1012,7 +1015,7 @@ subject value:
    :meth:`__getitem__`.
 
 
-.. _class_patterns:
+.. _class-patterns:
 
 Class Patterns
 ^^^^^^^^^^^^^^
@@ -1021,12 +1024,12 @@ A class pattern represents a class and its positional and keyword arguments
 (if any).  Syntax:
 
 .. productionlist:: python-grammar
-  class_pattern: `name_or_attr` '(' [`pattern_arguments` ','?] ')'
-  pattern_arguments: `positional_patterns` [',' `keyword_patterns`]
+  class_pattern: `name_or_attr` "(" [`pattern_arguments` ","?] ")"
+  pattern_arguments: `positional_patterns` ["," `keyword_patterns`]
                    : | `keyword_patterns`
-  positional_patterns: ','.`pattern`+
-  keyword_patterns: ','.`keyword_pattern`+
-  keyword_pattern: NAME '=' `pattern`
+  positional_patterns: ",".`pattern`+
+  keyword_patterns: ",".`keyword_pattern`+
+  keyword_pattern: NAME "=" `pattern`
 
 The same keyword should not be repeated in class patterns.
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -665,7 +665,7 @@ at most one irrefutable case block, and it must be last.
 
 A case block is considered irrefutable if it has no guard and its pattern is
 irrefutable.  A pattern is considered irrefutable if we can prove from its
-syntax alone that it will always succeed.  The following patterns are
+syntax alone that it will always succeed.  Only the following patterns are
 irrefutable:
 
 * :ref:`as-patterns` whose left-hand side is irrefutable

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -714,10 +714,6 @@ inspired most of the descriptions). Note that these descriptions are purely for
 illustration purposes and **may not** reflect
 the underlying implementation.  Furthermore, they do not cover all valid forms.
 
-The following is a very brief overview of the different patterns and an
-approximation of their behavior:
-
-
 
 .. _or-patterns:
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -691,8 +691,6 @@ The top-level syntax for ``patterns`` is:
 .. productionlist:: python-grammar
    patterns: `open_sequence_pattern` | `pattern`
    pattern: `as_pattern` | `or_pattern`
-   as_pattern: `or_pattern` "as" `capture_pattern`
-   or_pattern: "|".`closed_pattern`+
    closed_pattern: | `literal_pattern`
                  : | `capture_pattern`
                  : | `wildcard_pattern`
@@ -714,21 +712,21 @@ approximation of their behavior (credits to Raymond Hettinger for the idea):
 |                          |                   |                                                          |
 |                          |                   | 3. if failure test ...                                   |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`as-patterns`       | ``pattern``       | 1. test ``pattern``                                     |
+| :ref:`as-patterns`       | ``pattern``       | 1. test ``pattern``                                      |
 |                          |  :keyword:`as`    |                                                          |
 |                          |  ``capture``      | 2. if success, bind name into                            |
 |                          |                   |    ``capture``                                           |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`literal-patterns`  | ``"literal"``     | for strings and numbers, test ``subject == "literal"``         |
+| :ref:`literal-patterns`  | ``"literal"``     | for strings and numbers, test ``subject == "literal"``   |
 |                          |                   |                                                          |
 |                          |                   | otherwise, for singletons like ``None`` and :func:`bool`,|
-|                          |                   | test ``subject is literal``                                  |
+|                          |                   | test ``subject is literal``                              |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`capture-patterns`  | ``name``          | bind ``name = subject``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`wildcard-patterns` | ``_``             | ``pass``                                                 |
 +--------------------------+-------------------+----------------------------------------------------------+
-| :ref:`value-patterns`    | ``x.y``           | test ``subject == x.y``                            |
+| :ref:`value-patterns`    | ``x.y``           | test ``subject == x.y``                                  |
 +--------------------------+-------------------+----------------------------------------------------------+
 | :ref:`group-patterns`    | ``( pattern )``   | test ``pattern``                                         |
 +--------------------------+-------------------+----------------------------------------------------------+

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -561,14 +561,17 @@ Overview
 
 Here's an overview of the logical flow of a match statement:
 
+
 #. The subject expression ``subject_expr`` is evaluated and a resulting subject
-   value obtained.  If the subject expression contains a comma, a tuple is
+   value obtained. If the subject expression contains a comma, a tuple is
    constructed using :ref:`the standard rules <typesseq-tuple>`.
 
-#. The first ``case_block`` whose patterns succeed in matching the subject
-   value and whose ``guard`` condition (if present) is "truthy" is selected.
-
-   * If no case blocks qualify, the match statement is completed.
+#. Each pattern in a ``case_block`` is attempted to match with the subject value. The
+   specific rules for success or failure are described below. The match attempt can also
+   bind some or all of the standalone names within the pattern. The precise 
+   pattern binding rules vary per pattern type and are
+   specified below.  **Name bindings made during a successful pattern match
+   outlive the executed block and can be used after the match statement**.
 
       .. note::
 
@@ -579,10 +582,15 @@ Here's an overview of the logical flow of a match statement:
          intentional decision made to allow different implementations to add
          optimizations.
 
-   * Otherwise, name bindings occur and the ``block`` inside ``case_block`` is
-     executed.  The precise pattern binding rules vary per pattern type and are
-     specified below.  **Name bindings made during a successful pattern match
-     outlive the executed block and can be used after the match statement**.
+#. If the pattern succeeds, the corresponding guard (if present) is evaluated. In
+   this case all name bindings are guaranteed to have happened.
+
+   * If the guard evaluates as truthy or missing, the ``block`` inside ``case_block`` is
+     executed.
+
+   * Otherwise, the next ``case_block`` is attempted as described above.
+
+   * If there are no further case blocks, the match statement is completed.
 
 .. note::
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1068,7 +1068,7 @@ subject value:
    II. If all keyword patterns succeed, the class pattern succeeds.
 
    If any positional patterns are present, they are converted to keyword
-   patterns using the :data:`~class.__match_args__` attribute on the class
+   patterns using the :data:`~object.__match_args__` attribute on the class
    ``name_or_attr`` before matching:
 
    I. The equivalent of ``getattr(cls, "__match_args__", ()))`` is called.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -602,13 +602,13 @@ A sample match statement::
 
    >>> flag = False
    >>> match (100, 200):
-   ...    case (100, 300):
+   ...    case (100, 300):  # Mismatch: 200 != 300
    ...        print('Case 1')
-   ...    case (100, 200) if flag:
+   ...    case (100, 200) if flag:  # Successful match, but guard fails
    ...        print('Case 2')
-   ...    case (100, y):
+   ...    case (100, y):  # Matches and binds y to 200
    ...        print(f'Case 3, y: {y}')
-   ...    case _:
+   ...    case _:  # Pattern not attempted
    ...        print('Case 4, I match anything!')
    ...
    Case 3, y: 200

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2553,6 +2553,36 @@ For more information on context managers, see :ref:`typecontextmanager`.
       statement.
 
 
+.. _pattern-matching:
+
+Customizing positional arguments in class pattern matching
+----------------------------------------------------------
+
+When using a class name in a pattern, positional arguments in the pattern are not
+allowed by default, i.e. ``case MyClass(x, y)`` is typically invalid without special
+support in ``MyClass``. To be able to use that kind of patterns, the class needs to
+define a *__match_args__* attribute.
+
+.. data:: object.__match_args__
+
+   This class variable can be assigned a tuple or list of strings. When this class is
+   used in a class pattern with positional arguments, each positional argument will
+   be converted into a keyword argument, using the corresponding value in
+   *__match_args__* as the keyword. The absence of this attribute is equivalent to
+   setting it to ``()``.
+
+For example if ``MyClass.__match_args__`` is ``("left", "center", "right")`` that means
+that ``case MyClass(x, y)`` is equivalent to ``case MyClass(left=x, center=y)``. Note
+that the number of arguments in the pattern must be smaller than or equal to the number
+of elements in *__match_args__*; if it is larger, the pattern match attempt will raise
+a *TypeError*.
+
+.. seealso::
+
+   :pep:`634` - Structural Pattern Matching
+      The specification for the Python ``match`` statement.
+
+
 .. _special-lookup:
 
 Special method lookup

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2563,7 +2563,7 @@ allowed by default, i.e. ``case MyClass(x, y)`` is typically invalid without spe
 support in ``MyClass``. To be able to use that kind of patterns, the class needs to
 define a *__match_args__* attribute.
 
-.. data:: class.__match_args__
+.. data:: object.__match_args__
 
    This class variable can be assigned a tuple or list of strings. When this class is
    used in a class pattern with positional arguments, each positional argument will

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2563,7 +2563,7 @@ allowed by default, i.e. ``case MyClass(x, y)`` is typically invalid without spe
 support in ``MyClass``. To be able to use that kind of patterns, the class needs to
 define a *__match_args__* attribute.
 
-.. data:: object.__match_args__
+.. data:: class.__match_args__
 
    This class variable can be assigned a tuple or list of strings. When this class is
    used in a class pattern with positional arguments, each positional argument will

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2553,7 +2553,7 @@ For more information on context managers, see :ref:`typecontextmanager`.
       statement.
 
 
-.. _pattern-matching:
+.. _class-pattern-matching:
 
 Customizing positional arguments in class pattern matching
 ----------------------------------------------------------

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2577,6 +2577,8 @@ that the number of arguments in the pattern must be smaller than or equal to the
 of elements in *__match_args__*; if it is larger, the pattern match attempt will raise
 a *TypeError*.
 
+.. versionadded:: 3.10
+
 .. seealso::
 
    :pep:`634` - Structural Pattern Matching

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2571,7 +2571,7 @@ define a *__match_args__* attribute.
    *__match_args__* as the keyword. The absence of this attribute is equivalent to
    setting it to ``()``.
 
-For example if ``MyClass.__match_args__`` is ``("left", "center", "right")`` that means
+For example, if ``MyClass.__match_args__`` is ``("left", "center", "right")`` that means
 that ``case MyClass(x, y)`` is equivalent to ``case MyClass(left=x, center=y)``. Note
 that the number of arguments in the pattern must be smaller than or equal to the number
 of elements in *__match_args__*; if it is larger, the pattern match attempt will raise

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2575,7 +2575,7 @@ For example if ``MyClass.__match_args__`` is ``("left", "center", "right")`` tha
 that ``case MyClass(x, y)`` is equivalent to ``case MyClass(left=x, center=y)``. Note
 that the number of arguments in the pattern must be smaller than or equal to the number
 of elements in *__match_args__*; if it is larger, the pattern match attempt will raise
-a *TypeError*.
+a :exc:`TypeError`.
 
 .. versionadded:: 3.10
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -352,7 +352,7 @@ exactly as written here:
    async      elif       if         or         yield
 
 
-.. _soft_keywords:
+.. _soft-keywords:
 
 Soft Keywords
 -------------

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -351,13 +351,11 @@ exactly as written here:
    assert     del        global     not        with
    async      elif       if         or         yield
 
-.. index::
-   single: _, identifiers
-   single: __, identifiers
-.. _id-classes:
 
 Soft Keywords
 -------------
+
+.. index:: soft keyword, keyword
 
 .. versionadded:: 3.10
 
@@ -368,6 +366,12 @@ tokenizing.
 This is done to allow their use in the pattern matching statement, while still
 preserving compatibility with existing code that uses "match" and "case" as
 identifier names.
+
+
+.. index::
+   single: _, identifiers
+   single: __, identifiers
+.. _id-classes:
 
 Reserved classes of identifiers
 -------------------------------

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -351,14 +351,13 @@ exactly as written here:
    assert     del        global     not        with
    async      elif       if         or         yield
 
+
 .. _soft_keywords:
 
 Soft Keywords
 -------------
 
-.. index::
-   single: soft keyword; keyword
-   pair: soft; keyword
+.. index:: soft keyword, keyword
 
 .. versionadded:: 3.10
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -356,6 +356,19 @@ exactly as written here:
    single: __, identifiers
 .. _id-classes:
 
+Soft Keywords
+-------------
+
+.. versionadded:: 3.10
+
+The identifiers ``match`` and ``case`` can syntactically act as keywords in some
+specific contexts, but this distinction is done at the parser level, not when
+tokenizing.
+
+This is done to allow their use in the pattern matching statement, while still
+preserving compatibility with existing code that uses "match" and "case" as
+identifier names.
+
 Reserved classes of identifiers
 -------------------------------
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -359,12 +359,12 @@ Soft Keywords
 
 .. versionadded:: 3.10
 
-The identifiers ``match`` and ``case`` can syntactically act as keywords in some
-specific contexts, but this distinction is done at the parser level, not when
-tokenizing.
+The identifiers ``match``, ``case`` and ``_`` can syntactically act as keywords in some
+specific contexts related to the pattern matching statement, but this distinction is done
+at the parser level, not when tokenizing.
 
-This is done to allow their use in the pattern matching statement, while still
-preserving compatibility with existing code that uses "match" and "case" as
+This is done to allow their use while still
+preserving compatibility with existing code that uses ``match``, ``case`` and ``_`` as
 identifier names.
 
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -351,11 +351,14 @@ exactly as written here:
    assert     del        global     not        with
    async      elif       if         or         yield
 
+.. _soft_keywords:
 
 Soft Keywords
 -------------
 
-.. index:: soft keyword, keyword
+.. index::
+   single: soft keyword; keyword
+   pair: soft; keyword
 
 .. versionadded:: 3.10
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -367,7 +367,7 @@ syntactically act as keywords in contexts related to the pattern matching
 statement, but this distinction is done at the parser level, not when
 tokenizing.
 
-This is done to allow their use while still
+As soft keywords, their use with pattern matching is possible while still
 preserving compatibility with existing code that uses ``match``, ``case`` and ``_`` as
 identifier names.
 

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -361,9 +361,11 @@ Soft Keywords
 
 .. versionadded:: 3.10
 
-The identifiers ``match``, ``case`` and ``_`` can syntactically act as keywords in some
-specific contexts related to the pattern matching statement, but this distinction is done
-at the parser level, not when tokenizing.
+Some identifiers are only reserved under specific contexts. These are known as
+*soft keywords*.  The identifiers ``match``, ``case`` and ``_`` can
+syntactically act as keywords in contexts related to the pattern matching
+statement, but this distinction is done at the parser level, not when
+tokenizing.
 
 This is done to allow their use while still
 preserving compatibility with existing code that uses ``match``, ``case`` and ``_`` as

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -412,6 +412,9 @@ Several other key features of this statement:
           case Color.BLUE:
               print("I'm feeling the blues :(")
 
+For a more detailed explanation and additional examples, you can look into
+:pep:`636` which is written in a tutorial format.
+
 .. _tut-functions:
 
 Defining Functions

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -36,6 +36,9 @@ to avoid excessive indentation.  An  :keyword:`!if` ... :keyword:`!elif` ...
 :keyword:`!elif` ... sequence is a substitute for the ``switch`` or
 ``case`` statements found in other languages.
 
+If you're making comparison with constants, or checking for specific types or
+attributes, you may also find the :keyword:`!match` statement useful. For more
+details see :ref:`tut-match`.
 
 .. _tut-for:
 

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -246,6 +246,169 @@ at a more abstract level.  The :keyword:`!pass` is silently ignored::
    ...     pass   # Remember to implement this!
    ...
 
+
+.. _tut-match:
+
+:keyword:`!match` Statements
+============================
+
+A match statement takes an expression and compares its value to successive
+patterns given as one or more case blocks.  This is superficially
+similar to a switch statement in C, Java or JavaScript (and many
+other languages), but it can also extract components (sequence elements or
+object attributes) from the value into variables.
+
+The simplest form compares a subject value against one or more literals::
+
+    def http_error(status):
+        match status:
+            case 400:
+                return "Bad request"
+            case 404:
+                return "Not found"
+            case 418:
+                return "I'm a teapot"
+            case _:
+                return "Something's wrong with the Internet"
+
+Note the last block: the "variable name" ``_`` acts as a *wildcard* and
+never fails to match. If no case matches, none of the branches is executed.
+
+You can combine several literals in a single pattern using ``|`` ("or")::
+
+            case 401 | 403 | 404:
+                return "Not allowed"
+
+Patterns can look like unpacking assignments, and can be used to bind
+variables::
+
+    # point is an (x, y) tuple
+    match point:
+        case (0, 0):
+            print("Origin")
+        case (0, y):
+            print(f"Y={y}")
+        case (x, 0):
+            print(f"X={x}")
+        case (x, y):
+            print(f"X={x}, Y={y}")
+        case _:
+            raise ValueError("Not a point")
+
+Study that one carefully!  The first pattern has two literals, and can
+be thought of as an extension of the literal pattern shown above.  But
+the next two patterns combine a literal and a variable, and the
+variable *binds* a value from the subject (``point``).  The fourth
+pattern captures two values, which makes it conceptually similar to
+the unpacking assignment ``(x, y) = point``.
+
+If you are using classes to structure your data
+you can use the class name followed by an argument list resembling a
+constructor, but with the ability to capture attributes into variables::
+
+    class Point:
+        x: int
+        y: int
+
+    def where_is(point):
+        match point:
+            case Point(x=0, y=0):
+                print("Origin")
+            case Point(x=0, y=y):
+                print(f"Y={y}")
+            case Point(x=x, y=0):
+                print(f"X={x}")
+            case Point():
+                print("Somewhere else")
+            case _:
+                print("Not a point")
+
+You can use positional parameters with some builtin classes that provide an
+ordering for their attributes (e.g. dataclasses). You can also define a specific
+position for attributes in patterns by setting the ``__match_args__`` special
+attribute in your classes. If it's set to ("x", "y"), the following patterns are all
+equivalent (and all bind the ``y`` attribute to the ``var`` variable)::
+
+    Point(1, var)
+    Point(1, y=var)
+    Point(x=1, y=var)
+    Point(y=var, x=1)
+
+A recommended way to read patterns is to look at them as an extended form of what you
+would put on the left of an assignment, to understand which variables would be set to
+what.
+Only the standalone names (like ``var`` above) are assigned to by a match statement.
+Dotted names (like ``foo.bar``), attribute names (the ``x=`` and ``y=`` above) or class names
+(recognized by the "(...)" next to them like ``Point`` above) are never assigned to.
+
+Patterns can be arbitrarily nested.  For example, if we have a short
+list of points, we could match it like this::
+
+    match points:
+        case []:
+            print("No points")
+        case [Point(0, 0)]:
+            print("The origin")
+        case [Point(x, y)]:
+            print(f"Single point {x}, {y}")
+        case [Point(0, y1), Point(0, y2)]:
+            print(f"Two on the Y axis at {y1}, {y2}")
+        case _:
+            print("Something else")
+
+We can add an ``if`` clause to a pattern, known as a "guard".  If the
+guard is false, ``match`` goes on to try the next case block.  Note
+that value capture happens before the guard is evaluated::
+
+    match point:
+        case Point(x, y) if x == y:
+            print(f"Y=X at {x}")
+        case Point(x, y):
+            print(f"Not on the diagonal")
+
+Several other key features of this statement:
+
+- Like unpacking assignments, tuple and list patterns have exactly the
+  same meaning and actually match arbitrary sequences.  An important
+  exception is that they don't match iterators or strings.
+
+- Sequence patterns support extended unpacking: ``[x, y, *rest]`` and ``(x, y,
+  *rest)`` work similar to unpacking assignments.  The
+  name after ``*`` may also be ``_``, so ``(x, y, *_)`` matches a sequence
+  of at least two items without binding the remaining items.
+
+- Mapping patterns: ``{"bandwidth": b, "latency": l}`` captures the
+  ``"bandwidth"`` and ``"latency"`` values from a dictionary.  Unlike sequence
+  patterns, extra keys are ignored.  An unpacking like ``**rest`` is also
+  supported.  (But ``**_`` would be redundant, so it not allowed.)
+
+- Subpatterns may be captured using the ``as`` keyword::
+
+      case (Point(x1, y1), Point(x2, y2) as p2): ...
+
+  will capture the second element of the input as ``p2`` (as long as the input is
+  a sequence of two points)
+
+- Most literals are compared by equality, however the singletons ``True``,
+  ``False`` and ``None`` are compared by identity.
+
+- Patterns may use named constants.  These must be dotted names
+  to prevent them from being interpreted as capture variable::
+
+      from enum import Enum
+      class Color(Enum):
+          RED = 0
+          GREEN = 1
+          BLUE = 2
+
+      match color:
+          case Color.RED:
+              print("I see red!")
+          case Color.GREEN:
+              print("Grass is green")
+          case Color.BLUE:
+              print("I'm feeling the blues :(")
+
 .. _tut-functions:
 
 Defining Functions

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -36,7 +36,7 @@ to avoid excessive indentation.  An  :keyword:`!if` ... :keyword:`!elif` ...
 :keyword:`!elif` ... sequence is a substitute for the ``switch`` or
 ``case`` statements found in other languages.
 
-If you're making comparison with constants, or checking for specific types or
+If you're comparing the same value to several constants, or checking for specific types or
 attributes, you may also find the :keyword:`!match` statement useful. For more
 details see :ref:`tut-match`.
 

--- a/Misc/NEWS.d/next/Documentation/2021-02-27-23-56-34.bpo-42128.8AGXVv.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-02-27-23-56-34.bpo-42128.8AGXVv.rst
@@ -1,1 +1,0 @@
-skip news

--- a/Misc/NEWS.d/next/Documentation/2021-02-27-23-56-34.bpo-42128.8AGXVv.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-02-27-23-56-34.bpo-42128.8AGXVv.rst
@@ -1,0 +1,1 @@
+skip news


### PR DESCRIPTION
This covers documentation for the new match statement in 3.10, as requested by the SC in https://mail.python.org/archives/list/python-committers@python.org/message/SQC2FTLFV5A7DV7RCEAR2I2IKJKGK7W3/

The documentation includes:
* A large language reference update include syntax and behaviour of the match statement, largely based on the relevant sections of PEP-634 in the compound statements section.
* A significant new section in the "control flow" chapter of the tutorial based on the Appendix A of PEP-636
* An update to the "data model" reference chapter describing the new special attribute `__match_args__`
* A new section in the "lexical analysis" chapter describing the use of soft keywords.
* An update to the FAQ entry about "Why isn't there a switch or case statement in Python?"

<!-- issue-number: [bpo-42128](https://bugs.python.org/issue42128) -->
https://bugs.python.org/issue42128
<!-- /issue-number -->
