### PR TITLE
bpo-43319: Fixed the tutorial on venv about standard library

### DIFF
--- a/Doc/tutorial/venv.rst
+++ b/Doc/tutorial/venv.rst
@@ -48,7 +48,7 @@ place it, and run the :mod:`venv` module as a script with the directory path::
 
 This will create the ``tutorial-env`` directory if it doesn't exist,
 and also create directories inside it containing a copy of the Python
-interpreter, the standard library, and various supporting files.
+interpreter and various supporting files.
 
 A common directory location for a virtual environment is ``.venv``.
 This name keeps the directory typically hidden in your shell and thus


### PR DESCRIPTION
In the [official tutorial on virtual environment](https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments)

> This will create the tutorial-env directory if it doesn’t exist, and also create directories inside it containing a copy of the Python interpreter, **the standard library**, and various supporting files.

According to the actual behavior of `venv` and [PEP 405](https://www.python.org/dev/peps/pep-0405/#id15)'s description about virtual environment, no standard library file is included in the virtual environment's directory. 

<!-- issue-number: [bpo-43319](https://bugs.python.org/issue43319) -->
https://bugs.python.org/issue43319
<!-- /issue-number -->

Automerge-Triggered-By: GH:vsajip