### PR TITLE
Disambiguate that -m also terminates the option list in the manpage.

### DIFF
--- a/Misc/python.man
+++ b/Misc/python.man
@@ -165,7 +165,8 @@ Searches
 .I sys.path
 for the named module and runs the corresponding
 .I .py
-file as a script.
+file as a script. This terminates the option list (following options
+are passed as arguments to the module).
 .TP
 .B \-O
 Remove assert statements and any code conditional on the value of


### PR DESCRIPTION
It's documented in `python --help`, but not in the manpage. As I've seen someone trying:

    python -m sys -m uuid -c ...

today, I though it would worth fix it.
