### PR TITLE
bpo-43384: Run regen-stdlib-module-names from regen-all.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,6 @@ jobs:
           # Build Python with the libpython dynamic library
           ./configure --with-pydebug --enable-shared
           make -j4 regen-all
-          make regen-stdlib-module-names
       - name: Check for changes
         run: |
           changes=$(git status --porcelain)

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,6 @@ before_script:
   - eval "$(pyenv init -)"
   - pyenv global 3.8
   - PYTHON_FOR_REGEN=python3.8 make -j4 regen-all
-  - make regen-stdlib-module-names
   - changes=`git status --porcelain`
   - |
       # Check for changes in regenerated files

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -761,9 +761,10 @@ regen-limited-abi: all
 
 regen-all: regen-opcode regen-opcode-targets regen-typeslots \
 	regen-token regen-ast regen-keyword regen-importlib clinic \
-	regen-pegen-metaparser regen-pegen regen-frozen
+	regen-pegen-metaparser regen-pegen regen-frozen \
+	regen-stdlib-module-names
 	@echo
-	@echo "Note: make regen-stdlib-module-names and autoconf should be run manually"
+	@echo "Note: autoconf should be run manually"
 
 ############################################################################
 # Special rules for object files

--- a/Misc/NEWS.d/next/Build/2021-03-02-23-11-58.bpo-43384.IZE9y8.rst
+++ b/Misc/NEWS.d/next/Build/2021-03-02-23-11-58.bpo-43384.IZE9y8.rst
@@ -1,0 +1,1 @@
+Include "regen-stdlib-module-names" as part of "regen-all".


### PR DESCRIPTION
I don't see any obvious reason why `regen-stdlib-module-names` can't be run by `regen-all`.  Doing that simplifies the CI scripts a bit.