### PR TITLE
bpo-38530: Match exactly AttributeError and NameError when offering suggestions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1537,6 +1537,21 @@ class NameErrorTests(unittest.TestCase):
 
         self.assertNotIn("blech", err.getvalue())
 
+    def test_unbound_local_error_doesn_not_match(self):
+        def foo():
+            something = 3
+            print(somethong)
+            somethong = 3
+
+        try:
+            foo()
+        except UnboundLocalError as exc:
+            with support.captured_stderr() as err:
+                sys.__excepthook__(*sys.exc_info())
+
+        self.assertNotIn("something", err.getvalue())
+
+
 class AttributeErrorTests(unittest.TestCase):
     def test_attributes(self):
         # Setting 'attr' should not be a problem.

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -181,9 +181,9 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc) {
 PyObject *_Py_Offer_Suggestions(PyObject *exception) {
     PyObject *result = NULL;
     assert(!PyErr_Occurred());
-    if (PyErr_GivenExceptionMatches(exception, PyExc_AttributeError)) {
+    if (Py_IS_TYPE(exception, (PyTypeObject*)PyExc_AttributeError)) {
         result = offer_suggestions_for_attribute_error((PyAttributeErrorObject *) exception);
-    } else if (PyErr_GivenExceptionMatches(exception, PyExc_NameError)) {
+    } else if (Py_IS_TYPE(exception, (PyTypeObject*)PyExc_NameError)) {
         result = offer_suggestions_for_name_error((PyNameErrorObject *) exception);
     }
     return result;


### PR DESCRIPTION
…

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38530](https://bugs.python.org/issue38530) -->
https://bugs.python.org/issue38530
<!-- /issue-number -->
