### PR TITLE
Clarify glob logic a bit

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -56,8 +56,9 @@ def _iglob(pathname, root_dir, dir_fd, recursive, dironly):
             if _lexists(_join(root_dir, pathname), dir_fd):
                 yield pathname
         else:
-            # Patterns ending with a slash should match only directories
-            if _isdir(_join(root_dir, dirname), dir_fd):
+            # Empty basename means that pathname ends with a slash.
+            # It should match only directories.
+            if _isdir(_join(root_dir, pathname), dir_fd):
                 yield pathname
         return
     if not dirname:


### PR DESCRIPTION
This was flagged by a static analyzer as "possible copy-paste error"
(dirname vs. pathname), and it did take me a bit more time than
necessary to understand why this code is correct.
Mentioning the os.path.split behavior this relies on in a comment
should make it clearer.

Code is changed to work on `pathname` to make it clear that
we're checking the same thing as in the preceding branch.
In this case it is the same as `dirname`, except for a trailing
slash which is irrelevant for `_isdir`.
