### PR TITLE
Put contextvars docs into the concurrency category

### DIFF
--- a/Doc/library/concurrency.rst
+++ b/Doc/library/concurrency.rst
@@ -21,6 +21,7 @@ multitasking). Here's an overview:
    subprocess.rst
    sched.rst
    queue.rst
+   contextvars.rst
 
 
 The following are support modules for some of the above services:

--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -56,7 +56,6 @@ the `Python Package Index <https://pypi.org>`_.
    crypto.rst
    allos.rst
    concurrency.rst
-   contextvars.rst
    ipc.rst
    netdata.rst
    markup.rst


### PR DESCRIPTION


Automerge-Triggered-By: GH:brettcannon