### PR TITLE
bpo-43804: Add more info in documentation about building C/C++ Extensions on Windows using MSVC

### DIFF
--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -125,6 +125,10 @@ The second command created :file:`ni.dll` (and :file:`.obj` and :file:`.lib`),
 which knows how to find the necessary functions from spam, and also from the
 Python executable.
 
+.. note::
+
+   The above commands are only applicable for Python 32-bit versions.
+
 Not every identifier is exported to the lookup table.  If you want any other
 modules (including Python) to be able to see your identifiers, you have to say
 ``_declspec(dllexport)``, as in ``void _declspec(dllexport) initspam(void)`` or

--- a/Misc/NEWS.d/next/Documentation/2021-04-11-16-50-38.bpo-43804.JN--cJ.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-04-11-16-50-38.bpo-43804.JN--cJ.rst
@@ -1,0 +1,1 @@
+Add more info in the documentation about building C/C++ Extensions on Windows using MSVC.


### PR DESCRIPTION
In the context of Docs/extending/windows.rst, the command provided, for compiling the source code and linking the libraries to create a DLL, only works for Python 32-bit versions. But the documentation doesn't inform anything about that. This PR adds a note section with the text :-

"""

The above commands are only applicable for Python 32-bit versions.

"""

(This PR, if accepted, needs to be backported to all supported versions.)


<!-- issue-number: [bpo-43804](https://bugs.python.org/issue43804) -->
https://bugs.python.org/issue43804
<!-- /issue-number -->
