### PR TITLE
gh-87479: support pymalloc for subinterpreters. each subinterpreter ha…

### DIFF
--- a/Include/obmalloc.h
+++ b/Include/obmalloc.h
@@ -1,0 +1,181 @@
+#ifdef WITH_PYMALLOC
+#ifndef Py_OBMALLOC_H
+#define Py_OBMALLOC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "pyport.h"
+
+/*==========================================================================*/
+
+/*
+ * -- Main tunable settings section --
+ */
+
+/*
+ * Alignment of addresses returned to the user. 8-bytes alignment works
+ * on most current architectures (with 32-bit or 64-bit address busses).
+ * The alignment value is also used for grouping small requests in size
+ * classes spaced ALIGNMENT bytes apart.
+ *
+ * You shouldn't change this unless you know what you are doing.
+ */
+
+#if SIZEOF_VOID_P > 4
+#define PYMALLOC_ALIGNMENT              16               /* must be 2^N */
+#define PYMALLOC_ALIGNMENT_SHIFT         4
+#else
+#define PYMALLOC_ALIGNMENT               8               /* must be 2^N */
+#define PYMALLOC_ALIGNMENT_SHIFT         3
+#endif
+
+/* Return the number of bytes in size class I, as a uint. */
+#define PYMALLOC_INDEX2SIZE(I) (((uint)(I) + 1) << PYMALLOC_ALIGNMENT_SHIFT)
+
+/*
+ * Max size threshold below which malloc requests are considered to be
+ * small enough in order to use preallocated memory pools. You can tune
+ * this value according to your application behaviour and memory needs.
+ *
+ * Note: a size threshold of 512 guarantees that newly created dictionaries
+ * will be allocated from preallocated memory pools on 64-bit.
+ *
+ * The following invariants must hold:
+ *      1) ALIGNMENT <= SMALL_REQUEST_THRESHOLD <= 512
+ *      2) SMALL_REQUEST_THRESHOLD is evenly divisible by ALIGNMENT
+ *
+ * Although not required, for better performance and space efficiency,
+ * it is recommended that SMALL_REQUEST_THRESHOLD is set to a power of 2.
+ */
+#define PYMALLOC_SMALL_REQUEST_THRESHOLD 512
+#define PYMALLOC_NB_SMALL_SIZE_CLASSES   (PYMALLOC_SMALL_REQUEST_THRESHOLD / PYMALLOC_ALIGNMENT)
+
+/*
+ * The system's VMM page size can be obtained on most unices with a
+ * getpagesize() call or deduced from various header files. To make
+ * things simpler, we assume that it is 4K, which is OK for most systems.
+ * It is probably better if this is the native page size, but it doesn't
+ * have to be.  In theory, if SYSTEM_PAGE_SIZE is larger than the native page
+ * size, then `POOL_ADDR(p)->arenaindex' could rarely cause a segmentation
+ * violation fault.  4K is apparently OK for all the platforms that python
+ * currently targets.
+ */
+#define PYMALLOC_SYSTEM_PAGE_SIZE        (4 * 1024)
+#define PYMALLOC_SYSTEM_PAGE_SIZE_MASK   (PYMALLOC_SYSTEM_PAGE_SIZE - 1)
+
+/*
+ * Maximum amount of memory managed by the allocator for small requests.
+ */
+#ifdef WITH_MEMORY_LIMITS
+#ifndef PYMALLOC_SMALL_MEMORY_LIMIT
+#define PYMALLOC_SMALL_MEMORY_LIMIT      (64 * 1024 * 1024)      /* 64 MB -- more? */
+#endif
+#endif
+
+/*
+ * The allocator sub-allocates <Big> blocks of memory (called arenas) aligned
+ * on a page boundary. This is a reserved virtual address space for the
+ * current process (obtained through a malloc()/mmap() call). In no way this
+ * means that the memory arenas will be used entirely. A malloc(<Big>) is
+ * usually an address range reservation for <Big> bytes, unless all pages within
+ * this space are referenced subsequently. So malloc'ing big blocks and not
+ * using them does not mean "wasting memory". It's an addressable range
+ * wastage...
+ *
+ * Arenas are allocated with mmap() on systems supporting anonymous memory
+ * mappings to reduce heap fragmentation.
+ */
+#define PYMALLOC_ARENA_SIZE              (256 << 10)     /* 256KB */
+
+#ifdef WITH_MEMORY_LIMITS
+#define PYMALLOC_MAX_ARENAS              (PYMALLOC_SMALL_MEMORY_LIMIT / PYMALLOC_ARENA_SIZE)
+#endif
+
+/*
+ * Size of the pools used for small blocks. Should be a power of 2,
+ * between 1K and SYSTEM_PAGE_SIZE, that is: 1k, 2k, 4k.
+ */
+#define PYMALLOC_POOL_SIZE               PYMALLOC_SYSTEM_PAGE_SIZE        /* must be 2^N */
+#define PYMALLOC_POOL_SIZE_MASK          PYMALLOC_SYSTEM_PAGE_SIZE_MASK
+
+#define PYMALLOC_MAX_POOLS_IN_ARENA  (PYMALLOC_ARENA_SIZE / PYMALLOC_POOL_SIZE)
+#if PYMALLOC_MAX_POOLS_IN_ARENA * PYMALLOC_POOL_SIZE != PYMALLOC_ARENA_SIZE
+#   error "arena size not an exact multiple of pool size"
+#endif
+
+/*
+ * -- End of tunable settings section --
+ */
+
+/*==========================================================================*/
+
+
+typedef unsigned int _obmalloc_uint;
+
+/* When you say memory, my mind reasons in terms of (pointers to) blocks */
+typedef uint8_t _obmalloc_memory_block;
+
+/* Pool for small blocks. */
+struct _obmalloc_pool_header {
+    union { _obmalloc_memory_block *_padding;
+        _obmalloc_uint count; } ref;          /* number of allocated blocks    */
+    _obmalloc_memory_block *freeblock;                   /* pool's free list head         */
+    struct _obmalloc_pool_header *nextpool;       /* next pool of this size class  */
+    struct _obmalloc_pool_header *prevpool;       /* previous pool       ""        */
+    _obmalloc_uint arenaindex;                    /* index into arenas of base adr */
+    _obmalloc_uint szidx;                         /* block size class index        */
+    _obmalloc_uint nextoffset;                    /* bytes to virgin block         */
+    _obmalloc_uint maxnextoffset;                 /* largest valid nextoffset      */
+};
+
+
+/* Record keeping for arenas. */
+struct _obmalloc_arena_object {
+    /* The address of the arena, as returned by malloc.  Note that 0
+     * will never be returned by a successful malloc, and is used
+     * here to mark an _obmalloc_arena_object that doesn't correspond to an
+     * allocated arena.
+     */
+    uintptr_t address;
+
+    /* Pool-aligned pointer to the next pool to be carved off. */
+    _obmalloc_memory_block* pool_address;
+
+    /* The number of available pools in the arena:  free pools + never-
+     * allocated pools.
+     */
+    _obmalloc_uint nfreepools;
+
+    /* The total number of pools in the arena, whether or not available. */
+    _obmalloc_uint ntotalpools;
+
+    /* Singly-linked list of available pools. */
+    struct _obmalloc_pool_header* freepools;
+
+    /* Whenever this _obmalloc_arena_object is not associated with an allocated
+     * arena, the nextarena member is used to link all unassociated
+     * _obmalloc_arena_objects in the singly-linked `unused__obmalloc_arena_objects` list.
+     * The prevarena member is unused in this case.
+     *
+     * When this _obmalloc_arena_object is associated with an allocated arena
+     * with at least one available pool, both members are used in the
+     * doubly-linked `usable_arenas` list, which is maintained in
+     * increasing order of `nfreepools` values.
+     *
+     * Else this _obmalloc_arena_object is associated with an allocated arena
+     * all of whose pools are in use.  `nextarena` and `prevarena`
+     * are both meaningless in this case.
+     */
+    struct _obmalloc_arena_object* nextarena;
+    struct _obmalloc_arena_object* prevarena;
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !Py_OBMALLOC_H */
+#endif /* WITH_PYMALLOC */

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -14,7 +14,7 @@ _copy_raw_string(PyObject *strobj)
     if (str == NULL) {
         return NULL;
     }
-    char *copied = PyMem_Malloc(strlen(str)+1);
+    char *copied = PyMem_RawMalloc(strlen(str)+1);
     if (copied == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -59,7 +59,7 @@ static void
 _sharednsitem_clear(struct _sharednsitem *item)
 {
     if (item->name != NULL) {
-        PyMem_Free(item->name);
+        PyMem_RawFree(item->name);
         item->name = NULL;
     }
     _PyCrossInterpreterData_Release(&item->data);

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -289,17 +289,8 @@ _PyPreConfig_InitCompatConfig(PyPreConfig *config)
     config->coerce_c_locale_warn = 0;
 
     config->dev_mode = -1;
-#ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
-    /* bpo-40512: pymalloc is not compatible with subinterpreters,
-       force usage of libc malloc() which is thread-safe. */
-#ifdef Py_DEBUG
-    config->allocator = PYMEM_ALLOCATOR_MALLOC_DEBUG;
-#else
-    config->allocator = PYMEM_ALLOCATOR_MALLOC;
-#endif
-#else
+    
     config->allocator = PYMEM_ALLOCATOR_NOT_SET;
-#endif
 #ifdef MS_WINDOWS
     config->legacy_windows_fs_encoding = -1;
 #endif


### PR DESCRIPTION
two changes:
1. support pymalloc for subinterpreters. each subinterpreter has pymalloc_state

2. _copy_raw_string api alloc memory use PyMem_RawFree and PyMem_RawMalloc.

I extend _xxsubinterpretermodule.c to support call any function in sub interpreter. 
when i need return result from sub interpreter call. 

1. i need create item->name in shared item. will use pymem_malloc api to manage memory. when with_pymalloc macro defined, it will create memory and bound to interpreter(iterp1) pymalloc state.

2. after switch interpreter state, now in iterp2 state, get return value from shareditem, and i need free shared item. but item->name memory managed by interp1 pymalloc state. if i want to free them, i need switch to interpreter state 1.  it's complicated. 

so i think, in _sharednsitem_init _copy_raw_string,  item->name need malloc by PyMem_RawAPI. easy to management.

```
static int
_sharednsitem_init(struct _sharednsitem *item, PyObject *key, PyObject *value)
{
    item->name = _copy_raw_string(key);

...

static char *
_copy_raw_string(PyObject *strobj)
{
    const char *str = PyUnicode_AsUTF8(strobj);
    if (str == NULL) {
        return NULL;
    }
    char *copied = PyMem_Malloc(strlen(str)+1);
    if (copied == NULL) {
        PyErr_NoMemory();
        return NULL;
    }
    strcpy(copied, str);
    return copied;
}

```


```
_sharedns *result_shread = _sharedns_new(1);


#ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
    // Switch to interpreter.
    PyThreadState *new_tstate = PyInterpreterState_ThreadHead(interp);
    PyThreadState *save1 = PyEval_SaveThread();

    (void)PyThreadState_Swap(new_tstate);
#else
    // Switch to interpreter.
    PyThreadState *save_tstate = NULL;
    if (interp != PyInterpreterState_Get()) {
        // XXX Using the "head" thread isn't strictly correct.
        PyThreadState *tstate = PyInterpreterState_ThreadHead(interp);
        // XXX Possible GILState issues?
        save_tstate = PyThreadState_Swap(tstate);
    }
#endif
    
    PyObject *module = PyImport_ImportModule(PyUnicode_AsUTF8(module_name));
    PyObject *function = PyObject_GetAttr(module, function_name);
    
    result = PyObject_Call(function, args, kwargs);

    if (result == NULL) {
        // exception handler
        ...
    }

    if (result && _sharednsitem_init(&result_shread->items[0], PyUnicode_FromString("result"), result) != 0) {
        PyErr_Format(RunFailedError, "interp_call_function result convert to shared failed");
        return NULL;;
    }
#ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
    // Switch back.
    PyEval_RestoreThread(save1);
#else
    // Switch back.
    if (save_tstate != NULL) {
        PyThreadState_Swap(save_tstate);
    }
#endif
    // ...

    if (result) {
        result = _PyCrossInterpreterData_NewObject(&result_shread->items[0].data);
        _sharedns_free(result_shread);
    }
```


<!-- issue-number: [bpo-43313](https://bugs.python.org/issue43313) -->
https://bugs.python.org/issue43313
<!-- /issue-number -->

<!-- gh-issue-number: gh-87479 -->
* Issue: gh-87479
<!-- /gh-issue-number -->
