### PR TITLE
bpo-42923: Fix _Py_DumpExtensionModules() for NULL sysdict

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2551,12 +2551,14 @@ _Py_DumpExtensionModules(int fd, PyInterpreterState *interp)
     // memory cannot be allocated on the heap in a signal handler.
     // Iterate on the dict instead.
     PyObject *stdlib_module_names = NULL;
-    pos = 0;
-    while (PyDict_Next(interp->sysdict, &pos, &key, &value)) {
-        if (PyUnicode_Check(key)
-           && PyUnicode_CompareWithASCIIString(key, "stdlib_module_names") == 0) {
-            stdlib_module_names = value;
-            break;
+    if (interp->sysdict != NULL) {
+        pos = 0;
+        while (PyDict_Next(interp->sysdict, &pos, &key, &value)) {
+            if (PyUnicode_Check(key)
+               && PyUnicode_CompareWithASCIIString(key, "stdlib_module_names") == 0) {
+                stdlib_module_names = value;
+                break;
+            }
         }
     }
     // If we failed to get sys.stdlib_module_names or it's not a frozenset,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42923](https://bugs.python.org/issue42923) -->
https://bugs.python.org/issue42923
<!-- /issue-number -->
