### PR TITLE
[3.8] bpo-43856: Add a versionadded directive to the importlib.metadata docs (GH-25445)

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -7,6 +7,8 @@
 .. module:: importlib.metadata
    :synopsis: The implementation of the importlib metadata.
 
+.. versionadded:: 3.8
+
 **Source code:** :source:`Lib/importlib/metadata.py`
 
 .. note::


### PR DESCRIPTION


Use a versionadded directive to generate the text "New in version
3.8." (to match with the documentation of other modules).

Automerge-Triggered-By: GH:jaraco
(cherry picked from commit adf24bd835)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43856](https://bugs.python.org/issue43856) -->
https://bugs.python.org/issue43856
<!-- /issue-number -->
