### PR TITLE
Restrict GITHUB_TOKEN permissions for the 'stale' workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  pull-requests: write
+
 jobs:
   stale:
 


### PR DESCRIPTION
It should only need write-level permissions to pull requests.

Automerge-Triggered-By: GH:Mariatta