### PR TITLE
[3.8] bpo-43842: Fix race condition in test_logging SMTP test (GH-25436) (GH-25437)

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -836,6 +836,7 @@ class TestSMTPServer(smtpd.SMTPServer):
         self.port = self.socket.getsockname()[1]
         self._handler = handler
         self._thread = None
+        self._quit = False
         self.poll_interval = poll_interval
 
     def process_message(self, peer, mailfrom, rcpttos, data):
@@ -867,7 +868,8 @@ class TestSMTPServer(smtpd.SMTPServer):
                               :func:`select` or :func:`poll` call by
                               :func:`asyncore.loop`.
         """
-        asyncore.loop(poll_interval, map=self._map)
+        while not self._quit:
+            asyncore.loop(poll_interval, map=self._map, count=1)
 
     def stop(self, timeout=None):
         """
@@ -877,9 +879,10 @@ class TestSMTPServer(smtpd.SMTPServer):
         :param timeout: How long to wait for the server thread
                         to terminate.
         """
-        self.close()
+        self._quit = True
         support.join_thread(self._thread, timeout)
         self._thread = None
+        self.close()
         asyncore.close_all(map=self._map, ignore_all=True)
 
 

--- a/Misc/NEWS.d/next/Tests/2021-04-16-14-07-40.bpo-43842.w60GAH.rst
+++ b/Misc/NEWS.d/next/Tests/2021-04-16-14-07-40.bpo-43842.w60GAH.rst
@@ -1,0 +1,4 @@
+Fix a race condition in the SMTP test of test_logging. Don't close a file
+descriptor (socket) from a different thread while asyncore.loop() is polling
+the file descriptor.
+Patch by Victor Stinner.


### PR DESCRIPTION
Fix a race condition in the SMTP test of test_logging. Don't close a
file descriptor (socket) from a different thread while
asyncore.loop() is polling the file descriptor.

(cherry picked from commit 75ec103b3adbb7c619a0e22fa60f3d34c5a9e603)
(cherry picked from commit e1903e11a3d42512effe336026e0c67f602e5848)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43842](https://bugs.python.org/issue43842) -->
https://bugs.python.org/issue43842
<!-- /issue-number -->
