### PR TITLE
bpo-43666: Lib/_aix_support.py routines may fail in a WPAR environment

### DIFF
--- a/Lib/_aix_support.py
+++ b/Lib/_aix_support.py
@@ -15,8 +15,9 @@ def _aix_tag(vrtl, bd):
     # type: (List[int], int) -> str
     # Infer the ABI bitwidth from maxsize (assuming 64 bit as the default)
     _sz = 32 if sys.maxsize == (2**31-1) else 64
+    _bd = bd if bd != 0 else 9988
     # vrtl[version, release, technology_level]
-    return "aix-{:1x}{:1d}{:02d}-{:04d}-{}".format(vrtl[0], vrtl[1], vrtl[2], bd, _sz)
+    return "aix-{:1x}{:1d}{:02d}-{:04d}-{}".format(vrtl[0], vrtl[1], vrtl[2], _bd, _sz)
 
 
 # extract version, release and technology level from a VRMF string
@@ -26,19 +27,20 @@ def _aix_vrtl(vrmf):
     return [int(v[-1]), int(r), int(tl)]
 
 
-def _aix_bosmp64():
+def _aix_bos_rte():
     # type: () -> Tuple[str, int]
     """
     Return a Tuple[str, int] e.g., ['7.1.4.34', 1806]
-    The fileset bos.mp64 is the AIX kernel. It's VRMF and builddate
-    reflect the current ABI levels of the runtime environment.
+    The fileset bos.rte represents the current AIX run-time level. It's VRMF and
+    builddate reflect the current ABI levels of the runtime environment.
+    If no builddate is found give a value that will satisfy pep425 related queries
     """
-    # We expect all AIX systems to have lslpp installed in this location
-    out = subprocess.check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
+    # All AIX systems to have lslpp installed in this location
+    out = subprocess.check_output(["/usr/bin/lslpp", "-Lqc", "bos.rte"])
     out = out.decode("utf-8")
     out = out.strip().split(":")  # type: ignore
-    # Use str() and int() to help mypy see types
-    return (str(out[2]), int(out[-1]))
+    _bd = int(out[-1]) if out[-1] != '' else 9988
+    return (str(out[2]), _bd)
 
 
 def aix_platform():
@@ -47,11 +49,11 @@ def aix_platform():
     AIX filesets are identified by four decimal values: V.R.M.F.
     V (version) and R (release) can be retreived using ``uname``
     Since 2007, starting with AIX 5.3 TL7, the M value has been
-    included with the fileset bos.mp64 and represents the Technology
+    included with the fileset bos.rte and represents the Technology
     Level (TL) of AIX. The F (Fix) value also increases, but is not
     relevant for comparing releases and binary compatibility.
     For binary compatibility the so-called builddate is needed.
-    Again, the builddate of an AIX release is associated with bos.mp64.
+    Again, the builddate of an AIX release is associated with bos.rte.
     AIX ABI compatibility is described  as guaranteed at: https://www.ibm.com/\
     support/knowledgecenter/en/ssw_aix_72/install/binary_compatability.html
 
@@ -60,7 +62,7 @@ def aix_platform():
     e.g., "aix-6107-1415-32" for AIX 6.1 TL7 bd 1415, 32-bit
     and, "aix-6107-1415-64" for AIX 6.1 TL7 bd 1415, 64-bit
     """
-    vrmf, bd = _aix_bosmp64()
+    vrmf, bd = _aix_bos_rte()
     return _aix_tag(_aix_vrtl(vrmf), bd)
 
 
@@ -79,7 +81,7 @@ def aix_buildtag():
     Return the platform_tag of the system Python was built on.
     """
     # AIX_BUILDDATE is defined by configure with:
-    # lslpp -Lcq bos.mp64 | awk -F:  '{ print $NF }'
+    # lslpp -Lcq bos.rte | awk -F:  '{ print $NF }'
     build_date = sysconfig.get_config_var("AIX_BUILDDATE")
     try:
         build_date = int(build_date)

--- a/Misc/NEWS.d/next/Library/2021-03-30-08-39-08.bpo-43666.m72tlH.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-30-08-39-08.bpo-43666.m72tlH.rst
@@ -1,6 +1,6 @@
 AIX: `Lib/_aix_support.get_platform()` may fail in an AIX WPAR.
-The fileset `bos.rte` appears to have a builddate in both LPAR and WPAR
-so this fileset is queried rather than `bos.mp64`
+The fileset bos.rte appears to have a builddate in both LPAR and WPAR
+so this fileset is queried rather than bos.mp64.
 To prevent a similiar situation (no builddate in ODM) a value (9988)
 sufficient for completing a build is provided.
 Patch by M Felt.

--- a/Misc/NEWS.d/next/Library/2021-03-30-08-39-08.bpo-43666.m72tlH.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-30-08-39-08.bpo-43666.m72tlH.rst
@@ -1,0 +1,6 @@
+AIX: `Lib/_aix_support.get_platform()` may fail in an AIX WPAR.
+The fileset `bos.rte` appears to have a builddate in both LPAR and WPAR
+so this fileset is queried rather than `bos.mp64`
+To prevent a similiar situation (no builddate in ODM) a value (9988)
+sufficient for completing a build is provided.
+Patch by M Felt.


### PR DESCRIPTION
Backport for Python3.9 needed.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43666](https://bugs.python.org/issue43666) -->
https://bugs.python.org/issue43666
<!-- /issue-number -->
