### PR TITLE
bpo-43751: Fix anext() bug where it erroneously returned None

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -388,6 +388,26 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         with self.assertRaises(StopAsyncIteration):
             self.loop.run_until_complete(consume())
 
+        async def test_2():
+            g1 = gen()
+            self.assertEqual(await anext(g1), 1)
+            self.assertEqual(await anext(g1), 2)
+            with self.assertRaises(StopAsyncIteration):
+                await anext(g1)
+            with self.assertRaises(StopAsyncIteration):
+                await anext(g1)
+
+            g2 = gen()
+            self.assertEqual(await anext(g2, "default"), 1)
+            self.assertEqual(await anext(g2, "default"), 2)
+            self.assertEqual(await anext(g2, "default"), "default")
+            self.assertEqual(await anext(g2, "default"), "default")
+
+            return "completed"
+
+        result = self.loop.run_until_complete(test_2())
+        self.assertEqual(result, "completed")
+
     def test_async_gen_aiter(self):
         async def gen():
             yield 1

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -389,7 +389,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 else:
                     self.yielded += 1
                     return self.yielded
-        
+
         for gen in (agen, MyAsyncIter):
             g = gen()
             async def consume():

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -426,6 +426,25 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                     return self.yielded
         self.check_async_iterator_anext(MyAsyncIter)
 
+    def test_python_async_iterator_types_coroutine_anext(self):
+        import types
+        class MyAsyncIterWithTypesCoro:
+            """Asynchronously yield 1, then 2."""
+            def __init__(self):
+                self.yielded = 0
+            def __aiter__(self):
+                return self
+            @types.coroutine
+            def __anext__(self):
+                if False:
+                    yield "this is a generator-based coroutine"
+                if self.yielded >= 2:
+                    raise StopAsyncIteration()
+                else:
+                    self.yielded += 1
+                    return self.yielded
+        self.check_async_iterator_anext(MyAsyncIterWithTypesCoro)
+
     def test_async_gen_aiter(self):
         async def gen():
             yield 1

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-07-18-00-05.bpo-43751.8fHsqQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-07-18-00-05.bpo-43751.8fHsqQ.rst
@@ -1,0 +1,1 @@
+Fixed a bug where ``anext(ait, default)`` would erroneously return None.

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -316,7 +316,10 @@ anextawaitable_traverse(anextawaitableobject *obj, visitproc visit, void *arg)
 static PyObject *
 anextawaitable_iternext(anextawaitableobject *obj)
 {
-    PyObject *result = PyIter_Next(obj->wrapped);
+    assert(obj->wrapped != NULL);
+    unaryfunc getter = Py_TYPE(obj->wrapped)->tp_iternext;
+    assert(getter != NULL);
+    PyObject *result = getter(obj->wrapped);
     if (result != NULL) {
         return result;
     }

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -335,8 +335,8 @@ anextawaitable_iternext(anextawaitableobject *obj)
      *         yield 2
      *     gen = agen()
      *
-     * Then anext(g) can just call
-     * g.__anext__().__next__()
+     * Then anext(gen) can just call
+     * gen.__anext__().__next__()
      */
     if (type->tp_as_async && type->tp_as_async->am_await) {
         unaryfunc await_getter = type->tp_as_async->am_await;

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -356,10 +356,12 @@ anextawaitable_iternext(anextawaitableobject *obj)
         if (Py_TYPE(awaitable)->tp_iternext == NULL) {
             PyErr_SetString(PyExc_TypeError,
                             "__await__ returned a non-iterable");
+            Py_DECREF(awaitable);
             return NULL;
         }
     }
     PyObject *result = (*Py_TYPE(awaitable)->tp_iternext)(awaitable);
+    Py_DECREF(awaitable);
     if (result != NULL) {
         return result;
     }

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -318,7 +318,11 @@ anextawaitable_iternext(anextawaitableobject *obj)
 {
     assert(obj->wrapped != NULL);
     unaryfunc getter = Py_TYPE(obj->wrapped)->tp_iternext;
-    assert(getter != NULL);
+    if (getter == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+            "anext() argument was not async iterable.");
+        return NULL;
+    }
     PyObject *result = getter(obj->wrapped);
     if (result != NULL) {
         return result;

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -325,7 +325,7 @@ anextawaitable_iternext(anextawaitableobject *obj)
      *             ...
      *     a = A()
      *
-     * Then anext(a) should call
+     * Then `await anext(a)` should call
      * a.__anext__().__await__().__next__()
      *
      * On the other hand, given
@@ -335,12 +335,11 @@ anextawaitable_iternext(anextawaitableobject *obj)
      *         yield 2
      *     gen = agen()
      *
-     * Then anext(g) can just call
+     * Then `await anext(g)` can just call
      * g.__anext__().__next__()
      */
     if (type->tp_as_async && type->tp_as_async->am_await) {
-        unaryfunc await_getter = type->tp_as_async->am_await;
-        PyObject *result = await_getter(obj->wrapped);
+        PyObject *result = type->tp_as_async->am_await(obj->wrapped);
         if (result == NULL) {
             return NULL;
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43751](https://bugs.python.org/issue43751) -->
https://bugs.python.org/issue43751
<!-- /issue-number -->
