### PR TITLE
bpo-43588: fix sysmodule.c use static variables under building under building Python with --with-experimental-isolated-subinterpreters may cause crash

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -695,7 +695,6 @@ sys_displayhook(PyObject *module, PyObject *o)
 {
     PyObject *outf;
     PyObject *builtins;
-    static PyObject *newline = NULL;
     PyThreadState *tstate = _PyThreadState_GET();
 
     builtins = _PyImport_GetModuleId(&PyId_builtins);
@@ -736,11 +735,13 @@ sys_displayhook(PyObject *module, PyObject *o)
             return NULL;
         }
     }
-    if (newline == NULL) {
-        newline = PyUnicode_FromString("\n");
-        if (newline == NULL)
-            return NULL;
+
+    PyObject *newline = PyUnicode_FromString("\n");
+    if (newline == NULL)
+    {
+        return NULL;
     }
+
     if (PyFile_WriteObject(newline, outf, Py_PRINT_RAW) != 0)
         return NULL;
     if (_PyObject_SetAttrId(builtins, &PyId__, o) != 0)


### PR DESCRIPTION
https://bugs.python.org/issue43588

fix
```
./Python/sysmodule.c:    static PyObject *newline = NULL;
```

<!-- issue-number: [bpo-43588](https://bugs.python.org/issue43588) -->
https://bugs.python.org/issue43588
<!-- /issue-number -->
