### PR TITLE
bpo-41718: regrtest saved_test_environment avoids imports

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -211,6 +211,10 @@ def _test_module(the_module):
     support.run_unittest(tests)
 
 
+def save_env(ns, test_name):
+    return saved_test_environment(test_name, ns.verbose, ns.quiet, pgo=ns.pgo)
+
+
 def _runtest_inner2(ns, test_name):
     # Load the test function, run the test function, handle huntrleaks
     # and findleaks to detect leaks
@@ -229,12 +233,13 @@ def _runtest_inner2(ns, test_name):
         test_runner = functools.partial(_test_module, the_module)
 
     try:
-        if ns.huntrleaks:
-            # Return True if the test leaked references
-            refleak = dash_R(ns, test_name, test_runner)
-        else:
-            test_runner()
-            refleak = False
+        with save_env(ns, test_name):
+            if ns.huntrleaks:
+                # Return True if the test leaked references
+                refleak = dash_R(ns, test_name, test_runner)
+            else:
+                test_runner()
+                refleak = False
     finally:
         cleanup_test_droppings(test_name, ns.verbose)
 
@@ -268,7 +273,7 @@ def _runtest_inner(ns, test_name, display_failure=True):
     try:
         clear_caches()
 
-        with saved_test_environment(test_name, ns.verbose, ns.quiet, pgo=ns.pgo) as environment:
+        with save_env(ns, test_name):
             refleak = _runtest_inner2(ns, test_name)
     except support.ResourceDenied as msg:
         if not ns.quiet and not ns.pgo:
@@ -298,7 +303,7 @@ def _runtest_inner(ns, test_name, display_failure=True):
 
     if refleak:
         return FAILED
-    if environment.changed:
+    if support.environment_altered:
         return ENV_CHANGED
     return PASSED
 


### PR DESCRIPTION
`saved_test_environment` no longer imports modules at startup, but tries
to get them from `sys.modules`. If a module is missing, it skips the test.
It also directly sets `support.environment_altered`.

`runtest()` now creates two `saved_test_environment` instances: one before
importing the test module, one after importing it.

Removed imports from `test.libregrtest.save_env`:

* asyncio
* logging
* multiprocessing
* shutil
* sysconfig
* urllib.request
* warnings

This change may miss some bugs when a test method imports a module (ex: warnings) and the test has a side effect (ex: add a warnings filter), the side effect is not detected, because the module was not imported when Python enters the saved_test_environment context manager. But it reduces the number of modules imported by `libregrtest`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
