### PR TITLE
bpo-43934: SQLite 3.26.0 is the minimal version

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -19,7 +19,7 @@ PostgreSQL or Oracle.
 
 The sqlite3 module was written by Gerhard Häring.  It provides a SQL interface
 compliant with the DB-API 2.0 specification described by :pep:`249`, and
-requires SQLite 3.7.15 or newer.
+requires SQLite 3.26.0 or newer.
 
 To use the module, you must first create a :class:`Connection` object that
 represents the database.  Here the data will be stored in the

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1526,8 +1526,9 @@ Build Changes
   to build Python.
   (Contributed by Victor Stinner in :issue:`36020`.)
 
-* :mod:`sqlite3` requires SQLite 3.7.15 or higher. (Contributed by Sergey Fedoseev
-  and Erlend E. Aasland :issue:`40744` and :issue:`40810`.)
+* :mod:`sqlite3` requires SQLite 3.26.0 or higher. (Contributed by Sergey Fedoseev
+  and Erlend E. Aasland and Stéphane Wirtel :issue:`40744` and :issue:`40810`
+  and :issue:`43934`.)
 
 * The :mod:`atexit` module must now always be built as a built-in module.
   (Contributed by Victor Stinner in :issue:`42639`.)

--- a/Misc/NEWS.d/next/Library/2021-04-24-22-29-12.bpo-43934.fDzr87.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-24-22-29-12.bpo-43934.fDzr87.rst
@@ -1,0 +1,1 @@
+Require SQLite 3.26.0 or newer. Patch by Stéphane Wirtel.

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -29,8 +29,9 @@
 #include "microprotocols.h"
 #include "row.h"
 
-#if SQLITE_VERSION_NUMBER < 3007015
-#error "SQLite 3.7.15 or higher required"
+#define MINIMAL_SQLITE_VERSION_NUMBER 3026000
+#if SQLITE_VERSION_NUMBER < MINIMAL_SQLITE_VERSION_NUMBER
+#error "SQLite 3.26.0 or higher required"
 #endif
 
 #include "clinic/module.c.h"
@@ -364,8 +365,8 @@ PyMODINIT_FUNC PyInit__sqlite3(void)
 {
     PyObject *module;
 
-    if (sqlite3_libversion_number() < 3007015) {
-        PyErr_SetString(PyExc_ImportError, MODULE_NAME ": SQLite 3.7.15 or higher required");
+    if (sqlite3_libversion_number() < MINIMAL_SQLITE_VERSION_NUMBER) {
+        PyErr_SetString(PyExc_ImportError, MODULE_NAME ": SQLite 3.26.0 or higher required");
         return NULL;
     }
 

--- a/setup.py
+++ b/setup.py
@@ -1526,7 +1526,7 @@ class PyBuildExt(build_ext):
                              ]
         if CROSS_COMPILING:
             sqlite_inc_paths = []
-        MIN_SQLITE_VERSION_NUMBER = (3, 7, 15)  # Issue 40810
+        MIN_SQLITE_VERSION_NUMBER = (3, 26, 0)  # Issue 40810
         MIN_SQLITE_VERSION = ".".join([str(x)
                                     for x in MIN_SQLITE_VERSION_NUMBER])
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43934](https://bugs.python.org/issue43934) -->
https://bugs.python.org/issue43934
<!-- /issue-number -->
