### PR TITLE
bpo-43574: Dont overallocate list literals

### DIFF
--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -196,6 +196,15 @@ class ListTest(list_tests.CommonTest):
         self.assertEqual(iter_size, sys.getsizeof(list([0] * 10)))
         self.assertEqual(iter_size, sys.getsizeof(list(range(10))))
 
+    @cpython_only
+    def test_overallocation(self):
+        iterable = [1,2]
+        self.assertEqual(sys.getsizeof(iterable), sys.getsizeof(list(iterable)))
+
+        # bpo-43574: Don't overallocate for list literals
+        iterable = [1,2,3]
+        self.assertEqual(sys.getsizeof(iterable), sys.getsizeof(list(iterable)))
+
     def test_count_index_remove_crashes(self):
         # bpo-38610: The count(), index(), and remove() methods were not
         # holding strong references to list elements while calling

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -224,7 +224,8 @@ class ListTest(list_tests.CommonTest):
         overalloc_amts = []
         for literal in test_literals:
             # Ensure that both list literals, and lists made from an iterable
-            # of known size use the same amount of allocation.
+            # of known size use the same amount of allocation. It will be
+            # verified later that no over-allocation occurs for list literals.
             self.assertEqual(sizeof(literal), sizeof(list(literal)))
             self.assertEqual(sizeof(literal), sizeof(list(tuple(literal))))
 
@@ -238,6 +239,15 @@ class ListTest(list_tests.CommonTest):
         # bpo-38373: initialized or grown lists are not always over-allocated.
         # Confirm that over-allocation occurs at least some of the time.
         self.assertEqual(True, any(x>0 for x in overalloc_amts))
+
+        # Empty lists should overallocate on initial append/insert (unlike
+        # list-literals)
+        l1 = []
+        l1.append(1)
+        self.assertGreater(sizeof(l1), sizeof([1]))
+        l2 = []
+        l2.insert(0, 1)
+        self.assertGreater(sizeof(l2), sizeof([1]))
 
     def test_count_index_remove_crashes(self):
         # bpo-38610: The count(), index(), and remove() methods were not

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -2,6 +2,7 @@ import sys
 from test import list_tests
 from test.support import cpython_only
 import pickle
+import struct
 import unittest
 
 class ListTest(list_tests.CommonTest):
@@ -223,9 +224,13 @@ class ListTest(list_tests.CommonTest):
 
         overalloc_amts = []
         for literal in test_literals:
+            # Direct check that list-literals do not over-allocate, by
+            # calculating the total size of used pointers.
+            total_ptr_size = len(literal) * struct.calcsize('P')
+            self.assertEqual(sizeof(literal), sizeof([]) + total_ptr_size)
+
             # Ensure that both list literals, and lists made from an iterable
-            # of known size use the same amount of allocation. It will be
-            # verified later that no over-allocation occurs for list literals.
+            # of known size, use the same amount of allocation.
             self.assertEqual(sizeof(literal), sizeof(list(literal)))
             self.assertEqual(sizeof(literal), sizeof(list(tuple(literal))))
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-21-18-51-30.bpo-43574.mteI-I.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-21-18-51-30.bpo-43574.mteI-I.rst
@@ -1,2 +1,3 @@
-Restores previous list memory behavior where lists initialized from literals
-aren't over-allocated.
+``list`` objects don't overallocate when starting empty and then extended, or
+when set to be empty.  This effectively restores previous ``list`` memory
+behavior for lists initialized from literals.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-21-18-51-30.bpo-43574.mteI-I.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-21-18-51-30.bpo-43574.mteI-I.rst
@@ -1,0 +1,2 @@
+Restores previous list memory behavior where lists initialized from literals
+aren't over-allocated.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -58,26 +58,28 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
         return 0;
     }
 
-    /* This over-allocates proportional to the list size, making room
-     * for additional growth.  The over-allocation is mild, but is
-     * enough to give linear-time amortized behavior over a long
-     * sequence of appends() in the presence of a poorly-performing
-     * system realloc().
-     * Add padding to make the allocated size multiple of 4.
-     * The growth pattern is:  0, 4, 8, 16, 24, 32, 40, 52, 64, 76, ...
-     * Note: new_allocated won't overflow because the largest possible value
-     *       is PY_SSIZE_T_MAX * (9 / 8) + 6 which always fits in a size_t.
-     */
-    new_allocated = ((size_t)newsize + (newsize >> 3) + 6) & ~(size_t)3;
-    /* Do not overallocate if the new size is closer to overallocated size
-     * than to the old size.
-     */
-    if (newsize - Py_SIZE(self) > (Py_ssize_t)(new_allocated - newsize))
-        new_allocated = ((size_t)newsize + 3) & ~(size_t)3;
-
-    /* Don't overallocate for lists that start empty or are set to empty. */
-    if (newsize == 0 || Py_SIZE(self) == 0)
+    if (newsize == 0 || Py_SIZE(self) == 0) {
+        /* Don't overallocate for lists that start empty or are set to empty. */
         new_allocated = newsize;
+    } else {
+        /* This over-allocates proportional to the list size, making room
+         * for additional growth.  The over-allocation is mild, but is
+         * enough to give linear-time amortized behavior over a long
+         * sequence of appends() in the presence of a poorly-performing
+         * system realloc().
+         * Add padding to make the allocated size multiple of 4.
+         * The growth pattern is:  0, 4, 8, 16, 24, 32, 40, 52, 64, 76, ...
+         * Note: new_allocated won't overflow because the largest possible value
+         *       is PY_SSIZE_T_MAX * (9 / 8) + 6 which always fits in a size_t.
+         */
+        new_allocated = ((size_t)newsize + (newsize >> 3) + 6) & ~(size_t)3;
+        /* Do not overallocate if the new size is closer to overallocated size
+         * than to the old size.
+         */
+        if (newsize - Py_SIZE(self) > (Py_ssize_t)(new_allocated - newsize))
+            new_allocated = ((size_t)newsize + 3) & ~(size_t)3;
+    }
+
     num_allocated_bytes = new_allocated * sizeof(PyObject *);
     items = (PyObject **)PyMem_Realloc(self->ob_item, num_allocated_bytes);
     if (items == NULL) {

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -58,7 +58,7 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
         return 0;
     }
 
-    if (newsize == 0 || Py_SIZE(self) == 0) {
+    if (Py_SIZE(self) == 0 || newsize == 0) {
         /* Don't overallocate for lists that start empty or are set to empty. */
         new_allocated = newsize;
     }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -58,8 +58,11 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
         return 0;
     }
 
-    if (Py_SIZE(self) == 0 || newsize == 0) {
-        /* Don't overallocate for lists that start empty or are set to empty. */
+    if (newsize == 0 || (Py_SIZE(self) == 0 && newsize > 1)) {
+        /* Don't overallocate empty lists that are extended by more than 1
+         * element.  This helps ensure that list-literals aren't
+         * over-allocated, but still allows it for empty-list append/insert.
+         */
         new_allocated = newsize;
     }
     else {

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -61,7 +61,8 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
     if (newsize == 0 || Py_SIZE(self) == 0) {
         /* Don't overallocate for lists that start empty or are set to empty. */
         new_allocated = newsize;
-    } else {
+    }
+    else {
         /* This over-allocates proportional to the list size, making room
          * for additional growth.  The over-allocation is mild, but is
          * enough to give linear-time amortized behavior over a long
@@ -76,8 +77,9 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
         /* Do not overallocate if the new size is closer to overallocated size
          * than to the old size.
          */
-        if (newsize - Py_SIZE(self) > (Py_ssize_t)(new_allocated - newsize))
+        if (newsize - Py_SIZE(self) > (Py_ssize_t)(new_allocated - newsize)) {
             new_allocated = ((size_t)newsize + 3) & ~(size_t)3;
+        }
     }
 
     num_allocated_bytes = new_allocated * sizeof(PyObject *);

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -75,8 +75,9 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
     if (newsize - Py_SIZE(self) > (Py_ssize_t)(new_allocated - newsize))
         new_allocated = ((size_t)newsize + 3) & ~(size_t)3;
 
-    if (newsize == 0)
-        new_allocated = 0;
+    /* Don't overallocate for lists that start empty or are set to empty. */
+    if (newsize == 0 || Py_SIZE(self) == 0)
+        new_allocated = newsize;
     num_allocated_bytes = new_allocated * sizeof(PyObject *);
     items = (PyObject **)PyMem_Realloc(self->ob_item, num_allocated_bytes);
     if (items == NULL) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Before v3.9, list literals weren't over-allocated, but this behavior regressed starting with v3.9:

Switched to initializing list literals w/ LIST_EXTEND
https://bugs.python.org/issue39320
https://github.com/python/cpython/pull/17984

Commit where over-allocation of list literals first appeared
https://bugs.python.org/issue38328
https://github.com/python/cpython/pull/17114
https://github.com/python/cpython/commit/6dd9b64770af8905bef293c81d541eaaf8d8df52

This changes to the original behavior of not over-allocating lists for list literals, by not over-allocating any 0-length list that is extended.  Technically this is a change in behavior, as lists that are initialized to length 0, and then immediately extended, will not be over-allocated on that initial extension.  This change in behavior is likely innocuous, and possibly desirable, whereas the long-standing Python behavior of not using over-allocation for list literals is almost certainly desired.

Adds a test_overallocation test for lists to find regressions (assuming the regression doesn't alter the behavior of both the list-literal and list-initialization from a known length).

<!-- issue-number: [bpo-43574](https://bugs.python.org/issue43574) -->
https://bugs.python.org/issue43574
<!-- /issue-number -->
