### PR TITLE
bpo-43705: Document that SyntaxError's offsets are 1-indexed

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -410,13 +410,13 @@ The following exceptions are the exceptions that are usually raised.
 
    .. attribute:: lineno
 
-      Which line number in the file the error occurred in. Note that this is
-      1-indexed, the first line in the file would have a ``lineno`` of 1.
+      Which line number in the file the error occurred in. This is
+      1-indexed: the first line in the file has a ``lineno`` of 1.
 
    .. attribute:: offset
 
-      The column in the line where the error occurred. Note that this is
-      1-indexed, the first character in the line has an ``offset`` of 1.
+      The column in the line where the error occurred. This is
+      1-indexed: the first character in the line has an ``offset`` of 1.
 
    .. attribute:: text
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -402,9 +402,25 @@ The following exceptions are the exceptions that are usually raised.
    or :func:`eval`, or when reading the initial script or standard input
    (also interactively).
 
-   Instances of this class have attributes :attr:`filename`, :attr:`lineno`,
-   :attr:`offset` and :attr:`text` for easier access to the details.  :func:`str`
-   of the exception instance returns only the message.
+   The :func:`str` of the exception instance returns only the error message.
+
+   .. attribute:: filename
+
+      The name of the file the syntax error occurred in.
+
+   .. attribute:: lineno
+
+      Which line number in the file the error occurred in. Note that this is
+      1-indexed, the first line in the file would have a ``lineno`` of 1.
+
+   .. attribute:: offset
+
+      The column in the line where the error occurred. Note that this is
+      1-indexed, the first character in the line has an ``offset`` of 1.
+
+   .. attribute:: text
+
+      The source code text involved in the error.
 
 
 .. exception:: IndentationError


### PR DESCRIPTION
Changed the inline mentions of the attributes into a proper attribute list like `SystemExit` has.

<!-- issue-number: [bpo-43705](https://bugs.python.org/issue43705) -->
https://bugs.python.org/issue43705
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum