### PR TITLE
bpo-43214: site: Use UTF-8 for .pth files.

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -170,7 +170,7 @@ def addpackage(sitedir, name, known_paths):
     fullname = os.path.join(sitedir, name)
     _trace(f"Processing .pth file: {fullname!r}")
     try:
-        f = io.TextIOWrapper(io.open_code(fullname))
+        f = io.TextIOWrapper(io.open_code(fullname), encoding="utf-8")
     except OSError:
         return
     with f:

--- a/Misc/NEWS.d/next/Library/2021-03-13-16-10-39.bpo-43214.PRXoC7.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-13-16-10-39.bpo-43214.PRXoC7.rst
@@ -1,0 +1,2 @@
+Fix ``site`` module used locale-specific encoding for opening ``.pth``
+files.


### PR DESCRIPTION


<!-- issue-number: [bpo-43214](https://bugs.python.org/issue43214) -->
https://bugs.python.org/issue43214
<!-- /issue-number -->
