### PR TITLE
bpo-43651: PEP 597: Fix EncodingWarning in some tests

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -156,9 +156,9 @@ def _default_sysroot(cc):
 
     if _cache_default_sysroot is not None:
         return _cache_default_sysroot
-   
+
     contents = _read_output('%s -c -E -v - </dev/null' % (cc,), True)
-    in_incdirs = False   
+    in_incdirs = False
     for line in contents.splitlines():
         if line.startswith("#include <...>"):
             in_incdirs = True

--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -96,7 +96,7 @@ def _get_system_version():
     if _SYSTEM_VERSION is None:
         _SYSTEM_VERSION = ''
         try:
-            f = open('/System/Library/CoreServices/SystemVersion.plist')
+            f = open('/System/Library/CoreServices/SystemVersion.plist', encoding="utf-8")
         except OSError:
             # We're on a plain darwin box, fall back to the default
             # behaviour.

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -729,7 +729,7 @@ class FormatTestCase(unittest.TestCase):
 
     @support.requires_IEEE_754
     def test_format_testfile(self):
-        with open(format_testfile) as testfile:
+        with open(format_testfile, encoding="utf-8") as testfile:
             for line in testfile:
                 if line.startswith('--'):
                     continue
@@ -769,7 +769,7 @@ class FormatTestCase(unittest.TestCase):
 class ReprTestCase(unittest.TestCase):
     def test_repr(self):
         with open(os.path.join(os.path.split(__file__)[0],
-                  'floating_points.txt')) as floats_file:
+                  'floating_points.txt'), encoding="utf-8") as floats_file:
             for line in floats_file:
                 line = line.strip()
                 if not line or line.startswith('#'):

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1110,7 +1110,7 @@ x = (
         # see issue 38964
         with temp_cwd() as cwd:
             file_path = os.path.join(cwd, 't.py')
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding="utf-8") as f:
                 f.write('f"{a b}"') # This generates a SyntaxError
             _, _, stderr = assert_python_failure(file_path,
                                                  PYTHONIOENCODING='ascii')

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -750,7 +750,7 @@ class GCTests(unittest.TestCase):
             a.link = a
             raise SystemExit(0)"""
         self.addCleanup(unlink, TESTFN)
-        with open(TESTFN, 'w') as script:
+        with open(TESTFN, 'w', encoding="utf-8") as script:
             script.write(code)
         rc, out, err = assert_python_ok(TESTFN)
         self.assertEqual(out.strip(), b'__del__ called')

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -660,14 +660,14 @@ class TestOpen(BaseTest):
     def test_text_modes(self):
         uncompressed = data1.decode("ascii") * 50
         uncompressed_raw = uncompressed.replace("\n", os.linesep)
-        with gzip.open(self.filename, "wt") as f:
+        with gzip.open(self.filename, "wt", encoding="ascii") as f:
             f.write(uncompressed)
         with open(self.filename, "rb") as f:
             file_data = gzip.decompress(f.read()).decode("ascii")
             self.assertEqual(file_data, uncompressed_raw)
-        with gzip.open(self.filename, "rt") as f:
+        with gzip.open(self.filename, "rt", encoding="ascii") as f:
             self.assertEqual(f.read(), uncompressed)
-        with gzip.open(self.filename, "at") as f:
+        with gzip.open(self.filename, "at", encoding="ascii") as f:
             f.write(uncompressed)
         with open(self.filename, "rb") as f:
             file_data = gzip.decompress(f.read()).decode("ascii")
@@ -681,7 +681,7 @@ class TestOpen(BaseTest):
             self.assertEqual(f.read(), uncompressed_bytes)
         with gzip.open(io.BytesIO(compressed), "rb") as f:
             self.assertEqual(f.read(), uncompressed_bytes)
-        with gzip.open(io.BytesIO(compressed), "rt") as f:
+        with gzip.open(io.BytesIO(compressed), "rt", encoding="ascii") as f:
             self.assertEqual(f.read(), uncompressed_str)
 
     def test_bad_params(self):
@@ -722,9 +722,9 @@ class TestOpen(BaseTest):
     def test_newline(self):
         # Test with explicit newline (universal newline mode disabled).
         uncompressed = data1.decode("ascii") * 50
-        with gzip.open(self.filename, "wt", newline="\n") as f:
+        with gzip.open(self.filename, "wt", encoding="ascii", newline="\n") as f:
             f.write(uncompressed)
-        with gzip.open(self.filename, "rt", newline="\r") as f:
+        with gzip.open(self.filename, "rt", encoding="ascii", newline="\r") as f:
             self.assertEqual(f.readlines(), [uncompressed])
 
 

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -82,7 +82,7 @@ URL = "http://www.pythontest.net/hashlib/{}.txt"
 def read_vectors(hash_name):
     url = URL.format(hash_name)
     try:
-        testdata = support.open_urlresource(url)
+        testdata = support.open_urlresource(url, encoding="utf-8")
     except (OSError, HTTPException):
         raise unittest.SkipTest("Could not retrieve {}".format(url))
     with testdata:


### PR DESCRIPTION
* test_float
* _osx_support
* test_fstring
* test_gc
* test_gzip
* test_hashlib

<!-- issue-number: [bpo-43651](https://bugs.python.org/issue43651) -->
https://bugs.python.org/issue43651
<!-- /issue-number -->
