### PR TITLE
bpo-17792: more accurate error message for UnboundLocalError

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-22-17-50-30.bpo-17792._zssjS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-22-17-50-30.bpo-17792._zssjS.rst
@@ -1,1 +1,1 @@
-More accurate error message for UnboundLocalError: local variable could have been referenced after deletion, rather than before assignment.
+More accurate error messages for access of unbound locals or free vars.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-22-17-50-30.bpo-17792._zssjS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-22-17-50-30.bpo-17792._zssjS.rst
@@ -1,0 +1,1 @@
+More accurate error message for UnboundLocalError: local variable could have been referenced after deletion, rather than before assignment.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -103,7 +103,7 @@ static int get_exception_handler(PyCodeObject *, int, int*, int*, int*);
 #define UNBOUNDLOCAL_ERROR_MSG \
     "cannot access local variable '%s' where it is not associated with a value"
 #define UNBOUNDFREE_ERROR_MSG \
-    "accessed free variable '%.200s' where it is not associated with a" \
+    "cannot access free variable '%s' where it is not associated with a" \
     " value in enclosing scope"
 
 /* Dynamic execution profile */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -101,11 +101,9 @@ static int get_exception_handler(PyCodeObject *, int, int*, int*, int*);
 #define NAME_ERROR_MSG \
     "name '%.200s' is not defined"
 #define UNBOUNDLOCAL_ERROR_MSG \
-    "local variable '%.200s' referenced before assignment" \
-    " or after deletion"
+    "accessed local variable '%.200s' where it is not associated with a value"
 #define UNBOUNDFREE_ERROR_MSG \
-    "free variable '%.200s' referenced before assignment" \
-    " in enclosing scope"
+    "accessed free variable '%.200s' where it is not associated with a value"
 
 /* Dynamic execution profile */
 #ifdef DYNAMIC_EXECUTION_PROFILE

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -103,7 +103,8 @@ static int get_exception_handler(PyCodeObject *, int, int*, int*, int*);
 #define UNBOUNDLOCAL_ERROR_MSG \
     "accessed local variable '%.200s' where it is not associated with a value"
 #define UNBOUNDFREE_ERROR_MSG \
-    "accessed free variable '%.200s' where it is not associated with a value"
+    "accessed free variable '%.200s' where it is not associated with a" \
+    " value in enclosing scope"
 
 /* Dynamic execution profile */
 #ifdef DYNAMIC_EXECUTION_PROFILE

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -101,7 +101,7 @@ static int get_exception_handler(PyCodeObject *, int, int*, int*, int*);
 #define NAME_ERROR_MSG \
     "name '%.200s' is not defined"
 #define UNBOUNDLOCAL_ERROR_MSG \
-    "accessed local variable '%.200s' where it is not associated with a value"
+    "cannot access local variable '%s' where it is not associated with a value"
 #define UNBOUNDFREE_ERROR_MSG \
     "accessed free variable '%.200s' where it is not associated with a" \
     " value in enclosing scope"

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -101,7 +101,8 @@ static int get_exception_handler(PyCodeObject *, int, int*, int*, int*);
 #define NAME_ERROR_MSG \
     "name '%.200s' is not defined"
 #define UNBOUNDLOCAL_ERROR_MSG \
-    "local variable '%.200s' referenced before assignment"
+    "local variable '%.200s' referenced before assignment" \
+    " or after deletion"
 #define UNBOUNDFREE_ERROR_MSG \
     "free variable '%.200s' referenced before assignment" \
     " in enclosing scope"


### PR DESCRIPTION
Currently:

```
>>> def g():
...    x = 42
...    del x
...    print(x)
...
>>> g()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 4, in g
UnboundLocalError: local variable 'x' referenced before assignment
>>>
```

With this patch:

UnboundLocalError: local variable 'x' referenced before assignment or after deletion


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-17792](https://bugs.python.org/issue17792) -->
https://bugs.python.org/issue17792
<!-- /issue-number -->
