### PR TITLE
Update link to Django's Context class.

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -123,7 +123,7 @@ The class can be used to simulate nested scopes and is useful in templating.
       writing to any mapping in the chain.
 
     * Django's `Context class
-      <https://github.com/django/django/blob/master/django/template/context.py>`_
+      <https://github.com/django/django/blob/main/django/template/context.py>`_
       for templating is a read-only chain of mappings.  It also features
       pushing and popping of contexts similar to the
       :meth:`~collections.ChainMap.new_child` method and the

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -404,7 +404,7 @@ subclass which installs setuptools and pip into a created virtual environment::
             :param context: The information for the virtual environment
                             creation request being processed.
             """
-            url = 'https://raw.github.com/pypa/pip/master/contrib/get-pip.py'
+            url = 'https://bootstrap.pypa.io/get-pip.py'
             self.install_script(context, 'pip', url)
 
     def main(args=None):


### PR DESCRIPTION
Django repository was renamed to "main", see https://github.com/django/django/pull/14048 and a discussion on [django-developers](https://groups.google.com/g/django-developers/c/tctDuKUGosc/).

