### PR TITLE
bpo-43419: fix contextvars behaviors in asyncio REPL

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -9,7 +9,7 @@ import types
 import warnings
 import contextvars
 
-from . import futures, iscoroutinefunction
+from . import futures
 
 
 class AsyncIOInteractiveConsole(code.InteractiveConsole):
@@ -33,10 +33,6 @@ class AsyncIOInteractiveConsole(code.InteractiveConsole):
 
             func = types.FunctionType(code, self.locals)
             try:
-                if not iscoroutinefunction(func):
-                    code_ = self.compile("repl_ctx.run(repl_f)", self.filename)
-                    new_locals = dict(repl_ctx=repl_context, repl_f=func, **self.locals)
-                    func = types.FunctionType(code_, new_locals)
                 coro = func()
             except SystemExit:
                 raise
@@ -58,7 +54,7 @@ class AsyncIOInteractiveConsole(code.InteractiveConsole):
             except BaseException as exc:
                 future.set_exception(exc)
 
-        loop.call_soon_threadsafe(callback, context=repl_context.copy())
+        loop.call_soon_threadsafe(callback, context=repl_context)
 
         try:
             return future.result()


### PR DESCRIPTION
[bug tracker](https://bugs.python.org/issue43419)

I just make the little enhance to propagate `Context` between MainThread and REPLThread, to let contextvars work properly in asyncio REPL environment.

Here is the _new_ behavior after this PR merged:

```python
asyncio REPL 3.8.6 (default, Oct 18 2020, 00:27:24) 
[Clang 11.0.0 (clang-1100.0.33.16)] on darwin
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from contextvars import ContextVar
>>> ctx = ContextVar('ctx')
>>> ctx.get(None)
>>> ctx.set(1)
<Token var=<ContextVar name='ctx' at 0x10167c8b0> at 0x10167bd00>
>>> ctx.get()
1
>>> async def coro_f():
...   return ctx.get()
... 
>>> await coro_f()
1
>>> def normal_f():
...   return ctx.get()
... 
>>> normal_f()
1
>>> exit()
```

<!-- issue-number: [bpo-43419](https://bugs.python.org/issue43419) -->
https://bugs.python.org/issue43419
<!-- /issue-number -->
