### PR TITLE
bpo-38659: [Enum] do not check '_inverted_' during _test_simple_enum

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1616,8 +1616,8 @@ def _test_simple_enum(checked_enum, simple_enum):
                 simple_member_dict = simple_enum[name].__dict__
                 simple_member_keys = list(simple_member_dict.keys())
                 for key in set(checked_member_keys + simple_member_keys):
-                    if key in ('__module__', '__objclass__'):
-                        # keys known to be different
+                    if key in ('__module__', '__objclass__', '_inverted_'):
+                        # keys known to be different or absent
                         continue
                     elif key not in simple_member_keys:
                         failed_member.append("missing key %r not in the simple enum member %r" % (key, name))


### PR DESCRIPTION
Depending on usage, it's possible for Flag members to have the ``_inverted_`` attribute when they are testing, while the Flag being testing against will not have that attribute on its members -- so skip that comparison.

<!-- issue-number: [bpo-38659](https://bugs.python.org/issue38659) -->
https://bugs.python.org/issue38659
<!-- /issue-number -->
