### PR TITLE
bpo-38659: [Enum] add _simple_enum decorator

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -117,19 +117,6 @@ Module Contents
 
       Enum class decorator that ensures only one name is bound to any one value.
 
-   :func:`simple_enum`
-
-      Class decorator that converts a normal class into an :class:`Enum`.  No
-      safety checks are done, and some advanced behavior (such as
-      :func:`__init_subclass__`) is not available.  Enum creation can be faster
-      using :func:`simple_enum`.
-
-   :func:`test_simple_enum`
-
-      Function that can be used to test an enum created with 
-      :func:`simple_enum` with the corresponding :class:`Enum`-subclassed
-      version.
-
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 .. versionadded:: 3.10  ``StrEnum``
@@ -634,30 +621,3 @@ Utilites and Decorators
       Traceback (most recent call last):
       ...
       ValueError: duplicate values found in <enum 'Mistake'>: FOUR -> THREE
-
-.. decorator:: simple_enum
-
-   A :keyword:`class` decorator that converts a normal class into an enum::
-
-      >>> from enum import Enum, simple_enum
-      >>> @simple_enum(Enum):
-      ... class Color:
-      ...     RED = auto()
-      ...     GREEN = auto()
-      ...     BLUE = auto()
-      >>> Color
-      <enum 'Color'>
-
-.. function:: test_simple_enum
-
-   A function that can be used to test an enum created with :func:`simple_enum`
-   against the version created by subclassing :class:`Enum`::
-
-      >>> from enum import Enum, test_simple_enum
-      >>> class CheckedColor(Enum):
-      ...     RED = auto()
-      ...     GREEN = auto()
-      ...     BLUE = auto()
-      >>> test_simple_enum(CheckedColor, Color)
-
-   If differences are found, a :exc:`TypeError` is raised.

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -660,4 +660,4 @@ Utilites and Decorators
       ...     BLUE = auto()
       >>> test_simple_enum(CheckedColor, Color)
 
-   If differences are found, a :exc:`ValueError` is raised.
+   If differences are found, a :exc:`TypeError` is raised.

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -117,6 +117,19 @@ Module Contents
 
       Enum class decorator that ensures only one name is bound to any one value.
 
+   :func:`simple_enum`
+
+      Class decorator that converts a normal class into an :class:`Enum`.  No
+      safety checks are done, and some advanced behavior (such as
+      :func:`__init_subclass__`) is not available.  Enum creation can be faster
+      using :func:`simple_enum`.
+
+   :func:`test_simple_enum`
+
+      Function that can be used to test an enum created with 
+      :func:`simple_enum` with the corresponding :class:`Enum`-subclassed
+      version.
+
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 .. versionadded:: 3.10  ``StrEnum``
@@ -622,3 +635,29 @@ Utilites and Decorators
       ...
       ValueError: duplicate values found in <enum 'Mistake'>: FOUR -> THREE
 
+.. decorator:: simple_enum
+
+   A :keyword:`class` decorator that converts a normal class into an enum::
+
+      >>> from enum import Enum, simple_enum
+      >>> @simple_enum(Enum):
+      ... class Color:
+      ...     RED = auto()
+      ...     GREEN = auto()
+      ...     BLUE = auto()
+      >>> Color
+      <enum 'Color'>
+
+.. function:: test_simple_enum
+
+   A function that can be used to test an enum created with :func:`simple_enum`
+   against the version created by subclassing :class:`Enum`::
+
+      >>> from enum import Enum, test_simple_enum
+      >>> class CheckedColor(Enum):
+      ...     RED = auto()
+      ...     GREEN = auto()
+      ...     BLUE = auto()
+      >>> test_simple_enum(CheckedColor, Color)
+
+   If differences are found, a :exc:`ValueError` is raised.

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -27,7 +27,7 @@
 import sys
 from _ast import *
 from contextlib import contextmanager, nullcontext
-from enum import IntEnum, auto, simple_enum
+from enum import IntEnum, auto, _simple_enum
 
 
 def parse(source, filename='<unknown>', mode='exec', *,
@@ -636,7 +636,7 @@ class Param(expr_context):
 # We unparse those infinities to INFSTR.
 _INFSTR = "1e" + repr(sys.float_info.max_10_exp + 1)
 
-@simple_enum(IntEnum)
+@_simple_enum(IntEnum)
 class _Precedence:
     """Precedence table that originated from python grammar."""
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -27,7 +27,7 @@
 import sys
 from _ast import *
 from contextlib import contextmanager, nullcontext
-from enum import IntEnum, auto
+from enum import IntEnum, auto, simple_enum
 
 
 def parse(source, filename='<unknown>', mode='exec', *,
@@ -636,7 +636,8 @@ class Param(expr_context):
 # We unparse those infinities to INFSTR.
 _INFSTR = "1e" + repr(sys.float_info.max_10_exp + 1)
 
-class _Precedence(IntEnum):
+@simple_enum(IntEnum)
+class _Precedence:
     """Precedence table that originated from python grammar."""
 
     TUPLE = auto()

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1669,4 +1669,4 @@ def test_simple_enum(checked_enum, simple_enum):
                 # in the first checks above
                 pass
     if failed:
-        raise ValueError('enum mismatch:\n   %s' % '\n   '.join(failed))
+        raise TypeError('enum mismatch:\n   %s' % '\n   '.join(failed))

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1694,4 +1694,3 @@ def _old_convert_(etype, name, module, filter, source=None, *, boundary=None):
     cls.__reduce_ex__ = _reduce_ex_by_name
     cls.__repr__ = global_enum_repr
     return cls
-

--- a/Lib/http/__init__.py
+++ b/Lib/http/__init__.py
@@ -1,9 +1,9 @@
-from enum import IntEnum, simple_enum
+from enum import IntEnum, _simple_enum
 
 __all__ = ['HTTPStatus']
 
 
-@simple_enum(IntEnum)
+@_simple_enum(IntEnum)
 class HTTPStatus:
     """HTTP status codes and reason phrases
 

--- a/Lib/http/__init__.py
+++ b/Lib/http/__init__.py
@@ -1,8 +1,10 @@
-from enum import IntEnum
+from enum import IntEnum, simple_enum
 
 __all__ = ['HTTPStatus']
 
-class HTTPStatus(IntEnum):
+
+@simple_enum(IntEnum)
+class HTTPStatus:
     """HTTP status codes and reason phrases
 
     Status codes from the following RFCs are all observed:

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -26,14 +26,15 @@ import time
 import marshal
 import re
 
-from enum import Enum
+from enum import StrEnum, simple_enum
 from functools import cmp_to_key
 from dataclasses import dataclass
 from typing import Dict
 
 __all__ = ["Stats", "SortKey", "FunctionProfile", "StatsProfile"]
 
-class SortKey(str, Enum):
+@simple_enum(StrEnum)
+class SortKey:
     CALLS = 'calls', 'ncalls'
     CUMULATIVE = 'cumulative', 'cumtime'
     FILENAME = 'filename', 'module'

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -26,14 +26,14 @@ import time
 import marshal
 import re
 
-from enum import StrEnum, simple_enum
+from enum import StrEnum, _simple_enum
 from functools import cmp_to_key
 from dataclasses import dataclass
 from typing import Dict
 
 __all__ = ["Stats", "SortKey", "FunctionProfile", "StatsProfile"]
 
-@simple_enum(StrEnum)
+@_simple_enum(StrEnum)
 class SortKey:
     CALLS = 'calls', 'ncalls'
     CUMULATIVE = 'cumulative', 'cumtime'

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -142,9 +142,8 @@ __all__ = [
 
 __version__ = "2.2.1"
 
+@enum.global_enum
 @enum.simple_enum(enum.IntFlag, boundary=enum.KEEP)
-
-# class RegexFlag(enum.IntFlag, boundary=enum.KEEP):
 class RegexFlag:
     ASCII = A = sre_compile.SRE_FLAG_ASCII # assume ascii "locale"
     IGNORECASE = I = sre_compile.SRE_FLAG_IGNORECASE # ignore case

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -143,7 +143,7 @@ __all__ = [
 __version__ = "2.2.1"
 
 @enum.global_enum
-@enum.simple_enum(enum.IntFlag, boundary=enum.KEEP)
+@enum._simple_enum(enum.IntFlag, boundary=enum.KEEP)
 class RegexFlag:
     ASCII = A = sre_compile.SRE_FLAG_ASCII # assume ascii "locale"
     IGNORECASE = I = sre_compile.SRE_FLAG_IGNORECASE # ignore case

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -142,8 +142,10 @@ __all__ = [
 
 __version__ = "2.2.1"
 
-@enum.global_enum
-class RegexFlag(enum.IntFlag, boundary=enum.KEEP):
+@enum.simple_enum(enum.IntFlag, boundary=enum.KEEP)
+
+# class RegexFlag(enum.IntFlag, boundary=enum.KEEP):
+class RegexFlag:
     ASCII = A = sre_compile.SRE_FLAG_ASCII # assume ascii "locale"
     IGNORECASE = I = sre_compile.SRE_FLAG_IGNORECASE # ignore case
     LOCALE = L = sre_compile.SRE_FLAG_LOCALE # assume current 8-bit locale

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -94,6 +94,7 @@ import sys
 import os
 from collections import namedtuple
 from enum import Enum as _Enum, IntEnum as _IntEnum, IntFlag as _IntFlag
+from enum import simple_enum as _simple_enum
 
 import _ssl             # if we can't import it, let the error propagate
 
@@ -155,7 +156,8 @@ _PROTOCOL_NAMES = {value: name for name, value in _SSLMethod.__members__.items()
 _SSLv2_IF_EXISTS = getattr(_SSLMethod, 'PROTOCOL_SSLv2', None)
 
 
-class TLSVersion(_IntEnum):
+@_simple_enum(_IntEnum)
+class TLSVersion:
     MINIMUM_SUPPORTED = _ssl.PROTO_MINIMUM_SUPPORTED
     SSLv3 = _ssl.PROTO_SSLv3
     TLSv1 = _ssl.PROTO_TLSv1
@@ -165,7 +167,8 @@ class TLSVersion(_IntEnum):
     MAXIMUM_SUPPORTED = _ssl.PROTO_MAXIMUM_SUPPORTED
 
 
-class _TLSContentType(_IntEnum):
+@_simple_enum(_IntEnum)
+class _TLSContentType:
     """Content types (record layer)
 
     See RFC 8446, section B.1
@@ -179,7 +182,8 @@ class _TLSContentType(_IntEnum):
     INNER_CONTENT_TYPE = 0x101
 
 
-class _TLSAlertType(_IntEnum):
+@_simple_enum(_IntEnum)
+class _TLSAlertType:
     """Alert types for TLSContentType.ALERT messages
 
     See RFC 8466, section B.2
@@ -220,7 +224,8 @@ class _TLSAlertType(_IntEnum):
     NO_APPLICATION_PROTOCOL = 120
 
 
-class _TLSMessageType(_IntEnum):
+@_simple_enum(_IntEnum)
+class _TLSMessageType:
     """Message types (handshake protocol)
 
     See RFC 8446, section B.3

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -94,7 +94,7 @@ import sys
 import os
 from collections import namedtuple
 from enum import Enum as _Enum, IntEnum as _IntEnum, IntFlag as _IntFlag
-from enum import simple_enum as _simple_enum
+from enum import _simple_enum, _test_simple_enum
 
 import _ssl             # if we can't import it, let the error propagate
 

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -726,7 +726,7 @@ class AST_Tests(unittest.TestCase):
                     return self.__class__(self + 1)
                 except ValueError:
                     return self
-        enum.test_simple_enum(_Precedence, ast._Precedence)
+        enum._test_simple_enum(_Precedence, ast._Precedence)
 
 
 class ASTHelpers_Test(unittest.TestCase):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1,6 +1,7 @@
 import ast
 import builtins
 import dis
+import enum
 import os
 import sys
 import types
@@ -697,6 +698,35 @@ class AST_Tests(unittest.TestCase):
             ast.fix_missing_locations(expr)
             with self.assertRaisesRegex(ValueError, f"Name node can't be used with '{constant}' constant"):
                 compile(expr, "<test>", "eval")
+
+    def test_precedence_enum(self):
+        class _Precedence(enum.IntEnum):
+            """Precedence table that originated from python grammar."""
+            TUPLE = enum.auto()
+            YIELD = enum.auto()           # 'yield', 'yield from'
+            TEST = enum.auto()            # 'if'-'else', 'lambda'
+            OR = enum.auto()              # 'or'
+            AND = enum.auto()             # 'and'
+            NOT = enum.auto()             # 'not'
+            CMP = enum.auto()             # '<', '>', '==', '>=', '<=', '!=',
+                                          # 'in', 'not in', 'is', 'is not'
+            EXPR = enum.auto()
+            BOR = EXPR                    # '|'
+            BXOR = enum.auto()            # '^'
+            BAND = enum.auto()            # '&'
+            SHIFT = enum.auto()           # '<<', '>>'
+            ARITH = enum.auto()           # '+', '-'
+            TERM = enum.auto()            # '*', '@', '/', '%', '//'
+            FACTOR = enum.auto()          # unary '+', '-', '~'
+            POWER = enum.auto()           # '**'
+            AWAIT = enum.auto()           # 'await'
+            ATOM = enum.auto()
+            def next(self):
+                try:
+                    return self.__class__(self + 1)
+                except ValueError:
+                    return self
+        enum.test_simple_enum(_Precedence, ast._Precedence)
 
 
 class ASTHelpers_Test(unittest.TestCase):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -8,7 +8,7 @@ import unittest
 import threading
 from collections import OrderedDict
 from enum import Enum, IntEnum, StrEnum, EnumType, Flag, IntFlag, unique, auto
-from enum import STRICT, CONFORM, EJECT, KEEP, simple_enum, test_simple_enum
+from enum import STRICT, CONFORM, EJECT, KEEP, _simple_enum, _test_simple_enum
 from io import StringIO
 from pickle import dumps, loads, PicklingError, HIGHEST_PROTOCOL
 from test import support
@@ -2511,10 +2511,13 @@ class TestFlag(unittest.TestCase):
             d = 6
         #
         self.assertRaisesRegex(ValueError, 'invalid value: 7', Iron, 7)
+        #
         self.assertIs(Water(7), Water.ONE|Water.TWO)
         self.assertIs(Water(~9), Water.TWO)
+        #
         self.assertEqual(Space(7), 7)
         self.assertTrue(type(Space(7)) is int)
+        #
         self.assertEqual(list(Bizarre), [Bizarre.c])
         self.assertIs(Bizarre(3), Bizarre.b)
         self.assertIs(Bizarre(6), Bizarre.d)
@@ -3053,16 +3056,20 @@ class TestIntFlag(unittest.TestCase):
             EIGHT = 8
         self.assertIs(Space._boundary_, EJECT)
         #
+        #
         class Bizarre(IntFlag, boundary=KEEP):
             b = 3
             c = 4
             d = 6
         #
         self.assertRaisesRegex(ValueError, 'invalid value: 5', Iron, 5)
+        #
         self.assertIs(Water(7), Water.ONE|Water.TWO)
         self.assertIs(Water(~9), Water.TWO)
+        #
         self.assertEqual(Space(7), 7)
         self.assertTrue(type(Space(7)) is int)
+        #
         self.assertEqual(list(Bizarre), [Bizarre.c])
         self.assertIs(Bizarre(3), Bizarre.b)
         self.assertIs(Bizarre(6), Bizarre.d)
@@ -3578,7 +3585,7 @@ class TestStdLib(unittest.TestCase):
             self.fail("result does not equal expected, see print above")
 
     def test_test_simple_enum(self):
-        @simple_enum(Enum)
+        @_simple_enum(Enum)
         class SimpleColor:
             RED = 1
             GREEN = 2
@@ -3587,12 +3594,30 @@ class TestStdLib(unittest.TestCase):
             RED = 1
             GREEN = 2
             BLUE = 3
-        self.assertTrue(test_simple_enum(CheckedColor, SimpleColor) is None)
+        self.assertTrue(_test_simple_enum(CheckedColor, SimpleColor) is None)
         SimpleColor.GREEN._value_ = 9
         self.assertRaisesRegex(
                 TypeError, "enum mismatch",
-                test_simple_enum, CheckedColor, SimpleColor,
+                _test_simple_enum, CheckedColor, SimpleColor,
                 )
+        class CheckedMissing(IntFlag, boundary=KEEP):
+            SIXTY_FOUR = 64
+            ONE_TWENTY_EIGHT = 128
+            TWENTY_FORTY_EIGHT = 2048
+            ALL = 2048 + 128 + 64 + 12
+        CM = CheckedMissing
+        self.assertEqual(list(CheckedMissing), [CM.SIXTY_FOUR, CM.ONE_TWENTY_EIGHT, CM.TWENTY_FORTY_EIGHT])
+        #
+        @_simple_enum(IntFlag, boundary=KEEP)
+        class Missing:
+            SIXTY_FOUR = 64
+            ONE_TWENTY_EIGHT = 128
+            TWENTY_FORTY_EIGHT = 2048
+            ALL = 2048 + 128 + 64 + 12
+        M = Missing
+        self.assertEqual(list(CheckedMissing), [M.SIXTY_FOUR, M.ONE_TWENTY_EIGHT, M.TWENTY_FORTY_EIGHT])
+        #
+        _test_simple_enum(CheckedMissing, Missing)
         
 
 class MiscTestCase(unittest.TestCase):
@@ -3608,6 +3633,13 @@ CONVERT_TEST_NAME_B = 5
 CONVERT_TEST_NAME_A = 5  # This one should sort first.
 CONVERT_TEST_NAME_E = 5
 CONVERT_TEST_NAME_F = 5
+
+CONVERT_STRING_TEST_NAME_D = 5
+CONVERT_STRING_TEST_NAME_C = 5
+CONVERT_STRING_TEST_NAME_B = 5
+CONVERT_STRING_TEST_NAME_A = 5  # This one should sort first.
+CONVERT_STRING_TEST_NAME_E = 5
+CONVERT_STRING_TEST_NAME_F = 5
 
 class TestIntEnumConvert(unittest.TestCase):
     def test_convert_value_lookup_priority(self):
@@ -3656,14 +3688,16 @@ class TestIntEnumConvert(unittest.TestCase):
                 filter=lambda x: x.startswith('CONVERT_TEST_'))
 
     def test_convert_repr_and_str(self):
+        # reset global constants, as previous tests could have converted the 
+        # integer values to enums
         module = ('test.test_enum', '__main__')[__name__=='__main__']
         test_type = enum.IntEnum._convert_(
                 'UnittestConvert',
                 module,
-                filter=lambda x: x.startswith('CONVERT_TEST_'))
-        self.assertEqual(repr(test_type.CONVERT_TEST_NAME_A), '%s.CONVERT_TEST_NAME_A' % module)
-        self.assertEqual(str(test_type.CONVERT_TEST_NAME_A), 'CONVERT_TEST_NAME_A')
-        self.assertEqual(format(test_type.CONVERT_TEST_NAME_A), '5')
+                filter=lambda x: x.startswith('CONVERT_STRING_TEST_'))
+        self.assertEqual(repr(test_type.CONVERT_STRING_TEST_NAME_A), '%s.CONVERT_STRING_TEST_NAME_A' % module)
+        self.assertEqual(str(test_type.CONVERT_STRING_TEST_NAME_A), 'CONVERT_STRING_TEST_NAME_A')
+        self.assertEqual(format(test_type.CONVERT_STRING_TEST_NAME_A), '5')
 
 # global names for StrEnum._convert_ test
 CONVERT_STR_TEST_2 = 'goodbye'

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3618,7 +3618,7 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(list(CheckedMissing), [M.SIXTY_FOUR, M.ONE_TWENTY_EIGHT, M.TWENTY_FORTY_EIGHT])
         #
         _test_simple_enum(CheckedMissing, Missing)
-        
+
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
@@ -3688,7 +3688,7 @@ class TestIntEnumConvert(unittest.TestCase):
                 filter=lambda x: x.startswith('CONVERT_TEST_'))
 
     def test_convert_repr_and_str(self):
-        # reset global constants, as previous tests could have converted the 
+        # reset global constants, as previous tests could have converted the
         # integer values to enums
         module = ('test.test_enum', '__main__')[__name__=='__main__']
         test_type = enum.IntEnum._convert_(

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -8,7 +8,7 @@ import unittest
 import threading
 from collections import OrderedDict
 from enum import Enum, IntEnum, StrEnum, EnumType, Flag, IntFlag, unique, auto
-from enum import STRICT, CONFORM, EJECT, KEEP
+from enum import STRICT, CONFORM, EJECT, KEEP, simple_enum, test_simple_enum
 from io import StringIO
 from pickle import dumps, loads, PicklingError, HIGHEST_PROTOCOL
 from test import support
@@ -3577,6 +3577,23 @@ class TestStdLib(unittest.TestCase):
         if failed:
             self.fail("result does not equal expected, see print above")
 
+    def test_test_simple_enum(self):
+        @simple_enum(Enum)
+        class SimpleColor:
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+        class CheckedColor(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+        self.assertTrue(test_simple_enum(CheckedColor, SimpleColor) is None)
+        SimpleColor.GREEN._value_ = 9
+        self.assertRaisesRegex(
+                TypeError, "enum mismatch",
+                test_simple_enum, CheckedColor, SimpleColor,
+                )
+        
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1,3 +1,4 @@
+import enum
 import errno
 from http import client, HTTPStatus
 import io
@@ -523,6 +524,150 @@ class BasicTest(TestCase):
     def test_dir_with_added_behavior_on_status(self):
         # see issue40084
         self.assertTrue({'description', 'name', 'phrase', 'value'} <= set(dir(HTTPStatus(404))))
+
+    def test_simple_httpstatus(self):
+        class CheckedHTTPStatus(enum.IntEnum):
+            """HTTP status codes and reason phrases
+
+            Status codes from the following RFCs are all observed:
+
+                * RFC 7231: Hypertext Transfer Protocol (HTTP/1.1), obsoletes 2616
+                * RFC 6585: Additional HTTP Status Codes
+                * RFC 3229: Delta encoding in HTTP
+                * RFC 4918: HTTP Extensions for WebDAV, obsoletes 2518
+                * RFC 5842: Binding Extensions to WebDAV
+                * RFC 7238: Permanent Redirect
+                * RFC 2295: Transparent Content Negotiation in HTTP
+                * RFC 2774: An HTTP Extension Framework
+                * RFC 7725: An HTTP Status Code to Report Legal Obstacles
+                * RFC 7540: Hypertext Transfer Protocol Version 2 (HTTP/2)
+                * RFC 2324: Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0)
+                * RFC 8297: An HTTP Status Code for Indicating Hints
+                * RFC 8470: Using Early Data in HTTP
+            """
+            def __new__(cls, value, phrase, description=''):
+                obj = int.__new__(cls, value)
+                obj._value_ = value
+
+                obj.phrase = phrase
+                obj.description = description
+                return obj
+            # informational
+            CONTINUE = 100, 'Continue', 'Request received, please continue'
+            SWITCHING_PROTOCOLS = (101, 'Switching Protocols',
+                    'Switching to new protocol; obey Upgrade header')
+            PROCESSING = 102, 'Processing'
+            EARLY_HINTS = 103, 'Early Hints'
+            # success
+            OK = 200, 'OK', 'Request fulfilled, document follows'
+            CREATED = 201, 'Created', 'Document created, URL follows'
+            ACCEPTED = (202, 'Accepted',
+                'Request accepted, processing continues off-line')
+            NON_AUTHORITATIVE_INFORMATION = (203,
+                'Non-Authoritative Information', 'Request fulfilled from cache')
+            NO_CONTENT = 204, 'No Content', 'Request fulfilled, nothing follows'
+            RESET_CONTENT = 205, 'Reset Content', 'Clear input form for further input'
+            PARTIAL_CONTENT = 206, 'Partial Content', 'Partial content follows'
+            MULTI_STATUS = 207, 'Multi-Status'
+            ALREADY_REPORTED = 208, 'Already Reported'
+            IM_USED = 226, 'IM Used'
+            # redirection
+            MULTIPLE_CHOICES = (300, 'Multiple Choices',
+                'Object has several resources -- see URI list')
+            MOVED_PERMANENTLY = (301, 'Moved Permanently',
+                'Object moved permanently -- see URI list')
+            FOUND = 302, 'Found', 'Object moved temporarily -- see URI list'
+            SEE_OTHER = 303, 'See Other', 'Object moved -- see Method and URL list'
+            NOT_MODIFIED = (304, 'Not Modified',
+                'Document has not changed since given time')
+            USE_PROXY = (305, 'Use Proxy',
+                'You must use proxy specified in Location to access this resource')
+            TEMPORARY_REDIRECT = (307, 'Temporary Redirect',
+                'Object moved temporarily -- see URI list')
+            PERMANENT_REDIRECT = (308, 'Permanent Redirect',
+                'Object moved permanently -- see URI list')
+            # client error
+            BAD_REQUEST = (400, 'Bad Request',
+                'Bad request syntax or unsupported method')
+            UNAUTHORIZED = (401, 'Unauthorized',
+                'No permission -- see authorization schemes')
+            PAYMENT_REQUIRED = (402, 'Payment Required',
+                'No payment -- see charging schemes')
+            FORBIDDEN = (403, 'Forbidden',
+                'Request forbidden -- authorization will not help')
+            NOT_FOUND = (404, 'Not Found',
+                'Nothing matches the given URI')
+            METHOD_NOT_ALLOWED = (405, 'Method Not Allowed',
+                'Specified method is invalid for this resource')
+            NOT_ACCEPTABLE = (406, 'Not Acceptable',
+                'URI not available in preferred format')
+            PROXY_AUTHENTICATION_REQUIRED = (407,
+                'Proxy Authentication Required',
+                'You must authenticate with this proxy before proceeding')
+            REQUEST_TIMEOUT = (408, 'Request Timeout',
+                'Request timed out; try again later')
+            CONFLICT = 409, 'Conflict', 'Request conflict'
+            GONE = (410, 'Gone',
+                'URI no longer exists and has been permanently removed')
+            LENGTH_REQUIRED = (411, 'Length Required',
+                'Client must specify Content-Length')
+            PRECONDITION_FAILED = (412, 'Precondition Failed',
+                'Precondition in headers is false')
+            REQUEST_ENTITY_TOO_LARGE = (413, 'Request Entity Too Large',
+                'Entity is too large')
+            REQUEST_URI_TOO_LONG = (414, 'Request-URI Too Long',
+                'URI is too long')
+            UNSUPPORTED_MEDIA_TYPE = (415, 'Unsupported Media Type',
+                'Entity body in unsupported format')
+            REQUESTED_RANGE_NOT_SATISFIABLE = (416,
+                'Requested Range Not Satisfiable',
+                'Cannot satisfy request range')
+            EXPECTATION_FAILED = (417, 'Expectation Failed',
+                'Expect condition could not be satisfied')
+            IM_A_TEAPOT = (418, 'I\'m a Teapot',
+                'Server refuses to brew coffee because it is a teapot.')
+            MISDIRECTED_REQUEST = (421, 'Misdirected Request',
+                'Server is not able to produce a response')
+            UNPROCESSABLE_ENTITY = 422, 'Unprocessable Entity'
+            LOCKED = 423, 'Locked'
+            FAILED_DEPENDENCY = 424, 'Failed Dependency'
+            TOO_EARLY = 425, 'Too Early'
+            UPGRADE_REQUIRED = 426, 'Upgrade Required'
+            PRECONDITION_REQUIRED = (428, 'Precondition Required',
+                'The origin server requires the request to be conditional')
+            TOO_MANY_REQUESTS = (429, 'Too Many Requests',
+                'The user has sent too many requests in '
+                'a given amount of time ("rate limiting")')
+            REQUEST_HEADER_FIELDS_TOO_LARGE = (431,
+                'Request Header Fields Too Large',
+                'The server is unwilling to process the request because its header '
+                'fields are too large')
+            UNAVAILABLE_FOR_LEGAL_REASONS = (451,
+                'Unavailable For Legal Reasons',
+                'The server is denying access to the '
+                'resource as a consequence of a legal demand')
+            # server errors
+            INTERNAL_SERVER_ERROR = (500, 'Internal Server Error',
+                'Server got itself in trouble')
+            NOT_IMPLEMENTED = (501, 'Not Implemented',
+                'Server does not support this operation')
+            BAD_GATEWAY = (502, 'Bad Gateway',
+                'Invalid responses from another server/proxy')
+            SERVICE_UNAVAILABLE = (503, 'Service Unavailable',
+                'The server cannot process the request due to a high load')
+            GATEWAY_TIMEOUT = (504, 'Gateway Timeout',
+                'The gateway server did not receive a timely response')
+            HTTP_VERSION_NOT_SUPPORTED = (505, 'HTTP Version Not Supported',
+                'Cannot fulfill request')
+            VARIANT_ALSO_NEGOTIATES = 506, 'Variant Also Negotiates'
+            INSUFFICIENT_STORAGE = 507, 'Insufficient Storage'
+            LOOP_DETECTED = 508, 'Loop Detected'
+            NOT_EXTENDED = 510, 'Not Extended'
+            NETWORK_AUTHENTICATION_REQUIRED = (511,
+                'Network Authentication Required',
+                'The client needs to authenticate to gain network access')
+        enum.test_simple_enum(CheckedHTTPStatus, HTTPStatus)
+
 
     def test_status_lines(self):
         # Test HTTP status lines

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -666,7 +666,7 @@ class BasicTest(TestCase):
             NETWORK_AUTHENTICATION_REQUIRED = (511,
                 'Network Authentication Required',
                 'The client needs to authenticate to gain network access')
-        enum.test_simple_enum(CheckedHTTPStatus, HTTPStatus)
+        enum._test_simple_enum(CheckedHTTPStatus, HTTPStatus)
 
 
     def test_status_lines(self):

--- a/Lib/test/test_pstats.py
+++ b/Lib/test/test_pstats.py
@@ -3,6 +3,7 @@ import unittest
 from test import support
 from io import StringIO
 from pstats import SortKey
+from enum import StrEnum, test_simple_enum
 
 import pstats
 import cProfile
@@ -67,6 +68,25 @@ class StatsTestCase(unittest.TestCase):
             self.assertEqual(
                     self.stats.sort_type,
                     self.stats.sort_arg_dict_default[member.value][-1])
+        class CheckedSortKey(StrEnum):
+            CALLS = 'calls', 'ncalls'
+            CUMULATIVE = 'cumulative', 'cumtime'
+            FILENAME = 'filename', 'module'
+            LINE = 'line'
+            NAME = 'name'
+            NFL = 'nfl'
+            PCALLS = 'pcalls'
+            STDNAME = 'stdname'
+            TIME = 'time', 'tottime'
+            def __new__(cls, *values):
+                value = values[0]
+                obj = str.__new__(cls, value)
+                obj._value_ = value
+                for other_value in values[1:]:
+                    cls._value2member_map_[other_value] = obj
+                obj._all_values = values
+                return obj
+        test_simple_enum(CheckedSortKey, SortKey)
 
     def test_sort_starts_mix(self):
         self.assertRaises(TypeError, self.stats.sort_stats,

--- a/Lib/test/test_pstats.py
+++ b/Lib/test/test_pstats.py
@@ -3,7 +3,7 @@ import unittest
 from test import support
 from io import StringIO
 from pstats import SortKey
-from enum import StrEnum, test_simple_enum
+from enum import StrEnum, _test_simple_enum
 
 import pstats
 import cProfile
@@ -86,7 +86,7 @@ class StatsTestCase(unittest.TestCase):
                     cls._value2member_map_[other_value] = obj
                 obj._all_values = values
                 return obj
-        test_simple_enum(CheckedSortKey, SortKey)
+        _test_simple_enum(CheckedSortKey, SortKey)
 
     def test_sort_starts_mix(self):
         self.assertRaises(TypeError, self.stats.sort_stats,

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1,3 +1,4 @@
+import enum
 import errno
 import os
 import random
@@ -32,6 +33,32 @@ class GenericTests(unittest.TestCase):
             elif name.startswith('CTRL_'):
                 self.assertIsInstance(sig, signal.Signals)
                 self.assertEqual(sys.platform, "win32")
+
+        CheckedSignals = enum._old_convert_(
+                enum.IntEnum, 'Signals', 'signal',
+                lambda name:
+                    name.isupper()
+                    and (name.startswith('SIG') and not name.startswith('SIG_'))
+                    or name.startswith('CTRL_'),
+                source=signal,
+                )
+        enum._test_simple_enum(CheckedSignals, signal.Signals)
+
+        CheckedHandlers = enum._old_convert_(
+                enum.IntEnum, 'Handlers', 'signal',
+                lambda name: name in ('SIG_DFL', 'SIG_IGN'),
+                source=signal,
+                )
+        enum._test_simple_enum(CheckedHandlers, signal.Handlers)
+
+        Sigmasks = getattr(signal, 'Sigmasks', None)
+        if Sigmasks is not None:
+            CheckedSigmasks = enum._old_convert_(
+                    enum.IntEnum, 'Sigmasks', 'signal',
+                    lambda name: name in ('SIG_BLOCK', 'SIG_UNBLOCK', 'SIG_SETMASK'),
+                    source=signal,
+                    )
+            enum._test_simple_enum(CheckedSigmasks, Sigmasks)
 
 
 @unittest.skipIf(sys.platform == "win32", "Not valid on Windows")

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1941,6 +1941,41 @@ class GeneralModuleTests(unittest.TestCase):
                     fileno=afile.fileno())
             self.assertEqual(cm.exception.errno, errno.ENOTSOCK)
 
+    def test_addressfamily_enum(self):
+        import _socket, enum
+        CheckedAddressFamily = enum._old_convert_(
+                enum.IntEnum, 'AddressFamily', 'socket',
+                lambda C: C.isupper() and C.startswith('AF_'),
+                source=_socket,
+                )
+        enum._test_simple_enum(CheckedAddressFamily, socket.AddressFamily)
+
+    def test_socketkind_enum(self):
+        import _socket, enum
+        CheckedSocketKind = enum._old_convert_(
+                enum.IntEnum, 'SocketKind', 'socket',
+                lambda C: C.isupper() and C.startswith('SOCK_'),
+                source=_socket,
+                )
+        enum._test_simple_enum(CheckedSocketKind, socket.SocketKind)
+
+    def test_msgflag_enum(self):
+        import _socket, enum
+        CheckedMsgFlag = enum._old_convert_(
+                enum.IntFlag, 'MsgFlag', 'socket',
+                lambda C: C.isupper() and C.startswith('MSG_'),
+                source=_socket,
+                )
+        enum._test_simple_enum(CheckedMsgFlag, socket.MsgFlag)
+
+    def test_addressinfo_enum(self):
+        import _socket, enum
+        CheckedAddressInfo = enum._old_convert_(
+                enum.IntFlag, 'AddressInfo', 'socket',
+                lambda C: C.isupper() and C.startswith('AI_'),
+                source=_socket)
+        enum._test_simple_enum(CheckedAddressInfo, socket.AddressInfo)
+
 
 @unittest.skipUnless(HAVE_SOCKET_CAN, 'SocketCan required for this test.')
 class BasicCANTest(unittest.TestCase):

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1118,10 +1118,23 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(default | ssl.OP_NO_TLSv1, ctx.options)
         with warnings_helper.check_warnings():
             ctx.options = (ctx.options & ~ssl.OP_NO_TLSv1)
+        # <<<<<<< HEAD  FIXME
         self.assertEqual(default, ctx.options)
         ctx.options = 0
         # Ubuntu has OP_NO_SSLv3 forced on by default
         self.assertEqual(0, ctx.options & ~ssl.OP_NO_SSLv3)
+        # =======
+            self.assertEqual(
+                    default, ctx.options,
+                    'Failed comparison:\n   ssl.OP_ALL: %50s %s\n      default: %50s %s\n  ctx.options: %50s %s' % (enum.bin(ssl.OP_ALL), ssl.OP_ALL, enum.bin(default), default, enum.bin(ctx.options), ctx.options),
+                    )
+            ctx.options = 0
+            # Ubuntu has OP_NO_SSLv3 forced on by default
+            self.assertEqual(0, ctx.options & ~ssl.OP_NO_SSLv3)
+        else:
+            with self.assertRaises(ValueError):
+                ctx.options = 0
+        # >>>>>>> changes:
 
     def test_verify_mode_protocol(self):
         with warnings_helper.check_warnings():
@@ -4710,7 +4723,7 @@ class TestEnumerations(unittest.TestCase):
             TLSv1_2 = _ssl.PROTO_TLSv1_2
             TLSv1_3 = _ssl.PROTO_TLSv1_3
             MAXIMUM_SUPPORTED = _ssl.PROTO_MAXIMUM_SUPPORTED
-        enum.test_simple_enum(CheckedTLSVersion, TLSVersion)
+        enum._test_simple_enum(CheckedTLSVersion, TLSVersion)
 
     def test_tlscontenttype(self):
         class Checked_TLSContentType(enum.IntEnum):
@@ -4725,7 +4738,7 @@ class TestEnumerations(unittest.TestCase):
             # pseudo content types
             HEADER = 0x100
             INNER_CONTENT_TYPE = 0x101
-        enum.test_simple_enum(Checked_TLSContentType, _TLSContentType)
+        enum._test_simple_enum(Checked_TLSContentType, _TLSContentType)
 
     def test_tlsalerttype(self):
         class Checked_TLSAlertType(enum.IntEnum):
@@ -4767,7 +4780,7 @@ class TestEnumerations(unittest.TestCase):
             UNKNOWN_PSK_IDENTITY = 115
             CERTIFICATE_REQUIRED = 116
             NO_APPLICATION_PROTOCOL = 120
-        enum.test_simple_enum(Checked_TLSAlertType, _TLSAlertType)
+        enum._test_simple_enum(Checked_TLSAlertType, _TLSAlertType)
 
     def test_tlsmessagetype(self):
         class Checked_TLSMessageType(enum.IntEnum):
@@ -4797,8 +4810,56 @@ class TestEnumerations(unittest.TestCase):
             NEXT_PROTO = 67
             MESSAGE_HASH = 254
             CHANGE_CIPHER_SPEC = 0x0101
-        enum.test_simple_enum(Checked_TLSMessageType, _TLSMessageType)
+        enum._test_simple_enum(Checked_TLSMessageType, _TLSMessageType)
 
+    def test_sslmethod(self):
+        Checked_SSLMethod = enum._old_convert_(
+                enum.IntEnum, '_SSLMethod', 'ssl',
+                lambda name: name.startswith('PROTOCOL_') and name != 'PROTOCOL_SSLv23',
+                source=ssl._ssl,
+                )
+        enum._test_simple_enum(Checked_SSLMethod, ssl._SSLMethod)
+
+    def test_options(self):
+        CheckedOptions = enum._old_convert_(
+                enum.FlagEnum, 'Options', 'ssl',
+                lambda name: name.startswith('OP_'),
+                source=ssl._ssl,
+                )
+        enum._test_simple_enum(CheckedOptions, ssl.Options)
+
+
+    def test_alertdescription(self):
+        CheckedAlertDescription = enum._old_convert_(
+                enum.IntEnum, 'AlertDescription', 'ssl',
+                lambda name: name.startswith('ALERT_DESCRIPTION_'),
+                source=ssl._ssl,
+                )
+        enum._test_simple_enum(CheckedAlertDescription, ssl.AlertDescription)
+
+    def test_sslerrornumber(self):
+        Checked_SSLMethod = enum._old_convert_(
+                enum.IntEnum, '_SSLMethod', 'ssl',
+                lambda name: name.startswith('PROTOCOL_') and name != 'PROTOCOL_SSLv23',
+                source=ssl._ssl,
+                )
+        enum._test_simple_enum(Checked_SSLMethod, ssl._SSLMethod)
+
+    def test_verifyflags(self):
+        CheckedVerifyFlags = enum._old_convert_(
+                enum.FlagEnum, 'VerifyFlags', 'ssl',
+                lambda name: name.startswith('VERIFY_'),
+                source=ssl._ssl,
+                )
+        enum._test_simple_enum(CheckedVerifyFlags, ssl.VerifyFlags)
+
+    def test_verifymode(self):
+        CheckedVerifyMode = enum._old_convert_(
+                enum.IntEnum, 'VerifyMode', 'ssl',
+                lambda name: name.startswith('CERT_'),
+                source=ssl._ssl,
+                )
+        enum._test_simple_enum(CheckedVerifyMode, ssl.VerifyMode)
 
 def test_main(verbose=False):
     if support.verbose:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1118,23 +1118,10 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(default | ssl.OP_NO_TLSv1, ctx.options)
         with warnings_helper.check_warnings():
             ctx.options = (ctx.options & ~ssl.OP_NO_TLSv1)
-        # <<<<<<< HEAD  FIXME
         self.assertEqual(default, ctx.options)
         ctx.options = 0
         # Ubuntu has OP_NO_SSLv3 forced on by default
         self.assertEqual(0, ctx.options & ~ssl.OP_NO_SSLv3)
-        # =======
-            self.assertEqual(
-                    default, ctx.options,
-                    'Failed comparison:\n   ssl.OP_ALL: %50s %s\n      default: %50s %s\n  ctx.options: %50s %s' % (enum.bin(ssl.OP_ALL), ssl.OP_ALL, enum.bin(default), default, enum.bin(ctx.options), ctx.options),
-                    )
-            ctx.options = 0
-            # Ubuntu has OP_NO_SSLv3 forced on by default
-            self.assertEqual(0, ctx.options & ~ssl.OP_NO_SSLv3)
-        else:
-            with self.assertRaises(ValueError):
-                ctx.options = 0
-        # >>>>>>> changes:
 
     def test_verify_mode_protocol(self):
         with warnings_helper.check_warnings():

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -12,6 +12,8 @@ from test.support import warnings_helper
 import socket
 import select
 import time
+import datetime
+import enum
 import gc
 import os
 import errno
@@ -31,7 +33,7 @@ except ImportError:
 
 ssl = import_helper.import_module("ssl")
 
-from ssl import TLSVersion, _TLSContentType, _TLSMessageType
+from ssl import TLSVersion, _TLSContentType, _TLSMessageType, _TLSAlertType
 
 Py_DEBUG = hasattr(sys, 'gettotalrefcount')
 Py_DEBUG_WIN32 = Py_DEBUG and sys.platform == 'win32'
@@ -4695,6 +4697,107 @@ class TestSSLDebug(unittest.TestCase):
             with client_context.wrap_socket(socket.socket(),
                                             server_hostname=hostname) as s:
                 s.connect((HOST, server.port))
+
+
+class TestEnumerations(unittest.TestCase):
+
+    def test_tlsversion(self):
+        class CheckedTLSVersion(enum.IntEnum):
+            MINIMUM_SUPPORTED = _ssl.PROTO_MINIMUM_SUPPORTED
+            SSLv3 = _ssl.PROTO_SSLv3
+            TLSv1 = _ssl.PROTO_TLSv1
+            TLSv1_1 = _ssl.PROTO_TLSv1_1
+            TLSv1_2 = _ssl.PROTO_TLSv1_2
+            TLSv1_3 = _ssl.PROTO_TLSv1_3
+            MAXIMUM_SUPPORTED = _ssl.PROTO_MAXIMUM_SUPPORTED
+        enum.test_simple_enum(CheckedTLSVersion, TLSVersion)
+
+    def test_tlscontenttype(self):
+        class Checked_TLSContentType(enum.IntEnum):
+            """Content types (record layer)
+
+            See RFC 8446, section B.1
+            """
+            CHANGE_CIPHER_SPEC = 20
+            ALERT = 21
+            HANDSHAKE = 22
+            APPLICATION_DATA = 23
+            # pseudo content types
+            HEADER = 0x100
+            INNER_CONTENT_TYPE = 0x101
+        enum.test_simple_enum(Checked_TLSContentType, _TLSContentType)
+
+    def test_tlsalerttype(self):
+        class Checked_TLSAlertType(enum.IntEnum):
+            """Alert types for TLSContentType.ALERT messages
+
+            See RFC 8466, section B.2
+            """
+            CLOSE_NOTIFY = 0
+            UNEXPECTED_MESSAGE = 10
+            BAD_RECORD_MAC = 20
+            DECRYPTION_FAILED = 21
+            RECORD_OVERFLOW = 22
+            DECOMPRESSION_FAILURE = 30
+            HANDSHAKE_FAILURE = 40
+            NO_CERTIFICATE = 41
+            BAD_CERTIFICATE = 42
+            UNSUPPORTED_CERTIFICATE = 43
+            CERTIFICATE_REVOKED = 44
+            CERTIFICATE_EXPIRED = 45
+            CERTIFICATE_UNKNOWN = 46
+            ILLEGAL_PARAMETER = 47
+            UNKNOWN_CA = 48
+            ACCESS_DENIED = 49
+            DECODE_ERROR = 50
+            DECRYPT_ERROR = 51
+            EXPORT_RESTRICTION = 60
+            PROTOCOL_VERSION = 70
+            INSUFFICIENT_SECURITY = 71
+            INTERNAL_ERROR = 80
+            INAPPROPRIATE_FALLBACK = 86
+            USER_CANCELED = 90
+            NO_RENEGOTIATION = 100
+            MISSING_EXTENSION = 109
+            UNSUPPORTED_EXTENSION = 110
+            CERTIFICATE_UNOBTAINABLE = 111
+            UNRECOGNIZED_NAME = 112
+            BAD_CERTIFICATE_STATUS_RESPONSE = 113
+            BAD_CERTIFICATE_HASH_VALUE = 114
+            UNKNOWN_PSK_IDENTITY = 115
+            CERTIFICATE_REQUIRED = 116
+            NO_APPLICATION_PROTOCOL = 120
+        enum.test_simple_enum(Checked_TLSAlertType, _TLSAlertType)
+
+    def test_tlsmessagetype(self):
+        class Checked_TLSMessageType(enum.IntEnum):
+            """Message types (handshake protocol)
+
+            See RFC 8446, section B.3
+            """
+            HELLO_REQUEST = 0
+            CLIENT_HELLO = 1
+            SERVER_HELLO = 2
+            HELLO_VERIFY_REQUEST = 3
+            NEWSESSION_TICKET = 4
+            END_OF_EARLY_DATA = 5
+            HELLO_RETRY_REQUEST = 6
+            ENCRYPTED_EXTENSIONS = 8
+            CERTIFICATE = 11
+            SERVER_KEY_EXCHANGE = 12
+            CERTIFICATE_REQUEST = 13
+            SERVER_DONE = 14
+            CERTIFICATE_VERIFY = 15
+            CLIENT_KEY_EXCHANGE = 16
+            FINISHED = 20
+            CERTIFICATE_URL = 21
+            CERTIFICATE_STATUS = 22
+            SUPPLEMENTAL_DATA = 23
+            KEY_UPDATE = 24
+            NEXT_PROTO = 67
+            MESSAGE_HASH = 254
+            CHANGE_CIPHER_SPEC = 0x0101
+        enum.test_simple_enum(Checked_TLSMessageType, _TLSMessageType)
 
 
 def test_main(verbose=False):

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1463,20 +1463,21 @@ class UnicodeTest(string_tests.CommonTest,
             PI = 3.1415926
         class Int(enum.IntEnum):
             IDES = 15
-        class Str(str, enum.Enum):
+        class Str(enum.StrEnum):
+            # StrEnum uses the value and not the name for %s etc.
             ABC = 'abc'
         # Testing Unicode formatting strings...
         self.assertEqual("%s, %s" % (Str.ABC, Str.ABC),
-                         'ABC, ABC')
+                         'abc, abc')
         self.assertEqual("%s, %s, %d, %i, %u, %f, %5.2f" %
                         (Str.ABC, Str.ABC,
                          Int.IDES, Int.IDES, Int.IDES,
                          Float.PI, Float.PI),
-                         'ABC, ABC, 15, 15, 15, 3.141593,  3.14')
+                         'abc, abc, 15, 15, 15, 3.141593,  3.14')
 
         # formatting jobs delegated from the string implementation:
         self.assertEqual('...%(foo)s...' % {'foo':Str.ABC},
-                         '...ABC...')
+                         '...abc...')
         self.assertEqual('...%(foo)s...' % {'foo':Int.IDES},
                          '...IDES...')
         self.assertEqual('...%(foo)i...' % {'foo':Int.IDES},

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -37,7 +37,7 @@ class BaseTestUUID:
             safe = 0
             unsafe = -1
             unknown = None
-        enum.test_simple_enum(CheckedSafeUUID, py_uuid.SafeUUID)
+        enum._test_simple_enum(CheckedSafeUUID, py_uuid.SafeUUID)
 
     def test_UUID(self):
         equal = self.assertEqual

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -4,6 +4,7 @@ from test.support import import_helper
 import builtins
 import contextlib
 import copy
+import enum
 import io
 import os
 import pickle
@@ -30,6 +31,13 @@ def mock_get_command_stdout(data):
 
 class BaseTestUUID:
     uuid = None
+
+    def test_safe_uuid_enum(self):
+        class CheckedSafeUUID(enum.Enum):
+            safe = 0
+            unsafe = -1
+            unknown = None
+        enum.test_simple_enum(CheckedSafeUUID, py_uuid.SafeUUID)
 
     def test_UUID(self):
         equal = self.assertEqual

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -144,7 +144,7 @@ def _splitdict(tk, v, cut_minus=True, conv=None):
     return dict
 
 
-@enum.simple_enum(enum.StrEnum)
+@enum._simple_enum(enum.StrEnum)
 class EventType:
     KeyPress = '2'
     Key = KeyPress

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -144,7 +144,8 @@ def _splitdict(tk, v, cut_minus=True, conv=None):
     return dict
 
 
-class EventType(enum.StrEnum):
+@enum.simple_enum(enum.StrEnum)
+class EventType:
     KeyPress = '2'
     Key = KeyPress
     KeyRelease = '3'
@@ -184,8 +185,6 @@ class EventType(enum.StrEnum):
     Activate = '36'
     Deactivate = '37'
     MouseWheel = '38'
-
-    __str__ = str.__str__
 
 
 class Event:

--- a/Lib/tkinter/test/test_tkinter/test_misc.py
+++ b/Lib/tkinter/test/test_tkinter/test_misc.py
@@ -1,5 +1,6 @@
 import unittest
 import tkinter
+import enum
 from test import support
 from tkinter.test.support import AbstractTkTest, AbstractDefaultRootTest
 
@@ -260,6 +261,49 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
                          " keysym=Key-A keycode=65 char='A'"
                          " num=3 delta=-1 focus=True"
                          " x=10 y=20 width=300 height=200>")
+
+    def test_eventtype_enum(self):
+        class CheckedEventType(enum.StrEnum):
+            KeyPress = '2'
+            Key = KeyPress
+            KeyRelease = '3'
+            ButtonPress = '4'
+            Button = ButtonPress
+            ButtonRelease = '5'
+            Motion = '6'
+            Enter = '7'
+            Leave = '8'
+            FocusIn = '9'
+            FocusOut = '10'
+            Keymap = '11'           # undocumented
+            Expose = '12'
+            GraphicsExpose = '13'   # undocumented
+            NoExpose = '14'         # undocumented
+            Visibility = '15'
+            Create = '16'
+            Destroy = '17'
+            Unmap = '18'
+            Map = '19'
+            MapRequest = '20'
+            Reparent = '21'
+            Configure = '22'
+            ConfigureRequest = '23'
+            Gravity = '24'
+            ResizeRequest = '25'
+            Circulate = '26'
+            CirculateRequest = '27'
+            Property = '28'
+            SelectionClear = '29'   # undocumented
+            SelectionRequest = '30' # undocumented
+            Selection = '31'        # undocumented
+            Colormap = '32'
+            ClientMessage = '33'    # undocumented
+            Mapping = '34'          # undocumented
+            VirtualEvent = '35'     # undocumented
+            Activate = '36'
+            Deactivate = '37'
+            MouseWheel = '38'
+        enum.test_simple_enum(CheckedEventType, tkinter.EventType)
 
     def test_getboolean(self):
         for v in 'true', 'yes', 'on', '1', 't', 'y', 1, True:

--- a/Lib/tkinter/test/test_tkinter/test_misc.py
+++ b/Lib/tkinter/test/test_tkinter/test_misc.py
@@ -303,7 +303,7 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
             Activate = '36'
             Deactivate = '37'
             MouseWheel = '38'
-        enum.test_simple_enum(CheckedEventType, tkinter.EventType)
+        enum._test_simple_enum(CheckedEventType, tkinter.EventType)
 
     def test_getboolean(self):
         for v in 'true', 'yes', 'on', '1', 't', 'y', 1, True:

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -47,7 +47,7 @@ Typical usage:
 import os
 import sys
 
-from enum import Enum
+from enum import Enum, simple_enum
 
 
 __author__ = 'Ka-Ping Yee <ping@zesty.ca>'
@@ -75,7 +75,8 @@ int_ = int      # The built-in int type
 bytes_ = bytes  # The built-in bytes type
 
 
-class SafeUUID(Enum):
+@simple_enum(Enum)
+class SafeUUID:
     safe = 0
     unsafe = -1
     unknown = None

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -47,7 +47,7 @@ Typical usage:
 import os
 import sys
 
-from enum import Enum, simple_enum
+from enum import Enum, _simple_enum
 
 
 __author__ = 'Ka-Ping Yee <ping@zesty.ca>'
@@ -75,7 +75,7 @@ int_ = int      # The built-in int type
 bytes_ = bytes  # The built-in bytes type
 
 
-@simple_enum(Enum)
+@_simple_enum(Enum)
 class SafeUUID:
     safe = 0
     unsafe = -1

--- a/Misc/NEWS.d/next/Library/2021-04-08-11-47-31.bpo-38659.r_HFnU.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-08-11-47-31.bpo-38659.r_HFnU.rst
@@ -1,0 +1,4 @@
+A ``simple_enum`` decorator is added to the ``enum`` module to convert a
+normal class into an Enum. ``test_simple_enum`` added to test simple enums
+against a corresponding normal Enum.  Standard library modules updated to
+use ``simple_enum``.


### PR DESCRIPTION
add:

* `_simple_enum` decorator to transform a normal class into an enum
* `_test_simple_enum` function to compare
* `_old_convert_` to enable checking `_convert_` generated enums

`_simple_enum` takes a normal class and converts it into an enum:

    @simple_enum(Enum)
    class Color:
        RED = 1
        GREEN = 2
        BLUE = 3

`_old_convert_` works much like` _convert_` does, using the original logic:

    # in a test file
    import socket, enum
    CheckedAddressFamily = enum._old_convert_(
            enum.IntEnum, 'AddressFamily', 'socket',
            lambda C: C.isupper() and C.startswith('AF_'),
            source=_socket,
            )

`_test_simple_enum` takes a traditional enum and a simple enum and
compares the two:

    # in the REPL or the same module as Color
    class CheckedColor(Enum):
        RED = 1
        GREEN = 2
        BLUE = 3

    _test_simple_enum(CheckedColor, Color)

    _test_simple_enum(CheckedAddressFamily, socket.AddressFamily)

Any important differences will raise a TypeError

<!-- issue-number: [bpo-38659](https://bugs.python.org/issue38659) -->
https://bugs.python.org/issue38659
<!-- /issue-number -->
