### PR TITLE
bpo-41282: Fix distutils.utils.byte_compile() DeprecationWarning

### DIFF
--- a/Lib/distutils/__init__.py
+++ b/Lib/distutils/__init__.py
@@ -13,7 +13,8 @@ import warnings
 
 __version__ = sys.version[:sys.version.index(' ')]
 
-warnings.warn("The distutils package is deprecated and slated for "
-              "removal in Python 3.12. Use setuptools or check "
-              "PEP 632 for potential alternatives",
+_DEPRECATION_MESSAGE = ("The distutils package is deprecated and slated for "
+                        "removal in Python 3.12. Use setuptools or check "
+                        "PEP 632 for potential alternatives")
+warnings.warn(_DEPRECATION_MESSAGE,
               DeprecationWarning, 2)

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -9,6 +9,7 @@ import re
 import importlib.util
 import string
 import sys
+import distutils
 from distutils.errors import DistutilsPlatformError
 from distutils.dep_util import newer
 from distutils.spawn import spawn
@@ -419,8 +420,10 @@ byte_compile(files, optimize=%r, force=%r,
              direct=1)
 """ % (optimize, force, prefix, base_dir, verbose))
 
+        msg = distutils._DEPRECATION_MESSAGE
         cmd = [sys.executable]
         cmd.extend(subprocess._optim_args_from_interpreter_flags())
+        cmd.append(f'-Wignore:{msg}:DeprecationWarning')
         cmd.append(script_name)
         spawn(cmd, dry_run=dry_run)
         execute(os.remove, (script_name,), "removing %s" % script_name,

--- a/Lib/test/test_distutils.py
+++ b/Lib/test/test_distutils.py
@@ -5,14 +5,20 @@ the test_suite() function there returns a test suite that's ready to
 be run.
 """
 
-import distutils.tests
-import test.support
+import warnings
+from test import support
+from test.support import warnings_helper
+
+with warnings_helper.check_warnings(
+    ("The distutils package is deprecated", DeprecationWarning)):
+
+    import distutils.tests
 
 
 def test_main():
     # used by regrtest
-    test.support.run_unittest(distutils.tests.test_suite())
-    test.support.reap_children()
+    support.run_unittest(distutils.tests.test_suite())
+    support.reap_children()
 
 
 def load_tests(*_):


### PR DESCRIPTION
* byte_compile() of distutils.utils no longer logs a
  DeprecationWarning
* test_distutils no longer logs a DeprecationWarning

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41282](https://bugs.python.org/issue41282) -->
https://bugs.python.org/issue41282
<!-- /issue-number -->
