### PR TITLE
bpo-42246: Mark POP_TOP at end of expression statement as artificial, to conform to PEP 626.

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -786,6 +786,14 @@ if 1:
                 self.assertIn('LOAD_', opcodes[0].opname)
                 self.assertEqual('RETURN_VALUE', opcodes[1].opname)
 
+    def test_lineno_procedure_call(self):
+        def call():
+            (
+                print()
+            )
+        line1 = call.__code__.co_firstlineno + 1
+        assert line1 not in [line for (_, _, line) in call.__code__.co_lines()]
+
     def test_lineno_after_implicit_return(self):
         TRUE = True
         # Don't use constant True or False, as compiler will remove test

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3397,6 +3397,8 @@ compiler_visit_stmt_expr(struct compiler *c, expr_ty value)
     }
 
     VISIT(c, expr, value);
+    /* Mark POP_TOP as artificial */
+    c->u->u_lineno = -1;
     ADDOP(c, POP_TOP);
     return 1;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-42246](https://bugs.python.org/issue42246) -->
https://bugs.python.org/issue42246
<!-- /issue-number -->
