### PR TITLE
bpo-43907: add missing memoize call in pure python pickling of bytearray

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -818,6 +818,7 @@ class _Pickler:
             self._write_large_bytes(BYTEARRAY8 + pack("<Q", n), obj)
         else:
             self.write(BYTEARRAY8 + pack("<Q", n) + obj)
+        self.memoize(obj)
     dispatch[bytearray] = save_bytearray
 
     if _HAVE_PICKLE_BUFFER:

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1853,6 +1853,14 @@ class AbstractPickleTests(unittest.TestCase):
                     self.assertNotIn(b'bytearray', p)
                     self.assertTrue(opcode_in_pickle(pickle.BYTEARRAY8, p))
 
+    def test_bytearray_memoization_bug(self):
+        for proto in protocols:
+            for s in b'', b'xyz', b'xyz'*100:
+                b = bytearray(s)
+                p = self.dumps((b, b), proto)
+                b1, b2 = self.loads(p)
+                self.assertIs(b1, b2)
+
     def test_ints(self):
         for proto in protocols:
             n = sys.maxsize

--- a/Misc/NEWS.d/next/Library/2021-04-23-20-57-20.bpo-43907.3RJEjv.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-23-20-57-20.bpo-43907.3RJEjv.rst
@@ -1,0 +1,4 @@
+Fix a bug in the pure-Python pickle implementation when using protocol 5,
+where bytearray instances that occur several time in the pickled object
+graph would incorrectly unpickle into repeated copies of the bytearray
+object.


### PR DESCRIPTION
The pure python implementation of bytearray pickling in protocol 5 was missing the memoization call, which means that after unpickling identical bytearrays would turn into distinct objects. Found in PyPy (which uses the pickle.py implementation by default).


<!-- issue-number: [bpo-43907](https://bugs.python.org/issue43907) -->
https://bugs.python.org/issue43907
<!-- /issue-number -->
