### PR TITLE
bpo-43330: pass uri query parameters along xmlrpc requests

### DIFF
--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -1426,6 +1426,10 @@ class ServerProxy:
             raise OSError("unsupported XML-RPC protocol")
         self.__host = p.netloc
         self.__handler = p.path or "/RPC2"
+        if p.params:
+            self.__handler += f';{p.params}'
+        if p.query:
+            self.__handler += f'?{p.query}'
 
         if transport is None:
             if p.scheme == "https":

--- a/Misc/NEWS.d/next/Library/2021-03-01-12-09-25.bpo-43330.wXIGlD.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-01-12-09-25.bpo-43330.wXIGlD.rst
@@ -1,0 +1,1 @@
+Pass uri query parametters along xmlrpc requests


### PR DESCRIPTION
When using the `xmlrpc.client.ProxyServer` object to access via rpc a
remote server, the params and query segments of the uri were discarded.
The xml-rpc specification does not say anything about those two
segments and py2's xmlrpclib was sending them already.

<!-- issue-number: [bpo-43330](https://bugs.python.org/issue43330) -->
https://bugs.python.org/issue43330
<!-- /issue-number -->
