### PR TITLE
bpo-43680: Remove undocumented io.OpenWrapper

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1133,6 +1133,11 @@ Removed
   (Contributed by Yurii Karabas, Andrew Svetlov, Yury Selivanov and Kyle Stanley
   in :issue:`42392`.)
 
+* Remove the undocumented ``io.OpenWrapper`` and ``_pyio.OpenWrapper``
+  functions which could be used directly to define a method:
+  ``staticmethod(open)`` should now be used instead.
+  (Contributed by Victor Stinner in :issue:`43680`.)
+
 
 Porting to Python 3.10
 ======================

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -313,19 +313,6 @@ class DocDescriptor:
                  "errors=None, newline=None, closefd=True)\n\n" +
             open.__doc__)
 
-class OpenWrapper:
-    """Wrapper for builtins.open
-
-    Trick so that open won't become a bound method when stored
-    as a class variable (as dbm.dumb does).
-
-    See initstdio() in Python/pylifecycle.c.
-    """
-    __doc__ = DocDescriptor()
-
-    def __new__(cls, *args, **kwargs):
-        return open(*args, **kwargs)
-
 
 # In normal operation, both `UnsupportedOperation`s should be bound to the
 # same object.

--- a/Lib/io.py
+++ b/Lib/io.py
@@ -56,8 +56,6 @@ from _io import (DEFAULT_BUFFER_SIZE, BlockingIOError, UnsupportedOperation,
                  BufferedWriter, BufferedRWPair, BufferedRandom,
                  IncrementalNewlineDecoder, text_encoding, TextIOWrapper)
 
-OpenWrapper = _io.open # for compatibility with _pyio
-
 # Pretend this exception was created here.
 UnsupportedOperation.__module__ = "io"
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4574,6 +4574,13 @@ class PySignalsTest(SignalsTest):
     test_reentrant_write_text = None
 
 
+class PyioOpenWrapper:
+    """Wrapper for pyio.open Trick so that open won't become a bound method
+    when stored as a class variable."""
+    def __new__(cls, *args, **kwargs):
+        return pyio.open(*args, **kwargs)
+
+
 def load_tests(*args):
     tests = (CIOTest, PyIOTest, APIMismatchTest,
              CBufferedReaderTest, PyBufferedReaderTest,
@@ -4599,7 +4606,7 @@ def load_tests(*args):
     c_io_ns.update((x.__name__, globs["C" + x.__name__]) for x in mocks)
     py_io_ns.update((x.__name__, globs["Py" + x.__name__]) for x in mocks)
     # Avoid turning open into a bound method.
-    py_io_ns["open"] = pyio.OpenWrapper
+    py_io_ns["open"] = PyioOpenWrapper
     for test in tests:
         if test.__name__.startswith("C"):
             for name, obj in c_io_ns.items():

--- a/Misc/NEWS.d/next/Library/2021-03-31-15-08-59.bpo-43680.H_Mx8U.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-31-15-08-59.bpo-43680.H_Mx8U.rst
@@ -1,0 +1,3 @@
+Remove the undocumented ``io.OpenWrapper`` and ``_pyio.OpenWrapper``
+functions which could be used directly to define a method:
+``staticmethod(open)`` should now be used instead.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2213,11 +2213,11 @@ error:
     return NULL;
 }
 
-/* Set builtins.open to io.OpenWrapper */
+/* Set builtins.open to io.open */
 static PyStatus
 init_set_builtins_open(void)
 {
-    PyObject *iomod = NULL, *wrapper;
+    PyObject *iomod = NULL, *open_func;
     PyObject *bimod = NULL;
     PyStatus res = _PyStatus_OK();
 
@@ -2229,16 +2229,16 @@ init_set_builtins_open(void)
         goto error;
     }
 
-    if (!(wrapper = PyObject_GetAttrString(iomod, "OpenWrapper"))) {
+    if (!(open_func = PyObject_GetAttrString(iomod, "open"))) {
         goto error;
     }
 
     /* Set builtins.open */
-    if (PyObject_SetAttrString(bimod, "open", wrapper) == -1) {
-        Py_DECREF(wrapper);
+    if (PyObject_SetAttrString(bimod, "open", open_func) == -1) {
+        Py_DECREF(open_func);
         goto error;
     }
-    Py_DECREF(wrapper);
+    Py_DECREF(open_func);
     goto done;
 
 error:


### PR DESCRIPTION
Remove the undocumented io.OpenWrapper and _pyio.OpenWrapper
functions which could be used directly to define a method:
staticmethod(open) should now be used instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43680](https://bugs.python.org/issue43680) -->
https://bugs.python.org/issue43680
<!-- /issue-number -->
