### PR TITLE
bpo-43245: Add keyword argument support to ChainMap.new_child()

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -72,18 +72,22 @@ The class can be used to simulate nested scopes and is useful in templating.
         be modified to change which mappings are searched.  The list should
         always contain at least one mapping.
 
-    .. method:: new_child(m=None)
+    .. method:: new_child(m=None, **kwargs)
 
         Returns a new :class:`ChainMap` containing a new map followed by
         all of the maps in the current instance.  If ``m`` is specified,
         it becomes the new map at the front of the list of mappings; if not
         specified, an empty dict is used, so that a call to ``d.new_child()``
-        is equivalent to: ``ChainMap({}, *d.maps)``.  This method is used for
-        creating subcontexts that can be updated without altering values in any
-        of the parent mappings.
+        is equivalent to: ``ChainMap({}, *d.maps)``. If any keyword arguments
+        are specified, they update passed map or new empty dict. This method
+        is used for creating subcontexts that can be updated without altering
+        values in any of the parent mappings.
 
         .. versionchanged:: 3.4
            The optional ``m`` parameter was added.
+
+        .. versionchanged:: 3.10
+           Keyword arguments support was added.
 
     .. attribute:: parents
 

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1010,12 +1010,16 @@ class ChainMap(_collections_abc.MutableMapping):
 
     __copy__ = copy
 
-    def new_child(self, m=None):                # like Django's Context.push()
+    def new_child(self, m=None, **kwargs):      # like Django's Context.push()
         '''New ChainMap with a new map followed by all previous maps.
         If no map is provided, an empty dict is used.
+        Keyword arguments update the map or new empty dict.
         '''
         if m is None:
-            m = {}
+            m = kwargs
+        elif kwargs:
+            m = m.copy()
+            m.update(kwargs)
         return self.__class__(m, *self.maps)
 
     @property

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1018,7 +1018,6 @@ class ChainMap(_collections_abc.MutableMapping):
         if m is None:
             m = kwargs
         elif kwargs:
-            m = m.copy()
             m.update(kwargs)
         return self.__class__(m, *self.maps)
 

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -249,6 +249,10 @@ class TestChainMap(unittest.TestCase):
         for k, v in dict(a=1, B=20, C=30, z=100).items():             # check get
             self.assertEqual(d.get(k, 100), v)
 
+        c = ChainMap({'a': 1, 'b': 2})
+        d = c.new_child(b=20, c=30)
+        self.assertEqual(d.maps, [{'b': 20, 'c': 30}, {'a': 1, 'b': 2}])
+
     def test_union_operators(self):
         cm1 = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
         cm2 = ChainMap(dict(a=10, e=5), dict(b=20, d=4))

--- a/Misc/NEWS.d/next/Library/2021-03-08-22-14-37.bpo-43245.nXL-MC.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-08-22-14-37.bpo-43245.nXL-MC.rst
@@ -1,0 +1,1 @@
+Add keyword arguments support to ``ChainMap.new_child()``.


### PR DESCRIPTION
Support keyword argument within `ChainMap.new_child()` method, making it possible to write:
```
local = parent.new_child(foreground='white', background='cyan')
```
instead of
```
local = parent.new_child(dict(foreground='white', background='cyan'))
```

https://bugs.python.org/issue43245

<!-- issue-number: [bpo-43245](https://bugs.python.org/issue43245) -->
https://bugs.python.org/issue43245
<!-- /issue-number -->
