### PR TITLE
bpo-43823: Fix location of one of the errors for invalid dictionary literals

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -899,6 +899,7 @@ invalid_double_starred_kvpairs:
     | expression ':' a='*' bitwise_or { RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "cannot use a starred expression in a dictionary value") }
     | expression a=':' &('}'|',') { RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "expression expected after dictionary key and ':'") }
 invalid_kvpair:
-    | a=expression !(':') { RAISE_SYNTAX_ERROR("':' expected after dictionary key") }
+    | a=expression !(':') {
+        RAISE_ERROR_KNOWN_LOCATION(p, PyExc_SyntaxError, a->lineno, a->end_col_offset - 1, "':' expected after dictionary key") }
     | expression ':' a='*' bitwise_or { RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "cannot use a starred expression in a dictionary value") }
     | expression a=':' {RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "expression expected after dictionary key and ':'") }

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -19379,7 +19379,7 @@ invalid_kvpair_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_kvpair[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression !(':')"));
-            _res = RAISE_SYNTAX_ERROR ( "':' expected after dictionary key" );
+            _res = RAISE_ERROR_KNOWN_LOCATION ( p , PyExc_SyntaxError , a -> lineno , a -> end_col_offset - 1 , "':' expected after dictionary key" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);


### PR DESCRIPTION


<!-- issue-number: [bpo-43823](https://bugs.python.org/issue43823) -->
https://bugs.python.org/issue43823
<!-- /issue-number -->
