### PR TITLE
bpo-41139: Deprecate `cgi.log()`.

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1403,6 +1403,9 @@ Deprecated
   Python 3.12. Use :meth:`pathlib.Path.hardlink_to` instead.
   (Contributed by Barney Gale in :issue:`39950`.)
 
+* ``cgi.log()`` is deprecated and slated for for removal in Python 3.12.
+  (Contributed by Inada Naoki in :issue:`41139`.)
+
 
 Removed
 =======

--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -41,6 +41,7 @@ from email.message import Message
 import html
 import locale
 import tempfile
+import warnings
 
 __all__ = ["MiniFieldStorage", "FieldStorage", "parse", "parse_multipart",
            "parse_header", "test", "print_exception", "print_environ",
@@ -77,9 +78,11 @@ def initlog(*allargs):
 
     """
     global log, logfile, logfp
+    warnings.warn("cgi.log() is deprecated as of 3.10. Use logging instead",
+                  DeprecationWarning, stacklevel=2)
     if logfile and not logfp:
         try:
-            logfp = open(logfile, "a")
+            logfp = open(logfile, "a", encoding="locale")
         except OSError:
             pass
     if not logfp:

--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -6,6 +6,7 @@ import unittest
 from collections import namedtuple
 from io import StringIO, BytesIO
 from test import support
+from test.support import warnings_helper
 
 class HackedSysModule:
     # The regression test will have real values in sys.argv, which
@@ -220,6 +221,7 @@ Content-Length: 3
                     else:
                         self.assertEqual(fs.getvalue(key), expect_val[0])
 
+    @warnings_helper.ignore_warnings(category=DeprecationWarning)
     def test_log(self):
         cgi.log("Testing")
 

--- a/Misc/NEWS.d/next/Library/2021-04-26-17-47-48.bpo-41139.ROhn1k.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-26-17-47-48.bpo-41139.ROhn1k.rst
@@ -1,0 +1,1 @@
+Deprecate undocumented ``cgi.log()`` API.


### PR DESCRIPTION


<!-- issue-number: [bpo-41139](https://bugs.python.org/issue41139) -->
https://bugs.python.org/issue41139
<!-- /issue-number -->
