### PR TITLE
bpo-43770: Inherit default tp_getattro and tp_setattro

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -926,9 +926,6 @@ and :c:type:`PyType_Type` effectively act as defaults.)
 
       PyObject *tp_getattro(PyObject *self, PyObject *attr);
 
-   It is usually convenient to set this field to :c:func:`PyObject_GenericGetAttr`,
-   which implements the normal way of looking for object attributes.
-
    **Inheritance:**
 
    Group: :attr:`tp_getattr`, :attr:`tp_getattro`
@@ -951,9 +948,7 @@ and :c:type:`PyType_Type` effectively act as defaults.)
       int tp_setattro(PyObject *self, PyObject *attr, PyObject *value);
 
    In addition, setting *value* to ``NULL`` to delete an attribute must be
-   supported.  It is usually convenient to set this field to
-   :c:func:`PyObject_GenericSetAttr`, which implements the normal
-   way of setting object attributes.
+   supported.
 
    **Inheritance:**
 

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2334,7 +2334,7 @@ PyTypeObject PyByteArray_Type = {
     0,                                  /* tp_hash */
     0,                                  /* tp_call */
     bytearray_str,                      /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_getattro */
     0,                                  /* tp_setattro */
     &bytearray_as_buffer,               /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
@@ -2482,7 +2482,7 @@ PyTypeObject PyByteArrayIter_Type = {
     0,                                 /* tp_hash */
     0,                                 /* tp_call */
     0,                                 /* tp_str */
-    PyObject_GenericGetAttr,           /* tp_getattro */
+    0,                                 /* tp_getattro */
     0,                                 /* tp_setattro */
     0,                                 /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2908,7 +2908,7 @@ PyTypeObject PyBytes_Type = {
     (hashfunc)bytes_hash,                       /* tp_hash */
     0,                                          /* tp_call */
     bytes_str,                                  /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     &bytes_as_buffer,                           /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
@@ -3200,7 +3200,7 @@ PyTypeObject PyBytesIter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */

--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -171,7 +171,7 @@ PyTypeObject PyCell_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -346,7 +346,7 @@ PyTypeObject PyMethod_Type = {
     PyVectorcall_Call,                          /* tp_call */
     0,                                          /* tp_str */
     method_getattro,                            /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_HAVE_VECTORCALL,                 /* tp_flags */
@@ -586,7 +586,7 @@ PyTypeObject PyInstanceMethod_Type = {
     instancemethod_call,                        /* tp_call */
     0,                                          /* tp_str */
     instancemethod_getattro,                    /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT
         | Py_TPFLAGS_HAVE_GC,                   /* tp_flags */

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1215,7 +1215,7 @@ PyTypeObject PyCode_Type = {
     (hashfunc)code_hash,                /* tp_hash */
     0,                                  /* tp_call */
     0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_getattro */
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                 /* tp_flags */

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -1074,7 +1074,7 @@ PyTypeObject PyComplex_Type = {
     (hashfunc)complex_hash,                     /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -706,7 +706,7 @@ PyTypeObject PyMethodDescr_Type = {
     0,                                          /* tp_hash */
     PyVectorcall_Call,                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -746,7 +746,7 @@ PyTypeObject PyClassMethodDescr_Type = {
     0,                                          /* tp_hash */
     (ternaryfunc)classmethoddescr_call,         /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
@@ -783,7 +783,7 @@ PyTypeObject PyMemberDescr_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
@@ -820,7 +820,7 @@ PyTypeObject PyGetSetDescr_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
@@ -857,7 +857,7 @@ PyTypeObject PyWrapperDescr_Type = {
     0,                                          /* tp_hash */
     (ternaryfunc)wrapperdescr_call,             /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -1414,7 +1414,7 @@ PyTypeObject _PyMethodWrapper_Type = {
     (hashfunc)wrapper_hash,                     /* tp_hash */
     (ternaryfunc)wrapper_call,                  /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
@@ -1849,7 +1849,7 @@ PyTypeObject PyDictProxy_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     (reprfunc)mappingproxy_str,                 /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
@@ -1891,7 +1891,7 @@ PyTypeObject PyProperty_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3545,7 +3545,7 @@ PyTypeObject PyDict_Type = {
     PyObject_HashNotImplemented,                /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -3803,7 +3803,7 @@ PyTypeObject PyDictIterKey_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
@@ -3890,7 +3890,7 @@ PyTypeObject PyDictIterValue_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
@@ -4002,7 +4002,7 @@ PyTypeObject PyDictIterItem_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
@@ -4748,7 +4748,7 @@ PyTypeObject PyDictKeys_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
@@ -4854,7 +4854,7 @@ PyTypeObject PyDictItems_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
@@ -4935,7 +4935,7 @@ PyTypeObject PyDictValues_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -236,7 +236,7 @@ PyTypeObject PyEnum_Type = {
     0,                              /* tp_hash */
     0,                              /* tp_call */
     0,                              /* tp_str */
-    PyObject_GenericGetAttr,        /* tp_getattro */
+    0,                              /* tp_getattro */
     0,                              /* tp_setattro */
     0,                              /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -451,7 +451,7 @@ PyTypeObject PyReversed_Type = {
     0,                              /* tp_hash */
     0,                              /* tp_call */
     0,                              /* tp_str */
-    PyObject_GenericGetAttr,        /* tp_getattro */
+    0,                              /* tp_getattro */
     0,                              /* tp_setattro */
     0,                              /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -395,8 +395,8 @@ static PyTypeObject _PyExc_BaseException = {
     0,                          /*tp_hash */
     0,                          /*tp_call*/
     (reprfunc)BaseException_str,  /*tp_str*/
-    PyObject_GenericGetAttr,    /*tp_getattro*/
-    PyObject_GenericSetAttr,    /*tp_setattro*/
+    0,                          /*tp_getattro*/
+    0,                          /*tp_setattro*/
     0,                          /*tp_as_buffer*/
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASE_EXC_SUBCLASS,  /*tp_flags*/

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -504,7 +504,7 @@ PyTypeObject PyStdPrinter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                         /* tp_flags */

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1942,7 +1942,7 @@ PyTypeObject PyFloat_Type = {
     (hashfunc)float_hash,                       /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -747,8 +747,8 @@ PyTypeObject PyFrame_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     0,                                          /* tp_doc */

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -779,7 +779,7 @@ PyTypeObject PyGen_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -1027,7 +1027,7 @@ PyTypeObject PyCoro_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -1125,7 +1125,7 @@ PyTypeObject _PyCoroWrapper_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
@@ -1412,7 +1412,7 @@ PyTypeObject PyAsyncGen_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -1677,7 +1677,7 @@ PyTypeObject _PyAsyncGenASend_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
@@ -1786,7 +1786,7 @@ PyTypeObject _PyAsyncGenWrappedValue_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
@@ -2086,7 +2086,7 @@ PyTypeObject _PyAsyncGenAThrow_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -154,7 +154,7 @@ PyTypeObject PySeqIter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
@@ -273,7 +273,7 @@ PyTypeObject PyCallIter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
@@ -396,7 +396,7 @@ PyTypeObject _PyAnextAwaitable_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3048,7 +3048,7 @@ PyTypeObject PyList_Type = {
     PyObject_HashNotImplemented,                /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -3121,7 +3121,7 @@ PyTypeObject PyListIter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
@@ -3269,7 +3269,7 @@ PyTypeObject PyListRevIter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5635,7 +5635,7 @@ PyTypeObject PyLong_Type = {
     (hashfunc)long_hash,                        /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -167,7 +167,7 @@ PyTypeObject _PyManagedBuffer_Type = {
     0,                                       /* tp_hash */
     0,                                       /* tp_call */
     0,                                       /* tp_str */
-    PyObject_GenericGetAttr,                 /* tp_getattro */
+    0,                                          /* tp_setattro */
     0,                                       /* tp_setattro */
     0,                                       /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
@@ -3260,7 +3260,6 @@ static PyTypeObject PyMemoryIter_Type = {
     .tp_basicsize = sizeof(memoryiterobject),
     // methods
     .tp_dealloc = (destructor)memoryiter_dealloc,
-    .tp_getattro = PyObject_GenericGetAttr,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = (traverseproc)memoryiter_traverse,
     .tp_iter = PyObject_SelfIter,
@@ -3284,7 +3283,7 @@ PyTypeObject PyMemoryView_Type = {
     (hashfunc)memory_hash,                    /* tp_hash */
     0,                                        /* tp_call */
     0,                                        /* tp_str */
-    PyObject_GenericGetAttr,                  /* tp_getattro */
+    0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     &memory_as_buffer,                        /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,  /* tp_flags */

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -347,7 +347,7 @@ PyTypeObject PyCFunction_Type = {
     (hashfunc)meth_hash,                        /* tp_hash */
     cfunction_call,                             /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -870,7 +870,7 @@ PyTypeObject PyModule_Type = {
     0,                                          /* tp_call */
     0,                                          /* tp_str */
     (getattrofunc)module_getattro,              /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                    /* tp_flags */

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -216,8 +216,8 @@ PyTypeObject _PyNamespace_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
-    PyObject_GenericSetAttr,                    /* tp_setattro */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                    /* tp_flags */

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1885,7 +1885,7 @@ PyTypeObject PyODictIter_Type = {
     0,                                        /* tp_hash */
     0,                                        /* tp_call */
     0,                                        /* tp_str */
-    PyObject_GenericGetAttr,                  /* tp_getattro */
+    0,                                        /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,  /* tp_flags */

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -732,7 +732,7 @@ PyTypeObject PyRange_Type = {
         (hashfunc)range_hash,   /* tp_hash */
         0,                      /* tp_call */
         0,                      /* tp_str */
-        PyObject_GenericGetAttr,  /* tp_getattro */
+        0,                      /* tp_getattro */
         0,                      /* tp_setattro */
         0,                      /* tp_as_buffer */
         Py_TPFLAGS_DEFAULT,     /* tp_flags */
@@ -868,7 +868,7 @@ PyTypeObject PyRangeIter_Type = {
         0,                                      /* tp_hash */
         0,                                      /* tp_call */
         0,                                      /* tp_str */
-        PyObject_GenericGetAttr,                /* tp_getattro */
+        0,                                      /* tp_getattro */
         0,                                      /* tp_setattro */
         0,                                      /* tp_as_buffer */
         Py_TPFLAGS_DEFAULT,                     /* tp_flags */
@@ -1071,7 +1071,7 @@ PyTypeObject PyLongRangeIter_Type = {
         0,                                      /* tp_hash */
         0,                                      /* tp_call */
         0,                                      /* tp_str */
-        PyObject_GenericGetAttr,                /* tp_getattro */
+        0,                                      /* tp_getattro */
         0,                                      /* tp_setattro */
         0,                                      /* tp_as_buffer */
         Py_TPFLAGS_DEFAULT,                     /* tp_flags */

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -848,7 +848,7 @@ PyTypeObject PySetIter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
@@ -2103,7 +2103,7 @@ PyTypeObject PySet_Type = {
     PyObject_HashNotImplemented,        /* tp_hash */
     0,                                  /* tp_call */
     0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_getattro */
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -2204,7 +2204,7 @@ PyTypeObject PyFrozenSet_Type = {
     frozenset_hash,                     /* tp_hash */
     0,                                  /* tp_call */
     0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_getattro */
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -64,7 +64,7 @@ PyTypeObject PyEllipsis_Type = {
     0,                                  /* tp_hash */
     0,                                  /* tp_call */
     0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_getattro */
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                 /* tp_flags */
@@ -645,7 +645,7 @@ PyTypeObject PySlice_Type = {
     PyObject_HashNotImplemented,                /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -913,7 +913,7 @@ PyTypeObject PyTuple_Type = {
     (hashfunc)tuplehash,                        /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
@@ -1166,7 +1166,7 @@ PyTypeObject PyTupleIter_Type = {
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
     0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15644,7 +15644,7 @@ PyTypeObject PyUnicode_Type = {
     (hashfunc) unicode_hash,      /* tp_hash*/
     0,                            /* tp_call*/
     (reprfunc) unicode_str,       /* tp_str */
-    PyObject_GenericGetAttr,      /* tp_getattro */
+    0,                            /* tp_getattro */
     0,                            /* tp_setattro */
     0,                            /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
@@ -15988,7 +15988,7 @@ PyTypeObject PyUnicodeIter_Type = {
     0,                  /* tp_hash */
     0,                  /* tp_call */
     0,                  /* tp_str */
-    PyObject_GenericGetAttr,        /* tp_getattro */
+    0,                  /* tp_getattro */
     0,                  /* tp_setattro */
     0,                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -429,7 +429,6 @@ PyTypeObject _Py_UnionType = {
     .tp_free = PyObject_Del,
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_hash = union_hash,
-    .tp_getattro = PyObject_GenericGetAttr,
     .tp_members = union_members,
     .tp_methods = union_methods,
     .tp_richcompare = union_richcompare,


### PR DESCRIPTION
Don't set tp_getattro and tp_setattro explicitly to
PyObject_GenericGetAttr() and PyObject_GenericSetAttr(): they are the
default.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43770](https://bugs.python.org/issue43770) -->
https://bugs.python.org/issue43770
<!-- /issue-number -->
