### PR TITLE
bpo-43677: Fix a minor error in Doc/howto/descriptor.rst

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1064,7 +1064,7 @@ roughly equivalent to:
 .. testcode::
 
     class MethodType:
-        "Emulate Py_MethodType in Objects/classobject.c"
+        "Emulate PyMethod_Type in Objects/classobject.c"
 
         def __init__(self, func, obj):
             self.__func__ = func


### PR DESCRIPTION
It should be PyMethod_Type, not Py_MethodType.


<!-- issue-number: [bpo-43677](https://bugs.python.org/issue43677) -->
https://bugs.python.org/issue43677
<!-- /issue-number -->
