### PR TITLE
bpo-43639: Do not raise AttributeError on instance attribute update/deletion if data descriptor with missing __set__/__delete__ method found on its type

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-27-13-50-07.bpo-43639.e_CfKh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-27-13-50-07.bpo-43639.e_CfKh.rst
@@ -1,0 +1,3 @@
+Do not raise an :exc:`AttributeError` on instance attribute update/deletion if
+a data descriptor with a missing :meth:`__set__`/:meth:`__delete__` method is
+found on its type. Patch by Géry Ogam.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1299,7 +1299,9 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
         f = Py_TYPE(descr)->tp_descr_set;
         if (f != NULL) {
             res = f(descr, obj, value);
-            goto done;
+            if (res > -2) {
+                goto done;
+            }
         }
     }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7039,11 +7039,18 @@ slot_tp_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 static int
 slot_tp_descr_set(PyObject *self, PyObject *target, PyObject *value)
 {
-    PyObject* stack[3];
-    PyObject *res;
+    PyObject *stack[3];
+    PyTypeObject *tp = Py_TYPE(self);
+    PyObject *delete, *set, *res;
     _Py_IDENTIFIER(__delete__);
     _Py_IDENTIFIER(__set__);
 
+    delete = _PyType_LookupId(tp, &PyId___delete__);
+    set = _PyType_LookupId(tp, &PyId___set__);
+    if ((value == NULL && delete == NULL) ||
+        (value != NULL && set == NULL)) {
+        return -2;
+    }
     stack[0] = self;
     stack[1] = target;
     if (value == NULL) {


### PR DESCRIPTION
An exception `AttributeError` is raised on instance attribute update/deletion if a data descriptor with a missing method `__set__`/`__delete__` is found on the instance’s type.

The reason is that in the C implementation the function `slot_tp_descr_set` returns `-1` both when the looked up method `__set__`/`__delete__` is absent, and when the looked up method `__set__`/`__delete__` is present and its call raises an exception (frequently `AttributeError`). So the calling function `_PyObject_GenericSetAttrWithDict` has no way to make the distinction between the two cases and carry on its process on the instance in the former case, therefore an exception `AttributeError` is raised in the former case.

To solve this issue, the strategy adopted in this pull request is to make the function `slot_tp_descr_set` return `-2` instead of `-1` when the looked up method `__set__`/`__delete__` is absent. That way the calling function `_PyObject_GenericSetAttrWithDict` can detect it and carry on its process on the instance.

<!-- issue-number: [bpo-43639](https://bugs.python.org/issue43639) -->
https://bugs.python.org/issue43639
<!-- /issue-number -->
