### PR TITLE
Fix typo in the What's New for 3.10

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -175,7 +175,7 @@ AttributeErrors
 ~~~~~~~~~~~~~~~
 
 When printing :exc:`AttributeError`, :c:func:`PyErr_Display` will offer
-suggestions of simmilar attribute names in the object that the exception was
+suggestions of similar attribute names in the object that the exception was
 raised from:
 
 .. code-block:: python

--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-27-20-20-07.bpo-38530.ZyoDNn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-27-20-20-07.bpo-38530.ZyoDNn.rst
@@ -1,3 +1,3 @@
 When printing :exc:`AttributeError`, :c:func:`PyErr_Display` will offer
-suggestions of simmilar attribute names in the object that the exception was
+suggestions of similar attribute names in the object that the exception was
 raised from. Patch by Pablo Galindo


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
