### PR TITLE
[3.8] bpo-43285: Whats New entry for 3.8.9.

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2270,6 +2270,6 @@ Notable changes in Python 3.8.9
 
 A security fix alters the :class:`ftplib.FTP` behavior to not trust the
 IPv4 address sent from the remote server when setting up a passive data
-channel.  We reuse the ftp servers IP address instead.  For unusual code
+channel.  We reuse the ftp server IP address instead.  For unusual code
 requiring the old behavior, set a ``trust_server_pasv_ipv4_address``
 attribute on your FTP instance to ``True``.  (See :issue:`43285`)

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2264,3 +2264,12 @@ separator key, with ``&`` as the default.  This change also affects
 functions internally. For more details, please see their respective
 documentation.
 (Contributed by Adam Goldschmidt, Senthil Kumaran and Ken Jin in :issue:`42967`.)
+
+Notable changes in Python 3.8.9
+===============================
+
+A security fix alters the :class:`ftplib.FTP` behavior to not trust the
+IPv4 address sent from the remote server when setting up a passive data
+channel.  We reuse the ftp servers IP address instead.  For unusual code
+requiring the old behavior, set a ``trust_server_pasv_ipv4_address``
+attribute on your FTP instance to ``True``.  (See :issue:`43285`)


### PR DESCRIPTION
covers the ftplib security fix.

<!-- issue-number: [bpo-43285](https://bugs.python.org/issue43285) -->
https://bugs.python.org/issue43285
<!-- /issue-number -->
