### PR TITLE
bpo-43362: Fix invalid free and return check in _sha3 module (GH-25463)

### DIFF
--- a/Misc/NEWS.d/next/Security/2021-04-18-00-56-44.bpo-43362.__5aiP.rst
+++ b/Misc/NEWS.d/next/Security/2021-04-18-00-56-44.bpo-43362.__5aiP.rst
@@ -1,0 +1,2 @@
+Fix invalid free in _sha3 module. The issue was introduced in 3.10.0a1.
+Python 3.9 and earlier are not affected.


### PR DESCRIPTION
Commit 93d50a6a8d0c5d332c11aef267e66573a09765ac / GH-21855 changed the
order of variable definitions, which introduced a potential invalid free
bug. Py_buffer object is now initialized earlier and the result of
Keccak initialize is verified.

Co-authored-by: Alex Henrie <alexhenrie24@gmail.com>
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43362](https://bugs.python.org/issue43362) -->
https://bugs.python.org/issue43362
<!-- /issue-number -->
