### PR TITLE
bpo-42128: __match_args__ can't be a list anymore

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3401,7 +3401,7 @@ class TestMatchArgs(unittest.TestCase):
         self.assertEqual(C(42).__match_args__, ('a',))
 
     def test_explicit_match_args(self):
-        ma = []
+        ma = ()
         @dataclass
         class C:
             a: int

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -17,7 +17,7 @@ def no_perf(f):
 class MyClass:
     x: int
     y: str
-    __match_args__ = ["x", "y"]
+    __match_args__ = ("x", "y")
 
 
 @dataclasses.dataclass
@@ -2018,7 +2018,7 @@ class TestPatma(unittest.TestCase):
 
     def test_patma_200(self):
         class Class:
-            __match_args__ = ["a", "b"]
+            __match_args__ = ("a", "b")
         c = Class()
         c.a = 0
         c.b = 1
@@ -2046,7 +2046,7 @@ class TestPatma(unittest.TestCase):
         class Parent:
             __match_args__ = "a", "b"
         class Child(Parent):
-            __match_args__ = ["c", "d"]
+            __match_args__ = ("c", "d")
         c = Child()
         c.a = 0
         c.b = 1
@@ -2500,7 +2500,7 @@ class TestPatma(unittest.TestCase):
     @no_perf
     def test_patma_248(self):
         class Class:
-            __match_args__ = [None]
+            __match_args__ = (None,)
         x = Class()
         y = z = None
         with self.assertRaises(TypeError):
@@ -2513,7 +2513,7 @@ class TestPatma(unittest.TestCase):
     @no_perf
     def test_patma_249(self):
         class Class:
-            __match_args__ = []
+            __match_args__ = ()
         x = Class()
         y = z = None
         with self.assertRaises(TypeError):
@@ -2560,7 +2560,7 @@ class TestPatma(unittest.TestCase):
     @no_perf
     def test_patma_253(self):
         class Class:
-            __match_args__ = ["a", "a"]
+            __match_args__ = ("a", "a")
             a = None
         x = Class()
         w = y = z = None
@@ -2575,7 +2575,7 @@ class TestPatma(unittest.TestCase):
     @no_perf
     def test_patma_254(self):
         class Class:
-            __match_args__ = ["a"]
+            __match_args__ = ("a",)
             a = None
         x = Class()
         w = y = z = None
@@ -2840,6 +2840,22 @@ class TestPatma(unittest.TestCase):
                     y = 0
         self.assertEqual(x, range(10))
         self.assertIs(y, None)
+
+    @no_perf
+    def test_patma_282(self):
+        class Class:
+            __match_args__ = ["spam", "eggs"]
+            spam = 0
+            eggs = 1
+        x = Class()
+        w = y = z = None
+        with self.assertRaises(TypeError):
+            match x:
+                case Class(y, z):
+                    w = 0
+        self.assertIs(w, None)
+        self.assertIs(y, None)
+        self.assertIs(z, None)
 
 
 class PerfPatma(TestPatma):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-05-17-38-08.bpo-42128.1uVeGK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-05-17-38-08.bpo-42128.1uVeGK.rst
@@ -1,0 +1,1 @@
+:data:`~object.__match_args__` is no longer allowed to be a list.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1029,15 +1029,8 @@ match_class(PyThreadState *tstate, PyObject *subject, PyObject *type,
         int match_self = 0;
         match_args = PyObject_GetAttrString(type, "__match_args__");
         if (match_args) {
-            if (PyList_CheckExact(match_args)) {
-                Py_SETREF(match_args, PyList_AsTuple(match_args));
-            }
-            if (match_args == NULL) {
-                goto fail;
-            }
             if (!PyTuple_CheckExact(match_args)) {
-                const char *e = "%s.__match_args__ must be a list or tuple "
-                                "(got %s)";
+                const char *e = "%s.__match_args__ must be a tuple (got %s)";
                 _PyErr_Format(tstate, PyExc_TypeError, e,
                               ((PyTypeObject *)type)->tp_name,
                               Py_TYPE(match_args)->tp_name);


### PR DESCRIPTION
Docs are covered in #25185.


<!-- issue-number: [bpo-42128](https://bugs.python.org/issue42128) -->
https://bugs.python.org/issue42128
<!-- /issue-number -->
