### PR TITLE
bpo-43382: Pin test runner to Ubuntu 18 to un-break CI (for now)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
 
   build_ubuntu:
     name: 'Ubuntu'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:


### PR DESCRIPTION
Feel free to merge if there's any consensus. I'm going to sleep.

Also, should this be backported to 3.9 / 3.8 / 3.7? Probably, right?

<!-- issue-number: [bpo-43382](https://bugs.python.org/issue43382) -->
https://bugs.python.org/issue43382
<!-- /issue-number -->
