### PR TITLE
bpo-41718: libregrtest avoids importing datetime

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -1,4 +1,3 @@
-import datetime
 import faulthandler
 import locale
 import os
@@ -150,9 +149,12 @@ class Regrtest:
 
         # add the timestamp prefix:  "0:01:05 "
         test_time = time.monotonic() - self.start_time
-        test_time = datetime.timedelta(seconds=int(test_time))
-        line = f"{test_time} {line}"
 
+        mins, secs = divmod(int(test_time), 60)
+        hours, mins = divmod(mins, 60)
+        test_time = "%d:%02d:%02d" % (hours, mins, secs)
+
+        line = f"{test_time} {line}"
         if empty:
             line = line[:-1]
 

--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -9,8 +9,6 @@ import time
 import traceback
 import unittest
 
-from datetime import datetime
-
 class RegressionTestResult(unittest.TextTestResult):
     separator1 = '=' * 70 + '\n'
     separator2 = '-' * 70 + '\n'
@@ -21,6 +19,7 @@ class RegressionTestResult(unittest.TextTestResult):
         self.buffer = True
         if self.USE_XML:
             from xml.etree import ElementTree as ET
+            from datetime import datetime
             self.__ET = ET
             self.__suite = ET.Element('testsuite')
             self.__suite.set('start', datetime.utcnow().isoformat(' '))


### PR DESCRIPTION
* libregrtest reimplements datetime.timedelta.__str__()
* support.testresult only imports datetime if USE_XML is true.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
