### PR TITLE
bpo-37820: Test that the "URL:"" schema does not work in urllib

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1600,6 +1600,19 @@ class URLopener_Tests(FakeHTTPMixin, unittest.TestCase):
             self.assertRaises(OSError, DummyURLopener().open, url)
             self.assertRaises(OSError, DummyURLopener().retrieve, url)
 
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
+    def test_local_file_open_url(self):
+        # bpo-37820, urllib must reject URL: scheme with local file
+        class DummyURLopener(urllib.request.URLopener):
+            def open_local_file(self, url):
+                return url
+        for url in ('URL:example', 'URL:/example'):
+            self.assertRaises(ValueError, urllib.request.urlopen, url)
+            self.assertRaises(ValueError, urllib.request.URLopener().open, url)
+            self.assertRaises(ValueError, urllib.request.URLopener().retrieve, url)
+            self.assertRaises(ValueError, DummyURLopener().open, url)
+            self.assertRaises(ValueError, DummyURLopener().retrieve, url)
+
 
 class RequestTests(unittest.TestCase):
     """Unit tests for urllib.request.Request."""


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37820](https://bugs.python.org/issue37820) -->
https://bugs.python.org/issue37820
<!-- /issue-number -->
