### PR TITLE
distutils._msvccompiler: _get_vc_env() - correction of the erroneous 

### DIFF
--- a/Lib/distutils/_msvccompiler.py
+++ b/Lib/distutils/_msvccompiler.py
@@ -123,7 +123,7 @@ def _get_vc_env(plat_spec):
 
     try:
         out = subprocess.check_output(
-            'cmd /u /c "{}" {} && set'.format(vcvarsall, plat_spec),
+            'cmd /u /k "{}" {} && set && exit'.format(vcvarsall, plat_spec),
             stderr=subprocess.STDOUT,
         ).decode('utf-16le', errors='replace')
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
…command line for subprocess

# Correction for _get_vc_env() in distutils._msvccompiler

The command line used with subprocess to estimate the environment for Visual Studio is not functional in the way it is used. `cmd` has to be started with the `/k` flag instead and stopped with the `exit` command.
