### PR TITLE
bpo-43651: Fix EncodingWarning in `pydoc`.

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1594,7 +1594,8 @@ def plain(text):
 def pipepager(text, cmd):
     """Page through text by feeding it to another program."""
     import subprocess
-    proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, errors='backslashreplace')
+    proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
+                            errors='backslashreplace')
     try:
         with proc.stdin as pipe:
             try:

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1594,9 +1594,9 @@ def plain(text):
 def pipepager(text, cmd):
     """Page through text by feeding it to another program."""
     import subprocess
-    proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, errors='backslashreplace')
     try:
-        with io.TextIOWrapper(proc.stdin, errors='backslashreplace') as pipe:
+        with proc.stdin as pipe:
             try:
                 pipe.write(text)
             except KeyboardInterrupt:


### PR DESCRIPTION


<!-- issue-number: [bpo-43651](https://bugs.python.org/issue43651) -->
https://bugs.python.org/issue43651
<!-- /issue-number -->
