### PR TITLE
bpo-43935: Fix typo in Turtle.back() docstring

### DIFF
--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1645,7 +1645,7 @@ class TNavigator(object):
         Argument:
         distance -- a number
 
-        Move the turtle backward by distance ,opposite to the direction the
+        Move the turtle backward by distance, opposite to the direction the
         turtle is headed. Do not change the turtle's heading.
 
         Example (for a Turtle instance named turtle):


### PR DESCRIPTION


<!-- issue-number: [bpo-43935](https://bugs.python.org/issue43935) -->
https://bugs.python.org/issue43935
<!-- /issue-number -->
