### PR TITLE
bpo-43655: Tkinter Set _NET_WM_WINDOW_TYPE on FileDialog

### DIFF
--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -60,6 +60,7 @@ class FileDialog:
         self.directory = None
 
         self.top = Toplevel(master)
+        self.top.wm_attributes('-type', 'dialog')
         self.top.title(title)
         self.top.iconname(title)
 

--- a/Misc/NEWS.d/next/Library/2021-03-29-10-12-34.bpo-43655.iUxUkc.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-29-10-12-34.bpo-43655.iUxUkc.rst
@@ -1,0 +1,1 @@
+Tkinter now sets the _NET_WM_WINDOW_TYPE when using the FileDialog as dialog.


### PR DESCRIPTION
While trying to fix window behaviour in a python project (ASE: https://wiki.fysik.dtu.dk/ase/), I came across this problem:

Tkinter does not set the _NET_WM_WINDOW_TYPE when using the FileDialog class or it's derivatives. I could not find a reason for this and it leads to my window manager (i3) not automatically recognising the window as a dialogue (and thus not enabling floating). I think the window types are there exactly for that purpose, so I don't see why not to set this as the default for the FileDialog class.

I was able to change this by adding the line
```self.top.wm_attributes('-type', 'dialog')```
to the initialization of the FileDialog class.

Since I am an absolute beginner at this please do forgive if I missed something.

<!-- issue-number: [bpo-43655](https://bugs.python.org/issue43655) -->
https://bugs.python.org/issue43655
<!-- /issue-number -->
