### PR TITLE
bpo-43451: Render inspect function arguments one-per-line when they exceed a maximum length

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3115,7 +3115,13 @@ class Signature:
             # flag was not reset to 'False'
             result.append('/')
 
-        rendered = '({})'.format(', '.join(result))
+        # If arguments are liable exceed to some representative line width,
+        # write one per line with an indent. Improves pydoc rendering of
+        # complex annotations.
+        if (sum(map(len, result)) + (2 * len(result))) > 150:
+            rendered = '(\n    {}\n)'.format(',\n    '.join(result))
+        else:
+            rendered = '({})'.format(', '.join(result))
 
         if self.return_annotation is not _empty:
             anno = formatannotation(self.return_annotation)

--- a/Misc/NEWS.d/next/Library/2021-03-03-19-21-00.bpo-43451.xL4h94.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-03-19-21-00.bpo-43451.xL4h94.rst
@@ -1,0 +1,1 @@
+Wrap long arguments lists in ``pydoc`` terminal output.


### PR DESCRIPTION
This is a proposed fix for `pydoc` argument formatting in the presence of complex type annotations, see [issue 43451](https://bugs.python.org/issue43451) for a description.

Rendering of `pydoc aiohttp.client.ClientSession`, before (with truncation):

![image](https://user-images.githubusercontent.com/2315/110524839-cf735e80-810b-11eb-95ac-681989f2ff6b.png)

After (with truncation):

![image](https://user-images.githubusercontent.com/2315/110524885-ddc17a80-810b-11eb-9c0f-b6fbaaad6355.png)

Before (with wrapping):

![image](https://user-images.githubusercontent.com/2315/110524967-f598fe80-810b-11eb-9aba-8e7ba050c2f8.png)

After (with wrapping):

![image](https://user-images.githubusercontent.com/2315/110525009-021d5700-810c-11eb-85cc-8c08f9066cfa.png)


<!-- issue-number: [bpo-43451](https://bugs.python.org/issue43451) -->
https://bugs.python.org/issue43451
<!-- /issue-number -->
