### PR TITLE
bpo-43922: escape email line starting with a dot

### DIFF
--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -4573,6 +4573,12 @@ two line"""), """\
 one line
 
 two line""")
+        # Ensure a line doesn't start with a dot
+        eq(quoprimime.body_encode('example.com', maxlinelen=8), "example=\n=2Ecom")
+        eq(quoprimime.body_encode('........com', maxlinelen=8), "=2E....=\n=2E..com")
+        eq(quoprimime.body_encode('e...p...com', maxlinelen=4), "e..=\n=2E=\np..=\n=2E=\ncom")
+        eq(quoprimime.body_encode('...........', maxlinelen=4), "=2E=\n" * 9 + "=2E.")
+        #                                 ^ 8th char
 
 
 


### PR DESCRIPTION
Some mail clients do not correctly implement the RFC when it comes to
unespace lines starting with a double dot. They leave the double dots
as-is while they should remove them.

The quoted-printable transport requires a line to be maximum 78 chars
long, when a line is longer, the text is cut around the 78th char and an
equal (=) sign is inserted at the end to signal the line continues.

When a line would start with a dot (.), the dot is replaced by its
quoted-printable escape sequence (=2E).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43922](https://bugs.python.org/issue43922) -->
https://bugs.python.org/issue43922
<!-- /issue-number -->
