### PR TITLE
bpo-31861: Fix reference leak in builtin_anext_impl()

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1660,7 +1660,10 @@ builtin_anext_impl(PyObject *module, PyObject *aiterator,
         return awaitable;
     }
 
-    return PyAnextAwaitable_New(awaitable, default_value);
+    PyObject* new_awaitable = PyAnextAwaitable_New(
+            awaitable, default_value);
+    Py_DECREF(awaitable);
+    return new_awaitable;
 }
 
 


### PR DESCRIPTION
The problem is that `PyAnextAwaitable_New` takes hard ownership on the awaitable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-31861](https://bugs.python.org/issue31861) -->
https://bugs.python.org/issue31861
<!-- /issue-number -->
