### PR TITLE
bpo-43244: Remove aliases from pycore_ast.h

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -28,9 +28,9 @@ _PyPegen_parse(Parser *p)
 // The end
 '''
 file[mod_ty]: a=[statements] ENDMARKER { _PyPegen_make_module(p, a) }
-interactive[mod_ty]: a=statement_newline { Interactive(a, p->arena) }
-eval[mod_ty]: a=expressions NEWLINE* ENDMARKER { Expression(a, p->arena) }
-func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression NEWLINE* ENDMARKER { FunctionType(a, b, p->arena) }
+interactive[mod_ty]: a=statement_newline { _Py_Interactive(a, p->arena) }
+eval[mod_ty]: a=expressions NEWLINE* ENDMARKER { _Py_Expression(a, p->arena) }
+func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression NEWLINE* ENDMARKER { _Py_FunctionType(a, b, p->arena) }
 fstring[expr_ty]: star_expressions
 
 # type_expressions allow */** but ignore them
@@ -856,7 +856,7 @@ invalid_except_block:
     | 'except' a=expression ',' expressions ['as' NAME ] ':' {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "exception group must be parenthesized") }
     | 'except' expression ['as' NAME ] &&':'
-    | 'except' &&':' 
+    | 'except' &&':'
 
 invalid_match_stmt:
     | "match" subject_expr !':' { CHECK_VERSION(void*, 10, "Pattern matching is", RAISE_SYNTAX_ERROR("expected ':'") ) }

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -570,251 +570,184 @@ struct _type_ignore {
 
 
 // Note: these macros affect function definitions, not only call sites.
-#define Module(a0, a1, a2) _Py_Module(a0, a1, a2)
 mod_ty _Py_Module(asdl_stmt_seq * body, asdl_type_ignore_seq * type_ignores,
                   PyArena *arena);
-#define Interactive(a0, a1) _Py_Interactive(a0, a1)
 mod_ty _Py_Interactive(asdl_stmt_seq * body, PyArena *arena);
-#define Expression(a0, a1) _Py_Expression(a0, a1)
 mod_ty _Py_Expression(expr_ty body, PyArena *arena);
-#define FunctionType(a0, a1, a2) _Py_FunctionType(a0, a1, a2)
 mod_ty _Py_FunctionType(asdl_expr_seq * argtypes, expr_ty returns, PyArena
                         *arena);
-#define FunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) _Py_FunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
 stmt_ty _Py_FunctionDef(identifier name, arguments_ty args, asdl_stmt_seq *
                         body, asdl_expr_seq * decorator_list, expr_ty returns,
                         string type_comment, int lineno, int col_offset, int
                         end_lineno, int end_col_offset, PyArena *arena);
-#define AsyncFunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) _Py_AsyncFunctionDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
 stmt_ty _Py_AsyncFunctionDef(identifier name, arguments_ty args, asdl_stmt_seq
                              * body, asdl_expr_seq * decorator_list, expr_ty
                              returns, string type_comment, int lineno, int
                              col_offset, int end_lineno, int end_col_offset,
                              PyArena *arena);
-#define ClassDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_ClassDef(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
 stmt_ty _Py_ClassDef(identifier name, asdl_expr_seq * bases, asdl_keyword_seq *
                      keywords, asdl_stmt_seq * body, asdl_expr_seq *
                      decorator_list, int lineno, int col_offset, int
                      end_lineno, int end_col_offset, PyArena *arena);
-#define Return(a0, a1, a2, a3, a4, a5) _Py_Return(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Return(expr_ty value, int lineno, int col_offset, int end_lineno,
                    int end_col_offset, PyArena *arena);
-#define Delete(a0, a1, a2, a3, a4, a5) _Py_Delete(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Delete(asdl_expr_seq * targets, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
-#define Assign(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Assign(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_Assign(asdl_expr_seq * targets, expr_ty value, string type_comment,
                    int lineno, int col_offset, int end_lineno, int
                    end_col_offset, PyArena *arena);
-#define AugAssign(a0, a1, a2, a3, a4, a5, a6, a7) _Py_AugAssign(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_AugAssign(expr_ty target, operator_ty op, expr_ty value, int
                       lineno, int col_offset, int end_lineno, int
                       end_col_offset, PyArena *arena);
-#define AnnAssign(a0, a1, a2, a3, a4, a5, a6, a7, a8) _Py_AnnAssign(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 stmt_ty _Py_AnnAssign(expr_ty target, expr_ty annotation, expr_ty value, int
                       simple, int lineno, int col_offset, int end_lineno, int
                       end_col_offset, PyArena *arena);
-#define For(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_For(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
 stmt_ty _Py_For(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
                 asdl_stmt_seq * orelse, string type_comment, int lineno, int
                 col_offset, int end_lineno, int end_col_offset, PyArena *arena);
-#define AsyncFor(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) _Py_AsyncFor(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
 stmt_ty _Py_AsyncFor(expr_ty target, expr_ty iter, asdl_stmt_seq * body,
                      asdl_stmt_seq * orelse, string type_comment, int lineno,
                      int col_offset, int end_lineno, int end_col_offset,
                      PyArena *arena);
-#define While(a0, a1, a2, a3, a4, a5, a6, a7) _Py_While(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse,
                   int lineno, int col_offset, int end_lineno, int
                   end_col_offset, PyArena *arena);
-#define If(a0, a1, a2, a3, a4, a5, a6, a7) _Py_If(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse, int
                lineno, int col_offset, int end_lineno, int end_col_offset,
                PyArena *arena);
-#define With(a0, a1, a2, a3, a4, a5, a6, a7) _Py_With(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string
                  type_comment, int lineno, int col_offset, int end_lineno, int
                  end_col_offset, PyArena *arena);
-#define AsyncWith(a0, a1, a2, a3, a4, a5, a6, a7) _Py_AsyncWith(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_AsyncWith(asdl_withitem_seq * items, asdl_stmt_seq * body, string
                       type_comment, int lineno, int col_offset, int end_lineno,
                       int end_col_offset, PyArena *arena);
-#define Match(a0, a1, a2, a3, a4, a5, a6) _Py_Match(a0, a1, a2, a3, a4, a5, a6)
 stmt_ty _Py_Match(expr_ty subject, asdl_match_case_seq * cases, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
-#define Raise(a0, a1, a2, a3, a4, a5, a6) _Py_Raise(a0, a1, a2, a3, a4, a5, a6)
 stmt_ty _Py_Raise(expr_ty exc, expr_ty cause, int lineno, int col_offset, int
                   end_lineno, int end_col_offset, PyArena *arena);
-#define Try(a0, a1, a2, a3, a4, a5, a6, a7, a8) _Py_Try(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 stmt_ty _Py_Try(asdl_stmt_seq * body, asdl_excepthandler_seq * handlers,
                 asdl_stmt_seq * orelse, asdl_stmt_seq * finalbody, int lineno,
                 int col_offset, int end_lineno, int end_col_offset, PyArena
                 *arena);
-#define Assert(a0, a1, a2, a3, a4, a5, a6) _Py_Assert(a0, a1, a2, a3, a4, a5, a6)
 stmt_ty _Py_Assert(expr_ty test, expr_ty msg, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
-#define Import(a0, a1, a2, a3, a4, a5) _Py_Import(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Import(asdl_alias_seq * names, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
-#define ImportFrom(a0, a1, a2, a3, a4, a5, a6, a7) _Py_ImportFrom(a0, a1, a2, a3, a4, a5, a6, a7)
 stmt_ty _Py_ImportFrom(identifier module, asdl_alias_seq * names, int level,
                        int lineno, int col_offset, int end_lineno, int
                        end_col_offset, PyArena *arena);
-#define Global(a0, a1, a2, a3, a4, a5) _Py_Global(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Global(asdl_identifier_seq * names, int lineno, int col_offset, int
                    end_lineno, int end_col_offset, PyArena *arena);
-#define Nonlocal(a0, a1, a2, a3, a4, a5) _Py_Nonlocal(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Nonlocal(asdl_identifier_seq * names, int lineno, int col_offset,
                      int end_lineno, int end_col_offset, PyArena *arena);
-#define Expr(a0, a1, a2, a3, a4, a5) _Py_Expr(a0, a1, a2, a3, a4, a5)
 stmt_ty _Py_Expr(expr_ty value, int lineno, int col_offset, int end_lineno, int
                  end_col_offset, PyArena *arena);
-#define Pass(a0, a1, a2, a3, a4) _Py_Pass(a0, a1, a2, a3, a4)
 stmt_ty _Py_Pass(int lineno, int col_offset, int end_lineno, int
                  end_col_offset, PyArena *arena);
-#define Break(a0, a1, a2, a3, a4) _Py_Break(a0, a1, a2, a3, a4)
 stmt_ty _Py_Break(int lineno, int col_offset, int end_lineno, int
                   end_col_offset, PyArena *arena);
-#define Continue(a0, a1, a2, a3, a4) _Py_Continue(a0, a1, a2, a3, a4)
 stmt_ty _Py_Continue(int lineno, int col_offset, int end_lineno, int
                      end_col_offset, PyArena *arena);
-#define BoolOp(a0, a1, a2, a3, a4, a5, a6) _Py_BoolOp(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_BoolOp(boolop_ty op, asdl_expr_seq * values, int lineno, int
                    col_offset, int end_lineno, int end_col_offset, PyArena
                    *arena);
-#define NamedExpr(a0, a1, a2, a3, a4, a5, a6) _Py_NamedExpr(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_NamedExpr(expr_ty target, expr_ty value, int lineno, int
                       col_offset, int end_lineno, int end_col_offset, PyArena
                       *arena);
-#define BinOp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_BinOp(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_BinOp(expr_ty left, operator_ty op, expr_ty right, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
-#define UnaryOp(a0, a1, a2, a3, a4, a5, a6) _Py_UnaryOp(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_UnaryOp(unaryop_ty op, expr_ty operand, int lineno, int col_offset,
                     int end_lineno, int end_col_offset, PyArena *arena);
-#define Lambda(a0, a1, a2, a3, a4, a5, a6) _Py_Lambda(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_Lambda(arguments_ty args, expr_ty body, int lineno, int col_offset,
                    int end_lineno, int end_col_offset, PyArena *arena);
-#define IfExp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_IfExp(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_IfExp(expr_ty test, expr_ty body, expr_ty orelse, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
-#define Dict(a0, a1, a2, a3, a4, a5, a6) _Py_Dict(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_Dict(asdl_expr_seq * keys, asdl_expr_seq * values, int lineno, int
                  col_offset, int end_lineno, int end_col_offset, PyArena
                  *arena);
-#define Set(a0, a1, a2, a3, a4, a5) _Py_Set(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_Set(asdl_expr_seq * elts, int lineno, int col_offset, int
                 end_lineno, int end_col_offset, PyArena *arena);
-#define ListComp(a0, a1, a2, a3, a4, a5, a6) _Py_ListComp(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_ListComp(expr_ty elt, asdl_comprehension_seq * generators, int
                      lineno, int col_offset, int end_lineno, int
                      end_col_offset, PyArena *arena);
-#define SetComp(a0, a1, a2, a3, a4, a5, a6) _Py_SetComp(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_SetComp(expr_ty elt, asdl_comprehension_seq * generators, int
                     lineno, int col_offset, int end_lineno, int end_col_offset,
                     PyArena *arena);
-#define DictComp(a0, a1, a2, a3, a4, a5, a6, a7) _Py_DictComp(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_DictComp(expr_ty key, expr_ty value, asdl_comprehension_seq *
                      generators, int lineno, int col_offset, int end_lineno,
                      int end_col_offset, PyArena *arena);
-#define GeneratorExp(a0, a1, a2, a3, a4, a5, a6) _Py_GeneratorExp(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_GeneratorExp(expr_ty elt, asdl_comprehension_seq * generators, int
                          lineno, int col_offset, int end_lineno, int
                          end_col_offset, PyArena *arena);
-#define Await(a0, a1, a2, a3, a4, a5) _Py_Await(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_Await(expr_ty value, int lineno, int col_offset, int end_lineno,
                   int end_col_offset, PyArena *arena);
 expr_ty _Py_Yield(expr_ty value, int lineno, int col_offset, int end_lineno,
                   int end_col_offset, PyArena *arena);
-#define YieldFrom(a0, a1, a2, a3, a4, a5) _Py_YieldFrom(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_YieldFrom(expr_ty value, int lineno, int col_offset, int
                       end_lineno, int end_col_offset, PyArena *arena);
-#define Compare(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Compare(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_Compare(expr_ty left, asdl_int_seq * ops, asdl_expr_seq *
                     comparators, int lineno, int col_offset, int end_lineno,
                     int end_col_offset, PyArena *arena);
-#define Call(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Call(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_Call(expr_ty func, asdl_expr_seq * args, asdl_keyword_seq *
                  keywords, int lineno, int col_offset, int end_lineno, int
                  end_col_offset, PyArena *arena);
-#define FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7) _Py_FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_FormattedValue(expr_ty value, int conversion, expr_ty format_spec,
                            int lineno, int col_offset, int end_lineno, int
                            end_col_offset, PyArena *arena);
-#define JoinedStr(a0, a1, a2, a3, a4, a5) _Py_JoinedStr(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_JoinedStr(asdl_expr_seq * values, int lineno, int col_offset, int
                       end_lineno, int end_col_offset, PyArena *arena);
-#define Constant(a0, a1, a2, a3, a4, a5, a6) _Py_Constant(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_Constant(constant value, string kind, int lineno, int col_offset,
                      int end_lineno, int end_col_offset, PyArena *arena);
-#define Attribute(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Attribute(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_Attribute(expr_ty value, identifier attr, expr_context_ty ctx, int
                       lineno, int col_offset, int end_lineno, int
                       end_col_offset, PyArena *arena);
-#define Subscript(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Subscript(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_Subscript(expr_ty value, expr_ty slice, expr_context_ty ctx, int
                       lineno, int col_offset, int end_lineno, int
                       end_col_offset, PyArena *arena);
-#define Starred(a0, a1, a2, a3, a4, a5, a6) _Py_Starred(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_Starred(expr_ty value, expr_context_ty ctx, int lineno, int
                     col_offset, int end_lineno, int end_col_offset, PyArena
                     *arena);
-#define Name(a0, a1, a2, a3, a4, a5, a6) _Py_Name(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_Name(identifier id, expr_context_ty ctx, int lineno, int
                  col_offset, int end_lineno, int end_col_offset, PyArena
                  *arena);
-#define List(a0, a1, a2, a3, a4, a5, a6) _Py_List(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_List(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
                  col_offset, int end_lineno, int end_col_offset, PyArena
                  *arena);
-#define Tuple(a0, a1, a2, a3, a4, a5, a6) _Py_Tuple(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_Tuple(asdl_expr_seq * elts, expr_context_ty ctx, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
-#define Slice(a0, a1, a2, a3, a4, a5, a6, a7) _Py_Slice(a0, a1, a2, a3, a4, a5, a6, a7)
 expr_ty _Py_Slice(expr_ty lower, expr_ty upper, expr_ty step, int lineno, int
                   col_offset, int end_lineno, int end_col_offset, PyArena
                   *arena);
-#define MatchAs(a0, a1, a2, a3, a4, a5, a6) _Py_MatchAs(a0, a1, a2, a3, a4, a5, a6)
 expr_ty _Py_MatchAs(expr_ty pattern, identifier name, int lineno, int
                     col_offset, int end_lineno, int end_col_offset, PyArena
                     *arena);
-#define MatchOr(a0, a1, a2, a3, a4, a5) _Py_MatchOr(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_MatchOr(asdl_expr_seq * patterns, int lineno, int col_offset, int
                     end_lineno, int end_col_offset, PyArena *arena);
-#define comprehension(a0, a1, a2, a3, a4) _Py_comprehension(a0, a1, a2, a3, a4)
 comprehension_ty _Py_comprehension(expr_ty target, expr_ty iter, asdl_expr_seq
                                    * ifs, int is_async, PyArena *arena);
-#define ExceptHandler(a0, a1, a2, a3, a4, a5, a6, a7) _Py_ExceptHandler(a0, a1, a2, a3, a4, a5, a6, a7)
 excepthandler_ty _Py_ExceptHandler(expr_ty type, identifier name, asdl_stmt_seq
                                    * body, int lineno, int col_offset, int
                                    end_lineno, int end_col_offset, PyArena
                                    *arena);
-#define arguments(a0, a1, a2, a3, a4, a5, a6, a7) _Py_arguments(a0, a1, a2, a3, a4, a5, a6, a7)
 arguments_ty _Py_arguments(asdl_arg_seq * posonlyargs, asdl_arg_seq * args,
                            arg_ty vararg, asdl_arg_seq * kwonlyargs,
                            asdl_expr_seq * kw_defaults, arg_ty kwarg,
                            asdl_expr_seq * defaults, PyArena *arena);
-#define arg(a0, a1, a2, a3, a4, a5, a6, a7) _Py_arg(a0, a1, a2, a3, a4, a5, a6, a7)
 arg_ty _Py_arg(identifier arg, expr_ty annotation, string type_comment, int
                lineno, int col_offset, int end_lineno, int end_col_offset,
                PyArena *arena);
-#define keyword(a0, a1, a2, a3, a4, a5, a6) _Py_keyword(a0, a1, a2, a3, a4, a5, a6)
 keyword_ty _Py_keyword(identifier arg, expr_ty value, int lineno, int
                        col_offset, int end_lineno, int end_col_offset, PyArena
                        *arena);
-#define alias(a0, a1, a2) _Py_alias(a0, a1, a2)
 alias_ty _Py_alias(identifier name, identifier asname, PyArena *arena);
-#define withitem(a0, a1, a2) _Py_withitem(a0, a1, a2)
 withitem_ty _Py_withitem(expr_ty context_expr, expr_ty optional_vars, PyArena
                          *arena);
-#define match_case(a0, a1, a2, a3) _Py_match_case(a0, a1, a2, a3)
 match_case_ty _Py_match_case(expr_ty pattern, expr_ty guard, asdl_stmt_seq *
                              body, PyArena *arena);
-#define TypeIgnore(a0, a1, a2) _Py_TypeIgnore(a0, a1, a2)
 type_ignore_ty _Py_TypeIgnore(int lineno, string tag, PyArena *arena);
 
 

--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -96,7 +96,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_c_parser(self) -> None:
         grammar_source = """
-        start[mod_ty]: a[asdl_stmt_seq*]=stmt* $ { Module(a, NULL, p->arena) }
+        start[mod_ty]: a[asdl_stmt_seq*]=stmt* $ { _Py_Module(a, NULL, p->arena) }
         stmt[stmt_ty]: a=expr_stmt { a }
         expr_stmt[stmt_ty]: a=expression NEWLINE { _Py_Expr(a, EXTRA) }
         expression[expr_ty]: ( l=expression '+' r=term { _Py_BinOp(l, Add, r, EXTRA) }
@@ -237,7 +237,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_return_stmt_noexpr_action(self) -> None:
         grammar_source = """
-        start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
+        start[mod_ty]: a=[statements] ENDMARKER { _Py_Module(a, NULL, p->arena) }
         statements[asdl_stmt_seq*]: a[asdl_stmt_seq*]=statement+ { a }
         statement[stmt_ty]: simple_stmt
         simple_stmt[stmt_ty]: small_stmt
@@ -252,7 +252,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_gather_action_ast(self) -> None:
         grammar_source = """
-        start[mod_ty]: a[asdl_stmt_seq*]=';'.pass_stmt+ NEWLINE ENDMARKER { Module(a, NULL, p->arena) }
+        start[mod_ty]: a[asdl_stmt_seq*]=';'.pass_stmt+ NEWLINE ENDMARKER { _Py_Module(a, NULL, p->arena) }
         pass_stmt[stmt_ty]: a='pass' { _Py_Pass(EXTRA)}
         """
         test_source = """
@@ -263,7 +263,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_pass_stmt_action(self) -> None:
         grammar_source = """
-        start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
+        start[mod_ty]: a=[statements] ENDMARKER { _Py_Module(a, NULL, p->arena) }
         statements[asdl_stmt_seq*]: a[asdl_stmt_seq*]=statement+ { a }
         statement[stmt_ty]: simple_stmt
         simple_stmt[stmt_ty]: small_stmt
@@ -278,7 +278,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_if_stmt_action(self) -> None:
         grammar_source = """
-        start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
+        start[mod_ty]: a=[statements] ENDMARKER { _Py_Module(a, NULL, p->arena) }
         statements[asdl_stmt_seq*]: a=statement+ { (asdl_stmt_seq*)_PyPegen_seq_flatten(p, a) }
         statement[asdl_stmt_seq*]:  a=compound_stmt { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, a) } | simple_stmt
 
@@ -306,7 +306,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_same_name_different_types(self) -> None:
         grammar_source = """
-        start[mod_ty]: a[asdl_stmt_seq*]=import_from+ NEWLINE ENDMARKER { Module(a, NULL, p->arena)}
+        start[mod_ty]: a[asdl_stmt_seq*]=import_from+ NEWLINE ENDMARKER { _Py_Module(a, NULL, p->arena)}
         import_from[stmt_ty]: ( a='from' !'import' c=simple_name 'import' d=import_as_names_from {
                                 _Py_ImportFrom(c->v.Name.id, d, 0, EXTRA) }
                             | a='from' '.' 'import' c=import_as_names_from {
@@ -326,7 +326,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_with_stmt_with_paren(self) -> None:
         grammar_source = """
-        start[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
+        start[mod_ty]: a=[statements] ENDMARKER { _Py_Module(a, NULL, p->arena) }
         statements[asdl_stmt_seq*]: a=statement+ { (asdl_stmt_seq*)_PyPegen_seq_flatten(p, a) }
         statement[asdl_stmt_seq*]: a=compound_stmt { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, a) }
         compound_stmt[stmt_ty]: with_stmt
@@ -352,7 +352,7 @@ class TestCParser(TempdirManager, unittest.TestCase):
 
     def test_ternary_operator(self) -> None:
         grammar_source = """
-        start[mod_ty]: a=expr ENDMARKER { Module(a, NULL, p->arena) }
+        start[mod_ty]: a=expr ENDMARKER { _Py_Module(a, NULL, p->arena) }
         expr[asdl_stmt_seq*]: a=listcomp NEWLINE { (asdl_stmt_seq*)_PyPegen_singleton_seq(p, _Py_Expr(a, EXTRA)) }
         listcomp[expr_ty]: (
             a='[' b=NAME c=for_if_clauses d=']' { _Py_ListComp(b, c, EXTRA) }

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -264,6 +264,10 @@ class StructVisitor(EmitVisitor):
         self.emit("", depth)
 
 
+def ast_func_name(name):
+    return f"_Py_{name}"
+
+
 class PrototypeVisitor(EmitVisitor):
     """Generate function prototypes for the .h file"""
 
@@ -322,26 +326,13 @@ class PrototypeVisitor(EmitVisitor):
             argstr += ", PyArena *arena"
         else:
             argstr = "PyArena *arena"
-        margs = "a0"
-        for i in range(1, len(args)+1):
-            margs += ", a%d" % i
-        # bpo-43244: <winbase.h> defines Yield macro. Don't redefine it in
-        # pycore_ast.h: it is not needed outside Python-ast.c which calls
-        # directly _Py_Yield().
-        if name != "Yield":
-            self.emit("#define %s(%s) _Py_%s(%s)" % (name, margs, name, margs), 0,
-                    reflow=False)
-        self.emit("%s _Py_%s(%s);" % (ctype, name, argstr), False)
+        self.emit("%s %s(%s);" % (ctype, ast_func_name(name), argstr), False)
 
     def visitProduct(self, prod, name):
         self.emit_function(name, get_c_type(name),
                            self.get_args(prod.fields),
                            self.get_args(prod.attributes),
                            union=False)
-
-
-def pyfunc_name(name):
-    return f"_Py_{name}"
 
 
 class FunctionVisitor(PrototypeVisitor):
@@ -357,7 +348,7 @@ class FunctionVisitor(PrototypeVisitor):
         else:
             argstr = "PyArena *arena"
         self.emit("%s" % ctype, 0)
-        emit("%s(%s)" % (pyfunc_name(name), argstr))
+        emit("%s(%s)" % (ast_func_name(name), argstr))
         emit("{")
         emit("%s p;" % ctype, 1)
         for argtype, argname, opt in args:
@@ -496,7 +487,7 @@ class Obj2ModVisitor(PickleVisitor):
             for f in t.fields:
                 self.visitField(f, t.name, sum=sum, depth=2)
             args = [f.name for f in t.fields] + [a.name for a in sum.attributes]
-            self.emit("*out = %s(%s);" % (pyfunc_name(t.name), self.buildArgs(args)), 2)
+            self.emit("*out = %s(%s);" % (ast_func_name(t.name), self.buildArgs(args)), 2)
             self.emit("if (*out == NULL) goto failed;", 2)
             self.emit("return 0;", 2)
             self.emit("}", 1)
@@ -529,7 +520,7 @@ class Obj2ModVisitor(PickleVisitor):
             self.visitField(a, name, prod=prod, depth=1)
         args = [f.name for f in prod.fields]
         args.extend([a.name for a in prod.attributes])
-        self.emit("*out = %s(%s);" % (pyfunc_name(name), self.buildArgs(args)), 1)
+        self.emit("*out = %s(%s);" % (ast_func_name(name), self.buildArgs(args)), 1)
         self.emit("return 0;", 1)
         self.emit("failed:", 0)
         self.emit("Py_XDECREF(tmp);", 1)

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -897,7 +897,7 @@ interactive_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ interactive[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "statement_newline"));
-            _res = Interactive ( a , p -> arena );
+            _res = _Py_Interactive ( a , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -944,7 +944,7 @@ eval_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ eval[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expressions NEWLINE* $"));
-            _res = Expression ( a , p -> arena );
+            _res = _Py_Expression ( a , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);
@@ -1003,7 +1003,7 @@ func_type_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ func_type[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'(' type_expressions? ')' '->' expression NEWLINE* $"));
-            _res = FunctionType ( a , b , p -> arena );
+            _res = _Py_FunctionType ( a , b , p -> arena );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -34,9 +34,9 @@ _PyPegen_add_type_comment_to_arg(Parser *p, arg_ty a, Token *tc)
     if (tco == NULL) {
         return NULL;
     }
-    return arg(a->arg, a->annotation, tco,
-               a->lineno, a->col_offset, a->end_lineno, a->end_col_offset,
-               p->arena);
+    return _Py_arg(a->arg, a->annotation, tco,
+                   a->lineno, a->col_offset, a->end_lineno, a->end_col_offset,
+                   p->arena);
 }
 
 static int
@@ -568,7 +568,7 @@ _PyPegen_dummy_name(Parser *p, ...)
     if (!id) {
         return NULL;
     }
-    cache = Name(id, Load, 1, 0, 1, 0, p->arena);
+    cache = _Py_Name(id, Load, 1, 0, 1, 0, p->arena);
     return cache;
 }
 
@@ -919,8 +919,8 @@ _PyPegen_name_token(Parser *p)
         p->error_indicator = 1;
         return NULL;
     }
-    return Name(id, Load, t->lineno, t->col_offset, t->end_lineno, t->end_col_offset,
-                p->arena);
+    return _Py_Name(id, Load, t->lineno, t->col_offset, t->end_lineno,
+                    t->end_col_offset, p->arena);
 }
 
 void *
@@ -1035,8 +1035,8 @@ _PyPegen_number_token(Parser *p)
         return NULL;
     }
 
-    return Constant(c, NULL, t->lineno, t->col_offset, t->end_lineno, t->end_col_offset,
-                    p->arena);
+    return _Py_Constant(c, NULL, t->lineno, t->col_offset, t->end_lineno,
+                        t->end_col_offset, p->arena);
 }
 
 static int // bool
@@ -1551,7 +1551,7 @@ _PyPegen_alias_for_star(Parser *p)
         Py_DECREF(str);
         return NULL;
     }
-    return alias(str, NULL, p->arena);
+    return _Py_alias(str, NULL, p->arena);
 }
 
 /* Creates a new asdl_seq* with the identifiers of all the names in seq */
@@ -1667,19 +1667,22 @@ _set_list_context(Parser *p, expr_ty e, expr_context_ty ctx)
 static expr_ty
 _set_subscript_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Subscript(e->v.Subscript.value, e->v.Subscript.slice, ctx, EXTRA_EXPR(e, e));
+    return _Py_Subscript(e->v.Subscript.value, e->v.Subscript.slice,
+                         ctx, EXTRA_EXPR(e, e));
 }
 
 static expr_ty
 _set_attribute_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Attribute(e->v.Attribute.value, e->v.Attribute.attr, ctx, EXTRA_EXPR(e, e));
+    return _Py_Attribute(e->v.Attribute.value, e->v.Attribute.attr,
+                         ctx, EXTRA_EXPR(e, e));
 }
 
 static expr_ty
 _set_starred_context(Parser *p, expr_ty e, expr_context_ty ctx)
 {
-    return _Py_Starred(_PyPegen_set_expr_context(p, e->v.Starred.value, ctx), ctx, EXTRA_EXPR(e, e));
+    return _Py_Starred(_PyPegen_set_expr_context(p, e->v.Starred.value, ctx),
+                       ctx, EXTRA_EXPR(e, e));
 }
 
 /* Creates an `expr_ty` equivalent to `expr` but with `ctx` as context */
@@ -1987,8 +1990,8 @@ _PyPegen_make_arguments(Parser *p, asdl_arg_seq *slash_without_default,
         kwarg = star_etc->kwarg;
     }
 
-    return _Py_arguments(posonlyargs, posargs, vararg, kwonlyargs, kwdefaults, kwarg,
-                         posdefaults, p->arena);
+    return _Py_arguments(posonlyargs, posargs, vararg, kwonlyargs,
+                         kwdefaults, kwarg, posdefaults, p->arena);
 }
 
 /* Constructs an empty arguments_ty object, that gets used when a function accepts no
@@ -2017,8 +2020,8 @@ _PyPegen_empty_arguments(Parser *p)
         return NULL;
     }
 
-    return _Py_arguments(posonlyargs, posargs, NULL, kwonlyargs, kwdefaults, NULL, posdefaults,
-                         p->arena);
+    return _Py_arguments(posonlyargs, posargs, NULL, kwonlyargs,
+                         kwdefaults, NULL, posdefaults, p->arena);
 }
 
 /* Encapsulates the value of an operator_ty into an AugOperator struct */
@@ -2047,12 +2050,13 @@ _PyPegen_function_def_decorators(Parser *p, asdl_expr_seq *decorators, stmt_ty f
             p->arena);
     }
 
-    return _Py_FunctionDef(function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
-                           function_def->v.FunctionDef.body, decorators,
-                           function_def->v.FunctionDef.returns,
-                           function_def->v.FunctionDef.type_comment, function_def->lineno,
-                           function_def->col_offset, function_def->end_lineno,
-                           function_def->end_col_offset, p->arena);
+    return _Py_FunctionDef(
+        function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
+        function_def->v.FunctionDef.body, decorators,
+        function_def->v.FunctionDef.returns,
+        function_def->v.FunctionDef.type_comment, function_def->lineno,
+        function_def->col_offset, function_def->end_lineno,
+        function_def->end_col_offset, p->arena);
 }
 
 /* Construct a ClassDef equivalent to class_def, but with decorators */
@@ -2060,10 +2064,11 @@ stmt_ty
 _PyPegen_class_def_decorators(Parser *p, asdl_expr_seq *decorators, stmt_ty class_def)
 {
     assert(class_def != NULL);
-    return _Py_ClassDef(class_def->v.ClassDef.name, class_def->v.ClassDef.bases,
-                        class_def->v.ClassDef.keywords, class_def->v.ClassDef.body, decorators,
-                        class_def->lineno, class_def->col_offset, class_def->end_lineno,
-                        class_def->end_col_offset, p->arena);
+    return _Py_ClassDef(
+        class_def->v.ClassDef.name, class_def->v.ClassDef.bases,
+        class_def->v.ClassDef.keywords, class_def->v.ClassDef.body, decorators,
+        class_def->lineno, class_def->col_offset, class_def->end_lineno,
+        class_def->end_col_offset, p->arena);
 }
 
 /* Construct a KeywordOrStarred */
@@ -2214,8 +2219,9 @@ _PyPegen_concatenate_strings(Parser *p, asdl_seq *strings)
         if (_PyArena_AddPyObject(p->arena, bytes_str) < 0) {
             goto error;
         }
-        return Constant(bytes_str, NULL, first->lineno, first->col_offset, last->end_lineno,
-                        last->end_col_offset, p->arena);
+        return _Py_Constant(bytes_str, NULL, first->lineno,
+                            first->col_offset, last->end_lineno,
+                            last->end_col_offset, p->arena);
     }
 
     return _PyPegen_FstringParser_Finish(p, &state, first, last);
@@ -2244,14 +2250,15 @@ _PyPegen_make_module(Parser *p, asdl_stmt_seq *a) {
             if (tag == NULL) {
                 return NULL;
             }
-            type_ignore_ty ti = TypeIgnore(p->type_ignore_comments.items[i].lineno, tag, p->arena);
+            type_ignore_ty ti = _Py_TypeIgnore(p->type_ignore_comments.items[i].lineno,
+                                               tag, p->arena);
             if (ti == NULL) {
                 return NULL;
             }
             asdl_seq_SET(type_ignores, i, ti);
         }
     }
-    return Module(a, type_ignores, p->arena);
+    return _Py_Module(a, type_ignores, p->arena);
 }
 
 // Error reporting helpers
@@ -2362,7 +2369,7 @@ expr_ty _PyPegen_collect_call_seqs(Parser *p, asdl_expr_seq *a, asdl_seq *b,
 
     if (b == NULL) {
         return _Py_Call(_PyPegen_dummy_name(p), a, NULL, lineno, col_offset,
-                        end_lineno, end_col_offset, arena);
+                     end_lineno, end_col_offset, arena);
 
     }
 

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -797,10 +797,11 @@ fstring_find_expr(Parser *p, const char **str, const char *end, int raw, int rec
     /* And now create the FormattedValue node that represents this
        entire expression with the conversion and format spec. */
     //TODO: Fix this
-    *expression = FormattedValue(simple_expression, conversion,
-                                 format_spec, first_token->lineno,
-                                 first_token->col_offset, last_token->end_lineno,
-                                 last_token->end_col_offset, p->arena);
+    *expression = _Py_FormattedValue(simple_expression, conversion,
+                                     format_spec, first_token->lineno,
+                                     first_token->col_offset,
+                                     last_token->end_lineno,
+                                     last_token->end_col_offset, p->arena);
     if (!*expression) {
         goto error;
     }
@@ -1044,8 +1045,9 @@ make_str_node_and_del(Parser *p, PyObject **str, Token* first_token, Token *last
         return NULL;
     }
 
-    return Constant(s, kind, first_token->lineno, first_token->col_offset,
-                    last_token->end_lineno, last_token->end_col_offset, p->arena);
+    return _Py_Constant(s, kind, first_token->lineno, first_token->col_offset,
+                        last_token->end_lineno, last_token->end_col_offset,
+                        p->arena);
 
 }
 
@@ -1205,7 +1207,8 @@ _PyPegen_FstringParser_Finish(Parser *p, FstringParser *state, Token* first_toke
     }
 
     return _Py_JoinedStr(seq, first_token->lineno, first_token->col_offset,
-                         last_token->end_lineno, last_token->end_col_offset, p->arena);
+                         last_token->end_lineno, last_token->end_col_offset,
+                         p->arena);
 
 error:
     _PyPegen_FstringParser_Dealloc(state);

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -452,7 +452,8 @@ astfold_body(asdl_stmt_seq *stmts, PyArena *ctx_, _PyASTOptimizeState *state)
         }
         asdl_seq_SET(values, 0, st->v.Expr.value);
         expr_ty expr = _Py_JoinedStr(values, st->lineno, st->col_offset,
-                                     st->end_lineno, st->end_col_offset, ctx_);
+                                     st->end_lineno, st->end_col_offset,
+                                     ctx_);
         if (!expr) {
             return 0;
         }


### PR DESCRIPTION
Remove macros creating aliases without prefix in pycore_ast.h. For
example, Module() becomes _Py_Module(). Update Grammar/python.gram to
only use _Py_xxx() functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43244](https://bugs.python.org/issue43244) -->
https://bugs.python.org/issue43244
<!-- /issue-number -->
