### PR TITLE
bpo-43843: libregrtest uses threading.excepthook

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -10,7 +10,8 @@ try:
 except ImportError:
     gc = None
 
-from test.libregrtest.utils import setup_unraisable_hook
+from test.libregrtest.utils import (setup_unraisable_hook,
+                                    setup_threading_excepthook)
 
 
 def setup_tests(ns):
@@ -81,6 +82,7 @@ def setup_tests(ns):
         sys.addaudithook(_test_audit_hook)
 
     setup_unraisable_hook()
+    setup_threading_excepthook()
 
     if ns.timeout is not None:
         # For a slow buildbot worker, increase SHORT_TIMEOUT and LONG_TIMEOUT

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -86,6 +86,28 @@ def setup_unraisable_hook():
     sys.unraisablehook = regrtest_unraisable_hook
 
 
+orig_threading_excepthook = None
+
+
+def regrtest_threading_excepthook(args):
+    global orig_threading_excepthook
+    support.environment_altered = True
+    print_warning("Uncaught thread exception")
+    old_stderr = sys.stderr
+    try:
+        sys.stderr = sys.__stderr__
+        orig_threading_excepthook(args)
+    finally:
+        sys.stderr = old_stderr
+
+
+def setup_threading_excepthook():
+    global orig_threading_excepthook
+    import threading
+    orig_threading_excepthook = threading.excepthook
+    threading.excepthook = regrtest_threading_excepthook
+
+
 def clear_caches():
     # Clear the warnings registry, so they can be displayed again
     for mod in sys.modules.values():

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -92,7 +92,7 @@ orig_threading_excepthook = None
 def regrtest_threading_excepthook(args):
     global orig_threading_excepthook
     support.environment_altered = True
-    print_warning("Uncaught thread exception")
+    print_warning(f"Uncaught thread exception: {args.exc_type.__name__}")
     old_stderr = sys.stderr
     try:
         sys.stderr = sys.__stderr__

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -68,14 +68,23 @@ def print_warning(msg):
 orig_unraisablehook = None
 
 
+def flush_std_streams():
+    if sys.stdout is not None:
+        sys.stdout.flush()
+    if sys.stderr is not None:
+        sys.stderr.flush()
+
+
 def regrtest_unraisable_hook(unraisable):
     global orig_unraisablehook
     support.environment_altered = True
     print_warning("Unraisable exception")
     old_stderr = sys.stderr
     try:
+        flush_std_streams()
         sys.stderr = sys.__stderr__
         orig_unraisablehook(unraisable)
+        sys.stderr.flush()
     finally:
         sys.stderr = old_stderr
 
@@ -95,8 +104,10 @@ def regrtest_threading_excepthook(args):
     print_warning(f"Uncaught thread exception: {args.exc_type.__name__}")
     old_stderr = sys.stderr
     try:
+        flush_std_streams()
         sys.stderr = sys.__stderr__
         orig_threading_excepthook(args)
+        sys.stderr.flush()
     finally:
         sys.stderr = old_stderr
 

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -323,8 +323,11 @@ class ErrorHandlerTest(unittest.TestCase):
         self.check_result(handled=True)
 
     def test_threading_not_handled(self):
-        ThreadingErrorTestServer(SystemExit)
-        self.check_result(handled=False)
+        with threading_helper.catch_threading_exception() as cm:
+            ThreadingErrorTestServer(SystemExit)
+            self.check_result(handled=False)
+
+            self.assertIs(cm.exc_type, SystemExit)
 
     @requires_forking
     def test_forking_handled(self):

--- a/Misc/NEWS.d/next/Tests/2021-04-14-13-22-44.bpo-43843.ruIQKD.rst
+++ b/Misc/NEWS.d/next/Tests/2021-04-14-13-22-44.bpo-43843.ruIQKD.rst
@@ -1,0 +1,5 @@
+:mod:`test.libregrtest` now marks a test as ENV_CHANGED (altered the execution
+environment) if a thread raises an exception but does not catch it. It sets a
+hook on :func:`threading.excepthook`. Use ``--fail-env-changed`` option to mark
+the test as failed.
+Patch by Victor Stinner.


### PR DESCRIPTION
test.libregrtest now marks a test as ENV_CHANGED (altered the
execution environment) if a thread raises an exception but does not
catch it. It sets a hook on threading.excepthook. Use
--fail-env-changed option to mark the test as failed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43843](https://bugs.python.org/issue43843) -->
https://bugs.python.org/issue43843
<!-- /issue-number -->
