### PR TITLE
bpo-43651: Fix EncodingWarning in test_file and test_file_eintr

### DIFF
--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -52,7 +52,7 @@ class AutoFileTests:
         # verify readinto refuses text files
         a = array('b', b'x'*10)
         self.f.close()
-        self.f = self.open(TESTFN, 'r', encoding="ascii")
+        self.f = self.open(TESTFN, encoding="utf-8")
         if hasattr(self.f, "readinto"):
             self.assertRaises(TypeError, self.f.readinto, a)
 

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -52,7 +52,7 @@ class AutoFileTests:
         # verify readinto refuses text files
         a = array('b', b'x'*10)
         self.f.close()
-        self.f = self.open(TESTFN, 'r')
+        self.f = self.open(TESTFN, 'r', encoding="ascii")
         if hasattr(self.f, "readinto"):
             self.assertRaises(TypeError, self.f.readinto, a)
 

--- a/Lib/test/test_file_eintr.py
+++ b/Lib/test/test_file_eintr.py
@@ -213,7 +213,7 @@ class TestTextIOSignalInterrupt(TestFileIOSignalInterrupt):
     def _generate_infile_setup_code(self):
         """Returns the infile = ... line of code to make a TextIOWrapper."""
         return ('import %s as io ;'
-                'infile = io.open(sys.stdin.fileno(), "rt", encoding="ascii", newline=None) ;'
+                'infile = io.open(sys.stdin.fileno(), encoding="utf-8", newline=None) ;'
                 'assert isinstance(infile, io.TextIOWrapper)' %
                 self.modname)
 

--- a/Lib/test/test_file_eintr.py
+++ b/Lib/test/test_file_eintr.py
@@ -213,7 +213,7 @@ class TestTextIOSignalInterrupt(TestFileIOSignalInterrupt):
     def _generate_infile_setup_code(self):
         """Returns the infile = ... line of code to make a TextIOWrapper."""
         return ('import %s as io ;'
-                'infile = io.open(sys.stdin.fileno(), "rt", newline=None) ;'
+                'infile = io.open(sys.stdin.fileno(), "rt", encoding="ascii", newline=None) ;'
                 'assert isinstance(infile, io.TextIOWrapper)' %
                 self.modname)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43651](https://bugs.python.org/issue43651) -->
https://bugs.python.org/issue43651
<!-- /issue-number -->
