### PR TITLE
Fixed bug where PyToken_TwoChars sees <> as a valid symbol

### DIFF
--- a/Parser/token.c
+++ b/Parser/token.c
@@ -156,7 +156,6 @@ PyToken_TwoChars(int c1, int c2)
         switch (c2) {
         case '<': return LEFTSHIFT;
         case '=': return LESSEQUAL;
-        case '>': return NOTEQUAL;
         }
         break;
     case '=':


### PR DESCRIPTION
# Fixed bug where PyToken_TwoChars sees <> as a valid symbol
This is a trivial change.
Currently, PyToken_TwoChars sees <> as a valid symbol. This is caught earlier, so it does not matter, but this will be helpful for debugging and/or adding to PyToken_TwoChars. (Note: a similar case, back ticks, have already been removed from PyToken_OneChar).
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
