### PR TITLE
bpo-43456: Remove _xxsubinterpreters from sys.stdlib_module_names

### DIFF
--- a/Python/stdlib_module_names.h
+++ b/Python/stdlib_module_names.h
@@ -85,7 +85,6 @@ static const char* _Py_stdlib_module_names[] = {
 "_weakref",
 "_weakrefset",
 "_winapi",
-"_xxsubinterpreters",
 "_zoneinfo",
 "abc",
 "aifc",

--- a/Tools/scripts/generate_stdlib_module_names.py
+++ b/Tools/scripts/generate_stdlib_module_names.py
@@ -28,6 +28,7 @@ IGNORE = {
     '_testimportmultiple',
     '_testinternalcapi',
     '_testmultiphase',
+    '_xxsubinterpreters',
     '_xxtestfuzz',
     'distutils.tests',
     'idlelib.idle_test',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43456](https://bugs.python.org/issue43456) -->
https://bugs.python.org/issue43456
<!-- /issue-number -->
