### PR TITLE
bpo-41515: Fix assert in test which throws SyntaxWarning.

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2272,7 +2272,7 @@ class ClassVarTests(BaseTestCase):
         class BadModule:
             pass
         BadModule.__module__ = 'bad' # Something not in sys.modules
-        assert(get_type_hints(BadModule), {})
+        self.assertEqual(get_type_hints(BadModule), {})
 
 class FinalTests(BaseTestCase):
 


### PR DESCRIPTION


<!-- issue-number: [bpo-41515](https://bugs.python.org/issue41515) -->
https://bugs.python.org/issue41515
<!-- /issue-number -->
