### PR TITLE
bpo-43472: Ensure PyInterpreterState_New audit events are raised when called through _xxsubinterpreters module

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -26,12 +26,12 @@ always available.
 .. function:: addaudithook(hook)
 
    Append the callable *hook* to the list of active auditing hooks for the
-   current interpreter.
+   current (sub)interpreter.
 
    When an auditing event is raised through the :func:`sys.audit` function, each
    hook will be called in the order it was added with the event name and the
    tuple of arguments. Native hooks added by :c:func:`PySys_AddAuditHook` are
-   called first, followed by hooks added in the current interpreter.  Hooks
+   called first, followed by hooks added in the current (sub)interpreter.  Hooks
    can then log the event, raise an exception to abort the operation,
    or terminate the process entirely.
 

--- a/Misc/NEWS.d/next/Security/2021-04-21-22-53-31.bpo-43472.gjLBTb.rst
+++ b/Misc/NEWS.d/next/Security/2021-04-21-22-53-31.bpo-43472.gjLBTb.rst
@@ -1,0 +1,3 @@
+Ensures interpreter-level audit hooks receive the
+``cpython.PyInterpreterState_New`` event when called through the
+``_xxsubinterpreters`` module.

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2025,7 +2025,7 @@ interp_create(PyObject *self, PyObject *args, PyObject *kwds)
     }
 
     // Create and initialize the new interpreter.
-    PyThreadState *save_tstate = PyThreadState_Swap(NULL);
+    PyThreadState *save_tstate = PyThreadState_Get();
     // XXX Possible GILState issues?
     PyThreadState *tstate = _Py_NewInterpreter(isolated);
     PyThreadState_Swap(save_tstate);


### PR DESCRIPTION


<!-- issue-number: [bpo-43472](https://bugs.python.org/issue43472) -->
https://bugs.python.org/issue43472
<!-- /issue-number -->
