### PR TITLE
bpo-43358: Fix bad free in assemble function

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6664,12 +6664,12 @@ assemble(struct compiler *c, int addNone)
 
     for (basicblock *b = c->u->u_blocks; b != NULL; b = b->b_list) {
         if (normalize_basic_block(b)) {
-            goto error;
+            return NULL;
         }
     }
 
     if (ensure_exits_have_lineno(c)) {
-        goto error;
+        return NULL;
     }
 
     nblocks = 0;


### PR DESCRIPTION
The problematic code was added by commit 5977a7989d49c3e095c7659a58267d87a17b12b1 to fix [bpo-42246](https://bugs.python.org/issue42246).

<!-- issue-number: [bpo-43358](https://bugs.python.org/issue43358) -->
https://bugs.python.org/issue43358
<!-- /issue-number -->
