### PR TITLE
bpo-28528: Fix pdb.checkline() attribute error when 'curframe' is None.

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -752,7 +752,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         # this method should be callable before starting debugging, so default
         # to "no globals" if there is no current frame
-        globs = self.curframe.f_globals if hasattr(self, 'curframe') else None
+        try:
+            globs = self.curframe.f_globals
+        except AttributeError:
+            globs = None
         line = linecache.getline(filename, lineno, globs)
         if not line:
             self.message('End of file')

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -752,10 +752,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         # this method should be callable before starting debugging, so default
         # to "no globals" if there is no current frame
-        try:
-            globs = self.curframe.f_globals
-        except AttributeError:
-            globs = None
+        globs = self.curframe.f_globals if getattr(self, "curframe", None) else None
         line = linecache.getline(filename, lineno, globs)
         if not line:
             self.message('End of file')

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -752,7 +752,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         # this method should be callable before starting debugging, so default
         # to "no globals" if there is no current frame
-        globs = self.curframe.f_globals if getattr(self, "curframe", None) else None
+        frame = getattr(self, 'curframe', None)
+        globs = frame.f_globals if frame else None
         line = linecache.getline(filename, lineno, globs)
         if not line:
             self.message('End of file')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1296,9 +1296,6 @@ def test_pdb_issue_20766():
 
 
 class PdbTestCase(unittest.TestCase):
-    def setUp(self):
-        linecache.clearcache()  # Pdb.checkline() uses linecache.getline()
-
     def tearDown(self):
         os_helper.unlink(os_helper.TESTFN)
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1810,6 +1810,14 @@ def bœr():
             expected = '(Pdb) The correct file was executed'
             self.assertEqual(stdout.split('\n')[6].rstrip('\r'), expected)
 
+
+class ChecklineTests(unittest.TestCase):
+    def setUp(self):
+        linecache.clearcache()  # Pdb.checkline() uses linecache.getline()
+
+    def tearDown(self):
+        os_helper.unlink(os_helper.TESTFN)
+
     def test_checkline_before_debugging(self):
         with open(os_helper.TESTFN, "w") as f:
             f.write("print(123)")
@@ -1843,6 +1851,7 @@ def load_tests(*args):
     from test import test_pdb
     suites = [
         unittest.makeSuite(PdbTestCase),
+        unittest.makeSuite(ChecklineTests),
         doctest.DocTestSuite(test_pdb)
     ]
     return unittest.TestSuite(suites)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1806,6 +1806,14 @@ def bœr():
             expected = '(Pdb) The correct file was executed'
             self.assertEqual(stdout.split('\n')[6].rstrip('\r'), expected)
 
+    def test_issue28528(self):
+        with open(os_helper.TESTFN, "w") as f:
+            f.write("print(123)")
+        db = pdb.Pdb()
+        self.assertEqual(db.checkline(os_helper.TESTFN, 1), 1)
+        db.reset()
+        self.assertEqual(db.checkline(os_helper.TESTFN, 1), 1)
+
 
 def load_tests(*args):
     from test import test_pdb

--- a/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
@@ -1,2 +1,2 @@
-Fixed a bug where :mod:`pdb` would raise :exc:`AttributeError` if
-:meth:`~pdb.Pdb.checkline()` was called after :meth:`~pdb.Pdb.reset()`.
+Fixed a bug in :mod:`pdb` where :meth:`~pdb.Pdb.checkline` would raise
+:exc:`AttributeError` if it was called after :meth:`~pdb.Pdb.reset`.

--- a/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
@@ -1,0 +1,2 @@
+Fixed a bug where :mod:`pdb` would raise :exc:`AttributeError` if
+:meth:`~pdb.Pdb.checkline()` was called after :meth:`~pdb.Pdb.reset()`.

--- a/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
@@ -1,2 +1,2 @@
 Fix a bug in :mod:`pdb` where :meth:`~pdb.Pdb.checkline` raises
-:exc:`AttributeError` if it was called after :meth:`~pdb.Pdb.reset`.
+:exc:`AttributeError` if it is called after :meth:`~pdb.Pdb.reset`.

--- a/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-29-00-48-00.bpo-28528.JLAVWj.rst
@@ -1,2 +1,2 @@
-Fixed a bug in :mod:`pdb` where :meth:`~pdb.Pdb.checkline` would raise
+Fix a bug in :mod:`pdb` where :meth:`~pdb.Pdb.checkline` raises
 :exc:`AttributeError` if it was called after :meth:`~pdb.Pdb.reset`.


### PR DESCRIPTION
Test case copied from Kluyver's patch in the issue.

Co-authored-by: Thomas Kluyver <takowl@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28528](https://bugs.python.org/issue28528) -->
https://bugs.python.org/issue28528
<!-- /issue-number -->
