### PR TITLE
bpo-41111: xxlimited.c defines Py_LIMITED_API

### DIFF
--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -55,6 +55,8 @@
           pass
    */
 
+#define Py_LIMITED_API 0x030a0000
+
 #include "Python.h"
 
 // Module state

--- a/Modules/xxlimited_35.c
+++ b/Modules/xxlimited_35.c
@@ -5,9 +5,11 @@
  * See the xxlimited module for an extension module template.
  */
 
-/* Xxo objects */
+#define Py_LIMITED_API 0x03050000
 
 #include "Python.h"
+
+/* Xxo objects */
 
 static PyObject *ErrorObject;
 

--- a/PCbuild/xxlimited.vcxproj
+++ b/PCbuild/xxlimited.vcxproj
@@ -93,9 +93,6 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
   </PropertyGroup>
   <ItemDefinitionGroup>
-    <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);Py_LIMITED_API=0x030A0000</PreprocessorDefinitions>
-    </ClCompile>
     <Link>
       <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/PCbuild/xxlimited_35.vcxproj
+++ b/PCbuild/xxlimited_35.vcxproj
@@ -93,9 +93,6 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
   </PropertyGroup>
   <ItemDefinitionGroup>
-    <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);Py_LIMITED_API=0x03060000</PreprocessorDefinitions>
-    </ClCompile>
     <Link>
       <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/setup.py
+++ b/setup.py
@@ -1865,10 +1865,8 @@ class PyBuildExt(build_ext):
 ##         self.add(Extension('xx', ['xxmodule.c']))
 
         # Limited C API
-        self.add(Extension('xxlimited', ['xxlimited.c'],
-                           define_macros=[('Py_LIMITED_API', '0x030a0000')]))
-        self.add(Extension('xxlimited_35', ['xxlimited_35.c'],
-                           define_macros=[('Py_LIMITED_API', '0x03050000')]))
+        self.add(Extension('xxlimited', ['xxlimited.c']))
+        self.add(Extension('xxlimited_35', ['xxlimited_35.c']))
 
     def detect_tkinter_fromenv(self):
         # Build _tkinter using the Tcl/Tk locations specified by


### PR DESCRIPTION
xxlimited.c and xxlimited_35.c now define Py_LIMITED_API macros,
rather than having to do it in the build recipe.

Co-Authored-By: Hai Shi <shihai1992@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41111](https://bugs.python.org/issue41111) -->
https://bugs.python.org/issue41111
<!-- /issue-number -->
