### PR TITLE
bpo-41361: Optimized argument parsing for deque_rotate

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-03-13-08-18-01.bpo-41361.lXDIlr.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-13-08-18-01.bpo-41361.lXDIlr.rst
@@ -1,0 +1,1 @@
+:meth:`~collections.deque.rotate` calls are now slightly faster due to faster argument parsing.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -889,6 +889,7 @@ deque_rotate(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
             return NULL;
         }
         n = PyLong_AsSsize_t(index);
+        Py_DECREF(index);
         if (n == -1 && PyErr_Occurred()) {
             return NULL;
         }

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -880,8 +880,18 @@ deque_rotate(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
 {
     Py_ssize_t n=1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:rotate", &n)) {
+    if (!_PyArg_CheckPositional("deque.rotate", nargs, 0, 1)) {
         return NULL;
+    }
+    if (nargs) {
+        PyObject *index = _PyNumber_Index(args[0]);
+        if (index == NULL) {
+            return NULL;
+        }
+        n = PyLong_AsSsize_t(index);
+        if (n == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
     }
 
     if (!_deque_rotate(deque, n))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41361](https://bugs.python.org/issue41361) -->
https://bugs.python.org/issue41361
<!-- /issue-number -->
