### PR TITLE
Fix error in documentation for ast.match_case

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1252,7 +1252,7 @@ Control flow
    :class:`match_case` nodes with the different cases.
 
 
-.. class:: match_case(context_expr, optional_vars)
+.. class:: match_case(pattern, guard, body)
 
     A single case pattern in a ``match`` statement. ``pattern`` contains the
     match pattern that will be used to match the subject against. Notice that


### PR DESCRIPTION
This seems to be a copy and paste error introduced when adding documentation for the pattern matching ast nodes in #24673. The wrong arguments have been copied from the `ast.withitem` documentation.