### PR TITLE
[3.9] bpo-26053: Fix args echoed by pdb run command 

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1708,7 +1708,7 @@ def main():
             print("The program finished and will be restarted")
         except Restart:
             print("Restarting", mainpyfile, "with arguments:")
-            print("\t" + " ".join(args))
+            print("\t" + " ".join(sys.argv[1:]))
         except SystemExit:
             # In most cases SystemExit does not warrant a post-mortem session.
             print("The program exited via sys.exit(). Exit status:", end=' ')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1443,6 +1443,19 @@ def bœr():
             'Fail to handle a syntax error in the debuggee.'
             .format(expected, stdout))
 
+    def test_issue26053(self):
+        # run command of pdb prompt echoes the correct args
+        script = "print('hello')"
+        commands = """
+            continue
+            run a b c
+            run d e f
+            quit
+        """
+        stdout, stderr = self.run_pdb_script(script, commands)
+        output = '\n'.join([x.strip() for x in stdout.splitlines()])
+        self.assertIn("Restarting main.py with arguments:\na b c", output)
+        self.assertIn("Restarting main.py with arguments:\nd e f", output)
 
     def test_readrc_kwarg(self):
         script = textwrap.dedent("""

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1453,9 +1453,9 @@ def bœr():
             quit
         """
         stdout, stderr = self.run_pdb_script(script, commands)
-        output = '\n'.join([x.strip() for x in stdout.splitlines()])
-        self.assertIn("Restarting main.py with arguments:\na b c", output)
-        self.assertIn("Restarting main.py with arguments:\nd e f", output)
+        res = '\n'.join([x.strip() for x in stdout.splitlines()])
+        self.assertRegex(res, "Restarting .* with arguments:\na b c")
+        self.assertRegex(res, "Restarting .* with arguments:\nd e f")
 
     def test_readrc_kwarg(self):
         script = textwrap.dedent("""

--- a/Misc/NEWS.d/next/Library/2020-09-01-10-12-13.bpo-26053.hXikw_.rst
+++ b/Misc/NEWS.d/next/Library/2020-09-01-10-12-13.bpo-26053.hXikw_.rst
@@ -1,0 +1,1 @@
+Fixed bug where the :mod:`pdb` interactive run command echoed the args from the shell command line, even if those have been overridden at the pdb prompt.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-26053](https://bugs.python.org/issue26053) -->
https://bugs.python.org/issue26053
<!-- /issue-number -->
