### PR TITLE
bpo-43651: PEP 597: Fix pdeps used locale encoding.

### DIFF
--- a/Tools/scripts/pdeps.py
+++ b/Tools/scripts/pdeps.py
@@ -64,7 +64,7 @@ m_from = re.compile('^[ \t]*import[ \t]+([^#]+)')
 # Collect data from one file
 #
 def process(filename, table):
-    with open(filename) as fp:
+    with open(filename, encoding='utf-8') as fp:
         mod = os.path.basename(filename)
         if mod[-3:] == '.py':
             mod = mod[:-3]


### PR DESCRIPTION
Most Python source code encoding is UTF-8.


<!-- issue-number: [bpo-43651](https://bugs.python.org/issue43651) -->
https://bugs.python.org/issue43651
<!-- /issue-number -->
