### PR TITLE
bpo-43755: Update docs to reflect that lambda is not allowed in `comp_if` since 3.9

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -185,7 +185,7 @@ Common syntax elements for comprehensions are:
    comprehension: `assignment_expression` `comp_for`
    comp_for: ["async"] "for" `target_list` "in" `or_test` [`comp_iter`]
    comp_iter: `comp_for` | `comp_if`
-   comp_if: "if" `expression_nocond` [`comp_iter`]
+   comp_if: "if" `or_test` [`comp_iter`]
 
 The comprehension consists of a single expression followed by at least one
 :keyword:`!for` clause and zero or more :keyword:`!for` or :keyword:`!if` clauses.
@@ -1707,7 +1707,6 @@ Conditional expressions
 .. productionlist:: python-grammar
    conditional_expression: `or_test` ["if" `or_test` "else" `expression`]
    expression: `conditional_expression` | `lambda_expr`
-   expression_nocond: `or_test` | `lambda_expr_nocond`
 
 Conditional expressions (sometimes called a "ternary operator") have the lowest
 priority of all Python operations.
@@ -1733,7 +1732,6 @@ Lambdas
 
 .. productionlist:: python-grammar
    lambda_expr: "lambda" [`parameter_list`] ":" `expression`
-   lambda_expr_nocond: "lambda" [`parameter_list`] ":" `expression_nocond`
 
 Lambda expressions (sometimes called lambda forms) are used to create anonymous
 functions. The expression ``lambda parameters: expression`` yields a function

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -267,6 +267,10 @@ Other Language Changes
   :func:`~operator.countOf` of the :mod:`operator` module.
   (Contributed by Serhiy Storchaka in :issue:`40824`.)
 
+* Unparenthesized lambda expressions can no longer be the expression part in an
+  ``if`` clause in comprehensions and generator expressions. See :issue:`41848`
+  and :issue:`43755` for details.
+
 
 New Modules
 ===========

--- a/Misc/NEWS.d/next/Documentation/2021-04-06-14-55-45.bpo-43755.1m0fGq.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-04-06-14-55-45.bpo-43755.1m0fGq.rst
@@ -1,0 +1,3 @@
+Update documentation to reflect that unparenthesized lambda expressions can
+no longer be the expression part in an ``if`` clause in comprehensions and
+generator expressions since Python 3.9.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Update documentation to reflect that unparenthesized lambda expressions can no longer be the expression part in an ``if`` clause in comprehensions and generator expressions since Python 3.9.

<!-- issue-number: [bpo-43755](https://bugs.python.org/issue43755) -->
https://bugs.python.org/issue43755
<!-- /issue-number -->
