### PR TITLE
bpo-43756: Add new audit event to incorporate new arguments added to glob.glob

### DIFF
--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -65,6 +65,7 @@ For example, ``'[?]'`` matches the character ``'?'``.
    match.
 
    .. audit-event:: glob.glob pathname,recursive glob.glob
+   .. audit-event:: glob.glob/2 pathname,root_dir,dir_fd,recursive glob.glob
 
    .. note::
       Using the "``**``" pattern in large directory trees may consume
@@ -83,6 +84,13 @@ For example, ``'[?]'`` matches the character ``'?'``.
    without actually storing them all simultaneously.
 
    .. audit-event:: glob.glob pathname,recursive glob.iglob
+   .. audit-event:: glob.glob/2 pathname,root_dir,dir_fd,recursive glob.iglob
+
+   .. versionchanged:: 3.5
+      Support for recursive globs using "``**``".
+
+   .. versionchanged:: 3.10
+      Added the *root_dir* and *dir_fd* parameters.
 
 
 .. function:: escape(pathname)
@@ -128,4 +136,3 @@ default. For example, consider a directory containing :file:`card.gif` and
 
    Module :mod:`fnmatch`
       Shell-style filename (not path) expansion
-

--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -65,7 +65,7 @@ For example, ``'[?]'`` matches the character ``'?'``.
    match.
 
    .. audit-event:: glob.glob pathname,recursive glob.glob
-   .. audit-event:: glob.glob/2 pathname,root_dir,dir_fd,recursive glob.glob
+   .. audit-event:: glob.glob/2 pathname,recursive,root_dir,dir_fd glob.glob
 
    .. note::
       Using the "``**``" pattern in large directory trees may consume
@@ -84,7 +84,7 @@ For example, ``'[?]'`` matches the character ``'?'``.
    without actually storing them all simultaneously.
 
    .. audit-event:: glob.glob pathname,recursive glob.iglob
-   .. audit-event:: glob.glob/2 pathname,root_dir,dir_fd,recursive glob.iglob
+   .. audit-event:: glob.glob/2 pathname,recursive,root_dir,dir_fd glob.iglob
 
    .. versionchanged:: 3.5
       Support for recursive globs using "``**``".

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -34,6 +34,7 @@ def iglob(pathname, *, root_dir=None, dir_fd=None, recursive=False):
     zero or more directories and subdirectories.
     """
     sys.audit("glob.glob", pathname, recursive)
+    sys.audit("glob.glob/2", pathname, root_dir, dir_fd, recursive)
     if root_dir is not None:
         root_dir = os.fspath(root_dir)
     else:

--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -34,7 +34,7 @@ def iglob(pathname, *, root_dir=None, dir_fd=None, recursive=False):
     zero or more directories and subdirectories.
     """
     sys.audit("glob.glob", pathname, recursive)
-    sys.audit("glob.glob/2", pathname, root_dir, dir_fd, recursive)
+    sys.audit("glob.glob/2", pathname, recursive, root_dir, dir_fd)
     if root_dir is not None:
         root_dir = os.fspath(root_dir)
     else:

--- a/Misc/NEWS.d/next/Security/2021-04-06-18-07-48.bpo-43756.DLBNqQ.rst
+++ b/Misc/NEWS.d/next/Security/2021-04-06-18-07-48.bpo-43756.DLBNqQ.rst
@@ -1,0 +1,2 @@
+Add new audit event ``glob.glob/2`` to incorporate the new *root_dir* and
+*dir_fd* arguments added to :func:`glob.glob` and :func:`glob.iglob`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Add a new audit event `glob.glob/2` to incorporate the new `root_dir` and `dir_fd` arguments added to `glob.glob` and `glob.iglob` in Python 3.10.

<!-- issue-number: [bpo-43756](https://bugs.python.org/issue43756) -->
https://bugs.python.org/issue43756
<!-- /issue-number -->
