### PR TITLE
bpo-43651: PEP 597: Fix EncodingWarning in some tests

### DIFF
--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -1250,14 +1250,14 @@ class OpenTestCase(unittest.TestCase):
     def test_text_modes(self):
         uncompressed = INPUT.decode("ascii")
         uncompressed_raw = uncompressed.replace("\n", os.linesep)
-        with lzma.open(BytesIO(COMPRESSED_XZ), "rt") as f:
+        with lzma.open(BytesIO(COMPRESSED_XZ), "rt", encoding="ascii") as f:
             self.assertEqual(f.read(), uncompressed)
         with BytesIO() as bio:
-            with lzma.open(bio, "wt") as f:
+            with lzma.open(bio, "wt", encoding="ascii") as f:
                 f.write(uncompressed)
             file_data = lzma.decompress(bio.getvalue()).decode("ascii")
             self.assertEqual(file_data, uncompressed_raw)
-            with lzma.open(bio, "at") as f:
+            with lzma.open(bio, "at", encoding="ascii") as f:
                 f.write(uncompressed)
             file_data = lzma.decompress(bio.getvalue()).decode("ascii")
             self.assertEqual(file_data, uncompressed_raw * 2)
@@ -1334,17 +1334,18 @@ class OpenTestCase(unittest.TestCase):
         # Test with explicit newline (universal newline mode disabled).
         text = INPUT.decode("ascii")
         with BytesIO() as bio:
-            with lzma.open(bio, "wt", newline="\n") as f:
+            with lzma.open(bio, "wt", encoding="ascii", newline="\n") as f:
                 f.write(text)
             bio.seek(0)
-            with lzma.open(bio, "rt", newline="\r") as f:
+            with lzma.open(bio, "rt", encoding="ascii", newline="\r") as f:
                 self.assertEqual(f.readlines(), [text])
 
     def test_x_mode(self):
         self.addCleanup(unlink, TESTFN)
         for mode in ("x", "xb", "xt"):
             unlink(TESTFN)
-            with lzma.open(TESTFN, mode):
+            encoding = "ascii" if "t" in mode else None
+            with lzma.open(TESTFN, mode, encoding=encoding):
                 pass
             with self.assertRaises(FileExistsError):
                 with lzma.open(TESTFN, mode):

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -77,7 +77,7 @@ class TestMailbox(TestBase):
         self.assertEqual(len(self._box), 6)
         with self.assertWarns(DeprecationWarning):
             keys.append(self._box.add(
-                io.TextIOWrapper(io.BytesIO(_bytes_sample_message))))
+                io.TextIOWrapper(io.BytesIO(_bytes_sample_message), encoding="utf-8")))
         self.assertEqual(len(self._box), 7)
         self.assertEqual(self._box.get_string(keys[0]), self._template % 0)
         for i in (1, 2, 3, 4, 5, 6):
@@ -160,7 +160,7 @@ class TestMailbox(TestBase):
             self._non_latin_bin_msg.split(b'\n'))
 
     def test_add_text_file_warns(self):
-        with tempfile.TemporaryFile('w+') as f:
+        with tempfile.TemporaryFile('w+', encoding='utf-8') as f:
             f.write(_sample_message)
             f.seek(0)
             with self.assertWarns(DeprecationWarning):
@@ -724,9 +724,9 @@ class TestMaildir(TestMailbox, unittest.TestCase):
         # Remove old files from 'tmp'
         foo_path = os.path.join(self._path, 'tmp', 'foo')
         bar_path = os.path.join(self._path, 'tmp', 'bar')
-        with open(foo_path, 'w') as f:
+        with open(foo_path, 'w', encoding='utf-8') as f:
             f.write("@")
-        with open(bar_path, 'w') as f:
+        with open(bar_path, 'w', encoding='utf-8') as f:
             f.write("@")
         self._box.clean()
         self.assertTrue(os.path.exists(foo_path))
@@ -984,7 +984,7 @@ class _TestMboxMMDF(_TestSingleFile):
             os_helper.unlink(lock_remnant)
 
     def assertMailboxEmpty(self):
-        with open(self._path) as f:
+        with open(self._path, 'rb') as f:
             self.assertEqual(f.readlines(), [])
 
     def test_get_bytes_from(self):
@@ -1150,12 +1150,12 @@ class TestMbox(_TestMboxMMDF, unittest.TestCase):
     def test_message_separator(self):
         # Check there's always a single blank line after each message
         self._box.add('From: foo\n\n0')  # No newline at the end
-        with open(self._path) as f:
+        with open(self._path, encoding='utf-8') as f:
             data = f.read()
             self.assertEqual(data[-3:], '0\n\n')
 
         self._box.add('From: foo\n\n0\n')  # Newline at the end
-        with open(self._path) as f:
+        with open(self._path, encoding='utf-8') as f:
             data = f.read()
             self.assertEqual(data[-3:], '0\n\n')
 
@@ -1305,7 +1305,7 @@ class TestBabyl(_TestSingleFile, unittest.TestCase):
     _factory = lambda self, path, factory=None: mailbox.Babyl(path, factory)
 
     def assertMailboxEmpty(self):
-        with open(self._path) as f:
+        with open(self._path, 'rb') as f:
             self.assertEqual(f.readlines(), [])
 
     def tearDown(self):
@@ -1390,7 +1390,7 @@ class TestMessage(TestBase, unittest.TestCase):
 
     def test_initialize_with_file(self):
         # Initialize based on contents of file
-        with open(self._path, 'w+') as f:
+        with open(self._path, 'w+', encoding='utf-8') as f:
             f.write(_sample_message)
             f.seek(0)
             msg = self._factory(f)
@@ -2158,7 +2158,7 @@ class MaildirTestCase(unittest.TestCase):
         filename = ".".join((str(t), str(pid), "myhostname", "mydomain"))
         tmpname = os.path.join(self._dir, "tmp", filename)
         newname = os.path.join(self._dir, dir, filename)
-        with open(tmpname, "w") as fp:
+        with open(tmpname, "w", encoding="utf-8") as fp:
             self._msgfiles.append(tmpname)
             if mbox:
                 fp.write(FROM_)

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -64,7 +64,7 @@ class MimeTypesTestCase(unittest.TestCase):
         with os_helper.temp_dir() as directory:
             data = "x-application/x-unittest pyunit\n"
             file = pathlib.Path(directory, "sample.mimetype")
-            file.write_text(data)
+            file.write_text(data, encoding="utf-8")
             mime_dict = mimetypes.read_mime_types(file)
             eq(mime_dict[".pyunit"], "x-application/x-unittest")
 

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -45,8 +45,8 @@ class PosixTester(unittest.TestCase):
 
     def setUp(self):
         # create empty file
-        fp = open(os_helper.TESTFN, 'w+')
-        fp.close()
+        with open(os_helper.TESTFN, "wb"):
+            pass
         self.teardown_files = [ os_helper.TESTFN ]
         self._warnings_manager = warnings_helper.check_warnings()
         self._warnings_manager.__enter__()
@@ -1579,7 +1579,7 @@ class _PosixSpawnMixin:
         args = self.python_args('-c', script)
         pid = self.spawn_func(args[0], args, os.environ)
         support.wait_process(pid, exitcode=0)
-        with open(pidfile) as f:
+        with open(pidfile, encoding="utf-8") as f:
             self.assertEqual(f.read(), str(pid))
 
     def test_no_such_executable(self):
@@ -1602,14 +1602,14 @@ class _PosixSpawnMixin:
         self.addCleanup(os_helper.unlink, envfile)
         script = f"""if 1:
             import os
-            with open({envfile!r}, "w") as envfile:
+            with open({envfile!r}, "w", encoding="utf-8") as envfile:
                 envfile.write(os.environ['foo'])
         """
         args = self.python_args('-c', script)
         pid = self.spawn_func(args[0], args,
                               {**os.environ, 'foo': 'bar'})
         support.wait_process(pid, exitcode=0)
-        with open(envfile) as f:
+        with open(envfile, encoding="utf-8") as f:
             self.assertEqual(f.read(), 'bar')
 
     def test_none_file_actions(self):
@@ -1861,7 +1861,7 @@ class _PosixSpawnMixin:
                               file_actions=file_actions)
 
         support.wait_process(pid, exitcode=0)
-        with open(outfile) as f:
+        with open(outfile, encoding="utf-8") as f:
             self.assertEqual(f.read(), 'hello')
 
     def test_close_file(self):
@@ -1872,7 +1872,7 @@ class _PosixSpawnMixin:
             try:
                 os.fstat(0)
             except OSError as e:
-                with open({closefile!r}, 'w') as closefile:
+                with open({closefile!r}, 'w', encoding='utf-8') as closefile:
                     closefile.write('is closed %d' % e.errno)
             """
         args = self.python_args('-c', script)
@@ -1880,7 +1880,7 @@ class _PosixSpawnMixin:
                               file_actions=[(os.POSIX_SPAWN_CLOSE, 0)])
 
         support.wait_process(pid, exitcode=0)
-        with open(closefile) as f:
+        with open(closefile, encoding="utf-8") as f:
             self.assertEqual(f.read(), 'is closed %d' % errno.EBADF)
 
     def test_dup2(self):
@@ -1898,7 +1898,7 @@ class _PosixSpawnMixin:
             pid = self.spawn_func(args[0], args, os.environ,
                                   file_actions=file_actions)
             support.wait_process(pid, exitcode=0)
-        with open(dupfile) as f:
+        with open(dupfile, encoding="utf-8") as f:
             self.assertEqual(f.read(), 'hello')
 
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43651](https://bugs.python.org/issue43651) -->
https://bugs.python.org/issue43651
<!-- /issue-number -->
