### PR TITLE
Follow PEP-8 guidelines in tutorial for standard library

### DIFF
--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -78,8 +78,8 @@ and an optional number of lines to be displayed::
 
     import argparse
 
-    parser = argparse.ArgumentParser(prog = 'top',
-        description = 'Show top lines from each file')
+    description = 'Show top lines from each file'
+    parser = argparse.ArgumentParser(prog='top', description=description)
     parser.add_argument('filenames', nargs='+')
     parser.add_argument('-l', '--lines', type=int, default=10)
     args = parser.parse_args()


### PR DESCRIPTION
According to PEP-8, "Arguments on first line forbidden when not using vertical alignment."

No ticket created in b.p.o., as this is a trivial documentation change.

My understanding from reading other tickets related to PEP-8 compliance in the documentation (for example, https://bugs.python.org/issue26030) is that PRs should be submitted as users come across violations of the PEP. If my understanding is wrong, please let me know.