### PR TITLE
[3.8] bpo-43723: Backport IDLE doc change (GH-25174)

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -732,7 +732,7 @@ intended to be the same as executing the same code by the default method,
 directly with Python in a text-mode system console or terminal window.
 However, the different interface and operation occasionally affect
 visible results.  For instance, ``sys.modules`` starts with more entries,
-and ``threading.activeCount()`` returns 2 instead of 1.
+and ``threading.active_count()`` returns 2 instead of 1.
 
 By default, IDLE runs user code in a separate OS process rather than in
 the user interface process that runs the shell and editor.  In the execution


### PR DESCRIPTION
Change threading.activeCount to synonym threading.active_count.

Cherry-picked from 9825bdfbd5c966abf1f1b7264992d722a94c9613

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43723](https://bugs.python.org/issue43723) -->
https://bugs.python.org/issue43723
<!-- /issue-number -->
