### PR TITLE
bpo-43690: stable_abi.py no longer parses macros

### DIFF
--- a/Doc/data/stable_abi.dat
+++ b/Doc/data/stable_abi.dat
@@ -616,7 +616,6 @@ PyType_GetFlags
 PyType_GetModule
 PyType_GetModuleState
 PyType_GetSlot
-PyType_HasFeature
 PyType_IsSubtype
 PyType_Modified
 PyType_Ready


### PR DESCRIPTION
The stable_abi.py script no longer parse macros. Macro targets can be
static inline functions which are not part of the stable ABI, only
part of the limited C API.

Run "make regen-limited-abi" to exclude PyType_HasFeature from
Doc/data/stable_abi.dat.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43690](https://bugs.python.org/issue43690) -->
https://bugs.python.org/issue43690
<!-- /issue-number -->
