### PR TITLE
bpo-42955: Add _overlapped to sys.stdlib_module_names

### DIFF
--- a/Python/stdlib_module_names.h
+++ b/Python/stdlib_module_names.h
@@ -52,6 +52,7 @@ static const char* _Py_stdlib_module_names[] = {
 "_opcode",
 "_operator",
 "_osx_support",
+"_overlapped",
 "_pickle",
 "_posixshmem",
 "_posixsubprocess",

--- a/Tools/scripts/generate_stdlib_module_names.py
+++ b/Tools/scripts/generate_stdlib_module_names.py
@@ -42,6 +42,7 @@ IGNORE = {
 # Windows extension modules
 WINDOWS_MODULES = (
     '_msi',
+    '_overlapped',
     '_testconsole',
     '_winapi',
     'msvcrt',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42955](https://bugs.python.org/issue42955) -->
https://bugs.python.org/issue42955
<!-- /issue-number -->
