### PR TITLE
bpo-43928: Fix a typo in documentation

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -350,7 +350,7 @@ Other objects
       ``Py_CLEANUP_SUPPORTED`` was added.
 
 ``p`` (:class:`bool`) [int]
-   Tests the value passed in for truth (a boolean **p**\ redicate) and converts
+   Tests the value passed in for truth (a boolean **p**\ predicate) and converts
    the result to its equivalent C true/false integer value.
    Sets the int to ``1`` if the expression was true and ``0`` if it was false.
    This accepts any valid Python value.  See :ref:`truth` for more


### PR DESCRIPTION
The boolean predicate was typo in documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
[bpo-43928](https://bugs.python.org/issue43928): Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43928](https://bugs.python.org/issue43928) -->
https://bugs.python.org/issue43928
<!-- /issue-number -->
