### PR TITLE
bpo-43432: add function `clear` to module `os`

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -1118,3 +1118,10 @@ if name == 'nt':
             cookie,
             nt._remove_dll_directory
         )
+
+def clear():
+    """ Runs the clear command in the shell """
+    if name == 'nt':
+        system('cls')
+    else:
+        system('clear')

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4050,6 +4050,7 @@ class BlockingTests(unittest.TestCase):
         self.assertEqual(os.get_blocking(fd), True)
 
 
+
 class ExportsTests(unittest.TestCase):
     def test_os_all(self):
         self.assertIn('open', os.__all__)

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4050,6 +4050,14 @@ class BlockingTests(unittest.TestCase):
         self.assertEqual(os.get_blocking(fd), True)
 
 
+class ClearTests(unittest.TestCase):
+    def test_clear():
+        if os.name == 'nt':
+            pass
+            # TODO : add test for windows
+        else:
+            self.assertIn('\x1b[3J\x1b[H\x1b[2J', subprocess.check_output(sys.executable + ' -c "import os; os.clear()"', shell=True).decode())
+
 
 class ExportsTests(unittest.TestCase):
     def test_os_all(self):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4050,15 +4050,6 @@ class BlockingTests(unittest.TestCase):
         self.assertEqual(os.get_blocking(fd), True)
 
 
-class ClearTests(unittest.TestCase):
-    def test_clear():
-        if os.name == 'nt':
-            pass
-            # TODO : add test for windows
-        else:
-            self.assertIn('\x1b[3J\x1b[H\x1b[2J', subprocess.check_output(sys.executable + ' -c "import os; os.clear()"', shell=True).decode())
-
-
 class ExportsTests(unittest.TestCase):
     def test_os_all(self):
         self.assertIn('open', os.__all__)

--- a/Misc/NEWS.d/next/Library/2021-03-08-16-08-15.bpo-43432.Aq20oZ.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-08-16-08-15.bpo-43432.Aq20oZ.rst
@@ -1,0 +1,3 @@
+Added function `clear` to module `os`.
+This function clears the screen by running `cls` in windows and `clear` in unix.
+Patch by parsa shahmaleki


### PR DESCRIPTION
Now we can run:

```python
from os import clear
clear()
```
instead of:
```python
import os

if os.name == 'nt':
      os.system('cls')
else:
      os.system('clear')
```

<!-- issue-number: [bpo-43432](https://bugs.python.org/issue43432) -->
https://bugs.python.org/issue43432
<!-- /issue-number -->
