### PR TITLE
Doc: fix code example error at Guard

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -386,9 +386,9 @@ guard is false, ``match`` goes on to try the next case block.  Note
 that value capture happens before the guard is evaluated::
 
     match point:
-        case Point(x, y) if x == y:
+        case Point(x=x, y=y) if x == y:
             print(f"The point is located on the diagonal Y=X at {x}.")
-        case Point(x, y):
+        case Point(x=x, y=y):
             print(f"Point is not on the diagonal.")
 
 Other Key Features


### PR DESCRIPTION
Changes:

1. `case Point(x, y) if x == y:` -> `case Point(x=x, y=y) if x == y:`
2. `case Point(x, y):` -> `case Point(x=x, y=y):`

The original code will give the following error because class `Point` defined above is not a dataclass and has no `__match_args__` as the [doc](https://docs.python.org/3.10/whatsnew/3.10.html#patterns-with-positional-parameters) says:

```python
Traceback (most recent call last):
  File "/root/test.py", line 69, in <module>
    guard_test(point)
  File "/root/test.py", line 39, in guard_test
    case Point(x, y) if x == y:
TypeError: Point() accepts 0 positional sub-patterns (2 given)
```

Python version: `Python 3.10.0a6 (default, Mar  4 2021, 14:43:50) [GCC 7.5.0] on linux`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
