### PR TITLE
bpo-43888: Reduce coverage collection timeout to 1h40m in GHA

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,6 +54,7 @@ jobs:
         python -m test.pythoninfo
         export PYTHONPATH=`find .venv -name fullcoverage`
     - name: 'Tests with coverage'
+      timeout-minutes: 100  # 1h40m, ref https://bugs.python.org/issue43888
       run: >
         source ./.venv/bin/activate &&
         xvfb-run python -m coverage


### PR DESCRIPTION
Ref: https://bugs.python.org/issue43888

Signed-off-by: Sviatoslav Sydorenko <webknjaz@redhat.com>

<!-- issue-number: [bpo-43888](https://bugs.python.org/issue43888) -->
https://bugs.python.org/issue43888
<!-- /issue-number -->

Automerge-Triggered-By: GH:Mariatta