### PR TITLE
bpo-26227: Fixes decoding of host names on Windows from ANSI instead of UTF-8

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-04-21-23-37-34.bpo-26227.QMY_eA.rst
+++ b/Misc/NEWS.d/next/Windows/2021-04-21-23-37-34.bpo-26227.QMY_eA.rst
@@ -1,0 +1,2 @@
+Fixed decoding of host names in :func:`socket.gethostbyaddr` and
+:func:`socket.gethostbyname_ex`.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -5508,7 +5508,7 @@ sock_decode_hostname(const char *name)
 #ifdef MS_WINDOWS
     /* Issue #26227: gethostbyaddr() returns a string encoded
      * to the ANSI code page */
-    return PyUnicode_DecodeFSDefault(name);
+    return PyUnicode_DecodeMBCS(name, strlen(name), "surrogatepass");
 #else
     /* Decode from UTF-8 */
     return PyUnicode_FromString(name);


### PR DESCRIPTION


<!-- issue-number: [bpo-26227](https://bugs.python.org/issue26227) -->
https://bugs.python.org/issue26227
<!-- /issue-number -->
