### PR TITLE
gh-62432: Return unsuccessfully if no unit tests were run

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -2012,12 +2012,15 @@ Loading and running tests
 
    .. method:: wasSuccessful()
 
-      Return ``True`` if all tests run so far have passed, otherwise returns
-      ``False``.
+      Return ``True`` if all tests run so far have passed and at least one test
+      was found, otherwise returns ``False``.
 
       .. versionchanged:: 3.4
          Returns ``False`` if there were any :attr:`unexpectedSuccesses`
          from tests marked with the :func:`expectedFailure` decorator.
+
+      .. versionchanged:: 3.10b1
+         Returns ``False`` if no tests were found.
 
    .. method:: stop()
 

--- a/Lib/unittest/result.py
+++ b/Lib/unittest/result.py
@@ -159,10 +159,15 @@ class TestResult(object):
 
     def wasSuccessful(self):
         """Tells whether or not this result was a success."""
+        # testsRun > 0 ensures that we do not return success if test
+        # discovery failed.  We additionally need to check skipped list
+        # since class/module-level skips do not count towards testsRun.
+        #
         # The hasattr check is for test_result's OldResult test.  That
         # way this method works on objects that lack the attribute.
         # (where would such result instances come from? old stored pickles?)
-        return ((len(self.failures) == len(self.errors) == 0) and
+        return ((self.testsRun > 0 or len(getattr(self, 'skipped', ())) > 0) and
+                (len(self.failures) == len(self.errors) == 0) and
                 (not hasattr(self, 'unexpectedSuccesses') or
                  len(self.unexpectedSuccesses) == 0))
 

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -184,8 +184,11 @@ class TextTestRunner(object):
         if hasattr(result, 'separator2'):
             self.stream.writeln(result.separator2)
         run = result.testsRun
-        self.stream.writeln("Ran %d test%s in %.3fs" %
-                            (run, run != 1 and "s" or "", timeTaken))
+        if run > 0 or len(result.skipped) > 0:
+            self.stream.writeln("Ran %d test%s in %.3fs" %
+                                (run, run != 1 and "s" or "", timeTaken))
+        else:
+            self.stream.writeln("No tests found")
         self.stream.writeln()
 
         expectedFails = unexpectedSuccesses = skipped = 0

--- a/Misc/NEWS.d/next/Library/2021-03-16-13-15-44.bpo-18232.0CSR5D.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-16-13-15-44.bpo-18232.0CSR5D.rst
@@ -1,0 +1,2 @@
+:func:`unittest.TestResult.wasSuccessful` now returns False if no tests were
+found.


### PR DESCRIPTION
Change unittest.TestResult.wasSuccessful() to return False if no tests
were found.  Update the runner to explicitly print "No tests found"
to indicate the problem better.  Add a test ensuring that
wasSuccessful() still returns True if all tests were skipped, including
the special case of SkipTest exception in setUpClass() method.

This aids greatly with automated testing where an unexpected breakage
of test discovery could not be caught cleanly, as the test runner
returned success if no tests were found.  This is unlikely to be
the expected behavior in real usage.


<!-- issue-number: [bpo-18232](https://bugs.python.org/issue18232) -->
https://bugs.python.org/issue18232
<!-- /issue-number -->


<!-- gh-issue-number: gh-62432 -->
* Issue: gh-62432
<!-- /gh-issue-number -->
