### PR TITLE
bpo-43709: Remove pyc/pyo files from Tools/Parser in buildbot clean.bat

### DIFF
--- a/Misc/NEWS.d/next/build/2021-04-02-17-34-03.bpo-43709.urw_VP.rst
+++ b/Misc/NEWS.d/next/build/2021-04-02-17-34-03.bpo-43709.urw_VP.rst
@@ -1,0 +1,2 @@
+Remove pyc/pyo files from the Tools and Parser directories in Windows buildbot
+clean.bat script to avoid incompatible files between builds.

--- a/Tools/buildbot/clean.bat
+++ b/Tools/buildbot/clean.bat
@@ -11,6 +11,8 @@ call "%pcbuild%\build.bat" -t Clean -k -d %*
 
 echo Deleting .pyc/.pyo files ...
 del /s "%root%\Lib\*.pyc" "%root%\Lib\*.pyo"
+del /s "%root%\Tools\*.pyc" "%root%\Tools\*.pyo"
+del /s "%root%\Parser\*.pyc" "%root%\Parser\*.pyo"
 
 echo Deleting test leftovers ...
 rmdir /s /q "%root%\build"


### PR DESCRIPTION
The Windows buildbot clean.bat script needs to remove pyc/pyo files in the
Tools and Parser directories (in addition to the existing Lib directory)
to avoid incompatible files between builds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43709](https://bugs.python.org/issue43709) -->
https://bugs.python.org/issue43709
<!-- /issue-number -->
