### PR TITLE
bpo-41718: libregrtest runtest avoids import_helper

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -11,7 +11,6 @@ import traceback
 import unittest
 
 from test import support
-from test.support import import_helper
 from test.support import os_helper
 from test.libregrtest.utils import clear_caches
 from test.libregrtest.save_env import saved_test_environment
@@ -222,7 +221,10 @@ def _runtest_inner2(ns, test_name):
     abstest = get_abs_module(ns, test_name)
 
     # remove the module from sys.module to reload it if it was already imported
-    import_helper.unload(abstest)
+    try:
+        del sys.modules[abstest]
+    except KeyError:
+        pass
 
     the_module = importlib.import_module(abstest)
 


### PR DESCRIPTION
Inline import_helper.unload() in libregrtest.runtest to avoid one
import.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
