### PR TITLE
bpo-43641: Stop stating that TLS 1.2 is the most modern version in docs

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -740,9 +740,8 @@ Constants
 
 .. data:: PROTOCOL_TLSv1_2
 
-   Selects TLS version 1.2 as the channel encryption protocol. This is the
-   most modern version, and probably the best choice for maximum protection,
-   if both sides can speak it.  Available only with openssl version 1.0.1+.
+   Selects TLS version 1.2 as the channel encryption protocol.
+   Available only with openssl version 1.0.1+.
 
    .. versionadded:: 3.4
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43641](https://bugs.python.org/issue43641) -->
https://bugs.python.org/issue43641
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran