### PR TITLE
bpo-43487: Add unicode dundermethod fixer to 2to3

### DIFF
--- a/Lib/lib2to3/fixes/fix_unicode_dundermethods.py
+++ b/Lib/lib2to3/fixes/fix_unicode_dundermethods.py
@@ -1,0 +1,40 @@
+"""Fixer to convert name of __unicode__ class methods to __str__, unless it exists already.
+"""
+# Author: Bart Broere
+
+
+from lib2to3.fixer_base import BaseFix
+from lib2to3.pytree import Leaf
+
+
+class FixUnicodeDundermethods(BaseFix):
+
+    def match(self, node):
+        if isinstance(node, Leaf):
+            try:
+                if node.value == '__unicode__' and node.prev_sibling.value == 'def':
+                    return True
+            except AttributeError:
+                return False
+        return False
+
+    def transform(self, node, results):
+        try:
+            for element in node.parent.parent.parent.leaves():
+                if element.value == 'class':
+                    if not self._method_exists(node.parent.parent.parent, '__str__'):
+                        node.value = '__str__'
+                    return node
+                break
+        except AttributeError:
+            return None
+        return None
+
+    def _method_exists(self, class_node, method_name):
+        for element in class_node.leaves():
+            for element_j in element.leaves():
+                if element_j.value == 'def':
+                    if element_j.next_sibling.value == method_name:
+                        return True
+        return False
+

--- a/Lib/lib2to3/fixes/fix_unicode_dundermethods.py
+++ b/Lib/lib2to3/fixes/fix_unicode_dundermethods.py
@@ -8,11 +8,10 @@ from lib2to3.pytree import Leaf
 
 
 class FixUnicodeDundermethods(BaseFix):
-
     def match(self, node):
         if isinstance(node, Leaf):
             try:
-                if node.value == '__unicode__' and node.prev_sibling.value == 'def':
+                if node.value == "__unicode__" and node.prev_sibling.value == "def":
                     return True
             except AttributeError:
                 return False
@@ -21,9 +20,9 @@ class FixUnicodeDundermethods(BaseFix):
     def transform(self, node, results):
         try:
             for element in node.parent.parent.parent.leaves():
-                if element.value == 'class':
-                    if not self._method_exists(node.parent.parent.parent, '__str__'):
-                        node.value = '__str__'
+                if element.value == "class":
+                    if not self._method_exists(node.parent.parent.parent, "__str__"):
+                        node.value = "__str__"
                     return node
                 break
         except AttributeError:
@@ -33,8 +32,7 @@ class FixUnicodeDundermethods(BaseFix):
     def _method_exists(self, class_node, method_name):
         for element in class_node.leaves():
             for element_j in element.leaves():
-                if element_j.value == 'def':
+                if element_j.value == "def":
                     if element_j.next_sibling.value == method_name:
                         return True
         return False
-

--- a/Misc/NEWS.d/next/Library/2021-03-18-18-13-08.bpo-43487.WV817A.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-18-18-13-08.bpo-43487.WV817A.rst
@@ -1,2 +1,2 @@
-Add a fixer to the 2to3 library that converts `__unicode__` methods to
-`__str__`, if this can be done safely.
+Add a fixer to the 2to3 library that converts ``__unicode__`` methods 
+to ``__str__``, if this can be done safely.

--- a/Misc/NEWS.d/next/Library/2021-03-18-18-13-08.bpo-43487.WV817A.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-18-18-13-08.bpo-43487.WV817A.rst
@@ -1,2 +1,2 @@
-Add a fixer to the 2to3 library that converts ``__unicode__`` methods 
+Add a fixer to the 2to3 library that converts ``__unicode__`` methods
 to ``__str__``, if this can be done safely.

--- a/Misc/NEWS.d/next/Library/2021-03-18-18-13-08.bpo-43487.WV817A.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-18-18-13-08.bpo-43487.WV817A.rst
@@ -1,0 +1,2 @@
+Add a fixer to the 2to3 library that converts `__unicode__` methods to
+`__str__`, if this can be done safely.


### PR DESCRIPTION
While porting a (Django) code base recently, using 2to3, I missed the conversion from `__unicode__` to `__str__`. I have created my own `2to3` fixer, which might be useful for other people.

If it's not useful enough to be included in lib2to3, or has side effects that I did not foresee, please let me know :-)

<!-- issue-number: [bpo-43487](https://bugs.python.org/issue43487) -->
https://bugs.python.org/issue43487
<!-- /issue-number -->
