### PR TITLE
bpo-43918: document signature and default argument of `anext` builtin

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-23-03-46-45.bpo-43918.nNDY3S.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-23-03-46-45.bpo-43918.nNDY3S.rst
@@ -1,0 +1,1 @@
+Document the signature and ``default`` argument in the docstring of the new ``anext`` builtin.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1644,7 +1644,7 @@ iterator is exhausted, it is returned instead of raising StopAsyncIteration.
 static PyObject *
 builtin_anext_impl(PyObject *module, PyObject *aiterator,
                    PyObject *default_value)
-/*[clinic end generated code: output=f02c060c163a81fa input=27c03b6bb55945f3]*/
+/*[clinic end generated code: output=f02c060c163a81fa input=8f63f4f78590bb4c]*/
 {
     PyTypeObject *t;
     PyObject *awaitable;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1635,7 +1635,7 @@ anext as builtin_anext
     default: object = NULL
     /
 
-anext(aiterator[, default])
+async anext(aiterator[, default])
 
 Return the next item from the async iterator.  If default is given and the async
 iterator is exhausted, it is returned instead of raising StopAsyncIteration.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1635,13 +1635,16 @@ anext as builtin_anext
     default: object = NULL
     /
 
-Return the next item from the async iterator.
+anext(aiterator[, default])
+
+Return the next item from the async iterator.  If default is given and the async
+iterator is exhausted, it is returned instead of raising StopAsyncIteration.
 [clinic start generated code]*/
 
 static PyObject *
 builtin_anext_impl(PyObject *module, PyObject *aiterator,
                    PyObject *default_value)
-/*[clinic end generated code: output=f02c060c163a81fa input=699d11f4e38eca24]*/
+/*[clinic end generated code: output=f02c060c163a81fa input=27c03b6bb55945f3]*/
 {
     PyTypeObject *t;
     PyObject *awaitable;

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -543,7 +543,7 @@ PyDoc_STRVAR(builtin_anext__doc__,
 "anext($module, aiterator, default=<unrepresentable>, /)\n"
 "--\n"
 "\n"
-"anext(aiterator[, default])\n"
+"async anext(aiterator[, default])\n"
 "\n"
 "Return the next item from the async iterator.  If default is given and the async\n"
 "iterator is exhausted, it is returned instead of raising StopAsyncIteration.");
@@ -877,4 +877,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=286dfde3414e2f1d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e1d8057298b5de61 input=a9049054013a1b77]*/

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -543,7 +543,10 @@ PyDoc_STRVAR(builtin_anext__doc__,
 "anext($module, aiterator, default=<unrepresentable>, /)\n"
 "--\n"
 "\n"
-"Return the next item from the async iterator.");
+"anext(aiterator[, default])\n"
+"\n"
+"Return the next item from the async iterator.  If default is given and the async\n"
+"iterator is exhausted, it is returned instead of raising StopAsyncIteration.");
 
 #define BUILTIN_ANEXT_METHODDEF    \
     {"anext", (PyCFunction)(void(*)(void))builtin_anext, METH_FASTCALL, builtin_anext__doc__},
@@ -874,4 +877,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=da9ae459e9233259 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=286dfde3414e2f1d input=a9049054013a1b77]*/


### PR DESCRIPTION
As described at https://bugs.python.org/issue43918, the new `anext` builtin doesn't include any signature information.  `help(anext)` should show something like `anext(aiterator[, default])`, which is added in this PR.

I also added text describing the `default` argument as I understand it.  This text was adapted from `next`.  See the description in the documentation here: https://github.com/python/cpython/pull/23847/files#diff-6a7a07ac473fdd76734669b1b70626ad2176011129902f6add017810f54d0439R87

I ran the clinic on " Python/bltinmodule.c".

Alright, now I need to figure out how to add a blurb...

<!-- issue-number: [bpo-43918](https://bugs.python.org/issue43918) -->
https://bugs.python.org/issue43918
<!-- /issue-number -->
