### PR TITLE
bpo-40107: stop using os.open() to implement pathlib.Path.open()

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -393,7 +393,7 @@ class _NormalAccessor(_Accessor):
 
     stat = os.stat
 
-    open = os.open
+    open = io.open
 
     listdir = os.listdir
 
@@ -1087,10 +1087,6 @@ class Path(PurePath):
         # removed in the future.
         pass
 
-    def _opener(self, name, flags, mode=0o666):
-        # A stub for the opener argument to built-in open()
-        return self._accessor.open(self, flags, mode)
-
     # Public API
 
     @classmethod
@@ -1212,8 +1208,8 @@ class Path(PurePath):
         """
         if "b" not in mode:
             encoding = io.text_encoding(encoding)
-        return io.open(self, mode, buffering, encoding, errors, newline,
-                       opener=self._opener)
+        return self._accessor.open(self, mode, buffering, encoding, errors,
+                                   newline)
 
     def read_bytes(self):
         """


### PR DESCRIPTION
- Moves `io.open()` call into the path accessor
- Removes `os.open()` from path accessor (other usage removed in #18838)
- Removes a do-nothing `_opener` function

This is continuing on a theme of moving non-abstract path functionality into the accessor, in preparation for solving [bpo-24132](https://bugs.python.org/issue24132).

No change of behaviour.

<!-- issue-number: [bpo-40107](https://bugs.python.org/issue40107) -->
https://bugs.python.org/issue40107
<!-- /issue-number -->
