### PR TITLE
bpo-43682: @staticmethod inherits attributes

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -269,6 +269,11 @@ are always available.  They are listed here in alphabetical order.
       Class methods can now wrap other :term:`descriptors <descriptor>` such as
       :func:`property`.
 
+   .. versionchanged:: 3.10
+      Class methods now inherit the method attributes (``__module__``,
+      ``__name__``, ``__qualname__``, ``__doc__`` and ``__annotations__``) and
+      have a new ``__wrapped__`` attribute.
+
 .. function:: compile(source, filename, mode, flags=0, dont_inherit=False, optimize=-1)
 
    Compile the *source* into a code or AST object.  Code objects can be executed
@@ -1631,6 +1636,11 @@ are always available.  They are listed here in alphabetical order.
           builtin_open = staticmethod(open)
 
    For more information on static methods, see :ref:`types`.
+
+   .. versionchanged:: 3.10
+      Static methods now inherit the method attributes (``__module__``,
+      ``__name__``, ``__qualname__``, ``__doc__`` and ``__annotations__``) and
+      have a new ``__wrapped__`` attribute.
 
 
 .. index::

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -617,6 +617,12 @@ Other Language Changes
   respectively.
   (Contributed by Joshua Bronson, Daniel Pope, and Justin Wang in :issue:`31861`.)
 
+* Static methods (:func:`@staticmethod <staticmethod>`) and class methods
+  (:func:`@classmethod <classmethod>`) now inherit the method attributes
+  (``__module__``, ``__name__``, ``__qualname__``, ``__doc__``,
+  ``__annotations__``) and have a new ``__wrapped__`` attribute.
+  (Contributed by Victor Stinner in :issue:`43682`.)
+
 
 New Modules
 ===========

--- a/Lib/test/test_decorators.py
+++ b/Lib/test/test_decorators.py
@@ -77,7 +77,12 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(C.foo(), 42)
         self.assertEqual(C().foo(), 42)
 
-    def check_wrapper_attrs(self, wrapper, func):
+    def check_wrapper_attrs(self, method_wrapper, format_str):
+        def func(x):
+            return x
+        wrapper = method_wrapper(func)
+
+        self.assertIs(wrapper.__func__, func)
         self.assertIs(wrapper.__wrapped__, func)
 
         for attr in ('__module__', '__qualname__', '__name__',
@@ -85,31 +90,15 @@ class TestDecorators(unittest.TestCase):
             self.assertIs(getattr(wrapper, attr),
                           getattr(func, attr))
 
-    def test_staticmethod(self):
-        def func(x):
-            return x
-        wrapper = staticmethod(func)
-
-        self.assertIs(wrapper.__func__, func)
-        self.check_wrapper_attrs(wrapper, func)
-
-        self.assertEqual(repr(wrapper),
-                         f'<staticmethod({func!r})>')
+        self.assertEqual(repr(wrapper), format_str.format(func))
 
         self.assertRaises(TypeError, wrapper, 1)
+
+    def test_staticmethod(self):
+        self.check_wrapper_attrs(staticmethod, '<staticmethod({!r})>')
 
     def test_classmethod(self):
-        def func(x):
-            return x
-        wrapper = classmethod(func)
-
-        self.assertIs(wrapper.__func__, func)
-        self.check_wrapper_attrs(wrapper, func)
-
-        self.assertEqual(repr(wrapper),
-                         f'<classmethod({func!r})>')
-
-        self.assertRaises(TypeError, wrapper, 1)
+        self.check_wrapper_attrs(classmethod, '<classmethod({!r})>')
 
     def test_dotted(self):
         decorators = MiscDecorators()

--- a/Lib/test/test_decorators.py
+++ b/Lib/test/test_decorators.py
@@ -1,3 +1,4 @@
+from test import support
 import unittest
 
 def funcattrs(**kwds):
@@ -76,11 +77,39 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(C.foo(), 42)
         self.assertEqual(C().foo(), 42)
 
-    def test_staticmethod_function(self):
-        @staticmethod
-        def notamethod(x):
+    def check_wrapper_attrs(self, wrapper, func):
+        self.assertIs(wrapper.__wrapped__, func)
+
+        for attr in ('__module__', '__qualname__', '__name__',
+                     '__doc__', '__annotations__'):
+            self.assertIs(getattr(wrapper, attr),
+                          getattr(func, attr))
+
+    def test_staticmethod(self):
+        def func(x):
             return x
-        self.assertRaises(TypeError, notamethod, 1)
+        wrapper = staticmethod(func)
+
+        self.assertIs(wrapper.__func__, func)
+        self.check_wrapper_attrs(wrapper, func)
+
+        self.assertEqual(repr(wrapper),
+                         f'<staticmethod({func!r})>')
+
+        self.assertRaises(TypeError, wrapper, 1)
+
+    def test_classmethod(self):
+        def func(x):
+            return x
+        wrapper = classmethod(func)
+
+        self.assertIs(wrapper.__func__, func)
+        self.check_wrapper_attrs(wrapper, func)
+
+        self.assertEqual(repr(wrapper),
+                         f'<classmethod({func!r})>')
+
+        self.assertRaises(TypeError, wrapper, 1)
 
     def test_dotted(self):
         decorators = MiscDecorators()

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1545,7 +1545,9 @@ order (MRO) for bases """
         self.assertEqual(d.foo(1), (d, 1))
         self.assertEqual(D.foo(d, 1), (d, 1))
         # Test for a specific crash (SF bug 528132)
-        def f(cls, arg): return (cls, arg)
+        def f(cls, arg):
+            "f docstring"
+            return (cls, arg)
         ff = classmethod(f)
         self.assertEqual(ff.__get__(0, int)(42), (int, 42))
         self.assertEqual(ff.__get__(0)(42), (int, 42))
@@ -1571,10 +1573,16 @@ order (MRO) for bases """
             self.fail("classmethod shouldn't accept keyword args")
 
         cm = classmethod(f)
-        self.assertEqual(cm.__dict__, {})
+        cm_dict = {'__annotations__': {},
+                   '__doc__': "f docstring",
+                   '__module__': __name__,
+                   '__name__': 'f',
+                   '__qualname__': f.__qualname__}
+        self.assertEqual(cm.__dict__, cm_dict)
+
         cm.x = 42
         self.assertEqual(cm.x, 42)
-        self.assertEqual(cm.__dict__, {"x" : 42})
+        self.assertEqual(cm.__dict__, {"x" : 42, **cm_dict})
         del cm.x
         self.assertNotHasAttr(cm, "x")
 
@@ -1654,10 +1662,10 @@ order (MRO) for bases """
         self.assertEqual(d.foo(1), (d, 1))
         self.assertEqual(D.foo(d, 1), (d, 1))
         sm = staticmethod(None)
-        self.assertEqual(sm.__dict__, {})
+        self.assertEqual(sm.__dict__, {'__doc__': None})
         sm.x = 42
         self.assertEqual(sm.x, 42)
-        self.assertEqual(sm.__dict__, {"x" : 42})
+        self.assertEqual(sm.__dict__, {"x" : 42, '__doc__': None})
         del sm.x
         self.assertNotHasAttr(sm, "x")
 

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1142,7 +1142,8 @@ class TestDescriptions(unittest.TestCase):
                 '''A static method'''
                 ...
         self.assertEqual(self._get_summary_lines(X.__dict__['sm']),
-                         "<staticmethod object>")
+                         'sm(...)\n'
+                         '    A static method\n')
         self.assertEqual(self._get_summary_lines(X.sm), """\
 sm(x, y)
     A static method
@@ -1162,7 +1163,8 @@ sm(x, y)
                 '''A class method'''
                 ...
         self.assertEqual(self._get_summary_lines(X.__dict__['cm']),
-                         "<classmethod object>")
+                         'cm(...)\n'
+                         '    A class method\n')
         self.assertEqual(self._get_summary_lines(X.cm), """\
 cm(x) method of builtins.type instance
     A class method

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -203,9 +203,9 @@ class ReprTests(unittest.TestCase):
         class C:
             def foo(cls): pass
         x = staticmethod(C.foo)
-        self.assertTrue(repr(x).startswith('<staticmethod object at 0x'))
+        self.assertEqual(repr(x), f'<staticmethod({C.foo!r})>')
         x = classmethod(C.foo)
-        self.assertTrue(repr(x).startswith('<classmethod object at 0x'))
+        self.assertEqual(repr(x), f'<classmethod({C.foo!r})>')
 
     def test_unsortable(self):
         # Repr.repr() used to call sorted() on sets, frozensets and dicts

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-08-01-06-22.bpo-43682.eUn4p5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-08-01-06-22.bpo-43682.eUn4p5.rst
@@ -1,0 +1,5 @@
+Static methods (:func:`@staticmethod <staticmethod>`) and class methods
+(:func:`@classmethod <classmethod>`) now inherit the method attributes
+(``__module__``, ``__name__``, ``__qualname__``, ``__doc__``,
+``__annotations__``) and have a new ``__wrapped__`` attribute.
+Patch by Victor Stinner.


### PR DESCRIPTION
Static methods (@staticmethod) and class methods (@classmethod) now
inherit the method attributes (__module__, __name__, __qualname__,
__doc__, __annotations__) and have a new __wrapped__ attribute.

Changes:

* Add a repr() method to staticmethod and classmethod types.
* Add tests on the @classmethod decorator.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43682](https://bugs.python.org/issue43682) -->
https://bugs.python.org/issue43682
<!-- /issue-number -->
