### PR TITLE
bpo-43895: Remove an unnecessary cache of shared object handles

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-07-16-05-35.bpo-43895.JFjR0-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-07-16-05-35.bpo-43895.JFjR0-.rst
@@ -1,0 +1,4 @@
+An obsolete internal cache of shared object file handles added in 1995 that
+attempted, but did not guarantee, that a .so would not be dlopen'ed twice to
+work around flaws in mid-1990s posix-ish operating systems has been removed
+from dynload_shlib.c.


### PR DESCRIPTION

<!-- issue-number: [bpo-43895](https://bugs.python.org/issue43895) -->
https://bugs.python.org/issue43895
<!-- /issue-number -->
