### PR TITLE
bpo-43827: Fixed abc conflicts with __init_subclass__

### DIFF
--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -102,7 +102,7 @@ else:
         implementations defined by the registering ABC be callable (not
         even via super()).
         """
-        def __new__(mcls, name, bases, namespace, **kwargs):
+        def __new__(mcls, name, bases, namespace, /, **kwargs):
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
             _abc_init(cls)
             return cls

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -668,6 +668,19 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             class Receiver(ReceivesClassKwargs, abc_ABC, x=1, y=2, z=3):
                 pass
             self.assertEqual(saved_kwargs, dict(x=1, y=2, z=3))
+
+        def test_positional_only_and_kwonlyargs_with_init_subclass(self):
+            saved_kwargs = {}
+
+            class A:
+                def __init_subclass__(cls, **kwargs):
+                    super().__init_subclass__()
+                    saved_kwargs.update(kwargs)
+
+            class B(A, metaclass=abc_ABCMeta, name="test"):
+                pass
+            self.assertEqual(saved_kwargs, dict(name="test"))
+
     return TestLegacyAPI, TestABC, TestABCWithInitSubclass
 
 TestLegacyAPI_Py, TestABC_Py, TestABCWithInitSubclass_Py = test_factory(abc.ABCMeta,

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -753,6 +753,7 @@ Albert Hofkamp
 Chris Hogan
 Tomas Hoger
 Jonathan Hogg
+Vladyslav Hoi
 Kamilla Holanda
 Steve Holden
 Akintayo Holder

--- a/Misc/NEWS.d/next/Library/2021-04-16-17-32-44.bpo-43827.uJaXdP.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-16-17-32-44.bpo-43827.uJaXdP.rst
@@ -1,0 +1,1 @@
+All positional-or-keyword parameters to ``ABCMeta.__new__`` are now positional-only to avoid conflicts with keyword arguments to be passed to :meth:`__init_subclass__`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-43827](https://bugs.python.org/issue43827) -->
https://bugs.python.org/issue43827
<!-- /issue-number -->
