### PR TITLE
bpo-38822: Fixed os.stat failing on inaccessible directories with a trailing slash, rather than falling back to the parent directory's metadata

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-04-22-19-49-20.bpo-38822.jgdPmq.rst
+++ b/Misc/NEWS.d/next/Windows/2021-04-22-19-49-20.bpo-38822.jgdPmq.rst
@@ -1,0 +1,3 @@
+Fixed :func:`os.stat` failing on inaccessible directories with a trailing
+slash, rather than falling back to the parent directory's metadata. This
+implicitly affected :func:`os.path.exists` and :func:`os.path.isdir`.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1851,9 +1851,28 @@ attributes_from_dir(LPCWSTR pszFile, BY_HANDLE_FILE_INFORMATION *info, ULONG *re
 {
     HANDLE hFindFile;
     WIN32_FIND_DATAW FileData;
-    hFindFile = FindFirstFileW(pszFile, &FileData);
-    if (hFindFile == INVALID_HANDLE_VALUE)
+    LPCWSTR filename = pszFile;
+    size_t n = wcslen(pszFile);
+    if (n && (pszFile[n - 1] == L'\\' || pszFile[n - 1] == L'/')) {
+        // cannot use PyMem_Malloc here because we do not hold the GIL
+        filename = (LPCWSTR)malloc((n + 1) * sizeof(filename[0]));
+        wcsncpy_s((LPWSTR)filename, n + 1, pszFile, n);
+        while (--n > 0 && (filename[n] == L'\\' || filename[n] == L'/')) {
+            ((LPWSTR)filename)[n] = L'\0';
+        }
+        if (!n || filename[n] == L':') {
+            // Nothing left te query
+            free((void *)filename);
+            return FALSE;
+        }
+    }
+    hFindFile = FindFirstFileW(filename, &FileData);
+    if (pszFile != filename) {
+        free((void *)filename);
+    }
+    if (hFindFile == INVALID_HANDLE_VALUE) {
         return FALSE;
+    }
     FindClose(hFindFile);
     find_data_to_file_info(&FileData, info, reparse_tag);
     return TRUE;


### PR DESCRIPTION


<!-- issue-number: [bpo-38822](https://bugs.python.org/issue38822) -->
https://bugs.python.org/issue38822
<!-- /issue-number -->
