### PR TITLE
Docs: improve accuracy of socketserver reference

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -430,11 +430,8 @@ Request Handler Objects
    The :attr:`self.rfile` and :attr:`self.wfile` attributes can be
    read or written, respectively, to get the request data or return data
    to the client.
-
-   The :attr:`rfile` attributes of both classes support the
-   :class:`io.BufferedIOBase` readable interface, and
-   the :attr:`wfile` attributes of both classes support the
-   :class:`io.BufferedIOBase` writable interface.
+   The :attr:`!rfile` attributes support the :class:`io.BufferedIOBase` readable interface,
+   and :attr:`!wfile` attributes support the :class:`!io.BufferedIOBase` writable interface.
 
    .. versionchanged:: 3.6
       :attr:`StreamRequestHandler.wfile` also supports the

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -81,15 +81,15 @@ synchronous servers of four types::
    +------------+
    | BaseServer |
    +------------+
-         ^
          |
+         v
    +-----------+        +------------------+
-   | TCPServer |<-------| UnixStreamServer |
+   | TCPServer |------->| UnixStreamServer |
    +-----------+        +------------------+
-         ^
          |
+         v
    +-----------+        +--------------------+
-   | UDPServer |<-------| UnixDatagramServer |
+   | UDPServer |------->| UnixDatagramServer |
    +-----------+        +--------------------+
 
 Note that :class:`UnixDatagramServer` derives from :class:`UDPServer`, not from

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -93,9 +93,9 @@ synchronous servers of four types::
    +-----------+        +--------------------+
 
 Note that :class:`UnixDatagramServer` derives from :class:`UDPServer`, not from
-:class:`UnixStreamServer` --- the only difference between an IP and a Unix
-server is the address family, which is simply repeated in both Unix
-server classes.
+:class:`UnixStreamServer` --- the only difference between a TCP or UDP server
+and a Unix stream or datagram server is the address family, which is simply repeated in both Unix
+stream and datagram server classes.
 
 
 .. class:: ForkingMixIn

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -93,7 +93,8 @@ synchronous servers of four types::
    +-----------+        +--------------------+
 
 Note that :class:`UnixDatagramServer` derives from :class:`UDPServer`, not from
-:class:`UnixStreamServer` --- the only difference between an IP and a Unix server is the address family.
+:class:`UnixStreamServer` --- the only difference between an IP and a Unix
+server is the address family.
 
 
 .. class:: ForkingMixIn

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -93,9 +93,7 @@ synchronous servers of four types::
    +-----------+        +--------------------+
 
 Note that :class:`UnixDatagramServer` derives from :class:`UDPServer`, not from
-:class:`UnixStreamServer` --- the only difference between a TCP or UDP server
-and a Unix stream or datagram server is the address family, which is simply repeated in Unix
-stream and datagram server classes.
+:class:`UnixStreamServer` --- the only difference between an IP and a Unix server is the address family.
 
 
 .. class:: ForkingMixIn

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -94,7 +94,7 @@ synchronous servers of four types::
 
 Note that :class:`UnixDatagramServer` derives from :class:`UDPServer`, not from
 :class:`UnixStreamServer` --- the only difference between a TCP or UDP server
-and a Unix stream or datagram server is the address family, which is simply repeated in both Unix
+and a Unix stream or datagram server is the address family, which is simply repeated in Unix
 stream and datagram server classes.
 
 

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -81,15 +81,15 @@ synchronous servers of four types::
    +------------+
    | BaseServer |
    +------------+
+         ^
          |
-         v
    +-----------+        +------------------+
-   | TCPServer |------->| UnixStreamServer |
+   | TCPServer |<-------| UnixStreamServer |
    +-----------+        +------------------+
+         ^
          |
-         v
    +-----------+        +--------------------+
-   | UDPServer |------->| UnixDatagramServer |
+   | UDPServer |<-------| UnixDatagramServer |
    +-----------+        +--------------------+
 
 Note that :class:`UnixDatagramServer` derives from :class:`UDPServer`, not from

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -433,7 +433,7 @@ Request Handler Objects
 
    The :attr:`rfile` attributes of both classes support the
    :class:`io.BufferedIOBase` readable interface, and
-   :attr:`DatagramRequestHandler.wfile` supports the
+   the :attr:`wfile` attributes of both classes support the
    :class:`io.BufferedIOBase` writable interface.
 
    .. versionchanged:: 3.6

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -94,7 +94,7 @@ synchronous servers of four types::
 
 Note that :class:`UnixDatagramServer` derives from :class:`UDPServer`, not from
 :class:`UnixStreamServer` --- the only difference between an IP and a Unix
-stream server is the address family, which is simply repeated in both Unix
+server is the address family, which is simply repeated in both Unix
 server classes.
 
 


### PR DESCRIPTION
In the documentation of the `socketserver` standard library:
- update a restricted statement; the address family difference between `TCPServer` and `UnixStreamServer` is also true between `UDPServer` and `UnixDatagramServer`, as the second clause of the sentence and the implementation show;
- update an obsolete statement; [since Python 3.6](https://docs.python.org/3/library/socketserver.html#socketserver.StreamRequestHandler) the `StreamRequestHandler.wfile` attribute also supports the `io.BufferedIOBase` writable interface:

  > Changed in version 3.6: StreamRequestHandler.wfile also supports the [io.BufferedIOBase](https://docs.python.org/3/library/io.html#io.BufferedIOBase) writable interface.