### PR TITLE
bpo-43680: _pyio.open() becomes a static method

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -63,6 +63,13 @@ def text_encoding(encoding, stacklevel=2):
     return encoding
 
 
+# Wrapper for builtins.open
+#
+# Trick so that open() won't become a bound method when stored
+# as a class variable (as dbm.dumb does).
+#
+# See init_set_builtins_open() in Python/pylifecycle.c.
+@staticmethod
 def open(file, mode="r", buffering=-1, encoding=None, errors=None,
          newline=None, closefd=True, opener=None):
 
@@ -313,18 +320,9 @@ class DocDescriptor:
                  "errors=None, newline=None, closefd=True)\n\n" +
             open.__doc__)
 
-class OpenWrapper:
-    """Wrapper for builtins.open
 
-    Trick so that open won't become a bound method when stored
-    as a class variable (as dbm.dumb does).
-
-    See initstdio() in Python/pylifecycle.c.
-    """
-    __doc__ = DocDescriptor()
-
-    def __new__(cls, *args, **kwargs):
-        return open(*args, **kwargs)
+# bpo-43680: Alias to open() kept for backward compatibility
+OpenWrapper = open
 
 
 # In normal operation, both `UnsupportedOperation`s should be bound to the

--- a/Misc/NEWS.d/next/Library/2021-04-12-09-57-37.bpo-43680.o1zEk_.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-12-09-57-37.bpo-43680.o1zEk_.rst
@@ -1,0 +1,5 @@
+The Python :func:`_pyio.open` function becomes a static method to behave as
+func:`io.open` built-in function: don't become a bound method when stored as a
+class variable. It becomes possible since static methods are now callable in
+Python 3.10. Moreover, :func:`_pyio.OpenWrapper` becomes a simple alias to
+:func:`_pyio.open`.

--- a/Misc/NEWS.d/next/Library/2021-04-12-09-57-37.bpo-43680.o1zEk_.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-12-09-57-37.bpo-43680.o1zEk_.rst
@@ -1,5 +1,5 @@
 The Python :func:`_pyio.open` function becomes a static method to behave as
-func:`io.open` built-in function: don't become a bound method when stored as a
+:func:`io.open` built-in function: don't become a bound method when stored as a
 class variable. It becomes possible since static methods are now callable in
 Python 3.10. Moreover, :func:`_pyio.OpenWrapper` becomes a simple alias to
 :func:`_pyio.open`.

--- a/Misc/NEWS.d/next/Library/2021-04-12-09-57-37.bpo-43680.o1zEk_.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-12-09-57-37.bpo-43680.o1zEk_.rst
@@ -3,3 +3,4 @@ The Python :func:`_pyio.open` function becomes a static method to behave as
 class variable. It becomes possible since static methods are now callable in
 Python 3.10. Moreover, :func:`_pyio.OpenWrapper` becomes a simple alias to
 :func:`_pyio.open`.
+Patch by Victor Stinner.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2241,7 +2241,7 @@ error:
     return NULL;
 }
 
-/* Set builtins.open to io.OpenWrapper */
+/* Set builtins.open to io.open */
 static PyStatus
 init_set_builtins_open(void)
 {
@@ -2257,7 +2257,7 @@ init_set_builtins_open(void)
         goto error;
     }
 
-    if (!(wrapper = PyObject_GetAttrString(iomod, "OpenWrapper"))) {
+    if (!(wrapper = PyObject_GetAttrString(iomod, "open"))) {
         goto error;
     }
 
@@ -2279,7 +2279,7 @@ done:
 }
 
 
-/* Initialize sys.stdin, stdout, stderr and builtins.open */
+/* Create sys.stdin, sys.stdout and sys.stderr */
 static PyStatus
 init_sys_streams(PyThreadState *tstate)
 {


### PR DESCRIPTION
The Python _pyio.open() function becomes a static method to behave as
io.open() built-in function: don't become a bound method when stored
as a class variable. It becomes possible since static methods are now
callable in Python 3.10. Moreover, _pyio.OpenWrapper becomes a simple
alias to _pyio.open.

init_set_builtins_open() now sets builtins.open to io.open, rather
than setting it to io.OpenWrapper, since OpenWrapper is now an alias
to open in the io and _pyio modules.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43680](https://bugs.python.org/issue43680) -->
https://bugs.python.org/issue43680
<!-- /issue-number -->
