### PR TITLE
closes bpo-43349: Fix tuning(7) manpage hyperlink

### DIFF
--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -242,7 +242,7 @@ platform.
    used by all of this user id's processes.
    This limit is enforced only if bit 1 of the vm.overcommit sysctl is set.
    Please see
-   `tuning(7) <https://www.freebsd.org/cgi/man.cgi?query=tuning&sektion=7&format=html>`__
+   `tuning(7) <https://www.freebsd.org/cgi/man.cgi?query=tuning&sektion=7>`__
    for a complete description of this sysctl.
 
    .. availability:: FreeBSD 9 or later.

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -241,7 +241,9 @@ platform.
    The maximum size (in bytes) of the swap space that may be reserved or
    used by all of this user id's processes.
    This limit is enforced only if bit 1 of the vm.overcommit sysctl is set.
-   Please see :manpage:`tuning(7)` for a complete description of this sysctl.
+   Please see
+   `tuning(7) <https://www.freebsd.org/cgi/man.cgi?query=tuning&sektion=7&format=html>`__
+   for a complete description of this sysctl.
 
    .. availability:: FreeBSD 9 or later.
 


### PR DESCRIPTION
In https://docs.python.org/3.10/library/resource.html, the tuning(7) hyperlink
should point to the FreeBSD docs, as it's a FreeBSD specific man page.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43349](https://bugs.python.org/issue43349) -->
https://bugs.python.org/issue43349
<!-- /issue-number -->
