### PR TITLE
bpo-43852: Improve tuple creation in sqlite3

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -592,8 +592,7 @@ _pysqlite_build_py_params(sqlite3_context *context, int argc,
             goto error;
         }
 
-        PyTuple_SetItem(args, i, cur_py_value);
-
+        PyTuple_SET_ITEM(args, i, cur_py_value);
     }
 
     return args;

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -560,22 +560,17 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
                     PyErr_NoMemory();
                     goto error;
                 }
-                PyObject *descriptor = PyTuple_New(7);
+                column_name = _pysqlite_build_column_name(self, colname);
+                if (column_name == NULL) {
+                    goto error;
+                }
+                PyObject *descriptor = PyTuple_Pack(7, column_name,
+                                                    Py_None, Py_None, Py_None,
+                                                    Py_None, Py_None, Py_None);
+                Py_DECREF(column_name);
                 if (descriptor == NULL) {
                     goto error;
                 }
-                column_name = _pysqlite_build_column_name(self, colname);
-                if (column_name == NULL) {
-                    Py_DECREF(descriptor);
-                    goto error;
-                }
-                PyTuple_SET_ITEM(descriptor, 0, column_name);
-                PyTuple_SET_ITEM(descriptor, 1, Py_NewRef(Py_None));
-                PyTuple_SET_ITEM(descriptor, 2, Py_NewRef(Py_None));
-                PyTuple_SET_ITEM(descriptor, 3, Py_NewRef(Py_None));
-                PyTuple_SET_ITEM(descriptor, 4, Py_NewRef(Py_None));
-                PyTuple_SET_ITEM(descriptor, 5, Py_NewRef(Py_None));
-                PyTuple_SET_ITEM(descriptor, 6, Py_NewRef(Py_None));
                 PyTuple_SET_ITEM(self->description, i, descriptor);
             }
         }

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -469,7 +469,9 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
     if (!func_args) {
         goto error;
     }
-    PyTuple_SET_ITEM(func_args, 0, Py_NewRef(operation));
+    if (PyTuple_SetItem(func_args, 0, Py_NewRef(operation)) != 0) {
+        goto error;
+    }
 
     if (self->statement) {
         (void)pysqlite_statement_reset(self->statement);

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -357,7 +357,7 @@ _pysqlite_fetch_one_row(pysqlite_Cursor* self)
         if (!converted) {
             goto error;
         }
-        PyTuple_SetItem(row, i, converted);
+        PyTuple_SET_ITEM(row, i, converted);
     }
 
     if (PyErr_Occurred())
@@ -406,7 +406,6 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
     PyObject* func_args;
     PyObject* result;
     int numcols;
-    PyObject* descriptor;
     PyObject* column_name;
     sqlite_int64 lastrowid;
 
@@ -470,9 +469,7 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
     if (!func_args) {
         goto error;
     }
-    if (PyTuple_SetItem(func_args, 0, Py_NewRef(operation)) != 0) {
-        goto error;
-    }
+    PyTuple_SET_ITEM(func_args, 0, Py_NewRef(operation));
 
     if (self->statement) {
         (void)pysqlite_statement_reset(self->statement);
@@ -557,15 +554,14 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
                 goto error;
             }
             for (i = 0; i < numcols; i++) {
-                descriptor = PyTuple_New(7);
-                if (!descriptor) {
-                    goto error;
-                }
                 const char *colname;
                 colname = sqlite3_column_name(self->statement->st, i);
                 if (colname == NULL) {
                     PyErr_NoMemory();
-                    Py_DECREF(descriptor);
+                    goto error;
+                }
+                PyObject *descriptor = PyTuple_New(7);
+                if (descriptor == NULL) {
                     goto error;
                 }
                 column_name = _pysqlite_build_column_name(self, colname);
@@ -573,14 +569,14 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
                     Py_DECREF(descriptor);
                     goto error;
                 }
-                PyTuple_SetItem(descriptor, 0, column_name);
-                PyTuple_SetItem(descriptor, 1, Py_NewRef(Py_None));
-                PyTuple_SetItem(descriptor, 2, Py_NewRef(Py_None));
-                PyTuple_SetItem(descriptor, 3, Py_NewRef(Py_None));
-                PyTuple_SetItem(descriptor, 4, Py_NewRef(Py_None));
-                PyTuple_SetItem(descriptor, 5, Py_NewRef(Py_None));
-                PyTuple_SetItem(descriptor, 6, Py_NewRef(Py_None));
-                PyTuple_SetItem(self->description, i, descriptor);
+                PyTuple_SET_ITEM(descriptor, 0, column_name);
+                PyTuple_SET_ITEM(descriptor, 1, Py_NewRef(Py_None));
+                PyTuple_SET_ITEM(descriptor, 2, Py_NewRef(Py_None));
+                PyTuple_SET_ITEM(descriptor, 3, Py_NewRef(Py_None));
+                PyTuple_SET_ITEM(descriptor, 4, Py_NewRef(Py_None));
+                PyTuple_SET_ITEM(descriptor, 5, Py_NewRef(Py_None));
+                PyTuple_SET_ITEM(descriptor, 6, Py_NewRef(Py_None));
+                PyTuple_SET_ITEM(self->description, i, descriptor);
             }
         }
 


### PR DESCRIPTION
- Use `PyTuple_SET_ITEM` iso. `PyTuple_SetItem`
- In `_pysqlite_query_execute`, minimise decref's in case of error

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43852](https://bugs.python.org/issue43852) -->
https://bugs.python.org/issue43852
<!-- /issue-number -->
