### PR TITLE
bpo-43399: Fix ElementTree.extend not working on iterators

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -330,6 +330,9 @@ class ElementTreeTest(unittest.TestCase):
         elem.extend([e])
         self.serialize_check(elem, '<body><tag /><tag2 /></body>')
         elem.remove(e)
+        elem.extend(iter([e]))
+        self.serialize_check(elem, '<body><tag /><tag2 /></body>')
+        elem.remove(e)
 
         element = ET.Element("tag", key="value")
         self.serialize_check(element, '<tag key="value" />') # 1

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -252,7 +252,7 @@ class Element:
         """
         for element in elements:
             self._assert_is_element(element)
-        self._children.extend(elements)
+            self._children.append(element)
 
     def insert(self, index, subelement):
         """Insert *subelement* at position *index*."""

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1380,6 +1380,7 @@ Matheus Vieira Portela
 Davin Potts
 Guillaume Pratte
 Florian Preinstorfer
+Alex Prengère
 Amrit Prem
 Paul Prescod
 Donovan Preston

--- a/Misc/NEWS.d/next/Library/2021-03-04-17-53-46.bpo-43399.Wn95u-.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-04-17-53-46.bpo-43399.Wn95u-.rst
@@ -1,0 +1,2 @@
+Fix ``ElementTree.extend`` not working on iterators when using the
+Python implementation


### PR DESCRIPTION
This PR fixes [bpo-43399](https://bugs.python.org/issue43399).

<!-- issue-number: [bpo-43399](https://bugs.python.org/issue43399) -->
https://bugs.python.org/issue43399
<!-- /issue-number -->
