### PR TITLE
bpo-31870: Fix test_get_server_certificate_timeout on Windows (GH-25570)

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2137,9 +2137,13 @@ class SimpleBackgroundTests(unittest.TestCase):
         _test_get_server_certificate_fail(self, *self.server_addr)
 
     def test_get_server_certificate_timeout(self):
+        def servername_cb(ssl_sock, server_name, initial_context):
+            time.sleep(0.2)
+        self.server_context.set_servername_callback(servername_cb)
+
         with self.assertRaises(socket.timeout):
             ssl.get_server_certificate(self.server_addr, ca_certs=SIGNING_CA,
-                                       timeout=0.0001)
+                                       timeout=0.1)
 
     def test_ciphers(self):
         with test_wrap_socket(socket.socket(socket.AF_INET),


### PR DESCRIPTION
Some OS do not support millisecond granularity in select(). Use 100ms
timeout and a server callback with sleep to emulate a slow server.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-31870](https://bugs.python.org/issue31870) -->
https://bugs.python.org/issue31870
<!-- /issue-number -->
