### PR TITLE
bpo-43921: also accept EOF in post-handshake auth test (GH-25574)

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4424,9 +4424,11 @@ class TestPostHandshakeAuth(unittest.TestCase):
                                             server_hostname=hostname) as s:
                 s.connect((HOST, server.port))
                 s.write(b'PHA')
+                # test sometimes fails with EOF error. Test passes as long as
+                # server aborts connection with an error.
                 with self.assertRaisesRegex(
                     ssl.SSLError,
-                    'tlsv13 alert certificate required'
+                    '(certificate required|EOF occurred)'
                 ):
                     # receive CertificateRequest
                     self.assertEqual(s.recv(1024), b'OK\n')


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43921](https://bugs.python.org/issue43921) -->
https://bugs.python.org/issue43921
<!-- /issue-number -->
