### PR TITLE
bpo-43864: Silence a DeprecationWarning when running test_importlib.test_windows

### DIFF
--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import unittest
+import warnings
 from test import support
 from test.support import import_helper
 from contextlib import contextmanager
@@ -84,7 +85,9 @@ class WindowsRegistryFinderTests:
         self.assertIs(spec, None)
 
     def test_find_module_missing(self):
-        loader = self.machinery.WindowsRegistryFinder.find_module('spam')
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            loader = self.machinery.WindowsRegistryFinder.find_module('spam')
         self.assertIs(loader, None)
 
     def test_module_found(self):


### PR DESCRIPTION
WindowsRegistryFinder.find_module() is deprecated.

<!-- issue-number: [bpo-43864](https://bugs.python.org/issue43864) -->
https://bugs.python.org/issue43864
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon