### PR TITLE
[3.9] bpo-43710: Change layout of pystate struct to preserve intra-version ABI compatibiliy.

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -69,10 +69,10 @@ PyAPI_FUNC(void) Py_LeaveRecursiveCall(void);
 
 #define Py_ALLOW_RECURSION \
   do { unsigned char _old = PyThreadState_GET()->recursion_critical;\
-    PyThreadState_GET()->recursion_critical = 1;
+    PyThreadState_GET()->recursion_headroom = 1;
 
 #define Py_END_ALLOW_RECURSION \
-    PyThreadState_GET()->recursion_critical = _old; \
+    PyThreadState_GET()->recursion_headroom = _old; \
   } while(0);
 
 PyAPI_FUNC(const char *) PyEval_GetFuncName(PyObject *);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -58,9 +58,8 @@ struct _ts {
     /* Borrowed reference to the current frame (it can be NULL) */
     PyFrameObject *frame;
     int recursion_depth;
-    int recursion_headroom; /* Allow 50 more calls to handle any errors. */
-    char recursion_critical; /* The current calls must not cause
-                                a stack overflow. */
+    short recursion_headroom; /* Allow 50 more calls to handle any errors. */
+
     int stackcheck_counter;
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -577,7 +577,6 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->frame = NULL;
     tstate->recursion_depth = 0;
     tstate->recursion_headroom = 0;
-    tstate->recursion_critical = 0;
     tstate->stackcheck_counter = 0;
     tstate->tracing = 0;
     tstate->use_tracing = 0;


### PR DESCRIPTION
This PR replaces the original (in 3.9.0)
```C
    char overflowed;
    char recursion_critical;
```
with
```C
    short recursion_headroom; 
```
restoring the ABI broken by https://github.com/python/cpython/pull/24501

Since `recursion_headroom`, `overflowed`, and `recursion_critical` all serve the same purpose, indicating that RecursionError should not be raised unless overflow become excessive, we can safely merge them.

I choose to use `short recursion_headroom` rather than using `char recursion_headroom` and leaving `recursion_critical` in place, so that assignments to `recursion_critical` in code compiled for 3.9.0 will be visible as changes to `recursion_headroom`.

The layout will be the same (at least for all compilers where `sizeof(short) == sizeof(char)*2`).





<!-- issue-number: [bpo-43710](https://bugs.python.org/issue43710) -->
https://bugs.python.org/issue43710
<!-- /issue-number -->
