### PR TITLE
[3.8] bpo-43739: Fixing the example code in Doc/extending/extending.rst to declare and initialize the pmodule variable to be of the right type (GH-25331)

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -410,7 +410,7 @@ optionally followed by an import of the module::
        /* Optionally import the module; alternatively,
           import can be deferred until the embedded script
           imports it. */
-       pmodule = PyImport_ImportModule("spam");
+       PyObject *pmodule = PyImport_ImportModule("spam");
        if (!pmodule) {
            PyErr_Print();
            fprintf(stderr, "Error: could not import module 'spam'\n");

--- a/Misc/NEWS.d/next/Documentation/2021-04-10-10-57-33.bpo-43739.L4HjiX.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-04-10-10-57-33.bpo-43739.L4HjiX.rst
@@ -1,0 +1,1 @@
+Fixing the example code in Doc/extending/extending.rst to declare and initialize the pmodule variable to be of the right type.


### PR DESCRIPTION
In the example code of the Extending Python with C/C++ documentation the pmodule variable (that stores the return value of PyImport_ImportModule) was never declared. This PR fixes the problem by declaring and initializing the pmodule variable.

(This PR is for documentation version 3.8.)


<!-- issue-number: [bpo-43739](https://bugs.python.org/issue43739) -->
https://bugs.python.org/issue43739
<!-- /issue-number -->
