### PR TITLE
missing multiply symbol in the documentation

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2021-03-02-08-08-28.bpo-skipissue.MB-s2C.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-03-02-08-08-28.bpo-skipissue.MB-s2C.rst
@@ -1,0 +1,1 @@
+I found a typo in the documentation and corrected

--- a/Misc/NEWS.d/next/Documentation/2021-03-02-08-08-28.bpo-skipissue.MB-s2C.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-03-02-08-08-28.bpo-skipissue.MB-s2C.rst
@@ -1,1 +1,0 @@
-I found a typo in the documentation and corrected

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1875,7 +1875,7 @@ math_isqrt(PyObject *module, PyObject *n)
  *        (1) *
  *        (1) *
  *        (1 * 3 * 5) *
- *        (1 * 3 * 5 * 7 * 9)
+ *        (1 * 3 * 5 * 7 * 9) *
  *        (1 * 3 * 5 * 7 * 9 * 11 * 13 * 15 * 17 * 19)
  *
  * Here i goes from large to small: the first term corresponds to i=4 (any


### PR DESCRIPTION
I added the missing symbol to the documentation, thanks in advance.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
