### PR TITLE
bpo-43575: Use PEP 590 vectorcall to speed up map()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-21-12-26-32.bpo-43575.pl-nSg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-21-12-26-32.bpo-43575.pl-nSg.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``map()`` by using the :pep:`590` ``vectorcall`` calling
+convention. Patch by Dong-hee Na.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43575](https://bugs.python.org/issue43575) -->
https://bugs.python.org/issue43575
<!-- /issue-number -->
