### PR TITLE
bpo-42246: Mention that code.co_lnotab is deprecated in what's new for 3.10.

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -175,6 +175,8 @@ Tracing events, with the correct line number, are generated for all lines of cod
 
 The ``f_lineo`` attribute of frame objects will always contain the expected line number.
 
+The ``co_lnotab`` attribute of code objects is deprecated and will be removed in 3.12.
+Code that needs to convert from offset to line number should use the new ``co_lines()`` method instead.
 
 PEP 634: Structural Pattern Matching
 ------------------------------------


### PR DESCRIPTION


<!-- issue-number: [bpo-42246](https://bugs.python.org/issue42246) -->
https://bugs.python.org/issue42246
<!-- /issue-number -->
