### PR TITLE
bpo-43874: fix argparse sub parser error when sub parser has no "name"

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -727,6 +727,9 @@ def _get_action_name(argument):
         return argument.metavar
     elif argument.dest not in (None, SUPPRESS):
         return argument.dest
+    # if a subparser has no better name call it 'command'
+    elif isinstance(argument, _SubParsersAction):
+        return 'command'
     else:
         return None
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2060,6 +2060,13 @@ class TestAddSubparsers(TestCase):
         ret = parser.parse_args(())
         self.assertIsNone(ret.command)
 
+    def test_required_subparsers_with_no_name(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers(required=True)
+        subparser = subparsers.add_parser('run')
+        subparser.set_defaults(command='run')
+        self._test_required_subparsers(parser)
+
     def test_optional_subparsers(self):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers(dest='command', required=False)


### PR DESCRIPTION
This change updates the following crash to instead produce the error message "%(prog)s: error: the following arguments are required: command".

Previously, when creating a simple required sub parser the following will result in an error instead of an error message:

```python
>>> from argparse import ArgumentParser
>>>
>>> parser = ArgumentParser()
>>> subparsers = parser.add_subparsers(required=True)
>>> subparsers.add_parser('one')
>>> subparsers.add_parser('two')
>>>
>>> parser.parse_args([])
```
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.8/argparse.py", line 1768, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib64/python3.8/argparse.py", line 1800, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib64/python3.8/argparse.py", line 2035, in _parse_known_args
    ', '.join(required_actions))
TypeError: sequence item 0: expected str instance, NoneType found
```

<!-- issue-number: [bpo-43874](https://bugs.python.org/issue43874) -->
https://bugs.python.org/issue43874
<!-- /issue-number -->
