### PR TITLE
bpo-43669: Remove OpenSSL 0.9 to 1.1.0 specific documentation (GH-25453)

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -280,8 +280,6 @@ include a `salt <https://en.wikipedia.org/wiki/Salt_%28cryptography%29>`_.
    factor and *maxmem* limits memory (OpenSSL 1.1.0 defaults to 32 MiB).
    *dklen* is the length of the derived key.
 
-   .. availability:: OpenSSL 1.1+.
-
    .. versionadded:: 3.6
 
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4971,38 +4971,6 @@ _ssl_RAND_status_impl(PyObject *module)
     return PyLong_FromLong(RAND_status());
 }
 
-#ifndef OPENSSL_NO_EGD
-/* LCOV_EXCL_START */
-/*[clinic input]
-_ssl.RAND_egd
-    path: object(converter="PyUnicode_FSConverter")
-    /
-
-Queries the entropy gather daemon (EGD) on the socket named by 'path'.
-
-Returns number of bytes read.  Raises SSLError if connection to EGD
-fails or if it does not provide enough data to seed PRNG.
-[clinic start generated code]*/
-
-static PyObject *
-_ssl_RAND_egd_impl(PyObject *module, PyObject *path)
-/*[clinic end generated code: output=02a67c7c367f52fa input=1aeb7eb948312195]*/
-{
-    int bytes = RAND_egd(PyBytes_AsString(path));
-    Py_DECREF(path);
-    if (bytes == -1) {
-        PyErr_SetString(PySSLErrorObject,
-                        "EGD connection failed or EGD did not return "
-                        "enough data to seed the PRNG");
-        return NULL;
-    }
-    return PyLong_FromLong(bytes);
-}
-/* LCOV_EXCL_STOP */
-#endif /* OPENSSL_NO_EGD */
-
-
-
 /*[clinic input]
 _ssl.get_default_verify_paths
 
@@ -5445,7 +5413,6 @@ static PyMethodDef PySSL_methods[] = {
     _SSL_RAND_ADD_METHODDEF
     _SSL_RAND_BYTES_METHODDEF
     _SSL_RAND_PSEUDO_BYTES_METHODDEF
-    _SSL_RAND_EGD_METHODDEF
     _SSL_RAND_STATUS_METHODDEF
     _SSL_GET_DEFAULT_VERIFY_PATHS_METHODDEF
     _SSL_ENUM_CERTIFICATES_METHODDEF

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -1105,40 +1105,6 @@ _ssl_RAND_status(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _ssl_RAND_status_impl(module);
 }
 
-#if !defined(OPENSSL_NO_EGD)
-
-PyDoc_STRVAR(_ssl_RAND_egd__doc__,
-"RAND_egd($module, path, /)\n"
-"--\n"
-"\n"
-"Queries the entropy gather daemon (EGD) on the socket named by \'path\'.\n"
-"\n"
-"Returns number of bytes read.  Raises SSLError if connection to EGD\n"
-"fails or if it does not provide enough data to seed PRNG.");
-
-#define _SSL_RAND_EGD_METHODDEF    \
-    {"RAND_egd", (PyCFunction)_ssl_RAND_egd, METH_O, _ssl_RAND_egd__doc__},
-
-static PyObject *
-_ssl_RAND_egd_impl(PyObject *module, PyObject *path);
-
-static PyObject *
-_ssl_RAND_egd(PyObject *module, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    PyObject *path;
-
-    if (!PyUnicode_FSConverter(arg, &path)) {
-        goto exit;
-    }
-    return_value = _ssl_RAND_egd_impl(module, path);
-
-exit:
-    return return_value;
-}
-
-#endif /* !defined(OPENSSL_NO_EGD) */
-
 PyDoc_STRVAR(_ssl_get_default_verify_paths__doc__,
 "get_default_verify_paths($module, /)\n"
 "--\n"
@@ -1351,10 +1317,6 @@ exit:
 
 #endif /* defined(_MSC_VER) */
 
-#ifndef _SSL_RAND_EGD_METHODDEF
-    #define _SSL_RAND_EGD_METHODDEF
-#endif /* !defined(_SSL_RAND_EGD_METHODDEF) */
-
 #ifndef _SSL_ENUM_CERTIFICATES_METHODDEF
     #define _SSL_ENUM_CERTIFICATES_METHODDEF
 #endif /* !defined(_SSL_ENUM_CERTIFICATES_METHODDEF) */
@@ -1362,4 +1324,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=9468e58904a565a2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ae3d1851daba6562 input=a9049054013a1b77]*/


### PR DESCRIPTION
- Remove documentation that no longer applies to OpenSSL 1.1.1+
- Remove dead code. OpenSSL 1.1.1 does not support ``RAND_egd``.

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: [bpo-43669](https://bugs.python.org/issue43669) -->
https://bugs.python.org/issue43669
<!-- /issue-number -->
