### PR TITLE
[3.9] bpo-43285: Add a What's New entry for 3.9.3.

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -1529,3 +1529,12 @@ separator key, with ``&`` as the default.  This change also affects
 functions internally. For more details, please see their respective
 documentation.
 (Contributed by Adam Goldschmidt, Senthil Kumaran and Ken Jin in :issue:`42967`.)
+
+Notable changes in Python 3.9.3
+===============================
+
+A security fix alters the :class:`ftplib.FTP` behavior to not trust the
+IPv4 address sent from the remote server when setting up a passive data
+channel.  We reuse the ftp servers IP address instead.  For unusual code
+requiring the old behavior, set a ``trust_server_pasv_ipv4_address``
+attribute on your FTP instance to ``True``.  (See :issue:`43285`)

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -1535,6 +1535,6 @@ Notable changes in Python 3.9.3
 
 A security fix alters the :class:`ftplib.FTP` behavior to not trust the
 IPv4 address sent from the remote server when setting up a passive data
-channel.  We reuse the ftp servers IP address instead.  For unusual code
+channel.  We reuse the ftp server IP address instead.  For unusual code
 requiring the old behavior, set a ``trust_server_pasv_ipv4_address``
 attribute on your FTP instance to ``True``.  (See :issue:`43285`)


### PR DESCRIPTION
Covers the ftplib security fix.


<!-- issue-number: [bpo-43285](https://bugs.python.org/issue43285) -->
https://bugs.python.org/issue43285
<!-- /issue-number -->
