### PR TITLE
[3.8] bpo-39674: Fix collections ABC deprecation notice

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -48,7 +48,7 @@ def __getattr__(name):
         import warnings
         warnings.warn("Using or importing the ABCs from 'collections' instead "
                       "of from 'collections.abc' is deprecated since Python 3.3, "
-                      "and in 3.9 it will stop working",
+                      "and in 3.10 it will stop working",
                       DeprecationWarning, stacklevel=2)
         globals()[name] = obj
         return obj


### PR DESCRIPTION
The deprecation originally slated for 3.9 was deferred to 3.10
([bpo-39674](https://bugs.python.org/issue39674), GH-18545) and the documentation on the 3.8 release was
updated accordingly (GH-18748). However the deprecation notice in
the code was left as is, and still indicates deprecation with 3.9.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39674](https://bugs.python.org/issue39674) -->
https://bugs.python.org/issue39674
<!-- /issue-number -->
