### PR TITLE
bpo-43795: PEP-652: Clean up the stable ABI/limited API

### DIFF
--- a/Doc/data/stable_abi.dat
+++ b/Doc/data/stable_abi.dat
@@ -351,6 +351,7 @@ PyMapping_Length
 PyMapping_SetItemString
 PyMapping_Size
 PyMapping_Values
+PyMem_Calloc
 PyMem_Free
 PyMem_Malloc
 PyMem_Realloc

--- a/Doc/data/stable_abi.dat
+++ b/Doc/data/stable_abi.dat
@@ -351,16 +351,10 @@ PyMapping_Length
 PyMapping_SetItemString
 PyMapping_Size
 PyMapping_Values
-PyMarshal_ReadObjectFromString
-PyMarshal_WriteLongToFile
-PyMarshal_WriteObjectToFile
-PyMarshal_WriteObjectToString
 PyMem_Free
 PyMem_Malloc
 PyMem_Realloc
 PyMemberDescr_Type
-PyMember_GetOne
-PyMember_SetOne
 PyMemoryView_FromMemory
 PyMemoryView_FromObject
 PyMemoryView_GetContiguous

--- a/Include/cpython/fileutils.h
+++ b/Include/cpython/fileutils.h
@@ -32,6 +32,9 @@ PyAPI_FUNC(int) _Py_EncodeLocaleEx(
     int current_locale,
     _Py_error_handler errors);
 
+PyAPI_FUNC(char*) _Py_EncodeLocaleRaw(
+    const wchar_t *text,
+    size_t *error_pos);
 
 PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 

--- a/Include/cpython/pymem.h
+++ b/Include/cpython/pymem.h
@@ -10,8 +10,6 @@ PyAPI_FUNC(void) PyMem_RawFree(void *ptr);
 /* Try to get the allocators name set by _PyMem_SetupAllocators(). */
 PyAPI_FUNC(const char*) _PyMem_GetCurrentAllocatorName(void);
 
-PyAPI_FUNC(void *) PyMem_Calloc(size_t nelem, size_t elsize);
-
 /* strdup() using PyMem_RawMalloc() */
 PyAPI_FUNC(char *) _PyMem_RawStrdup(const char *str);
 

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -12,10 +12,6 @@ PyAPI_FUNC(wchar_t *) Py_DecodeLocale(
 PyAPI_FUNC(char*) Py_EncodeLocale(
     const wchar_t *text,
     size_t *error_pos);
-
-PyAPI_FUNC(char*) _Py_EncodeLocaleRaw(
-    const wchar_t *text,
-    size_t *error_pos);
 #endif
 
 #ifndef Py_LIMITED_API

--- a/Include/pyhash.h
+++ b/Include/pyhash.h
@@ -77,7 +77,6 @@ typedef union {
     } expat;
 } _Py_HashSecret_t;
 PyAPI_DATA(_Py_HashSecret_t) _Py_HashSecret;
-#endif
 
 #ifdef Py_DEBUG
 PyAPI_DATA(int) _Py_HashSecret_Initialized;
@@ -85,7 +84,6 @@ PyAPI_DATA(int) _Py_HashSecret_Initialized;
 
 
 /* hash function definition */
-#ifndef Py_LIMITED_API
 typedef struct {
     Py_hash_t (*const hash)(const void *, Py_ssize_t);
     const char *name;

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -50,6 +50,7 @@ extern "C" {
 */
 
 PyAPI_FUNC(void *) PyMem_Malloc(size_t size);
+PyAPI_FUNC(void *) PyMem_Calloc(size_t nelem, size_t elsize);
 PyAPI_FUNC(void *) PyMem_Realloc(void *ptr, size_t new_size);
 PyAPI_FUNC(void) PyMem_Free(void *ptr);
 

--- a/Misc/NEWS.d/next/C API/2021-04-20-15-06-29.bpo-43795.y0IP4c.rst
+++ b/Misc/NEWS.d/next/C API/2021-04-20-15-06-29.bpo-43795.y0IP4c.rst
@@ -1,0 +1,2 @@
+:c:func:`PyMem_Calloc` is now available in the limited C API
+(``Py_LIMITED_API``).


### PR DESCRIPTION
- `_Py_EncodeLocaleRaw`, which is private by name, undocumented,
  and wasn't exported in `python3.dll`, is moved to a private header.
- `_Py_HashSecret_Initialized`, again private by name, undocumented,
  and not exported in `python3.dll`, is excluded with `Py_LIMITED_API`.
- `PyMarshal_*` and `PyMember_*One` functions, declared in private headers and
  not exported in `python3.dll`, are removed from `Doc/data/stable_abi.dat`.
- `PyMem_Calloc` which *was* exported in `python3dll.c`, is moved to public
  headers where it joins its other `PyMem_*` friends.

Only the last change is documented in the blurb; others are not user-visible.
(Nothing uses `Doc/data/stable_abi.dat` yet.)


<!-- issue-number: [bpo-43795](https://bugs.python.org/issue43795) -->
https://bugs.python.org/issue43795
<!-- /issue-number -->
