### PR TITLE
bpo-43620: Remove reference to os.sep from os.path.join() doc

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -310,9 +310,6 @@ the :mod:`glob` module.)
    that the result will only end in a separator if the last part is empty.  If
    a component is an absolute path, all previous components are thrown away
    and joining continues from the absolute path component.
-   
-   On Windows, the directory separator is a backslash, while on POSIX platforms
-   it is a forward slash.
 
    On Windows, the drive letter is not reset when an absolute path component
    (e.g., ``r'\foo'``) is encountered.  If a component contains a drive

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -306,11 +306,13 @@ the :mod:`glob` module.)
 
    Join one or more path components intelligently.  The return value is the
    concatenation of *path* and any members of *\*paths* with exactly one
-   directory separator (``os.sep``) following each non-empty part except the
-   last, meaning that the result will only end in a separator if the last
-   part is empty.  If a component is an absolute path, all previous
-   components are thrown away and joining continues from the absolute path
-   component.
+   directory separator following each non-empty part except the last, meaning
+   that the result will only end in a separator if the last part is empty.  If
+   a component is an absolute path, all previous components are thrown away
+   and joining continues from the absolute path component.
+   
+   On Windows, the directory separator is a backslash, while on POSIX platforms
+   it is a forward slash.
 
    On Windows, the drive letter is not reset when an absolute path component
    (e.g., ``r'\foo'``) is encountered.  If a component contains a drive


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Bug Report: https://bugs.python.org/issue43620

Summary: This patch removes a reference to `os.sep` from the `os.path.join()` documentation, since `os.sep` is not actually referenced in the implementation, and its presence in the doc can be confusing.

<!-- issue-number: [bpo-43620](https://bugs.python.org/issue43620) -->
https://bugs.python.org/issue43620
<!-- /issue-number -->
