### PR TITLE
bpo-35306: Avoid raising OSError from pathlib.Path.exists when passed an invalid filename

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -33,6 +33,7 @@ _IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF, ELOOP)
 
 _IGNORED_WINERRORS = (
     21,  # ERROR_NOT_READY - drive exists but is not accessible
+    123, # ERROR_INVALID_NAME - fix for bpo-35306
     1921,  # ERROR_CANT_RESOLVE_FILENAME - fix for broken symlink pointing to itself
 )
 

--- a/Misc/NEWS.d/next/Windows/2021-04-22-20-39-49.bpo-35306.F0Cg6X.rst
+++ b/Misc/NEWS.d/next/Windows/2021-04-22-20-39-49.bpo-35306.F0Cg6X.rst
@@ -1,0 +1,2 @@
+Avoid raising errors from :meth:`pathlib.Path.exists()` when passed an
+invalid filename.


### PR DESCRIPTION


<!-- issue-number: [bpo-35306](https://bugs.python.org/issue35306) -->
https://bugs.python.org/issue35306
<!-- /issue-number -->
