### PR TITLE
bpo-43867: multiprocessing Server catchs SystemExit

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -188,9 +188,16 @@ class Server(object):
                 c = self.listener.accept()
             except OSError:
                 continue
-            t = threading.Thread(target=self.handle_request, args=(c,))
+            t = threading.Thread(target=self._thread_handle_request, args=(c,))
             t.daemon = True
             t.start()
+
+    def _thread_handle_request(self, c):
+        try:
+            self.handle_request(c)
+        except SystemExit:
+            # Server.serve_client() calls sys.exit(0) on EOF
+            c.close()
 
     def handle_request(self, c):
         '''

--- a/Misc/NEWS.d/next/Library/2021-04-16-16-46-44.bpo-43867.xT9QjF.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-16-16-46-44.bpo-43867.xT9QjF.rst
@@ -1,0 +1,3 @@
+The :mod:`multiprocessing` ``Server`` class now explicitly catchs
+:exc:`SystemExit` and closes the client connection in this case. It happens
+when the ``Server.serve_client()`` method reachs the end of file (EOF).


### PR DESCRIPTION
The multiprocessing Server class now explicitly catchs SystemExit and
closes the client connection in this case. It happens when the
Server.serve_client() method reachs the end of file (EOF).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43867](https://bugs.python.org/issue43867) -->
https://bugs.python.org/issue43867
<!-- /issue-number -->
