### PR TITLE
Use Py_FatalError() to report exception set

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1729,7 +1729,9 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
     /* _PyEval_EvalFrameDefault() must not be called with an exception set,
        because it can clear it (directly or indirectly) and so the
        caller loses its exception */
-    assert(!_PyErr_Occurred(tstate));
+    if (_PyErr_Occurred(tstate)) {
+        Py_FatalError("a function returned a result with an exception set");
+    }
 #endif
 
 main_loop:


### PR DESCRIPTION
Use Py_FatalError() in _PyEval_EvalFrameDefault() to report when an
exception is set. The function prints a useful error message and the
offending exception object instead of just a meaningless assertion
errror.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
