### PR TITLE
bpo-43390: Set SA_ONSTACK in PyOS_setsig

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-03-17-58-49.bpo-43390.epPpwV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-03-17-58-49.bpo-43390.epPpwV.rst
@@ -1,0 +1,6 @@
+CPython now sets the ``SA_ONSTACK`` flag in ``PyOS_setsig`` for the VM's
+default signal handlers.  This is friendlier to other in-process code that
+an extension module or embedding use could pull in (such as Golang's cgo)
+where tiny thread stacks are the norm and ``sigaltstack()`` has been used to
+provide for signal handlers.  This is a no-op change for the vast majority
+of processes that don't use sigaltstack.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2884,7 +2884,10 @@ PyOS_setsig(int sig, PyOS_sighandler_t handler)
     struct sigaction context, ocontext;
     context.sa_handler = handler;
     sigemptyset(&context.sa_mask);
-    context.sa_flags = 0;
+    /* Using SA_ONSTACK is friendlier to other C/C++/Golang-VM code that
+     * extension module or embedding code may use where tiny thread stacks
+     * are used.  https://bugs.python.org/issue43390 */
+    context.sa_flags = SA_ONSTACK;
     if (sigaction(sig, &context, &ocontext) == -1)
         return SIG_ERR;
     return ocontext.sa_handler;


### PR DESCRIPTION
Set the `SA_ONSTACK` flag in `PyOS_setsig` for the CPython VM's
  default signal handlers.  This is friendlier to other in-process code that an
  extension module or embedding use could pull in (such as Golang's cgo) where
  tiny thread stacks are the norm and `sigaltstack()` has been used to provide for
  signal handlers.  This is a no-op change for the vast majority of processes
  that don't use sigaltstack.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43390](https://bugs.python.org/issue43390) -->
https://bugs.python.org/issue43390
<!-- /issue-number -->
