### PR TITLE
bpo-43825: Fix deprecation warnings in test cases

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -862,7 +862,7 @@ class SyntaxErrorTests(unittest.TestCase):
         self.check_string(b"(1+2+3")
 
     def test_decoding_error_at_the_end_of_the_line(self):
-        self.check_string(b"'\u1f'")
+        self.check_string(br"'\u1f'")
 
 def test_main():
     support.run_unittest(CmdLineTest, IgnoreEnvironmentTest, SyntaxErrorTests)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1515,7 +1515,7 @@ class TestCollectionABCs(ABCTestCase):
         items = [5,43,2,1]
         s = MySet(items)
         r = s.pop()
-        self.assertEquals(len(s), len(items) - 1)
+        self.assertEqual(len(s), len(items) - 1)
         self.assertNotIn(r, s)
         self.assertIn(r, items)
 


### PR DESCRIPTION
* Fix deprecation warnings due to invalid escape sequences.
* Use self.assertEqual instead of deprecated self.assertEquals.

<!-- issue-number: [bpo-43825](https://bugs.python.org/issue43825) -->
https://bugs.python.org/issue43825
<!-- /issue-number -->
