### PR TITLE
gh-67955: Force the use of the default locale in add_gcc_paths()

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-03-18-06-31-37.bpo-23767.3OMrM4.rst
+++ b/Misc/NEWS.d/next/Build/2021-03-18-06-31-37.bpo-23767.3OMrM4.rst
@@ -1,0 +1,2 @@
+Force the use of the default locale in the ``add_gcc_paths()`` function in
+setup.py when parsing the output of ``gcc -v -E``.

--- a/setup.py
+++ b/setup.py
@@ -732,7 +732,8 @@ class PyBuildExt(build_ext):
         tmpfile = os.path.join(self.build_temp, 'ccpaths')
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        ret = run_command('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
+        ret = run_command('LC_ALL=C %s -E -v - </dev/null 2>%s 1>/dev/null'
+                          % (cc, tmpfile))
         is_gcc = False
         is_clang = False
         in_incdirs = False


### PR DESCRIPTION
Force the use of the default locale in the add_gcc_paths() function
in setup.py when parsing the output of `gcc -v -E`.  If the default
locale is not used, the output of gcc is localized and the output
parsing fails when cross compiling on a localized system.

<!-- issue-number: [bpo-23767](https://bugs.python.org/issue23767) -->
https://bugs.python.org/issue23767
<!-- /issue-number -->


<!-- gh-issue-number: gh-67955 -->
* Issue: gh-67955
<!-- /gh-issue-number -->
