### PR TITLE
bpo-43359: Remove dead assignment from Py_UniversalNewlineFgets

### DIFF
--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -261,7 +261,6 @@ Py_UniversalNewlineFgets(char *buf, int n, FILE *stream, PyObject *fobj)
         return NULL;
     }
     FLOCKFILE(stream);
-    c = 'x'; /* Shut up gcc warning */
     while (--n > 0 && (c = GETC(stream)) != EOF ) {
         if (skipnextlf ) {
             skipnextlf = 0;


### PR DESCRIPTION
This line is no longer needed and can be removed to make the code more readable.

<!-- issue-number: [bpo-43359](https://bugs.python.org/issue43359) -->
https://bugs.python.org/issue43359
<!-- /issue-number -->
