### PR TITLE
Doc: io: Remove "In-memory streams" section

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -106,6 +106,16 @@ stream by opening a file in binary mode with buffering disabled::
 The raw stream API is described in detail in the docs of :class:`RawIOBase`.
 
 
+In-memory streams
+^^^^^^^^^^^^^^^^^
+
+It is also possible to use a :class:`str` or :term:`bytes-like object` as a
+file for both reading and writing.  For strings :class:`StringIO` can be used
+like a file opened in text mode.  :class:`BytesIO` can be used like a file
+opened in binary mode.  Both provide full read-write capabilities with random
+access.
+
+
 High-level Module Interface
 ---------------------------
 
@@ -153,16 +163,6 @@ High-level Module Interface
 
    An exception inheriting :exc:`OSError` and :exc:`ValueError` that is raised
    when an unsupported operation is called on a stream.
-
-
-In-memory streams
-^^^^^^^^^^^^^^^^^
-
-It is also possible to use a :class:`str` or :term:`bytes-like object` as a
-file for both reading and writing.  For strings :class:`StringIO` can be used
-like a file opened in text mode.  :class:`BytesIO` can be used like a file
-opened in binary mode.  Both provide full read-write capabilities with random
-access.
 
 
 .. seealso::

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -106,16 +106,6 @@ stream by opening a file in binary mode with buffering disabled::
 The raw stream API is described in detail in the docs of :class:`RawIOBase`.
 
 
-In-memory streams
-^^^^^^^^^^^^^^^^^
-
-It is also possible to use a :class:`str` or :term:`bytes-like object` as a
-file for both reading and writing.  For strings :class:`StringIO` can be used
-like a file opened in text mode.  :class:`BytesIO` can be used like a file
-opened in binary mode.  Both provide full read-write capabilities with random
-access.
-
-
 High-level Module Interface
 ---------------------------
 


### PR DESCRIPTION
This section looks be misplaced. It was written in b530e14.