### PR TITLE
Simplify _exact_ratio() using duck typing

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -225,22 +225,8 @@ def _exact_ratio(x):
     x is expected to be an int, Fraction, Decimal or float.
     """
     try:
-        # Optimise the common case of floats. We expect that the most often
-        # used numeric type will be builtin floats, so try to make this as
-        # fast as possible.
-        if type(x) is float or type(x) is Decimal:
-            return x.as_integer_ratio()
-        try:
-            # x may be an int, Fraction, or Integral ABC.
-            return (x.numerator, x.denominator)
-        except AttributeError:
-            try:
-                # x may be a float or Decimal subclass.
-                return x.as_integer_ratio()
-            except AttributeError:
-                # Just give up?
-                pass
-    except (OverflowError, ValueError):
+        return x.as_integer_ratio()
+    except (AttributeError, OverflowError, ValueError):
         # float NAN or INF.
         assert not _isfinite(x)
         return (x, None)


### PR DESCRIPTION
The optional `as_integer_ratio()` does exist not for all numeric classes of the stdlib.  So, no need for type checks.

If this code does assume using types, that conform to the numbers ABC, but doesn't implement `as_integer_ratio()` - we could add a fallback to try `(x.numerator, x.denominator)` for the AttributeError.
