### PR TITLE
[3.8] bpo-28577: Special case added to IP v4 and v6 hosts for /32 and…

### DIFF
--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -487,7 +487,8 @@ dictionaries.
       hosts are all the IP addresses that belong to the network, except the
       network address itself and the network broadcast address.  For networks
       with a mask length of 31, the network address and network broadcast
-      address are also included in the result.
+      address are also included in the result. Networks with a mask of 32
+      will return a list containing the single host address.
 
          >>> list(ip_network('192.0.2.0/29').hosts())  #doctest: +NORMALIZE_WHITESPACE
          [IPv4Address('192.0.2.1'), IPv4Address('192.0.2.2'),
@@ -495,6 +496,8 @@ dictionaries.
           IPv4Address('192.0.2.5'), IPv4Address('192.0.2.6')]
          >>> list(ip_network('192.0.2.0/31').hosts())
          [IPv4Address('192.0.2.0'), IPv4Address('192.0.2.1')]
+         >>> list(ip_network('192.0.2.1/32').hosts())
+         [IPv4Address('192.0.2.1')]
 
    .. method:: overlaps(other)
 
@@ -656,6 +659,8 @@ dictionaries.
       hosts are all the IP addresses that belong to the network, except the
       Subnet-Router anycast address.  For networks with a mask length of 127,
       the Subnet-Router anycast address is also included in the result.
+      Networks with a mask of 128 will return a list containing the
+      single host address.
 
    .. method:: overlaps(other)
    .. method:: address_exclude(network)

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1458,6 +1458,8 @@ class IPv4Network(_BaseV4, _BaseNetwork):
 
         if self._prefixlen == (self._max_prefixlen - 1):
             self.hosts = self.__iter__
+        elif self._prefixlen == (self._max_prefixlen):
+            self.hosts = lambda: [IPv4Address(addr)]
 
     @property
     @functools.lru_cache()
@@ -2110,6 +2112,8 @@ class IPv6Network(_BaseV6, _BaseNetwork):
 
         if self._prefixlen == (self._max_prefixlen - 1):
             self.hosts = self.__iter__
+        elif self._prefixlen == self._max_prefixlen:
+            self.hosts = lambda: [IPv6Address(addr)]
 
     def hosts(self):
         """Generate Iterator over usable hosts in a network.

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -1124,10 +1124,27 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(list(ipaddress.ip_network(str_args).hosts()),
                          list(ipaddress.ip_network(tpl_args).hosts()))
 
+        # special case where the network is a /32
+        addrs = [ipaddress.IPv4Address('1.2.3.4')]
+        str_args = '1.2.3.4/32'
+        tpl_args = ('1.2.3.4', 32)
+        self.assertEqual(addrs, list(ipaddress.ip_network(str_args).hosts()))
+        self.assertEqual(addrs, list(ipaddress.ip_network(tpl_args).hosts()))
+        self.assertEqual(list(ipaddress.ip_network(str_args).hosts()),
+                         list(ipaddress.ip_network(tpl_args).hosts()))
+
         addrs = [ipaddress.IPv6Address('2001:658:22a:cafe::'),
                  ipaddress.IPv6Address('2001:658:22a:cafe::1')]
         str_args = '2001:658:22a:cafe::/127'
         tpl_args = ('2001:658:22a:cafe::', 127)
+        self.assertEqual(addrs, list(ipaddress.ip_network(str_args).hosts()))
+        self.assertEqual(addrs, list(ipaddress.ip_network(tpl_args).hosts()))
+        self.assertEqual(list(ipaddress.ip_network(str_args).hosts()),
+                         list(ipaddress.ip_network(tpl_args).hosts()))
+
+        addrs = [ipaddress.IPv6Address('2001:658:22a:cafe::1'), ]
+        str_args = '2001:658:22a:cafe::1/128'
+        tpl_args = ('2001:658:22a:cafe::1', 128)
         self.assertEqual(addrs, list(ipaddress.ip_network(str_args).hosts()))
         self.assertEqual(addrs, list(ipaddress.ip_network(tpl_args).hosts()))
         self.assertEqual(list(ipaddress.ip_network(str_args).hosts()),

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1815,6 +1815,7 @@ Jeff Wheeler
 Christopher White
 David White
 Mats Wichmann
+Pete Wicken
 Marcel Widjaja
 Truida Wiedijk
 Felix Wiemann

--- a/Misc/NEWS.d/next/Library/2020-03-02-23-52-38.bpo-28577.EK91ae.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-02-23-52-38.bpo-28577.EK91ae.rst
@@ -1,0 +1,1 @@
+The hosts method on 32-bit prefix length IPv4Networks and 128-bit prefix IPv6Networks now returns a list containing the single Address instead of an empty list.


### PR DESCRIPTION
… /128 networks (GH-18757)

The `.hosts()` method now returns the single address present in a /32 or /128 network..
(cherry picked from commit 8e9c47a947954c997d4b725f4551d50a1d896722)

Co-authored-by: Pete Wicken <2273100+JamoBox@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28577](https://bugs.python.org/issue28577) -->
https://bugs.python.org/issue28577
<!-- /issue-number -->
