### PR TITLE
bpo-43774: Remove --without-cycle-gc doc

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -911,12 +911,7 @@ the cycle itself.
 The cycle detector is able to detect garbage cycles and can reclaim them.
 The :mod:`gc` module exposes a way to run the detector (the
 :func:`~gc.collect` function), as well as configuration
-interfaces and the ability to disable the detector at runtime.  The cycle
-detector is considered an optional component; though it is included by default,
-it can be disabled at build time using the :option:`!--without-cycle-gc` option
-to the :program:`configure` script on Unix platforms (including Mac OS X).  If
-the cycle detector is disabled in this way, the :mod:`gc` module will not be
-available.
+interfaces and the ability to disable the detector at runtime.
 
 
 .. _refcountsinpython:


### PR DESCRIPTION
The configure --without-cycle-gc option has been removed in Python
2.3 by the commit cccd1e72481106b0a373117f32fda6261f3141a7. It's now
time to remove the last reference to it in the documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43774](https://bugs.python.org/issue43774) -->
https://bugs.python.org/issue43774
<!-- /issue-number -->
