### PR TITLE
bpo-43816: add 'extern "C"' to pyctype.h

### DIFF
--- a/Include/cpython/pyctype.h
+++ b/Include/cpython/pyctype.h
@@ -1,7 +1,6 @@
 #ifndef Py_LIMITED_API
 #ifndef PYCTYPE_H
 #define PYCTYPE_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,6 +35,5 @@ PyAPI_DATA(const unsigned char) _Py_ctype_toupper[256];
 #ifdef __cplusplus
 }
 #endif
-
 #endif /* !PYCTYPE_H */
 #endif /* !Py_LIMITED_API */

--- a/Include/cpython/pyctype.h
+++ b/Include/cpython/pyctype.h
@@ -2,6 +2,10 @@
 #ifndef PYCTYPE_H
 #define PYCTYPE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PY_CTF_LOWER  0x01
 #define PY_CTF_UPPER  0x02
 #define PY_CTF_ALPHA  (PY_CTF_LOWER|PY_CTF_UPPER)
@@ -28,6 +32,10 @@ PyAPI_DATA(const unsigned char) _Py_ctype_toupper[256];
 
 #define Py_TOLOWER(c) (_Py_ctype_tolower[Py_CHARMASK(c)])
 #define Py_TOUPPER(c) (_Py_ctype_toupper[Py_CHARMASK(c)])
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !PYCTYPE_H */
 #endif /* !Py_LIMITED_API */


### PR DESCRIPTION
## Issue

With Python 3.9.4, and when compiling with Visual Studio 2019, we have noticed that the variable `_Py_ctype_table` is *not* scoped with in an `extern "C"` block, and where the Python library (`python39.lib`) *has* been compiled with a C compiler.

This causes an issue when trying to refer to `_Py_ctype_table` from a C++ file, as the compiler tries to name-mangle the _use_ of `_Py_ctype_table`, but the linker cannot then tie the mangled name to non-mangled named from  `python39.lib`.

Example:

```
#include "Python.h"
int main() { return _Py_ctype_table[0]; }
```

Compilation:

```
cl.exe /Fe:test.exe /TP /I include test.cpp /link libs/python39.lib
Microsoft (R) C/C++ Optimizing Compiler Version 19.28.29336 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

test.cpp
Microsoft (R) Incremental Linker Version 14.28.29336.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:test.exe
libs/python39.lib
test.obj
test.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) unsigned int const * const _Py_ctype_table" (__imp_?_Py_ctype_table@@3QBIB) referenced in function main
test.exe : fatal error LNK1120: 1 unresolved externals
```

With `cl.exe`:

```
cl.exe /Bv  
Microsoft (R) C/C++ Optimizing Compiler Version 19.28.29336 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

Compiler Passes:
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\cl.exe:        Version 19.28.29336.0
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\c1.dll:        Version 19.28.29336.0
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\c1xx.dll:      Version 19.28.29336.0
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\c2.dll:        Version 19.28.29336.0
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\c1xx.dll:      Version 19.28.29336.0
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\link.exe:      Version 14.28.29336.0
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\mspdb140.dll:  Version 14.28.29336.0
 Z:\home\avj\visual_studio\MSVC\14.28.29333\bin\HostX64\x64\1033\clui.dll: Version 19.28.29336.0
```

A naïve check of Python.h (e126547c07) seems to suggest that:

* There are 82 includes
* 64 of these contain `extern "C"`
* 8 do not contain `extern "C"`
* The remaining 10 are either system includes or pyconfig.h

For the 8 that *do not* contain `extern "C"`, none of these use `PyAPI_DATA`. This leads me to believe that it is an oversight that `pyctype.h` does not have `extern "C"`

## Resolution

This PR resolves this issue by adding an `extern "C"` declaration to the top of `pyctype.h` (if compiling as C++).


Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>


<!-- issue-number: [bpo-43816](https://bugs.python.org/issue43816) -->
https://bugs.python.org/issue43816
<!-- /issue-number -->
