### PR TITLE
bpo-41718: Disable support.testresult XML output by default

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -93,6 +93,10 @@ def setup_tests(ns):
         support.SHORT_TIMEOUT = min(support.SHORT_TIMEOUT, ns.timeout)
         support.LONG_TIMEOUT = min(support.LONG_TIMEOUT, ns.timeout)
 
+    if ns.xmlpath:
+        from test.support.testresult import RegressionTestResult
+        RegressionTestResult.USE_XML = True
+
 
 def replace_stdout():
     """Set stdout encoder error handler to backslashreplace (as stderr error

--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -9,21 +9,22 @@ import time
 import traceback
 import unittest
 
-import xml.etree.ElementTree as ET
-
 from datetime import datetime
 
 class RegressionTestResult(unittest.TextTestResult):
     separator1 = '=' * 70 + '\n'
     separator2 = '-' * 70 + '\n'
+    USE_XML = False
 
     def __init__(self, stream, descriptions, verbosity):
         super().__init__(stream=stream, descriptions=descriptions, verbosity=0)
         self.buffer = True
-        self.__suite = ET.Element('testsuite')
-        self.__suite.set('start', datetime.utcnow().isoformat(' '))
-
-        self.__e = None
+        if self.USE_XML:
+            from xml.etree import ElementTree as ET
+            self.__ET = ET
+            self.__suite = ET.Element('testsuite')
+            self.__suite.set('start', datetime.utcnow().isoformat(' '))
+            self.__e = None
         self.__start_time = None
         self.__results = []
         self.__verbose = bool(verbosity)
@@ -42,17 +43,22 @@ class RegressionTestResult(unittest.TextTestResult):
 
     def startTest(self, test):
         super().startTest(test)
-        self.__e = e = ET.SubElement(self.__suite, 'testcase')
+        if self.USE_XML:
+            self.__e = e = self.__ET.SubElement(self.__suite, 'testcase')
         self.__start_time = time.perf_counter()
         if self.__verbose:
             self.stream.write(f'{self.getDescription(test)} ... ')
             self.stream.flush()
 
     def _add_result(self, test, capture=False, **args):
+        if not self.USE_XML:
+            return
         e = self.__e
         self.__e = None
         if e is None:
             return
+        ET = self.__ET
+
         e.set('name', args.pop('name', self.__getId(test)))
         e.set('status', args.pop('status', 'run'))
         e.set('result', args.pop('result', 'completed'))
@@ -147,6 +153,8 @@ class RegressionTestResult(unittest.TextTestResult):
             self.stream.write('%s\n' % err)
 
     def get_xml_element(self):
+        if not self.USE_XML:
+            raise ValueError("USE_XML is false")
         e = self.__suite
         e.set('tests', str(self.testsRun))
         e.set('errors', str(len(self.errors)))
@@ -174,6 +182,9 @@ def get_test_runner(stream, verbosity, capture_output=False):
     return get_test_runner_class(verbosity, capture_output)(stream)
 
 if __name__ == '__main__':
+    import xml.etree.ElementTree as ET
+    RegressionTestResult.USE_XML = True
+
     class TestTests(unittest.TestCase):
         def test_pass(self):
             pass


### PR DESCRIPTION
RegressionTestResult.USE_XML must now be set to True to get the JUnit
XML output.

Reduce the number of imports when --junit-xml=FILE option is not
used: 153 => 144 (-9).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
