### PR TITLE
bpo-43856: Add a versionadded directive to the importlib.metadata docs

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -7,6 +7,8 @@
 .. module:: importlib.metadata
    :synopsis: The implementation of the importlib metadata.
 
+.. versionadded:: 3.8
+
 **Source code:** :source:`Lib/importlib/metadata.py`
 
 .. note::


### PR DESCRIPTION
Use a versionadded directive to generate the text "New in version
3.8." (to match with the documentation of other modules).

<!-- issue-number: [bpo-43856](https://bugs.python.org/issue43856) -->
https://bugs.python.org/issue43856
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco