### PR TITLE
bpo-43541: Fix PyEval_EvalCodeEx() regression

### DIFF
--- a/Misc/NEWS.d/next/C API/2021-03-18-12-44-33.bpo-43541.ICigzd.rst
+++ b/Misc/NEWS.d/next/C API/2021-03-18-12-44-33.bpo-43541.ICigzd.rst
@@ -1,0 +1,2 @@
+Fix a ``PyEval_EvalCodeEx()`` regression: fix reference counting on
+builtins. Patch by Victor Stinner.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -847,7 +847,7 @@ PyFrameObject*
 PyFrame_New(PyThreadState *tstate, PyCodeObject *code,
             PyObject *globals, PyObject *locals)
 {
-    PyObject *builtins = _PyEval_BuiltinsFromGlobals(tstate, globals);
+    PyObject *builtins = _PyEval_BuiltinsFromGlobals(tstate, globals); // borrowed ref
     if (builtins == NULL) {
         return NULL;
     }

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -50,7 +50,7 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
     }
     Py_XINCREF(module);
 
-    builtins = _PyEval_BuiltinsFromGlobals(tstate, globals);
+    builtins = _PyEval_BuiltinsFromGlobals(tstate, globals); // borrowed ref
     if (builtins == NULL) {
         goto error;
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1127,7 +1127,7 @@ PyEval_EvalCode(PyObject *co, PyObject *globals, PyObject *locals)
     if (locals == NULL) {
         locals = globals;
     }
-    PyObject *builtins = _PyEval_BuiltinsFromGlobals(tstate, globals);
+    PyObject *builtins = _PyEval_BuiltinsFromGlobals(tstate, globals); // borrowed ref
     if (builtins == NULL) {
         return NULL;
     }
@@ -5140,12 +5140,11 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
     if (defaults == NULL) {
         return NULL;
     }
-    PyObject *builtins = _PyEval_BuiltinsFromGlobals(tstate, globals);
+    PyObject *builtins = _PyEval_BuiltinsFromGlobals(tstate, globals); // borrowed ref
     if (builtins == NULL) {
         Py_DECREF(defaults);
         return NULL;
     }
-    assert ((((PyCodeObject *)_co)->co_flags & (CO_NEWLOCALS | CO_OPTIMIZED)) == 0);
     if (locals == NULL) {
         locals = globals;
     }
@@ -5208,7 +5207,6 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
     }
 fail:
     Py_DECREF(defaults);
-    Py_DECREF(builtins);
     return res;
 }
 


### PR DESCRIPTION
* Remove an assertion which required CO_NEWLOCALS and CO_OPTIMIZED
  code flags. It is ok to call this function on a code with these
  flags set.
* Fix reference counting on builtins: remove Py_DECREF().
  Fix regression introduced in the
  commit 46496f9d12582bf11f4911ad0f23315d6f277907.

Add also a comment to document that _PyEval_BuiltinsFromGlobals()
returns a borrowed reference.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43541](https://bugs.python.org/issue43541) -->
https://bugs.python.org/issue43541
<!-- /issue-number -->
