### PR TITLE
bpo-43354: xmlrpc: Fix type documentation for Fault.faultCode

### DIFF
--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -378,7 +378,7 @@ Fault Objects
 
    .. attribute:: faultCode
 
-      A string indicating the fault type.
+      An int indicating the fault type.
 
 
    .. attribute:: faultString

--- a/Misc/NEWS.d/next/Documentation/2021-03-02-12-55-34.bpo-43354.ezZYkx.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-03-02-12-55-34.bpo-43354.ezZYkx.rst
@@ -1,0 +1,1 @@
+Fix type documentation for `Fault.faultCode`; the type has to be `int` instead of `str`.

--- a/Misc/NEWS.d/next/Documentation/2021-03-02-12-55-34.bpo-43354.ezZYkx.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-03-02-12-55-34.bpo-43354.ezZYkx.rst
@@ -1,1 +1,1 @@
-Fix type documentation for `Fault.faultCode`; the type has to be `int` instead of `str`.
+Fix type documentation for ``Fault.faultCode``; the type has to be ``int`` instead of ``str``.


### PR DESCRIPTION
The type of `faultCode` has to be an `int` instead of a `str`.

cf http://xmlrpc.com/spec.md

Pinging @pganssle 

<!-- issue-number: [bpo-43354](https://bugs.python.org/issue43354) -->
https://bugs.python.org/issue43354
<!-- /issue-number -->

Automerge-Triggered-By: GH:pganssle