### PR TITLE
html.parser: fix ‘<![CDATA[ ... ]]>’ handling not capturing ‘]’

### DIFF
--- a/Lib/_markupbase.py
+++ b/Lib/_markupbase.py
@@ -10,12 +10,12 @@ import re
 _declname_match = re.compile(r'[a-zA-Z][-_.a-zA-Z0-9]*\s*').match
 _declstringlit_match = re.compile(r'(\'[^\']*\'|"[^"]*")\s*').match
 _commentclose = re.compile(r'--\s*>')
-_markedsectionclose = re.compile(r']\s*]\s*>')
+_markedsectionclose = re.compile(r'](\s*]\s*>)')
 
 # An analysis of the MS-Word extensions is available at
 # http://www.planetpublish.com/xmlarena/xap/Thursday/WordtoXML.pdf
 
-_msmarkedsectionclose = re.compile(r']\s*>')
+_msmarkedsectionclose = re.compile(r'(]\s*>)')
 
 del re
 
@@ -157,7 +157,7 @@ class ParserBase:
         if not match:
             return -1
         if report:
-            j = match.start(0)
+            j = match.start(1)
             self.unknown_decl(rawdata[i+3: j])
         return match.end(0)
 

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -315,6 +315,14 @@ text
                                 ("endtag", element_lower)],
                             collector=Collector(convert_charrefs=False))
 
+    def test_cdata_decl(self):
+        self._run_check('<math><ms><![CDATA[x<y]]></ms></math>',
+                        [('starttag', 'math', []),
+                         ('starttag', 'ms', []),
+                         ('unknown decl', 'CDATA[x<y]'),
+                         ('endtag', 'ms'),
+                         ('endtag', 'math')])
+
     def test_comments(self):
         html = ("<!-- I'm a valid comment -->"
                 '<!--me too!-->'

--- a/Misc/NEWS.d/next/Library/2021-03-06-13-23-34.bpo-0.jzVmiO.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-06-13-23-34.bpo-0.jzVmiO.rst
@@ -1,0 +1,1 @@
+Fix html.parser dropping closing square bracket when passing CDATA content into unknown_decl method.


### PR DESCRIPTION
Per documentation, the unknown_decl method is called with ‘the entire
contents of the declaration inside the `<![...]>` markup.’  However,
this is not quite the case for `<![CDATA[...]]>` where the first of
the two final closing square brackets should be included but isn’t.
In other words, for such declaration unknown_decl is called with
`CDATA[...` string (observe unmatched brackets).

Not including the closing bracket doesn’t fit the documentation but
also makes it impossible to output the declaration without change
since `"<![" + data + "]>"` eats one of the brackets at the end.

Fix by including the first of the closing brackets when calling
unknown_decl.
