### PR TITLE
bpo-43842: Fix race condition in test_logging SMTP test

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -829,6 +829,7 @@ class TestSMTPServer(smtpd.SMTPServer):
         self.port = self.socket.getsockname()[1]
         self._handler = handler
         self._thread = None
+        self._quit = False
         self.poll_interval = poll_interval
 
     def process_message(self, peer, mailfrom, rcpttos, data):
@@ -860,16 +861,18 @@ class TestSMTPServer(smtpd.SMTPServer):
                               :func:`select` or :func:`poll` call by
                               :func:`asyncore.loop`.
         """
-        asyncore.loop(poll_interval, map=self._map)
+        while not self._quit:
+            asyncore.loop(poll_interval, map=self._map, count=1)
 
     def stop(self):
         """
         Stop the thread by closing the server instance.
         Wait for the server thread to terminate.
         """
-        self.close()
+        self._quit = True
         threading_helper.join_thread(self._thread)
         self._thread = None
+        self.close()
         asyncore.close_all(map=self._map, ignore_all=True)
 
 

--- a/Misc/NEWS.d/next/Tests/2021-04-16-14-07-40.bpo-43842.w60GAH.rst
+++ b/Misc/NEWS.d/next/Tests/2021-04-16-14-07-40.bpo-43842.w60GAH.rst
@@ -1,0 +1,4 @@
+Fix a race condition in the SMTP test of test_logging. Don't close a file
+descriptor (socket) from a different thread while asyncore.loop() is polling
+the file descriptor.
+Patch by Victor Stinner.


### PR DESCRIPTION
Fix a race condition in the SMTP test of test_logging. Don't close a
file descriptor (socket) from a different thread while
asyncore.loop() is polling the file descriptor.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43842](https://bugs.python.org/issue43842) -->
https://bugs.python.org/issue43842
<!-- /issue-number -->
