### PR TITLE
Reformat threading macros in _tkinter

### DIFF
--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -247,11 +247,13 @@ static PyThreadState *tcl_tstate = NULL;
 
 #define ENTER_TCL \
     { PyThreadState *tstate = PyThreadState_Get(); Py_BEGIN_ALLOW_THREADS \
-        if(tcl_lock)PyThread_acquire_lock(tcl_lock, 1); tcl_tstate = tstate;
+        if(tcl_lock) { PyThread_acquire_lock(tcl_lock, 1); } \
+        tcl_tstate = tstate;
 
 #define LEAVE_TCL \
     tcl_tstate = NULL; \
-    if(tcl_lock)PyThread_release_lock(tcl_lock); Py_END_ALLOW_THREADS}
+    if(tcl_lock) { PyThread_release_lock(tcl_lock); } \
+    Py_END_ALLOW_THREADS}
 
 #define ENTER_OVERLAP \
     Py_END_ALLOW_THREADS
@@ -261,12 +263,13 @@ static PyThreadState *tcl_tstate = NULL;
 
 #define ENTER_PYTHON \
     { PyThreadState *tstate = tcl_tstate; tcl_tstate = NULL; \
-        if(tcl_lock) \
-          PyThread_release_lock(tcl_lock); PyEval_RestoreThread((tstate)); }
+        if(tcl_lock) { PyThread_release_lock(tcl_lock); } \
+        PyEval_RestoreThread((tstate)); }
 
 #define LEAVE_PYTHON \
     { PyThreadState *tstate = PyEval_SaveThread(); \
-        if(tcl_lock)PyThread_acquire_lock(tcl_lock, 1); tcl_tstate = tstate; }
+        if(tcl_lock) { PyThread_acquire_lock(tcl_lock, 1); } \
+        tcl_tstate = tstate; }
 
 #define CHECK_TCL_APPARTMENT \
     if (((TkappObject *)self)->threaded && \

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -246,34 +246,45 @@ static PyThreadState *tcl_tstate = NULL;
 #endif
 
 #define ENTER_TCL \
-    { PyThreadState *tstate = PyThreadState_Get(); Py_BEGIN_ALLOW_THREADS \
+    { \
+        PyThreadState *tstate = PyThreadState_Get(); \
+        Py_BEGIN_ALLOW_THREADS \
         if(tcl_lock) { PyThread_acquire_lock(tcl_lock, 1); } \
         tcl_tstate = tstate;
 
 #define LEAVE_TCL \
-    tcl_tstate = NULL; \
-    if(tcl_lock) { PyThread_release_lock(tcl_lock); } \
-    Py_END_ALLOW_THREADS}
+        tcl_tstate = NULL; \
+        if(tcl_lock) { PyThread_release_lock(tcl_lock); } \
+        Py_END_ALLOW_THREADS \
+    }
 
 #define ENTER_OVERLAP \
     Py_END_ALLOW_THREADS
 
 #define LEAVE_OVERLAP_TCL \
-    tcl_tstate = NULL; if(tcl_lock)PyThread_release_lock(tcl_lock); }
+        tcl_tstate = NULL; \
+        if(tcl_lock) { PyThread_release_lock(tcl_lock); } \
+    }
 
 #define ENTER_PYTHON \
-    { PyThreadState *tstate = tcl_tstate; tcl_tstate = NULL; \
+    { \
+        PyThreadState *tstate = tcl_tstate; \
+        tcl_tstate = NULL; \
         if(tcl_lock) { PyThread_release_lock(tcl_lock); } \
-        PyEval_RestoreThread((tstate)); }
+        PyEval_RestoreThread((tstate)); \
+    }
 
 #define LEAVE_PYTHON \
-    { PyThreadState *tstate = PyEval_SaveThread(); \
+    { \
+        PyThreadState *tstate = PyEval_SaveThread(); \
         if(tcl_lock) { PyThread_acquire_lock(tcl_lock, 1); } \
-        tcl_tstate = tstate; }
+        tcl_tstate = tstate; \
+    }
 
 #define CHECK_TCL_APPARTMENT \
     if (((TkappObject *)self)->threaded && \
-        ((TkappObject *)self)->thread_id != Tcl_GetCurrentThread()) { \
+        ((TkappObject *)self)->thread_id != Tcl_GetCurrentThread()) \
+    { \
         PyErr_SetString(PyExc_RuntimeError, \
                         "Calling Tcl from different apartment"); \
         return 0; \


### PR DESCRIPTION
I got a static analyzer report about misleading indentation in `_tkinter`. The indentation really is misleading, the worst example being `ENTER_PYTHON`:

```
 #define ENTER_PYTHON \
    { PyThreadState *tstate = tcl_tstate; tcl_tstate = NULL; \
        if(tcl_lock) \
          PyThread_release_lock(tcl_lock); PyEval_RestoreThread((tstate)); }
```

That last line combines:
- a conditional statement whose `if` is one line above,
- a non-conditional statement, and
- a closing bracket that does NOT belong to the `if`.

I'm well aware that style-only changes are generally frowned upon in CPython. I propose making an exception here, since the code might actually be interpreted differently by humans than by machines.

Since I'm touching this code, I went ahead and reformatted the macros more thoroughly. If that's not wanted, I can drop the second commit.
(Deliberately breaking a PEP7 rule, I kept single-statement `if` blocks on one line in macros to limit noisy `\` lines. The bodies are bracketed to make the code flow clear.)
