### PR TITLE
bpo-43629: fix _PyRun_SimpleFileObject create __mai__ module and cache. Call this function multiple times, the attributes stored in the module dict will affect eachother.

### DIFF
--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -402,11 +402,18 @@ _PyRun_SimpleFileObject(FILE *fp, PyObject *filename, int closeit,
 {
     PyObject *m, *d, *v;
     int set_file_name = 0, ret = -1;
+    PyObject *module_name = PyUnicode_FromString("__main__");
+    PyInterpreterState *is = _PyInterpreterState_GET();
 
-    m = PyImport_AddModule("__main__");
-    if (m == NULL)
+    m = PyModule_NewObject(module_name);
+    if (m == NULL) {
         return -1;
-    Py_INCREF(m);
+    }
+    if (PyObject_SetItem(is->modules, module_name, m) != 0) {
+        Py_DECREF(m);
+        return -1;
+    }
+    
     d = PyModule_GetDict(m);
     if (_PyDict_GetItemStringWithError(d, "__file__") == NULL) {
         if (PyErr_Occurred()) {


### PR DESCRIPTION
fix _PyRun_SimpleFileObject create `__main__` module and cache. Call this function multiple times, the attributes stored in the module dict will affect eachother.

for example. 
if we run fileA, call _PyRun_SimpleFileObject will create `__main__` module, fileA add some attribute in `__main__` module dict.

now we run fileB. call _PyRun_SimpleFileObject will load cached `__main__` module. now in `__main__` module dict, we can get fileA's attribute.


dir(module), We got unexpected results
```
for name in dir(module):
    ...
```

in unittest, if we execute test, and don't exit. (unittest main.py TestProgram), set exit=False.
```
    def __init__(self, module='__main__', defaultTest=None, argv=None,
                    testRunner=None, testLoader=loader.defaultTestLoader,
                    exit=True, verbosity=1, failfast=None, catchbreak=None,
                    buffer=None, warnings=None, *, tb_locals=False):
```

then when unittest load tests. if we use _PyRun_SimpleFileObject to run unittest, it will Repeated load test cases
```
        for name in dir(module):
            obj = getattr(module, name)
            if isinstance(obj, type) and issubclass(obj, case.TestCase):
                tests.append(self.loadTestsFromTestCase(obj))
```


```
int
_PyRun_SimpleFileObject(FILE *fp, PyObject *filename, int closeit,
                        PyCompilerFlags *flags)
{
    PyObject *m, *d, *v;
    int set_file_name = 0, ret = -1;

    m = PyImport_AddModule("__main__");
    if (m == NULL)
        return -1;
    Py_INCREF(m);
    d = PyModule_GetDict(m);
```

<!-- issue-number: [bpo-43629](https://bugs.python.org/issue43629) -->
https://bugs.python.org/issue43629
<!-- /issue-number -->
