### PR TITLE
bpo-43441: fix [Subinterpreters]: global variable next_version_tag cause method cache bug

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -39,6 +39,7 @@ class object "PyObject *" "&PyBaseObject_Type"
         PyUnicode_IS_READY(name) &&                             \
         (PyUnicode_GET_LENGTH(name) <= MCACHE_MAX_ATTR_SIZE)
 
+// bpo-42745: next_version_tag remains shared by all interpreters because of static types
 // Used to set PyTypeObject.tp_version_tag
 static unsigned int next_version_tag = 0;
 
@@ -252,8 +253,9 @@ _PyType_InitCache(PyInterpreterState *interp)
 
 
 static unsigned int
-_PyType_ClearCache(struct type_cache *cache)
+_PyType_ClearCache(PyInterpreterState *interp)
 {
+    struct type_cache *cache = get_type_cache();
 #if MCACHE_STATS
     size_t total = cache->hits + cache->collisions + cache->misses;
     fprintf(stderr, "-- Method cache hits        = %zd (%d%%)\n",
@@ -267,7 +269,10 @@ _PyType_ClearCache(struct type_cache *cache)
 #endif
 
     unsigned int cur_version_tag = next_version_tag - 1;
-    next_version_tag = 0;
+    if (_Py_IsMainInterpreter(interp)) {
+        next_version_tag = 0;
+    }
+
     type_cache_clear(cache, 0);
 
     return cur_version_tag;
@@ -277,15 +282,15 @@ _PyType_ClearCache(struct type_cache *cache)
 unsigned int
 PyType_ClearCache(void)
 {
-    struct type_cache *cache = get_type_cache();
-    return _PyType_ClearCache(cache);
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    return _PyType_ClearCache(interp);
 }
 
 
 void
 _PyType_Fini(PyInterpreterState *interp)
 {
-    _PyType_ClearCache(&interp->type_cache);
+    _PyType_ClearCache(interp);
     if (_Py_IsMainInterpreter(interp)) {
         clear_slotdefs();
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -255,7 +255,7 @@ _PyType_InitCache(PyInterpreterState *interp)
 static unsigned int
 _PyType_ClearCache(PyInterpreterState *interp)
 {
-    struct type_cache *cache = get_type_cache();
+    struct type_cache *cache = &interp->type_cache;
 #if MCACHE_STATS
     size_t total = cache->hits + cache->collisions + cache->misses;
     fprintf(stderr, "-- Method cache hits        = %zd (%d%%)\n",


### PR DESCRIPTION
under building Python with --with-experimental-isolated-subinterpreters

when sub interpreter finalize. 
`_PyType_ClearCache` set next_version_tag = 0. 

Type shared between interpreters. 
another interpreter assign_version_tag "1" for a type, the type is first assign.

the dealloc interpreter had assign_version_tag  "1" for another type.

now, two different type has same version tag. it cause method cache wrong.

```
static unsigned int
_PyType_ClearCache(struct type_cache *cache)
{
#if MCACHE_STATS
    size_t total = cache->hits + cache->collisions + cache->misses;
    fprintf(stderr, "-- Method cache hits        = %zd (%d%%)\n",
            cache->hits, (int) (100.0 * cache->hits / total));
    fprintf(stderr, "-- Method cache true misses = %zd (%d%%)\n",
            cache->misses, (int) (100.0 * cache->misses / total));
    fprintf(stderr, "-- Method cache collisions  = %zd (%d%%)\n",
            cache->collisions, (int) (100.0 * cache->collisions / total));
    fprintf(stderr, "-- Method cache size        = %zd KiB\n",
            sizeof(cache->hashtable) / 1024);
#endif

    unsigned int cur_version_tag = next_version_tag - 1;
    next_version_tag = 0;
    type_cache_clear(cache, 0);

    return cur_version_tag;
}
```



<!-- issue-number: [bpo-43441](https://bugs.python.org/issue43441) -->
https://bugs.python.org/issue43441
<!-- /issue-number -->
