### PR TITLE
bpo-42854: Use SSL_read/write_ex() (GH-25468)

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1122,6 +1122,11 @@ SSL Sockets
       to create instances directly. This was never documented or officially
       supported.
 
+   .. versionchanged:: 3.10
+      Python now uses ``SSL_read_ex`` and ``SSL_write_ex`` internally. The
+      functions support reading and writing of data larger than 2 GB. Writing
+      zero-length data no longer fails with a protocol violation error.
+
 SSL sockets also have the following additional methods and attributes:
 
 .. method:: SSLSocket.read(len=1024, buffer=None)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1110,6 +1110,17 @@ class BasicSocketTests(unittest.TestCase):
         )
         self.assertIn(rc, errors)
 
+    def test_read_write_zero(self):
+        # empty reads and writes now work, bpo-42854, bpo-31711
+        client_context, server_context, hostname = testing_context()
+        server = ThreadedEchoServer(context=server_context)
+        with server:
+            with client_context.wrap_socket(socket.socket(),
+                                            server_hostname=hostname) as s:
+                s.connect((HOST, server.port))
+                self.assertEqual(s.recv(0), b"")
+                self.assertEqual(s.send(b""), 0)
+
 
 class ContextTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2021-04-19-03-54-29.bpo-42854.Y4M7Tv.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-19-03-54-29.bpo-42854.Y4M7Tv.rst
@@ -1,0 +1,4 @@
+The :mod:`ssl` module now uses ``SSL_read_ex`` and ``SSL_write_ex``
+internally. The functions support reading and writing of data larger
+than 2 GB. Writing zero-length data no longer fails with a protocol
+violation error.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2186,7 +2186,8 @@ static PyObject *
 _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
 /*[clinic end generated code: output=aa7a6be5527358d8 input=77262d994fe5100a]*/
 {
-    int len;
+    size_t count = 0;
+    int retval;
     int sockstate;
     _PySSLError err;
     int nonblocking;
@@ -2202,12 +2203,6 @@ _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
             return NULL;
         }
         Py_INCREF(sock);
-    }
-
-    if (b->len > INT_MAX) {
-        PyErr_Format(PyExc_OverflowError,
-                     "string longer than %d bytes", INT_MAX);
-        goto error;
     }
 
     if (sock != NULL) {
@@ -2239,8 +2234,8 @@ _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
 
     do {
         PySSL_BEGIN_ALLOW_THREADS
-        len = SSL_write(self->ssl, b->buf, (int)b->len);
-        err = _PySSL_errno(len <= 0, self->ssl, len);
+        retval = SSL_write_ex(self->ssl, b->buf, (int)b->len, &count);
+        err = _PySSL_errno(retval == 0, self->ssl, retval);
         PySSL_END_ALLOW_THREADS
         self->err = err;
 
@@ -2273,11 +2268,11 @@ _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
              err.ssl == SSL_ERROR_WANT_WRITE);
 
     Py_XDECREF(sock);
-    if (len <= 0)
-        return PySSL_SetError(self, len, __FILE__, __LINE__);
+    if (retval == 0)
+        return PySSL_SetError(self, retval, __FILE__, __LINE__);
     if (PySSL_ChainExceptions(self) < 0)
         return NULL;
-    return PyLong_FromLong(len);
+    return PyLong_FromSize_t(count);
 error:
     Py_XDECREF(sock);
     PySSL_ChainExceptions(self);
@@ -2327,7 +2322,8 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, int len, int group_right_1,
 {
     PyObject *dest = NULL;
     char *mem;
-    int count;
+    size_t count = 0;
+    int retval;
     int sockstate;
     _PySSLError err;
     int nonblocking;
@@ -2390,8 +2386,8 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, int len, int group_right_1,
 
     do {
         PySSL_BEGIN_ALLOW_THREADS
-        count = SSL_read(self->ssl, mem, len);
-        err = _PySSL_errno(count <= 0, self->ssl, count);
+        retval = SSL_read_ex(self->ssl, mem, len, &count);
+        err = _PySSL_errno(retval == 0, self->ssl, retval);
         PySSL_END_ALLOW_THREADS
         self->err = err;
 
@@ -2424,8 +2420,8 @@ _ssl__SSLSocket_read_impl(PySSLSocket *self, int len, int group_right_1,
     } while (err.ssl == SSL_ERROR_WANT_READ ||
              err.ssl == SSL_ERROR_WANT_WRITE);
 
-    if (count <= 0) {
-        PySSL_SetError(self, count, __FILE__, __LINE__);
+    if (retval == 0) {
+        PySSL_SetError(self, retval, __FILE__, __LINE__);
         goto error;
     }
     if (self->exc_type != NULL)
@@ -2438,7 +2434,7 @@ done:
         return dest;
     }
     else {
-        return PyLong_FromLong(count);
+        return PyLong_FromSize_t(count);
     }
 
 error:


### PR DESCRIPTION
The ssl module now uses ``SSL_read_ex`` and ``SSL_write_ex``
internally. The functions support reading and writing of data larger
than 2 GB. Writing zero-length data no longer fails with a protocol
violation error.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-42854](https://bugs.python.org/issue42854) -->
https://bugs.python.org/issue42854
<!-- /issue-number -->
