### PR TITLE
bpo-43893: omit leading spaces/tabs on typing.get_type_hints

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1925,6 +1925,9 @@ Introspection helpers
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.
 
+   .. versionchanged:: 3.10
+      For annotation strings, leading spaces and tabs are now stripped.
+
 .. function:: get_args(tp)
 .. function:: get_origin(tp)
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3023,6 +3023,11 @@ class GetTypeHintTests(BaseTestCase):
         # This previously raised an error under PEP 563.
         self.assertEqual(get_type_hints(Foo), {'x': str})
 
+    def test_whitespaces(self):
+        def testf() -> ' str': ...
+        self.assertEqual(gth(testf), {'return': str})
+        def testg(x: ' int'): ...
+        self.assertEqual(gth(testg), {'x': int})
 
 class GetUtilitiesTestCase(TestCase):
     def test_get_origin(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -585,7 +585,7 @@ class ForwardRef(_Final, _root=True):
             arg = arg[1:-1]
 
         try:
-            code = compile(arg, '<string>', 'eval')
+            code = compile(arg.lstrip(' \t'), '<string>', 'eval')
         except SyntaxError:
             raise SyntaxError(f"Forward reference must be an expression -- got {arg!r}")
         self.__forward_arg__ = arg

--- a/Misc/NEWS.d/next/Library/2021-04-20-14-50-37.bpo-43893.U8Bedj.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-20-14-50-37.bpo-43893.U8Bedj.rst
@@ -1,0 +1,1 @@
+Strip leading spaces and tabs on :func:`typing.get_type_hints`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-43893](https://bugs.python.org/issue43893) -->
https://bugs.python.org/issue43893
<!-- /issue-number -->
