### PR TITLE
bpo-43407: Docs: Clarify comparisons of time.monotonic() et al results

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -277,7 +277,7 @@ Functions
    Return the value (in fractional seconds) of a monotonic clock, i.e. a clock
    that cannot go backwards.  The clock is not affected by system clock updates.
    The reference point of the returned value is undefined, so that only the
-   difference between the results of consecutive calls is valid.
+   difference between the results of two calls is valid.
 
    Use :func:`monotonic_ns` to avoid the precision loss caused by the
    :class:`float` type.
@@ -306,7 +306,7 @@ Functions
    clock with the highest available resolution to measure a short duration.  It
    does include time elapsed during sleep and is system-wide.  The reference
    point of the returned value is undefined, so that only the difference between
-   the results of consecutive calls is valid.
+   the results of two calls is valid.
 
    Use :func:`perf_counter_ns` to avoid the precision loss caused by the
    :class:`float` type.
@@ -334,7 +334,7 @@ Functions
    CPU time of the current process.  It does not include time elapsed during
    sleep.  It is process-wide by definition.  The reference point of the
    returned value is undefined, so that only the difference between the results
-   of consecutive calls is valid.
+   of two calls is valid.
 
    Use :func:`process_time_ns` to avoid the precision loss caused by the
    :class:`float` type.
@@ -626,7 +626,7 @@ Functions
    CPU time of the current thread.  It does not include time elapsed during
    sleep.  It is thread-specific by definition.  The reference point of the
    returned value is undefined, so that only the difference between the results
-   of consecutive calls in the same thread is valid.
+   of two calls in the same thread is valid.
 
    Use :func:`thread_time_ns` to avoid the precision loss caused by the
    :class:`float` type.

--- a/Misc/NEWS.d/next/Documentation/2021-03-04-22-53-03.bpo-43407.x570l5.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-03-04-22-53-03.bpo-43407.x570l5.rst
@@ -1,0 +1,4 @@
+Clarified that a result from :func:`time.monotonic`,
+:func:`time.perf_counter`, :func:`time.process_time`, or
+:func:`time.thread_time` can be compared with the result from any following
+call to the same function - not just the next immediate call.


### PR DESCRIPTION
Previous wording implied that only the result of call N and N+1 could be
meaningfully compared. Whereas comparing call N and N+M is fine.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43407](https://bugs.python.org/issue43407) -->
https://bugs.python.org/issue43407
<!-- /issue-number -->
