### PR TITLE
bpo-43757: make pathlib use os.path.realpath() to resolve all symlinks in a path

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -364,8 +364,8 @@ the :mod:`glob` module.)
       The *strict* parameter was added.
 
    .. versionchanged:: 3.10
-      Raises :exc:`OSError` with :const:`~errno.ELOOP` when a symbolic link
-      cycle occurs. Previously returned one member of the cycle.
+      Raises :exc:`OSError` when a symbolic link cycle occurs. Previously
+      returned one member of the cycle.
 
 
 .. function:: relpath(path, start=os.curdir)

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -350,9 +350,10 @@ the :mod:`glob` module.)
    links encountered in the path (if they are supported by the operating
    system).
 
-   If the path doesn't exist and *strict* is ``True``, :exc:`FileNotFoundError`
-   is raised. If *strict* is ``False``, the path is resolved as far as possible
-   and any remainder is appended without checking whether it exists.
+   If a path doesn't exist or a symlink loop is encountered, and *strict* is
+   ``True``, :exc:`OSError` is raised. If *strict* is ``False``, the path is
+   resolved as far as possible and any remainder is appended without checking
+   whether it exists.
 
    .. note::
       This function emulates the operating system's procedure for making a path
@@ -370,10 +371,6 @@ the :mod:`glob` module.)
 
    .. versionchanged:: 3.10
       The *strict* parameter was added.
-
-   .. versionchanged:: 3.10
-      Raises :exc:`OSError` when a symbolic link cycle occurs. Previously
-      returned one member of the cycle.
 
 
 .. function:: relpath(path, start=os.curdir)

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -344,21 +344,28 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: realpath(path)
+.. function:: realpath(path, *, strict=False)
 
    Return the canonical path of the specified filename, eliminating any symbolic
    links encountered in the path (if they are supported by the operating
    system).
 
-   .. note::
-      When symbolic link cycles occur, the returned path will be one member of
-      the cycle, but no guarantee is made about which member that will be.
+   In non-strict mode (the default), missing or inaccessible ancestors are
+   permitted; when encountered, the remainder of the path joined on and
+   returned. In strict mode an :exc:`OSError` is raised in this scenario.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
 
    .. versionchanged:: 3.8
       Symbolic links and junctions are now resolved on Windows.
+
+   .. versionchanged:: 3.10
+      The *strict* parameter was added.
+
+   .. versionchanged:: 3.10
+      Raises :exc:`OSError` with :const:`~errno.ELOOP` when a symbolic link
+      cycle occurs. Previously returned one member of the cycle.
 
 
 .. function:: relpath(path, start=os.curdir)

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -350,9 +350,9 @@ the :mod:`glob` module.)
    links encountered in the path (if they are supported by the operating
    system).
 
-   In non-strict mode (the default), missing or inaccessible ancestors are
-   permitted; when encountered, the remainder of the path joined on and
-   returned. In strict mode an :exc:`OSError` is raised in this scenario.
+   If the path doesn't exist and *strict* is ``True``, :exc:`FileNotFoundError`
+   is raised. If *strict* is ``False``, the path is resolved as far as possible
+   and any remainder is appended without checking whether it exists.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -354,6 +354,14 @@ the :mod:`glob` module.)
    is raised. If *strict* is ``False``, the path is resolved as far as possible
    and any remainder is appended without checking whether it exists.
 
+   .. note::
+      This function emulates the operating system's procedure for making a path
+      canonical, which differs slightly between Windows and UNIX with respect
+      to how links and subsequent path components interact.
+
+      Operating system APIs make paths canonical as needed, so it's not
+      normally necessary to call this function.
+
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
 

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -635,7 +635,7 @@ else:
                 tail = join(name, tail) if tail else name
         return tail
 
-    def realpath(path):
+    def realpath(path, *, strict=False):
         path = normpath(path)
         if isinstance(path, bytes):
             prefix = b'\\\\?\\'
@@ -660,6 +660,8 @@ else:
             path = _getfinalpathname(path)
             initial_winerror = 0
         except OSError as ex:
+            if strict:
+                raise
             initial_winerror = ex.winerror
             path = _getfinalpathname_nonstrict(path)
         # The path returned by _getfinalpathname will always start with \\?\ -

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -603,7 +603,8 @@ else:
         # 87: ERROR_INVALID_PARAMETER
         # 123: ERROR_INVALID_NAME
         # 1920: ERROR_CANT_ACCESS_FILE
-        allowed_winerror = 1, 2, 3, 5, 21, 32, 50, 67, 87, 123, 1920
+        # 1921: ERROR_CANT_RESOLVE_FILENAME (implies unfollowable symlink)
+        allowed_winerror = 1, 2, 3, 5, 21, 32, 50, 67, 87, 123, 1920, 1921
 
         # Non-strict algorithm is to find as much of the target directory
         # as we can and join the rest.
@@ -659,10 +660,7 @@ else:
             path = _getfinalpathname(path)
             initial_winerror = 0
         except OSError as ex:
-            # ERROR_CANT_RESOLVE_FILENAME (1921) is from exceeding the
-            # max allowed number of reparse attempts (currently 63), which
-            # is either due to a loop or a chain of links that's too long.
-            if strict or ex.winerror == 1921:
+            if strict:
                 raise
             initial_winerror = ex.winerror
             path = _getfinalpathname_nonstrict(path)

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -659,7 +659,10 @@ else:
             path = _getfinalpathname(path)
             initial_winerror = 0
         except OSError as ex:
-            if strict:
+            # ERROR_CANT_RESOLVE_FILENAME (1921) is from exceeding the
+            # max allowed number of reparse attempts (currently 63), which
+            # is either due to a loop or a chain of links that's too long.
+            if strict or ex.winerror == 1921:
                 raise
             initial_winerror = ex.winerror
             path = _getfinalpathname_nonstrict(path)

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -603,8 +603,7 @@ else:
         # 87: ERROR_INVALID_PARAMETER
         # 123: ERROR_INVALID_NAME
         # 1920: ERROR_CANT_ACCESS_FILE
-        # 1921: ERROR_CANT_RESOLVE_FILENAME (implies unfollowable symlink)
-        allowed_winerror = 1, 2, 3, 5, 21, 32, 50, 67, 87, 123, 1920, 1921
+        allowed_winerror = 1, 2, 3, 5, 21, 32, 50, 67, 87, 123, 1920
 
         # Non-strict algorithm is to find as much of the target directory
         # as we can and join the rest.

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1058,14 +1058,13 @@ class Path(PurePath):
         normalizing it (for example turning slashes into backslashes under
         Windows).
         """
-        p = self._from_parts((self._accessor.realpath(self),))
         try:
-            if S_ISLNK(self.lstat().st_mode):
-                raise RuntimeError("Symlink loop from %r" % str(p))
-        except OSError:
-            if strict:
-                raise
-        return p
+            p = self._accessor.realpath(self, strict=strict)
+        except OSError as ex:
+            if ex.errno == ELOOP:
+                raise RuntimeError("Symlink loop from %r", ex.filename)
+            raise
+        return self._from_parts((p,))
 
     def stat(self, *, follow_symlinks=True):
         """

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -14,12 +14,6 @@ from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
 
 
-if os.name == 'nt':
-    from nt import _getfinalpathname
-else:
-    _getfinalpathname = None
-
-
 __all__ = [
     "PurePath", "PurePosixPath", "PureWindowsPath",
     "Path", "PosixPath", "WindowsPath",

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -446,6 +446,7 @@ def _joinrealpath(path, rest, strict, seen):
             # The symlink is not resolved, so we must have a symlink loop.
             # Raise OSError(errno.ELOOP)
             os.stat(newpath)
+        seen[newpath] = None # not resolved symlink
         path = _joinrealpath(path, os.readlink(newpath), strict, seen)
         seen[newpath] = path # resolved symlink
 

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -445,7 +445,8 @@ def _joinrealpath(path, rest, strict, seen):
                 # use cached value
                 continue
             # The symlink is not resolved, so we must have a symlink loop.
-            raise OSError(errno.ELOOP, os.strerror(errno.ELOOP), newpath)
+            # Raise OSError(errno.ELOOP)
+            os.stat(newpath)
         path = _joinrealpath(path, os.readlink(newpath), strict, seen)
         seen[newpath] = path # resolved symlink
 

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -434,8 +434,8 @@ def _joinrealpath(path, rest, strict, seen):
         else:
             is_link = stat.S_ISLNK(st.st_mode)
         if not is_link:
-             path = newpath
-             continue
+            path = newpath
+            continue
         # Resolve the symbolic link
         if newpath in seen:
             # Already seen this path

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -22,7 +22,6 @@ defpath = '/bin:/usr/bin'
 altsep = None
 devnull = '/dev/null'
 
-import errno
 import os
 import sys
 import stat

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -269,6 +269,18 @@ class TestNtpath(NtpathTestCase):
         self.assertPathEqual(ntpath.realpath(os.fsencode(ABSTFN + "1")),
                          os.fsencode(ABSTFN))
 
+    @unittest.skipUnless(hasattr(os, "symlink"),
+                         "Missing symlink implementation")
+    @skip_if_ABSTFN_contains_backslash
+    def test_realpath_strict(self):
+        # Bug #43757: raise FileNotFoundError in strict mode if we encounter
+        # a path that does not exist.
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
+        os.symlink(ABSTFN + "1", ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN, strict=True)
+        self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN + "2", strict=True)
+
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_relative(self):

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -269,9 +269,8 @@ class TestNtpath(NtpathTestCase):
         self.assertPathEqual(ntpath.realpath(os.fsencode(ABSTFN + "1")),
                          os.fsencode(ABSTFN))
 
-    @unittest.skipUnless(hasattr(os, "symlink"),
-                         "Missing symlink implementation")
-    @skip_if_ABSTFN_contains_backslash
+    @os_helper.skip_unless_symlink
+    @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_strict(self):
         # Bug #43757: raise FileNotFoundError in strict mode if we encounter
         # a path that does not exist.

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -415,13 +415,11 @@ class TestNtpath(NtpathTestCase):
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1", strict=True)
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "2", strict=True)
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\x", strict=True)
-
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\..\\x", strict=True)
         # Windows eliminates '..' components before resolving links, so the
-        # following 3 realpath() calls are not expected to raise.
+        # following 2 realpath() calls are not expected to raise.
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\..", strict=True),
                              ntpath.dirname(ABSTFN))
-        self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\..\\x", strict=True),
-                             ntpath.dirname(ABSTFN) + "\\x")
         os.symlink(ABSTFN + "x", ABSTFN + "y")
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\..\\"
                                              + ntpath.basename(ABSTFN) + "y",

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -368,6 +368,9 @@ class TestNtpath(NtpathTestCase):
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1")
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "2")
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\x")
+
+        # Windows eliminates '..' components before resolving links, so the
+        # following 3 realpath() calls are not expected to raise.
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\.."),
                              ntpath.dirname(ABSTFN))
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\..\\x"),

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -415,16 +415,15 @@ class TestNtpath(NtpathTestCase):
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1", strict=True)
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "2", strict=True)
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\x", strict=True)
-        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\..\\x", strict=True)
         # Windows eliminates '..' components before resolving links, so the
-        # following 2 realpath() calls are not expected to raise.
+        # following call is not expected to raise.
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\..", strict=True),
                              ntpath.dirname(ABSTFN))
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\..\\x", strict=True)
         os.symlink(ABSTFN + "x", ABSTFN + "y")
-        self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\..\\"
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\..\\"
                                              + ntpath.basename(ABSTFN) + "y",
-                                             strict=True),
-                             ABSTFN + "x")
+                                             strict=True)
         self.assertRaises(OSError, ntpath.realpath,
                           ABSTFN + "1\\..\\" + ntpath.basename(ABSTFN) + "1",
                           strict=True)

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -369,14 +369,14 @@ class TestNtpath(NtpathTestCase):
                           ABSTFN + "1\\..\\" + ntpath.basename(ABSTFN) + "1")
 
         os.symlink(ntpath.basename(ABSTFN) + "a\\b", ABSTFN + "a")
-        self.assertPathEqual(ntpath.realpath(ABSTFN + "a"), ABSTFN + "a")
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "a")
 
         os.symlink("..\\" + ntpath.basename(ntpath.dirname(ABSTFN))
                    + "\\" + ntpath.basename(ABSTFN) + "c", ABSTFN + "c")
-        self.assertPathEqual(ntpath.realpath(ABSTFN + "c"), ABSTFN + "c")
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "c")
 
         # Test using relative path as well.
-        self.assertPathEqual(ntpath.realpath(ntpath.basename(ABSTFN)), ABSTFN)
+        self.assertRaises(OSError, ntpath.realpath, ntpath.basename(ABSTFN))
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -358,6 +358,19 @@ class PosixPathTest(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, "symlink"),
                          "Missing symlink implementation")
     @skip_if_ABSTFN_contains_backslash
+    def test_realpath_strict(self):
+        # Bug #43757: raise FileNotFoundError in strict mode if we encounter
+        # a path that does not exist.
+        try:
+            os.symlink(ABSTFN+"1", ABSTFN)
+            self.assertRaises(FileNotFoundError, realpath, ABSTFN, strict=True)
+            self.assertRaises(FileNotFoundError, realpath, ABSTFN + "2", strict=True)
+        finally:
+            os_helper.unlink(ABSTFN)
+
+    @unittest.skipUnless(hasattr(os, "symlink"),
+                         "Missing symlink implementation")
+    @skip_if_ABSTFN_contains_backslash
     def test_realpath_relative(self):
         try:
             os.symlink(posixpath.relpath(ABSTFN+"1"), ABSTFN)

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -369,36 +369,33 @@ class PosixPathTest(unittest.TestCase):
                          "Missing symlink implementation")
     @skip_if_ABSTFN_contains_backslash
     def test_realpath_symlink_loops(self):
-        # Bug #930024, return the path unchanged if we get into an infinite
-        # symlink loop.
+        # Bug #43757, raise OSError if we get into an infinite symlink loop.
         try:
             os.symlink(ABSTFN, ABSTFN)
-            self.assertEqual(realpath(ABSTFN), ABSTFN)
+            self.assertRaises(OSError, realpath, ABSTFN)
 
             os.symlink(ABSTFN+"1", ABSTFN+"2")
             os.symlink(ABSTFN+"2", ABSTFN+"1")
-            self.assertEqual(realpath(ABSTFN+"1"), ABSTFN+"1")
-            self.assertEqual(realpath(ABSTFN+"2"), ABSTFN+"2")
+            self.assertRaises(OSError, realpath, ABSTFN+"1")
+            self.assertRaises(OSError, realpath, ABSTFN+"2")
 
-            self.assertEqual(realpath(ABSTFN+"1/x"), ABSTFN+"1/x")
-            self.assertEqual(realpath(ABSTFN+"1/.."), dirname(ABSTFN))
-            self.assertEqual(realpath(ABSTFN+"1/../x"), dirname(ABSTFN) + "/x")
+            self.assertRaises(OSError, realpath, ABSTFN+"1/x")
+            self.assertRaises(OSError, realpath, ABSTFN+"1/..")
+            self.assertRaises(OSError, realpath, ABSTFN+"1/../x")
             os.symlink(ABSTFN+"x", ABSTFN+"y")
-            self.assertEqual(realpath(ABSTFN+"1/../" + basename(ABSTFN) + "y"),
-                             ABSTFN + "y")
-            self.assertEqual(realpath(ABSTFN+"1/../" + basename(ABSTFN) + "1"),
-                             ABSTFN + "1")
+            self.assertRaises(OSError, realpath, ABSTFN+"1/../" + basename(ABSTFN) + "y")
+            self.assertRaises(OSError, realpath, ABSTFN+"1/../" + basename(ABSTFN) + "1")
 
             os.symlink(basename(ABSTFN) + "a/b", ABSTFN+"a")
-            self.assertEqual(realpath(ABSTFN+"a"), ABSTFN+"a/b")
+            self.assertRaises(OSError, realpath, ABSTFN+"a")
 
             os.symlink("../" + basename(dirname(ABSTFN)) + "/" +
                        basename(ABSTFN) + "c", ABSTFN+"c")
-            self.assertEqual(realpath(ABSTFN+"c"), ABSTFN+"c")
+            self.assertRaises(OSError, realpath, ABSTFN+"c")
 
             # Test using relative path as well.
             with os_helper.change_cwd(dirname(ABSTFN)):
-                self.assertEqual(realpath(basename(ABSTFN)), ABSTFN)
+                self.assertRaises(OSError, realpath, basename(ABSTFN))
         finally:
             os_helper.unlink(ABSTFN)
             os_helper.unlink(ABSTFN+"1")

--- a/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.b33fa0.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.b33fa0.rst
@@ -1,3 +1,3 @@
 :func:`os.path.realpath` now accepts a *strict* keyword-only argument.
-When set to ``True``, :exc:`FileNotFoundException` is raised if a path
-doesn't exist.
+When set to ``True``, :exc:`OSError` is raised if a path doesn't exist
+or a symlink loop is encountered.

--- a/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.b33fa0.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.b33fa0.rst
@@ -1,0 +1,3 @@
+:func:`os.path.realpath` now accepts a *strict* keyword-only argument.
+When set to ``True``, :exc:`FileNotFoundException` is raised if a path
+doesn't exist.

--- a/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.hEqA5d.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.hEqA5d.rst
@@ -1,2 +1,0 @@
-:func:`os.path.realpath` now raises :exc:`OSError` when a symlink loop is
-encountered. Previously it returned a path with unresolved symlinks.

--- a/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.hEqA5d.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.hEqA5d.rst
@@ -1,6 +1,2 @@
 :func:`os.path.realpath` now raises :exc:`OSError` when a symlink loop is
 encountered. Previously it returned a path with unresolved symlinks.
-
-:func:`os.path.realpath` now accepts a *strict* keyword-only argument.
-When set to ``True``, :exc:`FileNotFoundException` is raised if a path
-doesn't exist.

--- a/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.hEqA5d.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-22-11-27.bpo-25264.hEqA5d.rst
@@ -1,0 +1,6 @@
+:func:`os.path.realpath` now raises :exc:`OSError` when a symlink loop is
+encountered. Previously it returned a path with unresolved symlinks.
+
+:func:`os.path.realpath` now accepts a *strict* keyword-only argument.
+When set to ``True``, :exc:`FileNotFoundException` is raised if a path
+doesn't exist.


### PR DESCRIPTION
Removes a pathlib-specific implementation of `realpath()` that's mostly
copied from `ntpath` and `posixpath`.


<!-- issue-number: [bpo-43757](https://bugs.python.org/issue43757) -->
https://bugs.python.org/issue43757
<!-- /issue-number -->
