### PR TITLE
bpo-41370: Add note about ForwardRefs and PEP585 generic types in docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1948,9 +1948,14 @@ Introspection helpers
 .. class:: ForwardRef
 
    A class used for internal typing representation of string forward references.
-   For example, ``list["SomeClass"]`` is implicitly transformed into
-   ``list[ForwardRef("SomeClass")]``.  This class should not be instantiated by
+   For example, ``List["SomeClass"]`` is implicitly transformed into
+   ``List[ForwardRef("SomeClass")]``.  This class should not be instantiated by
    a user, but may be used by introspection tools.
+
+   .. note::
+      :pep:`585` generic types such as ``list["SomeClass"]`` will not be
+      implicitly transformed into ``list[ForwardRef("SomeClass")]`` and thus
+      will not be resolved to ``list[SomeClass]``.
 
    .. versionadded:: 3.7.4
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1955,7 +1955,7 @@ Introspection helpers
    .. note::
       :pep:`585` generic types such as ``list["SomeClass"]`` will not be
       implicitly transformed into ``list[ForwardRef("SomeClass")]`` and thus
-      will not be resolved to ``list[SomeClass]``.
+      will not automatically resolve to ``list[SomeClass]``.
 
    .. versionadded:: 3.7.4
 


### PR DESCRIPTION
Also fixed a small error in ForwardRef's description regarding ``list["SomeClass"]``.

<!-- issue-number: [bpo-41370](https://bugs.python.org/issue41370) -->
https://bugs.python.org/issue41370
<!-- /issue-number -->
