### PR TITLE
bpo-41515: Fix KeyError raised in get_type_hints

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2267,6 +2267,12 @@ class ClassVarTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(int, ClassVar)
 
+    def test_bad_module(self):
+        # bpo-41515
+        class BadModule:
+            pass
+        BadModule.__module__ = 'bad' # Something not in sys.modules
+        assert(get_type_hints(BadModule), {})
 
 class FinalTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1628,7 +1628,10 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False):
         hints = {}
         for base in reversed(obj.__mro__):
             if globalns is None:
-                base_globals = sys.modules[base.__module__].__dict__
+                try:
+                    base_globals = sys.modules[base.__module__].__dict__
+                except KeyError:
+                    continue
             else:
                 base_globals = globalns
             ann = base.__dict__.get('__annotations__', {})

--- a/Misc/NEWS.d/next/Library/2021-04-12-06-01-10.bpo-41515.YaVReb.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-12-06-01-10.bpo-41515.YaVReb.rst
@@ -1,0 +1,2 @@
+Fix :exc:`KeyError` raised in :func:`typing.get_type_hints()` due to
+synthetic modules that don't appear in ``sys.modules``.

--- a/Misc/NEWS.d/next/Library/2021-04-12-06-01-10.bpo-41515.YaVReb.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-12-06-01-10.bpo-41515.YaVReb.rst
@@ -1,2 +1,2 @@
-Fix :exc:`KeyError` raised in :func:`typing.get_type_hints()` due to
+Fix :exc:`KeyError` raised in :func:`typing.get_type_hints` due to
 synthetic modules that don't appear in ``sys.modules``.


### PR DESCRIPTION
typing.get_type_hints raises KeyError on synthetic modules that don't appear in sys.modules.

<!-- issue-number: [bpo-41515](https://bugs.python.org/issue41515) -->
https://bugs.python.org/issue41515
<!-- /issue-number -->
