### PR TITLE
bpo-42128: Update pattern matching docs to match new PEP changes

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1030,7 +1030,7 @@ subject value:
 
    For a number of built-in types (specified below), a single positional
    subpattern is accepted which will match the entire subject; for these types
-   no keyword patterns are accepted.
+   keyword patterns also work as for other types.
 
    If only keyword patterns are present, they are processed as follows,
    one by one:
@@ -1057,7 +1057,7 @@ subject value:
 
       * If this raises an exception, the exception bubbles up.
 
-      * If the returned value is not a list or tuple, the conversion fails and
+      * If the returned value is not a tuple, the conversion fails and
         :exc:`TypeError` is raised.
 
       * If there are more positional patterns than ``len(cls.__match_args__)``,

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2565,7 +2565,7 @@ define a *__match_args__* attribute.
 
 .. data:: object.__match_args__
 
-   This class variable can be assigned a tuple or list of strings. When this class is
+   This class variable can be assigned a tuple of strings. When this class is
    used in a class pattern with positional arguments, each positional argument will
    be converted into a keyword argument, using the corresponding value in
    *__match_args__* as the keyword. The absence of this attribute is equivalent to


### PR DESCRIPTION
On python-dev, changes to PEP 634 were discussed and proposed, this patch just brings the docs up to speed:
1.  builtin types accept keyword argument patterns
2. ``__match_args__`` must be a tuple

Ref: https://mail.python.org/archives/list/python-dev@python.org/thread/YYIT3QXMLPNLXQAQ5BCXE4LLJ57EE7JV/

https://github.com/python/peps/pull/1908 and https://github.com/python/peps/pull/1909 needs to be merged before this can be merged.

<!-- issue-number: [bpo-42128](https://bugs.python.org/issue42128) -->
https://bugs.python.org/issue42128
<!-- /issue-number -->
