### PR TITLE
bpo-38530: Cover more error paths in error suggestion functions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1741,6 +1741,16 @@ class AttributeErrorTests(unittest.TestCase):
         self.assertNotIn("blech", err.getvalue())
         self.assertNotIn("oh no!", err.getvalue())
 
+    def test_attribute_error_with_bad_name(self):
+        try:
+            raise AttributeError(name=12, obj=23)
+        except AttributeError as exc:
+            with support.captured_stderr() as err:
+                sys.__excepthook__(*sys.exc_info())
+
+        self.assertNotIn("?", err.getvalue())
+
+
 class ImportErrorTests(unittest.TestCase):
 
     def test_attributes(self):

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -8,7 +8,7 @@
 #define MAX_STRING_SIZE 25
 
 /* Calculate the Levenshtein distance between string1 and string2 */
-static size_t
+static Py_ssize_t
 levenshtein_distance(const char *a, size_t a_size,
                      const char *b, size_t b_size) {
 
@@ -33,7 +33,7 @@ levenshtein_distance(const char *a, size_t a_size,
 
     size_t *buffer = PyMem_Calloc(a_size, sizeof(size_t));
     if (buffer == NULL) {
-        return 0;
+        return -1;
     }
 
     // Initialize the buffer row
@@ -99,6 +99,9 @@ calculate_suggestions(PyObject *dir,
         }
         Py_ssize_t current_distance = levenshtein_distance(
                 name_str, name_size, item_str, item_size);
+        if (current_distance == -1) {
+            return NULL;
+        }
         if (current_distance == 0 || current_distance > MAX_DISTANCE) {
             continue;
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38530](https://bugs.python.org/issue38530) -->
https://bugs.python.org/issue38530
<!-- /issue-number -->
