### PR TITLE
[3.9] bpo-43556: Fix the attr names for ast.expr and ast.stmt in the docs

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -80,10 +80,11 @@ Node classes
                   end_col_offset
 
       Instances of :class:`ast.expr` and :class:`ast.stmt` subclasses have
-      :attr:`lineno`, :attr:`col_offset`, :attr:`lineno`, and :attr:`col_offset`
-      attributes.  The :attr:`lineno` and :attr:`end_lineno` are the first and
-      last line numbers of source text span (1-indexed so the first line is line 1)
-      and the :attr:`col_offset` and :attr:`end_col_offset` are the corresponding
+      :attr:`lineno`, :attr:`col_offset`, :attr:`end_lineno`, and
+      :attr:`end_col_offset` attributes.  The :attr:`lineno` and
+      :attr:`end_lineno` are the first and last line numbers of the source
+      text span (1-indexed so the first line is line 1), and the
+      :attr:`col_offset` and :attr:`end_col_offset` are the corresponding
       UTF-8 byte offsets of the first and last tokens that generated the node.
       The UTF-8 offset is recorded because the parser uses UTF-8 internally.
 


### PR DESCRIPTION
The lineno and col_offset attributes were duplicated.


<!-- issue-number: [bpo-43556](https://bugs.python.org/issue43556) -->
https://bugs.python.org/issue43556
<!-- /issue-number -->
