### PR TITLE
bpo-43659: check for curses.update_lines_cols() in Lib/test/test_curses.py

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1174,6 +1174,7 @@ class TestCurses(unittest.TestCase):
 
 class MiscTests(unittest.TestCase):
 
+    @requires_curses_func('update_lines_cols')
     def test_update_lines_cols(self):
         curses.update_lines_cols()
         lines, cols = curses.LINES, curses.COLS


### PR DESCRIPTION
* AIX libcurses.a does not provide support for `curses.update_lines_cols()`. This patch permits the test_curses
to skip a test that requires `curses.update_lines_cols()` support.
* Backport to Python3.8 and/or Python3.9 also needed.
* Further, a NEWS blurb is not included. One can be added if deemed necessary.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43659](https://bugs.python.org/issue43659) -->
https://bugs.python.org/issue43659
<!-- /issue-number -->
