### PR TITLE
bpo-43377: Make `_PyErr_Display` available in the CPython API

### DIFF
--- a/Include/cpython/pythonrun.h
+++ b/Include/cpython/pythonrun.h
@@ -129,3 +129,6 @@ PyAPI_FUNC(PyObject *) PyRun_FileFlags(FILE *fp, const char *p, int s, PyObject 
 /* Stuff with no proper home (yet) */
 PyAPI_FUNC(char *) PyOS_Readline(FILE *, FILE *, const char *);
 PyAPI_DATA(PyThreadState*) _PyOS_ReadlineTState;
+
+PyAPI_FUNC(void) _PyErr_Display(PyObject *file, PyObject *exception,
+                                PyObject *value, PyObject *tb);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -106,8 +106,6 @@ PyAPI_FUNC(int) _Py_HandleSystemExit(int *exitcode_p);
 PyAPI_FUNC(PyObject*) _PyErr_WriteUnraisableDefaultHook(PyObject *unraisable);
 
 PyAPI_FUNC(void) _PyErr_Print(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyErr_Display(PyObject *file, PyObject *exception,
-                                PyObject *value, PyObject *tb);
 
 PyAPI_FUNC(void) _PyThreadState_DeleteCurrent(PyThreadState *tstate);
 


### PR DESCRIPTION
Includes the `_PyErr_Display` helper in `Include/cpython`, for use by embedders.

<!-- issue-number: [bpo-43377](https://bugs.python.org/issue43377) -->
https://bugs.python.org/issue43377
<!-- /issue-number -->
