### PR TITLE
bpo-43651: PEP 597: Fix EncodingWarning in some tests

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -816,7 +816,7 @@ class RunStringTests(TestBase):
                 try:
                     os.fork()
                 except RuntimeError:
-                    with open('{file.name}', 'w') as out:
+                    with open('{file.name}', 'w', encoding='utf-8') as out:
                         out.write('{expected}')
                 """)
             interpreters.run_string(self.id, script)

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -25,11 +25,11 @@ def _captured_script(script):
     indented = script.replace('\n', '\n                ')
     wrapped = dedent(f"""
         import contextlib
-        with open({w}, 'w') as spipe:
+        with open({w}, 'w', encoding="utf-8") as spipe:
             with contextlib.redirect_stdout(spipe):
                 {indented}
         """)
-    return wrapped, open(r)
+    return wrapped, open(r, encoding="utf-8")
 
 
 def _run_output(interp, request, shared=None):
@@ -45,7 +45,7 @@ def _running(interp):
     def run():
         interpreters.run_string(interp, dedent(f"""
             # wait for "signal"
-            with open({r}) as rpipe:
+            with open({r}, encoding="utf-8") as rpipe:
                 rpipe.read()
             """))
 
@@ -54,7 +54,7 @@ def _running(interp):
 
     yield
 
-    with open(w, 'w') as spipe:
+    with open(w, 'w', encoding="utf-8") as spipe:
         spipe.write('done')
     t.join()
 
@@ -806,7 +806,7 @@ class RunStringTests(TestBase):
     @unittest.skipUnless(hasattr(os, 'fork'), "test needs os.fork()")
     def test_fork(self):
         import tempfile
-        with tempfile.NamedTemporaryFile('w+') as file:
+        with tempfile.NamedTemporaryFile('w+', encoding="utf-8") as file:
             file.write('')
             file.flush()
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -45,7 +45,7 @@ class TempDirMixin(object):
 
     def create_readonly_file(self, filename):
         file_path = os.path.join(self.temp_dir, filename)
-        with open(file_path, 'w') as file:
+        with open(file_path, 'w', encoding="utf-8") as file:
             file.write(filename)
         os.chmod(file_path, stat.S_IREAD)
 
@@ -1468,7 +1468,7 @@ class TestArgumentsFromFile(TempDirMixin, ParserTestCase):
             ('invalid', '@no-such-path\n'),
         ]
         for path, text in file_texts:
-            with open(path, 'w') as file:
+            with open(path, 'w', encoding="utf-8") as file:
                 file.write(text)
 
     parser_signature = Sig(fromfile_prefix_chars='@')
@@ -1498,7 +1498,7 @@ class TestArgumentsFromFileConverter(TempDirMixin, ParserTestCase):
             ('hello', 'hello world!\n'),
         ]
         for path, text in file_texts:
-            with open(path, 'w') as file:
+            with open(path, 'w', encoding="utf-8") as file:
                 file.write(text)
 
     class FromFileConverterArgumentParser(ErrorRaisingArgumentParser):
@@ -1580,7 +1580,8 @@ class TestFileTypeR(TempDirMixin, ParserTestCase):
     def setUp(self):
         super(TestFileTypeR, self).setUp()
         for file_name in ['foo', 'bar']:
-            with open(os.path.join(self.temp_dir, file_name), 'w') as file:
+            with open(os.path.join(self.temp_dir, file_name),
+                      'w', encoding="utf-8") as file:
                 file.write(file_name)
         self.create_readonly_file('readonly')
 
@@ -1601,7 +1602,7 @@ class TestFileTypeDefaults(TempDirMixin, ParserTestCase):
     """Test that a file is not created unless the default is needed"""
     def setUp(self):
         super(TestFileTypeDefaults, self).setUp()
-        file = open(os.path.join(self.temp_dir, 'good'), 'w')
+        file = open(os.path.join(self.temp_dir, 'good'), 'w', encoding="utf-8")
         file.write('good')
         file.close()
 
@@ -1620,7 +1621,8 @@ class TestFileTypeRB(TempDirMixin, ParserTestCase):
     def setUp(self):
         super(TestFileTypeRB, self).setUp()
         for file_name in ['foo', 'bar']:
-            with open(os.path.join(self.temp_dir, file_name), 'w') as file:
+            with open(os.path.join(self.temp_dir, file_name),
+                      'w', encoding="utf-8") as file:
                 file.write(file_name)
 
     argument_signatures = [

--- a/Lib/test/test_baseexception.py
+++ b/Lib/test/test_baseexception.py
@@ -28,8 +28,9 @@ class ExceptionClassTests(unittest.TestCase):
             except TypeError:
                 pass
 
-        inheritance_tree = open(os.path.join(os.path.split(__file__)[0],
-                                                'exception_hierarchy.txt'))
+        inheritance_tree = open(
+                os.path.join(os.path.split(__file__)[0], 'exception_hierarchy.txt'),
+                encoding="utf-8")
         try:
             superclass_name = inheritance_tree.readline().rstrip()
             try:

--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -539,7 +539,7 @@ def create_modules(modules):
         try:
             for m in modules:
                 fname = m + '.py'
-                with open(fname, 'w') as f:
+                with open(fname, 'w', encoding="utf-8") as f:
                     f.write(textwrap.dedent(modules[m]))
                 linecache.checkcache(fname)
             importlib.invalidate_caches()

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -235,7 +235,7 @@ class BoolTest(unittest.TestCase):
 
     def test_fileclosed(self):
         try:
-            with open(os_helper.TESTFN, "w") as f:
+            with open(os_helper.TESTFN, "w", encoding="utf-8") as f:
                 self.assertIs(f.closed, False)
             self.assertIs(f.closed, True)
         finally:

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1199,7 +1199,7 @@ class BuiltinTest(unittest.TestCase):
             current_locale_encoding = locale.getpreferredencoding(False)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", EncodingWarning)
-                fp = open(TESTFN, 'w', encoding="utf-8")
+                fp = open(TESTFN, 'w')
             with fp:
                 self.assertEqual(fp.encoding, current_locale_encoding)
         finally:

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1159,7 +1159,7 @@ class BuiltinTest(unittest.TestCase):
 
     def write_testfile(self):
         # NB the first 4 lines are also used to test input, below
-        fp = open(TESTFN, 'w')
+        fp = open(TESTFN, 'w', encoding="utf-8")
         self.addCleanup(unlink, TESTFN)
         with fp:
             fp.write('1+1\n')
@@ -1171,7 +1171,7 @@ class BuiltinTest(unittest.TestCase):
 
     def test_open(self):
         self.write_testfile()
-        fp = open(TESTFN, 'r')
+        fp = open(TESTFN, encoding="utf-8")
         with fp:
             self.assertEqual(fp.readline(4), '1+1\n')
             self.assertEqual(fp.readline(), 'The quick brown fox jumps over the lazy dog.\n')
@@ -1197,7 +1197,7 @@ class BuiltinTest(unittest.TestCase):
 
             self.write_testfile()
             current_locale_encoding = locale.getpreferredencoding(False)
-            fp = open(TESTFN, 'w')
+            fp = open(TESTFN, 'w', encoding="utf-8")
             with fp:
                 self.assertEqual(fp.encoding, current_locale_encoding)
         finally:
@@ -1205,7 +1205,7 @@ class BuiltinTest(unittest.TestCase):
             os.environ.update(old_environ)
 
     def test_open_non_inheritable(self):
-        fileobj = open(__file__)
+        fileobj = open(__file__, encoding="utf-8")
         with fileobj:
             self.assertFalse(os.get_inheritable(fileobj.fileno()))
 
@@ -1300,7 +1300,7 @@ class BuiltinTest(unittest.TestCase):
 
     def test_input(self):
         self.write_testfile()
-        fp = open(TESTFN, 'r')
+        fp = open(TESTFN, encoding="utf-8")
         savestdin = sys.stdin
         savestdout = sys.stdout # Eats the echo
         try:
@@ -2022,7 +2022,7 @@ class PtyTests(unittest.TestCase):
         os.write(fd, terminal_input)
 
         # Get results from the pipe
-        with open(r, "r") as rpipe:
+        with open(r, encoding="utf-8") as rpipe:
             lines = []
             while True:
                 line = rpipe.readline().strip()

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1197,7 +1197,9 @@ class BuiltinTest(unittest.TestCase):
 
             self.write_testfile()
             current_locale_encoding = locale.getpreferredencoding(False)
-            fp = open(TESTFN, 'w', encoding="utf-8")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", EncodingWarning)
+                fp = open(TESTFN, 'w', encoding="utf-8")
             with fp:
                 self.assertEqual(fp.encoding, current_locale_encoding)
         finally:

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -2846,7 +2846,7 @@ the verbose version, and then check the output:
     >>> from test.support.os_helper import temp_dir
     >>> with temp_dir() as tmpdir:
     ...     fn = os.path.join(tmpdir, 'myfile.doc')
-    ...     with open(fn, 'w') as f:
+    ...     with open(fn, 'w', encoding='utf-8') as f:
     ...         _ = f.write('This is a very simple test file.\n')
     ...         _ = f.write('   >>> 1 + 1\n')
     ...         _ = f.write('   2\n')
@@ -2909,7 +2909,7 @@ text files).
     ...         _ = f.write('\n')
     ...         _ = f.write('And that is it.\n')
     ...     fn2 = os.path.join(tmpdir, 'myfile2.py')
-    ...     with open(fn2, 'w') as f:
+    ...     with open(fn2, 'w', encoding='utf-8') as f:
     ...         _ = f.write('def test_func():\n')
     ...         _ = f.write('   \"\"\"\n')
     ...         _ = f.write('   This is simple python test function.\n')

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -2898,7 +2898,7 @@ text files).
     >>> from test.support.os_helper import temp_dir
     >>> with temp_dir() as tmpdir:
     ...     fn = os.path.join(tmpdir, 'myfile.doc')
-    ...     with open(fn, 'w') as f:
+    ...     with open(fn, 'w', encoding="utf-8") as f:
     ...         _ = f.write('This is another simple test file.\n')
     ...         _ = f.write('   >>> 1 + 1\n')
     ...         _ = f.write('   2\n')

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -54,9 +54,9 @@ class ExceptionTests(unittest.TestCase):
         self.assertRaises(AttributeError, getattr, sys, "undefined_attribute")
 
         self.raise_catch(EOFError, "EOFError")
-        fp = open(TESTFN, 'w')
+        fp = open(TESTFN, 'w', encoding="utf-8")
         fp.close()
-        fp = open(TESTFN, 'r')
+        fp = open(TESTFN, 'r', encoding="utf-8")
         savestdin = sys.stdin
         try:
             try:

--- a/Lib/test/test_opcodes.py
+++ b/Lib/test/test_opcodes.py
@@ -24,7 +24,7 @@ class OpcodeTest(unittest.TestCase):
     def test_setup_annotations_line(self):
         # check that SETUP_ANNOTATIONS does not create spurious line numbers
         try:
-            with open(ann_module.__file__) as f:
+            with open(ann_module.__file__, encoding="utf-8") as f:
                 txt = f.read()
             co = compile(txt, ann_module.__file__, 'exec')
             self.assertEqual(co.co_firstlineno, 1)

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -47,7 +47,7 @@ class TestSupport(unittest.TestCase):
         self.assertNotIn("sched", sys.modules)
 
     def test_unlink(self):
-        with open(TESTFN, "w") as f:
+        with open(TESTFN, "w", encoding="utf-8") as f:
             pass
         os_helper.unlink(TESTFN)
         self.assertFalse(os.path.exists(TESTFN))
@@ -79,7 +79,7 @@ class TestSupport(unittest.TestCase):
 
     def test_forget(self):
         mod_filename = TESTFN + '.py'
-        with open(mod_filename, 'w') as f:
+        with open(mod_filename, 'w', encoding="utf-8") as f:
             print('foo = 1', file=f)
         sys.path.insert(0, os.curdir)
         importlib.invalidate_caches()

--- a/Parser/asdl.py
+++ b/Parser/asdl.py
@@ -204,7 +204,7 @@ def check(mod):
 
 def parse(filename):
     """Parse ASDL from the given file and return a Module node describing it."""
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         parser = ASDLParser()
         return parser.parse(f.read())
 


### PR DESCRIPTION
* test__xxsubinterpreters
* test_builtin
* test_doctest
* test_exceptions
* test_opcodes
* test_support
* test_argparse
* test_baseexception
* test_bdb
* test_bool
* test_asdl_parser

<!-- issue-number: [bpo-43651](https://bugs.python.org/issue43651) -->
https://bugs.python.org/issue43651
<!-- /issue-number -->
