### PR TITLE
Remove mention of dst parameter from description of os.lstat()

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2027,7 +2027,7 @@ features:
       Added the *dir_fd* parameter.
 
    .. versionchanged:: 3.6
-      Accepts a :term:`path-like object` for *src* and *dst*.
+      Accepts a :term:`path-like object`.
 
    .. versionchanged:: 3.8
       On Windows, now opens reparse points that represent another path


### PR DESCRIPTION
It looks like it was accidentally copy-pasted in 
6fa7aada9bd3616e0beeb266e818497b2ec1c859.