### PR TITLE
bpo-43223: [SECURITY] Patched Open Redirection In SimpleHTTPServer Module

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -101,6 +101,7 @@ import shutil
 import socket # For gethostbyaddr()
 import socketserver
 import sys
+import re
 import time
 import urllib.parse
 import contextlib
@@ -331,6 +332,12 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                     "Bad HTTP/0.9 request type (%r)" % command)
                 return False
         self.command, self.path = command, path
+
+        # bpo-43223: The purpose of replacing '//' with '/' is to protect against 
+        # open redirect attacks reside within http.server module which can be triggered
+        # if the path contains '//' at the beginning because web clients treat //path as
+        # an absolute url without scheme (similar to http://path) rather than a relative path
+        self.path = re.sub(r'^(/)+', '/', self.path)
 
         # Examine the headers and look for a Connection directive.
         try:

--- a/Lib/test/test_http/test_http.py
+++ b/Lib/test/test_http/test_http.py
@@ -1,0 +1,11 @@
+import unittest
+import re
+
+class TestHTTP(unittest.TestCase):
+
+    def test_http_parse_request(self):
+        self.assertEqual(re.sub(r'^/+', '/', '//test.com'), '/test.com', '//test.com should be converted to a proper relative path')
+        self.assertEqual(re.sub(r'^/+', '/', '///test.com'), '/test.com', '///test.com should be converted to a proper relative path')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Misc/NEWS.d/next/Security/2021-03-13-21-25-29.bpo-43223.ieBVWq.rst
+++ b/Misc/NEWS.d/next/Security/2021-03-13-21-25-29.bpo-43223.ieBVWq.rst
@@ -1,0 +1,2 @@
+:mod:`http.server`: Fix an open redirection vulnerability in the HTTP server when an URL contains ``//``.
+Vulnerability discovered and fixed by Hamza Avvan.


### PR DESCRIPTION
Due to no protection against multiple (/) at the beginning of a url an attacker could achieve an open redirection by crafting a malformed URI followed by an existing directory.

Payload: `http://127.0.0.1:8000//attacker.com/..%2f..%2f../anyexistingdirectory`

The main reason behind open redirection is that there's no (/) at the end of `anyexistingdirectory` because the server is checking for the path supplied is a valid directory at `send_head()` method from [Lib/http/server.py](https://github.com/hamzaavvan/cpython/blob/master/Lib/http/server.py#L683).  Right after that, it's checking for the path ending with a (/) or not. So, if there's no (/) at the end of the path then the server will issue a Location header to redirect the web client to that specific directory.

While issuing the redirection, this part `//attacker.com/..%2f..%2f../anyexistingdirectory` will be sent to the Location header's value due to which any web client or browser will consider it as a new url because of multiple (/) at the beginning of the path.

So to mitigate this issue I decided to use regex to replace all the occurrences of (/) from the beginning of the path.
```python
 self.path = re.sub(r'(^(/|\\)+)', '/', self.path)
```

This regex will replace multiple entries (if present) of (/) or (\\) from the beginning of the path. So that the path would be:

1. //attacker.com/..%2f..%2f../anyexistingdirectory **->** /attacker.com/..%2f..%2f../anyexistingdirectory
2. //\\attacker.com/..%2f..%2f../anyexistingdirectory **->** /attacker.com/..%2f..%2f../anyexistingdirectory
3. \\//\\attacker.com/..%2f..%2f../anyexistingdirectory **->** /attacker.com/..%2f..%2f../anyexistingdirectory

And according to these test cases there was no redirection issued from the server after implementing the fix.

<!-- issue-number: [bpo-43223](https://bugs.python.org/issue43223) -->
https://bugs.python.org/issue43223
<!-- /issue-number -->
