### PR TITLE
WIP: Cache for obmalloc arena_map_is_used()

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1397,6 +1397,12 @@ static int arena_map_bot_count;
 static arena_map_bot_t arena_map_root;
 #endif
 
+/* arena_map_cache[...] is a directly mapped cache for the result of
+ * address_in_range(pool).  The two low order bits correspond to the return
+ * value of address_in_range(), 00 == no entry, 01 == small, 10 == large.  For
+ * the cache, small means it was allocated by obmalloc, large is allocated by
+ * other malloc.  The high order bits are the pool address.
+ */
 #define CACHE_BITS 7
 #define CACHE_SIZE (1<<CACHE_BITS)
 #define CACHE_MASK (CACHE_SIZE - 1)


### PR DESCRIPTION
This is an experiment to add a small cache for the result of the arena_map_is_used() function.  This function is performance critical.  It is possible that using a cache could be a faster approach.  Also, it could allow us to expand the arena tree map to cover a larger address space (e.g. full 64-bits) or to shrink its memory usage.

This needs a lot more polish before it is ready and even then it would be questionable if it's worth the extra complexity.  Based on some preliminary benchmarking, it seems about as fast as without the cache.  With some further optimization, I suspect it could be faster.