### PR TITLE
bpo-37146: Move _PyEval_DeactivateOpCache() to the internal C API

### DIFF
--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -28,5 +28,3 @@ PyAPI_FUNC(Py_ssize_t) _PyEval_RequestCodeExtraIndex(freefunc);
 
 PyAPI_FUNC(int) _PyEval_SliceIndex(PyObject *, Py_ssize_t *);
 PyAPI_FUNC(int) _PyEval_SliceIndexNotNone(PyObject *, Py_ssize_t *);
-
-PyAPI_FUNC(void) _PyEval_DeactivateOpCache(void);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -62,6 +62,8 @@ extern void _PyEval_FiniGIL(PyInterpreterState *interp);
 
 extern void _PyEval_ReleaseLock(PyThreadState *tstate);
 
+extern void _PyEval_DeactivateOpCache(void);
+
 
 /* --- _Py_EnterRecursiveCall() ----------------------------------------- */
 


### PR DESCRIPTION
Don't export the symbol anymore.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37146](https://bugs.python.org/issue37146) -->
https://bugs.python.org/issue37146
<!-- /issue-number -->
