### PR TITLE
[3.7] bpo-37788: Fix continuous memory leak occurs when multiple subthreads which are not joined are started.

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-04-02-11-56-50.bpo-37788.jbaJGP.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-02-11-56-50.bpo-37788.jbaJGP.rst
@@ -1,0 +1,1 @@
+Add threading.Thread._discard_tstate_locks() method to check whether the lock of other subthreads can be deleted from the _shutdown_locks list when the subthread task ends and prevent continuous leakage of tstate locks.


### PR DESCRIPTION
Add threading.Thread._discard_tstate_locks() method to check whether the lock of other subthreads can be deleted from the _shutdown_locks list when the subthread task ends and prevent continuous leakage of tstate locks.

<!-- issue-number: [bpo-37788](https://bugs.python.org/issue37788) -->
https://bugs.python.org/issue37788
<!-- /issue-number -->
