### PR TITLE
bpo-43568: Drop support for MACOSX_DEPLOYMENT_TARGET < 10.3

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -525,10 +525,10 @@ def get_platform_osx(_config_vars, osname, release, machine):
             try:
                 macrelease = tuple(int(i) for i in macrelease.split('.')[0:2])
             except ValueError:
-                macrelease = (10, 0)
+                macrelease = (10, 3)
         else:
             # assume no universal support
-            macrelease = (10, 0)
+            macrelease = (10, 3)
 
         if (macrelease >= (10, 4)) and '-arch' in cflags.strip():
             # The universal build will build fat binaries, but not on

--- a/Lib/distutils/spawn.py
+++ b/Lib/distutils/spawn.py
@@ -56,17 +56,15 @@ def spawn(cmd, search_path=1, verbose=0, dry_run=0):
             from distutils import sysconfig
             _cfg_target = sysconfig.get_config_var(
                                   'MACOSX_DEPLOYMENT_TARGET') or ''
-            if _cfg_target:
-                _cfg_target_split = [int(x) for x in _cfg_target.split('.')]
         if _cfg_target:
             # ensure that the deployment target of build process is not less
             # than that used when the interpreter was built. This ensures
             # extension modules are built with correct compatibility values
             cur_target = os.environ.get('MACOSX_DEPLOYMENT_TARGET', _cfg_target)
-            if _cfg_target_split > [int(x) for x in cur_target.split('.')]:
-                my_msg = ('$MACOSX_DEPLOYMENT_TARGET mismatch: '
-                          'now "%s" but "%s" during configure'
-                                % (cur_target, _cfg_target))
+            if [int(x) for x in cur_target.split('.')][:2] < [10, 3]:
+                my_msg = ('$MACOSX_DEPLOYMENT_TARGET too old: '
+                          'now "%s", minimum supported is "10.3"'
+                                % cur_target)
                 raise DistutilsPlatformError(my_msg)
             env = dict(os.environ,
                        MACOSX_DEPLOYMENT_TARGET=cur_target)

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1070,7 +1070,7 @@ class PosixTester(unittest.TestCase):
         # Issues 16698: OS X ABIs prior to 10.6 have limits on getgroups()
         if sys.platform == 'darwin':
             import sysconfig
-            dt = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') or '10.0'
+            dt = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') or '10.3'
             if tuple(int(n) for n in dt.split('.')[0:2]) < (10, 6):
                 raise unittest.SkipTest("getgroups(2) is broken prior to 10.6")
 

--- a/configure.ac
+++ b/configure.ac
@@ -2638,19 +2638,7 @@ then
 		   test ${dep_target_minor} -le 2
 		then
 			# building for OS X 10.0 through 10.2
-			LDSHARED='$(CC) -bundle'
-			LDCXXSHARED='$(CXX) -bundle'
-			if test "$enable_framework" ; then
-				# Link against the framework. All externals should be defined.
-				BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-				LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-				LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			else
-				# No framework, use the Python app as bundle-loader
-				BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDPYTHON)'
-				LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-				LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-			fi
+			AC_MSG_ERROR([MACOSX_DEPLOYMENT_TARGET too old ($MACOSX_DEPLOYMENT_TARGET), only 10.3 or later is supported])
 		else
 			# building for OS X 10.3 and later
 			LDSHARED='$(CC) -bundle -undefined dynamic_lookup'


### PR DESCRIPTION
Allows simplifying the runtime check, which was really only there to prevent trying to use `-undefined dynamic_lookup` on OS versions where it's not supported, i.e. 10.2 and older.

<!-- issue-number: [bpo-43568](https://bugs.python.org/issue43568) -->
https://bugs.python.org/issue43568
<!-- /issue-number -->
