### PR TITLE
bpo-43534: fixes simpledialog not transient to default root

### DIFF
--- a/Lib/tkinter/simpledialog.py
+++ b/Lib/tkinter/simpledialog.py
@@ -109,8 +109,8 @@ class Dialog(Toplevel):
         # If the parent is not viewable, don't
         # make the child transient, or else it
         # would be opened withdrawn
-        if parent is not None and parent.winfo_viewable():
-            self.transient(parent)
+        if master is not None and master.winfo_viewable():
+            self.transient(master)
 
         if title:
             self.title(title)

--- a/Lib/tkinter/simpledialog.py
+++ b/Lib/tkinter/simpledialog.py
@@ -115,7 +115,7 @@ class Dialog(Toplevel):
         if title:
             self.title(title)
 
-        self.parent = parent
+        self.parent = master
 
         self.result = None
 
@@ -130,7 +130,7 @@ class Dialog(Toplevel):
 
         self.protocol("WM_DELETE_WINDOW", self.cancel)
 
-        _place_window(self, parent)
+        _place_window(self, master)
 
         self.initial_focus.focus_set()
 
@@ -195,7 +195,7 @@ class Dialog(Toplevel):
     def cancel(self, event=None):
 
         # put focus back to the parent window
-        if self.parent is not None:
+        if self.parent is not None and self.parent.winfo_viewable():
             self.parent.focus_set()
         self.destroy()
 

--- a/Misc/NEWS.d/next/Library/2021-03-18-11-20-50.bpo-43534.D2ul4c.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-18-11-20-50.bpo-43534.D2ul4c.rst
@@ -1,0 +1,1 @@
+Fixes a regression with simpledialog which caused dialogs to not be transient to the default root.


### PR DESCRIPTION
Fixes a regression with 3d569fd6 affecting turtle dialogs.

<!-- issue-number: [bpo-43534](https://bugs.python.org/issue43534) -->
https://bugs.python.org/issue43534
<!-- /issue-number -->
