### PR TITLE
bpo-43688: Fix Py_LIMITED_API version of xxlimited

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -79,15 +79,15 @@ PyAPI_FUNC(PyObject *) PyCMethod_New(PyMethodDef *, PyObject *,
 
 #define METH_COEXIST   0x0040
 
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
-#define METH_FASTCALL  0x0080
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030a0000
+#  define METH_FASTCALL  0x0080
 #endif
 
 /* This bit is preserved for Stackless Python */
 #ifdef STACKLESS
-#define METH_STACKLESS 0x0100
+#  define METH_STACKLESS 0x0100
 #else
-#define METH_STACKLESS 0x0000
+#  define METH_STACKLESS 0x0000
 #endif
 
 /* METH_METHOD means the function stores an

--- a/PCbuild/xxlimited.vcxproj
+++ b/PCbuild/xxlimited.vcxproj
@@ -94,7 +94,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);Py_LIMITED_API=0x03100000</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);Py_LIMITED_API=0x030A0000</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/setup.py
+++ b/setup.py
@@ -1867,7 +1867,7 @@ class PyBuildExt(build_ext):
         if 'd' not in sysconfig.get_config_var('ABIFLAGS'):
             # Non-debug mode: Build xxlimited with limited API
             self.add(Extension('xxlimited', ['xxlimited.c'],
-                               define_macros=[('Py_LIMITED_API', '0x03100000')]))
+                               define_macros=[('Py_LIMITED_API', '0x030a0000')]))
             self.add(Extension('xxlimited_35', ['xxlimited_35.c'],
                                define_macros=[('Py_LIMITED_API', '0x03050000')]))
         else:


### PR DESCRIPTION
xxlimited targets Python 3.10, not Python 3.16: fix the hexdecimal
version number used in the Py_LIMITED_API macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43688](https://bugs.python.org/issue43688) -->
https://bugs.python.org/issue43688
<!-- /issue-number -->
