### PR TITLE
bpo-32822: Add finally with return/break/continue to the tutorial

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -405,6 +405,10 @@ points discuss more complex cases when an exception occurs:
   or :keyword:`!else` clause. Again, the exception is re-raised after
   the :keyword:`!finally` clause has been executed.
 
+* If the :keyword:`!finally` clause executes a :keyword:`break`,
+  :keyword:`continue` or :keyword:`return` statement, exceptions are not
+  re-raised.
+
 * If the :keyword:`!try` statement reaches a :keyword:`break`,
   :keyword:`continue` or :keyword:`return` statement, the
   :keyword:`!finally` clause will execute just prior to the

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -774,6 +774,7 @@ Christian Hudon
 Benoît Hudson
 Lawrence Hudson
 Michael Hudson
+Roberto Hueso Gomez
 Jim Hugunin
 Greg Humphreys
 Chris Hunt


### PR DESCRIPTION
Hi everyone, this is my first PR to `cpython`, so any feedback/advice is more than welcome :smile:.
This behavior is documented in the [reference](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement) but not in the tutorial.

<!-- issue-number: [bpo-32822](https://bugs.python.org/issue32822) -->
https://bugs.python.org/issue32822
<!-- /issue-number -->
