### PR TITLE
bpo-42967: coerce bytes separator to string in urllib.parse_qs(l)

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -893,6 +893,8 @@ class UrlParseTestCase(unittest.TestCase):
             with self.subTest(f"Original: {orig!r}, Expected: {expect!r}"):
                 result = urllib.parse.parse_qs(orig, separator=';')
                 self.assertEqual(result, expect, "Error parsing %r" % orig)
+                result_bytes = urllib.parse.parse_qs(orig, separator=b';')
+                self.assertEqual(result_bytes, expect, "Error parsing %r" % orig)
 
 
     def test_parse_qsl_separator(self):
@@ -912,6 +914,8 @@ class UrlParseTestCase(unittest.TestCase):
             with self.subTest(f"Original: {orig!r}, Expected: {expect!r}"):
                 result = urllib.parse.parse_qsl(orig, separator=';')
                 self.assertEqual(result, expect, "Error parsing %r" % orig)
+                result_bytes = urllib.parse.parse_qsl(orig, separator=b';')
+                self.assertEqual(result_bytes, expect, "Error parsing %r" % orig)
 
 
     def test_urlencode_sequences(self):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -733,6 +733,7 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         Returns a list, as G-d intended.
     """
     qs, _coerce_result = _coerce_args(qs)
+    separator, _ = _coerce_args(separator)
 
     if not separator or (not isinstance(separator, (str, bytes))):
         raise ValueError("Separator must be of type string or bytes.")

--- a/Misc/NEWS.d/next/Library/2021-03-11-00-31-41.bpo-42967.2PeQRw.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-11-00-31-41.bpo-42967.2PeQRw.rst
@@ -1,0 +1,3 @@
+Allow :class:`bytes` ``separator`` argument in ``urllib.parse.parse_qs`` and
+``urllib.parse.parse_qsl`` when parsing :class:`str` query strings.  Previously,
+this would cause a ``TypeError``.

--- a/Misc/NEWS.d/next/Library/2021-03-11-00-31-41.bpo-42967.2PeQRw.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-11-00-31-41.bpo-42967.2PeQRw.rst
@@ -1,3 +1,3 @@
 Allow :class:`bytes` ``separator`` argument in ``urllib.parse.parse_qs`` and
 ``urllib.parse.parse_qsl`` when parsing :class:`str` query strings.  Previously,
-this would cause a ``TypeError``.
+this raised a ``TypeError``.


### PR DESCRIPTION
``urllib.parse_qsl`` previously (and currently) deals with bytes query string by coercing them to string internally. After [bpo-42967](https://bugs.python.org/issue42967) was fixed, a new ``separator`` argument was added. This patch follows the rest of parse_qsl by coercing the ``separator`` to string too.

<!-- issue-number: [bpo-42967](https://bugs.python.org/issue42967) -->
https://bugs.python.org/issue42967
<!-- /issue-number -->
