### PR TITLE
bpo-41718: runpy now imports pkgutil in functions

### DIFF
--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -16,7 +16,6 @@ import importlib.util
 import io
 import types
 import os
-from pkgutil import read_code, get_importer
 
 __all__ = [
     "run_module", "run_path",
@@ -233,6 +232,7 @@ def _get_main_module_details(error=ImportError):
 
 def _get_code_from_file(run_name, fname):
     # Check for a compiled file first
+    from pkgutil import read_code
     decoded_path = os.path.abspath(os.fsdecode(fname))
     with io.open_code(decoded_path) as f:
         code = read_code(f)
@@ -255,6 +255,7 @@ def run_path(path_name, init_globals=None, run_name=None):
     if run_name is None:
         run_name = "<run_path>"
     pkg_name = run_name.rpartition(".")[0]
+    from pkgutil import get_importer
     importer = get_importer(path_name)
     # Trying to avoid importing imp so as to not consume the deprecation warning.
     is_NullImporter = False


### PR DESCRIPTION
Reduce the number of modules imported by "python3 -m module".

The runpy module no longer imports at startup (in the module body),
but only in functions using it: _get_code_from_file() and run_path().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41718](https://bugs.python.org/issue41718) -->
https://bugs.python.org/issue41718
<!-- /issue-number -->
