### PR TITLE
gh-91851: Micro optimizations for Fraction's arithmetic

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -395,8 +395,10 @@ class Fraction(numbers.Rational):
 
         """
         def forward(a, b):
-            if isinstance(b, (int, Fraction)):
+            if isinstance(b, Fraction):
                 return monomorphic_operator(a, b)
+            elif isinstance(b, int):
+                return monomorphic_operator(a, Fraction(b))
             elif isinstance(b, float):
                 return fallback_operator(float(a), b)
             elif isinstance(b, complex):
@@ -409,7 +411,7 @@ class Fraction(numbers.Rational):
         def reverse(b, a):
             if isinstance(a, numbers.Rational):
                 # Includes ints.
-                return monomorphic_operator(a, b)
+                return fallback_operator(Fraction(a), b)
             elif isinstance(a, numbers.Real):
                 return fallback_operator(float(a), float(b))
             elif isinstance(a, numbers.Complex):
@@ -491,8 +493,8 @@ class Fraction(numbers.Rational):
 
     def _add(a, b):
         """a + b"""
-        na, da = a.numerator, a.denominator
-        nb, db = b.numerator, b.denominator
+        na, da = a._numerator, a._denominator
+        nb, db = b._numerator, b._denominator
         g = math.gcd(da, db)
         if g == 1:
             return Fraction(na * db + da * nb, da * db, _normalize=False)
@@ -507,8 +509,8 @@ class Fraction(numbers.Rational):
 
     def _sub(a, b):
         """a - b"""
-        na, da = a.numerator, a.denominator
-        nb, db = b.numerator, b.denominator
+        na, da = a._numerator, a._denominator
+        nb, db = b._numerator, b._denominator
         g = math.gcd(da, db)
         if g == 1:
             return Fraction(na * db - da * nb, da * db, _normalize=False)
@@ -523,8 +525,8 @@ class Fraction(numbers.Rational):
 
     def _mul(a, b):
         """a * b"""
-        na, da = a.numerator, a.denominator
-        nb, db = b.numerator, b.denominator
+        na, da = a._numerator, a._denominator
+        nb, db = b._numerator, b._denominator
         g1 = math.gcd(na, db)
         if g1 > 1:
             na //= g1
@@ -540,8 +542,8 @@ class Fraction(numbers.Rational):
     def _div(a, b):
         """a / b"""
         # Same as _mul(), with inversed b.
-        na, da = a.numerator, a.denominator
-        nb, db = b.numerator, b.denominator
+        na, da = a._numerator, a._denominator
+        nb, db = b._numerator, b._denominator
         g1 = math.gcd(na, nb)
         if g1 > 1:
             na //= g1

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -411,7 +411,7 @@ class Fraction(numbers.Rational):
         def reverse(b, a):
             if isinstance(a, numbers.Rational):
                 # Includes ints.
-                return fallback_operator(Fraction(a), b)
+                return monomorphic_operator(Fraction(a), b)
             elif isinstance(a, numbers.Real):
                 return fallback_operator(float(a), float(b))
             elif isinstance(a, numbers.Complex):

--- a/Misc/NEWS.d/next/Library/2022-04-23-08-12-14.gh-issue-91851.Jd47V6.rst
+++ b/Misc/NEWS.d/next/Library/2022-04-23-08-12-14.gh-issue-91851.Jd47V6.rst
@@ -1,0 +1,1 @@
+Optimize the :class:`~fractions.Fraction` arithmetics for small components.


### PR DESCRIPTION
This apply some suggestions from the #24779 review.

I've tested also direct imports (e.g. `from math import gcd`), [suggested](https://github.com/python/cpython/pull/24779#issuecomment-801449419) by @tim-one, but the difference doesn't seems to be noticeable.

Resolves #91851

<!-- gh-issue-number: gh-91851 -->
* Issue: gh-91851
<!-- /gh-issue-number -->

Benchmarks (taken from the second commit msg):

That makes arithmetics for small components just as fast
as before https://github.com/python/cpython/pull/24779, except for a mixed case (e.g.
Fraction + int):

On master:
```
  $ ./python -m timeit -s 'from fractions import Fraction as F' \
    -s 'a = F(7, 8)' -s 'b = F(3, 4)' 'a + b'
  20000 loops, best of 5: 12.4 usec per loop
  $ ./python -m timeit -s 'from fractions import Fraction as F' \
    -s 'a = F(7, 8)' -s 'b = 3' 'a + b'
  20000 loops, best of 5: 10.3 usec per loop
  $ ./python -m timeit -s 'from fractions import Fraction as F' \
    -s 'a = 3' -s 'b = F(3, 4)' 'a + b'
  20000 loops, best of 5: 12.6 usec per loop
```

With the patch:
```
  $ ./python -m timeit -s 'from fractions import Fraction as F' \
    -s 'a = F(7, 8)' -s 'b = F(3, 4)' 'a + b'
  20000 loops, best of 5: 9.98 usec per loop
  $ ./python -m timeit -s 'from fractions import Fraction as F' \
    -s 'a = F(7, 8)' -s 'b = 3' 'a + b'
  20000 loops, best of 5: 15.6 usec per loop
  $ ./python -m timeit -s 'from fractions import Fraction as F' \
    -s 'a = 3' -s 'b = F(3, 4)' 'a + b'
  20000 loops, best of 5: 16.6 usec per loop
```