### PR TITLE
bpo-34932: Add socket.TCP_KEEPALIVE for macOS

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -381,6 +381,8 @@ Constants
 
    .. versionchanged:: 3.10
       ``IP_RECVTOS`` was added.
+       Added ``TCP_KEEPALIVE``. On MacOS this constant can be used in the same
+       way that ``TCP_KEEPIDLE`` is used on Linux.
 
 .. data:: AF_CAN
           PF_CAN

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -6446,6 +6446,12 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
             sock.bind(("type", "n" * 64))
 
 
+@unittest.skipUnless(sys.platform == 'darwin', 'macOS specific test')
+class TestMacOSTCPFlags(unittest.TestCase):
+     def test_tcp_keepalive(self):
+         self.assertTrue(socket.TCP_KEEPALIVE)
+
+
 @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
 class TestMSWindowsTCPFlags(unittest.TestCase):
     knownTCPFlags = {
@@ -6704,6 +6710,7 @@ def test_main():
         SendfileUsingSendfileTest,
     ])
     tests.append(TestMSWindowsTCPFlags)
+    tests.append(TestMacOSTCPFlags)
 
     thread_info = threading_helper.threading_setup()
     support.run_unittest(*tests)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -6448,8 +6448,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
 
 @unittest.skipUnless(sys.platform == 'darwin', 'macOS specific test')
 class TestMacOSTCPFlags(unittest.TestCase):
-     def test_tcp_keepalive(self):
-         self.assertTrue(socket.TCP_KEEPALIVE)
+    def test_tcp_keepalive(self):
+        self.assertTrue(socket.TCP_KEEPALIVE)
 
 
 @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")

--- a/Misc/NEWS.d/next/macOS/2021-03-29-21-11-23.bpo-34932.f3Hdyd.rst
+++ b/Misc/NEWS.d/next/macOS/2021-03-29-21-11-23.bpo-34932.f3Hdyd.rst
@@ -1,1 +1,1 @@
-Add socket.TCP_KEEPIDLE support to macOS.
+Add socket.TCP_KEEPALIVE support for macOS. Patch by Shane Harvey.

--- a/Misc/NEWS.d/next/macOS/2021-03-29-21-11-23.bpo-34932.f3Hdyd.rst
+++ b/Misc/NEWS.d/next/macOS/2021-03-29-21-11-23.bpo-34932.f3Hdyd.rst
@@ -1,0 +1,1 @@
+Add socket.TCP_KEEPIDLE support to macOS.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8160,7 +8160,7 @@ PyInit__socket(void)
     PyModule_AddIntMacro(m, TCP_KEEPIDLE);
 #endif
     /* TCP_KEEPALIVE is OSX's TCP_KEEPIDLE equivalent */
-#ifdef  TCP_KEEPALIVE
+#if defined(__APPLE__) && defined(TCP_KEEPALIVE)
     PyModule_AddIntMacro(m, TCP_KEEPALIVE);
 #endif
 #ifdef  TCP_KEEPINTVL

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8156,8 +8156,11 @@ PyInit__socket(void)
 #ifdef  TCP_CORK
     PyModule_AddIntMacro(m, TCP_CORK);
 #endif
-#ifdef  TCP_KEEPIDLE
+#if defined(TCP_KEEPIDLE)
     PyModule_AddIntMacro(m, TCP_KEEPIDLE);
+#elif defined(__APPLE__) && defined(TCP_KEEPALIVE)
+    /* TCP_KEEPALIVE is equivalent to TCP_KEEPIDLE on OSX. */
+    PyModule_AddIntConstant(m, "TCP_KEEPIDLE", TCP_KEEPALIVE);
 #endif
 #ifdef  TCP_KEEPINTVL
     PyModule_AddIntMacro(m, TCP_KEEPINTVL);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8156,11 +8156,12 @@ PyInit__socket(void)
 #ifdef  TCP_CORK
     PyModule_AddIntMacro(m, TCP_CORK);
 #endif
-#if defined(TCP_KEEPIDLE)
+#ifdef  TCP_KEEPIDLE
     PyModule_AddIntMacro(m, TCP_KEEPIDLE);
-#elif defined(__APPLE__) && defined(TCP_KEEPALIVE)
-    /* TCP_KEEPALIVE is equivalent to TCP_KEEPIDLE on OSX. */
-    PyModule_AddIntConstant(m, "TCP_KEEPIDLE", TCP_KEEPALIVE);
+#endif
+    /* TCP_KEEPALIVE is OSX's TCP_KEEPIDLE equivalent */
+#ifdef  TCP_KEEPALIVE
+    PyModule_AddIntMacro(m, TCP_KEEPALIVE);
 #endif
 #ifdef  TCP_KEEPINTVL
     PyModule_AddIntMacro(m, TCP_KEEPINTVL);


### PR DESCRIPTION
This change adds socket.TCP_KEEPALIVE for macOS.

<!-- issue-number: [bpo-34932](https://bugs.python.org/issue34932) -->
https://bugs.python.org/issue34932
<!-- /issue-number -->
