### PR TITLE
bpo-43896: Update the Sphinx directive for super from function to class

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1677,7 +1677,7 @@ are always available.  They are listed here in alphabetical order.
    .. versionchanged:: 3.8
       The *start* parameter can be specified as a keyword argument.
 
-.. function:: super([type[, object-or-type]])
+.. class:: super([type[, object-or-type]])
 
    Return a proxy object that delegates method calls to a parent or sibling
    class of *type*.  This is useful for accessing inherited methods that have


### PR DESCRIPTION
This PR updates the page [*Built-in Functions*](https://docs.python.org/3/library/functions.html#super) of the Python library documentation: `super` is not a `function` (`isinstance(super, type(lambda: None))` is `False`), it is a `type` (`isinstance(super, type)` is `True`), like `int`, `tuple`, `set`, etc. So it should get the same “class” prefix, i.e.

> **super**([*type*[, *object-or-type*]])

should become

> *class* **super**([*type*[, *object-or-type*]])

<!-- issue-number: [bpo-43896](https://bugs.python.org/issue43896) -->
https://bugs.python.org/issue43896
<!-- /issue-number -->
