### PR TITLE
bpo-38605: Update "Future statements" docs since PEP 563 is always enabled

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -874,14 +874,11 @@ can appear before a future statement are:
 * blank lines, and
 * other future statements.
 
-The only feature that requires using the future statement is
-``annotations`` (see :pep:`563`).
-
 All historical features enabled by the future statement are still recognized
 by Python 3.  The list includes ``absolute_import``, ``division``,
 ``generators``, ``generator_stop``, ``unicode_literals``,
-``print_function``, ``nested_scopes`` and ``with_statement``.  They are
-all redundant because they are always enabled, and only kept for
+``print_function``, ``nested_scopes``, ``with_statement`` and ``annotations``.
+They are all redundant because they are always enabled, and only kept for
 backwards compatibility.
 
 A future statement is recognized and treated specially at compile time: Changes


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Update documentation section for "Future statements" to reflect that `from __future__ import annotations` is on by default, and no features require using the future statement now.

<!-- issue-number: [bpo-38605](https://bugs.python.org/issue38605) -->
https://bugs.python.org/issue38605
<!-- /issue-number -->

Automerge-Triggered-By: GH:isidentical