### PR TITLE
bpo-43760: Speed up check for tracing in interpreter dispatch

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -29,6 +29,14 @@ typedef int (*Py_tracefunc)(PyObject *, PyFrameObject *, int, PyObject *);
 #define PyTrace_OPCODE 7
 
 
+typedef struct _cframe {
+    /* This struct will be threaded through the C stack
+     * allowing faster access to state that must can be modified
+     * outside of the interpreter must be accessed within it */
+    int use_tracing;
+    struct _cframe *previous;
+} CFrame;
+
 typedef struct _err_stackitem {
     /* This struct represents an entry on the exception stack, which is a
      * per-coroutine state. (Coroutine in the computer science sense,
@@ -61,7 +69,7 @@ struct _ts {
        This is to prevent the actual trace/profile code from being recorded in
        the trace/profile. */
     int tracing;
-    int use_tracing;
+    CFrame *cframe;
 
     Py_tracefunc c_profilefunc;
     Py_tracefunc c_tracefunc;
@@ -128,6 +136,7 @@ struct _ts {
 
     /* Unique thread state id. */
     uint64_t id;
+    CFrame root_cframe;
 
     /* XXX signal handlers should also be here */
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -33,12 +33,6 @@ struct _pending_calls {
 
 struct _ceval_state {
     int recursion_limit;
-    /* Records whether tracing is on for any thread.  Counts the number
-       of threads for which tstate->c_tracefunc is non-NULL, so if the
-       value is 0, we know we don't have to check this thread's
-       c_tracefunc.  This speeds up the if statement in
-       _PyEval_EvalFrameDefault() after fast_next_opcode. */
-    int tracing_possible;
     /* This single variable consolidates all requests to break out of
        the fast path in the eval loop. */
     _Py_atomic_int eval_breaker;

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-08-12-20-29.bpo-43760.tBIsD8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-08-12-20-29.bpo-43760.tBIsD8.rst
@@ -1,2 +1,2 @@
-The flag to check whether tracing is enabled for the thread is now kept on
-the C stack, instead of the heap, to streamline dispatch in the interpreter.
+Move the flag for checking whether tracing is enabled to the C stack, from of the heap.
+Should speed up dispatch in the interpreter.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-08-12-20-29.bpo-43760.tBIsD8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-08-12-20-29.bpo-43760.tBIsD8.rst
@@ -1,0 +1,2 @@
+The flag to check whether tracing is enabled for the thread is now kept on
+the C stack, instead of the heap, to streamline dispatch in the interpreter.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-08-12-20-29.bpo-43760.tBIsD8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-08-12-20-29.bpo-43760.tBIsD8.rst
@@ -1,2 +1,2 @@
-Move the flag for checking whether tracing is enabled to the C stack, from of the heap.
+Move the flag for checking whether tracing is enabled to the C stack, from the heap.
 Should speed up dispatch in the interpreter.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1615,6 +1615,10 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
     /* Mark trace_info as uninitialized */
     trace_info.code = NULL;
 
+    /* WARNING: Because the CFrame lives on the C stack,
+     * but can be accessed from a heap allocated object (tstate)
+     * strict stack discipline must be maintained.
+     */
     CFrame *prev_cframe = tstate->cframe;
     trace_info.cframe.use_tracing = prev_cframe->use_tracing;
     trace_info.cframe.previous = prev_cframe;
@@ -4588,7 +4592,7 @@ exiting:
 
     /* pop frame */
 exit_eval_frame:
-
+    /* Restore previous cframe */
     tstate->cframe = trace_info.cframe.previous;
     tstate->cframe->use_tracing = trace_info.cframe.use_tracing;
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -624,7 +624,8 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->recursion_headroom = 0;
     tstate->stackcheck_counter = 0;
     tstate->tracing = 0;
-    tstate->use_tracing = 0;
+    tstate->root_cframe.use_tracing = 0;
+    tstate->cframe = &tstate->root_cframe;
     tstate->gilstate_counter = 0;
     tstate->async_exc = NULL;
     tstate->thread_id = PyThread_get_thread_ident();

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -252,7 +252,7 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
 
         /* Disallow tracing in hooks unless explicitly enabled */
         ts->tracing++;
-        ts->use_tracing = 0;
+        ts->cframe->use_tracing = 0;
         while ((hook = PyIter_Next(hooks)) != NULL) {
             _Py_IDENTIFIER(__cantrace__);
             PyObject *o;
@@ -265,14 +265,14 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
                 break;
             }
             if (canTrace) {
-                ts->use_tracing = (ts->c_tracefunc || ts->c_profilefunc);
+                ts->cframe->use_tracing = (ts->c_tracefunc || ts->c_profilefunc);
                 ts->tracing--;
             }
             PyObject* args[2] = {eventName, eventArgs};
             o = _PyObject_FastCallTstate(ts, hook, args, 2);
             if (canTrace) {
                 ts->tracing++;
-                ts->use_tracing = 0;
+                ts->cframe->use_tracing = 0;
             }
             if (!o) {
                 break;
@@ -280,7 +280,7 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
             Py_DECREF(o);
             Py_CLEAR(hook);
         }
-        ts->use_tracing = (ts->c_tracefunc || ts->c_profilefunc);
+        ts->cframe->use_tracing = (ts->c_tracefunc || ts->c_profilefunc);
         ts->tracing--;
         if (_PyErr_Occurred(ts)) {
             goto exit;


### PR DESCRIPTION
The code to check if tracing is active occurs once per opcode in the interpreter and is executed in the order of 100 million times per second. It needs to be as efficient as possible. It cannot be kept in a register as it needs to be modified outside of the interpreter, so on the C stack is the fastest possible location for it.

This PR keeps `use_tracing` in the C frame of the current interpreter making the check for tracing as fast as possible.

Doing so complicates access to `use_tracing` from other code and requires us to be careful about maintaining stack discipline.
For anything less performance critical than `use_tracing` this probably wouldn't be worth it, but as `use_tracing` is so performance critical it is worth it.

<!-- issue-number: [bpo-43760](https://bugs.python.org/issue43760) -->
https://bugs.python.org/issue43760
<!-- /issue-number -->
