### PR TITLE
bpo-43938: improve dataclasses.FrozenInstanceError documentation

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -601,4 +601,4 @@ Exceptions
 
    Raised when an implicitly defined :meth:`__setattr__` or
    :meth:`__delattr__` is called on a dataclass which was defined with
-   ``frozen=True``.
+   ``frozen=True``. It is a subclass of :exc:`AttributeError`.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1452,6 +1452,7 @@ Vlad Riscutia
 Wes Rishel
 Daniel Riti
 Juan M. Bello Rivas
+Llandy Riveron Del Risco
 Mohd Sanad Zaki Rizvi
 Davide Rizzo
 Anthony Roach

--- a/Misc/NEWS.d/next/Documentation/2021-04-25-22-44-27.bpo-43938.nC660q.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-04-25-22-44-27.bpo-43938.nC660q.rst
@@ -1,0 +1,2 @@
+Update dataclasses documentation to express that FrozenInstanceError is
+derived from AttributeError.


### PR DESCRIPTION
Update documentation to reflect that dataclasses.FrozenInstanceError is derived by AttributeError.

https://bugs.python.org/issue43938

<!-- issue-number: [bpo-43938](https://bugs.python.org/issue43938) -->
https://bugs.python.org/issue43938
<!-- /issue-number -->
