### PR TITLE
bpo-43720: Update import-related stdlib deprecation messages to say they will be removed in Python 3.12

### DIFF
--- a/Lib/imp.py
+++ b/Lib/imp.py
@@ -28,7 +28,8 @@ import tokenize
 import types
 import warnings
 
-warnings.warn("the imp module is deprecated in favour of importlib; "
+warnings.warn("the imp module is deprecated in favour of importlib and slated "
+              "for removal in Python 3.12; "
               "see the module's documentation for alternative uses",
               DeprecationWarning, stacklevel=2)
 

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -149,7 +149,8 @@ def set_package(fxn):
     """
     @functools.wraps(fxn)
     def set_package_wrapper(*args, **kwargs):
-        warnings.warn('The import system now takes care of this automatically.',
+        warnings.warn('The import system now takes care of this automatically; '
+                      'this decorator is slated for removal in Python 3.12',
                       DeprecationWarning, stacklevel=2)
         module = fxn(*args, **kwargs)
         if getattr(module, '__package__', None) is None:
@@ -168,7 +169,8 @@ def set_loader(fxn):
     """
     @functools.wraps(fxn)
     def set_loader_wrapper(self, *args, **kwargs):
-        warnings.warn('The import system now takes care of this automatically.',
+        warnings.warn('The import system now takes care of this automatically; '
+                      'this decorator is slated for removal in Python 3.12',
                       DeprecationWarning, stacklevel=2)
         module = fxn(self, *args, **kwargs)
         if getattr(module, '__loader__', None) is None:
@@ -195,7 +197,8 @@ def module_for_loader(fxn):
     the second argument.
 
     """
-    warnings.warn('The import system now takes care of this automatically.',
+    warnings.warn('The import system now takes care of this automatically; '
+                  'this decorator is slated for removal in Python 3.12',
                   DeprecationWarning, stacklevel=2)
     @functools.wraps(fxn)
     def module_for_loader_wrapper(self, fullname, *args, **kwargs):

--- a/Lib/pkgutil.py
+++ b/Lib/pkgutil.py
@@ -204,7 +204,8 @@ class ImpImporter:
 
     def __init__(self, path=None):
         global imp
-        warnings.warn("This emulation is deprecated, use 'importlib' instead",
+        warnings.warn("This emulation is deprecated and slated for removal "
+                      "in Python 3.12; use 'importlib' instead",
              DeprecationWarning)
         _import_imp()
         self.path = path
@@ -271,7 +272,8 @@ class ImpLoader:
     code = source = None
 
     def __init__(self, fullname, file, filename, etc):
-        warnings.warn("This emulation is deprecated, use 'importlib' instead",
+        warnings.warn("This emulation is deprecated and slated for removal in "
+                      "Python 3.12; use 'importlib' instead",
                       DeprecationWarning)
         _import_imp()
         self.file = file

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -498,7 +498,8 @@ class ImportlibMigrationTests(unittest.TestCase):
 
     def check_deprecated(self):
         return check_warnings(
-            ("This emulation is deprecated, use 'importlib' instead",
+            ("This emulation is deprecated and slated for removal in "
+             "Python 3.12; use 'importlib' instead",
              DeprecationWarning))
 
     def test_importer_deprecated(self):

--- a/Misc/NEWS.d/next/Library/2021-04-03-13-45-51.bpo-43720.FDZ5cZ.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-03-13-45-51.bpo-43720.FDZ5cZ.rst
@@ -1,0 +1,2 @@
+Document various stdlib deprecations in imp, pkgutil, and importlib.util for removal in Python
+3.12.


### PR DESCRIPTION


<!-- issue-number: [bpo-43720](https://bugs.python.org/issue43720) -->
https://bugs.python.org/issue43720
<!-- /issue-number -->
