### PR TITLE
bpo-41661: Document os.path.relpath() behavior on Windows with different drives

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -366,7 +366,8 @@ the :mod:`glob` module.)
    Return a relative filepath to *path* either from the current directory or
    from an optional *start* directory.  This is a path computation:  the
    filesystem is not accessed to confirm the existence or nature of *path* or
-   *start*.
+   *start*.  On Windows, :exc:`ValueError` is raised when *path* and *start*
+   are on different drives.
 
    *start* defaults to :attr:`os.curdir`.
 


### PR DESCRIPTION


<!-- issue-number: [bpo-41661](https://bugs.python.org/issue41661) -->
https://bugs.python.org/issue41661
<!-- /issue-number -->
