### PR TITLE
bpo-41718: importlib no longer imports warnings

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -54,8 +54,6 @@ _unpack_uint32 = _bootstrap_external._unpack_uint32
 # Fully bootstrapped at this point, import whatever you like, circular
 # dependencies and startup overhead minimisation permitting :)
 
-import warnings
-
 
 # Public API #########################################################
 
@@ -78,6 +76,7 @@ def find_loader(name, path=None):
     This function is deprecated in favor of importlib.util.find_spec().
 
     """
+    import warnings
     warnings.warn('Deprecated since Python 3.4. '
                   'Use importlib.util.find_spec() instead.',
                   DeprecationWarning, stacklevel=2)

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -16,7 +16,6 @@ import _imp
 import functools
 import sys
 import types
-import warnings
 
 
 def source_hash(source_bytes):
@@ -149,6 +148,7 @@ def set_package(fxn):
     """
     @functools.wraps(fxn)
     def set_package_wrapper(*args, **kwargs):
+        import warnings
         warnings.warn('The import system now takes care of this automatically.',
                       DeprecationWarning, stacklevel=2)
         module = fxn(*args, **kwargs)
@@ -168,6 +168,7 @@ def set_loader(fxn):
     """
     @functools.wraps(fxn)
     def set_loader_wrapper(self, *args, **kwargs):
+        import warnings
         warnings.warn('The import system now takes care of this automatically.',
                       DeprecationWarning, stacklevel=2)
         module = fxn(self, *args, **kwargs)
@@ -195,6 +196,7 @@ def module_for_loader(fxn):
     the second argument.
 
     """
+    import warnings
     warnings.warn('The import system now takes care of this automatically.',
                   DeprecationWarning, stacklevel=2)
     @functools.wraps(fxn)


### PR DESCRIPTION
The importlib module no longer imports warnings at startup, but only
when the deprecated find_loader() function is called.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
