### PR TITLE
bpo-40642: use file-relative include for initconfig.h in pystate.h

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -2,7 +2,7 @@
 #  error "this header file must not be included directly"
 #endif
 
-#include "cpython/initconfig.h"
+#include "initconfig.h"
 
 PyAPI_FUNC(int) _PyInterpreterState_RequiresIDRef(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_RequireIDRef(PyInterpreterState *, int);

--- a/Misc/NEWS.d/next/C API/2021-03-04-18-35-26.bpo-40642.cPnmu2.rst
+++ b/Misc/NEWS.d/next/C API/2021-03-04-18-35-26.bpo-40642.cPnmu2.rst
@@ -1,0 +1,1 @@
+Use file-relative include for ``initconfig.h`` in ``pystate.h``.


### PR DESCRIPTION
Suggested by Andrew Tomazos in bpo:

> This will mean that state.h will find initconfig.h using a file-relative include (as all the other include directives do), instead of relying on the installed Include directory being put in the header search path.

> As this include directive is the only one with this property, the benefit of this change would be that the Include folder would be able to be installed in any subdirectory of a search path, rather than requiring its own dedicated one.

> This would mean (for example) you could install different versions of the Python headers side by side and then select between them using preprocessor directives - rather than having to switch up global compiler options.

<!-- issue-number: [bpo-40642](https://bugs.python.org/issue40642) -->
https://bugs.python.org/issue40642
<!-- /issue-number -->
