### PR TITLE
bpo-41837: Update macOS installer build to use OpenSSL 1.1.1j.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -242,9 +242,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.1i",
-              url="https://www.openssl.org/source/openssl-1.1.1i.tar.gz",
-              checksum='08987c3cf125202e2b0840035efb392c',
+              name="OpenSSL 1.1.1j",
+              url="https://www.openssl.org/source/openssl-1.1.1j.tar.gz",
+              checksum='cccaa064ed860a2b4d1303811bf5c682',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2021-02-28-22-49-46.bpo-41837.9fqyXC.rst
+++ b/Misc/NEWS.d/next/macOS/2021-02-28-22-49-46.bpo-41837.9fqyXC.rst
@@ -1,0 +1,1 @@
+Update macOS installer build to use OpenSSL 1.1.1j.


### PR DESCRIPTION


<!-- issue-number: [bpo-41837](https://bugs.python.org/issue41837) -->
https://bugs.python.org/issue41837
<!-- /issue-number -->
