### PR TITLE
bpo-43648: Remove redundant datefmt option in logging file config

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -684,7 +684,6 @@ Here is the logging.conf file:
 
     [formatter_simpleFormatter]
     format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
-    datefmt=
 
 The output is nearly identical to that of the non-config-file-based example:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
[bpo-43648](https://bugs.python.org/issue43648): Remove redundant datefmt option in logging file config


<!-- issue-number: [bpo-43648](https://bugs.python.org/issue43648) -->
https://bugs.python.org/issue43648
<!-- /issue-number -->

Automerge-Triggered-By: GH:vsajip