### PR TITLE
bpo-43901: Lazy-create an empty annotations dict in all unannotated user classes and modules

### DIFF
--- a/Lib/test/ann_module4.py
+++ b/Lib/test/ann_module4.py
@@ -1,0 +1,5 @@
+# This ann_module isn't for test_typing,
+# it's for test_module
+
+a:int=3
+b:str=4

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -382,8 +382,7 @@ class GrammarTests(unittest.TestCase):
         self.assertEqual(CC.__annotations__['xx'], 'ANNOT')
 
     def test_var_annot_module_semantics(self):
-        with self.assertRaises(AttributeError):
-            print(test.__annotations__)
+        self.assertEqual(test.__annotations__, {})
         self.assertEqual(ann_module.__annotations__,
                      {1: 2, 'x': int, 'y': str, 'f': typing.Tuple[int, int]})
         self.assertEqual(ann_module.M.__annotations__,

--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -286,6 +286,60 @@ a = A(destroyed)"""
             melon = Descr()
         self.assertRaises(RuntimeError, getattr, M("mymod"), "melon")
 
+    def test_lazy_create_annotations(self):
+        # module objects lazy create their __annotations__ dict on demand.
+        # the annotations dict is stored in module.__dict__.
+        # a freshly created module shouldn't have an annotations dict yet.
+        foo = ModuleType("foo")
+        for i in range(4):
+            self.assertFalse("__annotations__" in foo.__dict__)
+            d = foo.__annotations__
+            self.assertTrue("__annotations__" in foo.__dict__)
+            self.assertEqual(foo.__annotations__, d)
+            self.assertEqual(foo.__dict__['__annotations__'], d)
+            if i % 2:
+                del foo.__annotations__
+            else:
+                del foo.__dict__['__annotations__']
+
+    def test_setting_annotations(self):
+        foo = ModuleType("foo")
+        for i in range(4):
+            self.assertFalse("__annotations__" in foo.__dict__)
+            d = {'a': int}
+            foo.__annotations__ = d
+            self.assertTrue("__annotations__" in foo.__dict__)
+            self.assertEqual(foo.__annotations__, d)
+            self.assertEqual(foo.__dict__['__annotations__'], d)
+            if i % 2:
+                del foo.__annotations__
+            else:
+                del foo.__dict__['__annotations__']
+
+    def test_annotations_getset_raises(self):
+        # module has no dict, all operations fail
+        foo = ModuleType.__new__(ModuleType)
+        with self.assertRaises(TypeError):
+            print(foo.__annotations__)
+        with self.assertRaises(TypeError):
+            foo.__annotations__ = {}
+        with self.assertRaises(TypeError):
+            del foo.__annotations__
+
+        # double delete
+        foo = ModuleType("foo")
+        foo.__annotations__ = {}
+        del foo.__annotations__
+        with self.assertRaises(AttributeError):
+            del foo.__annotations__
+
+    def test_annotations_are_created_correctly(self):
+        from test import ann_module4
+        self.assertTrue("__annotations__" in ann_module4.__dict__)
+        del ann_module4.__annotations__
+        self.assertFalse("__annotations__" in ann_module4.__dict__)
+
+
     # frozen and namespace module reprs are tested in importlib.
 
 

--- a/Lib/test/test_opcodes.py
+++ b/Lib/test/test_opcodes.py
@@ -31,10 +31,9 @@ class OpcodeTest(unittest.TestCase):
         except OSError:
             pass
 
-    def test_no_annotations_if_not_needed(self):
+    def test_default_annotations_exist(self):
         class C: pass
-        with self.assertRaises(AttributeError):
-            C.__annotations__
+        self.assertEqual(C.__annotations__, {})
 
     def test_use_existing_annotations(self):
         ns = {'__annotations__': {1: 2}}

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -68,6 +68,11 @@ CLASSES
      |  __dict__%s
      |\x20\x20
      |  __weakref__%s
+     |\x20\x20
+     |  ----------------------------------------------------------------------
+     |  Data and other attributes defined here:
+     |\x20\x20
+     |  __annotations__ = {}
 \x20\x20\x20\x20
     class B(builtins.object)
      |  Data descriptors defined here:
@@ -102,6 +107,11 @@ CLASSES
      |\x20\x20
      |  __weakref__
      |      list of weak references to the object (if defined)
+     |\x20\x20
+     |  ----------------------------------------------------------------------
+     |  Data and other attributes defined here:
+     |\x20\x20
+     |  __annotations__ = {}
 
 FUNCTIONS
     doc_func()
@@ -176,6 +186,10 @@ Data descriptors defined here:<br>
 <dl><dt><strong>__weakref__</strong></dt>
 <dd><tt>%s</tt></dd>
 </dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__annotations__</strong> = {}</dl>
+
 </td></tr></table> <p>
 <table width="100%%" cellspacing=0 cellpadding=2 border=0 summary="section">
 <tr bgcolor="#ffc8d8">
@@ -218,6 +232,10 @@ Data descriptors defined here:<br>
 <dl><dt><strong>__weakref__</strong></dt>
 <dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
 </dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__annotations__</strong> = {}</dl>
+
 </td></tr></table></td></tr></table><p>
 <table width="100%%" cellspacing=0 cellpadding=2 border=0 summary="section">
 <tr bgcolor="#eeaa77">
@@ -277,6 +295,11 @@ class DA(builtins.object)
  |  __weakref__%s
  |\x20\x20
  |  ham
+ |\x20\x20
+ |  ----------------------------------------------------------------------
+ |  Data and other attributes defined here:
+ |\x20\x20
+ |  __annotations__ = {}
  |\x20\x20
  |  ----------------------------------------------------------------------
  |  Data and other attributes inherited from Meta:
@@ -814,6 +837,11 @@ class B(A)
  |      Configure resources of an item TAGORID.
  |\x20\x20
  |  ----------------------------------------------------------------------
+ |  Data and other attributes defined here:
+ |\x20\x20
+ |  __annotations__ = {}
+ |\x20\x20
+ |  ----------------------------------------------------------------------
  |  Methods inherited from A:
  |\x20\x20
  |  a_size(self)
@@ -857,6 +885,10 @@ Methods defined here:<br>
 <dl><dt><a name="B-itemconfig"><strong>itemconfig</strong></a> = <a href="#B-itemconfigure">itemconfigure</a>(self, tagOrId, cnf=None, **kw)</dt></dl>
 
 <dl><dt><a name="B-itemconfigure"><strong>itemconfigure</strong></a>(self, tagOrId, cnf=None, **kw)</dt><dd><tt>Configure&nbsp;resources&nbsp;of&nbsp;an&nbsp;item&nbsp;TAGORID.</tt></dd></dl>
+
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__annotations__</strong> = {}</dl>
 
 <hr>
 Methods inherited from A:<br>

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -68,11 +68,6 @@ CLASSES
      |  __dict__%s
      |\x20\x20
      |  __weakref__%s
-     |\x20\x20
-     |  ----------------------------------------------------------------------
-     |  Data and other attributes defined here:
-     |\x20\x20
-     |  __annotations__ = {}
 \x20\x20\x20\x20
     class B(builtins.object)
      |  Data descriptors defined here:
@@ -107,11 +102,6 @@ CLASSES
      |\x20\x20
      |  __weakref__
      |      list of weak references to the object (if defined)
-     |\x20\x20
-     |  ----------------------------------------------------------------------
-     |  Data and other attributes defined here:
-     |\x20\x20
-     |  __annotations__ = {}
 
 FUNCTIONS
     doc_func()
@@ -186,10 +176,6 @@ Data descriptors defined here:<br>
 <dl><dt><strong>__weakref__</strong></dt>
 <dd><tt>%s</tt></dd>
 </dl>
-<hr>
-Data and other attributes defined here:<br>
-<dl><dt><strong>__annotations__</strong> = {}</dl>
-
 </td></tr></table> <p>
 <table width="100%%" cellspacing=0 cellpadding=2 border=0 summary="section">
 <tr bgcolor="#ffc8d8">
@@ -232,10 +218,6 @@ Data descriptors defined here:<br>
 <dl><dt><strong>__weakref__</strong></dt>
 <dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
 </dl>
-<hr>
-Data and other attributes defined here:<br>
-<dl><dt><strong>__annotations__</strong> = {}</dl>
-
 </td></tr></table></td></tr></table><p>
 <table width="100%%" cellspacing=0 cellpadding=2 border=0 summary="section">
 <tr bgcolor="#eeaa77">
@@ -295,11 +277,6 @@ class DA(builtins.object)
  |  __weakref__%s
  |\x20\x20
  |  ham
- |\x20\x20
- |  ----------------------------------------------------------------------
- |  Data and other attributes defined here:
- |\x20\x20
- |  __annotations__ = {}
  |\x20\x20
  |  ----------------------------------------------------------------------
  |  Data and other attributes inherited from Meta:
@@ -837,11 +814,6 @@ class B(A)
  |      Configure resources of an item TAGORID.
  |\x20\x20
  |  ----------------------------------------------------------------------
- |  Data and other attributes defined here:
- |\x20\x20
- |  __annotations__ = {}
- |\x20\x20
- |  ----------------------------------------------------------------------
  |  Methods inherited from A:
  |\x20\x20
  |  a_size(self)
@@ -885,10 +857,6 @@ Methods defined here:<br>
 <dl><dt><a name="B-itemconfig"><strong>itemconfig</strong></a> = <a href="#B-itemconfigure">itemconfigure</a>(self, tagOrId, cnf=None, **kw)</dt></dl>
 
 <dl><dt><a name="B-itemconfigure"><strong>itemconfigure</strong></a>(self, tagOrId, cnf=None, **kw)</dt><dd><tt>Configure&nbsp;resources&nbsp;of&nbsp;an&nbsp;item&nbsp;TAGORID.</tt></dd></dl>
-
-<hr>
-Data and other attributes defined here:<br>
-<dl><dt><strong>__annotations__</strong> = {}</dl>
 
 <hr>
 Methods inherited from A:<br>

--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -1,0 +1,51 @@
+import unittest
+
+class TypeAnnotationTests(unittest.TestCase):
+
+    def test_lazy_create_annotations(self):
+        # type objects lazy create their __annotations__ dict on demand.
+        # the annotations dict is stored in type.__dict__.
+        # a freshly created type shouldn't have an annotations dict yet.
+        foo = type("Foo", (), {})
+        for i in range(3):
+            self.assertFalse("__annotations__" in foo.__dict__)
+            d = foo.__annotations__
+            self.assertTrue("__annotations__" in foo.__dict__)
+            self.assertEqual(foo.__annotations__, d)
+            self.assertEqual(foo.__dict__['__annotations__'], d)
+            del foo.__annotations__
+
+    def test_setting_annotations(self):
+        foo = type("Foo", (), {})
+        for i in range(3):
+            self.assertFalse("__annotations__" in foo.__dict__)
+            d = {'a': int}
+            foo.__annotations__ = d
+            self.assertTrue("__annotations__" in foo.__dict__)
+            self.assertEqual(foo.__annotations__, d)
+            self.assertEqual(foo.__dict__['__annotations__'], d)
+            del foo.__annotations__
+
+    def test_annotations_getset_raises(self):
+        # builtin types don't have __annotations__ (yet!)
+        with self.assertRaises(AttributeError):
+            print(float.__annotations__)
+        with self.assertRaises(TypeError):
+            float.__annotations__ = {}
+        with self.assertRaises(TypeError):
+            del float.__annotations__
+
+        # double delete
+        foo = type("Foo", (), {})
+        foo.__annotations__ = {}
+        del foo.__annotations__
+        with self.assertRaises(AttributeError):
+            del foo.__annotations__
+
+    def test_annotations_are_created_correctly(self):
+        class C:
+            a:int=3
+            b:str=4
+        self.assertTrue("__annotations__" in C.__dict__)
+        del C.__annotations__
+        self.assertFalse("__annotations__" in C.__dict__)

--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -101,5 +101,3 @@ class TypeAnnotationTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             del D.__annotations__
         self.assertEqual(D.__annotations__, {})
-
-

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1627,6 +1627,8 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False):
             else:
                 base_globals = globalns
             ann = base.__dict__.get('__annotations__', {})
+            if isinstance(ann, types.GetSetDescriptorType):
+                ann = {}
             base_locals = dict(vars(base)) if localns is None else localns
             for name, value in ann.items():
                 if value is None:

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-25-22-50-47.bpo-43901.oKjG5E.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-25-22-50-47.bpo-43901.oKjG5E.rst
@@ -1,0 +1,3 @@
+Change class and module objects to lazy-create empty annotations dicts on
+demand.  The annotations dicts are stored in the object's __dict__ for
+backwards compatibility.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -847,13 +847,8 @@ module_get_annotations(PyModuleObject *m, void *Py_UNUSED(ignored))
 {
     PyObject *dict = _PyObject_GetAttrId((PyObject *)m, &PyId___dict__);
 
-    if (dict == NULL) {
-        const char *name = PyModule_GetName((PyObject *)m);
-        if (name) {
-            PyErr_Format(PyExc_TypeError,
-                     "%.200s.__dict__ is not a dictionary",
-                     name);
-        }
+    if ((dict == NULL) || !PyDict_Check(dict)) {
+        PyErr_Format(PyExc_TypeError, "<module>.__dict__ is not a dictionary");
         return NULL;
     }
 
@@ -887,13 +882,8 @@ module_set_annotations(PyModuleObject *m, PyObject *value, void *Py_UNUSED(ignor
 {
     PyObject *dict = _PyObject_GetAttrId((PyObject *)m, &PyId___dict__);
 
-    if (dict == NULL) {
-        const char *name = PyModule_GetName((PyObject *)m);
-        if (name) {
-            PyErr_Format(PyExc_TypeError,
-                         "%.200s.__dict__ is not a dictionary",
-                         name);
-        }
+    if ((dict == NULL) || !PyDict_Check(dict)) {
+        PyErr_Format(PyExc_TypeError, "<module>.__dict__ is not a dictionary");
         return -1;
     }
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -12,6 +12,9 @@ static Py_ssize_t max_module_number;
 _Py_IDENTIFIER(__doc__);
 _Py_IDENTIFIER(__name__);
 _Py_IDENTIFIER(__spec__);
+_Py_IDENTIFIER(__dict__);
+_Py_IDENTIFIER(__dir__);
+_Py_IDENTIFIER(__annotations__);
 
 static PyMemberDef module_members[] = {
     {"__dict__", T_OBJECT, offsetof(PyModuleObject, md_dict), READONLY},
@@ -807,8 +810,6 @@ module_clear(PyModuleObject *m)
 static PyObject *
 module_dir(PyObject *self, PyObject *args)
 {
-    _Py_IDENTIFIER(__dict__);
-    _Py_IDENTIFIER(__dir__);
     PyObject *result = NULL;
     PyObject *dict = _PyObject_GetAttrId(self, &PyId___dict__);
 
@@ -839,6 +840,83 @@ static PyMethodDef module_methods[] = {
     {"__dir__", module_dir, METH_NOARGS,
      PyDoc_STR("__dir__() -> list\nspecialized dir() implementation")},
     {0}
+};
+
+static PyObject *
+module_get_annotations(PyModuleObject *m, void *Py_UNUSED(ignored))
+{
+    PyObject *dict = _PyObject_GetAttrId((PyObject *)m, &PyId___dict__);
+
+    if (dict == NULL) {
+        const char *name = PyModule_GetName((PyObject *)m);
+        if (!name) {
+            name = "<module>";
+        }
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s.__dict__ is not a dictionary",
+                     name);
+        return NULL;
+    }
+
+    PyObject *annotations;
+    /* there's no _PyDict_GetItemId without WithError, so let's LBYL. */
+    if (_PyDict_ContainsId(dict, &PyId___annotations__)) {
+        annotations = _PyDict_GetItemIdWithError(dict, &PyId___annotations__);
+        /*
+        ** _PyDict_GetItemIdWithError could still fail,
+        ** for instance with a well-timed Ctrl-C or a MemoryError.
+        ** so let's be totally safe.
+        */
+        if (annotations) {
+            Py_INCREF(annotations);
+        }
+    } else {
+        annotations = PyDict_New();
+        if (annotations) {
+            int result = _PyDict_SetItemId(dict, &PyId___annotations__, annotations);
+            if (result) {
+                Py_CLEAR(annotations);
+            }
+        }
+    }
+    Py_DECREF(dict);
+    return annotations;
+}
+
+static int
+module_set_annotations(PyModuleObject *m, PyObject *value, void *Py_UNUSED(ignored))
+{
+    PyObject *dict = _PyObject_GetAttrId((PyObject *)m, &PyId___dict__);
+
+    if (dict == NULL) {
+        const char *name = PyModule_GetName((PyObject *)m);
+        if (!name) {
+            name = "<module>";
+        }
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s.__dict__ is not a dictionary",
+                     name);
+        return -1;
+    }
+
+    if (value != NULL) {
+        /* set */
+        return _PyDict_SetItemId(dict, &PyId___annotations__, value);
+    }
+
+    /* delete */
+    if (!_PyDict_ContainsId(dict, &PyId___annotations__)) {
+        PyErr_Format(PyExc_AttributeError, "__annotations__");
+        return -1;
+    }
+
+    return _PyDict_DelItemId(dict, &PyId___annotations__);
+}
+
+
+static PyGetSetDef module_getsets[] = {
+    {"__annotations__", (getter)module_get_annotations, (setter)module_set_annotations},
+    {NULL}
 };
 
 PyTypeObject PyModule_Type = {
@@ -872,7 +950,7 @@ PyTypeObject PyModule_Type = {
     0,                                          /* tp_iternext */
     module_methods,                             /* tp_methods */
     module_members,                             /* tp_members */
-    0,                                          /* tp_getset */
+    module_getsets,                             /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -849,12 +849,11 @@ module_get_annotations(PyModuleObject *m, void *Py_UNUSED(ignored))
 
     if (dict == NULL) {
         const char *name = PyModule_GetName((PyObject *)m);
-        if (!name) {
-            name = "<module>";
-        }
-        PyErr_Format(PyExc_TypeError,
+        if (name) {
+            PyErr_Format(PyExc_TypeError,
                      "%.200s.__dict__ is not a dictionary",
                      name);
+        }
         return NULL;
     }
 
@@ -890,12 +889,11 @@ module_set_annotations(PyModuleObject *m, PyObject *value, void *Py_UNUSED(ignor
 
     if (dict == NULL) {
         const char *name = PyModule_GetName((PyObject *)m);
-        if (!name) {
-            name = "<module>";
+        if (name) {
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s.__dict__ is not a dictionary",
+                         name);
         }
-        PyErr_Format(PyExc_TypeError,
-                     "%.200s.__dict__ is not a dictionary",
-                     name);
         return -1;
     }
 


### PR DESCRIPTION
The behavior of the `__annotations__` member is wildly different between the three objects (function, class, module) that support it.  Many of these differences are minor, but one in particular has been an awful wart for years: classes can inherit `__annotations__` from their base classes.  This is incontestably a misfire of the original design--it's never useful, it's only confusing, and libraries who examine annotations have had to work around it for years.

I started a thread in January 2021 in which I brought up this and other inconsistencies with respect to `__annotations__`:

    https://mail.python.org/archives/list/python-dev@python.org/thread/AWKVI3NRCHKPIDPCJYGVLW4HBYTEOQYL/

The reaction was positive: yes, that's a genuine problem, and there's an easy, highly compatible fix that everybody liked: classes should always have an `__annotations__` dict set.  So that the behavior is consistent, modules should always have one set too.

Happily, lazy-creating the annotations dict is an adequate fix, as long as the annotations dict is still stored in the object's `__dict__`.  Code written using the old best practice, which peeks in the `__dict__` for annotations on classes, will still see (or not see) the dict as it did before, so it will continue to work unchanged.  (Lazy-creating the annotations dict doesn't actually _fix_ the inherited annotations problem for such code--but this code is already working around the problem, so this is fine.)  Going forward, code written for 3.10+ can always use `getattr()` to get the annotations dict from any object.

<!-- issue-number: [bpo-43901](https://bugs.python.org/issue43901) -->
https://bugs.python.org/issue43901
<!-- /issue-number -->
