### PR TITLE
bpo-41718: Reduce libregrtest runtest imports

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -5,6 +5,7 @@ import warnings
 from inspect import isabstract
 from test import support
 from test.support import os_helper
+from test.libregrtest.utils import clear_caches
 
 try:
     from _abc import _get_dump
@@ -179,102 +180,6 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs):
             obj._abc_caches_clear()
 
     clear_caches()
-
-
-def clear_caches():
-    # Clear the warnings registry, so they can be displayed again
-    for mod in sys.modules.values():
-        if hasattr(mod, '__warningregistry__'):
-            del mod.__warningregistry__
-
-    # Flush standard output, so that buffered data is sent to the OS and
-    # associated Python objects are reclaimed.
-    for stream in (sys.stdout, sys.stderr, sys.__stdout__, sys.__stderr__):
-        if stream is not None:
-            stream.flush()
-
-    # Clear assorted module caches.
-    # Don't worry about resetting the cache if the module is not loaded
-    try:
-        distutils_dir_util = sys.modules['distutils.dir_util']
-    except KeyError:
-        pass
-    else:
-        distutils_dir_util._path_created.clear()
-    re.purge()
-
-    try:
-        _strptime = sys.modules['_strptime']
-    except KeyError:
-        pass
-    else:
-        _strptime._regex_cache.clear()
-
-    try:
-        urllib_parse = sys.modules['urllib.parse']
-    except KeyError:
-        pass
-    else:
-        urllib_parse.clear_cache()
-
-    try:
-        urllib_request = sys.modules['urllib.request']
-    except KeyError:
-        pass
-    else:
-        urllib_request.urlcleanup()
-
-    try:
-        linecache = sys.modules['linecache']
-    except KeyError:
-        pass
-    else:
-        linecache.clearcache()
-
-    try:
-        mimetypes = sys.modules['mimetypes']
-    except KeyError:
-        pass
-    else:
-        mimetypes._default_mime_types()
-
-    try:
-        filecmp = sys.modules['filecmp']
-    except KeyError:
-        pass
-    else:
-        filecmp._cache.clear()
-
-    try:
-        struct = sys.modules['struct']
-    except KeyError:
-        pass
-    else:
-        struct._clearcache()
-
-    try:
-        doctest = sys.modules['doctest']
-    except KeyError:
-        pass
-    else:
-        doctest.master = None
-
-    try:
-        ctypes = sys.modules['ctypes']
-    except KeyError:
-        pass
-    else:
-        ctypes._reset_cache()
-
-    try:
-        typing = sys.modules['typing']
-    except KeyError:
-        pass
-    else:
-        for f in typing._cleanups:
-            f()
-
-    support.gc_collect()
 
 
 def warm_caches():

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -13,7 +13,7 @@ import unittest
 from test import support
 from test.support import import_helper
 from test.support import os_helper
-from test.libregrtest.refleak import dash_R, clear_caches
+from test.libregrtest.utils import clear_caches
 from test.libregrtest.save_env import saved_test_environment
 from test.libregrtest.utils import format_duration, print_warning
 
@@ -225,6 +225,9 @@ def _runtest_inner2(ns, test_name):
     import_helper.unload(abstest)
 
     the_module = importlib.import_module(abstest)
+
+    if ns.huntrleaks:
+        from test.libregrtest.refleak import dash_R
 
     # If the test has a test_main, that will run the appropriate
     # tests.  If not, use normal unittest test loading.

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -84,3 +84,105 @@ def setup_unraisable_hook():
     global orig_unraisablehook
     orig_unraisablehook = sys.unraisablehook
     sys.unraisablehook = regrtest_unraisable_hook
+
+
+def clear_caches():
+    # Clear the warnings registry, so they can be displayed again
+    for mod in sys.modules.values():
+        if hasattr(mod, '__warningregistry__'):
+            del mod.__warningregistry__
+
+    # Flush standard output, so that buffered data is sent to the OS and
+    # associated Python objects are reclaimed.
+    for stream in (sys.stdout, sys.stderr, sys.__stdout__, sys.__stderr__):
+        if stream is not None:
+            stream.flush()
+
+    # Clear assorted module caches.
+    # Don't worry about resetting the cache if the module is not loaded
+    try:
+        distutils_dir_util = sys.modules['distutils.dir_util']
+    except KeyError:
+        pass
+    else:
+        distutils_dir_util._path_created.clear()
+
+    try:
+        re = sys.modules['re']
+    except KeyError:
+        pass
+    else:
+        re.purge()
+
+    try:
+        _strptime = sys.modules['_strptime']
+    except KeyError:
+        pass
+    else:
+        _strptime._regex_cache.clear()
+
+    try:
+        urllib_parse = sys.modules['urllib.parse']
+    except KeyError:
+        pass
+    else:
+        urllib_parse.clear_cache()
+
+    try:
+        urllib_request = sys.modules['urllib.request']
+    except KeyError:
+        pass
+    else:
+        urllib_request.urlcleanup()
+
+    try:
+        linecache = sys.modules['linecache']
+    except KeyError:
+        pass
+    else:
+        linecache.clearcache()
+
+    try:
+        mimetypes = sys.modules['mimetypes']
+    except KeyError:
+        pass
+    else:
+        mimetypes._default_mime_types()
+
+    try:
+        filecmp = sys.modules['filecmp']
+    except KeyError:
+        pass
+    else:
+        filecmp._cache.clear()
+
+    try:
+        struct = sys.modules['struct']
+    except KeyError:
+        pass
+    else:
+        struct._clearcache()
+
+    try:
+        doctest = sys.modules['doctest']
+    except KeyError:
+        pass
+    else:
+        doctest.master = None
+
+    try:
+        ctypes = sys.modules['ctypes']
+    except KeyError:
+        pass
+    else:
+        ctypes._reset_cache()
+
+    try:
+        typing = sys.modules['typing']
+    except KeyError:
+        pass
+    else:
+        for f in typing._cleanups:
+            f()
+
+    support.gc_collect()


### PR DESCRIPTION
Move clear_caches() from libregrtest.refleak to libregrtest.utils to
avoid importing libregrtest.refleak when it's not needed.

clear_caches() now only calls re.purge() if 're' is in sys.modules.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
