### PR TITLE
[3.8] bpo-43799: OpenSSL 3.0.0: declare OPENSSL_API_COMPAT 1.1.1 (GH-25329) (GH-25383)

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-04-10-11-35-50.bpo-43799.1iV4pX.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-10-11-35-50.bpo-43799.1iV4pX.rst
@@ -1,0 +1,2 @@
+OpenSSL 3.0.0: define ``OPENSSL_API_COMPAT`` 1.1.1 to suppress deprecation
+warnings. Python requires OpenSSL 1.1.1 APIs.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -11,6 +11,13 @@
  *
  */
 
+/* Don't warn about deprecated functions, */
+#ifndef OPENSSL_API_COMPAT
+  // 0x10101000L == 1.1.1, 30000 == 3.0.0
+  #define OPENSSL_API_COMPAT 0x10101000L
+#endif
+#define OPENSSL_NO_DEPRECATED 1
+
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
@@ -24,7 +31,7 @@
 #include <openssl/hmac.h>
 /* We use the object interface to discover what hashes OpenSSL supports. */
 #include <openssl/objects.h>
-#include "openssl/err.h"
+#include <openssl/err.h>
 
 #ifndef OPENSSL_THREADS
 #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -14,6 +14,13 @@
        http://bugs.python.org/issue8108#msg102867 ?
 */
 
+/* Don't warn about deprecated functions, */
+#ifndef OPENSSL_API_COMPAT
+  // 0x10101000L == 1.1.1, 30000 == 3.0.0
+  #define OPENSSL_API_COMPAT 0x10101000L
+#endif
+#define OPENSSL_NO_DEPRECATED 1
+
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
@@ -43,14 +50,6 @@ static PySocketModule_APIObject PySocketModule;
 #include <poll.h>
 #elif defined(HAVE_SYS_POLL_H)
 #include <sys/poll.h>
-#endif
-
-/* Don't warn about deprecated functions */
-#ifdef __GNUC__
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 /* Include OpenSSL header files */
@@ -150,23 +149,19 @@ static void _PySSLFixErrno(void) {
 #  define PY_OPENSSL_1_1_API 1
 #endif
 
-/* OpenSSL API compat */
-#ifdef OPENSSL_API_COMPAT
-#if OPENSSL_API_COMPAT >= 0x10100000L
-
-/* OpenSSL API 1.1.0+ does not include version methods */
+/* OpenSSL API 1.1.0+ does not include version methods. Define the methods
+ * unless OpenSSL is compiled without the methods. It's the easiest way to
+ * make 1.0.2, 1.1.0, 1.1.1, and 3.0.0 happy without deprecation warnings.
+ */
 #ifndef OPENSSL_NO_TLS1_METHOD
-#define OPENSSL_NO_TLS1_METHOD 1
+extern const SSL_METHOD *TLSv1_method(void);
 #endif
 #ifndef OPENSSL_NO_TLS1_1_METHOD
-#define OPENSSL_NO_TLS1_1_METHOD 1
+extern const SSL_METHOD *TLSv1_1_method(void);
 #endif
 #ifndef OPENSSL_NO_TLS1_2_METHOD
-#define OPENSSL_NO_TLS1_2_METHOD 1
+extern const SSL_METHOD *TLSv1_2_method(void);
 #endif
-
-#endif /* >= 1.1.0 compcat */
-#endif /* OPENSSL_API_COMPAT */
 
 /* LibreSSL 2.7.0 provides necessary OpenSSL 1.1.0 APIs */
 #if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>.
(cherry picked from commit a4833883c9b81b6b272cc7c5b67fa1658b65304c)


<!-- issue-number: [bpo-43799](https://bugs.python.org/issue43799) -->
https://bugs.python.org/issue43799
<!-- /issue-number -->
