### PR TITLE
bpo-43562: fix test_ssl to skip on unreachable network

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2301,6 +2301,8 @@ class NetworkedTests(unittest.TestCase):
             rc = s.connect_ex((REMOTE_HOST, 443))
             if rc == 0:
                 self.skipTest("REMOTE_HOST responded too quickly")
+            elif rc == errno.ENETUNREACH:
+                self.skipTest("Network unreachable.")
             self.assertIn(rc, (errno.EAGAIN, errno.EWOULDBLOCK))
 
     @unittest.skipUnless(socket_helper.IPV6_ENABLED, 'Needs IPv6')


### PR DESCRIPTION
This test checks result code of the connection directly, so it never raises an exception that can be suppressed by `support.transient_internet`. Directly support skipping the test in case of unreachable network.


<!-- issue-number: [bpo-43562](https://bugs.python.org/issue43562) -->
https://bugs.python.org/issue43562
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran