### PR TITLE
bpo-43772: fix TypeVar.__ror__

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -185,8 +185,16 @@ class TypeVarTests(BaseTestCase):
         self.assertEqual(Union[X, int].__args__, (X, int))
         self.assertEqual(Union[X, int].__parameters__, (X,))
         self.assertIs(Union[X, int].__origin__, Union)
+
+    def test_or(self):
+        X = TypeVar('X')
+        # use a string because str doesn't implement
+        # __or__/__ror__ itself
         self.assertEqual(X | "x", Union[X, "x"])
         self.assertEqual("x" | X, Union["x", X])
+        # make sure the order is correct
+        self.assertEqual(get_args(X | "x"), (X, ForwardRef("x")))
+        self.assertEqual(get_args("x" | X), (ForwardRef("x"), X))
 
     def test_union_constrained(self):
         A = TypeVar('A', str, bytes)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -185,6 +185,8 @@ class TypeVarTests(BaseTestCase):
         self.assertEqual(Union[X, int].__args__, (X, int))
         self.assertEqual(Union[X, int].__parameters__, (X,))
         self.assertIs(Union[X, int].__origin__, Union)
+        self.assertEqual(X | "x", Union[X, "x"])
+        self.assertEqual("x" | X, Union["x", X])
 
     def test_union_constrained(self):
         A = TypeVar('A', str, bytes)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -646,8 +646,8 @@ class _TypeVarLike:
     def __or__(self, right):
         return Union[self, right]
 
-    def __ror__(self, right):
-        return Union[self, right]
+    def __ror__(self, left):
+        return Union[left, self]
 
     def __repr__(self):
         if self.__covariant__:

--- a/Misc/NEWS.d/next/Library/2021-04-10-19-14-49.bpo-43772.Bxq0zQ.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-10-19-14-49.bpo-43772.Bxq0zQ.rst
@@ -1,0 +1,1 @@
+Fixed the return value of ``TypeVar.__ror__``. Patch by Jelle Zijlstra.


### PR DESCRIPTION
A very simple change.

<!-- issue-number: [bpo-43772](https://bugs.python.org/issue43772) -->
https://bugs.python.org/issue43772
<!-- /issue-number -->
