### PR TITLE
bpo-43795: PEP-652: Simplify headers for easier static analysis

### DIFF
--- a/Include/boolobject.h
+++ b/Include/boolobject.h
@@ -15,7 +15,8 @@ PyAPI_DATA(PyTypeObject) PyBool_Type;
 Don't forget to apply Py_INCREF() when returning either!!! */
 
 /* Don't use these directly */
-PyAPI_DATA(struct _longobject) _Py_FalseStruct, _Py_TrueStruct;
+PyAPI_DATA(struct _longobject) _Py_FalseStruct;
+PyAPI_DATA(struct _longobject) _Py_TrueStruct;
 
 /* Use these macros */
 #define Py_False ((PyObject *) &_Py_FalseStruct)

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -861,6 +861,7 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
    PyAPI_FUNC(void) _Py_NO_RETURN PyThread_exit_thread(void);
 
    XLC support is intentionally omitted due to bpo-40244 */
+#ifndef _Py_NO_RETURN
 #if defined(__clang__) || \
     (defined(__GNUC__) && \
      ((__GNUC__ >= 3) || \
@@ -870,6 +871,7 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #  define _Py_NO_RETURN __declspec(noreturn)
 #else
 #  define _Py_NO_RETURN
+#endif
 #endif
 
 


### PR DESCRIPTION
As part of the PEP-652 implementation, I'll tighten the CI check
for functions/data defined with `Py_LIMITED_API`.

Discussion in https://discuss.python.org/t/pep-652-maintaining-the-stable-abi/6986
suggests that parsing C headers is OK (though personally I'd rather generate it...),
but writing a full C parser is a monumental task and adding an existing one as a
dependency brings too many vendoring/bootstraping issues.

So, for the check I'll use a "simple" regex on preprocessor output, and adapt
the few trivial places where the regex won't work.

- Keep declarations in the limited API to one item per line
- Make it possible to override `_Py_NO_RETURN`, so the annotation can be
  removed from preprocessor output.


<!-- issue-number: [bpo-43795](https://bugs.python.org/issue43795) -->
https://bugs.python.org/issue43795
<!-- /issue-number -->
