### PR TITLE
bpo-43446: Fix footnote in sqlite3 docs

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1090,5 +1090,5 @@ committed:
 .. [#f1] The sqlite3 module is not built with loadable extension support by
    default, because some platforms (notably Mac OS X) have SQLite
    libraries which are compiled without this feature. To get loadable
-   extension support, you must pass --enable-loadable-sqlite-extensions to
+   extension support, you must pass ``--enable-loadable-sqlite-extensions`` to
    configure.

--- a/Misc/NEWS.d/next/Documentation/2021-03-09-21-01-59.bpo-43446.mifJIy.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-03-09-21-01-59.bpo-43446.mifJIy.rst
@@ -1,1 +1,0 @@
-Fix footnote in sqlite3 docs

--- a/Misc/NEWS.d/next/Documentation/2021-03-09-21-01-59.bpo-43446.mifJIy.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-03-09-21-01-59.bpo-43446.mifJIy.rst
@@ -1,0 +1,1 @@
+Fix footnote in sqlite3 docs


### PR DESCRIPTION
Wrap argument in inline markup to prevent leaving out second dash.

Before change:
![image](https://user-images.githubusercontent.com/22010517/110537356-e2455d80-8122-11eb-8a93-249fa72f19e7.png)

After change:
![image](https://user-images.githubusercontent.com/22010517/110537402-ec675c00-8122-11eb-9c8f-3eba50a6a4ba.png)


<!-- issue-number: [bpo-43446](https://bugs.python.org/issue43446) -->
https://bugs.python.org/issue43446
<!-- /issue-number -->
