### PR TITLE
[3.9] bpo-43745: Actually updates Windows release to OpenSSL 1.1.1k. (GH-25213)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-04-06-12-27-33.bpo-43745.rdKNda.rst
+++ b/Misc/NEWS.d/next/Windows/2021-04-06-12-27-33.bpo-43745.rdKNda.rst
@@ -1,0 +1,2 @@
+Actually updates Windows release to OpenSSL 1.1.1k. Earlier releases were
+mislabelled and actually included 1.1.1i again.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1k
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1k-1
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -63,7 +63,7 @@
     <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
     <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
     <opensslDir>$(ExternalsDir)openssl-1.1.1k\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1k\$(ArchName)\</opensslOutDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1k-1\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>


### PR DESCRIPTION
Earlier releases were mislabelled and included 1.1.1i again.
The tag/directory name is updated to ensure that builds get the fresh bits. However, the openssl-bin-1.1.1k tag in the repository has been forcibly updated, so fresh builds will be fine even without this change.


<!-- issue-number: [bpo-43745](https://bugs.python.org/issue43745) -->
https://bugs.python.org/issue43745
<!-- /issue-number -->
