### PR TITLE
Fix `valuerror` typo in test code

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2308,7 +2308,7 @@ def sqr(x, wait=0.0):
 def mul(x, y):
     return x*y
 
-def raise_large_valuerror(wait):
+def raise_large_valueerror(wait):
     time.sleep(wait)
     raise ValueError("x" * 1024**2)
 
@@ -2640,7 +2640,7 @@ class _TestPool(BaseTestCase):
         with self.assertRaises(ValueError):
             with self.Pool(2) as p:
                 try:
-                    p.map(raise_large_valuerror, [0, 1])
+                    p.map(raise_large_valueerror, [0, 1])
                 finally:
                     time.sleep(0.5)
                     p.close()

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4288,7 +4288,7 @@ class ThreadedTests(unittest.TestCase):
             if not any(alg in name for alg in expected_algs):
                 self.fail(name)
 
-    def test_read_write_after_close_raises_valuerror(self):
+    def test_read_write_after_close_raises_valueerror(self):
         client_context, server_context, hostname = testing_context()
         server = ThreadedEchoServer(context=server_context, chatty=False)
 


### PR DESCRIPTION
I discovered a typo in test code when I made it myself trying to search the code base for `ValueError`.