### PR TITLE
bpo-43651: PEP 597: Fix EncodingWarning in some tests

### DIFF
--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -102,7 +102,7 @@ class ImportTests(unittest.TestCase):
         temp_mod_name = 'test_imp_helper'
         sys.path.insert(0, '.')
         try:
-            with open(temp_mod_name + '.py', 'w') as file:
+            with open(temp_mod_name + '.py', 'w', encoding="latin-1") as file:
                 file.write("# coding: cp1252\nu = 'test.test_imp'\n")
             file, filename, info = imp.find_module(temp_mod_name)
             file.close()
@@ -157,7 +157,7 @@ class ImportTests(unittest.TestCase):
             # if the curdir is not in sys.path the test fails when run with
             # ./python ./Lib/test/regrtest.py test_imp
             sys.path.insert(0, os.curdir)
-            with open(temp_mod_name + '.py', 'w') as file:
+            with open(temp_mod_name + '.py', 'w', encoding="utf-8") as file:
                 file.write('a = 1\n')
             file, filename, info = imp.find_module(temp_mod_name)
             with file:
@@ -185,7 +185,7 @@ class ImportTests(unittest.TestCase):
 
             if not os.path.exists(test_package_name):
                 os.mkdir(test_package_name)
-            with open(init_file_name, 'w') as file:
+            with open(init_file_name, 'w', encoding="utf-8") as file:
                 file.write('b = 2\n')
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
@@ -310,7 +310,7 @@ class ImportTests(unittest.TestCase):
     def test_multiple_calls_to_get_data(self):
         # Issue #18755: make sure multiple calls to get_data() can succeed.
         loader = imp._LoadSourceCompatibility('imp', imp.__file__,
-                                              open(imp.__file__))
+                                              open(imp.__file__, encoding="utf-8"))
         loader.get_data(imp.__file__)  # File should be closed
         loader.get_data(imp.__file__)  # Will need to create a newly opened file
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -117,7 +117,7 @@ class ImportTests(unittest.TestCase):
     def test_from_import_star_invalid_type(self):
         import re
         with _ready_to_import() as (name, path):
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write("__all__ = [b'invalid_type']")
             globals = {}
             with self.assertRaisesRegex(
@@ -126,7 +126,7 @@ class ImportTests(unittest.TestCase):
                 exec(f"from {name} import *", globals)
             self.assertNotIn(b"invalid_type", globals)
         with _ready_to_import() as (name, path):
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write("globals()[b'invalid_type'] = object()")
             globals = {}
             with self.assertRaisesRegex(
@@ -155,7 +155,7 @@ class ImportTests(unittest.TestCase):
             else:
                 pyc = TESTFN + ".pyc"
 
-            with open(source, "w") as f:
+            with open(source, "w", encoding='utf-8') as f:
                 print("# This tests Python's ability to import a",
                       ext, "file.", file=f)
                 a = random.randrange(1000)
@@ -195,7 +195,7 @@ class ImportTests(unittest.TestCase):
         filename = module + '.py'
 
         # Create a file with a list of 65000 elements.
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             f.write('d = [\n')
             for i in range(65000):
                 f.write('"",\n')
@@ -232,7 +232,7 @@ class ImportTests(unittest.TestCase):
 
     def test_failing_import_sticks(self):
         source = TESTFN + ".py"
-        with open(source, "w") as f:
+        with open(source, "w", encoding='utf-8') as f:
             print("a = 1/0", file=f)
 
         # New in 2.4, we shouldn't be able to import that no matter how often
@@ -281,7 +281,7 @@ class ImportTests(unittest.TestCase):
     def test_failing_reload(self):
         # A failing reload should leave the module object in sys.modules.
         source = TESTFN + os.extsep + "py"
-        with open(source, "w") as f:
+        with open(source, "w", encoding='utf-8') as f:
             f.write("a = 1\nb=2\n")
 
         sys.path.insert(0, os.curdir)
@@ -298,7 +298,7 @@ class ImportTests(unittest.TestCase):
             remove_files(TESTFN)
 
             # Now damage the module.
-            with open(source, "w") as f:
+            with open(source, "w", encoding='utf-8') as f:
                 f.write("a = 10\nb=20//0\n")
 
             self.assertRaises(ZeroDivisionError, importlib.reload, mod)
@@ -320,7 +320,7 @@ class ImportTests(unittest.TestCase):
     def test_file_to_source(self):
         # check if __file__ points to the source file where available
         source = TESTFN + ".py"
-        with open(source, "w") as f:
+        with open(source, "w", encoding='utf-8') as f:
             f.write("test = None\n")
 
         sys.path.insert(0, os.curdir)
@@ -369,7 +369,7 @@ class ImportTests(unittest.TestCase):
         try:
             source = TESTFN + ".py"
             compiled = importlib.util.cache_from_source(source)
-            with open(source, 'w') as f:
+            with open(source, 'w', encoding='utf-8') as f:
                 pass
             try:
                 os.utime(source, (2 ** 33 - 5, 2 ** 33 - 5))
@@ -574,7 +574,7 @@ class FilePermissionTests(unittest.TestCase):
         # with later updates, see issue #6074 for details
         with _ready_to_import() as (name, path):
             # Write a Python file, make it read-only and import it
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write("x = 'original'\n")
             # Tweak the mtime of the source to ensure pyc gets updated later
             s = os.stat(path)
@@ -584,7 +584,7 @@ class FilePermissionTests(unittest.TestCase):
             self.assertEqual(m.x, 'original')
             # Change the file and then reimport it
             os.chmod(path, 0o600)
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write("x = 'rewritten'\n")
             unload(name)
             importlib.invalidate_caches()
@@ -623,7 +623,7 @@ func_filename = func.__code__.co_filename
         self.sys_path = sys.path[:]
         self.orig_module = sys.modules.pop(self.module_name, None)
         os.mkdir(self.dir_name)
-        with open(self.file_name, "w") as f:
+        with open(self.file_name, "w", encoding='utf-8') as f:
             f.write(self.module_source)
         sys.path.insert(0, self.dir_name)
         importlib.invalidate_caches()
@@ -704,7 +704,8 @@ class PathsTests(unittest.TestCase):
 
     # Regression test for http://bugs.python.org/issue1293.
     def test_trailing_slash(self):
-        with open(os.path.join(self.path, 'test_trailing_slash.py'), 'w') as f:
+        with open(os.path.join(self.path, 'test_trailing_slash.py'),
+                  'w', encoding='utf-8') as f:
             f.write("testdata = 'test_trailing_slash'")
         sys.path.append(self.path+'/')
         mod = __import__("test_trailing_slash")
@@ -842,7 +843,7 @@ class PycacheTests(unittest.TestCase):
     def setUp(self):
         self.source = TESTFN + '.py'
         self._clean()
-        with open(self.source, 'w') as fp:
+        with open(self.source, 'w', encoding='utf-8') as fp:
             print('# This is a test file written by test_import.py', file=fp)
         sys.path.insert(0, os.curdir)
         importlib.invalidate_caches()
@@ -941,9 +942,9 @@ class PycacheTests(unittest.TestCase):
         os.mkdir('pep3147')
         self.addCleanup(cleanup)
         # Touch the __init__.py
-        with open(os.path.join('pep3147', '__init__.py'), 'w'):
+        with open(os.path.join('pep3147', '__init__.py'), 'wb'):
             pass
-        with open(os.path.join('pep3147', 'foo.py'), 'w'):
+        with open(os.path.join('pep3147', 'foo.py'), 'wb'):
             pass
         importlib.invalidate_caches()
         m = __import__('pep3147.foo')
@@ -964,9 +965,9 @@ class PycacheTests(unittest.TestCase):
         os.mkdir('pep3147')
         self.addCleanup(cleanup)
         # Touch the __init__.py
-        with open(os.path.join('pep3147', '__init__.py'), 'w'):
+        with open(os.path.join('pep3147', '__init__.py'), 'wb'):
             pass
-        with open(os.path.join('pep3147', 'foo.py'), 'w'):
+        with open(os.path.join('pep3147', 'foo.py'), 'wb'):
             pass
         importlib.invalidate_caches()
         m = __import__('pep3147.foo')
@@ -986,7 +987,7 @@ class PycacheTests(unittest.TestCase):
         # source size is enough to trigger recomputation of the pyc file.
         __import__(TESTFN)
         unload(TESTFN)
-        with open(self.source, 'a') as fp:
+        with open(self.source, 'a', encoding='utf-8') as fp:
             print("x = 5", file=fp)
         m = __import__(TESTFN)
         self.assertEqual(m.x, 5)
@@ -1118,7 +1119,7 @@ class ImportTracebackTests(unittest.TestCase):
 
     def create_module(self, mod, contents, ext=".py"):
         fname = os.path.join(TESTFN, mod + ext)
-        with open(fname, "w") as f:
+        with open(fname, "w", encoding='utf-8') as f:
             f.write(contents)
         self.addCleanup(unload, mod)
         importlib.invalidate_caches()
@@ -1195,10 +1196,10 @@ class ImportTracebackTests(unittest.TestCase):
         os.mkdir(pkg_path)
         # Touch the __init__.py
         init_path = os.path.join(pkg_path, '__init__.py')
-        with open(init_path, 'w') as f:
+        with open(init_path, 'w', encoding='utf-8') as f:
             f.write(parent)
         bar_path = os.path.join(pkg_path, 'bar.py')
-        with open(bar_path, 'w') as f:
+        with open(bar_path, 'w', encoding='utf-8') as f:
             f.write(child)
         importlib.invalidate_caches()
         return init_path, bar_path

--- a/Lib/test/test_importlib/fixtures.py
+++ b/Lib/test/test_importlib/fixtures.py
@@ -250,7 +250,7 @@ def build_files(file_defs, prefix=pathlib.Path()):
                 with full_name.open('wb') as f:
                     f.write(contents)
             else:
-                with full_name.open('w') as f:
+                with full_name.open('w', encoding='utf-8') as f:
                     f.write(DALS(contents))
 
 

--- a/Lib/test/test_importlib/source/test_file_loader.py
+++ b/Lib/test/test_importlib/source/test_file_loader.py
@@ -124,7 +124,7 @@ class SimpleTest(abc.LoaderTests):
                 module = loader.load_module('_temp')
             module_id = id(module)
             module_dict_id = id(module.__dict__)
-            with open(mapping['_temp'], 'w') as file:
+            with open(mapping['_temp'], 'w', encoding='utf-8') as file:
                 file.write("testing_var = 42\n")
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', DeprecationWarning)
@@ -145,7 +145,7 @@ class SimpleTest(abc.LoaderTests):
             orig_module = types.ModuleType(name)
             for attr in attributes:
                 setattr(orig_module, attr, value)
-            with open(mapping[name], 'w') as file:
+            with open(mapping[name], 'w', encoding='utf-8') as file:
                 file.write('+++ bad syntax +++')
             loader = self.machinery.SourceFileLoader('_temp', mapping['_temp'])
             with self.assertRaises(SyntaxError):
@@ -162,7 +162,7 @@ class SimpleTest(abc.LoaderTests):
     # [syntax error]
     def test_bad_syntax(self):
         with util.create_modules('_temp') as mapping:
-            with open(mapping['_temp'], 'w') as file:
+            with open(mapping['_temp'], 'w', encoding='utf-8') as file:
                 file.write('=')
             loader = self.machinery.SourceFileLoader('_temp', mapping['_temp'])
             with self.assertRaises(SyntaxError):
@@ -175,7 +175,7 @@ class SimpleTest(abc.LoaderTests):
         # Loading a module found from an empty string entry on sys.path should
         # not only work, but keep all attributes relative.
         file_path = '_temp.py'
-        with open(file_path, 'w') as file:
+        with open(file_path, 'w', encoding='utf-8') as file:
             file.write("# test file for importlib")
         try:
             with util.uncache('_temp'):
@@ -199,7 +199,7 @@ class SimpleTest(abc.LoaderTests):
         with util.create_modules('_temp') as mapping:
             source = mapping['_temp']
             compiled = self.util.cache_from_source(source)
-            with open(source, 'w') as f:
+            with open(source, 'w', encoding='utf-8') as f:
                 f.write("x = 5")
             try:
                 os.utime(source, (2 ** 33 - 5, 2 ** 33 - 5))

--- a/Lib/test/test_importlib/source/test_finder.py
+++ b/Lib/test/test_importlib/source/test_finder.py
@@ -127,7 +127,7 @@ class FinderTests(abc.FinderTests):
         # The empty string from sys.path means to search in the cwd.
         finder = self.machinery.FileFinder('', (self.machinery.SourceFileLoader,
             self.machinery.SOURCE_SUFFIXES))
-        with open('mod.py', 'w') as file:
+        with open('mod.py', 'w', encoding='utf-8') as file:
             file.write("# test file for importlib")
         try:
             loader = self._find(finder, 'mod', loader_only=True)

--- a/Lib/test/test_importlib/test_api.py
+++ b/Lib/test/test_importlib/test_api.py
@@ -312,7 +312,7 @@ class ReloadTests:
                                 '__file__': None,
                                 }
                     os.mkdir(name)
-                    with open(bad_path, 'w') as init_file:
+                    with open(bad_path, 'w', encoding='utf-8') as init_file:
                         init_file.write('eggs = None')
                     module = self.init.import_module(name)
                     ns = vars(module).copy()

--- a/Lib/test/test_importlib/test_files.py
+++ b/Lib/test/test_importlib/test_files.py
@@ -15,7 +15,7 @@ class FilesTests:
 
     def test_read_text(self):
         files = resources.files(self.data)
-        actual = files.joinpath('utf-8.file').read_text()
+        actual = files.joinpath('utf-8.file').read_text(encoding='utf-8')
         assert actual == 'Hello, UTF-8 world!\n'
 
     @unittest.skipUnless(

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -83,7 +83,7 @@ class NameNormalizationTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.Test
         metadata_dir = site_dir / 'my_pkg.dist-info'
         metadata_dir.mkdir()
         metadata = metadata_dir / 'METADATA'
-        with metadata.open('w') as strm:
+        with metadata.open('w', encoding='utf-8') as strm:
             strm.write('Version: 1.0\n')
         return 'my-pkg'
 
@@ -102,7 +102,7 @@ class NameNormalizationTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.Test
         metadata_dir = site_dir / 'CherryPy.dist-info'
         metadata_dir.mkdir()
         metadata = metadata_dir / 'METADATA'
-        with metadata.open('w') as strm:
+        with metadata.open('w', encoding='utf-8') as strm:
             strm.write('Version: 1.0\n')
         return 'CherryPy'
 

--- a/Lib/test/test_importlib/test_pkg_import.py
+++ b/Lib/test/test_importlib/test_pkg_import.py
@@ -42,7 +42,7 @@ class TestImport(unittest.TestCase):
         compiled_path = cache_from_source(self.module_path)
         if os.path.exists(compiled_path):
             os.remove(compiled_path)
-        with open(self.module_path, 'w') as f:
+        with open(self.module_path, 'w', encoding='utf-8') as f:
             f.write(contents)
 
     def test_package_import__semantics(self):

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -116,7 +116,7 @@ def case_insensitive_tests(test):
 
 def submodule(parent, name, pkg_dir, content=''):
     path = os.path.join(pkg_dir, name + '.py')
-    with open(path, 'w') as subfile:
+    with open(path, 'w', encoding='utf-8') as subfile:
         subfile.write(content)
     return '{}.{}'.format(parent, name), path
 
@@ -176,7 +176,7 @@ def temp_module(name, content='', *, pkg=False):
                         content = ''
                 if content is not None:
                     # not a namespace package
-                    with open(modpath, 'w') as modfile:
+                    with open(modpath, 'w', encoding='utf-8') as modfile:
                         modfile.write(content)
                 yield location
 
@@ -384,7 +384,7 @@ def create_modules(*names):
                     os.mkdir(file_path)
                     created_paths.append(file_path)
             file_path = os.path.join(file_path, name_parts[-1] + '.py')
-            with open(file_path, 'w') as file:
+            with open(file_path, 'w', encoding='utf-8') as file:
                 file.write(source.format(name))
             created_paths.append(file_path)
             mapping[name] = file_path

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -74,7 +74,9 @@ def write_file(path, content, binary=False):
     """
     if isinstance(path, tuple):
         path = os.path.join(*path)
-    with open(path, 'wb' if binary else 'w') as fp:
+    mode = 'wb' if binary else 'w'
+    encoding = None if binary else "utf-8"
+    with open(path, mode, encoding=encoding) as fp:
         fp.write(content)
 
 def write_test_file(path, size):
@@ -104,7 +106,9 @@ def read_file(path, binary=False):
     """
     if isinstance(path, tuple):
         path = os.path.join(*path)
-    with open(path, 'rb' if binary else 'r') as fp:
+    mode = 'rb' if binary else 'r'
+    encoding = None if binary else "utf-8"
+    with open(path, mode, encoding=encoding) as fp:
         return fp.read()
 
 def rlistdir(path):
@@ -674,7 +678,7 @@ class TestCopyTree(BaseTest, unittest.TestCase):
         flag = []
         src = self.mkdtemp()
         dst = tempfile.mktemp(dir=self.mkdtemp())
-        with open(os.path.join(src, 'foo'), 'w') as f:
+        with open(os.path.join(src, 'foo'), 'w', encoding='utf-8') as f:
             f.close()
         shutil.copytree(src, dst, copy_function=custom_cpfun)
         self.assertEqual(len(flag), 1)
@@ -746,7 +750,7 @@ class TestCopyTree(BaseTest, unittest.TestCase):
         src_dir = self.mkdtemp()
         dst_dir = os.path.join(self.mkdtemp(), 'destination')
         os.mkdir(os.path.join(src_dir, 'real_dir'))
-        with open(os.path.join(src_dir, 'real_dir', 'test.txt'), 'w'):
+        with open(os.path.join(src_dir, 'real_dir', 'test.txt'), 'wb'):
             pass
         os.symlink(os.path.join(src_dir, 'real_dir'),
                    os.path.join(src_dir, 'link_to_dir'),
@@ -1172,14 +1176,14 @@ class TestCopy(BaseTest, unittest.TestCase):
         src = os.path.join(TESTFN, 'cheese')
         dst = os.path.join(TESTFN, 'shop')
         try:
-            with open(src, 'w') as f:
+            with open(src, 'w', encoding='utf-8') as f:
                 f.write('cheddar')
             try:
                 os.link(src, dst)
             except PermissionError as e:
                 self.skipTest('os.link(): %s' % e)
             self.assertRaises(shutil.SameFileError, shutil.copyfile, src, dst)
-            with open(src, 'r') as f:
+            with open(src, 'r', encoding='utf-8') as f:
                 self.assertEqual(f.read(), 'cheddar')
             os.remove(dst)
         finally:
@@ -1192,14 +1196,14 @@ class TestCopy(BaseTest, unittest.TestCase):
         src = os.path.join(TESTFN, 'cheese')
         dst = os.path.join(TESTFN, 'shop')
         try:
-            with open(src, 'w') as f:
+            with open(src, 'w', encoding='utf-8') as f:
                 f.write('cheddar')
             # Using `src` here would mean we end up with a symlink pointing
             # to TESTFN/TESTFN/cheese, while it should point at
             # TESTFN/cheese.
             os.symlink('cheese', dst)
             self.assertRaises(shutil.SameFileError, shutil.copyfile, src, dst)
-            with open(src, 'r') as f:
+            with open(src, 'r', encoding='utf-8') as f:
                 self.assertEqual(f.read(), 'cheddar')
             os.remove(dst)
         finally:
@@ -2586,7 +2590,7 @@ class TestGetTerminalSize(unittest.TestCase):
 
             # sys.__stdout__ is not a terminal on Unix
             # or fileno() not in (0, 1, 2) on Windows
-            with open(os.devnull, 'w') as f, \
+            with open(os.devnull, 'w', encoding='utf-8') as f, \
                  support.swap_attr(sys, '__stdout__', f):
                 size = shutil.get_terminal_size(fallback=(30, 40))
             self.assertEqual(size.columns, 30)


### PR DESCRIPTION
* test_shutil
* test_imp
* test_import
* test_importlib

<!-- issue-number: [bpo-43651](https://bugs.python.org/issue43651) -->
https://bugs.python.org/issue43651
<!-- /issue-number -->
