### PR TITLE
bpo-43764: Fix `__match_args__` generation logic for dataclasses

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1017,7 +1017,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
                        str(inspect.signature(cls)).replace(' -> NoneType', ''))
 
     if '__match_args__' not in cls.__dict__:
-        cls.__match_args__ = tuple(f.name for f in flds if f.init)
+        cls.__match_args__ = tuple(f.name for f in field_list if f.init)
 
     abc.update_abstractmethods(cls)
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3432,6 +3432,14 @@ class TestMatchArgs(unittest.TestCase):
             __match_args__ = ma
         self.assertIs(C(42).__match_args__, ma)
 
+    def test_bpo_43764(self):
+        @dataclass(repr=False, eq=False, init=False)
+        class X:
+            a: int
+            b: int
+            c: int
+        self.assertEqual(X.__match_args__, ("a", "b", "c"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2021-04-08-09-59-20.bpo-43764.tHjO60.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-09-59-20.bpo-43764.tHjO60.rst
@@ -1,0 +1,2 @@
+Fix an issue where :data:`~object.__match_args__` generation could fail for
+some :mod:`dataclasses`.


### PR DESCRIPTION
```py
>>> @dataclass(repr=False, eq=False, init=False)
... class X:
...     a: int
...     b: int
...     c: int
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/home/bucher/src/cpython/Lib/dataclasses.py", line 1042, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
  File "/home/bucher/src/cpython/Lib/dataclasses.py", line 1020, in _process_class
    cls.__match_args__ = tuple(f.name for f in flds if f.init)
UnboundLocalError: local variable 'flds' referenced before assignment
```


<!-- issue-number: [bpo-43764](https://bugs.python.org/issue43764) -->
https://bugs.python.org/issue43764
<!-- /issue-number -->
