### PR TITLE
bpo-42998: add 'user' parameter to pathlib.Path.home()

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -702,18 +702,24 @@ call fails (for example because the path doesn't exist).
       PosixPath('/home/antoine/pathlib')
 
 
-.. classmethod:: Path.home()
+.. classmethod:: Path.home(user=None)
 
-   Return a new path object representing the user's home directory (as
+   Return a new path object representing a user's home directory (as
    returned by :func:`os.path.expanduser` with ``~`` construct). If the home
-   directory can't be resolved, :exc:`RuntimeError` is raised.
+   directory can't be resolved, :exc:`RuntimeError` is raised. If no user name
+   is given, the current user's home directory is used.
 
    ::
 
       >>> Path.home()
       PosixPath('/home/antoine')
+      >>> Path.home('barney')
+      PosixPath('/home/barney')
 
    .. versionadded:: 3.5
+
+   .. versionchanged:: 3.10
+      The *user* parameter was added.
 
 
 .. method:: Path.stat(*, follow_symlinks=True)

--- a/Misc/NEWS.d/next/Library/2021-04-08-20-07-43.bpo-25271.c27ipG.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-20-07-43.bpo-25271.c27ipG.rst
@@ -1,0 +1,1 @@
+Add *user* parameter to `pathlib.Path.home()`


### PR DESCRIPTION
Also slightly re-arrange the internals such that `expanduser()` calls `home()`.
This is to aid with the creation of an `AbstractPath` class in [bpo-24132](https://bugs.python.org/issue24132),
where `cwd()` and `home()` will be abstract methods, but not `absolute()`
or `expanduser()`.

<!-- issue-number: [bpo-42998](https://bugs.python.org/issue42998) -->
https://bugs.python.org/issue42998
<!-- /issue-number -->
