### PR TITLE
bpo-43466: Link with libz in PY_UNSUPPORTED_OPENSSL_BUILD path (GH-25587)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2466,7 +2466,8 @@ class PyBuildExt(build_ext):
                 extra_linker_args.append(f"-Wl,--exclude-libs,lib{lib}.a")
             openssl_extension_kwargs["extra_link_args"] = extra_linker_args
             # don't link OpenSSL shared libraries.
-            openssl_extension_kwargs["libraries"] = []
+            # include libz for OpenSSL build flavors with compression support
+            openssl_extension_kwargs["libraries"] = ["z"]
 
         self.add(
             Extension(


### PR DESCRIPTION
Some OpenSSL build flavors need libz for compression support.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43466](https://bugs.python.org/issue43466) -->
https://bugs.python.org/issue43466
<!-- /issue-number -->
