### PR TITLE
bpo-43846: Use less stack for large literals and calls

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -961,6 +961,32 @@ class TestExpressionStackSize(unittest.TestCase):
     def test_binop(self):
         self.check_stack_size("x + " * self.N + "x")
 
+    def test_list(self):
+        self.check_stack_size("[" + "x, " * self.N + "x]")
+
+    def test_tuple(self):
+        self.check_stack_size("(" + "x, " * self.N + "x)")
+
+    def test_set(self):
+        self.check_stack_size("{" + "x, " * self.N + "x}")
+
+    def test_dict(self):
+        self.check_stack_size("{" + "x:x, " * self.N + "x:x}")
+
+    def test_func_args(self):
+        self.check_stack_size("f(" + "x, " * self.N + ")")
+
+    def test_func_kwargs(self):
+        kwargs = (f'a{i}=x' for i in range(self.N))
+        self.check_stack_size("f(" +  ", ".join(kwargs) + ")")
+
+    def test_func_args(self):
+        self.check_stack_size("o.m(" + "x, " * self.N + ")")
+
+    def test_meth_kwargs(self):
+        kwargs = (f'a{i}=x' for i in range(self.N))
+        self.check_stack_size("o.m(" +  ", ".join(kwargs) + ")")
+
     def test_func_and(self):
         code = "def f(x):\n"
         code += "   x and x\n" * self.N

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-14-13-53-08.bpo-43846.2jO97c.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-14-13-53-08.bpo-43846.2jO97c.rst
@@ -1,0 +1,1 @@
+Data stack usage is much reduced for large literal and call expressions.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -47,9 +47,8 @@
  * memory use for large constants, etc.
  *
  * The value 30 is plucked out of thin air.
- * Code that this impacts is rare (dynamically),
- * so exact value is unimportant.
- * An experimentally determined
+ * Code that could use more stack than this is
+ * rare, so the exact value is unimportant.
  */
 #define STACK_USE_GUIDELINE 30
 
@@ -61,6 +60,10 @@
  * For performance reasons we will
  * want to reduce this to a
  * few hundred in the future.
+ *
+ * NOTE: Whatever MAX_ALLOWED_STACK_USE is
+ * set to, it should never restrict what Python
+ * we can write, just how we compile it.
  */
 #define MAX_ALLOWED_STACK_USE (STACK_USE_GUIDELINE * 100)
 


### PR DESCRIPTION
Prevents excessive stack usage for oversized calls and literals.
Having a soft upper limit on stack usage allows us to design more efficient stack layouts
without worrying about code that uses huge amounts of stack.

As giant literals and calls are rare, this PR should have negligible effect on performance.


<!-- issue-number: [bpo-43846](https://bugs.python.org/issue43846) -->
https://bugs.python.org/issue43846
<!-- /issue-number -->
