### PR TITLE
bpo-35930: Raising an exception raised in a "future" instance will create reference cycles

### DIFF
--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -386,7 +386,11 @@ class Future(object):
 
     def __get_result(self):
         if self._exception:
-            raise self._exception
+            try:
+                raise self._exception
+            finally:
+                # Break a reference cycle with the exception in self._exception
+                self = None
         else:
             return self._result
 
@@ -426,20 +430,24 @@ class Future(object):
                 timeout.
             Exception: If the call raised then that exception will be raised.
         """
-        with self._condition:
-            if self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]:
-                raise CancelledError()
-            elif self._state == FINISHED:
-                return self.__get_result()
+        try:
+            with self._condition:
+                if self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]:
+                    raise CancelledError()
+                elif self._state == FINISHED:
+                    return self.__get_result()
 
-            self._condition.wait(timeout)
+                self._condition.wait(timeout)
 
-            if self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]:
-                raise CancelledError()
-            elif self._state == FINISHED:
-                return self.__get_result()
-            else:
-                raise TimeoutError()
+                if self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]:
+                    raise CancelledError()
+                elif self._state == FINISHED:
+                    return self.__get_result()
+                else:
+                    raise TimeoutError()
+        finally:
+            # Break a reference cycle with the exception in self._exception
+            self = None
 
     def exception(self, timeout=None):
         """Return the exception raised by the call that the future represents.

--- a/Misc/NEWS.d/next/Library/2021-03-23-17-18-56.bpo-35930.RZ51pM.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-23-17-18-56.bpo-35930.RZ51pM.rst
@@ -1,0 +1,2 @@
+Raising an exception raised in a "future" instance will create reference
+cycles.


### PR DESCRIPTION


<!-- issue-number: [bpo-35930](https://bugs.python.org/issue35930) -->
https://bugs.python.org/issue35930
<!-- /issue-number -->
