### PR TITLE
bpo-43423 Fix IndexError in subprocess _communicate function

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1535,9 +1535,9 @@ class Popen(object):
                 self.stderr.close()
 
             # All data exchanged.  Translate lists into strings.
-            if stdout is not None:
+            if stdout:
                 stdout = stdout[0]
-            if stderr is not None:
+            if stderr:
                 stderr = stderr[0]
 
             return (stdout, stderr)

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1535,10 +1535,8 @@ class Popen(object):
                 self.stderr.close()
 
             # All data exchanged.  Translate lists into strings.
-            if stdout:
-                stdout = stdout[0]
-            if stderr:
-                stderr = stderr[0]
+            stdout = stdout[0] if stdout else None
+            stderr = stderr[0] if stderr else None
 
             return (stdout, stderr)
 

--- a/Misc/NEWS.d/next/Library/2021-03-11-15-44-18.bpo-43423.rRomRD.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-11-15-44-18.bpo-43423.rRomRD.rst
@@ -1,0 +1,1 @@
+Fixed subprocess communicate function could raise an IndexError when there is an empty buffer

--- a/Misc/NEWS.d/next/Library/2021-03-11-15-44-18.bpo-43423.rRomRD.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-11-15-44-18.bpo-43423.rRomRD.rst
@@ -1,1 +1,2 @@
-Fixed subprocess communicate function could raise an IndexError when there is an empty buffer
+:func:`subprocess.communicate` no longer raises an IndexError when there is an
+empty stdout or stderr IO buffer during a timeout on Windows.


### PR DESCRIPTION
It is possible to run into an IndexError in the subprocess module's _communicate function.

```
    return run(
  File "subprocess.py", line 491, in run
  File "subprocess.py", line 1024, in communicate
  File "subprocess.py", line 1418, in _communicate
IndexError: list index out of range
```

The lines in question are: 

```
            if stdout is not None:
                stdout = stdout[0]
            if stderr is not None:
                stderr = stderr[0]
```

I believe this is due to the fact there is no safety checking to make sure that `self._stdout_buff` and `self._stderr_buff` have any content in them after being set to empty lists. 

The fix I suggest is to change the checks from `if stdout is not None` to simply `if stdout` to make sure it is a populated list, as well as for `stderr`. 

Example fixed code: 

```
            if stdout:
                stdout = stdout[0]
            if stderr:
                stderr = stderr[0]
```

If a more stringent check is required, we could expand that out to check type and length, such as `isinstance(stdout, list) and len(stdout) > 0:` but that is more then necessary currently.




<!-- issue-number: [bpo-43423](https://bugs.python.org/issue43423) -->
https://bugs.python.org/issue43423
<!-- /issue-number -->
