### PR TITLE
bpo-43433: Reattach query parameters after parsing URI

### DIFF
--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -1426,6 +1426,8 @@ class ServerProxy:
             raise OSError("unsupported XML-RPC protocol")
         self.__host = p.netloc
         self.__handler = p.path or "/RPC2"
+        if p.query:
+            self.__handler += "?" + p.query
 
         if transport is None:
             if p.scheme == "https":


### PR DESCRIPTION
Reinstate pre-3.9 behaviour where query parameters would be carried through in the path component.

<!-- issue-number: [bpo-43433](https://bugs.python.org/issue43433) -->
https://bugs.python.org/issue43433
<!-- /issue-number -->
