### PR TITLE
Documentation fix for random.gauss

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -326,7 +326,7 @@ be found in any statistics text.
 
 .. function:: gauss(mu, sigma)
 
-   Gaussian distribution.  *mu* is the mean, and *sigma* is the standard
+   Normal distribution.  *mu* is the mean, and *sigma* is the standard
    deviation.  This is slightly faster than the :func:`normalvariate` function
    defined below.
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -326,9 +326,9 @@ be found in any statistics text.
 
 .. function:: gauss(mu, sigma)
 
-   Normal distribution.  *mu* is the mean, and *sigma* is the standard
-   deviation.  This is slightly faster than the :func:`normalvariate` function
-   defined below.
+   Normal distribution, also called the Gaussian distribution.  *mu* is the mean,
+   and *sigma* is the standard deviation.  This is slightly faster than
+   the :func:`normalvariate` function defined below.
 
    Multithreading note:  When two threads call this function
    simultaneously, it is possible that they will receive the


### PR DESCRIPTION
Keep the documentation of random.gauss and random.normalvariate in line, because they represent the same thing. The current state of calling the one "Gaussian distribution" and the other "Normal distribution" can cause confusion. They are both the same distribution.