### PR TITLE
bpo-42128: Add __match_args__ to structseq-based classes

### DIFF
--- a/Lib/test/test_structseq.py
+++ b/Lib/test/test_structseq.py
@@ -122,5 +122,13 @@ class StructSeqTest(unittest.TestCase):
                     self.assertEqual(list(t[start:stop:step]),
                                      L[start:stop:step])
 
+    def test_match_args(self):
+        t = time.gmtime()
+        expected_args = ('tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min',
+                         'tm_sec', 'tm_wday', 'tm_yday', 'tm_isdst', 'tm_zone',
+                         'tm_gmtoff')
+        self.assertEqual(t.__match_args__, expected_args)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_structseq.py
+++ b/Lib/test/test_structseq.py
@@ -124,15 +124,12 @@ class StructSeqTest(unittest.TestCase):
 
     def test_match_args(self):
         expected_args = ('tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min',
-                         'tm_sec', 'tm_wday', 'tm_yday', 'tm_isdst', 'tm_zone',
-                         'tm_gmtoff')
+                         'tm_sec', 'tm_wday', 'tm_yday', 'tm_isdst')
         self.assertEqual(time.struct_time.__match_args__, expected_args)
 
     def test_match_args_with_unnamed_fields(self):
         expected_args = ('st_mode', 'st_ino', 'st_dev', 'st_nlink', 'st_uid',
-                         'st_gid', 'st_size', 'st_atime', 'st_mtime', 'st_ctime',
-                         'st_atime_ns', 'st_mtime_ns', 'st_ctime_ns', 'st_blksize',
-                         'st_blocks', 'st_rdev')
+                         'st_gid', 'st_size')
         self.assertEqual(os.stat_result.n_unnamed_fields, 3)
         self.assertEqual(os.stat_result.__match_args__, expected_args)
 

--- a/Lib/test/test_structseq.py
+++ b/Lib/test/test_structseq.py
@@ -123,11 +123,18 @@ class StructSeqTest(unittest.TestCase):
                                      L[start:stop:step])
 
     def test_match_args(self):
-        t = time.gmtime()
         expected_args = ('tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min',
                          'tm_sec', 'tm_wday', 'tm_yday', 'tm_isdst', 'tm_zone',
                          'tm_gmtoff')
-        self.assertEqual(t.__match_args__, expected_args)
+        self.assertEqual(time.struct_time.__match_args__, expected_args)
+
+    def test_match_args_with_unnamed_fields(self):
+        expected_args = ('st_mode', 'st_ino', 'st_dev', 'st_nlink', 'st_uid',
+                         'st_gid', 'st_size', 'st_atime', 'st_mtime', 'st_ctime',
+                         'st_atime_ns', 'st_mtime_ns', 'st_ctime_ns', 'st_blksize',
+                         'st_blocks', 'st_rdev')
+        self.assertEqual(os.stat_result.n_unnamed_fields, 3)
+        self.assertEqual(os.stat_result.__match_args__, expected_args)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-03-19-04-23.bpo-42128.VouZjn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-03-19-04-23.bpo-42128.VouZjn.rst
@@ -1,0 +1,2 @@
+Add ``__match_args__`` to :c:type:`structsequence` based classes. Patch by
+Pablo Galindo.

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -15,6 +15,7 @@
 static const char visible_length_key[] = "n_sequence_fields";
 static const char real_length_key[] = "n_fields";
 static const char unnamed_fields_key[] = "n_unnamed_fields";
+static const char match_args_key[] = "__match_args__";
 
 /* Fields with this name have only a field index, not a field name.
    They are only allowed for indices < n_visible_fields. */
@@ -399,6 +400,31 @@ initialize_structseq_dict(PyStructSequence_Desc *desc, PyObject* dict,
     SET_DICT_FROM_SIZE(visible_length_key, desc->n_in_sequence);
     SET_DICT_FROM_SIZE(real_length_key, n_members);
     SET_DICT_FROM_SIZE(unnamed_fields_key, n_unnamed_members);
+
+    // Prepare and set __match_args__
+    PyObject* keys = PyTuple_New(n_members - n_unnamed_members);
+    if (keys == NULL) {
+        return -1;
+    }
+
+    Py_ssize_t i, k;
+    for (i = k = 0; i < n_members; ++i) {
+        if (desc->fields[i].name == PyStructSequence_UnnamedField) {
+            continue;
+        }
+        PyObject* new_member = PyUnicode_FromString(desc->fields[i].name);
+        if (new_member == NULL) {
+            Py_DECREF(keys);
+            return -1;                                                         \
+        }
+        PyTuple_SET_ITEM(keys, k, new_member);
+        k++;
+    }
+    if (PyDict_SetItemString(dict, match_args_key, keys) < 0) {
+        Py_DECREF(keys);
+        return -1;
+    }
+    Py_DECREF(keys);
     return 0;
 }
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -402,13 +402,20 @@ initialize_structseq_dict(PyStructSequence_Desc *desc, PyObject* dict,
     SET_DICT_FROM_SIZE(unnamed_fields_key, n_unnamed_members);
 
     // Prepare and set __match_args__
-    PyObject* keys = PyTuple_New(n_members - n_unnamed_members);
+    Py_ssize_t i, k;
+    Py_ssize_t n_match_args = 0;
+    for (i = k = 0; i < desc->n_in_sequence; ++i) {
+        if (desc->fields[i].name == PyStructSequence_UnnamedField) {
+            continue;
+        }
+        n_match_args++;
+    }
+    PyObject* keys = PyTuple_New(n_match_args);
     if (keys == NULL) {
         return -1;
     }
 
-    Py_ssize_t i, k;
-    for (i = k = 0; i < n_members; ++i) {
+    for (i = k = 0; i < desc->n_in_sequence; ++i) {
         if (desc->fields[i].name == PyStructSequence_UnnamedField) {
             continue;
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42128](https://bugs.python.org/issue42128) -->
https://bugs.python.org/issue42128
<!-- /issue-number -->
