### PR TITLE
bpo-43640: Update TLS/SSL security consids. due to TLS 1.0 and TLS 1.1 deprecation

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -721,10 +721,6 @@ Constants
 
    Selects TLS version 1.0 as the channel encryption protocol.
 
-   .. warning::
-
-      TLS version 1.0 is insecure. Its use is highly discouraged.
-
    .. deprecated:: 3.6
 
       OpenSSL has deprecated all version specific protocols. Use the default
@@ -736,10 +732,6 @@ Constants
    Available only with openssl version 1.0.1+.
 
    .. versionadded:: 3.4
-
-   .. warning::
-
-      TLS version 1.1 is insecure. Its use is highly discouraged.
 
    .. deprecated:: 3.6
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -2669,7 +2669,8 @@ to specify :const:`CERT_REQUIRED` and similarly check the client certificate.
 Protocol versions
 '''''''''''''''''
 
-SSL versions 2 and 3 are considered insecure and are therefore dangerous to
+SSL versions 2 and 3, TLS 1.0, and TLS 1.1 are considered insecure and are
+therefore dangerous to
 use.  If you want maximum compatibility between clients and servers, it is
 recommended to use :const:`PROTOCOL_TLS_CLIENT` or
 :const:`PROTOCOL_TLS_SERVER` as the protocol version. SSLv2 and SSLv3 are

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -721,6 +721,10 @@ Constants
 
    Selects TLS version 1.0 as the channel encryption protocol.
 
+   .. warning::
+
+      TLS version 1.0 is insecure. Its use is highly discouraged.
+
    .. deprecated:: 3.6
 
       OpenSSL has deprecated all version specific protocols. Use the default
@@ -732,6 +736,10 @@ Constants
    Available only with openssl version 1.0.1+.
 
    .. versionadded:: 3.4
+
+   .. warning::
+
+      TLS version 1.1 is insecure. Its use is highly discouraged.
 
    .. deprecated:: 3.6
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -693,10 +693,6 @@ Constants
    This protocol is not available if OpenSSL is compiled with the
    ``OPENSSL_NO_SSL2`` flag.
 
-   .. warning::
-
-      SSL version 2 is insecure.  Its use is highly discouraged.
-
    .. deprecated:: 3.6
 
       OpenSSL has removed support for SSLv2.
@@ -707,10 +703,6 @@ Constants
 
    This protocol is not be available if OpenSSL is compiled with the
    ``OPENSSL_NO_SSLv3`` flag.
-
-   .. warning::
-
-      SSL version 3 is insecure.  Its use is highly discouraged.
 
    .. deprecated:: 3.6
 


### PR DESCRIPTION
TLS 1.0 and TLS 1.1 have recently been deprecated.
https://datatracker.ietf.org/doc/rfc8996/


<!-- issue-number: [bpo-43640](https://bugs.python.org/issue43640) -->
https://bugs.python.org/issue43640
<!-- /issue-number -->
