### PR TITLE
[3.8] bpo-43439: Wrapt the tuple in the audit events for the gc module (GH-24836)

### DIFF
--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1480,7 +1480,7 @@ static PyObject *
 gc_get_referrers(PyObject *self, PyObject *args)
 {
     int i;
-    if (PySys_Audit("gc.get_referrers", "O", args) < 0) {
+    if (PySys_Audit("gc.get_referrers", "(O)", args) < 0) {
         return NULL;
     }
 
@@ -1512,7 +1512,7 @@ static PyObject *
 gc_get_referents(PyObject *self, PyObject *args)
 {
     Py_ssize_t i;
-    if (PySys_Audit("gc.get_referents", "O", args) < 0) {
+    if (PySys_Audit("gc.get_referents", "(O)", args) < 0) {
         return NULL;
     }
     PyObject *result = PyList_New(0);


### PR DESCRIPTION


<!-- issue-number: [bpo-43439](https://bugs.python.org/issue43439) -->
https://bugs.python.org/issue43439
<!-- /issue-number -->
