### PR TITLE
Fix typo in compile.c

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5754,7 +5754,7 @@ compiler_pattern_mapping(struct compiler *c, expr_ty p, pattern_context *pc)
     asdl_expr_seq *keys = p->v.Dict.keys;
     asdl_expr_seq *values = p->v.Dict.values;
     Py_ssize_t size = asdl_seq_LEN(values);
-    // A starred pattern will be a keyless value. It is guranteed to be last:
+    // A starred pattern will be a keyless value. It is guaranteed to be last:
     int star = size ? !asdl_seq_GET(keys, size - 1) : 0;
     ADDOP(c, MATCH_MAPPING);
     ADDOP_JUMP(c, POP_JUMP_IF_FALSE, fail_pop_1);


### PR DESCRIPTION
guranteed -> guaranteed
