### PR TITLE
bpo-43362: Fix bad free in py_sha3_new_impl function

### DIFF
--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -202,6 +202,7 @@ py_sha3_new_impl(PyTypeObject *type, PyObject *data, int usedforsecurity)
     assert(state != NULL);
 
     HashReturn res;
+    Py_buffer buf = {NULL, NULL};
     if (type == state->sha3_224_type) {
         res = Keccak_HashInitialize_SHA3_224(&self->hash_state);
     } else if (type == state->sha3_256_type) {
@@ -229,7 +230,6 @@ py_sha3_new_impl(PyTypeObject *type, PyObject *data, int usedforsecurity)
         goto error;
     }
 
-    Py_buffer buf = {NULL, NULL};
     if (data) {
         GET_BUFFER_VIEW_OR_ERROR(data, &buf, goto error);
         if (buf.len >= HASHLIB_GIL_MINSIZE) {


### PR DESCRIPTION
Initializing `buf.obj` to `NULL` earlier in the function prevents the possibility of `PyBuffer_Release` being called on an invalid object.

<!-- issue-number: [bpo-43362](https://bugs.python.org/issue43362) -->
https://bugs.python.org/issue43362
<!-- /issue-number -->
