### PR TITLE
bpo-43271: Re-enable ceval.c optimizations for Windows debug builds

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -182,8 +182,9 @@ typedef int Py_ssize_clean_t;
  */
 
 #if defined(_MSC_VER)
-#  if defined(PY_LOCAL_AGGRESSIVE) && !defined(Py_DEBUG)
+#  if defined(PY_LOCAL_AGGRESSIVE)
    /* enable more aggressive optimization for MSVC */
+   /* active in both release and debug builds - see bpo-43271 */
 #  pragma optimize("gt", on)
 #endif
    /* ignore warnings if the compiler decides not to inline a function */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -7,6 +7,7 @@
    */
 
 /* enable more aggressive intra-module optimizations, where available */
+/* affects both release and debug builds - see bpo-43271 */
 #define PY_LOCAL_AGGRESSIVE
 
 #include "Python.h"


### PR DESCRIPTION
Partially reverts commit b74396c3167cc780f01309148db02709bc37b432

The optimizations are necessary to prevent the interpreter from
crashing in a number of tests involving recursion.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43271](https://bugs.python.org/issue43271) -->
https://bugs.python.org/issue43271
<!-- /issue-number -->
