### PR TITLE
Fixed linenumber missing when audit hook has an error

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -224,6 +224,7 @@ class AuditEvent(Directive):
         info['source'].append((env.docname, target))
 
         pnode = nodes.paragraph(text, classes=["audit-hook"], ids=ids)
+        pnode.line = self.lineno
         if self.content:
             self.state.nested_parse(self.content, self.content_offset, pnode)
         else:


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/issues/8932

Co-authored-by: tk0miya <i.tkomiya@gmail.com>