### PR TITLE
bpo-43631: Update to OpenSSL 1.1.1k

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -57,7 +57,7 @@ jobs:
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1k
 
   steps:
   - template: ./posix-steps.yml
@@ -83,7 +83,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1k
 
   steps:
   - template: ./posix-steps.yml

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -57,7 +57,7 @@ jobs:
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1k
 
   steps:
   - template: ./posix-steps.yml
@@ -83,7 +83,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1g
+    openssl_version: 1.1.1k
 
   steps:
   - template: ./posix-steps.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
-      OPENSSL_VER: 1.1.1f
+      OPENSSL_VER: 1.1.1k
     steps:
     - uses: actions/checkout@v2
     - name: Register gcc problem matcher

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
     name: 'Ubuntu (Coverage)'
     runs-on: ubuntu-latest
     env:
-      OPENSSL_VER: 1.1.1f
+      OPENSSL_VER: 1.1.1k
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 
 env:
   global:
-    - OPENSSL=1.1.1f
+    - OPENSSL=1.1.1k
     - OPENSSL_DIR="$HOME/multissl/openssl/${OPENSSL}"
     - PATH="${OPENSSL_DIR}/bin:$PATH"
     - CFLAGS="-I${OPENSSL_DIR}/include"

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -244,7 +244,7 @@ def library_recipes():
           dict(
               name="OpenSSL 1.1.1k",
               url="https://www.openssl.org/source/openssl-1.1.1k.tar.gz",
-              checksum='cccaa064ed860a2b4d1303811bf5c682',
+              checksum='c4e7d95f782b08116afa27b30393dd27',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -242,8 +242,8 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.1j",
-              url="https://www.openssl.org/source/openssl-1.1.1j.tar.gz",
+              name="OpenSSL 1.1.1k",
+              url="https://www.openssl.org/source/openssl-1.1.1k.tar.gz",
               checksum='cccaa064ed860a2b4d1303811bf5c682',
               buildrecipe=build_universal_openssl,
               configure=None,

--- a/Misc/NEWS.d/next/Build/2021-03-26-09-16-34.bpo-43631.msJyPi.rst
+++ b/Misc/NEWS.d/next/Build/2021-03-26-09-16-34.bpo-43631.msJyPi.rst
@@ -1,0 +1,1 @@
+Update macOS, Windows, and CI to OpenSSL 1.1.1k.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1i
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1k
 set libraries=%libraries%                                       sqlite-3.34.0.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.10.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.10.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1i
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1k
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.10.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -62,8 +62,8 @@
     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
     <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
     <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1i\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1i\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.1k\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1k\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -169,7 +169,7 @@ _lzma
     Homepage:
         http://tukaani.org/xz/
 _ssl
-    Python wrapper for version 1.1.1i of the OpenSSL secure sockets
+    Python wrapper for version 1.1.1k of the OpenSSL secure sockets
     library, which is downloaded from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -48,7 +48,7 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1j",
+    "1.1.1k",
     # "3.0.0-alpha12"
 ]
 


### PR DESCRIPTION
- [x] Build OpenSSL 1.1.1k for macOS
- [x] Build OpenSSL 1.1.1k for Windows

I have also updated multissl tester and various CI configurations to use latest OpenSSL. The versions were all over the place.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-43631](https://bugs.python.org/issue43631) -->
https://bugs.python.org/issue43631
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran