### PR TITLE
bpo-39899: ntpath.expanduser(): don't check the basename of the directory matches the username if we're requesting the current user's home directory

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -313,18 +313,19 @@ def expanduser(path):
         userhome = join(drive, os.environ['HOMEPATH'])
 
     if i != 1: #~user
-        # Try to guess user home directory.  By default all users directories
-        # are located in the same place and are named by corresponding
-        # usernames.  If current user home directory points to nonstandard
-        # place, this guess is likely wrong, and so we bail out.
-        current_user = os.environ.get('USERNAME')
-        if current_user != basename(userhome):
-            return path
-
         target_user = path[1:i]
         if isinstance(target_user, bytes):
             target_user = os.fsdecode(target_user)
+        current_user = os.environ.get('USERNAME')
+
         if target_user != current_user:
+            # Try to guess user home directory.  By default all user
+            # profile directories are located in the same place and are
+            # named by corresponding usernames.  If userhome isn't a
+            # normal profile directory, this guess is likely wrong,
+            # so we bail out.
+            if current_user != basename(userhome):
+                return path
             userhome = join(dirname(userhome), target_user)
 
     if isinstance(path, bytes):


### PR DESCRIPTION
Eryk Sun [spotted](https://bugs.python.org/issue39899#msg390497) that the implementation in #18841 shouldn't perform the basename check if we're querying for the current user's home directory via `~user`.

<!-- issue-number: [bpo-39899](https://bugs.python.org/issue39899) -->
https://bugs.python.org/issue39899
<!-- /issue-number -->
