### PR TITLE
bpo-43607: Fix urllib handling of Windows paths with \\?\ prefix

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -50,6 +50,14 @@ def pathname2url(p):
     # becomes
     #   ///C:/foo/bar/spam.foo
     import urllib.parse
+    # First, clean up some special forms. We are going to sacrifice
+    # the additional information anyway
+    if p[:4] == '\\\\?\\':
+        p = p[4:]
+        if p[:4].upper() == 'UNC\\':
+            p = '\\' + p[4:]
+        elif p[1:2] != ':':
+            raise OSError('Bad path: ' + p)
     if not ':' in p:
         # No drive specifier, just convert slashes and quote the name
         if p[:2] == '\\\\':
@@ -59,7 +67,7 @@ def pathname2url(p):
             p = '\\\\' + p
         components = p.split('\\')
         return urllib.parse.quote('/'.join(components))
-    comp = p.split(':')
+    comp = p.split(':', maxsplit=2)
     if len(comp) != 2 or len(comp[0]) > 1:
         error = 'Bad path: ' + p
         raise OSError(error)

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1526,6 +1526,22 @@ class Pathname_Tests(unittest.TestCase):
                          "url2pathname() failed; %s != %s" %
                          (expect, result))
 
+    def test_prefixes(self):
+        # Test special prefixes are correctly handled in pathname2url()
+        given = '\\\\?\\C:\\dir'
+        expect = '///C:/dir'
+        result = urllib.request.pathname2url(given)
+        self.assertEqual(expect, result,
+                         "pathname2url() failed; %s != %s" %
+                         (expect, result))
+        given = '\\\\?\\unc\\server\\share\\dir'
+        expect = '/server/share/dir'
+        result = urllib.request.pathname2url(given)
+        self.assertEqual(expect, result,
+                         "pathname2url() failed; %s != %s" %
+                         (expect, result))
+
+
     @unittest.skipUnless(sys.platform == 'win32',
                          'test specific to the urllib.url2path function.')
     def test_ntpath(self):

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1526,6 +1526,8 @@ class Pathname_Tests(unittest.TestCase):
                          "url2pathname() failed; %s != %s" %
                          (expect, result))
 
+    @unittest.skipUnless(sys.platform == 'win32',
+                         'test specific to the nturl2path functions.')
     def test_prefixes(self):
         # Test special prefixes are correctly handled in pathname2url()
         given = '\\\\?\\C:\\dir'

--- a/Misc/NEWS.d/next/Library/2021-04-22-22-39-58.bpo-43607.7IYDkG.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-22-22-39-58.bpo-43607.7IYDkG.rst
@@ -1,0 +1,2 @@
+:mod:`urllib` can now convert Windows paths with ``\\?\`` prefixes into URL
+paths.


### PR DESCRIPTION


<!-- issue-number: [bpo-43607](https://bugs.python.org/issue43607) -->
https://bugs.python.org/issue43607
<!-- /issue-number -->
