### PR TITLE
gh-87526: Remove dead initialization from parse_abbr function

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1709,11 +1709,11 @@ static Py_ssize_t
 parse_abbr(const char *const p, PyObject **abbr)
 {
     const char *ptr = p;
-    char buff = *ptr;
     const char *str_start;
     const char *str_end;
 
     if (*ptr == '<') {
+        char buff;
         ptr++;
         str_start = ptr;
         while ((buff = *ptr) != '>') {


### PR DESCRIPTION
Straightforward dead code elimination.

<!-- issue-number: [bpo-43360](https://bugs.python.org/issue43360) -->
https://bugs.python.org/issue43360
<!-- /issue-number -->


<!-- gh-issue-number: gh-87526 -->
* Issue: gh-87526
<!-- /gh-issue-number -->
