### PR TITLE
Fix typo in 3.10's What's New documentation

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -420,7 +420,7 @@ For example::
        case ('warning', code, 40):
            print("A warning has been received.")
        case ('error', code, _):
-           print(f"An error {code} occured.")
+           print(f"An error {code} occurred.")
 
 In the above case, ``test_variable`` will match for ('error', code, 100) and
 ('error', code, 800).


### PR DESCRIPTION
"occured" ->  "occurred"

Automerge-Triggered-By: GH:Mariatta