### PR TITLE
bpo-38820: Old OpenSSL 3.0.0 releases are in /old/3.0/ (GH-25624)

### DIFF
--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -33,6 +33,7 @@ try:
     from urllib.error import HTTPError
 except ImportError:
     from urllib2 import urlopen, HTTPError
+import re
 import shutil
 import string
 import subprocess
@@ -448,11 +449,14 @@ class BuildOpenSSL(AbstractBuilder):
     @property
     def short_version(self):
         """Short version for OpenSSL download URL"""
-        short_version = self.version.rstrip(string.ascii_letters)
-        if short_version.startswith("0.9"):
-            short_version = "0.9.x"
-        return short_version
-
+        mo = re.search(r"^(\d+)\.(\d+)\.(\d+)", self.version)
+        parsed = tuple(int(m) for m in mo.groups())
+        if parsed < (1, 0, 0):
+            return "0.9.x"
+        if parsed >= (3, 0, 0):
+            # OpenSSL 3.0.0 -> /old/3.0/
+            parsed = parsed[:2]
+        return ".".join(str(i) for i in parsed)
 
 class BuildLibreSSL(AbstractBuilder):
     library = "LibreSSL"


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38820](https://bugs.python.org/issue38820) -->
https://bugs.python.org/issue38820
<!-- /issue-number -->
