### PR TITLE
bpo-42914: pprint.pprint function displays integer with underscores

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -36,7 +36,7 @@ The :mod:`pprint` module defines one class:
 .. index:: single: ...; placeholder
 
 .. class:: PrettyPrinter(indent=1, width=80, depth=None, stream=None, *, \
-                         compact=False, sort_dicts=True, underscore_numbers=True)
+                         compact=False, sort_dicts=True, underscore_numbers=False)
 
    Construct a :class:`PrettyPrinter` instance.  This constructor understands
    several keyword parameters.  An output stream may be set using the *stream*
@@ -56,9 +56,9 @@ The :mod:`pprint` module defines one class:
    as will fit within the *width* will be formatted on each output line. If
    *sort_dicts* is true (the default), dictionaries will be formatted with their
    keys sorted, otherwise they will display in insertion order.  If
-   *underscore_numbers* is true (the default), integers will be formatted with
+   *underscore_numbers* is true, integers will be formatted with
    ```_``` character for a thousands separator, otherwise underscores are not
-   displayed.
+   displayed (the default).
 
    .. versionchanged:: 3.4
       Added the *compact* parameter.
@@ -96,7 +96,7 @@ The :mod:`pprint` module defines one class:
 The :mod:`pprint` module also provides several shortcut functions:
 
 .. function:: pformat(object, indent=1, width=80, depth=None, *, \
-                      compact=False, sort_dicts=True, underscore_numbers=True)
+                      compact=False, sort_dicts=True, underscore_numbers=False)
 
    Return the formatted representation of *object* as a string.  *indent*,
    *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* will be passed to the
@@ -124,7 +124,7 @@ The :mod:`pprint` module also provides several shortcut functions:
 
 
 .. function:: pprint(object, stream=None, indent=1, width=80, depth=None, *, \
-                     compact=False, sort_dicts=True, underscore_numbers=True)
+                     compact=False, sort_dicts=True, underscore_numbers=False)
 
    Prints the formatted representation of *object* on *stream*, followed by a
    newline.  If *stream* is ``None``, ``sys.stdout`` is used.  This may be used

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -36,7 +36,7 @@ The :mod:`pprint` module defines one class:
 .. index:: single: ...; placeholder
 
 .. class:: PrettyPrinter(indent=1, width=80, depth=None, stream=None, *, \
-                         compact=False, sort_dicts=True)
+                         compact=False, sort_dicts=True, underscore_numbers=True)
 
    Construct a :class:`PrettyPrinter` instance.  This constructor understands
    several keyword parameters.  An output stream may be set using the *stream*
@@ -55,7 +55,10 @@ The :mod:`pprint` module defines one class:
    will be formatted on a separate line.  If *compact* is true, as many items
    as will fit within the *width* will be formatted on each output line. If
    *sort_dicts* is true (the default), dictionaries will be formatted with their
-   keys sorted, otherwise they will display in insertion order.
+   keys sorted, otherwise they will display in insertion order.  If
+   *underscore_numbers* is true (the default), integers will be formatted with
+   ```_``` character for a thousands separator, otherwise underscores are not
+   displayed.
 
    .. versionchanged:: 3.4
       Added the *compact* parameter.
@@ -63,6 +66,8 @@ The :mod:`pprint` module defines one class:
    .. versionchanged:: 3.8
       Added the *sort_dicts* parameter.
 
+   .. versionchanged:: 3.10
+      Added the *underscore_numbers* parameter.
 
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
@@ -91,10 +96,10 @@ The :mod:`pprint` module defines one class:
 The :mod:`pprint` module also provides several shortcut functions:
 
 .. function:: pformat(object, indent=1, width=80, depth=None, *, \
-                      compact=False, sort_dicts=True)
+                      compact=False, sort_dicts=True, underscore_numbers=True)
 
    Return the formatted representation of *object* as a string.  *indent*,
-   *width*, *depth*, *compact* and *sort_dicts* will be passed to the
+   *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* will be passed to the
    :class:`PrettyPrinter` constructor as formatting parameters.
 
    .. versionchanged:: 3.4
@@ -102,6 +107,9 @@ The :mod:`pprint` module also provides several shortcut functions:
 
    .. versionchanged:: 3.8
       Added the *sort_dicts* parameter.
+
+   .. versionchanged:: 3.10
+      Added the *underscore_numbers* parameter.
 
 
 .. function:: pp(object, *args, sort_dicts=False, **kwargs)
@@ -116,13 +124,13 @@ The :mod:`pprint` module also provides several shortcut functions:
 
 
 .. function:: pprint(object, stream=None, indent=1, width=80, depth=None, *, \
-                     compact=False, sort_dicts=True)
+                     compact=False, sort_dicts=True, underscore_numbers=True)
 
    Prints the formatted representation of *object* on *stream*, followed by a
    newline.  If *stream* is ``None``, ``sys.stdout`` is used.  This may be used
    in the interactive interpreter instead of the :func:`print` function for
    inspecting values (you can even reassign ``print = pprint.pprint`` for use
-   within a scope).  *indent*, *width*, *depth*, *compact* and *sort_dicts* will
+   within a scope).  *indent*, *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* will
    be passed to the :class:`PrettyPrinter` constructor as formatting parameters.
 
    .. versionchanged:: 3.4
@@ -130,6 +138,9 @@ The :mod:`pprint` module also provides several shortcut functions:
 
    .. versionchanged:: 3.8
       Added the *sort_dicts* parameter.
+
+   .. versionchanged:: 3.10
+      Added the *underscore_numbers* parameter.
 
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -53,10 +53,11 @@ def pprint(object, stream=None, indent=1, width=80, depth=None, *,
     printer.pprint(object)
 
 def pformat(object, indent=1, width=80, depth=None, *,
-            compact=False, sort_dicts=True):
+            compact=False, sort_dicts=True, underscore_numbers=True):
     """Format a Python object into a pretty-printed representation."""
     return PrettyPrinter(indent=indent, width=width, depth=depth,
-                         compact=compact, sort_dicts=sort_dicts).pformat(object)
+                         compact=compact, sort_dicts=sort_dicts,
+                         underscore_numbers=underscore_numbers).pformat(object)
 
 def pp(object, *args, sort_dicts=False, **kwargs):
     """Pretty-print a Python object"""
@@ -102,7 +103,7 @@ def _safe_tuple(t):
 
 class PrettyPrinter:
     def __init__(self, indent=1, width=80, depth=None, stream=None, *,
-                 compact=False, sort_dicts=True):
+                 compact=False, sort_dicts=True, underscore_numbers=True):
         """Handle pretty printing operations onto a stream using a set of
         configured parameters.
 
@@ -143,6 +144,7 @@ class PrettyPrinter:
             self._stream = _sys.stdout
         self._compact = bool(compact)
         self._sort_dicts = sort_dicts
+        self._underscore_numbers = underscore_numbers
 
     def pprint(self, object):
         self._format(object, self._stream, 0, 0, {}, 0)
@@ -525,6 +527,13 @@ class PrettyPrinter:
             return repr(object), True, False
 
         r = getattr(typ, "__repr__", None)
+
+        if issubclass(typ, int):
+            if self._underscore_numbers:
+                return "{:_d}".format(object), True, False
+            else:
+                return repr(object), True, False
+
         if issubclass(typ, dict) and r is dict.__repr__:
             if not object:
                 return "{}", True, False
@@ -592,7 +601,7 @@ class PrettyPrinter:
         rep = repr(object)
         return rep, (rep and not rep.startswith('<')), False
 
-_builtin_scalars = frozenset({str, bytes, bytearray, int, float, complex,
+_builtin_scalars = frozenset({str, bytes, bytearray, float, complex,
                               bool, type(None)})
 
 def _recursion(object):

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -45,15 +45,15 @@ __all__ = ["pprint","pformat","isreadable","isrecursive","saferepr",
 
 
 def pprint(object, stream=None, indent=1, width=80, depth=None, *,
-           compact=False, sort_dicts=True, underscore_numbers=True):
+           compact=False, sort_dicts=True, underscore_numbers=False):
     """Pretty-print a Python object to a stream [default is sys.stdout]."""
     printer = PrettyPrinter(
         stream=stream, indent=indent, width=width, depth=depth,
-        compact=compact, sort_dicts=sort_dicts, underscore_numbers=True)
+        compact=compact, sort_dicts=sort_dicts, underscore_numbers=False)
     printer.pprint(object)
 
 def pformat(object, indent=1, width=80, depth=None, *,
-            compact=False, sort_dicts=True, underscore_numbers=True):
+            compact=False, sort_dicts=True, underscore_numbers=False):
     """Format a Python object into a pretty-printed representation."""
     return PrettyPrinter(indent=indent, width=width, depth=depth,
                          compact=compact, sort_dicts=sort_dicts,
@@ -103,7 +103,7 @@ def _safe_tuple(t):
 
 class PrettyPrinter:
     def __init__(self, indent=1, width=80, depth=None, stream=None, *,
-                 compact=False, sort_dicts=True, underscore_numbers=True):
+                 compact=False, sort_dicts=True, underscore_numbers=False):
         """Handle pretty printing operations onto a stream using a set of
         configured parameters.
 

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -34,6 +34,7 @@ saferepr()
 
 """
 
+import builtins
 import collections as _collections
 import re
 import sys as _sys
@@ -530,7 +531,7 @@ class PrettyPrinter:
 
         if issubclass(typ, int):
             if self._underscore_numbers:
-                return "{:_d}".format(object), True, False
+                return builtins.format(object, "_d"), True, False
             else:
                 return repr(object), True, False
 

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -45,11 +45,11 @@ __all__ = ["pprint","pformat","isreadable","isrecursive","saferepr",
 
 
 def pprint(object, stream=None, indent=1, width=80, depth=None, *,
-           compact=False, sort_dicts=True):
+           compact=False, sort_dicts=True, underscore_numbers=True):
     """Pretty-print a Python object to a stream [default is sys.stdout]."""
     printer = PrettyPrinter(
         stream=stream, indent=indent, width=width, depth=depth,
-        compact=compact, sort_dicts=sort_dicts)
+        compact=compact, sort_dicts=sort_dicts, underscore_numbers=True)
     printer.pprint(object)
 
 def pformat(object, indent=1, width=80, depth=None, *,

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -529,7 +529,7 @@ class PrettyPrinter:
 
         r = getattr(typ, "__repr__", None)
 
-        if issubclass(typ, int):
+        if issubclass(typ, int) and r is int.__repr__:
             if self._underscore_numbers:
                 return builtins.format(object, "_d"), True, False
             else:

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -34,7 +34,6 @@ saferepr()
 
 """
 
-import builtins
 import collections as _collections
 import re
 import sys as _sys
@@ -531,7 +530,7 @@ class PrettyPrinter:
 
         if issubclass(typ, int) and r is int.__repr__:
             if self._underscore_numbers:
-                return builtins.format(object, "_d"), True, False
+                return f"{object:_d}", True, False
             else:
                 return repr(object), True, False
 

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -327,6 +327,14 @@ class QueryTestCase(unittest.TestCase):
         self.assertEqual(pprint.pformat(1234567), '1_234_567')
         self.assertEqual(pprint.pformat(1234567, underscore_numbers=False), '1234567')
 
+        class Temperature(int):
+            def __new__(cls, celsius_degrees):
+                return super().__new__(Temperature, celsius_degrees)
+            def __repr__(self):
+                kelvin_degrees = self + 273.15
+                return f"{kelvin_degrees}°K"
+        self.assertEqual(pprint.pformat(Temperature(1000)), '1273.15°K')
+
     def test_sorted_dict(self):
         # Starting in Python 2.5, pprint sorts dict displays by key regardless
         # of how small the dictionary may be.

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -206,6 +206,7 @@ class QueryTestCase(unittest.TestCase):
             self.assertEqual(pprint.pformat(simple), native)
             self.assertEqual(pprint.pformat(simple, width=1, indent=0)
                              .replace('\n', ' '), native)
+            self.assertEqual(pprint.pformat(simple, underscore_numbers=True), native)
             self.assertEqual(pprint.saferepr(simple), native)
 
     def test_container_repr_override_called(self):

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -245,12 +245,12 @@ class QueryTestCase(unittest.TestCase):
              'write_io_runtime_us': 43690}
         exp = """\
 {'RPM_cal': 0,
- 'RPM_cal2': 48_059,
+ 'RPM_cal2': 48059,
  'Speed_cal': 0,
  'controldesk_runtime_us': 0,
  'main_code_runtime_us': 0,
  'read_io_runtime_us': 0,
- 'write_io_runtime_us': 43_690}"""
+ 'write_io_runtime_us': 43690}"""
         for type in [dict, dict2]:
             self.assertEqual(pprint.pformat(type(o)), exp)
 
@@ -324,8 +324,8 @@ class QueryTestCase(unittest.TestCase):
      '2']]]]]""")
 
     def test_integer(self):
-        self.assertEqual(pprint.pformat(1234567), '1_234_567')
-        self.assertEqual(pprint.pformat(1234567, underscore_numbers=False), '1234567')
+        self.assertEqual(pprint.pformat(1234567), '1234567')
+        self.assertEqual(pprint.pformat(1234567, underscore_numbers=True), '1_234_567')
 
         class Temperature(int):
             def __new__(cls, celsius_degrees):

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -323,7 +323,7 @@ class QueryTestCase(unittest.TestCase):
      '1 '
      '2']]]]]""")
 
-    def test_numbers(self):
+    def test_integer(self):
         self.assertEqual(pprint.pformat(1234567), '1_234_567')
         self.assertEqual(pprint.pformat(1234567, underscore_numbers=False), '1234567')
 

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -245,12 +245,12 @@ class QueryTestCase(unittest.TestCase):
              'write_io_runtime_us': 43690}
         exp = """\
 {'RPM_cal': 0,
- 'RPM_cal2': 48059,
+ 'RPM_cal2': 48_059,
  'Speed_cal': 0,
  'controldesk_runtime_us': 0,
  'main_code_runtime_us': 0,
  'read_io_runtime_us': 0,
- 'write_io_runtime_us': 43690}"""
+ 'write_io_runtime_us': 43_690}"""
         for type in [dict, dict2]:
             self.assertEqual(pprint.pformat(type(o)), exp)
 
@@ -322,6 +322,10 @@ class QueryTestCase(unittest.TestCase):
       3],
      '1 '
      '2']]]]]""")
+
+    def test_numbers(self):
+        self.assertEqual(pprint.pformat(1234567), '1_234_567')
+        self.assertEqual(pprint.pformat(1234567, underscore_numbers=False), '1234567')
 
     def test_sorted_dict(self):
         # Starting in Python 2.5, pprint sorts dict displays by key regardless

--- a/Misc/NEWS.d/next/Library/2021-03-14-21-47-28.bpo-42914.9U1o33.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-14-21-47-28.bpo-42914.9U1o33.rst
@@ -1,3 +1,3 @@
-pprint.pprint() displays integers with thousands separated by an underscore
-character to improve readability (for example 1_000_000 instead of 1000000)
-if underscore_numbers parameter is enabled.
+:func:`pprint.pprint` gains a new boolean ``underscore_numbers`` optional
+argument to emit integers with thousands separated by an underscore character
+for improved readability (for example ``1_000_000`` instead of ``1000000``).

--- a/Misc/NEWS.d/next/Library/2021-03-14-21-47-28.bpo-42914.9U1o33.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-14-21-47-28.bpo-42914.9U1o33.rst
@@ -1,0 +1,2 @@
+pprint.pprint() displays integers with thousands separated by an underscore
+character to improve readability (for example 1_000_000 instead of 1000000).

--- a/Misc/NEWS.d/next/Library/2021-03-14-21-47-28.bpo-42914.9U1o33.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-14-21-47-28.bpo-42914.9U1o33.rst
@@ -1,2 +1,3 @@
 pprint.pprint() displays integers with thousands separated by an underscore
-character to improve readability (for example 1_000_000 instead of 1000000).
+character to improve readability (for example 1_000_000 instead of 1000000)
+if underscore_numbers parameter is enabled.


### PR DESCRIPTION
This PR implements the separation for big integers by `_` character for better readability for `pprint.pprint()` and `pprint.pformat()`. So 123456 is displayed as '1_234_56'.

A new parameter (`underscore_numbers`) is added so this new behavior can be disabled.

<!-- issue-number: [bpo-42914](https://bugs.python.org/issue42914) -->
https://bugs.python.org/issue42914
<!-- /issue-number -->
