### PR TITLE
bpo-40645: Fix reference leak in the _hashopenssl extension

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-29-11-55-06.bpo-40645.PhaT-B.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-29-11-55-06.bpo-40645.PhaT-B.rst
@@ -1,0 +1,2 @@
+Fix reference leak in the :mod:`_hashopenssl` extension. Patch by Pablo
+Galindo.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -865,7 +865,7 @@ EVP_new_impl(PyObject *module, PyObject *name_obj, PyObject *data_obj,
 /*[clinic end generated code: output=ddd5053f92dffe90 input=c24554d0337be1b0]*/
 {
     Py_buffer view = { 0 };
-    PyObject *ret_obj;
+    PyObject *ret_obj = NULL;
     char *name;
     const EVP_MD *digest = NULL;
 
@@ -879,13 +879,14 @@ EVP_new_impl(PyObject *module, PyObject *name_obj, PyObject *data_obj,
 
     digest = py_digest_by_name(name);
     if (digest == NULL) {
-        return NULL;
+        goto exit;
     }
 
     ret_obj = EVPnew(module, digest,
                      (unsigned char*)view.buf, view.len,
                      usedforsecurity);
 
+exit:
     if (data_obj)
         PyBuffer_Release(&view);
     return ret_obj;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40645](https://bugs.python.org/issue40645) -->
https://bugs.python.org/issue40645
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran