### PR TITLE
bpo-43466: Use pkg-config with --static in the PY_UNSUPPORTED_OPENSSL_BUILD path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2447,8 +2447,13 @@ class PyBuildExt(build_ext):
         # features like DSO engines or external OSSL providers don't work.
         # Only tested on GCC and clang on X86_64.
         if os.environ.get("PY_UNSUPPORTED_OPENSSL_BUILD") == "static":
+            import subprocess, shutil
+            pkgconfig = os.getenv("PKG_CONFIG", shutil.which("pkg-config"))
+            libs_out = subprocess.check_output(
+                    [pkgconfig, "--static", "--libs-only-l", "openssl"]).decode()
+            openssl_libs_static =  {v.strip() for v in libs_out.split("-l") if v.strip()}
             extra_linker_args = []
-            for lib in openssl_extension_kwargs["libraries"]:
+            for lib in openssl_libs_static:
                 # link statically
                 extra_linker_args.append(f"-l:lib{lib}.a")
                 # don't export symbols


### PR DESCRIPTION
I tested in a bunch of old distributions (including RHEL6) and we need to run `pkg-config` with "--static" to obtain the actual expanded list of static libs.

<!-- issue-number: [bpo-43466](https://bugs.python.org/issue43466) -->
https://bugs.python.org/issue43466
<!-- /issue-number -->
