### PR TITLE
bpo-43706: Use PEP 590 vectorcall to speed up enumerate()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-03-02-44-15.bpo-43706.jjsXlT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-03-02-44-15.bpo-43706.jjsXlT.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``enumerate()`` by using the :pep:`590` ``vectorcall``
+calling convention. Patch by Dong-hee Na.

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -83,7 +83,7 @@ enum_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *start)
 
 // TODO: Use AC when bpo-43447 is supported
 static PyObject *
-enum_vectorcall(PyObject *type, PyObject * const*args,
+enum_vectorcall(PyObject *type, PyObject *const *args,
                 size_t nargsf, PyObject *kwnames)
 {
     assert(PyType_Check(type));
@@ -91,7 +91,8 @@ enum_vectorcall(PyObject *type, PyObject * const*args,
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
     Py_ssize_t nkwargs = 0;
     if (nargs == 0) {
-        PyErr_SetString(PyExc_TypeError, "enumerate() missing required argument 'iterable'");
+        PyErr_SetString(PyExc_TypeError,
+            "enumerate() missing required argument 'iterable'");
         return NULL;
     }
     if (kwnames != NULL) {
@@ -102,7 +103,8 @@ enum_vectorcall(PyObject *type, PyObject * const*args,
         if (nkwargs == 1) {
             PyObject *kw = PyTuple_GET_ITEM(kwnames, 0);
             if (!_PyUnicode_EqualToASCIIString(kw, "start")) {
-                PyErr_Format(PyExc_TypeError, "'%S' is an invalid keyword argument for enumerate()", kw);
+                PyErr_Format(PyExc_TypeError,
+                    "'%S' is an invalid keyword argument for enumerate()", kw);
                 return NULL;
             }
         }
@@ -113,7 +115,8 @@ enum_vectorcall(PyObject *type, PyObject * const*args,
         return enum_new_impl(tp, args[0], NULL);
     }
 
-    PyErr_Format(PyExc_TypeError, "enumerate() takes at most 2 arguments (%d given)", nargs + nkwargs);
+    PyErr_Format(PyExc_TypeError,
+        "enumerate() takes at most 2 arguments (%d given)", nargs + nkwargs);
     return NULL;
 }
 

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -81,6 +81,42 @@ enum_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *start)
     return (PyObject *)en;
 }
 
+// TODO: Use AC when bpo-43447 is supported
+static PyObject *
+enum_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
+{
+    assert(PyType_Check(type));
+    PyTypeObject *tp = (PyTypeObject *)type;
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    Py_ssize_t nkwargs = 0;
+    if (nargs == 0) {
+        PyErr_SetString(PyExc_TypeError, "enumerate() missing required argument 'iterable'");
+        return NULL;
+    }
+    if (kwnames != NULL) {
+        nkwargs = PyTuple_GET_SIZE(kwnames);
+    }
+
+    if (nargs + nkwargs == 2) {
+        if (nkwargs == 1) {
+            PyObject *kw = PyTuple_GET_ITEM(kwnames, 0);
+            if (!_PyUnicode_EqualToASCIIString(kw, "start")) {
+                PyErr_Format(PyExc_TypeError, "'%S' is an invalid keyword argument for enumerate()", kw);
+                return NULL;
+            }
+        }
+        return enum_new_impl(tp, args[0], args[1]);
+    }
+
+    if (nargs == 1 && nkwargs == 0) {
+        return enum_new_impl(tp, args[0], NULL);
+    }
+
+    PyErr_Format(PyExc_TypeError, "enumerate() takes at most 2 arguments (%d given)", nargs + nkwargs);
+    return NULL;
+}
+
 static void
 enum_dealloc(enumobject *en)
 {
@@ -261,6 +297,7 @@ PyTypeObject PyEnum_Type = {
     PyType_GenericAlloc,            /* tp_alloc */
     enum_new,                       /* tp_new */
     PyObject_GC_Del,                /* tp_free */
+    .tp_vectorcall = (vectorcallfunc)enum_vectorcall
 };
 
 /* Reversed Object ***************************************************************/

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -83,8 +83,8 @@ enum_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *start)
 
 // TODO: Use AC when bpo-43447 is supported
 static PyObject *
-enum_vectorcall(PyObject *type, PyObject *const *args,
-                size_t nargsf, PyObject *kwnames)
+enumerate_vectorcall(PyObject *type, PyObject *const *args,
+                     size_t nargsf, PyObject *kwnames)
 {
     assert(PyType_Check(type));
     PyTypeObject *tp = (PyTypeObject *)type;
@@ -300,7 +300,7 @@ PyTypeObject PyEnum_Type = {
     PyType_GenericAlloc,            /* tp_alloc */
     enum_new,                       /* tp_new */
     PyObject_GC_Del,                /* tp_free */
-    .tp_vectorcall = (vectorcallfunc)enum_vectorcall
+    .tp_vectorcall = (vectorcallfunc)enumerate_vectorcall
 };
 
 /* Reversed Object ***************************************************************/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43706](https://bugs.python.org/issue43706) -->
https://bugs.python.org/issue43706
<!-- /issue-number -->


| Benchmark       | base   | vectorcall           |
|-----------------|:------:|:--------------------:|
| bench enumerate | 533 ns | 341 ns: 1.56x faster |


| Benchmark       | base (PGO+LTO) | vectorcall (PGO+LTO)      |
|-----------------|:--------:|:--------------------:|
| bench enumerate | 384 ns   | 277 ns: 1.39x faster |