### PR TITLE
bpo-43510: PEP 597: Accept `encoding="locale"` in binary mode.

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -221,7 +221,7 @@ def open(file, mode="r", buffering=-1, encoding=None, errors=None,
         raise ValueError("can't have read/write/append mode at once")
     if not (creating or reading or writing or appending):
         raise ValueError("must have exactly one of read/write/append mode")
-    if binary and encoding is not None:
+    if binary and encoding is not None and encoding != "locale":
         raise ValueError("binary mode doesn't take an encoding argument")
     if binary and errors is not None:
         raise ValueError("binary mode doesn't take an errors argument")

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -531,6 +531,17 @@ class IOTest(unittest.TestCase):
                     self.assertRaises(OSError, obj.truncate)
                     self.assertRaises(OSError, obj.truncate, 0)
 
+    def test_open_binmode_encoding(self):
+        """open() raises ValueError when encoding is specified in bin mode"""
+        self.assertRaises(ValueError, self.open, os_helper.TESTFN,
+                          "wb", encoding="utf-8")
+
+        # encoding=None and encoding="locale" is allowed.
+        with self.open(os_helper.TESTFN, "wb", encoding=None):
+            pass
+        with self.open(os_helper.TESTFN, "wb", encoding="locale"):
+            pass
+
     def test_open_handles_NUL_chars(self):
         fn_with_NUL = 'foo\0bar'
         self.assertRaises(ValueError, self.open, fn_with_NUL, 'w')

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -346,7 +346,8 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
         goto error;
     }
 
-    if (binary && encoding != NULL) {
+    if (binary && encoding != NULL
+            && strcmp(encoding, "locale") != 0) {
         PyErr_SetString(PyExc_ValueError,
                         "binary mode doesn't take an encoding argument");
         goto error;


### PR DESCRIPTION
It make `encoding="locale"` usable everywhere `encoding=None` is
allowed.

<!-- issue-number: [bpo-43510](https://bugs.python.org/issue43510) -->
https://bugs.python.org/issue43510
<!-- /issue-number -->
