### PR TITLE
bpo-43760: Streamline dispatch sequence for machines without computed gotos.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1299,13 +1299,11 @@ eval_frame_handle_pending(PyThreadState *tstate)
 #endif
 
 #if USE_COMPUTED_GOTOS
-#define TARGET(op) \
-    op: \
-    TARGET_##op
-#define DISPATCH_GOTO goto *opcode_targets[opcode];
+#define TARGET(op) op: TARGET_##op
+#define DISPATCH_GOTO() goto *opcode_targets[opcode]
 #else
 #define TARGET(op) op
-#define DISPATCH_GOTO goto dispatch_opcode;
+#define DISPATCH_GOTO() goto dispatch_opcode
 #endif
 
 #define DISPATCH() \
@@ -1315,7 +1313,7 @@ eval_frame_handle_pending(PyThreadState *tstate)
         } \
         f->f_lasti = INSTR_OFFSET(); \
         NEXTOPARG(); \
-        DISPATCH_GOTO \
+        DISPATCH_GOTO(); \
     }
 
 #define CHECK_EVAL_BREAKER() \
@@ -1594,7 +1592,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
 #endif
     PyObject **stack_pointer;  /* Next free slot in value stack */
     const _Py_CODEUNIT *next_instr;
-    uint8_t opcode;    /* Current opcode */
+    int opcode;        /* Current opcode */
     int oparg;         /* Current opcode argument, if any */
     PyObject **fastlocals, **freevars;
     PyObject *retval = NULL;            /* Return value */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1796,14 +1796,14 @@ main_loop:
                                         tstate->c_traceobj,
                                         tstate, f,
                                         &trace_info);
-            if (err) {
-                /* trace function raised an exception */
-                goto error;
-            }
             /* Reload possibly changed frame fields */
             JUMPTO(f->f_lasti);
             stack_pointer = f->f_valuestack+f->f_stackdepth;
             f->f_stackdepth = -1;
+            if (err) {
+                /* trace function raised an exception */
+                goto error;
+            }
             NEXTOPARG();
         }
 


### PR DESCRIPTION
* Do fetch and decode at end of opocde then jump directly to switch.
  Should allow compilers that don't support computed-gotos, specifically MSVC,
  to generate better code.

* Cleans up the code

This should have no effect when computed gotos are used.

<!-- issue-number: [bpo-43760](https://bugs.python.org/issue43760) -->
https://bugs.python.org/issue43760
<!-- /issue-number -->
