### PR TITLE
bpo-43244: Rename pycore_ast.h functions to _PyAST_xxx()

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -28,9 +28,9 @@ _PyPegen_parse(Parser *p)
 // The end
 '''
 file[mod_ty]: a=[statements] ENDMARKER { _PyPegen_make_module(p, a) }
-interactive[mod_ty]: a=statement_newline { Interactive(a, p->arena) }
-eval[mod_ty]: a=expressions NEWLINE* ENDMARKER { Expression(a, p->arena) }
-func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression NEWLINE* ENDMARKER { FunctionType(a, b, p->arena) }
+interactive[mod_ty]: a=statement_newline { _PyAST_Interactive(a, p->arena) }
+eval[mod_ty]: a=expressions NEWLINE* ENDMARKER { _PyAST_Expression(a, p->arena) }
+func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression NEWLINE* ENDMARKER { _PyAST_FunctionType(a, b, p->arena) }
 fstring[expr_ty]: star_expressions
 
 # type_expressions allow */** but ignore them
@@ -56,7 +56,7 @@ statement[asdl_stmt_seq*]: a=compound_stmt { (asdl_stmt_seq*)_PyPegen_singleton_
 statement_newline[asdl_stmt_seq*]:
     | a=compound_stmt NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, a) }
     | simple_stmts
-    | NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, CHECK(stmt_ty, _Py_Pass(EXTRA))) }
+    | NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, CHECK(stmt_ty, _PyAST_Pass(EXTRA))) }
     | ENDMARKER { _PyPegen_interactive_exit(p) }
 simple_stmts[asdl_stmt_seq*]:
     | a=simple_stmt !';' NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, a) } # Not needed, there for speedup
@@ -65,16 +65,16 @@ simple_stmts[asdl_stmt_seq*]:
 # will throw a SyntaxError.
 simple_stmt[stmt_ty] (memo):
     | assignment
-    | e=star_expressions { _Py_Expr(e, EXTRA) }
+    | e=star_expressions { _PyAST_Expr(e, EXTRA) }
     | &'return' return_stmt
     | &('import' | 'from') import_stmt
     | &'raise' raise_stmt
-    | 'pass' { _Py_Pass(EXTRA) }
+    | 'pass' { _PyAST_Pass(EXTRA) }
     | &'del' del_stmt
     | &'yield' yield_stmt
     | &'assert' assert_stmt
-    | 'break' { _Py_Break(EXTRA) }
-    | 'continue' { _Py_Continue(EXTRA) }
+    | 'break' { _PyAST_Break(EXTRA) }
+    | 'continue' { _PyAST_Continue(EXTRA) }
     | &'global' global_stmt
     | &'nonlocal' nonlocal_stmt
 compound_stmt[stmt_ty]:
@@ -94,15 +94,15 @@ assignment[stmt_ty]:
             stmt_ty,
             6,
             "Variable annotation syntax is",
-            _Py_AnnAssign(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, c, 1, EXTRA)
+            _PyAST_AnnAssign(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, c, 1, EXTRA)
         ) }
     | a=('(' b=single_target ')' { b }
          | single_subscript_attribute_target) ':' b=expression c=['=' d=annotated_rhs { d }] {
-        CHECK_VERSION(stmt_ty, 6, "Variable annotations syntax is", _Py_AnnAssign(a, b, c, 0, EXTRA)) }
+        CHECK_VERSION(stmt_ty, 6, "Variable annotations syntax is", _PyAST_AnnAssign(a, b, c, 0, EXTRA)) }
     | a[asdl_expr_seq*]=(z=star_targets '=' { z })+ b=(yield_expr | star_expressions) !'=' tc=[TYPE_COMMENT] {
-         _Py_Assign(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+         _PyAST_Assign(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | a=single_target b=augassign ~ c=(yield_expr | star_expressions) {
-         _Py_AugAssign(a, b->kind, c, EXTRA) }
+         _PyAST_AugAssign(a, b->kind, c, EXTRA) }
     | invalid_assignment
 
 augassign[AugOperator*]:
@@ -121,26 +121,26 @@ augassign[AugOperator*]:
     | '//=' { _PyPegen_augoperator(p, FloorDiv) }
 
 global_stmt[stmt_ty]: 'global' a[asdl_expr_seq*]=','.NAME+ {
-    _Py_Global(CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p, a)), EXTRA) }
+    _PyAST_Global(CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p, a)), EXTRA) }
 nonlocal_stmt[stmt_ty]: 'nonlocal' a[asdl_expr_seq*]=','.NAME+ {
-    _Py_Nonlocal(CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p, a)), EXTRA) }
+    _PyAST_Nonlocal(CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p, a)), EXTRA) }
 
-yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
+yield_stmt[stmt_ty]: y=yield_expr { _PyAST_Expr(y, EXTRA) }
 
-assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _Py_Assert(a, b, EXTRA) }
+assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _PyAST_Assert(a, b, EXTRA) }
 
 del_stmt[stmt_ty]:
-    | 'del' a=del_targets &(';' | NEWLINE) { _Py_Delete(a, EXTRA) }
+    | 'del' a=del_targets &(';' | NEWLINE) { _PyAST_Delete(a, EXTRA) }
     | invalid_del_stmt
 
 import_stmt[stmt_ty]: import_name | import_from
-import_name[stmt_ty]: 'import' a=dotted_as_names { _Py_Import(a, EXTRA) }
+import_name[stmt_ty]: 'import' a=dotted_as_names { _PyAST_Import(a, EXTRA) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from[stmt_ty]:
     | 'from' a=('.' | '...')* b=dotted_name 'import' c=import_from_targets {
-        _Py_ImportFrom(b->v.Name.id, c, _PyPegen_seq_count_dots(a), EXTRA) }
+        _PyAST_ImportFrom(b->v.Name.id, c, _PyPegen_seq_count_dots(a), EXTRA) }
     | 'from' a=('.' | '...')+ 'import' b=import_from_targets {
-        _Py_ImportFrom(NULL, b, _PyPegen_seq_count_dots(a), EXTRA) }
+        _PyAST_ImportFrom(NULL, b, _PyPegen_seq_count_dots(a), EXTRA) }
 import_from_targets[asdl_alias_seq*]:
     | '(' a=import_from_as_names [','] ')' { a }
     | import_from_as_names !','
@@ -149,13 +149,13 @@ import_from_targets[asdl_alias_seq*]:
 import_from_as_names[asdl_alias_seq*]:
     | a[asdl_alias_seq*]=','.import_from_as_name+ { a }
 import_from_as_name[alias_ty]:
-    | a=NAME b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
+    | a=NAME b=['as' z=NAME { z }] { _PyAST_alias(a->v.Name.id,
                                                (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                p->arena) }
 dotted_as_names[asdl_alias_seq*]:
     | a[asdl_alias_seq*]=','.dotted_as_name+ { a }
 dotted_as_name[alias_ty]:
-    | a=dotted_name b=['as' z=NAME { z }] { _Py_alias(a->v.Name.id,
+    | a=dotted_name b=['as' z=NAME { z }] { _PyAST_alias(a->v.Name.id,
                                                       (b) ? ((expr_ty) b)->v.Name.id : NULL,
                                                       p->arena) }
 dotted_name[expr_ty]:
@@ -164,77 +164,77 @@ dotted_name[expr_ty]:
 
 if_stmt[stmt_ty]:
     | 'if' a=named_expression &&':' b=block c=elif_stmt {
-        _Py_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
-    | 'if' a=named_expression &&':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
+        _PyAST_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
+    | 'if' a=named_expression &&':' b=block c=[else_block] { _PyAST_If(a, b, c, EXTRA) }
 elif_stmt[stmt_ty]:
     | 'elif' a=named_expression &&':' b=block c=elif_stmt {
-        _Py_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
-    | 'elif' a=named_expression &&':' b=block c=[else_block] { _Py_If(a, b, c, EXTRA) }
+        _PyAST_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
+    | 'elif' a=named_expression &&':' b=block c=[else_block] { _PyAST_If(a, b, c, EXTRA) }
 else_block[asdl_stmt_seq*]: 'else' &&':' b=block { b }
 
 while_stmt[stmt_ty]:
-    | 'while' a=named_expression &&':' b=block c=[else_block] { _Py_While(a, b, c, EXTRA) }
+    | 'while' a=named_expression &&':' b=block c=[else_block] { _PyAST_While(a, b, c, EXTRA) }
 
 for_stmt[stmt_ty]:
     | 'for' t=star_targets 'in' ~ ex=star_expressions &&':' tc=[TYPE_COMMENT] b=block el=[else_block] {
-        _Py_For(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+        _PyAST_For(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | ASYNC 'for' t=star_targets 'in' ~ ex=star_expressions &&':' tc=[TYPE_COMMENT] b=block el=[else_block] {
-        CHECK_VERSION(stmt_ty, 5, "Async for loops are", _Py_AsyncFor(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
+        CHECK_VERSION(stmt_ty, 5, "Async for loops are", _PyAST_AsyncFor(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
     | invalid_for_target
 
 with_stmt[stmt_ty]:
     | 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
-        _Py_With(a, b, NULL, EXTRA) }
+        _PyAST_With(a, b, NULL, EXTRA) }
     | 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
-        _Py_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+        _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | ASYNC 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
-       CHECK_VERSION(stmt_ty, 5, "Async with statements are", _Py_AsyncWith(a, b, NULL, EXTRA)) }
+       CHECK_VERSION(stmt_ty, 5, "Async with statements are", _PyAST_AsyncWith(a, b, NULL, EXTRA)) }
     | ASYNC 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
-       CHECK_VERSION(stmt_ty, 5, "Async with statements are", _Py_AsyncWith(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
+       CHECK_VERSION(stmt_ty, 5, "Async with statements are", _PyAST_AsyncWith(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
     | invalid_with_stmt
 
 with_item[withitem_ty]:
-    | e=expression 'as' t=star_target &(',' | ')' | ':') { _Py_withitem(e, t, p->arena) }
+    | e=expression 'as' t=star_target &(',' | ')' | ':') { _PyAST_withitem(e, t, p->arena) }
     | invalid_with_item
-    | e=expression { _Py_withitem(e, NULL, p->arena) }
+    | e=expression { _PyAST_withitem(e, NULL, p->arena) }
 
 try_stmt[stmt_ty]:
-    | 'try' &&':' b=block f=finally_block { _Py_Try(b, NULL, NULL, f, EXTRA) }
-    | 'try' &&':' b=block ex[asdl_excepthandler_seq*]=except_block+ el=[else_block] f=[finally_block] { _Py_Try(b, ex, el, f, EXTRA) }
+    | 'try' &&':' b=block f=finally_block { _PyAST_Try(b, NULL, NULL, f, EXTRA) }
+    | 'try' &&':' b=block ex[asdl_excepthandler_seq*]=except_block+ el=[else_block] f=[finally_block] { _PyAST_Try(b, ex, el, f, EXTRA) }
 except_block[excepthandler_ty]:
     | 'except' e=expression t=['as' z=NAME { z }] ':' b=block {
-        _Py_ExceptHandler(e, (t) ? ((expr_ty) t)->v.Name.id : NULL, b, EXTRA) }
-    | 'except' ':' b=block { _Py_ExceptHandler(NULL, NULL, b, EXTRA) }
+        _PyAST_ExceptHandler(e, (t) ? ((expr_ty) t)->v.Name.id : NULL, b, EXTRA) }
+    | 'except' ':' b=block { _PyAST_ExceptHandler(NULL, NULL, b, EXTRA) }
     | invalid_except_block
 finally_block[asdl_stmt_seq*]: 'finally' ':' a=block { a }
 
 match_stmt[stmt_ty]:
     | "match" subject=subject_expr ':' NEWLINE INDENT cases[asdl_match_case_seq*]=case_block+ DEDENT {
-        CHECK_VERSION(stmt_ty, 10, "Pattern matching is", _Py_Match(subject, cases, EXTRA)) }
+        CHECK_VERSION(stmt_ty, 10, "Pattern matching is", _PyAST_Match(subject, cases, EXTRA)) }
     | invalid_match_stmt
 subject_expr[expr_ty]:
     | value=star_named_expression ',' values=star_named_expressions? {
-        _Py_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, value, values)), Load, EXTRA) }
+        _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, value, values)), Load, EXTRA) }
     | named_expression
 case_block[match_case_ty]:
     | "case" pattern=patterns guard=guard? ':' body=block {
-        _Py_match_case(pattern, guard, body, p->arena) }
+        _PyAST_match_case(pattern, guard, body, p->arena) }
     | invalid_case_block
 guard[expr_ty]: 'if' guard=named_expression { guard }
 
 patterns[expr_ty]:
     | values[asdl_expr_seq*]=open_sequence_pattern {
-        _Py_Tuple(values, Load, EXTRA) }
+        _PyAST_Tuple(values, Load, EXTRA) }
     | pattern
 pattern[expr_ty]:
     | as_pattern
     | or_pattern
 as_pattern[expr_ty]:
     | pattern=or_pattern 'as' target=capture_pattern {
-        _Py_MatchAs(pattern, target->v.Name.id, EXTRA) }
+        _PyAST_MatchAs(pattern, target->v.Name.id, EXTRA) }
 or_pattern[expr_ty]:
     | patterns[asdl_expr_seq*]='|'.closed_pattern+ {
-        asdl_seq_LEN(patterns) == 1 ? asdl_seq_GET(patterns, 0) : _Py_MatchOr(patterns, EXTRA) }
+        asdl_seq_LEN(patterns) == 1 ? asdl_seq_GET(patterns, 0) : _PyAST_MatchOr(patterns, EXTRA) }
 closed_pattern[expr_ty]:
     | literal_pattern
     | capture_pattern
@@ -247,28 +247,28 @@ closed_pattern[expr_ty]:
 
 literal_pattern[expr_ty]:
     | signed_number !('+' | '-')
-    | real=signed_number '+' imag=NUMBER { _Py_BinOp(real, Add, imag, EXTRA) }
-    | real=signed_number '-' imag=NUMBER  { _Py_BinOp(real, Sub, imag, EXTRA) }
+    | real=signed_number '+' imag=NUMBER { _PyAST_BinOp(real, Add, imag, EXTRA) }
+    | real=signed_number '-' imag=NUMBER  { _PyAST_BinOp(real, Sub, imag, EXTRA) }
     | strings
-    | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
-    | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
-    | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
+    | 'None' { _PyAST_Constant(Py_None, NULL, EXTRA) }
+    | 'True' { _PyAST_Constant(Py_True, NULL, EXTRA) }
+    | 'False' { _PyAST_Constant(Py_False, NULL, EXTRA) }
 signed_number[expr_ty]:
     | NUMBER
-    | '-' number=NUMBER { _Py_UnaryOp(USub, number, EXTRA) }
+    | '-' number=NUMBER { _PyAST_UnaryOp(USub, number, EXTRA) }
 
 capture_pattern[expr_ty]:
     | !"_" name=NAME !('.' | '(' | '=') {
         _PyPegen_set_expr_context(p, name, Store) }
 
 wildcard_pattern[expr_ty]:
-    | "_" { _Py_Name(CHECK(PyObject*, _PyPegen_new_identifier(p, "_")), Store, EXTRA) }
+    | "_" { _PyAST_Name(CHECK(PyObject*, _PyPegen_new_identifier(p, "_")), Store, EXTRA) }
 
 value_pattern[expr_ty]:
     | attr=attr !('.' | '(' | '=') { attr }
 attr[expr_ty]:
     | value=name_or_attr '.' attr=NAME {
-        _Py_Attribute(value, attr->v.Name.id, Load, EXTRA) }
+        _PyAST_Attribute(value, attr->v.Name.id, Load, EXTRA) }
 name_or_attr[expr_ty]:
     | attr
     | NAME
@@ -277,8 +277,8 @@ group_pattern[expr_ty]:
     | '(' pattern=pattern ')' { pattern }
 
 sequence_pattern[expr_ty]:
-    | '[' values=maybe_sequence_pattern? ']' { _Py_List(values, Load, EXTRA) }
-    | '(' values=open_sequence_pattern? ')' { _Py_Tuple(values, Load, EXTRA) }
+    | '[' values=maybe_sequence_pattern? ']' { _PyAST_List(values, Load, EXTRA) }
+    | '(' values=open_sequence_pattern? ')' { _PyAST_Tuple(values, Load, EXTRA) }
 open_sequence_pattern[asdl_seq*]:
     | value=maybe_star_pattern ',' values=maybe_sequence_pattern? {
         _PyPegen_seq_insert_in_front(p, value, values) }
@@ -289,11 +289,11 @@ maybe_star_pattern[expr_ty]:
     | pattern
 star_pattern[expr_ty]:
     | '*' value=(capture_pattern | wildcard_pattern) {
-        _Py_Starred(value, Store, EXTRA) }
+        _PyAST_Starred(value, Store, EXTRA) }
 
 mapping_pattern[expr_ty]:
     | '{' items=items_pattern? '}' {
-        _Py_Dict(CHECK(asdl_expr_seq*, _PyPegen_get_keys(p, items)), CHECK(asdl_expr_seq*, _PyPegen_get_values(p, items)), EXTRA) }
+        _PyAST_Dict(CHECK(asdl_expr_seq*, _PyPegen_get_keys(p, items)), CHECK(asdl_expr_seq*, _PyPegen_get_values(p, items)), EXTRA) }
 items_pattern[asdl_seq*]:
     | items=','.key_value_pattern+ ','? { items }
 key_value_pattern[KeyValuePair*]:
@@ -304,26 +304,26 @@ double_star_pattern[KeyValuePair*]:
     | '**' value=capture_pattern { _PyPegen_key_value_pair(p, NULL, value) }
 
 class_pattern[expr_ty]:
-    | func=name_or_attr '(' ')' { _Py_Call(func, NULL, NULL, EXTRA) }
+    | func=name_or_attr '(' ')' { _PyAST_Call(func, NULL, NULL, EXTRA) }
     | func=name_or_attr '(' args=positional_patterns ','? ')' {
-        _Py_Call(func, args, NULL, EXTRA) }
+        _PyAST_Call(func, args, NULL, EXTRA) }
     | func=name_or_attr '(' keywords=keyword_patterns ','? ')' {
-        _Py_Call(func, NULL, keywords, EXTRA) }
+        _PyAST_Call(func, NULL, keywords, EXTRA) }
     | func=name_or_attr '(' args=positional_patterns ',' keywords=keyword_patterns ','? ')' {
-        _Py_Call(func, args, keywords, EXTRA) }
+        _PyAST_Call(func, args, keywords, EXTRA) }
 positional_patterns[asdl_expr_seq*]:
     | args[asdl_expr_seq*]=','.pattern+ { args }
 keyword_patterns[asdl_keyword_seq*]:
     | keywords[asdl_keyword_seq*]=','.keyword_pattern+ { keywords }
 keyword_pattern[keyword_ty]:
-    | arg=NAME '=' value=pattern { _Py_keyword(arg->v.Name.id, value, EXTRA) }
+    | arg=NAME '=' value=pattern { _PyAST_keyword(arg->v.Name.id, value, EXTRA) }
 
 return_stmt[stmt_ty]:
-    | 'return' a=[star_expressions] { _Py_Return(a, EXTRA) }
+    | 'return' a=[star_expressions] { _PyAST_Return(a, EXTRA) }
 
 raise_stmt[stmt_ty]:
-    | 'raise' a=expression b=['from' z=expression { z }] { _Py_Raise(a, b, EXTRA) }
-    | 'raise' { _Py_Raise(NULL, NULL, EXTRA) }
+    | 'raise' a=expression b=['from' z=expression { z }] { _PyAST_Raise(a, b, EXTRA) }
+    | 'raise' { _PyAST_Raise(NULL, NULL, EXTRA) }
 
 function_def[stmt_ty]:
     | d=decorators f=function_def_raw { _PyPegen_function_def_decorators(p, d, f) }
@@ -331,7 +331,7 @@ function_def[stmt_ty]:
 
 function_def_raw[stmt_ty]:
     | 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] &&':' tc=[func_type_comment] b=block {
-        _Py_FunctionDef(n->v.Name.id,
+        _PyAST_FunctionDef(n->v.Name.id,
                         (params) ? params : CHECK(arguments_ty, _PyPegen_empty_arguments(p)),
                         b, NULL, a, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | ASYNC 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] &&':' tc=[func_type_comment] b=block {
@@ -339,7 +339,7 @@ function_def_raw[stmt_ty]:
             stmt_ty,
             5,
             "Async functions are",
-            _Py_AsyncFunctionDef(n->v.Name.id,
+            _PyAST_AsyncFunctionDef(n->v.Name.id,
                             (params) ? params : CHECK(arguments_ty, _PyPegen_empty_arguments(p)),
                             b, NULL, a, NEW_TYPE_COMMENT(p, tc), EXTRA)
         ) }
@@ -403,7 +403,7 @@ param_with_default[NameDefaultPair*]:
 param_maybe_default[NameDefaultPair*]:
     | a=param c=default? ',' tc=TYPE_COMMENT? { _PyPegen_name_default_pair(p, a, c, tc) }
     | a=param c=default? tc=TYPE_COMMENT? &')' { _PyPegen_name_default_pair(p, a, c, tc) }
-param[arg_ty]: a=NAME b=annotation? { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
+param[arg_ty]: a=NAME b=annotation? { _PyAST_arg(a->v.Name.id, b, NULL, EXTRA) }
 
 annotation[expr_ty]: ':' a=expression { a }
 default[expr_ty]: '=' a=expression { a }
@@ -415,7 +415,7 @@ class_def[stmt_ty]:
     | class_def_raw
 class_def_raw[stmt_ty]:
     | 'class' a=NAME b=['(' z=[arguments] ')' { z }] &&':' c=block {
-        _Py_ClassDef(a->v.Name.id,
+        _PyAST_ClassDef(a->v.Name.id,
                      (b) ? ((expr_ty) b)->v.Call.args : NULL,
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                      c, NULL, EXTRA) }
@@ -427,19 +427,19 @@ block[asdl_stmt_seq*] (memo):
 
 star_expressions[expr_ty]:
     | a=star_expression b=(',' c=star_expression { c })+ [','] {
-        _Py_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)), Load, EXTRA) }
-    | a=star_expression ',' { _Py_Tuple(CHECK(asdl_expr_seq*, _PyPegen_singleton_seq(p, a)), Load, EXTRA) }
+        _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)), Load, EXTRA) }
+    | a=star_expression ',' { _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_singleton_seq(p, a)), Load, EXTRA) }
     | star_expression
 star_expression[expr_ty] (memo):
-    | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
+    | '*' a=bitwise_or { _PyAST_Starred(a, Load, EXTRA) }
     | expression
 
 star_named_expressions[asdl_expr_seq*]: a[asdl_expr_seq*]=','.star_named_expression+ [','] { a }
 star_named_expression[expr_ty]:
-    | '*' a=bitwise_or { _Py_Starred(a, Load, EXTRA) }
+    | '*' a=bitwise_or { _PyAST_Starred(a, Load, EXTRA) }
     | named_expression
 named_expression[expr_ty]:
-    | a=NAME ':=' ~ b=expression { _Py_NamedExpr(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, EXTRA) }
+    | a=NAME ':=' ~ b=expression { _PyAST_NamedExpr(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), b, EXTRA) }
     | expression !':='
     | invalid_named_expression
 
@@ -447,17 +447,17 @@ annotated_rhs[expr_ty]: yield_expr | star_expressions
 
 expressions[expr_ty]:
     | a=expression b=(',' c=expression { c })+ [','] {
-        _Py_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)), Load, EXTRA) }
-    | a=expression ',' { _Py_Tuple(CHECK(asdl_expr_seq*, _PyPegen_singleton_seq(p, a)), Load, EXTRA) }
+        _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)), Load, EXTRA) }
+    | a=expression ',' { _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_singleton_seq(p, a)), Load, EXTRA) }
     | expression
 expression[expr_ty] (memo):
-    | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA) }
+    | a=disjunction 'if' b=disjunction 'else' c=expression { _PyAST_IfExp(b, a, c, EXTRA) }
     | disjunction
     | lambdef
 
 lambdef[expr_ty]:
     | 'lambda' a=[lambda_params] ':' b=expression {
-        _Py_Lambda((a) ? a : CHECK(arguments_ty, _PyPegen_empty_arguments(p)), b, EXTRA) }
+        _PyAST_Lambda((a) ? a : CHECK(arguments_ty, _PyPegen_empty_arguments(p)), b, EXTRA) }
 
 lambda_params[arguments_ty]:
     | invalid_lambda_parameters
@@ -503,26 +503,26 @@ lambda_param_with_default[NameDefaultPair*]:
 lambda_param_maybe_default[NameDefaultPair*]:
     | a=lambda_param c=default? ',' { _PyPegen_name_default_pair(p, a, c, NULL) }
     | a=lambda_param c=default? &':' { _PyPegen_name_default_pair(p, a, c, NULL) }
-lambda_param[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
+lambda_param[arg_ty]: a=NAME { _PyAST_arg(a->v.Name.id, NULL, NULL, EXTRA) }
 
 disjunction[expr_ty] (memo):
-    | a=conjunction b=('or' c=conjunction { c })+ { _Py_BoolOp(
+    | a=conjunction b=('or' c=conjunction { c })+ { _PyAST_BoolOp(
         Or,
         CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)),
         EXTRA) }
     | conjunction
 conjunction[expr_ty] (memo):
-    | a=inversion b=('and' c=inversion { c })+ { _Py_BoolOp(
+    | a=inversion b=('and' c=inversion { c })+ { _PyAST_BoolOp(
         And,
         CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)),
         EXTRA) }
     | inversion
 inversion[expr_ty] (memo):
-    | 'not' a=inversion { _Py_UnaryOp(Not, a, EXTRA) }
+    | 'not' a=inversion { _PyAST_UnaryOp(Not, a, EXTRA) }
     | comparison
 comparison[expr_ty]:
     | a=bitwise_or b=compare_op_bitwise_or_pair+ {
-        _Py_Compare(
+        _PyAST_Compare(
             a,
             CHECK(asdl_int_seq*, _PyPegen_get_cmpops(p, b)),
             CHECK(asdl_expr_seq*, _PyPegen_get_exprs(p, b)),
@@ -552,98 +552,98 @@ isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { _PyPegen_cmpop_expr_
 is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, Is, a) }
 
 bitwise_or[expr_ty]:
-    | a=bitwise_or '|' b=bitwise_xor { _Py_BinOp(a, BitOr, b, EXTRA) }
+    | a=bitwise_or '|' b=bitwise_xor { _PyAST_BinOp(a, BitOr, b, EXTRA) }
     | bitwise_xor
 bitwise_xor[expr_ty]:
-    | a=bitwise_xor '^' b=bitwise_and { _Py_BinOp(a, BitXor, b, EXTRA) }
+    | a=bitwise_xor '^' b=bitwise_and { _PyAST_BinOp(a, BitXor, b, EXTRA) }
     | bitwise_and
 bitwise_and[expr_ty]:
-    | a=bitwise_and '&' b=shift_expr { _Py_BinOp(a, BitAnd, b, EXTRA) }
+    | a=bitwise_and '&' b=shift_expr { _PyAST_BinOp(a, BitAnd, b, EXTRA) }
     | shift_expr
 shift_expr[expr_ty]:
-    | a=shift_expr '<<' b=sum { _Py_BinOp(a, LShift, b, EXTRA) }
-    | a=shift_expr '>>' b=sum { _Py_BinOp(a, RShift, b, EXTRA) }
+    | a=shift_expr '<<' b=sum { _PyAST_BinOp(a, LShift, b, EXTRA) }
+    | a=shift_expr '>>' b=sum { _PyAST_BinOp(a, RShift, b, EXTRA) }
     | sum
 
 sum[expr_ty]:
-    | a=sum '+' b=term { _Py_BinOp(a, Add, b, EXTRA) }
-    | a=sum '-' b=term { _Py_BinOp(a, Sub, b, EXTRA) }
+    | a=sum '+' b=term { _PyAST_BinOp(a, Add, b, EXTRA) }
+    | a=sum '-' b=term { _PyAST_BinOp(a, Sub, b, EXTRA) }
     | term
 term[expr_ty]:
-    | a=term '*' b=factor { _Py_BinOp(a, Mult, b, EXTRA) }
-    | a=term '/' b=factor { _Py_BinOp(a, Div, b, EXTRA) }
-    | a=term '//' b=factor { _Py_BinOp(a, FloorDiv, b, EXTRA) }
-    | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA) }
-    | a=term '@' b=factor { CHECK_VERSION(expr_ty, 5, "The '@' operator is", _Py_BinOp(a, MatMult, b, EXTRA)) }
+    | a=term '*' b=factor { _PyAST_BinOp(a, Mult, b, EXTRA) }
+    | a=term '/' b=factor { _PyAST_BinOp(a, Div, b, EXTRA) }
+    | a=term '//' b=factor { _PyAST_BinOp(a, FloorDiv, b, EXTRA) }
+    | a=term '%' b=factor { _PyAST_BinOp(a, Mod, b, EXTRA) }
+    | a=term '@' b=factor { CHECK_VERSION(expr_ty, 5, "The '@' operator is", _PyAST_BinOp(a, MatMult, b, EXTRA)) }
     | factor
 factor[expr_ty] (memo):
-    | '+' a=factor { _Py_UnaryOp(UAdd, a, EXTRA) }
-    | '-' a=factor { _Py_UnaryOp(USub, a, EXTRA) }
-    | '~' a=factor { _Py_UnaryOp(Invert, a, EXTRA) }
+    | '+' a=factor { _PyAST_UnaryOp(UAdd, a, EXTRA) }
+    | '-' a=factor { _PyAST_UnaryOp(USub, a, EXTRA) }
+    | '~' a=factor { _PyAST_UnaryOp(Invert, a, EXTRA) }
     | power
 power[expr_ty]:
-    | a=await_primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA) }
+    | a=await_primary '**' b=factor { _PyAST_BinOp(a, Pow, b, EXTRA) }
     | await_primary
 await_primary[expr_ty] (memo):
-    | AWAIT a=primary { CHECK_VERSION(expr_ty, 5, "Await expressions are", _Py_Await(a, EXTRA)) }
+    | AWAIT a=primary { CHECK_VERSION(expr_ty, 5, "Await expressions are", _PyAST_Await(a, EXTRA)) }
     | primary
 primary[expr_ty]:
     | invalid_primary  # must be before 'primay genexp' because of invalid_genexp
-    | a=primary '.' b=NAME { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
-    | a=primary b=genexp { _Py_Call(a, CHECK(asdl_expr_seq*, (asdl_expr_seq*)_PyPegen_singleton_seq(p, b)), NULL, EXTRA) }
+    | a=primary '.' b=NAME { _PyAST_Attribute(a, b->v.Name.id, Load, EXTRA) }
+    | a=primary b=genexp { _PyAST_Call(a, CHECK(asdl_expr_seq*, (asdl_expr_seq*)_PyPegen_singleton_seq(p, b)), NULL, EXTRA) }
     | a=primary '(' b=[arguments] ')' {
-        _Py_Call(a,
+        _PyAST_Call(a,
                  (b) ? ((expr_ty) b)->v.Call.args : NULL,
                  (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                  EXTRA) }
-    | a=primary '[' b=slices ']' { _Py_Subscript(a, b, Load, EXTRA) }
+    | a=primary '[' b=slices ']' { _PyAST_Subscript(a, b, Load, EXTRA) }
     | atom
 
 slices[expr_ty]:
     | a=slice !',' { a }
-    | a[asdl_expr_seq*]=','.slice+ [','] { _Py_Tuple(a, Load, EXTRA) }
+    | a[asdl_expr_seq*]=','.slice+ [','] { _PyAST_Tuple(a, Load, EXTRA) }
 slice[expr_ty]:
-    | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _Py_Slice(a, b, c, EXTRA) }
+    | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _PyAST_Slice(a, b, c, EXTRA) }
     | a=named_expression { a }
 atom[expr_ty]:
     | NAME
-    | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }
-    | 'False' { _Py_Constant(Py_False, NULL, EXTRA) }
-    | 'None' { _Py_Constant(Py_None, NULL, EXTRA) }
+    | 'True' { _PyAST_Constant(Py_True, NULL, EXTRA) }
+    | 'False' { _PyAST_Constant(Py_False, NULL, EXTRA) }
+    | 'None' { _PyAST_Constant(Py_None, NULL, EXTRA) }
     | &STRING strings
     | NUMBER
     | &'(' (tuple | group | genexp)
     | &'[' (list | listcomp)
     | &'{' (dict | set | dictcomp | setcomp)
-    | '...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
+    | '...' { _PyAST_Constant(Py_Ellipsis, NULL, EXTRA) }
 
 strings[expr_ty] (memo): a=STRING+ { _PyPegen_concatenate_strings(p, a) }
 list[expr_ty]:
-    | '[' a=[star_named_expressions] ']' { _Py_List(a, Load, EXTRA) }
+    | '[' a=[star_named_expressions] ']' { _PyAST_List(a, Load, EXTRA) }
 listcomp[expr_ty]:
-    | '[' a=named_expression b=for_if_clauses ']' { _Py_ListComp(a, b, EXTRA) }
+    | '[' a=named_expression b=for_if_clauses ']' { _PyAST_ListComp(a, b, EXTRA) }
     | invalid_comprehension
 tuple[expr_ty]:
     | '(' a=[y=star_named_expression ',' z=[star_named_expressions] { _PyPegen_seq_insert_in_front(p, y, z) } ] ')' {
-        _Py_Tuple(a, Load, EXTRA) }
+        _PyAST_Tuple(a, Load, EXTRA) }
 group[expr_ty]:
     | '(' a=(yield_expr | named_expression) ')' { a }
     | invalid_group
 genexp[expr_ty]:
-    | '(' a=named_expression b=for_if_clauses ')' { _Py_GeneratorExp(a, b, EXTRA) }
+    | '(' a=named_expression b=for_if_clauses ')' { _PyAST_GeneratorExp(a, b, EXTRA) }
     | invalid_comprehension
-set[expr_ty]: '{' a=star_named_expressions '}' { _Py_Set(a, EXTRA) }
+set[expr_ty]: '{' a=star_named_expressions '}' { _PyAST_Set(a, EXTRA) }
 setcomp[expr_ty]:
-    | '{' a=named_expression b=for_if_clauses '}' { _Py_SetComp(a, b, EXTRA) }
+    | '{' a=named_expression b=for_if_clauses '}' { _PyAST_SetComp(a, b, EXTRA) }
     | invalid_comprehension
 dict[expr_ty]:
     | '{' a=[double_starred_kvpairs] '}' {
-        _Py_Dict(
+        _PyAST_Dict(
             CHECK(asdl_expr_seq*, _PyPegen_get_keys(p, a)),
             CHECK(asdl_expr_seq*, _PyPegen_get_values(p, a)),
             EXTRA) }
 dictcomp[expr_ty]:
-    | '{' a=kvpair b=for_if_clauses '}' { _Py_DictComp(a->key, a->value, b, EXTRA) }
+    | '{' a=kvpair b=for_if_clauses '}' { _PyAST_DictComp(a->key, a->value, b, EXTRA) }
     | invalid_dict_comprehension
 double_starred_kvpairs[asdl_seq*]: a=','.double_starred_kvpair+ [','] { a }
 double_starred_kvpair[KeyValuePair*]:
@@ -654,21 +654,21 @@ for_if_clauses[asdl_comprehension_seq*]:
     | a[asdl_comprehension_seq*]=for_if_clause+ { a }
 for_if_clause[comprehension_ty]:
     | ASYNC 'for' a=star_targets 'in' ~ b=disjunction c[asdl_expr_seq*]=('if' z=disjunction { z })* {
-        CHECK_VERSION(comprehension_ty, 6, "Async comprehensions are", _Py_comprehension(a, b, c, 1, p->arena)) }
+        CHECK_VERSION(comprehension_ty, 6, "Async comprehensions are", _PyAST_comprehension(a, b, c, 1, p->arena)) }
     | 'for' a=star_targets 'in' ~ b=disjunction c[asdl_expr_seq*]=('if' z=disjunction { z })* {
-        _Py_comprehension(a, b, c, 0, p->arena) }
+        _PyAST_comprehension(a, b, c, 0, p->arena) }
     | invalid_for_target
 
 yield_expr[expr_ty]:
-    | 'yield' 'from' a=expression { _Py_YieldFrom(a, EXTRA) }
-    | 'yield' a=[star_expressions] { _Py_Yield(a, EXTRA) }
+    | 'yield' 'from' a=expression { _PyAST_YieldFrom(a, EXTRA) }
+    | 'yield' a=[star_expressions] { _PyAST_Yield(a, EXTRA) }
 
 arguments[expr_ty] (memo):
     | a=args [','] &')' { a }
     | invalid_arguments
 args[expr_ty]:
     | a[asdl_expr_seq*]=','.(starred_expression | named_expression !'=')+ b=[',' k=kwargs {k}] { _PyPegen_collect_call_seqs(p, a, b, EXTRA) }
-    | a=kwargs { _Py_Call(_PyPegen_dummy_name(p),
+    | a=kwargs { _PyAST_Call(_PyPegen_dummy_name(p),
                           CHECK_NULL_ALLOWED(asdl_expr_seq*, _PyPegen_seq_extract_starred_exprs(p, a)),
                           CHECK_NULL_ALLOWED(asdl_keyword_seq*, _PyPegen_seq_delete_starred_exprs(p, a)),
                           EXTRA) }
@@ -677,72 +677,72 @@ kwargs[asdl_seq*]:
     | ','.kwarg_or_starred+
     | ','.kwarg_or_double_starred+
 starred_expression[expr_ty]:
-    | '*' a=expression { _Py_Starred(a, Load, EXTRA) }
+    | '*' a=expression { _PyAST_Starred(a, Load, EXTRA) }
 kwarg_or_starred[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
-        _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
+        _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _PyAST_keyword(a->v.Name.id, b, EXTRA)), 1) }
     | a=starred_expression { _PyPegen_keyword_or_starred(p, a, 0) }
     | invalid_kwarg
 kwarg_or_double_starred[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
-        _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
-    | '**' a=expression { _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(NULL, a, EXTRA)), 1) }
+        _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _PyAST_keyword(a->v.Name.id, b, EXTRA)), 1) }
+    | '**' a=expression { _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _PyAST_keyword(NULL, a, EXTRA)), 1) }
     | invalid_kwarg
 
 # NOTE: star_targets may contain *bitwise_or, targets may not.
 star_targets[expr_ty]:
     | a=star_target !',' { a }
     | a=star_target b=(',' c=star_target { c })* [','] {
-        _Py_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)), Store, EXTRA) }
+        _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)), Store, EXTRA) }
 star_targets_list_seq[asdl_expr_seq*]: a[asdl_expr_seq*]=','.star_target+ [','] { a }
 star_targets_tuple_seq[asdl_expr_seq*]:
     | a=star_target b=(',' c=star_target { c })+ [','] { (asdl_expr_seq*) _PyPegen_seq_insert_in_front(p, a, b) }
     | a=star_target ',' { (asdl_expr_seq*) _PyPegen_singleton_seq(p, a) }
 star_target[expr_ty] (memo):
     | '*' a=(!'*' star_target) {
-        _Py_Starred(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), Store, EXTRA) }
+        _PyAST_Starred(CHECK(expr_ty, _PyPegen_set_expr_context(p, a, Store)), Store, EXTRA) }
     | target_with_star_atom
 target_with_star_atom[expr_ty] (memo):
-    | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
-    | a=t_primary '[' b=slices ']' !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
+    | a=t_primary '.' b=NAME !t_lookahead { _PyAST_Attribute(a, b->v.Name.id, Store, EXTRA) }
+    | a=t_primary '[' b=slices ']' !t_lookahead { _PyAST_Subscript(a, b, Store, EXTRA) }
     | star_atom
 star_atom[expr_ty]:
     | a=NAME { _PyPegen_set_expr_context(p, a, Store) }
     | '(' a=target_with_star_atom ')' { _PyPegen_set_expr_context(p, a, Store) }
-    | '(' a=[star_targets_tuple_seq] ')' { _Py_Tuple(a, Store, EXTRA) }
-    | '[' a=[star_targets_list_seq] ']' { _Py_List(a, Store, EXTRA) }
+    | '(' a=[star_targets_tuple_seq] ')' { _PyAST_Tuple(a, Store, EXTRA) }
+    | '[' a=[star_targets_list_seq] ']' { _PyAST_List(a, Store, EXTRA) }
 
 single_target[expr_ty]:
     | single_subscript_attribute_target
     | a=NAME { _PyPegen_set_expr_context(p, a, Store) }
     | '(' a=single_target ')' { a }
 single_subscript_attribute_target[expr_ty]:
-    | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
-    | a=t_primary '[' b=slices ']' !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
+    | a=t_primary '.' b=NAME !t_lookahead { _PyAST_Attribute(a, b->v.Name.id, Store, EXTRA) }
+    | a=t_primary '[' b=slices ']' !t_lookahead { _PyAST_Subscript(a, b, Store, EXTRA) }
 
 del_targets[asdl_expr_seq*]: a[asdl_expr_seq*]=','.del_target+ [','] { a }
 del_target[expr_ty] (memo):
-    | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Del, EXTRA) }
-    | a=t_primary '[' b=slices ']' !t_lookahead { _Py_Subscript(a, b, Del, EXTRA) }
+    | a=t_primary '.' b=NAME !t_lookahead { _PyAST_Attribute(a, b->v.Name.id, Del, EXTRA) }
+    | a=t_primary '[' b=slices ']' !t_lookahead { _PyAST_Subscript(a, b, Del, EXTRA) }
     | del_t_atom
 del_t_atom[expr_ty]:
     | a=NAME { _PyPegen_set_expr_context(p, a, Del) }
     | '(' a=del_target ')' { _PyPegen_set_expr_context(p, a, Del) }
-    | '(' a=[del_targets] ')' { _Py_Tuple(a, Del, EXTRA) }
-    | '[' a=[del_targets] ']' { _Py_List(a, Del, EXTRA) }
+    | '(' a=[del_targets] ')' { _PyAST_Tuple(a, Del, EXTRA) }
+    | '[' a=[del_targets] ']' { _PyAST_List(a, Del, EXTRA) }
 
 targets[asdl_expr_seq*]: a[asdl_expr_seq*]=','.target+ [','] { a }
 target[expr_ty] (memo):
-    | a=t_primary '.' b=NAME !t_lookahead { _Py_Attribute(a, b->v.Name.id, Store, EXTRA) }
-    | a=t_primary '[' b=slices ']' !t_lookahead { _Py_Subscript(a, b, Store, EXTRA) }
+    | a=t_primary '.' b=NAME !t_lookahead { _PyAST_Attribute(a, b->v.Name.id, Store, EXTRA) }
+    | a=t_primary '[' b=slices ']' !t_lookahead { _PyAST_Subscript(a, b, Store, EXTRA) }
     | t_atom
 t_primary[expr_ty]:
-    | a=t_primary '.' b=NAME &t_lookahead { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
-    | a=t_primary '[' b=slices ']' &t_lookahead { _Py_Subscript(a, b, Load, EXTRA) }
+    | a=t_primary '.' b=NAME &t_lookahead { _PyAST_Attribute(a, b->v.Name.id, Load, EXTRA) }
+    | a=t_primary '[' b=slices ']' &t_lookahead { _PyAST_Subscript(a, b, Load, EXTRA) }
     | a=t_primary b=genexp &t_lookahead {
-        _Py_Call(a, CHECK(asdl_expr_seq*, (asdl_expr_seq*)_PyPegen_singleton_seq(p, b)), NULL, EXTRA) }
+        _PyAST_Call(a, CHECK(asdl_expr_seq*, (asdl_expr_seq*)_PyPegen_singleton_seq(p, b)), NULL, EXTRA) }
     | a=t_primary '(' b=[arguments] ')' &t_lookahead {
-        _Py_Call(a,
+        _PyAST_Call(a,
                  (b) ? ((expr_ty) b)->v.Call.args : NULL,
                  (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
                  EXTRA) }
@@ -751,8 +751,8 @@ t_lookahead: '(' | '[' | '.'
 t_atom[expr_ty]:
     | a=NAME { _PyPegen_set_expr_context(p, a, Store) }
     | '(' a=target ')' { _PyPegen_set_expr_context(p, a, Store) }
-    | '(' b=[targets] ')' { _Py_Tuple(b, Store, EXTRA) }
-    | '[' b=[targets] ']' { _Py_List(b, Store, EXTRA) }
+    | '(' b=[targets] ')' { _PyAST_Tuple(b, Store, EXTRA) }
+    | '[' b=[targets] ']' { _PyAST_List(b, Store, EXTRA) }
 
 
 # From here on, there are rules for invalid syntax with specialised error messages
@@ -856,7 +856,7 @@ invalid_except_block:
     | 'except' a=expression ',' expressions ['as' NAME ] ':' {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "exception group must be parenthesized") }
     | 'except' expression ['as' NAME ] &&':'
-    | 'except' &&':' 
+    | 'except' &&':'
 
 invalid_match_stmt:
     | "match" subject_expr !':' { CHECK_VERSION(void*, 10, "Pattern matching is", RAISE_SYNTAX_ERROR("expected ':'") ) }

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -570,252 +570,193 @@ struct _type_ignore {
 
 
 // Note: these macros affect function definitions, not only call sites.
-#define Module(a0, a1, a2) _Py_Module(a0, a1, a2)
-mod_ty _Py_Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores,
-                  PyArena *arena);
-#define Interactive(a0, a1) _Py_Interactive(a0, a1)
-mod_ty _Py_Interactive(asdl_stmt_seq * body, PyArena *arena);
-#define Expression(a0, a1) _Py_Expression(a0, a1)
-mod_ty _Py_Expression(expr_ty body, PyArena *arena);
-#define FunctionType(a0, a1, a2) _Py_FunctionType(a0, a1, a2)
-mod_ty _Py_FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena
-                        *arena);
-#define FunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) _Py_FunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-stmt_ty _Py_FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq *
-                        body, asdl_expr_seq * decorator_list, expr_ty returns,
-                        string type_comment, int lineno, int col_offset, int
-                        end_lineno, int end_col_offset, PyArena *arena);
-#define AsyncFunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) _Py_AsyncFunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-stmt_ty _Py_AsyncFunctionDef(identifier name, arguments_ty args, asdl_stmt_seq
-                             * body, asdl_expr_seq * decorator_list, expr_ty
-                             returns, string type_comment, int lineno, int
-                             col_offset, int end_lineno, int end_col_offset,
-                             PyArena *arena);
-#define ClassDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_ClassDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
-stmt_ty _Py_ClassDef(identifier name, asdl_expr_seq * bases, asdl_keyword_seq *
-                     keywords, asdl_stmt_seq * body, asdl_expr_seq *
-                     decorator_list, int lineno, int col_offset, int
-                     end_lineno, int end_col_offset, PyArena *arena);
-#define Return(a0, a1, a2, a3, a4, a5) _Py_Return(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Return(expr_ty value, int lineno, int col_offset, int end_lineno,
-                   int end_col_offset, PyArena *arena);
-#define Delete(a0, a1, a2, a3, a4, a5) _Py_Delete(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int
-                   end_lineno, int end_col_offset, PyArena *arena);
-#define Assign(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Assign(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_Assign(asdl_expr_seq * targets, expr_ty value, string type_comment,
-                   int lineno, int col_offset, int end_lineno, int
-                   end_col_offset, PyArena *arena);
-#define AugAssign(a0, a1, a2, a3, a4, a5, a6, a7) _Py_AugAssign(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_AugAssign(expr_ty target, operator_ty op, expr_ty value, int
-                      lineno, int col_offset, int end_lineno, int
-                      end_col_offset, PyArena *arena);
-#define AnnAssign(a0, a1, a2, a3, a4, a5, a6, a7, a8) _Py_AnnAssign(a0, a1, a2, a3, a4, a5, a6, a7, a8)
-stmt_ty _Py_AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int
-                      simple, int lineno, int col_offset, int end_lineno, int
-                      end_col_offset, PyArena *arena);
-#define For(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_For(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
-stmt_ty _Py_For(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
-                asdl_stmt_seq * orelse, string type_comment, int lineno, int
-                col_offset, int end_lineno, int end_col_offset, PyArena *arena);
-#define AsyncFor(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_AsyncFor(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
-stmt_ty _Py_AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
-                     asdl_stmt_seq * orelse, string type_comment, int lineno,
-                     int col_offset, int end_lineno, int end_col_offset,
+mod_ty _PyAST_Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores,
                      PyArena *arena);
-#define While(a0, a1, a2, a3, a4, a5, a6, a7) _Py_While(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse,
-                  int lineno, int col_offset, int end_lineno, int
-                  end_col_offset, PyArena *arena);
-#define If(a0, a1, a2, a3, a4, a5, a6, a7) _Py_If(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int
-               lineno, int col_offset, int end_lineno, int end_col_offset,
-               PyArena *arena);
-#define With(a0, a1, a2, a3, a4, a5, a6, a7) _Py_With(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string
-                 type_comment, int lineno, int col_offset, int end_lineno, int
-                 end_col_offset, PyArena *arena);
-#define AsyncWith(a0, a1, a2, a3, a4, a5, a6, a7) _Py_AsyncWith(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body, string
+mod_ty _PyAST_Interactive(asdl_stmt_seq * body, PyArena *arena);
+mod_ty _PyAST_Expression(expr_ty body, PyArena *arena);
+mod_ty _PyAST_FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena
+                           *arena);
+stmt_ty _PyAST_FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq *
+                           body, asdl_expr_seq * decorator_list, expr_ty
+                           returns, string type_comment, int lineno, int
+                           col_offset, int end_lineno, int end_col_offset,
+                           PyArena *arena);
+stmt_ty _PyAST_AsyncFunctionDef(identifier name, arguments_ty args,
+                                asdl_stmt_seq * body, asdl_expr_seq *
+                                decorator_list, expr_ty returns, string
+                                type_comment, int lineno, int col_offset, int
+                                end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_ClassDef(identifier name, asdl_expr_seq * bases,
+                        asdl_keyword_seq * keywords, asdl_stmt_seq * body,
+                        asdl_expr_seq * decorator_list, int lineno, int
+                        col_offset, int end_lineno, int end_col_offset, PyArena
+                        *arena);
+stmt_ty _PyAST_Return(expr_ty value, int lineno, int col_offset, int
+                      end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int
+                      end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Assign(asdl_expr_seq * targets, expr_ty value, string
                       type_comment, int lineno, int col_offset, int end_lineno,
                       int end_col_offset, PyArena *arena);
-#define Match(a0, a1, a2, a3, a4, a5, a6) _Py_Match(a0, a1, a2, a3, a4, a5, a6)
-stmt_ty _Py_Match(expr_ty subject, asdl_match_case_seq * cases, int lineno, int
-                  col_offset, int end_lineno, int end_col_offset, PyArena
-                  *arena);
-#define Raise(a0, a1, a2, a3, a4, a5, a6) _Py_Raise(a0, a1, a2, a3, a4, a5, a6)
-stmt_ty _Py_Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset, int
-                  end_lineno, int end_col_offset, PyArena *arena);
-#define Try(a0, a1, a2, a3, a4, a5, a6, a7, a8) _Py_Try(a0, a1, a2, a3, a4, a5, a6, a7, a8)
-stmt_ty _Py_Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers,
-                asdl_stmt_seq * orelse, asdl_stmt_seq * finalbody, int lineno,
-                int col_offset, int end_lineno, int end_col_offset, PyArena
-                *arena);
-#define Assert(a0, a1, a2, a3, a4, a5, a6) _Py_Assert(a0, a1, a2, a3, a4, a5, a6)
-stmt_ty _Py_Assert(expr_ty test, expr_ty msg, int lineno, int col_offset, int
-                   end_lineno, int end_col_offset, PyArena *arena);
-#define Import(a0, a1, a2, a3, a4, a5) _Py_Import(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Import(asdl_alias_seq * names, int lineno, int col_offset, int
-                   end_lineno, int end_col_offset, PyArena *arena);
-#define ImportFrom(a0, a1, a2, a3, a4, a5, a6, a7) _Py_ImportFrom(a0, a1, a2, a3, a4, a5, a6, a7)
-stmt_ty _Py_ImportFrom(identifier module, asdl_alias_seq * names, int level,
-                       int lineno, int col_offset, int end_lineno, int
-                       end_col_offset, PyArena *arena);
-#define Global(a0, a1, a2, a3, a4, a5) _Py_Global(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Global(asdl_identifier_seq * names, int lineno, int col_offset, int
-                   end_lineno, int end_col_offset, PyArena *arena);
-#define Nonlocal(a0, a1, a2, a3, a4, a5) _Py_Nonlocal(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Nonlocal(asdl_identifier_seq * names, int lineno, int col_offset,
-                     int end_lineno, int end_col_offset, PyArena *arena);
-#define Expr(a0, a1, a2, a3, a4, a5) _Py_Expr(a0, a1, a2, a3, a4, a5)
-stmt_ty _Py_Expr(expr_ty value, int lineno, int col_offset, int end_lineno, int
-                 end_col_offset, PyArena *arena);
-#define Pass(a0, a1, a2, a3, a4) _Py_Pass(a0, a1, a2, a3, a4)
-stmt_ty _Py_Pass(int lineno, int col_offset, int end_lineno, int
-                 end_col_offset, PyArena *arena);
-#define Break(a0, a1, a2, a3, a4) _Py_Break(a0, a1, a2, a3, a4)
-stmt_ty _Py_Break(int lineno, int col_offset, int end_lineno, int
-                  end_col_offset, PyArena *arena);
-#define Continue(a0, a1, a2, a3, a4) _Py_Continue(a0, a1, a2, a3, a4)
-stmt_ty _Py_Continue(int lineno, int col_offset, int end_lineno, int
-                     end_col_offset, PyArena *arena);
-#define BoolOp(a0, a1, a2, a3, a4, a5, a6) _Py_BoolOp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int
-                   col_offset, int end_lineno, int end_col_offset, PyArena
-                   *arena);
-#define NamedExpr(a0, a1, a2, a3, a4, a5, a6) _Py_NamedExpr(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_NamedExpr(expr_ty target, expr_ty value, int lineno, int
-                      col_offset, int end_lineno, int end_col_offset, PyArena
-                      *arena);
-#define BinOp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_BinOp(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_BinOp(expr_ty left, operator_ty op, expr_ty right, int lineno, int
-                  col_offset, int end_lineno, int end_col_offset, PyArena
-                  *arena);
-#define UnaryOp(a0, a1, a2, a3, a4, a5, a6) _Py_UnaryOp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_UnaryOp(unaryop_ty op, expr_ty operand, int lineno, int col_offset,
-                    int end_lineno, int end_col_offset, PyArena *arena);
-#define Lambda(a0, a1, a2, a3, a4, a5, a6) _Py_Lambda(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Lambda(arguments_ty args, expr_ty body, int lineno, int col_offset,
-                   int end_lineno, int end_col_offset, PyArena *arena);
-#define IfExp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_IfExp(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno, int
-                  col_offset, int end_lineno, int end_col_offset, PyArena
-                  *arena);
-#define Dict(a0, a1, a2, a3, a4, a5, a6) _Py_Dict(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno, int
-                 col_offset, int end_lineno, int end_col_offset, PyArena
-                 *arena);
-#define Set(a0, a1, a2, a3, a4, a5) _Py_Set(a0, a1, a2, a3, a4, a5)
-expr_ty _Py_Set(asdl_expr_seq * elts, int lineno, int col_offset, int
-                end_lineno, int end_col_offset, PyArena *arena);
-#define ListComp(a0, a1, a2, a3, a4, a5, a6) _Py_ListComp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_ListComp(expr_ty elt, asdl_comprehension_seq * generators, int
-                     lineno, int col_offset, int end_lineno, int
-                     end_col_offset, PyArena *arena);
-#define SetComp(a0, a1, a2, a3, a4, a5, a6) _Py_SetComp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_SetComp(expr_ty elt, asdl_comprehension_seq * generators, int
-                    lineno, int col_offset, int end_lineno, int end_col_offset,
-                    PyArena *arena);
-#define DictComp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_DictComp(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq *
-                     generators, int lineno, int col_offset, int end_lineno,
-                     int end_col_offset, PyArena *arena);
-#define GeneratorExp(a0, a1, a2, a3, a4, a5, a6) _Py_GeneratorExp(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators, int
+stmt_ty _PyAST_AugAssign(expr_ty target, operator_ty op, expr_ty value, int
                          lineno, int col_offset, int end_lineno, int
                          end_col_offset, PyArena *arena);
-#define Await(a0, a1, a2, a3, a4, a5) _Py_Await(a0, a1, a2, a3, a4, a5)
-expr_ty _Py_Await(expr_ty value, int lineno, int col_offset, int end_lineno,
-                  int end_col_offset, PyArena *arena);
-expr_ty _Py_Yield(expr_ty value, int lineno, int col_offset, int end_lineno,
-                  int end_col_offset, PyArena *arena);
-#define YieldFrom(a0, a1, a2, a3, a4, a5) _Py_YieldFrom(a0, a1, a2, a3, a4, a5)
-expr_ty _Py_YieldFrom(expr_ty value, int lineno, int col_offset, int
-                      end_lineno, int end_col_offset, PyArena *arena);
-#define Compare(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Compare(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq *
-                    comparators, int lineno, int col_offset, int end_lineno,
+stmt_ty _PyAST_AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int
+                         simple, int lineno, int col_offset, int end_lineno,
+                         int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_For(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
+                   asdl_stmt_seq * orelse, string type_comment, int lineno, int
+                   col_offset, int end_lineno, int end_col_offset, PyArena
+                   *arena);
+stmt_ty _PyAST_AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
+                        asdl_stmt_seq * orelse, string type_comment, int
+                        lineno, int col_offset, int end_lineno, int
+                        end_col_offset, PyArena *arena);
+stmt_ty _PyAST_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq *
+                     orelse, int lineno, int col_offset, int end_lineno, int
+                     end_col_offset, PyArena *arena);
+stmt_ty _PyAST_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse,
+                  int lineno, int col_offset, int end_lineno, int
+                  end_col_offset, PyArena *arena);
+stmt_ty _PyAST_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string
+                    type_comment, int lineno, int col_offset, int end_lineno,
                     int end_col_offset, PyArena *arena);
-#define Call(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Call(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq *
-                 keywords, int lineno, int col_offset, int end_lineno, int
-                 end_col_offset, PyArena *arena);
-#define FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7) _Py_FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_FormattedValue(expr_ty value, int conversion, expr_ty format_spec,
-                           int lineno, int col_offset, int end_lineno, int
-                           end_col_offset, PyArena *arena);
-#define JoinedStr(a0, a1, a2, a3, a4, a5) _Py_JoinedStr(a0, a1, a2, a3, a4, a5)
-expr_ty _Py_JoinedStr(asdl_expr_seq * values, int lineno, int col_offset, int
-                      end_lineno, int end_col_offset, PyArena *arena);
-#define Constant(a0, a1, a2, a3, a4, a5, a6) _Py_Constant(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Constant(constant value, string kind, int lineno, int col_offset,
+stmt_ty _PyAST_AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body,
+                         string type_comment, int lineno, int col_offset, int
+                         end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Match(expr_ty subject, asdl_match_case_seq * cases, int lineno,
+                     int col_offset, int end_lineno, int end_col_offset,
+                     PyArena *arena);
+stmt_ty _PyAST_Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset,
                      int end_lineno, int end_col_offset, PyArena *arena);
-#define Attribute(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Attribute(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_Attribute(expr_ty value, identifier attr, expr_context_ty ctx, int
-                      lineno, int col_offset, int end_lineno, int
-                      end_col_offset, PyArena *arena);
-#define Subscript(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Subscript(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_Subscript(expr_ty value, expr_ty slice, expr_context_ty ctx, int
-                      lineno, int col_offset, int end_lineno, int
-                      end_col_offset, PyArena *arena);
-#define Starred(a0, a1, a2, a3, a4, a5, a6) _Py_Starred(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Starred(expr_ty value, expr_context_ty ctx, int lineno, int
-                    col_offset, int end_lineno, int end_col_offset, PyArena
-                    *arena);
-#define Name(a0, a1, a2, a3, a4, a5, a6) _Py_Name(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Name(identifier id, expr_context_ty ctx, int lineno, int
-                 col_offset, int end_lineno, int end_col_offset, PyArena
-                 *arena);
-#define List(a0, a1, a2, a3, a4, a5, a6) _Py_List(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
-                 col_offset, int end_lineno, int end_col_offset, PyArena
-                 *arena);
-#define Tuple(a0, a1, a2, a3, a4, a5, a6) _Py_Tuple(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
-                  col_offset, int end_lineno, int end_col_offset, PyArena
-                  *arena);
-#define Slice(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Slice(a0, a1, a2, a3, a4, a5, a6, a7)
-expr_ty _Py_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int
-                  col_offset, int end_lineno, int end_col_offset, PyArena
-                  *arena);
-#define MatchAs(a0, a1, a2, a3, a4, a5, a6) _Py_MatchAs(a0, a1, a2, a3, a4, a5, a6)
-expr_ty _Py_MatchAs(expr_ty pattern, identifier name, int lineno, int
-                    col_offset, int end_lineno, int end_col_offset, PyArena
-                    *arena);
-#define MatchOr(a0, a1, a2, a3, a4, a5) _Py_MatchOr(a0, a1, a2, a3, a4, a5)
-expr_ty _Py_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset, int
-                    end_lineno, int end_col_offset, PyArena *arena);
-#define comprehension(a0, a1, a2, a3, a4) _Py_comprehension(a0, a1, a2, a3, a4)
-comprehension_ty _Py_comprehension(expr_ty target, expr_ty iter, asdl_expr_seq
-                                   * ifs, int is_async, PyArena *arena);
-#define ExceptHandler(a0, a1, a2, a3, a4, a5, a6, a7) _Py_ExceptHandler(a0, a1, a2, a3, a4, a5, a6, a7)
-excepthandler_ty _Py_ExceptHandler(expr_ty type, identifier name, asdl_stmt_seq
-                                   * body, int lineno, int col_offset, int
-                                   end_lineno, int end_col_offset, PyArena
-                                   *arena);
-#define arguments(a0, a1, a2, a3, a4, a5, a6, a7) _Py_arguments(a0, a1, a2, a3, a4, a5, a6, a7)
-arguments_ty _Py_arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args,
-                           arg_ty vararg, asdl_arg_seq * kwonlyargs,
-                           asdl_expr_seq * kw_defaults, arg_ty kwarg,
-                           asdl_expr_seq * defaults, PyArena *arena);
-#define arg(a0, a1, a2, a3, a4, a5, a6, a7) _Py_arg(a0, a1, a2, a3, a4, a5, a6, a7)
-arg_ty _Py_arg(identifier arg, expr_ty annotation, string type_comment, int
-               lineno, int col_offset, int end_lineno, int end_col_offset,
-               PyArena *arena);
-#define keyword(a0, a1, a2, a3, a4, a5, a6) _Py_keyword(a0, a1, a2, a3, a4, a5, a6)
-keyword_ty _Py_keyword(identifier arg, expr_ty value, int lineno, int
+stmt_ty _PyAST_Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers,
+                   asdl_stmt_seq * orelse, asdl_stmt_seq * finalbody, int
+                   lineno, int col_offset, int end_lineno, int end_col_offset,
+                   PyArena *arena);
+stmt_ty _PyAST_Assert(expr_ty test, expr_ty msg, int lineno, int col_offset,
+                      int end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Import(asdl_alias_seq * names, int lineno, int col_offset, int
+                      end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_ImportFrom(identifier module, asdl_alias_seq * names, int level,
+                          int lineno, int col_offset, int end_lineno, int
+                          end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Global(asdl_identifier_seq * names, int lineno, int col_offset,
+                      int end_lineno, int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Nonlocal(asdl_identifier_seq * names, int lineno, int
+                        col_offset, int end_lineno, int end_col_offset, PyArena
+                        *arena);
+stmt_ty _PyAST_Expr(expr_ty value, int lineno, int col_offset, int end_lineno,
+                    int end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Pass(int lineno, int col_offset, int end_lineno, int
+                    end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Break(int lineno, int col_offset, int end_lineno, int
+                     end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Continue(int lineno, int col_offset, int end_lineno, int
+                        end_col_offset, PyArena *arena);
+expr_ty _PyAST_BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int
+                      col_offset, int end_lineno, int end_col_offset, PyArena
+                      *arena);
+expr_ty _PyAST_NamedExpr(expr_ty target, expr_ty value, int lineno, int
+                         col_offset, int end_lineno, int end_col_offset,
+                         PyArena *arena);
+expr_ty _PyAST_BinOp(expr_ty left, operator_ty op, expr_ty right, int lineno,
+                     int col_offset, int end_lineno, int end_col_offset,
+                     PyArena *arena);
+expr_ty _PyAST_UnaryOp(unaryop_ty op, expr_ty operand, int lineno, int
                        col_offset, int end_lineno, int end_col_offset, PyArena
                        *arena);
-#define alias(a0, a1, a2) _Py_alias(a0, a1, a2)
-alias_ty _Py_alias(identifier name, identifier asname, PyArena *arena);
-#define withitem(a0, a1, a2) _Py_withitem(a0, a1, a2)
-withitem_ty _Py_withitem(expr_ty context_expr, expr_ty optional_vars, PyArena
-                         *arena);
-#define match_case(a0, a1, a2, a3) _Py_match_case(a0, a1, a2, a3)
-match_case_ty _Py_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq *
-                             body, PyArena *arena);
-#define TypeIgnore(a0, a1, a2) _Py_TypeIgnore(a0, a1, a2)
-type_ignore_ty _Py_TypeIgnore(int lineno, string tag, PyArena *arena);
+expr_ty _PyAST_Lambda(arguments_ty args, expr_ty body, int lineno, int
+                      col_offset, int end_lineno, int end_col_offset, PyArena
+                      *arena);
+expr_ty _PyAST_IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno,
+                     int col_offset, int end_lineno, int end_col_offset,
+                     PyArena *arena);
+expr_ty _PyAST_Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno,
+                    int col_offset, int end_lineno, int end_col_offset, PyArena
+                    *arena);
+expr_ty _PyAST_Set(asdl_expr_seq * elts, int lineno, int col_offset, int
+                   end_lineno, int end_col_offset, PyArena *arena);
+expr_ty _PyAST_ListComp(expr_ty elt, asdl_comprehension_seq * generators, int
+                        lineno, int col_offset, int end_lineno, int
+                        end_col_offset, PyArena *arena);
+expr_ty _PyAST_SetComp(expr_ty elt, asdl_comprehension_seq * generators, int
+                       lineno, int col_offset, int end_lineno, int
+                       end_col_offset, PyArena *arena);
+expr_ty _PyAST_DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq *
+                        generators, int lineno, int col_offset, int end_lineno,
+                        int end_col_offset, PyArena *arena);
+expr_ty _PyAST_GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators,
+                            int lineno, int col_offset, int end_lineno, int
+                            end_col_offset, PyArena *arena);
+expr_ty _PyAST_Await(expr_ty value, int lineno, int col_offset, int end_lineno,
+                     int end_col_offset, PyArena *arena);
+expr_ty _PyAST_Yield(expr_ty value, int lineno, int col_offset, int end_lineno,
+                     int end_col_offset, PyArena *arena);
+expr_ty _PyAST_YieldFrom(expr_ty value, int lineno, int col_offset, int
+                         end_lineno, int end_col_offset, PyArena *arena);
+expr_ty _PyAST_Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq *
+                       comparators, int lineno, int col_offset, int end_lineno,
+                       int end_col_offset, PyArena *arena);
+expr_ty _PyAST_Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq *
+                    keywords, int lineno, int col_offset, int end_lineno, int
+                    end_col_offset, PyArena *arena);
+expr_ty _PyAST_FormattedValue(expr_ty value, int conversion, expr_ty
+                              format_spec, int lineno, int col_offset, int
+                              end_lineno, int end_col_offset, PyArena *arena);
+expr_ty _PyAST_JoinedStr(asdl_expr_seq * values, int lineno, int col_offset,
+                         int end_lineno, int end_col_offset, PyArena *arena);
+expr_ty _PyAST_Constant(constant value, string kind, int lineno, int
+                        col_offset, int end_lineno, int end_col_offset, PyArena
+                        *arena);
+expr_ty _PyAST_Attribute(expr_ty value, identifier attr, expr_context_ty ctx,
+                         int lineno, int col_offset, int end_lineno, int
+                         end_col_offset, PyArena *arena);
+expr_ty _PyAST_Subscript(expr_ty value, expr_ty slice, expr_context_ty ctx, int
+                         lineno, int col_offset, int end_lineno, int
+                         end_col_offset, PyArena *arena);
+expr_ty _PyAST_Starred(expr_ty value, expr_context_ty ctx, int lineno, int
+                       col_offset, int end_lineno, int end_col_offset, PyArena
+                       *arena);
+expr_ty _PyAST_Name(identifier id, expr_context_ty ctx, int lineno, int
+                    col_offset, int end_lineno, int end_col_offset, PyArena
+                    *arena);
+expr_ty _PyAST_List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
+                    col_offset, int end_lineno, int end_col_offset, PyArena
+                    *arena);
+expr_ty _PyAST_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
+                     col_offset, int end_lineno, int end_col_offset, PyArena
+                     *arena);
+expr_ty _PyAST_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno,
+                     int col_offset, int end_lineno, int end_col_offset,
+                     PyArena *arena);
+expr_ty _PyAST_MatchAs(expr_ty pattern, identifier name, int lineno, int
+                       col_offset, int end_lineno, int end_col_offset, PyArena
+                       *arena);
+expr_ty _PyAST_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset,
+                       int end_lineno, int end_col_offset, PyArena *arena);
+comprehension_ty _PyAST_comprehension(expr_ty target, expr_ty iter,
+                                      asdl_expr_seq * ifs, int is_async,
+                                      PyArena *arena);
+excepthandler_ty _PyAST_ExceptHandler(expr_ty type, identifier name,
+                                      asdl_stmt_seq * body, int lineno, int
+                                      col_offset, int end_lineno, int
+                                      end_col_offset, PyArena *arena);
+arguments_ty _PyAST_arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args,
+                              arg_ty vararg, asdl_arg_seq * kwonlyargs,
+                              asdl_expr_seq * kw_defaults, arg_ty kwarg,
+                              asdl_expr_seq * defaults, PyArena *arena);
+arg_ty _PyAST_arg(identifier arg, expr_ty annotation, string type_comment, int
+                  lineno, int col_offset, int end_lineno, int end_col_offset,
+                  PyArena *arena);
+keyword_ty _PyAST_keyword(identifier arg, expr_ty value, int lineno, int
+                          col_offset, int end_lineno, int end_col_offset,
+                          PyArena *arena);
+alias_ty _PyAST_alias(identifier name, identifier asname, PyArena *arena);
+withitem_ty _PyAST_withitem(expr_ty context_expr, expr_ty optional_vars,
+                            PyArena *arena);
+match_case_ty _PyAST_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq *
+                                body, PyArena *arena);
+type_ignore_ty _PyAST_TypeIgnore(int lineno, string tag, PyArena *arena);
 
 
 PyObject* PyAST_mod2obj(mod_ty t);

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -897,7 +897,7 @@ interactive_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ interactive[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "statement_newline"));
-            _res = Interactive ( a , p -> arena );
+            _res = _PyAST_Interactive ( a , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -944,7 +944,7 @@ eval_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ eval[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expressions NEWLINE* $"));
-            _res = Expression ( a , p -> arena );
+            _res = _PyAST_Expression ( a , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1003,7 +1003,7 @@ func_type_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ func_type[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' type_expressions? ')' '->' expression NEWLINE* $"));
-            _res = FunctionType ( a , b , p -> arena );
+            _res = _PyAST_FunctionType ( a , b , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1496,7 +1496,7 @@ statement_newline_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = ( asdl_stmt_seq * ) _PyPegen_singleton_seq ( p , CHECK ( stmt_ty , _Py_Pass ( EXTRA ) ) );
+            _res = ( asdl_stmt_seq * ) _PyPegen_singleton_seq ( p , CHECK ( stmt_ty , _PyAST_Pass ( EXTRA ) ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1692,7 +1692,7 @@ simple_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Expr ( e , EXTRA );
+            _res = _PyAST_Expr ( e , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1788,7 +1788,7 @@ simple_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Pass ( EXTRA );
+            _res = _PyAST_Pass ( EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1884,7 +1884,7 @@ simple_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Break ( EXTRA );
+            _res = _PyAST_Break ( EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1917,7 +1917,7 @@ simple_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Continue ( EXTRA );
+            _res = _PyAST_Continue ( EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2224,7 +2224,7 @@ assignment_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 6 , "Variable annotation syntax is" , _Py_AnnAssign ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , c , 1 , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 6 , "Variable annotation syntax is" , _PyAST_AnnAssign ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , c , 1 , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2266,7 +2266,7 @@ assignment_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 6 , "Variable annotations syntax is" , _Py_AnnAssign ( a , b , c , 0 , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 6 , "Variable annotations syntax is" , _PyAST_AnnAssign ( a , b , c , 0 , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2307,7 +2307,7 @@ assignment_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Assign ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            _res = _PyAST_Assign ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2349,7 +2349,7 @@ assignment_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_AugAssign ( a , b -> kind , c , EXTRA );
+            _res = _PyAST_AugAssign ( a , b -> kind , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2776,7 +2776,7 @@ global_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Global ( CHECK ( asdl_identifier_seq * , _PyPegen_map_names_to_ids ( p , a ) ) , EXTRA );
+            _res = _PyAST_Global ( CHECK ( asdl_identifier_seq * , _PyPegen_map_names_to_ids ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2838,7 +2838,7 @@ nonlocal_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Nonlocal ( CHECK ( asdl_identifier_seq * , _PyPegen_map_names_to_ids ( p , a ) ) , EXTRA );
+            _res = _PyAST_Nonlocal ( CHECK ( asdl_identifier_seq * , _PyPegen_map_names_to_ids ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2897,7 +2897,7 @@ yield_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Expr ( y , EXTRA );
+            _res = _PyAST_Expr ( y , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -2962,7 +2962,7 @@ assert_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Assert ( a , b , EXTRA );
+            _res = _PyAST_Assert ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3026,7 +3026,7 @@ del_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Delete ( a , EXTRA );
+            _res = _PyAST_Delete ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3162,7 +3162,7 @@ import_name_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Import ( a , EXTRA );
+            _res = _PyAST_Import ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3235,7 +3235,7 @@ import_from_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_ImportFrom ( b -> v . Name . id , c , _PyPegen_seq_count_dots ( a ) , EXTRA );
+            _res = _PyAST_ImportFrom ( b -> v . Name . id , c , _PyPegen_seq_count_dots ( a ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3277,7 +3277,7 @@ import_from_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_ImportFrom ( NULL , b , _PyPegen_seq_count_dots ( a ) , EXTRA );
+            _res = _PyAST_ImportFrom ( NULL , b , _PyPegen_seq_count_dots ( a ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3481,7 +3481,7 @@ import_from_as_name_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ import_from_as_name[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME ['as' NAME]"));
-            _res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
+            _res = _PyAST_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3566,7 +3566,7 @@ dotted_as_name_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ dotted_as_name[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "dotted_name ['as' NAME]"));
-            _res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
+            _res = _PyAST_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3737,7 +3737,7 @@ if_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_If ( a , b , CHECK ( asdl_stmt_seq * , _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
+            _res = _PyAST_If ( a , b , CHECK ( asdl_stmt_seq * , _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3782,7 +3782,7 @@ if_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_If ( a , b , c , EXTRA );
+            _res = _PyAST_If ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3855,7 +3855,7 @@ elif_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_If ( a , b , CHECK ( asdl_stmt_seq * , _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
+            _res = _PyAST_If ( a , b , CHECK ( asdl_stmt_seq * , _PyPegen_singleton_seq ( p , c ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -3900,7 +3900,7 @@ elif_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_If ( a , b , c , EXTRA );
+            _res = _PyAST_If ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4018,7 +4018,7 @@ while_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_While ( a , b , c , EXTRA );
+            _res = _PyAST_While ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4104,7 +4104,7 @@ for_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_For ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            _res = _PyAST_For ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4168,7 +4168,7 @@ for_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 5 , "Async for loops are" , _Py_AsyncFor ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 5 , "Async for loops are" , _PyAST_AsyncFor ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4274,7 +4274,7 @@ with_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_With ( a , b , NULL , EXTRA );
+            _res = _PyAST_With ( a , b , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4319,7 +4319,7 @@ with_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_With ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            _res = _PyAST_With ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4374,7 +4374,7 @@ with_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 5 , "Async with statements are" , _Py_AsyncWith ( a , b , NULL , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 5 , "Async with statements are" , _PyAST_AsyncWith ( a , b , NULL , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4422,7 +4422,7 @@ with_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 5 , "Async with statements are" , _Py_AsyncWith ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 5 , "Async with statements are" , _PyAST_AsyncWith ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4493,7 +4493,7 @@ with_item_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ with_item[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression 'as' star_target &(',' | ')' | ':')"));
-            _res = _Py_withitem ( e , t , p -> arena );
+            _res = _PyAST_withitem ( e , t , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4536,7 +4536,7 @@ with_item_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ with_item[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression"));
-            _res = _Py_withitem ( e , NULL , p -> arena );
+            _res = _PyAST_withitem ( e , NULL , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4606,7 +4606,7 @@ try_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Try ( b , NULL , NULL , f , EXTRA );
+            _res = _PyAST_Try ( b , NULL , NULL , f , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4654,7 +4654,7 @@ try_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Try ( b , ex , el , f , EXTRA );
+            _res = _PyAST_Try ( b , ex , el , f , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4728,7 +4728,7 @@ except_block_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_ExceptHandler ( e , ( t ) ? ( ( expr_ty ) t ) -> v . Name . id : NULL , b , EXTRA );
+            _res = _PyAST_ExceptHandler ( e , ( t ) ? ( ( expr_ty ) t ) -> v . Name . id : NULL , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4767,7 +4767,7 @@ except_block_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_ExceptHandler ( NULL , NULL , b , EXTRA );
+            _res = _PyAST_ExceptHandler ( NULL , NULL , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4912,7 +4912,7 @@ match_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 10 , "Pattern matching is" , _Py_Match ( subject , cases , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 10 , "Pattern matching is" , _PyAST_Match ( subject , cases , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -4996,7 +4996,7 @@ subject_expr_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , value , values ) ) , Load , EXTRA );
+            _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , value , values ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5068,7 +5068,7 @@ case_block_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ case_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "\"case\" patterns guard? ':' block"));
-            _res = _Py_match_case ( pattern , guard , body , p -> arena );
+            _res = _PyAST_match_case ( pattern , guard , body , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5190,7 +5190,7 @@ patterns_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( values , Load , EXTRA );
+            _res = _PyAST_Tuple ( values , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5329,7 +5329,7 @@ as_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_MatchAs ( pattern , target -> v . Name . id , EXTRA );
+            _res = _PyAST_MatchAs ( pattern , target -> v . Name . id , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5388,7 +5388,7 @@ or_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = asdl_seq_LEN ( patterns ) == 1 ? asdl_seq_GET ( patterns , 0 ) : _Py_MatchOr ( patterns , EXTRA );
+            _res = asdl_seq_LEN ( patterns ) == 1 ? asdl_seq_GET ( patterns , 0 ) : _PyAST_MatchOr ( patterns , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5658,7 +5658,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( real , Add , imag , EXTRA );
+            _res = _PyAST_BinOp ( real , Add , imag , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5697,7 +5697,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( real , Sub , imag , EXTRA );
+            _res = _PyAST_BinOp ( real , Sub , imag , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5749,7 +5749,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Constant ( Py_None , NULL , EXTRA );
+            _res = _PyAST_Constant ( Py_None , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5782,7 +5782,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Constant ( Py_True , NULL , EXTRA );
+            _res = _PyAST_Constant ( Py_True , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5815,7 +5815,7 @@ literal_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Constant ( Py_False , NULL , EXTRA );
+            _res = _PyAST_Constant ( Py_False , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -5896,7 +5896,7 @@ signed_number_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_UnaryOp ( USub , number , EXTRA );
+            _res = _PyAST_UnaryOp ( USub , number , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6000,7 +6000,7 @@ wildcard_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Name ( CHECK ( PyObject * , _PyPegen_new_identifier ( p , "_" ) ) , Store , EXTRA );
+            _res = _PyAST_Name ( CHECK ( PyObject * , _PyPegen_new_identifier ( p , "_" ) ) , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6140,7 +6140,7 @@ attr_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Attribute ( value , attr -> v . Name . id , Load , EXTRA );
+            _res = _PyAST_Attribute ( value , attr -> v . Name . id , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6308,7 +6308,7 @@ sequence_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_List ( values , Load , EXTRA );
+            _res = _PyAST_List ( values , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6347,7 +6347,7 @@ sequence_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( values , Load , EXTRA );
+            _res = _PyAST_Tuple ( values , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6556,7 +6556,7 @@ star_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Starred ( value , Store , EXTRA );
+            _res = _PyAST_Starred ( value , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6621,7 +6621,7 @@ mapping_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Dict ( CHECK ( asdl_expr_seq * , _PyPegen_get_keys ( p , items ) ) , CHECK ( asdl_expr_seq * , _PyPegen_get_values ( p , items ) ) , EXTRA );
+            _res = _PyAST_Dict ( CHECK ( asdl_expr_seq * , _PyPegen_get_keys ( p , items ) ) , CHECK ( asdl_expr_seq * , _PyPegen_get_values ( p , items ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6845,7 +6845,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( func , NULL , NULL , EXTRA );
+            _res = _PyAST_Call ( func , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6891,7 +6891,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( func , args , NULL , EXTRA );
+            _res = _PyAST_Call ( func , args , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6937,7 +6937,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( func , NULL , keywords , EXTRA );
+            _res = _PyAST_Call ( func , NULL , keywords , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -6989,7 +6989,7 @@ class_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( func , args , keywords , EXTRA );
+            _res = _PyAST_Call ( func , args , keywords , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7136,7 +7136,7 @@ keyword_pattern_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_keyword ( arg -> v . Name . id , value , EXTRA );
+            _res = _PyAST_keyword ( arg -> v . Name . id , value , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7198,7 +7198,7 @@ return_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Return ( a , EXTRA );
+            _res = _PyAST_Return ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7263,7 +7263,7 @@ raise_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Raise ( a , b , EXTRA );
+            _res = _PyAST_Raise ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7296,7 +7296,7 @@ raise_stmt_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Raise ( NULL , NULL , EXTRA );
+            _res = _PyAST_Raise ( NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7444,7 +7444,7 @@ function_def_raw_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_FunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            _res = _PyAST_FunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -7504,7 +7504,7 @@ function_def_raw_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( stmt_ty , 5 , "Async functions are" , _Py_AsyncFunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
+            _res = CHECK_VERSION ( stmt_ty , 5 , "Async functions are" , _PyAST_AsyncFunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -8450,7 +8450,7 @@ param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_arg ( a -> v . Name . id , b , NULL , EXTRA );
+            _res = _PyAST_arg ( a -> v . Name . id , b , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -8713,7 +8713,7 @@ class_def_raw_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_ClassDef ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , c , NULL , EXTRA );
+            _res = _PyAST_ClassDef ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , c , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -8875,7 +8875,7 @@ star_expressions_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Load , EXTRA );
+            _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -8911,7 +8911,7 @@ star_expressions_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_singleton_seq ( p , a ) ) , Load , EXTRA );
+            _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_singleton_seq ( p , a ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -8996,7 +8996,7 @@ star_expression_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Starred ( a , Load , EXTRA );
+            _res = _PyAST_Starred ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -9123,7 +9123,7 @@ star_named_expression_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Starred ( a , Load , EXTRA );
+            _res = _PyAST_Starred ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -9210,7 +9210,7 @@ named_expression_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_NamedExpr ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , EXTRA );
+            _res = _PyAST_NamedExpr ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -9375,7 +9375,7 @@ expressions_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Load , EXTRA );
+            _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -9411,7 +9411,7 @@ expressions_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_singleton_seq ( p , a ) ) , Load , EXTRA );
+            _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_singleton_seq ( p , a ) ) , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -9505,7 +9505,7 @@ expression_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_IfExp ( b , a , c , EXTRA );
+            _res = _PyAST_IfExp ( b , a , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -9612,7 +9612,7 @@ lambdef_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Lambda ( ( a ) ? a : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , EXTRA );
+            _res = _PyAST_Lambda ( ( a ) ? a : CHECK ( arguments_ty , _PyPegen_empty_arguments ( p ) ) , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -10450,7 +10450,7 @@ lambda_param_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_arg ( a -> v . Name . id , NULL , NULL , EXTRA );
+            _res = _PyAST_arg ( a -> v . Name . id , NULL , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -10516,7 +10516,7 @@ disjunction_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BoolOp ( Or , CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , EXTRA );
+            _res = _PyAST_BoolOp ( Or , CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -10602,7 +10602,7 @@ conjunction_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BoolOp ( And , CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , EXTRA );
+            _res = _PyAST_BoolOp ( And , CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -10688,7 +10688,7 @@ inversion_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_UnaryOp ( Not , a , EXTRA );
+            _res = _PyAST_UnaryOp ( Not , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -10770,7 +10770,7 @@ comparison_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Compare ( a , CHECK ( asdl_int_seq * , _PyPegen_get_cmpops ( p , b ) ) , CHECK ( asdl_expr_seq * , _PyPegen_get_exprs ( p , b ) ) , EXTRA );
+            _res = _PyAST_Compare ( a , CHECK ( asdl_int_seq * , _PyPegen_get_cmpops ( p , b ) ) , CHECK ( asdl_expr_seq * , _PyPegen_get_exprs ( p , b ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -11549,7 +11549,7 @@ bitwise_or_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , BitOr , b , EXTRA );
+            _res = _PyAST_BinOp ( a , BitOr , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -11665,7 +11665,7 @@ bitwise_xor_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , BitXor , b , EXTRA );
+            _res = _PyAST_BinOp ( a , BitXor , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -11781,7 +11781,7 @@ bitwise_and_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , BitAnd , b , EXTRA );
+            _res = _PyAST_BinOp ( a , BitAnd , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -11897,7 +11897,7 @@ shift_expr_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , LShift , b , EXTRA );
+            _res = _PyAST_BinOp ( a , LShift , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -11936,7 +11936,7 @@ shift_expr_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , RShift , b , EXTRA );
+            _res = _PyAST_BinOp ( a , RShift , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12052,7 +12052,7 @@ sum_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , Add , b , EXTRA );
+            _res = _PyAST_BinOp ( a , Add , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12091,7 +12091,7 @@ sum_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , Sub , b , EXTRA );
+            _res = _PyAST_BinOp ( a , Sub , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12213,7 +12213,7 @@ term_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , Mult , b , EXTRA );
+            _res = _PyAST_BinOp ( a , Mult , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12252,7 +12252,7 @@ term_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , Div , b , EXTRA );
+            _res = _PyAST_BinOp ( a , Div , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12291,7 +12291,7 @@ term_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , FloorDiv , b , EXTRA );
+            _res = _PyAST_BinOp ( a , FloorDiv , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12330,7 +12330,7 @@ term_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , Mod , b , EXTRA );
+            _res = _PyAST_BinOp ( a , Mod , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12369,7 +12369,7 @@ term_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( expr_ty , 5 , "The '@' operator is" , _Py_BinOp ( a , MatMult , b , EXTRA ) );
+            _res = CHECK_VERSION ( expr_ty , 5 , "The '@' operator is" , _PyAST_BinOp ( a , MatMult , b , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12454,7 +12454,7 @@ factor_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_UnaryOp ( UAdd , a , EXTRA );
+            _res = _PyAST_UnaryOp ( UAdd , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12490,7 +12490,7 @@ factor_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_UnaryOp ( USub , a , EXTRA );
+            _res = _PyAST_UnaryOp ( USub , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12526,7 +12526,7 @@ factor_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_UnaryOp ( Invert , a , EXTRA );
+            _res = _PyAST_UnaryOp ( Invert , a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12611,7 +12611,7 @@ power_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_BinOp ( a , Pow , b , EXTRA );
+            _res = _PyAST_BinOp ( a , Pow , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12696,7 +12696,7 @@ await_primary_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( expr_ty , 5 , "Await expressions are" , _Py_Await ( a , EXTRA ) );
+            _res = CHECK_VERSION ( expr_ty , 5 , "Await expressions are" , _PyAST_Await ( a , EXTRA ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12838,7 +12838,7 @@ primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Attribute ( a , b -> v . Name . id , Load , EXTRA );
+            _res = _PyAST_Attribute ( a , b -> v . Name . id , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12874,7 +12874,7 @@ primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( a , CHECK ( asdl_expr_seq * , ( asdl_expr_seq * ) _PyPegen_singleton_seq ( p , b ) ) , NULL , EXTRA );
+            _res = _PyAST_Call ( a , CHECK ( asdl_expr_seq * , ( asdl_expr_seq * ) _PyPegen_singleton_seq ( p , b ) ) , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12916,7 +12916,7 @@ primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( a , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , EXTRA );
+            _res = _PyAST_Call ( a , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -12958,7 +12958,7 @@ primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Subscript ( a , b , Load , EXTRA );
+            _res = _PyAST_Subscript ( a , b , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13066,7 +13066,7 @@ slices_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( a , Load , EXTRA );
+            _res = _PyAST_Tuple ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13134,7 +13134,7 @@ slice_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Slice ( a , b , c , EXTRA );
+            _res = _PyAST_Slice ( a , b , c , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13246,7 +13246,7 @@ atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Constant ( Py_True , NULL , EXTRA );
+            _res = _PyAST_Constant ( Py_True , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13279,7 +13279,7 @@ atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Constant ( Py_False , NULL , EXTRA );
+            _res = _PyAST_Constant ( Py_False , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13312,7 +13312,7 @@ atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Constant ( Py_None , NULL , EXTRA );
+            _res = _PyAST_Constant ( Py_None , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13448,7 +13448,7 @@ atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Constant ( Py_Ellipsis , NULL , EXTRA );
+            _res = _PyAST_Constant ( Py_Ellipsis , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13559,7 +13559,7 @@ list_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_List ( a , Load , EXTRA );
+            _res = _PyAST_List ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13627,7 +13627,7 @@ listcomp_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_ListComp ( a , b , EXTRA );
+            _res = _PyAST_ListComp ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13711,7 +13711,7 @@ tuple_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( a , Load , EXTRA );
+            _res = _PyAST_Tuple ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13845,7 +13845,7 @@ genexp_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_GeneratorExp ( a , b , EXTRA );
+            _res = _PyAST_GeneratorExp ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13929,7 +13929,7 @@ set_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Set ( a , EXTRA );
+            _res = _PyAST_Set ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -13997,7 +13997,7 @@ setcomp_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_SetComp ( a , b , EXTRA );
+            _res = _PyAST_SetComp ( a , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14081,7 +14081,7 @@ dict_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Dict ( CHECK ( asdl_expr_seq * , _PyPegen_get_keys ( p , a ) ) , CHECK ( asdl_expr_seq * , _PyPegen_get_values ( p , a ) ) , EXTRA );
+            _res = _PyAST_Dict ( CHECK ( asdl_expr_seq * , _PyPegen_get_keys ( p , a ) ) , CHECK ( asdl_expr_seq * , _PyPegen_get_values ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14149,7 +14149,7 @@ dictcomp_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_DictComp ( a -> key , a -> value , b , EXTRA );
+            _res = _PyAST_DictComp ( a -> key , a -> value , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14426,7 +14426,7 @@ for_if_clause_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "ASYNC 'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
-            _res = CHECK_VERSION ( comprehension_ty , 6 , "Async comprehensions are" , _Py_comprehension ( a , b , c , 1 , p -> arena ) );
+            _res = CHECK_VERSION ( comprehension_ty , 6 , "Async comprehensions are" , _PyAST_comprehension ( a , b , c , 1 , p -> arena ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14469,7 +14469,7 @@ for_if_clause_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'for' star_targets 'in' ~ disjunction (('if' disjunction))*"));
-            _res = _Py_comprehension ( a , b , c , 0 , p -> arena );
+            _res = _PyAST_comprehension ( a , b , c , 0 , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14557,7 +14557,7 @@ yield_expr_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_YieldFrom ( a , EXTRA );
+            _res = _PyAST_YieldFrom ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14593,7 +14593,7 @@ yield_expr_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Yield ( a , EXTRA );
+            _res = _PyAST_Yield ( a , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14759,7 +14759,7 @@ args_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( _PyPegen_dummy_name ( p ) , CHECK_NULL_ALLOWED ( asdl_expr_seq * , _PyPegen_seq_extract_starred_exprs ( p , a ) ) , CHECK_NULL_ALLOWED ( asdl_keyword_seq * , _PyPegen_seq_delete_starred_exprs ( p , a ) ) , EXTRA );
+            _res = _PyAST_Call ( _PyPegen_dummy_name ( p ) , CHECK_NULL_ALLOWED ( asdl_expr_seq * , _PyPegen_seq_extract_starred_exprs ( p , a ) ) , CHECK_NULL_ALLOWED ( asdl_keyword_seq * , _PyPegen_seq_delete_starred_exprs ( p , a ) ) , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14909,7 +14909,7 @@ starred_expression_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Starred ( a , Load , EXTRA );
+            _res = _PyAST_Starred ( a , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -14974,7 +14974,7 @@ kwarg_or_starred_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _Py_keyword ( a -> v . Name . id , b , EXTRA ) ) , 1 );
+            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _PyAST_keyword ( a -> v . Name . id , b , EXTRA ) ) , 1 );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15082,7 +15082,7 @@ kwarg_or_double_starred_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _Py_keyword ( a -> v . Name . id , b , EXTRA ) ) , 1 );
+            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _PyAST_keyword ( a -> v . Name . id , b , EXTRA ) ) , 1 );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15118,7 +15118,7 @@ kwarg_or_double_starred_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _Py_keyword ( NULL , a , EXTRA ) ) , 1 );
+            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _PyAST_keyword ( NULL , a , EXTRA ) ) , 1 );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15229,7 +15229,7 @@ star_targets_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Store , EXTRA );
+            _res = _PyAST_Tuple ( CHECK ( asdl_expr_seq * , _PyPegen_seq_insert_in_front ( p , a , b ) ) , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15415,7 +15415,7 @@ star_target_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Starred ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , Store , EXTRA );
+            _res = _PyAST_Starred ( CHECK ( expr_ty , _PyPegen_set_expr_context ( p , a , Store ) ) , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15509,7 +15509,7 @@ target_with_star_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Attribute ( a , b -> v . Name . id , Store , EXTRA );
+            _res = _PyAST_Attribute ( a , b -> v . Name . id , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15553,7 +15553,7 @@ target_with_star_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Subscript ( a , b , Store , EXTRA );
+            _res = _PyAST_Subscript ( a , b , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15696,7 +15696,7 @@ star_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( a , Store , EXTRA );
+            _res = _PyAST_Tuple ( a , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15735,7 +15735,7 @@ star_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_List ( a , Store , EXTRA );
+            _res = _PyAST_List ( a , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15894,7 +15894,7 @@ single_subscript_attribute_target_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Attribute ( a , b -> v . Name . id , Store , EXTRA );
+            _res = _PyAST_Attribute ( a , b -> v . Name . id , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -15938,7 +15938,7 @@ single_subscript_attribute_target_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Subscript ( a , b , Store , EXTRA );
+            _res = _PyAST_Subscript ( a , b , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16057,7 +16057,7 @@ del_target_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Attribute ( a , b -> v . Name . id , Del , EXTRA );
+            _res = _PyAST_Attribute ( a , b -> v . Name . id , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16101,7 +16101,7 @@ del_target_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Subscript ( a , b , Del , EXTRA );
+            _res = _PyAST_Subscript ( a , b , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16240,7 +16240,7 @@ del_t_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( a , Del , EXTRA );
+            _res = _PyAST_Tuple ( a , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16279,7 +16279,7 @@ del_t_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_List ( a , Del , EXTRA );
+            _res = _PyAST_List ( a , Del , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16398,7 +16398,7 @@ target_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Attribute ( a , b -> v . Name . id , Store , EXTRA );
+            _res = _PyAST_Attribute ( a , b -> v . Name . id , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16442,7 +16442,7 @@ target_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Subscript ( a , b , Store , EXTRA );
+            _res = _PyAST_Subscript ( a , b , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16566,7 +16566,7 @@ t_primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Attribute ( a , b -> v . Name . id , Load , EXTRA );
+            _res = _PyAST_Attribute ( a , b -> v . Name . id , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16610,7 +16610,7 @@ t_primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Subscript ( a , b , Load , EXTRA );
+            _res = _PyAST_Subscript ( a , b , Load , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16648,7 +16648,7 @@ t_primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( a , CHECK ( asdl_expr_seq * , ( asdl_expr_seq * ) _PyPegen_singleton_seq ( p , b ) ) , NULL , EXTRA );
+            _res = _PyAST_Call ( a , CHECK ( asdl_expr_seq * , ( asdl_expr_seq * ) _PyPegen_singleton_seq ( p , b ) ) , NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16692,7 +16692,7 @@ t_primary_raw(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Call ( a , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , EXTRA );
+            _res = _PyAST_Call ( a , ( b ) ? ( ( expr_ty ) b ) -> v . Call . args : NULL , ( b ) ? ( ( expr_ty ) b ) -> v . Call . keywords : NULL , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16911,7 +16911,7 @@ t_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_Tuple ( b , Store , EXTRA );
+            _res = _PyAST_Tuple ( b , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -16950,7 +16950,7 @@ t_atom_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = _Py_List ( b , Store , EXTRA );
+            _res = _PyAST_List ( b , Store , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -34,9 +34,9 @@ _PyPegen_add_type_comment_to_arg(Parser *p, arg_ty a, Token *tc)
     if (tco == NULL) {
         return NULL;
     }
-    return arg(a->arg, a->annotation, tco,
-               a->lineno, a->col_offset, a->end_lineno, a->end_col_offset,
-               p->arena);
+    return _PyAST_arg(a->arg, a->annotation, tco,
+                      a->lineno, a->col_offset, a->end_lineno, a->end_col_offset,
+                      p->arena);
 }
 
 static int
@@ -568,7 +568,7 @@ _PyPegen_dummy_name(Parser *p, ...)
     if (!id) {
         return NULL;
     }
-    cache = Name(id, Load, 1, 0, 1, 0, p->arena);
+    cache = _PyAST_Name(id, Load, 1, 0, 1, 0, p->arena);
     return cache;
 }
 
@@ -919,8 +919,8 @@ _PyPegen_name_token(Parser *p)
         p->error_indicator = 1;
         return NULL;
     }
-    return Name(id, Load, t->lineno, t->col_offset, t->end_lineno, t->end_col_offset,
-                p->arena);
+    return _PyAST_Name(id, Load, t->lineno, t->col_offset, t->end_lineno,
+                       t->end_col_offset, p->arena);
 }
 
 void *
@@ -1035,8 +1035,8 @@ _PyPegen_number_token(Parser *p)
         return NULL;
     }
 
-    return Constant(c, NULL, t->lineno, t->col_offset, t->end_lineno, t->end_col_offset,
-                    p->arena);
+    return _PyAST_Constant(c, NULL, t->lineno, t->col_offset, t->end_lineno,
+                           t->end_col_offset, p->arena);
 }
 
 static int // bool
@@ -1514,7 +1514,7 @@ _PyPegen_join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
         return NULL;
     }
 
-    return _Py_Name(uni, Load, EXTRA_EXPR(first_name, second_name));
+    return _PyAST_Name(uni, Load, EXTRA_EXPR(first_name, second_name));
 }
 
 /* Counts the total number of dots in seq's tokens */
@@ -1551,7 +1551,7 @@ _PyPegen_alias_for_star(Parser *p)
         Py_DECREF(str);
         return NULL;
     }
-    return alias(str, NULL, p->arena);
+    return _PyAST_alias(str, NULL, p->arena);
 }
 
 /* Creates a new asdl_seq* with the identifiers of all the names in seq */
@@ -1643,13 +1643,13 @@ _set_seq_context(Parser *p, asdl_expr_seq *seq, expr_context_ty ctx)
 static expr_ty
 _set_name_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Name(e->v.Name.id, ctx, EXTRA_EXPR(e, e));
+    return _PyAST_Name(e->v.Name.id, ctx, EXTRA_EXPR(e, e));
 }
 
 static expr_ty
 _set_tuple_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Tuple(
+    return _PyAST_Tuple(
             _set_seq_context(p, e->v.Tuple.elts, ctx),
             ctx,
             EXTRA_EXPR(e, e));
@@ -1658,7 +1658,7 @@ _set_tuple_context(Parser *p, expr_ty e, expr_context_ty ctx)
 static expr_ty
 _set_list_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_List(
+    return _PyAST_List(
             _set_seq_context(p, e->v.List.elts, ctx),
             ctx,
             EXTRA_EXPR(e, e));
@@ -1667,19 +1667,22 @@ _set_list_context(Parser *p, expr_ty e, expr_context_ty ctx)
 static expr_ty
 _set_subscript_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Subscript(e->v.Subscript.value, e->v.Subscript.slice, ctx, EXTRA_EXPR(e, e));
+    return _PyAST_Subscript(e->v.Subscript.value, e->v.Subscript.slice,
+                            ctx, EXTRA_EXPR(e, e));
 }
 
 static expr_ty
 _set_attribute_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Attribute(e->v.Attribute.value, e->v.Attribute.attr, ctx, EXTRA_EXPR(e, e));
+    return _PyAST_Attribute(e->v.Attribute.value, e->v.Attribute.attr,
+                            ctx, EXTRA_EXPR(e, e));
 }
 
 static expr_ty
 _set_starred_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Starred(_PyPegen_set_expr_context(p, e->v.Starred.value, ctx), ctx, EXTRA_EXPR(e, e));
+    return _PyAST_Starred(_PyPegen_set_expr_context(p, e->v.Starred.value, ctx),
+                          ctx, EXTRA_EXPR(e, e));
 }
 
 /* Creates an `expr_ty` equivalent to `expr` but with `ctx` as context */
@@ -1987,8 +1990,8 @@ _PyPegen_make_arguments(Parser *p, asdl_arg_seq *slash_without_default,
         kwarg = star_etc->kwarg;
     }
 
-    return _Py_arguments(posonlyargs, posargs, vararg, kwonlyargs, kwdefaults, kwarg,
-                         posdefaults, p->arena);
+    return _PyAST_arguments(posonlyargs, posargs, vararg, kwonlyargs,
+                            kwdefaults, kwarg, posdefaults, p->arena);
 }
 
 /* Constructs an empty arguments_ty object, that gets used when a function accepts no
@@ -2017,8 +2020,8 @@ _PyPegen_empty_arguments(Parser *p)
         return NULL;
     }
 
-    return _Py_arguments(posonlyargs, posargs, NULL, kwonlyargs, kwdefaults, NULL, posdefaults,
-                         p->arena);
+    return _PyAST_arguments(posonlyargs, posargs, NULL, kwonlyargs,
+                            kwdefaults, NULL, posdefaults, p->arena);
 }
 
 /* Encapsulates the value of an operator_ty into an AugOperator struct */
@@ -2039,7 +2042,7 @@ _PyPegen_function_def_decorators(Parser *p, asdl_expr_seq *decorators, stmt_ty f
 {
     assert(function_def != NULL);
     if (function_def->kind == AsyncFunctionDef_kind) {
-        return _Py_AsyncFunctionDef(
+        return _PyAST_AsyncFunctionDef(
             function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
             function_def->v.FunctionDef.body, decorators, function_def->v.FunctionDef.returns,
             function_def->v.FunctionDef.type_comment, function_def->lineno,
@@ -2047,12 +2050,13 @@ _PyPegen_function_def_decorators(Parser *p, asdl_expr_seq *decorators, stmt_ty f
             p->arena);
     }
 
-    return _Py_FunctionDef(function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
-                           function_def->v.FunctionDef.body, decorators,
-                           function_def->v.FunctionDef.returns,
-                           function_def->v.FunctionDef.type_comment, function_def->lineno,
-                           function_def->col_offset, function_def->end_lineno,
-                           function_def->end_col_offset, p->arena);
+    return _PyAST_FunctionDef(
+        function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
+        function_def->v.FunctionDef.body, decorators,
+        function_def->v.FunctionDef.returns,
+        function_def->v.FunctionDef.type_comment, function_def->lineno,
+        function_def->col_offset, function_def->end_lineno,
+        function_def->end_col_offset, p->arena);
 }
 
 /* Construct a ClassDef equivalent to class_def, but with decorators */
@@ -2060,10 +2064,11 @@ stmt_ty
 _PyPegen_class_def_decorators(Parser *p, asdl_expr_seq *decorators, stmt_ty class_def)
 {
     assert(class_def != NULL);
-    return _Py_ClassDef(class_def->v.ClassDef.name, class_def->v.ClassDef.bases,
-                        class_def->v.ClassDef.keywords, class_def->v.ClassDef.body, decorators,
-                        class_def->lineno, class_def->col_offset, class_def->end_lineno,
-                        class_def->end_col_offset, p->arena);
+    return _PyAST_ClassDef(
+        class_def->v.ClassDef.name, class_def->v.ClassDef.bases,
+        class_def->v.ClassDef.keywords, class_def->v.ClassDef.body, decorators,
+        class_def->lineno, class_def->col_offset, class_def->end_lineno,
+        class_def->end_col_offset, p->arena);
 }
 
 /* Construct a KeywordOrStarred */
@@ -2214,8 +2219,9 @@ _PyPegen_concatenate_strings(Parser *p, asdl_seq *strings)
         if (_PyArena_AddPyObject(p->arena, bytes_str) < 0) {
             goto error;
         }
-        return Constant(bytes_str, NULL, first->lineno, first->col_offset, last->end_lineno,
-                        last->end_col_offset, p->arena);
+        return _PyAST_Constant(bytes_str, NULL, first->lineno,
+                               first->col_offset, last->end_lineno,
+                               last->end_col_offset, p->arena);
     }
 
     return _PyPegen_FstringParser_Finish(p, &state, first, last);
@@ -2244,14 +2250,15 @@ _PyPegen_make_module(Parser *p, asdl_stmt_seq *a) {
             if (tag == NULL) {
                 return NULL;
             }
-            type_ignore_ty ti = TypeIgnore(p->type_ignore_comments.items[i].lineno, tag, p->arena);
+            type_ignore_ty ti = _PyAST_TypeIgnore(p->type_ignore_comments.items[i].lineno,
+                                                  tag, p->arena);
             if (ti == NULL) {
                 return NULL;
             }
             asdl_seq_SET(type_ignores, i, ti);
         }
     }
-    return Module(a, type_ignores, p->arena);
+    return _PyAST_Module(a, type_ignores, p->arena);
 }
 
 // Error reporting helpers
@@ -2361,7 +2368,7 @@ expr_ty _PyPegen_collect_call_seqs(Parser *p, asdl_expr_seq *a, asdl_seq *b,
     Py_ssize_t total_len = args_len;
 
     if (b == NULL) {
-        return _Py_Call(_PyPegen_dummy_name(p), a, NULL, lineno, col_offset,
+        return _PyAST_Call(_PyPegen_dummy_name(p), a, NULL, lineno, col_offset,
                         end_lineno, end_col_offset, arena);
 
     }
@@ -2383,6 +2390,6 @@ expr_ty _PyPegen_collect_call_seqs(Parser *p, asdl_expr_seq *a, asdl_seq *b,
         asdl_seq_SET(args, i, asdl_seq_GET(starreds, i - args_len));
     }
 
-    return _Py_Call(_PyPegen_dummy_name(p), args, keywords, lineno,
-                    col_offset, end_lineno, end_col_offset, arena);
+    return _PyAST_Call(_PyPegen_dummy_name(p), args, keywords, lineno,
+                       col_offset, end_lineno, end_col_offset, arena);
 }

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -797,10 +797,11 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
     /* And now create the FormattedValue node that represents this
        entire expression with the conversion and format spec. */
     //TODO: Fix this
-    *expression = FormattedValue(simple_expression, conversion,
-                                 format_spec, first_token->lineno,
-                                 first_token->col_offset, last_token->end_lineno,
-                                 last_token->end_col_offset, p->arena);
+    *expression = _PyAST_FormattedValue(simple_expression, conversion,
+                                        format_spec, first_token->lineno,
+                                        first_token->col_offset,
+                                        last_token->end_lineno,
+                                        last_token->end_col_offset, p->arena);
     if (!*expression) {
         goto error;
     }
@@ -1044,8 +1045,9 @@ make_str_node_and_del(Parser *p, PyObject **str, Token* first_token, Token *last
         return NULL;
     }
 
-    return Constant(s, kind, first_token->lineno, first_token->col_offset,
-                    last_token->end_lineno, last_token->end_col_offset, p->arena);
+    return _PyAST_Constant(s, kind, first_token->lineno, first_token->col_offset,
+                           last_token->end_lineno, last_token->end_col_offset,
+                           p->arena);
 
 }
 
@@ -1204,8 +1206,9 @@ _PyPegen_FstringParser_Finish(Parser *p, FstringParser *state, Token* first_toke
         goto error;
     }
 
-    return _Py_JoinedStr(seq, first_token->lineno, first_token->col_offset,
-                         last_token->end_lineno, last_token->end_col_offset, p->arena);
+    return _PyAST_JoinedStr(seq, first_token->lineno, first_token->col_offset,
+                            last_token->end_lineno, last_token->end_col_offset,
+                            p->arena);
 
 error:
     _PyPegen_FstringParser_Dealloc(state);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1776,8 +1776,8 @@ static int obj2ast_type_ignore(struct ast_state *state, PyObject* obj,
                                type_ignore_ty* out, PyArena* arena);
 
 mod_ty
-_Py_Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores, PyArena
-           *arena)
+_PyAST_Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores,
+              PyArena *arena)
 {
     mod_ty p;
     p = (mod_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -1790,7 +1790,7 @@ _Py_Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores, PyArena
 }
 
 mod_ty
-_Py_Interactive(asdl_stmt_seq * body, PyArena *arena)
+_PyAST_Interactive(asdl_stmt_seq * body, PyArena *arena)
 {
     mod_ty p;
     p = (mod_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -1802,7 +1802,7 @@ _Py_Interactive(asdl_stmt_seq * body, PyArena *arena)
 }
 
 mod_ty
-_Py_Expression(expr_ty body, PyArena *arena)
+_PyAST_Expression(expr_ty body, PyArena *arena)
 {
     mod_ty p;
     if (!body) {
@@ -1819,7 +1819,7 @@ _Py_Expression(expr_ty body, PyArena *arena)
 }
 
 mod_ty
-_Py_FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena *arena)
+_PyAST_FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena *arena)
 {
     mod_ty p;
     if (!returns) {
@@ -1837,10 +1837,10 @@ _Py_FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena *arena)
 }
 
 stmt_ty
-_Py_FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq * body,
-                asdl_expr_seq * decorator_list, expr_ty returns, string
-                type_comment, int lineno, int col_offset, int end_lineno, int
-                end_col_offset, PyArena *arena)
+_PyAST_FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq * body,
+                   asdl_expr_seq * decorator_list, expr_ty returns, string
+                   type_comment, int lineno, int col_offset, int end_lineno,
+                   int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!name) {
@@ -1871,10 +1871,10 @@ _Py_FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq * body,
 }
 
 stmt_ty
-_Py_AsyncFunctionDef(identifier name, arguments_ty args, asdl_stmt_seq * body,
-                     asdl_expr_seq * decorator_list, expr_ty returns, string
-                     type_comment, int lineno, int col_offset, int end_lineno,
-                     int end_col_offset, PyArena *arena)
+_PyAST_AsyncFunctionDef(identifier name, arguments_ty args, asdl_stmt_seq *
+                        body, asdl_expr_seq * decorator_list, expr_ty returns,
+                        string type_comment, int lineno, int col_offset, int
+                        end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!name) {
@@ -1905,10 +1905,10 @@ _Py_AsyncFunctionDef(identifier name, arguments_ty args, asdl_stmt_seq * body,
 }
 
 stmt_ty
-_Py_ClassDef(identifier name, asdl_expr_seq * bases, asdl_keyword_seq *
-             keywords, asdl_stmt_seq * body, asdl_expr_seq * decorator_list,
-             int lineno, int col_offset, int end_lineno, int end_col_offset,
-             PyArena *arena)
+_PyAST_ClassDef(identifier name, asdl_expr_seq * bases, asdl_keyword_seq *
+                keywords, asdl_stmt_seq * body, asdl_expr_seq * decorator_list,
+                int lineno, int col_offset, int end_lineno, int end_col_offset,
+                PyArena *arena)
 {
     stmt_ty p;
     if (!name) {
@@ -1933,8 +1933,8 @@ _Py_ClassDef(identifier name, asdl_expr_seq * bases, asdl_keyword_seq *
 }
 
 stmt_ty
-_Py_Return(expr_ty value, int lineno, int col_offset, int end_lineno, int
-           end_col_offset, PyArena *arena)
+_PyAST_Return(expr_ty value, int lineno, int col_offset, int end_lineno, int
+              end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -1950,8 +1950,8 @@ _Py_Return(expr_ty value, int lineno, int col_offset, int end_lineno, int
 }
 
 stmt_ty
-_Py_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int end_lineno,
-           int end_col_offset, PyArena *arena)
+_PyAST_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int
+              end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -1967,9 +1967,9 @@ _Py_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int end_lineno,
 }
 
 stmt_ty
-_Py_Assign(asdl_expr_seq * targets, expr_ty value, string type_comment, int
-           lineno, int col_offset, int end_lineno, int end_col_offset, PyArena
-           *arena)
+_PyAST_Assign(asdl_expr_seq * targets, expr_ty value, string type_comment, int
+              lineno, int col_offset, int end_lineno, int end_col_offset,
+              PyArena *arena)
 {
     stmt_ty p;
     if (!value) {
@@ -1992,8 +1992,8 @@ _Py_Assign(asdl_expr_seq * targets, expr_ty value, string type_comment, int
 }
 
 stmt_ty
-_Py_AugAssign(expr_ty target, operator_ty op, expr_ty value, int lineno, int
-              col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_AugAssign(expr_ty target, operator_ty op, expr_ty value, int lineno, int
+                 col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!target) {
@@ -2026,9 +2026,9 @@ _Py_AugAssign(expr_ty target, operator_ty op, expr_ty value, int lineno, int
 }
 
 stmt_ty
-_Py_AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int simple,
-              int lineno, int col_offset, int end_lineno, int end_col_offset,
-              PyArena *arena)
+_PyAST_AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int simple,
+                 int lineno, int col_offset, int end_lineno, int
+                 end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!target) {
@@ -2057,9 +2057,9 @@ _Py_AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int simple,
 }
 
 stmt_ty
-_Py_For(expr_ty target, expr_ty iter, asdl_stmt_seq * body, asdl_stmt_seq *
-        orelse, string type_comment, int lineno, int col_offset, int
-        end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_For(expr_ty target, expr_ty iter, asdl_stmt_seq * body, asdl_stmt_seq *
+           orelse, string type_comment, int lineno, int col_offset, int
+           end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!target) {
@@ -2089,9 +2089,9 @@ _Py_For(expr_ty target, expr_ty iter, asdl_stmt_seq * body, asdl_stmt_seq *
 }
 
 stmt_ty
-_Py_AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body, asdl_stmt_seq
-             * orelse, string type_comment, int lineno, int col_offset, int
-             end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
+                asdl_stmt_seq * orelse, string type_comment, int lineno, int
+                col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!target) {
@@ -2121,9 +2121,9 @@ _Py_AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body, asdl_stmt_seq
 }
 
 stmt_ty
-_Py_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int
-          lineno, int col_offset, int end_lineno, int end_col_offset, PyArena
-          *arena)
+_PyAST_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int
+             lineno, int col_offset, int end_lineno, int end_col_offset,
+             PyArena *arena)
 {
     stmt_ty p;
     if (!test) {
@@ -2146,8 +2146,9 @@ _Py_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int
 }
 
 stmt_ty
-_Py_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int lineno,
-       int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int
+          lineno, int col_offset, int end_lineno, int end_col_offset, PyArena
+          *arena)
 {
     stmt_ty p;
     if (!test) {
@@ -2170,9 +2171,9 @@ _Py_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int lineno,
 }
 
 stmt_ty
-_Py_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string type_comment,
-         int lineno, int col_offset, int end_lineno, int end_col_offset,
-         PyArena *arena)
+_PyAST_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string
+            type_comment, int lineno, int col_offset, int end_lineno, int
+            end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2190,9 +2191,9 @@ _Py_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string type_comment,
 }
 
 stmt_ty
-_Py_AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body, string
-              type_comment, int lineno, int col_offset, int end_lineno, int
-              end_col_offset, PyArena *arena)
+_PyAST_AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body, string
+                 type_comment, int lineno, int col_offset, int end_lineno, int
+                 end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2210,8 +2211,8 @@ _Py_AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body, string
 }
 
 stmt_ty
-_Py_Match(expr_ty subject, asdl_match_case_seq * cases, int lineno, int
-          col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Match(expr_ty subject, asdl_match_case_seq * cases, int lineno, int
+             col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!subject) {
@@ -2233,8 +2234,8 @@ _Py_Match(expr_ty subject, asdl_match_case_seq * cases, int lineno, int
 }
 
 stmt_ty
-_Py_Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset, int
-          end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset, int
+             end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2251,9 +2252,9 @@ _Py_Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset, int
 }
 
 stmt_ty
-_Py_Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers, asdl_stmt_seq
-        * orelse, asdl_stmt_seq * finalbody, int lineno, int col_offset, int
-        end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers,
+           asdl_stmt_seq * orelse, asdl_stmt_seq * finalbody, int lineno, int
+           col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2272,8 +2273,8 @@ _Py_Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers, asdl_stmt_seq
 }
 
 stmt_ty
-_Py_Assert(expr_ty test, expr_ty msg, int lineno, int col_offset, int
-           end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Assert(expr_ty test, expr_ty msg, int lineno, int col_offset, int
+              end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!test) {
@@ -2295,8 +2296,8 @@ _Py_Assert(expr_ty test, expr_ty msg, int lineno, int col_offset, int
 }
 
 stmt_ty
-_Py_Import(asdl_alias_seq * names, int lineno, int col_offset, int end_lineno,
-           int end_col_offset, PyArena *arena)
+_PyAST_Import(asdl_alias_seq * names, int lineno, int col_offset, int
+              end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2312,9 +2313,9 @@ _Py_Import(asdl_alias_seq * names, int lineno, int col_offset, int end_lineno,
 }
 
 stmt_ty
-_Py_ImportFrom(identifier module, asdl_alias_seq * names, int level, int
-               lineno, int col_offset, int end_lineno, int end_col_offset,
-               PyArena *arena)
+_PyAST_ImportFrom(identifier module, asdl_alias_seq * names, int level, int
+                  lineno, int col_offset, int end_lineno, int end_col_offset,
+                  PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2332,8 +2333,8 @@ _Py_ImportFrom(identifier module, asdl_alias_seq * names, int level, int
 }
 
 stmt_ty
-_Py_Global(asdl_identifier_seq * names, int lineno, int col_offset, int
-           end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Global(asdl_identifier_seq * names, int lineno, int col_offset, int
+              end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2349,8 +2350,8 @@ _Py_Global(asdl_identifier_seq * names, int lineno, int col_offset, int
 }
 
 stmt_ty
-_Py_Nonlocal(asdl_identifier_seq * names, int lineno, int col_offset, int
-             end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Nonlocal(asdl_identifier_seq * names, int lineno, int col_offset, int
+                end_lineno, int end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2366,8 +2367,8 @@ _Py_Nonlocal(asdl_identifier_seq * names, int lineno, int col_offset, int
 }
 
 stmt_ty
-_Py_Expr(expr_ty value, int lineno, int col_offset, int end_lineno, int
-         end_col_offset, PyArena *arena)
+_PyAST_Expr(expr_ty value, int lineno, int col_offset, int end_lineno, int
+            end_col_offset, PyArena *arena)
 {
     stmt_ty p;
     if (!value) {
@@ -2388,8 +2389,8 @@ _Py_Expr(expr_ty value, int lineno, int col_offset, int end_lineno, int
 }
 
 stmt_ty
-_Py_Pass(int lineno, int col_offset, int end_lineno, int end_col_offset,
-         PyArena *arena)
+_PyAST_Pass(int lineno, int col_offset, int end_lineno, int end_col_offset,
+            PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2404,8 +2405,8 @@ _Py_Pass(int lineno, int col_offset, int end_lineno, int end_col_offset,
 }
 
 stmt_ty
-_Py_Break(int lineno, int col_offset, int end_lineno, int end_col_offset,
-          PyArena *arena)
+_PyAST_Break(int lineno, int col_offset, int end_lineno, int end_col_offset,
+             PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2420,8 +2421,8 @@ _Py_Break(int lineno, int col_offset, int end_lineno, int end_col_offset,
 }
 
 stmt_ty
-_Py_Continue(int lineno, int col_offset, int end_lineno, int end_col_offset,
-             PyArena *arena)
+_PyAST_Continue(int lineno, int col_offset, int end_lineno, int end_col_offset,
+                PyArena *arena)
 {
     stmt_ty p;
     p = (stmt_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2436,8 +2437,8 @@ _Py_Continue(int lineno, int col_offset, int end_lineno, int end_col_offset,
 }
 
 expr_ty
-_Py_BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int col_offset,
-           int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int col_offset,
+              int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!op) {
@@ -2459,8 +2460,8 @@ _Py_BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int col_offset,
 }
 
 expr_ty
-_Py_NamedExpr(expr_ty target, expr_ty value, int lineno, int col_offset, int
-              end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_NamedExpr(expr_ty target, expr_ty value, int lineno, int col_offset, int
+                 end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!target) {
@@ -2487,8 +2488,8 @@ _Py_NamedExpr(expr_ty target, expr_ty value, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_BinOp(expr_ty left, operator_ty op, expr_ty right, int lineno, int
-          col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_BinOp(expr_ty left, operator_ty op, expr_ty right, int lineno, int
+             col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!left) {
@@ -2521,8 +2522,8 @@ _Py_BinOp(expr_ty left, operator_ty op, expr_ty right, int lineno, int
 }
 
 expr_ty
-_Py_UnaryOp(unaryop_ty op, expr_ty operand, int lineno, int col_offset, int
-            end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_UnaryOp(unaryop_ty op, expr_ty operand, int lineno, int col_offset, int
+               end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!op) {
@@ -2549,8 +2550,8 @@ _Py_UnaryOp(unaryop_ty op, expr_ty operand, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_Lambda(arguments_ty args, expr_ty body, int lineno, int col_offset, int
-           end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Lambda(arguments_ty args, expr_ty body, int lineno, int col_offset, int
+              end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!args) {
@@ -2577,8 +2578,8 @@ _Py_Lambda(arguments_ty args, expr_ty body, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno, int
-          col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno, int
+             col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!test) {
@@ -2611,8 +2612,8 @@ _Py_IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno, int
 }
 
 expr_ty
-_Py_Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno, int
-         col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno, int
+            col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2629,8 +2630,8 @@ _Py_Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno, int
 }
 
 expr_ty
-_Py_Set(asdl_expr_seq * elts, int lineno, int col_offset, int end_lineno, int
-        end_col_offset, PyArena *arena)
+_PyAST_Set(asdl_expr_seq * elts, int lineno, int col_offset, int end_lineno,
+           int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2646,8 +2647,9 @@ _Py_Set(asdl_expr_seq * elts, int lineno, int col_offset, int end_lineno, int
 }
 
 expr_ty
-_Py_ListComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno, int
-             col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_ListComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno,
+                int col_offset, int end_lineno, int end_col_offset, PyArena
+                *arena)
 {
     expr_ty p;
     if (!elt) {
@@ -2669,8 +2671,9 @@ _Py_ListComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno, int
 }
 
 expr_ty
-_Py_SetComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno, int
-            col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_SetComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno,
+               int col_offset, int end_lineno, int end_col_offset, PyArena
+               *arena)
 {
     expr_ty p;
     if (!elt) {
@@ -2692,9 +2695,9 @@ _Py_SetComp(expr_ty elt, asdl_comprehension_seq * generators, int lineno, int
 }
 
 expr_ty
-_Py_DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq * generators,
-             int lineno, int col_offset, int end_lineno, int end_col_offset,
-             PyArena *arena)
+_PyAST_DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq *
+                generators, int lineno, int col_offset, int end_lineno, int
+                end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!key) {
@@ -2722,9 +2725,9 @@ _Py_DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq * generators,
 }
 
 expr_ty
-_Py_GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators, int lineno,
-                 int col_offset, int end_lineno, int end_col_offset, PyArena
-                 *arena)
+_PyAST_GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators, int
+                    lineno, int col_offset, int end_lineno, int end_col_offset,
+                    PyArena *arena)
 {
     expr_ty p;
     if (!elt) {
@@ -2746,8 +2749,8 @@ _Py_GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators, int lineno,
 }
 
 expr_ty
-_Py_Await(expr_ty value, int lineno, int col_offset, int end_lineno, int
-          end_col_offset, PyArena *arena)
+_PyAST_Await(expr_ty value, int lineno, int col_offset, int end_lineno, int
+             end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!value) {
@@ -2768,8 +2771,8 @@ _Py_Await(expr_ty value, int lineno, int col_offset, int end_lineno, int
 }
 
 expr_ty
-_Py_Yield(expr_ty value, int lineno, int col_offset, int end_lineno, int
-          end_col_offset, PyArena *arena)
+_PyAST_Yield(expr_ty value, int lineno, int col_offset, int end_lineno, int
+             end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2785,8 +2788,8 @@ _Py_Yield(expr_ty value, int lineno, int col_offset, int end_lineno, int
 }
 
 expr_ty
-_Py_YieldFrom(expr_ty value, int lineno, int col_offset, int end_lineno, int
-              end_col_offset, PyArena *arena)
+_PyAST_YieldFrom(expr_ty value, int lineno, int col_offset, int end_lineno, int
+                 end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!value) {
@@ -2807,9 +2810,9 @@ _Py_YieldFrom(expr_ty value, int lineno, int col_offset, int end_lineno, int
 }
 
 expr_ty
-_Py_Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq * comparators, int
-            lineno, int col_offset, int end_lineno, int end_col_offset, PyArena
-            *arena)
+_PyAST_Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq * comparators,
+               int lineno, int col_offset, int end_lineno, int end_col_offset,
+               PyArena *arena)
 {
     expr_ty p;
     if (!left) {
@@ -2832,9 +2835,9 @@ _Py_Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq * comparators, int
 }
 
 expr_ty
-_Py_Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq * keywords, int
-         lineno, int col_offset, int end_lineno, int end_col_offset, PyArena
-         *arena)
+_PyAST_Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq * keywords,
+            int lineno, int col_offset, int end_lineno, int end_col_offset,
+            PyArena *arena)
 {
     expr_ty p;
     if (!func) {
@@ -2857,9 +2860,9 @@ _Py_Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq * keywords, int
 }
 
 expr_ty
-_Py_FormattedValue(expr_ty value, int conversion, expr_ty format_spec, int
-                   lineno, int col_offset, int end_lineno, int end_col_offset,
-                   PyArena *arena)
+_PyAST_FormattedValue(expr_ty value, int conversion, expr_ty format_spec, int
+                      lineno, int col_offset, int end_lineno, int
+                      end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!value) {
@@ -2882,8 +2885,8 @@ _Py_FormattedValue(expr_ty value, int conversion, expr_ty format_spec, int
 }
 
 expr_ty
-_Py_JoinedStr(asdl_expr_seq * values, int lineno, int col_offset, int
-              end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_JoinedStr(asdl_expr_seq * values, int lineno, int col_offset, int
+                 end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -2899,8 +2902,8 @@ _Py_JoinedStr(asdl_expr_seq * values, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_Constant(constant value, string kind, int lineno, int col_offset, int
-             end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Constant(constant value, string kind, int lineno, int col_offset, int
+                end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!value) {
@@ -2922,9 +2925,9 @@ _Py_Constant(constant value, string kind, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_Attribute(expr_ty value, identifier attr, expr_context_ty ctx, int lineno,
-              int col_offset, int end_lineno, int end_col_offset, PyArena
-              *arena)
+_PyAST_Attribute(expr_ty value, identifier attr, expr_context_ty ctx, int
+                 lineno, int col_offset, int end_lineno, int end_col_offset,
+                 PyArena *arena)
 {
     expr_ty p;
     if (!value) {
@@ -2957,9 +2960,9 @@ _Py_Attribute(expr_ty value, identifier attr, expr_context_ty ctx, int lineno,
 }
 
 expr_ty
-_Py_Subscript(expr_ty value, expr_ty slice, expr_context_ty ctx, int lineno,
-              int col_offset, int end_lineno, int end_col_offset, PyArena
-              *arena)
+_PyAST_Subscript(expr_ty value, expr_ty slice, expr_context_ty ctx, int lineno,
+                 int col_offset, int end_lineno, int end_col_offset, PyArena
+                 *arena)
 {
     expr_ty p;
     if (!value) {
@@ -2992,8 +2995,8 @@ _Py_Subscript(expr_ty value, expr_ty slice, expr_context_ty ctx, int lineno,
 }
 
 expr_ty
-_Py_Starred(expr_ty value, expr_context_ty ctx, int lineno, int col_offset, int
-            end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Starred(expr_ty value, expr_context_ty ctx, int lineno, int col_offset,
+               int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!value) {
@@ -3020,8 +3023,8 @@ _Py_Starred(expr_ty value, expr_context_ty ctx, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_Name(identifier id, expr_context_ty ctx, int lineno, int col_offset, int
-         end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Name(identifier id, expr_context_ty ctx, int lineno, int col_offset, int
+            end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!id) {
@@ -3048,8 +3051,8 @@ _Py_Name(identifier id, expr_context_ty ctx, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int col_offset,
-         int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
+            col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!ctx) {
@@ -3071,8 +3074,8 @@ _Py_List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int col_offset,
 }
 
 expr_ty
-_Py_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
-          col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
+             col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!ctx) {
@@ -3094,8 +3097,8 @@ _Py_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
 }
 
 expr_ty
-_Py_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int
-          col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int
+             col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -3113,8 +3116,8 @@ _Py_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int
 }
 
 expr_ty
-_Py_MatchAs(expr_ty pattern, identifier name, int lineno, int col_offset, int
-            end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_MatchAs(expr_ty pattern, identifier name, int lineno, int col_offset,
+               int end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!pattern) {
@@ -3141,8 +3144,8 @@ _Py_MatchAs(expr_ty pattern, identifier name, int lineno, int col_offset, int
 }
 
 expr_ty
-_Py_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset, int
-            end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset, int
+               end_lineno, int end_col_offset, PyArena *arena)
 {
     expr_ty p;
     p = (expr_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -3158,8 +3161,8 @@ _Py_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset, int
 }
 
 comprehension_ty
-_Py_comprehension(expr_ty target, expr_ty iter, asdl_expr_seq * ifs, int
-                  is_async, PyArena *arena)
+_PyAST_comprehension(expr_ty target, expr_ty iter, asdl_expr_seq * ifs, int
+                     is_async, PyArena *arena)
 {
     comprehension_ty p;
     if (!target) {
@@ -3183,9 +3186,9 @@ _Py_comprehension(expr_ty target, expr_ty iter, asdl_expr_seq * ifs, int
 }
 
 excepthandler_ty
-_Py_ExceptHandler(expr_ty type, identifier name, asdl_stmt_seq * body, int
-                  lineno, int col_offset, int end_lineno, int end_col_offset,
-                  PyArena *arena)
+_PyAST_ExceptHandler(expr_ty type, identifier name, asdl_stmt_seq * body, int
+                     lineno, int col_offset, int end_lineno, int
+                     end_col_offset, PyArena *arena)
 {
     excepthandler_ty p;
     p = (excepthandler_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -3203,9 +3206,10 @@ _Py_ExceptHandler(expr_ty type, identifier name, asdl_stmt_seq * body, int
 }
 
 arguments_ty
-_Py_arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args, arg_ty vararg,
-              asdl_arg_seq * kwonlyargs, asdl_expr_seq * kw_defaults, arg_ty
-              kwarg, asdl_expr_seq * defaults, PyArena *arena)
+_PyAST_arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args, arg_ty
+                 vararg, asdl_arg_seq * kwonlyargs, asdl_expr_seq *
+                 kw_defaults, arg_ty kwarg, asdl_expr_seq * defaults, PyArena
+                 *arena)
 {
     arguments_ty p;
     p = (arguments_ty)_PyArena_Malloc(arena, sizeof(*p));
@@ -3222,8 +3226,8 @@ _Py_arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args, arg_ty vararg,
 }
 
 arg_ty
-_Py_arg(identifier arg, expr_ty annotation, string type_comment, int lineno,
-        int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_arg(identifier arg, expr_ty annotation, string type_comment, int lineno,
+           int col_offset, int end_lineno, int end_col_offset, PyArena *arena)
 {
     arg_ty p;
     if (!arg) {
@@ -3245,8 +3249,8 @@ _Py_arg(identifier arg, expr_ty annotation, string type_comment, int lineno,
 }
 
 keyword_ty
-_Py_keyword(identifier arg, expr_ty value, int lineno, int col_offset, int
-            end_lineno, int end_col_offset, PyArena *arena)
+_PyAST_keyword(identifier arg, expr_ty value, int lineno, int col_offset, int
+               end_lineno, int end_col_offset, PyArena *arena)
 {
     keyword_ty p;
     if (!value) {
@@ -3267,7 +3271,7 @@ _Py_keyword(identifier arg, expr_ty value, int lineno, int col_offset, int
 }
 
 alias_ty
-_Py_alias(identifier name, identifier asname, PyArena *arena)
+_PyAST_alias(identifier name, identifier asname, PyArena *arena)
 {
     alias_ty p;
     if (!name) {
@@ -3284,7 +3288,7 @@ _Py_alias(identifier name, identifier asname, PyArena *arena)
 }
 
 withitem_ty
-_Py_withitem(expr_ty context_expr, expr_ty optional_vars, PyArena *arena)
+_PyAST_withitem(expr_ty context_expr, expr_ty optional_vars, PyArena *arena)
 {
     withitem_ty p;
     if (!context_expr) {
@@ -3301,8 +3305,8 @@ _Py_withitem(expr_ty context_expr, expr_ty optional_vars, PyArena *arena)
 }
 
 match_case_ty
-_Py_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq * body, PyArena
-               *arena)
+_PyAST_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq * body, PyArena
+                  *arena)
 {
     match_case_ty p;
     if (!pattern) {
@@ -3320,7 +3324,7 @@ _Py_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq * body, PyArena
 }
 
 type_ignore_ty
-_Py_TypeIgnore(int lineno, string tag, PyArena *arena)
+_PyAST_TypeIgnore(int lineno, string tag, PyArena *arena)
 {
     type_ignore_ty p;
     if (!tag) {
@@ -5037,7 +5041,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Module(body, type_ignores, arena);
+        *out = _PyAST_Module(body, type_ignores, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5082,7 +5086,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Interactive(body, arena);
+        *out = _PyAST_Interactive(body, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5107,7 +5111,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Expression(body, arena);
+        *out = _PyAST_Expression(body, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5166,7 +5170,7 @@ obj2ast_mod(struct ast_state *state, PyObject* obj, mod_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_FunctionType(argtypes, returns, arena);
+        *out = _PyAST_FunctionType(argtypes, returns, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5377,9 +5381,9 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_FunctionDef(name, args, body, decorator_list, returns,
-                               type_comment, lineno, col_offset, end_lineno,
-                               end_col_offset, arena);
+        *out = _PyAST_FunctionDef(name, args, body, decorator_list, returns,
+                                  type_comment, lineno, col_offset, end_lineno,
+                                  end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5514,9 +5518,10 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_AsyncFunctionDef(name, args, body, decorator_list, returns,
-                                    type_comment, lineno, col_offset,
-                                    end_lineno, end_col_offset, arena);
+        *out = _PyAST_AsyncFunctionDef(name, args, body, decorator_list,
+                                       returns, type_comment, lineno,
+                                       col_offset, end_lineno, end_col_offset,
+                                       arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5677,9 +5682,9 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_ClassDef(name, bases, keywords, body, decorator_list,
-                            lineno, col_offset, end_lineno, end_col_offset,
-                            arena);
+        *out = _PyAST_ClassDef(name, bases, keywords, body, decorator_list,
+                               lineno, col_offset, end_lineno, end_col_offset,
+                               arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5704,8 +5709,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Return(value, lineno, col_offset, end_lineno,
-                          end_col_offset, arena);
+        *out = _PyAST_Return(value, lineno, col_offset, end_lineno,
+                             end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5750,8 +5755,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Delete(targets, lineno, col_offset, end_lineno,
-                          end_col_offset, arena);
+        *out = _PyAST_Delete(targets, lineno, col_offset, end_lineno,
+                             end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5824,8 +5829,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Assign(targets, value, type_comment, lineno, col_offset,
-                          end_lineno, end_col_offset, arena);
+        *out = _PyAST_Assign(targets, value, type_comment, lineno, col_offset,
+                             end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5878,8 +5883,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_AugAssign(target, op, value, lineno, col_offset, end_lineno,
-                             end_col_offset, arena);
+        *out = _PyAST_AugAssign(target, op, value, lineno, col_offset,
+                                end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -5946,8 +5951,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_AnnAssign(target, annotation, value, simple, lineno,
-                             col_offset, end_lineno, end_col_offset, arena);
+        *out = _PyAST_AnnAssign(target, annotation, value, simple, lineno,
+                                col_offset, end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6068,8 +6073,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_For(target, iter, body, orelse, type_comment, lineno,
-                       col_offset, end_lineno, end_col_offset, arena);
+        *out = _PyAST_For(target, iter, body, orelse, type_comment, lineno,
+                          col_offset, end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6190,8 +6195,9 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_AsyncFor(target, iter, body, orelse, type_comment, lineno,
-                            col_offset, end_lineno, end_col_offset, arena);
+        *out = _PyAST_AsyncFor(target, iter, body, orelse, type_comment,
+                               lineno, col_offset, end_lineno, end_col_offset,
+                               arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6284,8 +6290,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_While(test, body, orelse, lineno, col_offset, end_lineno,
-                         end_col_offset, arena);
+        *out = _PyAST_While(test, body, orelse, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6378,8 +6384,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_If(test, body, orelse, lineno, col_offset, end_lineno,
-                      end_col_offset, arena);
+        *out = _PyAST_If(test, body, orelse, lineno, col_offset, end_lineno,
+                         end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6472,8 +6478,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_With(items, body, type_comment, lineno, col_offset,
-                        end_lineno, end_col_offset, arena);
+        *out = _PyAST_With(items, body, type_comment, lineno, col_offset,
+                           end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6566,8 +6572,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_AsyncWith(items, body, type_comment, lineno, col_offset,
-                             end_lineno, end_col_offset, arena);
+        *out = _PyAST_AsyncWith(items, body, type_comment, lineno, col_offset,
+                                end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6626,8 +6632,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Match(subject, cases, lineno, col_offset, end_lineno,
-                         end_col_offset, arena);
+        *out = _PyAST_Match(subject, cases, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6666,8 +6672,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Raise(exc, cause, lineno, col_offset, end_lineno,
-                         end_col_offset, arena);
+        *out = _PyAST_Raise(exc, cause, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6814,8 +6820,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Try(body, handlers, orelse, finalbody, lineno, col_offset,
-                       end_lineno, end_col_offset, arena);
+        *out = _PyAST_Try(body, handlers, orelse, finalbody, lineno,
+                          col_offset, end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6854,8 +6860,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Assert(test, msg, lineno, col_offset, end_lineno,
-                          end_col_offset, arena);
+        *out = _PyAST_Assert(test, msg, lineno, col_offset, end_lineno,
+                             end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6900,8 +6906,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Import(names, lineno, col_offset, end_lineno,
-                          end_col_offset, arena);
+        *out = _PyAST_Import(names, lineno, col_offset, end_lineno,
+                             end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -6974,8 +6980,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_ImportFrom(module, names, level, lineno, col_offset,
-                              end_lineno, end_col_offset, arena);
+        *out = _PyAST_ImportFrom(module, names, level, lineno, col_offset,
+                                 end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7020,8 +7026,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Global(names, lineno, col_offset, end_lineno,
-                          end_col_offset, arena);
+        *out = _PyAST_Global(names, lineno, col_offset, end_lineno,
+                             end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7066,8 +7072,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Nonlocal(names, lineno, col_offset, end_lineno,
-                            end_col_offset, arena);
+        *out = _PyAST_Nonlocal(names, lineno, col_offset, end_lineno,
+                               end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7092,8 +7098,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Expr(value, lineno, col_offset, end_lineno, end_col_offset,
-                        arena);
+        *out = _PyAST_Expr(value, lineno, col_offset, end_lineno,
+                           end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7104,7 +7110,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     if (isinstance) {
 
-        *out = _Py_Pass(lineno, col_offset, end_lineno, end_col_offset, arena);
+        *out = _PyAST_Pass(lineno, col_offset, end_lineno, end_col_offset,
+                           arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7115,7 +7122,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     if (isinstance) {
 
-        *out = _Py_Break(lineno, col_offset, end_lineno, end_col_offset, arena);
+        *out = _PyAST_Break(lineno, col_offset, end_lineno, end_col_offset,
+                            arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7126,8 +7134,8 @@ obj2ast_stmt(struct ast_state *state, PyObject* obj, stmt_ty* out, PyArena*
     }
     if (isinstance) {
 
-        *out = _Py_Continue(lineno, col_offset, end_lineno, end_col_offset,
-                            arena);
+        *out = _PyAST_Continue(lineno, col_offset, end_lineno, end_col_offset,
+                               arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7262,8 +7270,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_BoolOp(op, values, lineno, col_offset, end_lineno,
-                          end_col_offset, arena);
+        *out = _PyAST_BoolOp(op, values, lineno, col_offset, end_lineno,
+                             end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7302,8 +7310,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_NamedExpr(target, value, lineno, col_offset, end_lineno,
-                             end_col_offset, arena);
+        *out = _PyAST_NamedExpr(target, value, lineno, col_offset, end_lineno,
+                                end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7356,8 +7364,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_BinOp(left, op, right, lineno, col_offset, end_lineno,
-                         end_col_offset, arena);
+        *out = _PyAST_BinOp(left, op, right, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7396,8 +7404,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_UnaryOp(op, operand, lineno, col_offset, end_lineno,
-                           end_col_offset, arena);
+        *out = _PyAST_UnaryOp(op, operand, lineno, col_offset, end_lineno,
+                              end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7436,8 +7444,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Lambda(args, body, lineno, col_offset, end_lineno,
-                          end_col_offset, arena);
+        *out = _PyAST_Lambda(args, body, lineno, col_offset, end_lineno,
+                             end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7490,8 +7498,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_IfExp(test, body, orelse, lineno, col_offset, end_lineno,
-                         end_col_offset, arena);
+        *out = _PyAST_IfExp(test, body, orelse, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7570,8 +7578,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Dict(keys, values, lineno, col_offset, end_lineno,
-                        end_col_offset, arena);
+        *out = _PyAST_Dict(keys, values, lineno, col_offset, end_lineno,
+                           end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7616,8 +7624,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Set(elts, lineno, col_offset, end_lineno, end_col_offset,
-                       arena);
+        *out = _PyAST_Set(elts, lineno, col_offset, end_lineno, end_col_offset,
+                          arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7676,8 +7684,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_ListComp(elt, generators, lineno, col_offset, end_lineno,
-                            end_col_offset, arena);
+        *out = _PyAST_ListComp(elt, generators, lineno, col_offset, end_lineno,
+                               end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7736,8 +7744,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_SetComp(elt, generators, lineno, col_offset, end_lineno,
-                           end_col_offset, arena);
+        *out = _PyAST_SetComp(elt, generators, lineno, col_offset, end_lineno,
+                              end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7810,8 +7818,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_DictComp(key, value, generators, lineno, col_offset,
-                            end_lineno, end_col_offset, arena);
+        *out = _PyAST_DictComp(key, value, generators, lineno, col_offset,
+                               end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7870,8 +7878,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_GeneratorExp(elt, generators, lineno, col_offset,
-                                end_lineno, end_col_offset, arena);
+        *out = _PyAST_GeneratorExp(elt, generators, lineno, col_offset,
+                                   end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7896,8 +7904,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Await(value, lineno, col_offset, end_lineno, end_col_offset,
-                         arena);
+        *out = _PyAST_Await(value, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7922,8 +7930,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Yield(value, lineno, col_offset, end_lineno, end_col_offset,
-                         arena);
+        *out = _PyAST_Yield(value, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -7948,8 +7956,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_YieldFrom(value, lineno, col_offset, end_lineno,
-                             end_col_offset, arena);
+        *out = _PyAST_YieldFrom(value, lineno, col_offset, end_lineno,
+                                end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8042,8 +8050,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Compare(left, ops, comparators, lineno, col_offset,
-                           end_lineno, end_col_offset, arena);
+        *out = _PyAST_Compare(left, ops, comparators, lineno, col_offset,
+                              end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8136,8 +8144,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_Call(func, args, keywords, lineno, col_offset, end_lineno,
-                        end_col_offset, arena);
+        *out = _PyAST_Call(func, args, keywords, lineno, col_offset,
+                           end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8190,9 +8198,9 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_FormattedValue(value, conversion, format_spec, lineno,
-                                  col_offset, end_lineno, end_col_offset,
-                                  arena);
+        *out = _PyAST_FormattedValue(value, conversion, format_spec, lineno,
+                                     col_offset, end_lineno, end_col_offset,
+                                     arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8237,8 +8245,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_JoinedStr(values, lineno, col_offset, end_lineno,
-                             end_col_offset, arena);
+        *out = _PyAST_JoinedStr(values, lineno, col_offset, end_lineno,
+                                end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8277,8 +8285,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Constant(value, kind, lineno, col_offset, end_lineno,
-                            end_col_offset, arena);
+        *out = _PyAST_Constant(value, kind, lineno, col_offset, end_lineno,
+                               end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8331,8 +8339,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Attribute(value, attr, ctx, lineno, col_offset, end_lineno,
-                             end_col_offset, arena);
+        *out = _PyAST_Attribute(value, attr, ctx, lineno, col_offset,
+                                end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8385,8 +8393,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Subscript(value, slice, ctx, lineno, col_offset, end_lineno,
-                             end_col_offset, arena);
+        *out = _PyAST_Subscript(value, slice, ctx, lineno, col_offset,
+                                end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8425,8 +8433,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Starred(value, ctx, lineno, col_offset, end_lineno,
-                           end_col_offset, arena);
+        *out = _PyAST_Starred(value, ctx, lineno, col_offset, end_lineno,
+                              end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8465,8 +8473,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Name(id, ctx, lineno, col_offset, end_lineno,
-                        end_col_offset, arena);
+        *out = _PyAST_Name(id, ctx, lineno, col_offset, end_lineno,
+                           end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8525,8 +8533,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_List(elts, ctx, lineno, col_offset, end_lineno,
-                        end_col_offset, arena);
+        *out = _PyAST_List(elts, ctx, lineno, col_offset, end_lineno,
+                           end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8585,8 +8593,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Tuple(elts, ctx, lineno, col_offset, end_lineno,
-                         end_col_offset, arena);
+        *out = _PyAST_Tuple(elts, ctx, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8639,8 +8647,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_Slice(lower, upper, step, lineno, col_offset, end_lineno,
-                         end_col_offset, arena);
+        *out = _PyAST_Slice(lower, upper, step, lineno, col_offset, end_lineno,
+                            end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8679,8 +8687,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_MatchAs(pattern, name, lineno, col_offset, end_lineno,
-                           end_col_offset, arena);
+        *out = _PyAST_MatchAs(pattern, name, lineno, col_offset, end_lineno,
+                              end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -8725,8 +8733,8 @@ obj2ast_expr(struct ast_state *state, PyObject* obj, expr_ty* out, PyArena*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_MatchOr(patterns, lineno, col_offset, end_lineno,
-                           end_col_offset, arena);
+        *out = _PyAST_MatchOr(patterns, lineno, col_offset, end_lineno,
+                              end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -9130,7 +9138,7 @@ obj2ast_comprehension(struct ast_state *state, PyObject* obj, comprehension_ty*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    *out = _Py_comprehension(target, iter, ifs, is_async, arena);
+    *out = _PyAST_comprehension(target, iter, ifs, is_async, arena);
     return 0;
 failed:
     Py_XDECREF(tmp);
@@ -9275,8 +9283,8 @@ obj2ast_excepthandler(struct ast_state *state, PyObject* obj, excepthandler_ty*
             }
             Py_CLEAR(tmp);
         }
-        *out = _Py_ExceptHandler(type, name, body, lineno, col_offset,
-                                 end_lineno, end_col_offset, arena);
+        *out = _PyAST_ExceptHandler(type, name, body, lineno, col_offset,
+                                    end_lineno, end_col_offset, arena);
         if (*out == NULL) goto failed;
         return 0;
     }
@@ -9491,8 +9499,8 @@ obj2ast_arguments(struct ast_state *state, PyObject* obj, arguments_ty* out,
         }
         Py_CLEAR(tmp);
     }
-    *out = _Py_arguments(posonlyargs, args, vararg, kwonlyargs, kw_defaults,
-                         kwarg, defaults, arena);
+    *out = _PyAST_arguments(posonlyargs, args, vararg, kwonlyargs, kw_defaults,
+                            kwarg, defaults, arena);
     return 0;
 failed:
     Py_XDECREF(tmp);
@@ -9602,8 +9610,8 @@ obj2ast_arg(struct ast_state *state, PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    *out = _Py_arg(arg, annotation, type_comment, lineno, col_offset,
-                   end_lineno, end_col_offset, arena);
+    *out = _PyAST_arg(arg, annotation, type_comment, lineno, col_offset,
+                      end_lineno, end_col_offset, arena);
     return 0;
 failed:
     Py_XDECREF(tmp);
@@ -9700,8 +9708,8 @@ obj2ast_keyword(struct ast_state *state, PyObject* obj, keyword_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    *out = _Py_keyword(arg, value, lineno, col_offset, end_lineno,
-                       end_col_offset, arena);
+    *out = _PyAST_keyword(arg, value, lineno, col_offset, end_lineno,
+                          end_col_offset, arena);
     return 0;
 failed:
     Py_XDECREF(tmp);
@@ -9742,7 +9750,7 @@ obj2ast_alias(struct ast_state *state, PyObject* obj, alias_ty* out, PyArena*
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    *out = _Py_alias(name, asname, arena);
+    *out = _PyAST_alias(name, asname, arena);
     return 0;
 failed:
     Py_XDECREF(tmp);
@@ -9783,7 +9791,7 @@ obj2ast_withitem(struct ast_state *state, PyObject* obj, withitem_ty* out,
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    *out = _Py_withitem(context_expr, optional_vars, arena);
+    *out = _PyAST_withitem(context_expr, optional_vars, arena);
     return 0;
 failed:
     Py_XDECREF(tmp);
@@ -9858,7 +9866,7 @@ obj2ast_match_case(struct ast_state *state, PyObject* obj, match_case_ty* out,
         }
         Py_CLEAR(tmp);
     }
-    *out = _Py_match_case(pattern, guard, body, arena);
+    *out = _PyAST_match_case(pattern, guard, body, arena);
     return 0;
 failed:
     Py_XDECREF(tmp);
@@ -9913,7 +9921,7 @@ obj2ast_type_ignore(struct ast_state *state, PyObject* obj, type_ignore_ty*
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = _Py_TypeIgnore(lineno, tag, arena);
+        *out = _PyAST_TypeIgnore(lineno, tag, arena);
         if (*out == NULL) goto failed;
         return 0;
     }

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -451,8 +451,9 @@ astfold_body(asdl_stmt_seq *stmts, PyArena *ctx_, _PyASTOptimizeState *state)
             return 0;
         }
         asdl_seq_SET(values, 0, st->v.Expr.value);
-        expr_ty expr = _Py_JoinedStr(values, st->lineno, st->col_offset,
-                                     st->end_lineno, st->end_col_offset, ctx_);
+        expr_ty expr = _PyAST_JoinedStr(values, st->lineno, st->col_offset,
+                                        st->end_lineno, st->end_col_offset,
+                                        ctx_);
         if (!expr) {
             return 0;
         }


### PR DESCRIPTION
Rename AST functions of pycore_ast.h to use the "_PyAST_" prefix.
Remove macros creating aliases without prefix. For example, Module()
becomes _PyAST_Module(). Update Grammar/python.gram to use
_PyAST_xxx() functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43244](https://bugs.python.org/issue43244) -->
https://bugs.python.org/issue43244
<!-- /issue-number -->
