### PR TITLE
bpo-43655: Tkinter and IDLE dialog windows are now recognized as dialogs by window managers on macOS and X Window

### DIFF
--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -4,6 +4,7 @@ Dialog for building Tkinter accelerator key bindings
 from tkinter import Toplevel, Listbox, StringVar, TclError
 from tkinter.ttk import Frame, Button, Checkbutton, Entry, Label, Scrollbar
 from tkinter import messagebox
+from tkinter.simpledialog import _setup_dialog
 import string
 import sys
 
@@ -63,6 +64,7 @@ class GetKeysDialog(Toplevel):
         self.resizable(height=False, width=False)
         self.title(title)
         self.transient(parent)
+        _setup_dialog(self)
         self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self.cancel)
         self.parent = parent

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -21,7 +21,6 @@ from tkinter.ttk import (Frame, LabelFrame, Button, Checkbutton, Entry, Label,
 from tkinter import colorchooser
 import tkinter.font as tkfont
 from tkinter import messagebox
-from tkinter.simpledialog import _setup_dialog
 
 from idlelib.config import idleConf, ConfigChanges
 from idlelib.config_key import GetKeysDialog
@@ -78,7 +77,6 @@ class ConfigDialog(Toplevel):
         self.create_widgets()
         self.resizable(height=FALSE, width=FALSE)
         self.transient(parent)
-        _setup_dialog(self)
         self.protocol("WM_DELETE_WINDOW", self.cancel)
         self.fontpage.fontlist.focus_set()
         # XXX Decide whether to keep or delete these key bindings.

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -21,6 +21,7 @@ from tkinter.ttk import (Frame, LabelFrame, Button, Checkbutton, Entry, Label,
 from tkinter import colorchooser
 import tkinter.font as tkfont
 from tkinter import messagebox
+from tkinter.simpledialog import _setup_dialog
 
 from idlelib.config import idleConf, ConfigChanges
 from idlelib.config_key import GetKeysDialog
@@ -77,6 +78,7 @@ class ConfigDialog(Toplevel):
         self.create_widgets()
         self.resizable(height=FALSE, width=FALSE)
         self.transient(parent)
+        _setup_dialog(self)
         self.protocol("WM_DELETE_WINDOW", self.cancel)
         self.fontpage.fontlist.focus_set()
         # XXX Decide whether to keep or delete these key bindings.

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -28,6 +28,7 @@ from tkinter import Toplevel, StringVar, BooleanVar, W, E, S
 from tkinter.ttk import Frame, Button, Entry, Label, Checkbutton
 from tkinter import filedialog
 from tkinter.font import Font
+from tkinter.simpledialog import _setup_dialog
 
 class Query(Toplevel):
     """Base class for getting verified answer from a user.
@@ -60,13 +61,8 @@ class Query(Toplevel):
         if not _utest:  # Otherwise fail when directly run unittest.
             self.grab_set()
 
-        windowingsystem = self.tk.call('tk', 'windowingsystem')
-        if windowingsystem == 'aqua':
-            try:
-                self.tk.call('::tk::unsupported::MacWindowStyle', 'style',
-                             self._w, 'moveableModal', '')
-            except:
-                pass
+        _setup_dialog(self)
+        if self._windowingsystem == 'aqua':
             self.bind("<Command-.>", self.cancel)
         self.bind('<Key-Escape>', self.cancel)
         self.protocol("WM_DELETE_WINDOW", self.cancel)

--- a/Lib/idlelib/searchbase.py
+++ b/Lib/idlelib/searchbase.py
@@ -2,6 +2,7 @@
 
 from tkinter import Toplevel
 from tkinter.ttk import Frame, Entry, Label, Button, Checkbutton, Radiobutton
+from tkinter.simpledialog import _setup_dialog
 
 
 class SearchDialogBase:
@@ -83,6 +84,7 @@ class SearchDialogBase:
         top.protocol("WM_DELETE_WINDOW", self.close)
         top.wm_title(self.title)
         top.wm_iconname(self.icon)
+        _setup_dialog(top)
         self.top = top
         self.frame = Frame(top, padding="5px")
         self.frame.grid(sticky="nwes")

--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -24,6 +24,7 @@ from tkinter import (
 )
 from tkinter.dialog import Dialog
 from tkinter import commondialog
+from tkinter.simpledialog import _setup_dialog
 
 
 dialogstates = {}

--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -62,6 +62,7 @@ class FileDialog:
         self.top = Toplevel(master)
         self.top.title(title)
         self.top.iconname(title)
+        _setup_dialog(self.top)
 
         self.botframe = Frame(self.top)
         self.botframe.pack(side=BOTTOM, fill=X)

--- a/Lib/tkinter/simpledialog.py
+++ b/Lib/tkinter/simpledialog.py
@@ -40,6 +40,9 @@ class SimpleDialog:
         if title:
             self.root.title(title)
             self.root.iconname(title)
+
+        _setup_dialog(self.root)
+
         self.message = Message(self.root, text=text, aspect=400)
         self.message.pack(expand=1, fill=BOTH)
         self.frame = Frame(self.root)
@@ -114,6 +117,8 @@ class Dialog(Toplevel):
 
         if title:
             self.title(title)
+
+        _setup_dialog(self)
 
         self.parent = parent
 
@@ -251,6 +256,13 @@ def _place_window(w, parent=None):
     w.wm_geometry('+%d+%d' % (x, y))
     w.wm_deiconify() # Become visible at the desired location
 
+
+def _setup_dialog(w):
+    if w._windowingsystem == "aqua":
+        w.tk.call("::tk::unsupported::MacWindowStyle", "style",
+                  w, "moveableModal", "")
+    elif w._windowingsystem == "x11":
+        w.wm_attributes("-type", "dialog")
 
 # --------------------------------------------------------------------
 # convenience dialogues

--- a/Misc/NEWS.d/next/IDLE/2021-04-04-20-52-07.bpo-43655.HSyaKH.rst
+++ b/Misc/NEWS.d/next/IDLE/2021-04-04-20-52-07.bpo-43655.HSyaKH.rst
@@ -1,0 +1,2 @@
+IDLE dialog windows are now recognized as dialogs by window managers on
+macOS and X Window.

--- a/Misc/NEWS.d/next/Library/2021-04-04-20-51-19.bpo-43655.LwGy8R.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-04-20-51-19.bpo-43655.LwGy8R.rst
@@ -1,0 +1,2 @@
+:mod:`tkinter` dialog windows are now recognized as dialogs by window
+managers on macOS and X Window.


### PR DESCRIPTION


<!-- issue-number: [bpo-43655](https://bugs.python.org/issue43655) -->
https://bugs.python.org/issue43655
<!-- /issue-number -->
