### PR TITLE
[3.9] bpo-43499: Restrict co_code to be under INT_MAX in codeobject (GH-20628)

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -166,6 +166,14 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
         return NULL;
     }
 
+    /* Make sure that code is indexable with an int, this is
+       a long running assumption in ceval.c and many parts of
+       the interpreter. */
+    if (PyBytes_GET_SIZE(code) > INT_MAX) {
+        PyErr_SetString(PyExc_OverflowError, "co_code larger than INT_MAX");
+        return NULL;
+    }
+
     /* Check for any inner or outer closure references */
     n_cellvars = PyTuple_GET_SIZE(cellvars);
     if (!n_cellvars && !PyTuple_GET_SIZE(freevars)) {

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -397,7 +397,9 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         return -1;
     }
 
-    int len = PyBytes_GET_SIZE(f->f_code->co_code)/sizeof(_Py_CODEUNIT);
+    /* PyCode_NewWithPosOnlyArgs limits co_code to be under INT_MAX so this
+     * should never overflow. */
+    int len = (int)(PyBytes_GET_SIZE(f->f_code->co_code) / sizeof(_Py_CODEUNIT));
     int *lines = marklines(f->f_code, len);
     if (lines == NULL) {
         return -1;


### PR DESCRIPTION
Backport of https://github.com/python/cpython/pull/20628 to the 3.9 branch as requested by Serhiy.

<!-- issue-number: [bpo-43499](https://bugs.python.org/issue43499) -->
https://bugs.python.org/issue43499
<!-- /issue-number -->
