### PR TITLE
bpo-41974: Remove part of the doc note regarding complex.__float__

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1144,10 +1144,7 @@ These are not used in annotations. They are building blocks for creating generic
    .. note::
 
         :func:`runtime_checkable` will check only the presence of the required methods,
-        not their type signatures! For example, :class:`builtins.complex <complex>`
-        implements :func:`__float__`, therefore it passes an :func:`issubclass` check
-        against :class:`SupportsFloat`. However, the ``complex.__float__`` method
-        exists only to raise a :class:`TypeError` with a more informative message.
+        not their type signatures.
 
    .. versionadded:: 3.8
 


### PR DESCRIPTION
Wasn't sure if there was anything more to add to it, or a simple trim like this is sufficient. Will change if needed.

<!-- issue-number: [bpo-41974](https://bugs.python.org/issue41974) -->
https://bugs.python.org/issue41974
<!-- /issue-number -->
