### PR TITLE
bpo-43680: Deprecate io.OpenWrapper

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -313,15 +313,16 @@ except AttributeError:
 
 def __getattr__(name):
     if name == "OpenWrapper":
-        import warnings
-        warnings.warn('OpenWrapper is deprecated, use open instead',
-                      DeprecationWarning, stacklevel=2)
         # bpo-43680: Until Python 3.9, _pyio.open was not a static method and
         # builtins.open was set to OpenWrapper to not become a bound method
         # when set to a class variable. _io.open is a built-in function whereas
         # _pyio.open is a Python function. In Python 3.10, _pyio.open() is now
         # a static method, and builtins.open() is now io.open().
-        OpenWrapper = _io.open
+        import warnings
+        warnings.warn('OpenWrapper is deprecated, use open instead',
+                      DeprecationWarning, stacklevel=2)
+        global OpenWrapper
+        OpenWrapper = open
         return OpenWrapper
     raise AttributeError(name)
 

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -311,18 +311,19 @@ except AttributeError:
     open_code = _open_code_with_warning
 
 
-class DocDescriptor:
-    """Helper for builtins.open.__doc__
-    """
-    def __get__(self, obj, typ=None):
-        return (
-            "open(file, mode='r', buffering=-1, encoding=None, "
-                 "errors=None, newline=None, closefd=True)\n\n" +
-            open.__doc__)
-
-
-# bpo-43680: Alias to open() kept for backward compatibility
-OpenWrapper = open
+def __getattr__(name):
+    if name == "OpenWrapper":
+        import warnings
+        warnings.warn('OpenWrapper is deprecated, use open instead',
+                      DeprecationWarning, stacklevel=2)
+        # bpo-43680: Until Python 3.9, _pyio.open was not a static method and
+        # builtins.open was set to OpenWrapper to not become a bound method
+        # when set to a class variable. _io.open is a built-in function whereas
+        # _pyio.open is a Python function. In Python 3.10, _pyio.open() is now
+        # a static method, and builtins.open() is now io.open().
+        OpenWrapper = _io.open
+        return OpenWrapper
+    raise AttributeError(name)
 
 
 # In normal operation, both `UnsupportedOperation`s should be bound to the

--- a/Lib/io.py
+++ b/Lib/io.py
@@ -56,7 +56,21 @@ from _io import (DEFAULT_BUFFER_SIZE, BlockingIOError, UnsupportedOperation,
                  BufferedWriter, BufferedRWPair, BufferedRandom,
                  IncrementalNewlineDecoder, text_encoding, TextIOWrapper)
 
-OpenWrapper = _io.open # for compatibility with _pyio
+
+def __getattr__(name):
+    if name == "OpenWrapper":
+        import warnings
+        warnings.warn('OpenWrapper is deprecated, use open instead',
+                      DeprecationWarning, stacklevel=2)
+        # bpo-43680: Until Python 3.9, _pyio.open was not a static method and
+        # builtins.open was set to OpenWrapper to not become a bound method
+        # when set to a class variable. _io.open is a built-in function whereas
+        # _pyio.open is a Python function. In Python 3.10, _pyio.open() is now
+        # a static method, and builtins.open() is now io.open().
+        OpenWrapper = _io.open
+        return OpenWrapper
+    raise AttributeError(name)
+
 
 # Pretend this exception was created here.
 UnsupportedOperation.__module__ = "io"

--- a/Lib/io.py
+++ b/Lib/io.py
@@ -59,15 +59,16 @@ from _io import (DEFAULT_BUFFER_SIZE, BlockingIOError, UnsupportedOperation,
 
 def __getattr__(name):
     if name == "OpenWrapper":
-        import warnings
-        warnings.warn('OpenWrapper is deprecated, use open instead',
-                      DeprecationWarning, stacklevel=2)
         # bpo-43680: Until Python 3.9, _pyio.open was not a static method and
         # builtins.open was set to OpenWrapper to not become a bound method
         # when set to a class variable. _io.open is a built-in function whereas
         # _pyio.open is a Python function. In Python 3.10, _pyio.open() is now
         # a static method, and builtins.open() is now io.open().
-        OpenWrapper = _io.open
+        import warnings
+        warnings.warn('OpenWrapper is deprecated, use open instead',
+                      DeprecationWarning, stacklevel=2)
+        global OpenWrapper
+        OpenWrapper = open
         return OpenWrapper
     raise AttributeError(name)
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4283,6 +4283,14 @@ class MiscIOTest(unittest.TestCase):
         self.assertTrue(
             warnings[1].startswith(b"<string>:8: EncodingWarning: "))
 
+    @support.cpython_only
+    # Depending if OpenWrapper was already created or not, the warning is
+    # emitted or not. For example, the attribute is already created when this
+    # test is run multiple times.
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
+    def test_openwrapper(self):
+        self.assertIs(self.io.OpenWrapper, self.io.open)
+
 
 class CMiscIOTest(MiscIOTest):
     io = io

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4598,8 +4598,6 @@ def load_tests(*args):
     globs = globals()
     c_io_ns.update((x.__name__, globs["C" + x.__name__]) for x in mocks)
     py_io_ns.update((x.__name__, globs["Py" + x.__name__]) for x in mocks)
-    # Avoid turning open into a bound method.
-    py_io_ns["open"] = pyio.OpenWrapper
     for test in tests:
         if test.__name__.startswith("C"):
             for name, obj in c_io_ns.items():

--- a/Misc/NEWS.d/next/Library/2021-04-12-11-20-34.bpo-43680.SR0Epv.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-12-11-20-34.bpo-43680.SR0Epv.rst
@@ -1,0 +1,6 @@
+Deprecate io.OpenWrapper and _pyio.OpenWrapper: use io.open and _pyio.open
+instead. Until Python 3.9, _pyio.open was not a static method and
+builtins.open was set to OpenWrapper to not become a bound method when set
+to a class variable. _io.open is a built-in function whereas _pyio.open is a
+Python function. In Python 3.10, _pyio.open() is now a static method, and
+builtins.open() is now io.open().


### PR DESCRIPTION
Deprecate io.OpenWrapper and _pyio.OpenWrapper: use io.open and
_pyio.open instead. Until Python 3.9, _pyio.open was not a static
method and builtins.open was set to OpenWrapper to not become a bound
method when set to a class variable. _io.open is a built-in function
whereas _pyio.open is a Python function. In Python 3.10, _pyio.open()
is now a static method, and builtins.open() is now io.open().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43680](https://bugs.python.org/issue43680) -->
https://bugs.python.org/issue43680
<!-- /issue-number -->
