### PR TITLE
bpo-43723: deprecate camelCase aliases from threading

### DIFF
--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -319,11 +319,11 @@ Here's a trivial example::
            try:
                arg = q.get(block=False)
            except queue.Empty:
-               print('Worker', threading.currentThread(), end=' ')
+               print('Worker', threading.current_thread(), end=' ')
                print('queue empty')
                break
            else:
-               print('Worker', threading.currentThread(), end=' ')
+               print('Worker', threading.current_thread(), end=' ')
                print('running with argument', arg)
                time.sleep(0.5)
 

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -732,7 +732,7 @@ intended to be the same as executing the same code by the default method,
 directly with Python in a text-mode system console or terminal window.
 However, the different interface and operation occasionally affect
 visible results.  For instance, ``sys.modules`` starts with more entries,
-and ``threading.activeCount()`` returns 2 instead of 1.
+and ``threading.active_count()`` returns 2 instead of 1.
 
 By default, IDLE runs user code in a separate OS process rather than in
 the user interface process that runs the shell and editor.  In the execution

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -42,7 +42,8 @@ This module defines the following functions:
    Return the number of :class:`Thread` objects currently alive.  The returned
    count is equal to the length of the list returned by :func:`.enumerate`.
 
-   The function `activeCount` is a deprecated alias for this function.
+   The function ``activeCount`` is a deprecated alias for this function.
+
 
 .. function:: current_thread()
 
@@ -51,7 +52,7 @@ This module defines the following functions:
    :mod:`threading` module, a dummy thread object with limited functionality is
    returned.
 
-   The function `currentThread` is a deprecated alias for this function.
+   The function ``currentThread`` is a deprecated alias for this function.
 
 
 .. function:: excepthook(args, /)
@@ -774,7 +775,7 @@ item to the buffer only needs to wake up one consumer thread.
       calling thread has not acquired the lock when this method is called, a
       :exc:`RuntimeError` is raised.
 
-      The method `notifyAll` is a deprecated alias for this method.
+      The method ``notifyAll`` is a deprecated alias for this method.
 
 
 .. _semaphore-objects:
@@ -913,7 +914,7 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
 
       Return ``True`` if and only if the internal flag is true.
 
-      The method `isSet` is a deprecated alias for this method.
+      The method ``isSet`` is a deprecated alias for this method.
 
    .. method:: set()
 

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -16,9 +16,9 @@ level :mod:`_thread` module.  See also the :mod:`queue` module.
 
 .. note::
 
-   While they are not listed below, the ``camelCase`` names used for some
+   The ``camelCase`` names used for some
    methods and functions in this module in the Python 2.x series are still
-   supported by this module.
+   supported by this module. They will be removed in the future.
 
 
 .. impl-detail::
@@ -42,6 +42,8 @@ This module defines the following functions:
    Return the number of :class:`Thread` objects currently alive.  The returned
    count is equal to the length of the list returned by :func:`.enumerate`.
 
+   .. deprecated-removed:: 3.10 3.12
+      The function `activeCount` is an alias for this function.
 
 .. function:: current_thread()
 
@@ -49,6 +51,9 @@ This module defines the following functions:
    of control.  If the caller's thread of control was not created through the
    :mod:`threading` module, a dummy thread object with limited functionality is
    returned.
+
+   .. deprecated-removed:: 3.10 3.12
+      The function `currentThread` is an alias for this function.
 
 
 .. function:: excepthook(args, /)
@@ -384,6 +389,8 @@ since it is impossible to detect the termination of alien threads.
       Old getter/setter API for :attr:`~Thread.name`; use it directly as a
       property instead.
 
+      .. deprecated-removed:: 3.10 3.12
+
    .. attribute:: ident
 
       The 'thread identifier' of this thread or ``None`` if the thread has not
@@ -435,6 +442,8 @@ since it is impossible to detect the termination of alien threads.
 
       Old getter/setter API for :attr:`~Thread.daemon`; use it directly as a
       property instead.
+
+      .. deprecated-removed:: 3.10 3.12
 
 
 .. _lock-objects:
@@ -771,6 +780,9 @@ item to the buffer only needs to wake up one consumer thread.
       calling thread has not acquired the lock when this method is called, a
       :exc:`RuntimeError` is raised.
 
+      .. deprecated-removed:: 3.10 3.12
+         The method `notifyAll` is an alias for this method.
+
 
 .. _semaphore-objects:
 
@@ -907,6 +919,9 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
    .. method:: is_set()
 
       Return ``True`` if and only if the internal flag is true.
+
+      .. deprecated-removed:: 3.10 3.12
+         The method `isSet` is an alias for this method.
 
    .. method:: set()
 

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -16,9 +16,9 @@ level :mod:`_thread` module.  See also the :mod:`queue` module.
 
 .. note::
 
-   The ``camelCase`` names used for some
-   methods and functions in this module in the Python 2.x series are still
-   supported by this module for compatibility with Python 2.5 and lower.
+   In the Python 2.x series, this module contained ``camelCase`` names
+   for some methods and functions. These are deprecated as of Python 3.10,
+   but they are still supported for compatibility with Python 2.5 and lower.
 
 
 .. impl-detail::
@@ -388,6 +388,8 @@ since it is impossible to detect the termination of alien threads.
       Deprecated getter/setter API for :attr:`~Thread.name`; use it directly as a
       property instead.
 
+      .. deprecated: 3.10
+
    .. attribute:: ident
 
       The 'thread identifier' of this thread or ``None`` if the thread has not
@@ -439,6 +441,8 @@ since it is impossible to detect the termination of alien threads.
 
       Deprecated getter/setter API for :attr:`~Thread.daemon`; use it directly as a
       property instead.
+
+      .. deprecated: 3.10
 
 
 .. _lock-objects:

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -388,7 +388,7 @@ since it is impossible to detect the termination of alien threads.
       Deprecated getter/setter API for :attr:`~Thread.name`; use it directly as a
       property instead.
 
-      .. deprecated: 3.10
+      .. deprecated:: 3.10
 
    .. attribute:: ident
 
@@ -442,7 +442,7 @@ since it is impossible to detect the termination of alien threads.
       Deprecated getter/setter API for :attr:`~Thread.daemon`; use it directly as a
       property instead.
 
-      .. deprecated: 3.10
+      .. deprecated:: 3.10
 
 
 .. _lock-objects:

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -18,7 +18,7 @@ level :mod:`_thread` module.  See also the :mod:`queue` module.
 
    The ``camelCase`` names used for some
    methods and functions in this module in the Python 2.x series are still
-   supported by this module. They will be removed in the future.
+   supported by this module for compatibility with Python 2.5 and lower.
 
 
 .. impl-detail::
@@ -42,7 +42,7 @@ This module defines the following functions:
    Return the number of :class:`Thread` objects currently alive.  The returned
    count is equal to the length of the list returned by :func:`.enumerate`.
 
-   .. deprecated-removed:: 3.10 3.12
+   .. deprecated:: 3.10
       The function `activeCount` is an alias for this function.
 
 .. function:: current_thread()
@@ -52,7 +52,7 @@ This module defines the following functions:
    :mod:`threading` module, a dummy thread object with limited functionality is
    returned.
 
-   .. deprecated-removed:: 3.10 3.12
+   .. deprecated:: 3.10
       The function `currentThread` is an alias for this function.
 
 
@@ -389,7 +389,7 @@ since it is impossible to detect the termination of alien threads.
       Old getter/setter API for :attr:`~Thread.name`; use it directly as a
       property instead.
 
-      .. deprecated-removed:: 3.10 3.12
+      .. deprecated:: 3.10
 
    .. attribute:: ident
 
@@ -443,7 +443,7 @@ since it is impossible to detect the termination of alien threads.
       Old getter/setter API for :attr:`~Thread.daemon`; use it directly as a
       property instead.
 
-      .. deprecated-removed:: 3.10 3.12
+      .. deprecated:: 3.10
 
 
 .. _lock-objects:
@@ -780,7 +780,7 @@ item to the buffer only needs to wake up one consumer thread.
       calling thread has not acquired the lock when this method is called, a
       :exc:`RuntimeError` is raised.
 
-      .. deprecated-removed:: 3.10 3.12
+      .. deprecated:: 3.10
          The method `notifyAll` is an alias for this method.
 
 
@@ -920,7 +920,7 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
 
       Return ``True`` if and only if the internal flag is true.
 
-      .. deprecated-removed:: 3.10 3.12
+      .. deprecated:: 3.10
          The method `isSet` is an alias for this method.
 
    .. method:: set()

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -42,8 +42,7 @@ This module defines the following functions:
    Return the number of :class:`Thread` objects currently alive.  The returned
    count is equal to the length of the list returned by :func:`.enumerate`.
 
-   .. deprecated:: 3.10
-      The function `activeCount` is an alias for this function.
+   The function `activeCount` is a deprecated alias for this function.
 
 .. function:: current_thread()
 
@@ -52,8 +51,7 @@ This module defines the following functions:
    :mod:`threading` module, a dummy thread object with limited functionality is
    returned.
 
-   .. deprecated:: 3.10
-      The function `currentThread` is an alias for this function.
+   The function `currentThread` is a deprecated alias for this function.
 
 
 .. function:: excepthook(args, /)
@@ -386,10 +384,8 @@ since it is impossible to detect the termination of alien threads.
    .. method:: getName()
                setName()
 
-      Old getter/setter API for :attr:`~Thread.name`; use it directly as a
+      Deprecated getter/setter API for :attr:`~Thread.name`; use it directly as a
       property instead.
-
-      .. deprecated:: 3.10
 
    .. attribute:: ident
 
@@ -440,10 +436,8 @@ since it is impossible to detect the termination of alien threads.
    .. method:: isDaemon()
                setDaemon()
 
-      Old getter/setter API for :attr:`~Thread.daemon`; use it directly as a
+      Deprecated getter/setter API for :attr:`~Thread.daemon`; use it directly as a
       property instead.
-
-      .. deprecated:: 3.10
 
 
 .. _lock-objects:
@@ -780,8 +774,7 @@ item to the buffer only needs to wake up one consumer thread.
       calling thread has not acquired the lock when this method is called, a
       :exc:`RuntimeError` is raised.
 
-      .. deprecated:: 3.10
-         The method `notifyAll` is an alias for this method.
+      The method `notifyAll` is a deprecated alias for this method.
 
 
 .. _semaphore-objects:
@@ -920,8 +913,7 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
 
       Return ``True`` if and only if the internal flag is true.
 
-      .. deprecated:: 3.10
-         The method `isSet` is an alias for this method.
+      The method `isSet` is a deprecated alias for this method.
 
    .. method:: set()
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1071,14 +1071,24 @@ Deprecated
   (Contributed by Erlend E. Aasland in :issue:`24464`.)
 
 * The following `threading` methods are now deprecated:
-  `threading.currentThread` => :func:`threading.current_thread`;
-  `threading.activeCount` => :func:`threading.active_count`;
-  `threading.Condition.notifyAll` => :meth:`threading.Condition.notify_all`;
-  `threading.Event.isSet` => :meth:`threading.Event.is_set`;
-  `threading.Thread.setName` => :attr:`threading.Thread.name`;
-  `threading.thread.getName` => :attr:`threading.Thread.name`;
-  `threading.Thread.isDaemon` => :attr:`threading.Thread.daemon`;
-  `threading.Thread.setDaemon` => :attr:`threading.Thread.daemon`.
+
+  * `threading.currentThread` => :func:`threading.current_thread`
+
+  * `threading.activeCount` => :func:`threading.active_count`
+
+  * `threading.Condition.notifyAll` =>
+    :meth:`threading.Condition.notify_all`
+
+  * `threading.Event.isSet` => :meth:`threading.Event.is_set`
+
+  * `threading.Thread.setName` => :attr:`threading.Thread.name`
+
+  * `threading.thread.getName` => :attr:`threading.Thread.name`
+
+  * `threading.Thread.isDaemon` => :attr:`threading.Thread.daemon`
+
+  * `threading.Thread.setDaemon` => :attr:`threading.Thread.daemon`
+
   (Contributed by Jelle Zijlstra in :issue:`21574`.)
 
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1070,24 +1070,24 @@ Deprecated
   ``cache=shared`` query parameter.
   (Contributed by Erlend E. Aasland in :issue:`24464`.)
 
-* The following `threading` methods are now deprecated:
+* The following ``threading`` methods are now deprecated:
 
-  * `threading.currentThread` => :func:`threading.current_thread`
+  * ``threading.currentThread`` => :func:`threading.current_thread`
 
-  * `threading.activeCount` => :func:`threading.active_count`
+  * ``threading.activeCount`` => :func:`threading.active_count`
 
-  * `threading.Condition.notifyAll` =>
+  * ``threading.Condition.notifyAll`` =>
     :meth:`threading.Condition.notify_all`
 
-  * `threading.Event.isSet` => :meth:`threading.Event.is_set`
+  * ``threading.Event.isSet`` => :meth:`threading.Event.is_set`
 
-  * `threading.Thread.setName` => :attr:`threading.Thread.name`
+  * ``threading.Thread.setName`` => :attr:`threading.Thread.name`
 
-  * `threading.thread.getName` => :attr:`threading.Thread.name`
+  * ``threading.thread.getName`` => :attr:`threading.Thread.name`
 
-  * `threading.Thread.isDaemon` => :attr:`threading.Thread.daemon`
+  * ``threading.Thread.isDaemon`` => :attr:`threading.Thread.daemon`
 
-  * `threading.Thread.setDaemon` => :attr:`threading.Thread.daemon`
+  * ``threading.Thread.setDaemon`` => :attr:`threading.Thread.daemon`
 
   (Contributed by Jelle Zijlstra in :issue:`21574`.)
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1070,6 +1070,17 @@ Deprecated
   ``cache=shared`` query parameter.
   (Contributed by Erlend E. Aasland in :issue:`24464`.)
 
+* The following `threading` methods are now deprecated:
+  `threading.currentThread` => :func:`threading.current_thread`;
+  `threading.activeCount` => :func:`threading.active_count`;
+  `threading.Condition.notifyAll` => :meth:`threading.Condition.notify_all`;
+  `threading.Event.isSet` => :meth:`threading.Event.is_set`;
+  `threading.Thread.setName` => :attr:`threading.Thread.name`;
+  `threading.thread.getName` => :attr:`threading.Thread.name`;
+  `threading.Thread.isDaemon` => :attr:`threading.Thread.daemon`;
+  `threading.Thread.setDaemon` => :attr:`threading.Thread.daemon`.
+  (Contributed by Jelle Zijlstra in :issue:`21574`.)
+
 
 Removed
 =======

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -154,9 +154,9 @@ class ThreadTests(BaseTestCase):
 
     def test_ident_of_no_threading_threads(self):
         # The ident still must work for the main thread and dummy threads.
-        self.assertIsNotNone(threading.currentThread().ident)
+        self.assertIsNotNone(threading.current_thread().ident)
         def f():
-            ident.append(threading.currentThread().ident)
+            ident.append(threading.current_thread().ident)
             done.set()
         done = threading.Event()
         ident = []
@@ -447,13 +447,28 @@ class ThreadTests(BaseTestCase):
         # Just a quick sanity check to make sure the old method names are
         # still present
         t = threading.Thread()
-        t.isDaemon()
-        t.setDaemon(True)
-        t.getName()
-        t.setName("name")
+        with self.assertWarnsRegex(DeprecationWarning, r'use \.daemon'):
+            t.isDaemon()
+        with self.assertWarnsRegex(DeprecationWarning, r'use \.daemon'):
+            t.setDaemon(True)
+        with self.assertWarnsRegex(DeprecationWarning, r'use \.name'):
+            t.getName()
+        with self.assertWarnsRegex(DeprecationWarning, r'use \.name'):
+            t.setName("name")
+
         e = threading.Event()
-        e.isSet()
-        threading.activeCount()
+        with self.assertWarnsRegex(DeprecationWarning, 'use is_set()'):
+            e.isSet()
+
+        cond = threading.Condition()
+        cond.acquire()
+        with self.assertWarnsRegex(DeprecationWarning, 'use notify_all()'):
+            cond.notifyAll()
+
+        with self.assertWarnsRegex(DeprecationWarning, 'use active_count()'):
+            threading.activeCount()
+        with self.assertWarnsRegex(DeprecationWarning, 'use current_thread()'):
+            threading.currentThread()
 
     def test_repr_daemon(self):
         t = threading.Thread()

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -447,13 +447,17 @@ class ThreadTests(BaseTestCase):
         # Just a quick sanity check to make sure the old method names are
         # still present
         t = threading.Thread()
-        with self.assertWarnsRegex(DeprecationWarning, r'use \.daemon'):
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   r'get the daemon attribute'):
             t.isDaemon()
-        with self.assertWarnsRegex(DeprecationWarning, r'use \.daemon'):
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   r'set the daemon attribute'):
             t.setDaemon(True)
-        with self.assertWarnsRegex(DeprecationWarning, r'use \.name'):
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   r'get the name attribute'):
             t.getName()
-        with self.assertWarnsRegex(DeprecationWarning, r'use \.name'):
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   r'set the name attribute'):
             t.setName("name")
 
         e = threading.Event()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -388,7 +388,16 @@ class Condition:
         """
         self.notify(len(self._waiters))
 
-    notifyAll = notify_all
+    def notifyAll(self):
+        """Wake up all threads waiting on this condition.
+
+        This method is deprecated, use notify_all() instead.
+
+        """
+        import warnings
+        warnings.warn('notifyAll() is deprecated, use notify_all() instead',
+                      DeprecationWarning, stacklevel=2)
+        self.notify_all()
 
 
 class Semaphore:
@@ -538,7 +547,16 @@ class Event:
         """Return true if and only if the internal flag is true."""
         return self._flag
 
-    isSet = is_set
+    def isSet(self):
+        """Return true if and only if the internal flag is true.
+
+        This method is deprecated, use notify_all() instead.
+
+        """
+        import warnings
+        warnings.warn('isSet() is deprecated, use is_set() instead',
+                      DeprecationWarning, stacklevel=2)
+        return self.is_set()
 
     def set(self):
         """Set the internal flag to true.
@@ -1146,15 +1164,47 @@ class Thread:
         self._daemonic = daemonic
 
     def isDaemon(self):
+        """Return whether this thread is a daemon.
+
+        This method is deprecated, use the .daemon property instead.
+
+        """
+        import warnings
+        warnings.warn('isDaemon() is deprecated, use .daemon instead',
+                      DeprecationWarning, stacklevel=2)
         return self.daemon
 
     def setDaemon(self, daemonic):
+        """Set whether this thread is a daemon.
+
+        This method is deprecated, use the .daemon property instead.
+
+        """
+        import warnings
+        warnings.warn('setDaemon() is deprecated, use .daemon instead',
+                      DeprecationWarning, stacklevel=2)
         self.daemon = daemonic
 
     def getName(self):
+        """Return a string used for identification purposes only.
+
+        This method is deprecated, use the .name property instead.
+
+        """
+        import warnings
+        warnings.warn('getName() is deprecated, use .name instead',
+                      DeprecationWarning, stacklevel=2)
         return self.name
 
     def setName(self, name):
+        """Set the name string for this thread.
+
+        This method is deprecated, use the .name property instead.
+
+        """
+        import warnings
+        warnings.warn('setName() is deprecated, use .name instead',
+                      DeprecationWarning, stacklevel=2)
         self.name = name
 
 
@@ -1349,7 +1399,16 @@ def current_thread():
     except KeyError:
         return _DummyThread()
 
-currentThread = current_thread
+def currentThread():
+    """Return the current Thread object, corresponding to the caller's thread of control.
+
+    This function is deprecated, use current_thread() instead.
+
+    """
+    import warnings
+    warnings.warn('currentThread() is deprecated, use current_thread() instead',
+                  DeprecationWarning, stacklevel=2)
+    return current_thread()
 
 def active_count():
     """Return the number of Thread objects currently alive.
@@ -1361,7 +1420,16 @@ def active_count():
     with _active_limbo_lock:
         return len(_active) + len(_limbo)
 
-activeCount = active_count
+def activeCount():
+    """Return the number of Thread objects currently alive.
+
+    This function is deprecated, use active_count() instead.
+
+    """
+    import warnings
+    warnings.warn('activeCount() is deprecated, use active_count() instead',
+                  DeprecationWarning, stacklevel=2)
+    return active_count()
 
 def _enumerate():
     # Same as enumerate(), but without the lock. Internal use only.

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1166,11 +1166,11 @@ class Thread:
     def isDaemon(self):
         """Return whether this thread is a daemon.
 
-        This method is deprecated, use the .daemon property instead.
+        This method is deprecated, use the daemon attribute instead.
 
         """
         import warnings
-        warnings.warn('isDaemon() is deprecated, use .daemon instead',
+        warnings.warn('isDaemon() is deprecated, get the daemon attribute instead',
                       DeprecationWarning, stacklevel=2)
         return self.daemon
 
@@ -1181,29 +1181,29 @@ class Thread:
 
         """
         import warnings
-        warnings.warn('setDaemon() is deprecated, use .daemon instead',
+        warnings.warn('setDaemon() is deprecated, set the daemon attribute instead',
                       DeprecationWarning, stacklevel=2)
         self.daemon = daemonic
 
     def getName(self):
         """Return a string used for identification purposes only.
 
-        This method is deprecated, use the .name property instead.
+        This method is deprecated, use the name attribute instead.
 
         """
         import warnings
-        warnings.warn('getName() is deprecated, use .name instead',
+        warnings.warn('getName() is deprecated, get the name attribute instead',
                       DeprecationWarning, stacklevel=2)
         return self.name
 
     def setName(self, name):
         """Set the name string for this thread.
 
-        This method is deprecated, use the .name property instead.
+        This method is deprecated, use the name attribute instead.
 
         """
         import warnings
-        warnings.warn('setName() is deprecated, use .name instead',
+        warnings.warn('setName() is deprecated, set the name attribute instead',
                       DeprecationWarning, stacklevel=2)
         self.name = name
 

--- a/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
@@ -1,6 +1,10 @@
-The following `threading` methods are now deprecated:
-`threading.currentThread`, `threading.activeCount`,
-`threading.Condition.notifyAll`, `threading.Event.isSet`,
-`threading.Thread.setName`, `threading.thread.getName`,
-`threading.Thread.isDaemon`, and `threading.Thread.setDaemon`. Patch by
-Jelle Zijlstra.
+The following `threading` methods are now deprecated and should be replaced:
+`threading.currentThread` => :func:`threading.current_thread`;
+`threading.activeCount` => :func:`threading.active_count`;
+`threading.Condition.notifyAll` => :meth:`threading.Condition.notify_all`;
+`threading.Event.isSet` => :meth:`threading.Event.is_set`;
+`threading.Thread.setName` => :attr:`threading.Thread.name`;
+`threading.thread.getName` => :attr:`threading.Thread.name`;
+`threading.Thread.isDaemon` => :attr:`threading.Thread.daemon`;
+`threading.Thread.setDaemon` => :attr:`threading.Thread.daemon`.
+Patch by Jelle Zijlstra.

--- a/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
@@ -1,19 +1,19 @@
-The following `threading` methods are now deprecated and should be replaced:
+The following ``threading`` methods are now deprecated and should be replaced:
 
-- `currentThread` => :func:`threading.current_thread`
+- ``currentThread`` => :func:`threading.current_thread`
 
-- `activeCount` => :func:`threading.active_count`
+- ``activeCount`` => :func:`threading.active_count`
 
-- `Condition.notifyAll` => :meth:`threading.Condition.notify_all`
+- ``Condition.notifyAll`` => :meth:`threading.Condition.notify_all`
 
-- `Event.isSet` => :meth:`threading.Event.is_set`
+- ``Event.isSet`` => :meth:`threading.Event.is_set`
 
-- `Thread.setName` => :attr:`threading.Thread.name`
+- ``Thread.setName`` => :attr:`threading.Thread.name`
 
-- `thread.getName` => :attr:`threading.Thread.name`
+- ``thread.getName`` => :attr:`threading.Thread.name`
 
-- `Thread.isDaemon` => :attr:`threading.Thread.daemon`
+- ``Thread.isDaemon`` => :attr:`threading.Thread.daemon`
 
-- `Thread.setDaemon` => :attr:`threading.Thread.daemon`
+- ``Thread.setDaemon`` => :attr:`threading.Thread.daemon`
 
 Patch by Jelle Zijlstra.

--- a/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
@@ -1,10 +1,19 @@
 The following `threading` methods are now deprecated and should be replaced:
-`threading.currentThread` => :func:`threading.current_thread`;
-`threading.activeCount` => :func:`threading.active_count`;
-`threading.Condition.notifyAll` => :meth:`threading.Condition.notify_all`;
-`threading.Event.isSet` => :meth:`threading.Event.is_set`;
-`threading.Thread.setName` => :attr:`threading.Thread.name`;
-`threading.thread.getName` => :attr:`threading.Thread.name`;
-`threading.Thread.isDaemon` => :attr:`threading.Thread.daemon`;
-`threading.Thread.setDaemon` => :attr:`threading.Thread.daemon`.
+
+- `currentThread` => :func:`threading.current_thread`
+
+- `activeCount` => :func:`threading.active_count`
+
+- `Condition.notifyAll` => :meth:`threading.Condition.notify_all`
+
+- `Event.isSet` => :meth:`threading.Event.is_set`
+
+- `Thread.setName` => :attr:`threading.Thread.name`
+
+- `thread.getName` => :attr:`threading.Thread.name`
+
+- `Thread.isDaemon` => :attr:`threading.Thread.daemon`
+
+- `Thread.setDaemon` => :attr:`threading.Thread.daemon`
+
 Patch by Jelle Zijlstra.

--- a/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-03-18-03-44.bpo-43723.uBhBZS.rst
@@ -1,0 +1,6 @@
+The following `threading` methods are now deprecated:
+`threading.currentThread`, `threading.activeCount`,
+`threading.Condition.notifyAll`, `threading.Event.isSet`,
+`threading.Thread.setName`, `threading.thread.getName`,
+`threading.Thread.isDaemon`, and `threading.Thread.setDaemon`. Patch by
+Jelle Zijlstra.


### PR DESCRIPTION
The snake_case names have existed since Python 2.6, so there is
no reason to keep the old camelCase names around. One similar
method, threading.Thread.isAlive, was already removed in
Python 3.9 ([bpo-37804](https://bugs.python.org/issue37804)).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43723](https://bugs.python.org/issue43723) -->
https://bugs.python.org/issue43723
<!-- /issue-number -->
