### PR TITLE
bpo-43391: Remove the reference to Python 2.4 from the doc-string

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -5,7 +5,6 @@
 # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
 #
 # Licensed to PSF under a Contributor Agreement.
-# See http://www.python.org/2.4/license for licensing details.
 
 r"""Subprocesses with accessible I/O streams
 


### PR DESCRIPTION
Removed not working reference to Python 2.4 licensing details from `subprocess` module docstring.

<!-- issue-number: [bpo-43391](https://bugs.python.org/issue43391) -->
https://bugs.python.org/issue43391
<!-- /issue-number -->
