### PR TITLE
bpo-43910 Fix handling of quoted values in cgi.parse_header

### DIFF
--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -570,6 +570,12 @@ this is the content of the fake file
         self.assertEqual(
             cgi.parse_header('form-data; name="files"; filename="fo\\"o;bar"'),
             ("form-data", {"name": "files", "filename": 'fo"o;bar'}))
+        self.assertEqual(
+            cgi.parse_header('form-data; filename="foo;bar\\\\"; name="files"'),
+            ("form-data", {"name": "files", "filename": 'foo;bar\\'}))
+        self.assertEqual(
+            cgi.parse_header('form-data; filename="fo\\o;bar"'),
+            ("form-data", {"filename": 'foo;bar'}))
 
     def test_all(self):
         not_exported = {


### PR DESCRIPTION
Updates the logic in cgi.parse_header to do a proper scan over the string managing the parse state properly. This corrects cases where a quoted value ends with a backslash character. This PR also correctly unescapes characters other than the backslash or double quote character by replacing them with the octet literal following a backslash in a quoted string (although according to the spec clients should not quote anything other than those two characters).

The goal is to recognize the language detailed in https://www.w3.org/Protocols/rfc1341/4_Content-Type.html (with additional details on quoted-string at https://greenbytes.de/tech/webdav/draft-ietf-httpbis-p1-messaging-16.html#rfc.section.3.2.1.p.3 ).

Note that this method has no validation that the header value is well formed and always returns a value. Do to this we recognize a slightly larger language that looks something like

```
wsp = any (possibly empty) string of white space characters
header = wsp type wsp [ ';' parameter ]*
type = any char but ';'
parameter = wsp mixed-string wsp '=' wsp mixed-string wsp
mixed-string = empty-string | ( quoted-string | any char but ';', '=', '"' ) mixed-string
```

This also eliminates an unnecessary quadratic loop (that was also the source of the correctness problem) 

<!-- issue-number: [bpo-43910](https://bugs.python.org/issue43910) -->
https://bugs.python.org/issue43910
<!-- /issue-number -->
