### PR TITLE
[3.9] fix typo in warning (GH-20620)

### DIFF
--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -42,7 +42,7 @@ def _parse_python_tzpath(env_var):
         msg = _get_invalid_paths_message(raw_tzpath)
 
         warnings.warn(
-            "Invalid paths specified in PYTHONTZPATH environment variable."
+            "Invalid paths specified in PYTHONTZPATH environment variable. "
             + msg,
             InvalidTZPathWarning,
         )


### PR DESCRIPTION
* Add space after period to warning in _tzpath.py

Currently:
InvalidTZPathWarning: Invalid paths specified in PYTHONTZPATH environment variable.Paths should be absolute but found the following relative paths: ...

* Update _tzpath.py
(cherry picked from commit a31cf86bc2d9c0738b2a0251af766d6b247683fc)

Co-authored-by: Allen <64019758+aboddie@users.noreply.github.com>