### PR TITLE
bpo-43637: Fix a possible memory leak in winreg.SetValueEx()

### DIFF
--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -1813,6 +1813,7 @@ winreg_SetValueEx_impl(PyObject *module, HKEY key,
     if (PySys_Audit("winreg.SetValue", "nunO",
                     (Py_ssize_t)key, value_name, (Py_ssize_t)type,
                     value) < 0) {
+        PyMem_Free(data);
         return NULL;
     }
     Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION


<!-- issue-number: [bpo-43637](https://bugs.python.org/issue43637) -->
https://bugs.python.org/issue43637
<!-- /issue-number -->
