### PR TITLE
bpo-43368: Fix fetching empty bytes on SQLite.

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -409,6 +409,10 @@ class RegressionTests(unittest.TestCase):
             self.con.execute("select 1")  # trigger seg fault
             method(None)
 
+    def test_return_empty_bytestring(self):
+        cur = self.con.execute("select X''")
+        val = cur.fetchone()[0]
+        self.assertEqual(val, b'')
 
 
 def suite():

--- a/Misc/NEWS.d/next/Library/2021-03-02-13-45-05.bpo-43368.t9XEkQ.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-02-13-45-05.bpo-43368.t9XEkQ.rst
@@ -1,0 +1,2 @@
+Fix a regression introduced in GH-24562, where an empty bytestring was fetched
+as ``None`` instead of ``b''`` in :mod:`sqlite3`. Patch by Mariusz Felisiak.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -333,12 +333,8 @@ _pysqlite_fetch_one_row(pysqlite_Cursor* self)
             } else {
                 /* coltype == SQLITE_BLOB */
                 const char *blob = sqlite3_column_blob(self->statement->st, i);
-                if (!blob) {
-                    converted = Py_NewRef(Py_None);
-                } else {
-                    nbytes = sqlite3_column_bytes(self->statement->st, i);
-                    converted = PyBytes_FromStringAndSize(blob, nbytes);
-                }
+                nbytes = sqlite3_column_bytes(self->statement->st, i);
+                converted = PyBytes_FromStringAndSize(blob, nbytes);
             }
         }
 


### PR DESCRIPTION
[bpo-43368](https://bugs.python.org/issue43368)

Regression in 47feb1feb28631b6647699b7633109aa85340966 ([bpo-43249](https://bugs.python.org/issue43249))

<!-- issue-number: [bpo-43368](https://bugs.python.org/issue43368) -->
https://bugs.python.org/issue43368
<!-- /issue-number -->
