### PR TITLE
bpo-38605: Set the release for `__future__.annotations` to 3.11

### DIFF
--- a/Lib/__future__.py
+++ b/Lib/__future__.py
@@ -143,5 +143,5 @@ generator_stop = _Feature((3, 5, 0, "beta", 1),
                           CO_FUTURE_GENERATOR_STOP)
 
 annotations = _Feature((3, 7, 0, "beta", 1),
-                       (3, 10, 0, "alpha", 0),
+                       (3, 11, 0, "alpha", 0),
                        CO_FUTURE_ANNOTATIONS)


### PR DESCRIPTION


<!-- issue-number: [bpo-38605](https://bugs.python.org/issue38605) -->
https://bugs.python.org/issue38605
<!-- /issue-number -->
