### PR TITLE
Completion following `[` character

### DIFF
--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -86,10 +86,16 @@ class Completer:
                 return None
 
         if state == 0:
+            fore = ''
+            if text.rfind('[') > text.rfind(']'):
+                fore, aft = text.rsplit('[')
+                fore += '['
+                text = aft
             if "." in text:
-                self.matches = self.attr_matches(text)
+                matches = self.attr_matches(text)
             else:
-                self.matches = self.global_matches(text)
+                matches = self.global_matches(text)
+            self.matches = [fore + match for match in matches]
         try:
             return self.matches[state]
         except IndexError:

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -137,5 +137,12 @@ class TestRlcompleter(unittest.TestCase):
         self.assertEqual(completer.complete('Ellipsis', 0), 'Ellipsis()')
         self.assertIsNone(completer.complete('Ellipsis', 1))
 
+    def test_square_brackets(self):
+        completer = rlcompleter.Completer({'element_one': 1, 'element_two': 2, 'word': 'complete'})
+        self.assertEqual(completer.complete('word[eleme', 0), 'word[element_one')
+        self.assertEqual(completer.complete('word[eleme', 1), 'word[element_two')
+        self.assertIsNone(completer.complete('word[eleme', 2))
+        self.assertEqual(completer.complete('"complete"[elem', 0), '"complete"[element_one')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've been trying to look at this ticket in another project, PDB++: https://github.com/pdbpp/pdbpp/issues/219

I see that it can be fixed by breaking apart the command after `[` characters in rlcompleter. Is this something that you would consider fixing as below or is the code too specific and better addressed in PDB++? As I'm not sure this is appropriate for work in rlcompleter I have not yet created a bug to associate with this PR - I'm sorry if this breaks convention.

Thank you for help.