### PR TITLE
bpo-43660: Fix crash when displaying exceptions with custom values for sys.stderr

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1516,15 +1516,14 @@ class SizeofTest(unittest.TestCase):
         # If the default displayhook doesn't take a strong reference
         # to sys.stderr the following code can crash. See bpo-43660
         # for more details.
-        code = """
-if True:
-    import sys
-    class MyStderr:
-        def write(self, s):
-            sys.stderr = None
-    sys.stderr = MyStderr()
-    1/0
-"""
+        code = textwrap.dedent('''
+            import sys
+            class MyStderr:
+                def write(self, s):
+                    sys.stderr = None
+            sys.stderr = MyStderr()
+            1/0
+        ''')
         rc, out, err = assert_python_failure('-c', code)
         self.assertEqual(out, b"")
         self.assertEqual(err, b"")

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1526,8 +1526,8 @@ if True:
     1/0
 """
         rc, out, err = assert_python_failure('-c', code)
-        self.assertEqual(out, "")
-        self.assertEqual(err, "")
+        self.assertEqual(out, b"")
+        self.assertEqual(err, b"")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1512,6 +1512,22 @@ class SizeofTest(unittest.TestCase):
         self.assertIsNone(cur.firstiter)
         self.assertIsNone(cur.finalizer)
 
+    def test_changing_sys_stderr_and_removing_reference(self):
+        # If the default displayhook doesn't take a strong reference
+        # to sys.stderr the following code can crash. See bpo-43660
+        # for more details.
+        code = """
+if True:
+    import sys
+    class MyStderr:
+        def write(self, s):
+            sys.stderr = None
+    sys.stderr = MyStderr()
+    1/0
+"""
+        rc, out, err = assert_python_failure('-c', code)
+        self.assertEqual(out, "")
+        self.assertEqual(err, "")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-29-19-50-34.bpo-43660.scTgag.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-29-19-50-34.bpo-43660.scTgag.rst
@@ -1,0 +1,3 @@
+Fix crash that happens when replacing ``sys.stderr`` with a callable that
+can remove the object while an exception is being printed. Patch by Pablo
+Galindo.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1082,8 +1082,9 @@ PyErr_Display(PyObject *exception, PyObject *value, PyObject *tb)
     if (file == Py_None) {
         return;
     }
-
+    Py_INCREF(file);
     _PyErr_Display(file, exception, value, tb);
+    Py_DECREF(file);
 }
 
 PyObject *


### PR DESCRIPTION
…

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43660](https://bugs.python.org/issue43660) -->
https://bugs.python.org/issue43660
<!-- /issue-number -->
