### PR TITLE
bpo-43244: Remove PyAST_Validate() function

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1353,3 +1353,8 @@ Removed
   Python already implicitly installs signal handlers: see
   :c:member:`PyConfig.install_signal_handlers`.
   (Contributed by Victor Stinner in :issue:`41713`.)
+
+* Remove the ``PyAST_Validate()`` function. It is no longer possible to build a
+  AST object (``mod_ty`` type) with the public C API. The function was already
+  excluded from the limited C API (:pep:`384`).
+  (Contributed by Victor Stinner in :issue:`43244`.)

--- a/Include/ast.h
+++ b/Include/ast.h
@@ -7,8 +7,6 @@ extern "C" {
 
 #include "Python-ast.h"   /* mod_ty */
 
-PyAPI_FUNC(int) PyAST_Validate(mod_ty);
-
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -10,6 +10,8 @@ extern "C" {
 
 #include "Python-ast.h"           // expr_ty
 
+extern int _PyAST_Validate(mod_ty);
+
 /* _PyAST_ExprAsUnicode is defined in ast_unparse.c */
 extern PyObject* _PyAST_ExprAsUnicode(expr_ty);
 

--- a/Misc/NEWS.d/next/C API/2021-03-17-23-20-07.bpo-43244.diyn2C.rst
+++ b/Misc/NEWS.d/next/C API/2021-03-17-23-20-07.bpo-43244.diyn2C.rst
@@ -1,0 +1,3 @@
+Remove the ``PyAST_Validate()`` function. It is no longer possible to build a
+AST object (``mod_ty`` type) with the public C API. The function was already
+excluded from the limited C API (:pep:`384`). Patch by Victor Stinner.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include "pycore_ast.h"           // _PyAST_Validate()
 #include <errcode.h>
 #include "tokenizer.h"
 
@@ -1271,7 +1272,7 @@ _PyPegen_run_parser(Parser *p)
         p->start_rule == Py_file_input ||
         p->start_rule == Py_eval_input)
     {
-        if (!PyAST_Validate(res)) {
+        if (!_PyAST_Validate(res)) {
             return NULL;
         }
     }

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -551,7 +551,7 @@ validate_exprs(asdl_expr_seq *exprs, expr_context_ty ctx, int null_ok)
 }
 
 int
-PyAST_Validate(mod_ty mod)
+_PyAST_Validate(mod_ty mod)
 {
     int res = 0;
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include "ast.h"
 #undef Yield   /* undefine macro conflicting with <winbase.h> */
+#include "pycore_ast.h"           // _PyAST_Validate()
 #include "pycore_object.h"        // _Py_AddToAllObjects()
 #include "pycore_pyerrors.h"      // _PyErr_NoMemory()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
@@ -835,7 +836,7 @@ builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
                 PyArena_Free(arena);
                 goto error;
             }
-            if (!PyAST_Validate(mod)) {
+            if (!_PyAST_Validate(mod)) {
                 PyArena_Free(arena);
                 goto error;
             }


### PR DESCRIPTION
Rename PyAST_Validate() function to _PyAST_Validate() and move it to
the internal C API. Don't export the function anymore: replace
PyAPI_FUNC() with extern. The function was excluded from the limited
C API (PEP 384).

The function was added in [bpo-12575](https://bugs.python.org/issue12575) by
the commit 832bfe2ebd5ecfa92031cd40c8b41835ba90487f.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43244](https://bugs.python.org/issue43244) -->
https://bugs.python.org/issue43244
<!-- /issue-number -->
