### PR TITLE
bpo-38605: Update __future__ module doc as `annotations` is now "mandatory in 3.11"

### DIFF
--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -90,7 +90,7 @@ language using this mechanism:
 | generator_stop   | 3.5.0b1     | 3.7          | :pep:`479`:                                 |
 |                  |             |              | *StopIteration handling inside generators*  |
 +------------------+-------------+--------------+---------------------------------------------+
-| annotations      | 3.7.0b1     | 3.10         | :pep:`563`:                                 |
+| annotations      | 3.7.0b1     | 3.11         | :pep:`563`:                                 |
 |                  |             |              | *Postponed evaluation of annotations*       |
 +------------------+-------------+--------------+---------------------------------------------+
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38605](https://bugs.python.org/issue38605) -->
https://bugs.python.org/issue38605
<!-- /issue-number -->

Automerge-Triggered-By: GH:isidentical