### PR TITLE
bpo-40137: Move state lookups out of the critical path

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -782,6 +782,7 @@ typedef struct lru_cache_object {
     PyObject *func;
     Py_ssize_t maxsize;
     Py_ssize_t misses;
+    /* the kwd_mark is used delimit args and keywords in the cache keys */
     PyObject *kwd_mark;
     PyTypeObject *lru_list_elem_type;
     PyObject *cache_info_type;
@@ -874,10 +875,8 @@ static PyObject *
 infinite_lru_cache_wrapper(lru_cache_object *self, PyObject *args, PyObject *kwds)
 {
     PyObject *result;
-    PyObject *key;
     Py_hash_t hash;
-
-    key = lru_cache_make_key(self->kwd_mark, args, kwds, self->typed);
+    PyObject *key = lru_cache_make_key(self->kwd_mark, args, kwds, self->typed);
     if (!key)
         return NULL;
     hash = PyObject_Hash(key);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1159,6 +1159,11 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return NULL;
     }
 
+    state = get_functools_state_by_type(type);
+    if (state == NULL) {
+        return NULL;
+    }
+
     /* select the caching function, and make/inc maxsize_O */
     if (maxsize_O == Py_None) {
         wrapper = infinite_lru_cache_wrapper;
@@ -1186,13 +1191,6 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     obj = (lru_cache_object *)type->tp_alloc(type, 0);
     if (obj == NULL) {
         Py_DECREF(cachedict);
-        return NULL;
-    }
-
-    state = get_functools_state_by_type(Py_TYPE(obj));
-    if (state == NULL) {
-        Py_DECREF(cachedict);
-        Py_DECREF(obj);
         return NULL;
     }
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -12,18 +12,6 @@
    All rights reserved.
 */
 
-/* partial object **********************************************************/
-
-typedef struct {
-    PyObject_HEAD
-    PyObject *fn;
-    PyObject *args;
-    PyObject *kw;
-    PyObject *dict;        /* __dict__ */
-    PyObject *weakreflist; /* List of weak references */
-    vectorcallfunc vectorcall;
-} partialobject;
-
 typedef struct _functools_state {
     /* this object is used delimit args and keywords in the cache keys */
     PyObject *kwd_mark;
@@ -39,6 +27,19 @@ get_functools_state(PyObject *module)
     assert(state != NULL);
     return (_functools_state *)state;
 }
+
+
+/* partial object **********************************************************/
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *fn;
+    PyObject *args;
+    PyObject *kw;
+    PyObject *dict;        /* __dict__ */
+    PyObject *weakreflist; /* List of weak references */
+    vectorcallfunc vectorcall;
+} partialobject;
 
 static void partial_setvectorcall(partialobject *pto);
 static struct PyModuleDef _functools_module;

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1205,8 +1205,10 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     obj->func = func;
     obj->misses = obj->hits = 0;
     obj->maxsize = maxsize;
-    obj->kwd_mark = state->kwd_mark;                        // Borrowed
-    obj->lru_list_elem_type = state->lru_list_elem_type;    // Borrowed
+    Py_INCREF(state->kwd_mark);
+    obj->kwd_mark = state->kwd_mark;
+    Py_INCREF(state->lru_list_elem_type);
+    obj->lru_list_elem_type = state->lru_list_elem_type;
     Py_INCREF(cache_info_type);
     obj->cache_info_type = cache_info_type;
     obj->dict = NULL;
@@ -1242,6 +1244,8 @@ lru_cache_tp_clear(lru_cache_object *self)
     lru_list_elem *list = lru_cache_unlink_list(self);
     Py_CLEAR(self->func);
     Py_CLEAR(self->cache);
+    Py_CLEAR(self->kwd_mark);
+    Py_CLEAR(self->lru_list_elem_type);
     Py_CLEAR(self->cache_info_type);
     Py_CLEAR(self->dict);
     lru_cache_clear_list(list);
@@ -1334,6 +1338,8 @@ lru_cache_tp_traverse(lru_cache_object *self, visitproc visit, void *arg)
     }
     Py_VISIT(self->func);
     Py_VISIT(self->cache);
+    Py_VISIT(self->kwd_mark);
+    Py_VISIT(self->lru_list_elem_type);
     Py_VISIT(self->cache_info_type);
     Py_VISIT(self->dict);
     return 0;


### PR DESCRIPTION


<!-- issue-number: [bpo-40137](https://bugs.python.org/issue40137) -->
https://bugs.python.org/issue40137
<!-- /issue-number -->
