### PR TITLE
[3.9] bpo-42999: Expand and clarify pathlib.Path.link_to() documentation. (GH-24294)

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1119,6 +1119,20 @@ call fails (for example because the path doesn't exist).
       of :func:`os.symlink`'s.
 
 
+.. method:: Path.link_to(target)
+
+   Make *target* a hard link to this path.
+
+   .. warning::
+
+      This function does not make this path a hard link to *target*, despite
+      the implication of the function and argument names. The argument order
+      (target, link) is the reverse of :func:`Path.symlink_to`, but matches
+      that of :func:`os.link`.
+
+   .. versionadded:: 3.8
+
+
 .. method:: Path.touch(mode=0o666, exist_ok=True)
 
    Create a file at this given path.  If *mode* is given, it is combined
@@ -1141,13 +1155,6 @@ call fails (for example because the path doesn't exist).
 
    .. versionchanged:: 3.8
       The *missing_ok* parameter was added.
-
-
-.. method:: Path.link_to(target)
-
-   Create a hard link pointing to a path named *target*.
-
-   .. versionadded:: 3.8
 
 
 .. method:: Path.write_bytes(data)

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1401,7 +1401,7 @@ class Path(PurePath):
         matches that of os.link.
 
         """
-        self._accessor.link(self, target)
+        self._accessor.link_to(self, target)
 
     # Convenience functions for querying the stat results
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1358,12 +1358,6 @@ class Path(PurePath):
         """
         return self._accessor.lstat(self)
 
-    def link_to(self, target):
-        """
-        Create a hard link pointing to a path named target.
-        """
-        self._accessor.link_to(self, target)
-
     def rename(self, target):
         """
         Rename this path to the target path.
@@ -1392,10 +1386,22 @@ class Path(PurePath):
 
     def symlink_to(self, target, target_is_directory=False):
         """
-        Make this path a symlink pointing to the given path.
-        Note the order of arguments (self, target) is the reverse of os.symlink's.
+        Make this path a symlink pointing to the target path.
+        Note the order of arguments (link, target) is the reverse of os.symlink.
         """
         self._accessor.symlink(target, self, target_is_directory)
+
+    def link_to(self, target):
+        """
+        Make the target path a hard link pointing to this path.
+
+        Note this function does not make this path a hard link to *target*,
+        despite the implication of the function and argument names. The order
+        of arguments (target, link) is the reverse of Path.symlink_to, but
+        matches that of os.link.
+
+        """
+        self._accessor.link(self, target)
 
     # Convenience functions for querying the stat results
 


### PR DESCRIPTION


<!-- issue-number: [bpo-42999](https://bugs.python.org/issue42999) -->
https://bugs.python.org/issue42999
<!-- /issue-number -->
