### PR TITLE
Update Condition class

### DIFF
--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -230,7 +230,7 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
         super().__init__(loop=loop)
         if lock is None:
             lock = Lock()
-        elif lock._loop is not self._get_loop():
+        elif lock._loop is not None and lock._loop is not self._get_loop():
             raise ValueError("loop argument must agree with lock")
 
         self._lock = lock


### PR DESCRIPTION
The `loop` parameter will be removed in version 3.10. As far as I can see, `loop` parameter is still present in source code, but it is initialized to special value `mixin._marker`. It is still in source code probably for backward compatibility reasons. If this is true, we should be able to check if `lock._loop is not None`, and then check if it matches with `self._loop()`.

I run into this issue with 3rd party library `aetcd3` which does not explicitly check loop of its `asyncio.Lock/Condition` instances, but `asyncio.locks.Condition` does not correctly check for this condition. After monkey-patching `asyncio.Condition`, everything works as expected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
