### PR TITLE
Trivial change in fractions module docs: real -> rational numbers

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -1,7 +1,7 @@
 # Originally contributed by Sjoerd Mullender.
 # Significantly modified by Jeffrey Yasskin <jyasskin at gmail.com>.
 
-"""Fraction, infinite-precision, real numbers."""
+"""Fraction, infinite-precision, rational numbers."""
 
 from decimal import Decimal
 import math


### PR DESCRIPTION
Obviously, the former was a little misleading: not only rationals
may be considered as "infinite-precision, real numbers" - but, for
example, any real finite extension of the rationals.
