### PR TITLE
[3.7] bpo-43660: Fix crash when displaying exceptions with custom values for sys.stderr (GH-25075).

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1292,6 +1292,21 @@ class SizeofTest(unittest.TestCase):
         self.assertIsNone(cur.firstiter)
         self.assertIsNone(cur.finalizer)
 
+    def test_changing_sys_stderr_and_removing_reference(self):
+        # If the default displayhook doesn't take a strong reference
+        # to sys.stderr the following code can crash. See bpo-43660
+        # for more details.
+        code = textwrap.dedent('''
+            import sys
+            class MyStderr:
+                def write(self, s):
+                    sys.stderr = None
+            sys.stderr = MyStderr()
+            1/0
+        ''')
+        rc, out, err = assert_python_failure('-c', code)
+        self.assertEqual(out, b"")
+        self.assertEqual(err, b"")
 
 def test_main():
     test.support.run_unittest(SysModuleTest, SizeofTest)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-29-19-50-34.bpo-43660.scTgag.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-29-19-50-34.bpo-43660.scTgag.rst
@@ -1,0 +1,3 @@
+Fix crash that happens when replacing ``sys.stderr`` with a callable that
+can remove the object while an exception is being printed. Patch by Pablo
+Galindo.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -932,7 +932,9 @@ PyErr_Display(PyObject *exception, PyObject *value, PyObject *tb)
         seen = PySet_New(NULL);
         if (seen == NULL)
             PyErr_Clear();
+        Py_INCREF(f);
         print_exception_recursive(f, value, seen);
+        Py_DECREF(f);
         Py_XDECREF(seen);
     }
 }


### PR DESCRIPTION
…

(cherry picked from commit 09b90a037d18f5d4acdf1b14082e57bda78e85d3)

Co-authored-by: Pablo Galindo <Pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43660](https://bugs.python.org/issue43660) -->
https://bugs.python.org/issue43660
<!-- /issue-number -->
