### PR TITLE
bpo-41282: setup.py ignores distutils DeprecationWarning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ except ImportError:
 
 with warnings.catch_warnings():
     # bpo-41282 (PEP 632) deprecated distutils but setup.py still uses it
-    warnings.simplefilter("ignore", DeprecationWarning)
+    warnings.filterwarnings("ignore", "The distutils package is deprecated",
+                            DeprecationWarning)
 
     from distutils import log
     from distutils.command.build_ext import build_ext

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import sysconfig
+import warnings
 from glob import glob, escape
 import _osx_support
 
@@ -30,14 +31,18 @@ except ImportError:
     SUBPROCESS_BOOTSTRAP = True
 
 
-from distutils import log
-from distutils.command.build_ext import build_ext
-from distutils.command.build_scripts import build_scripts
-from distutils.command.install import install
-from distutils.command.install_lib import install_lib
-from distutils.core import Extension, setup
-from distutils.errors import CCompilerError, DistutilsError
-from distutils.spawn import find_executable
+with warnings.catch_warnings():
+    # bpo-41282 (PEP 632) deprecated distutils but setup.py still uses it
+    warnings.simplefilter("ignore", DeprecationWarning)
+
+    from distutils import log
+    from distutils.command.build_ext import build_ext
+    from distutils.command.build_scripts import build_scripts
+    from distutils.command.install import install
+    from distutils.command.install_lib import install_lib
+    from distutils.core import Extension, setup
+    from distutils.errors import CCompilerError, DistutilsError
+    from distutils.spawn import find_executable
 
 
 # Compile extensions used to test Python?


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41282](https://bugs.python.org/issue41282) -->
https://bugs.python.org/issue41282
<!-- /issue-number -->
