### PR TITLE
[3.9] bpo-43439: Add audit hooks for gc functions (GH-24794).

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -72,6 +72,8 @@ The :mod:`gc` module provides the following functions:
    .. versionchanged:: 3.8
       New *generation* parameter.
 
+   .. audit-event:: gc.get_objects generation gc.get_objects
+
 .. function:: get_stats()
 
    Return a list of three per-generation dictionaries containing collection
@@ -140,6 +142,8 @@ The :mod:`gc` module provides the following functions:
    invalid state. Avoid using :func:`get_referrers` for any purpose other than
    debugging.
 
+   .. audit-event:: gc.get_referrers objs gc.get_referrers
+
 
 .. function:: get_referents(*objs)
 
@@ -151,6 +155,7 @@ The :mod:`gc` module provides the following functions:
    be involved in a cycle.  So, for example, if an integer is directly reachable
    from an argument, that integer object may or may not appear in the result list.
 
+   .. audit-event:: gc.get_referents objs gc.get_referents
 
 .. function:: is_tracked(obj)
 

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -323,6 +323,24 @@ def test_socket():
         sock.close()
 
 
+def test_gc():
+    import gc
+
+    def hook(event, args):
+        if event.startswith("gc."):
+            print(event, *args)
+
+    sys.addaudithook(hook)
+
+    gc.get_objects(generation=1)
+
+    x = object()
+    y = [x]
+
+    gc.get_referrers(x)
+    gc.get_referents(y)
+
+
 if __name__ == "__main__":
     from test.support import suppress_msvcrt_asserts
 

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -115,5 +115,18 @@ class AuditTest(unittest.TestCase):
         self.assertEqual(events[2][0], "socket.bind")
         self.assertTrue(events[2][2].endswith("('127.0.0.1', 8080)"))
 
+    def test_gc(self):
+        returncode, events, stderr = self.run_python("test_gc")
+        if returncode:
+            self.fail(stderr)
+
+        if support.verbose:
+            print(*events, sep='\n')
+        self.assertEqual(
+            [event[0] for event in events],
+            ["gc.get_objects", "gc.get_referrers", "gc.get_referents"]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Security/2021-03-08-23-06-07.bpo-43439.5U3lXm.rst
+++ b/Misc/NEWS.d/next/Security/2021-03-08-23-06-07.bpo-43439.5U3lXm.rst
@@ -1,0 +1,2 @@
+Add audit hooks for :func:`gc.get_objects`, :func:`gc.get_referrers` and
+:func:`gc.get_referents`. Patch by Pablo Galindo.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1674,6 +1674,11 @@ gc_get_referrers(PyObject *self, PyObject *args)
 {
     PyThreadState *tstate = _PyThreadState_GET();
     int i;
+
+    if (PySys_Audit("gc.get_referrers", "O", args) < 0) {
+        return NULL;
+    }
+
     PyObject *result = PyList_New(0);
     if (!result) {
         return NULL;
@@ -1704,6 +1709,9 @@ static PyObject *
 gc_get_referents(PyObject *self, PyObject *args)
 {
     Py_ssize_t i;
+    if (PySys_Audit("gc.get_referents", "O", args) < 0) {
+        return NULL;
+    }
     PyObject *result = PyList_New(0);
 
     if (result == NULL)
@@ -1745,6 +1753,10 @@ gc_get_objects_impl(PyObject *module, Py_ssize_t generation)
     int i;
     PyObject* result;
     GCState *gcstate = &tstate->interp->gc;
+
+    if (PySys_Audit("gc.get_objects", "n", generation) < 0) {
+        return NULL;
+    }
 
     result = PyList_New(0);
     if (result == NULL) {


### PR DESCRIPTION
(cherry picked from commit b4f9089d4aa787c5b74134c98e5f0f11d9e63095)

Co-authored-by: Pablo Galindo <Pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43439](https://bugs.python.org/issue43439) -->
https://bugs.python.org/issue43439
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran