### PR TITLE
gh-70280: allow using custom sys.displayhook's with doctest

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -1448,7 +1448,6 @@ DocTestRunner objects
    runner compares expected output to actual output, and how it displays failures.
    For more information, see section :ref:`doctest-options`.
 
-
    :class:`DocTestParser` defines the following methods:
 
 
@@ -1515,6 +1514,10 @@ DocTestRunner objects
       output checker, and the results are formatted by the
       :meth:`DocTestRunner.report_\*` methods.
 
+      .. versionchanged:: 3.12
+          Added support for testing examples with a customized
+          :func:`sys.displayhook` value.  Previously, this wasn't allowed and
+          the method was always using the :func:`sys.__displayhook__` anyway.
 
    .. method:: summarize(verbose=None)
 

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1496,10 +1496,6 @@ class DocTestRunner:
         self.save_linecache_getlines = linecache.getlines
         linecache.getlines = self.__patched_linecache_getlines
 
-        # Make sure sys.displayhook just prints the value to stdout
-        save_displayhook = sys.displayhook
-        sys.displayhook = sys.__displayhook__
-
         try:
             return self.__run(test, compileflags, out)
         finally:
@@ -1507,7 +1503,6 @@ class DocTestRunner:
             pdb.set_trace = save_set_trace
             sys.settrace(save_trace)
             linecache.getlines = self.save_linecache_getlines
-            sys.displayhook = save_displayhook
             if clear_globs:
                 test.globs.clear()
                 import builtins

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -1191,33 +1191,29 @@ unexpected exception:
     TestResults(failed=1, attempted=1)
 """
     def displayhook(): r"""
-Test that changing sys.displayhook doesn't matter for doctest.
+Test changing sys.displayhook.
 
-    >>> import sys
-    >>> orig_displayhook = sys.displayhook
+    >>> from unittest.mock import patch
     >>> def my_displayhook(x):
     ...     print('hi!')
-    >>> sys.displayhook = my_displayhook
     >>> def f():
     ...     '''
+    ...     >>> 3
+    ...     hi!
+    ...     >>> # test changing displayhook in the doctest
+    ...     >>> import sys
+    ...     >>> sys.displayhook = lambda x: print('spam')
+    ...     >>> 3
+    ...     spam
+    ...     >>> sys.displayhook = sys.__displayhook__
     ...     >>> 3
     ...     3
     ...     '''
     >>> test = doctest.DocTestFinder().find(f)[0]
-    >>> r = doctest.DocTestRunner(verbose=False).run(test)
-    >>> post_displayhook = sys.displayhook
-
-    We need to restore sys.displayhook now, so that we'll be able to test
-    results.
-
-    >>> sys.displayhook = orig_displayhook
-
-    Ok, now we can check that everything is ok.
-
+    >>> with patch('sys.displayhook', my_displayhook):
+    ...     r = doctest.DocTestRunner(verbose=False).run(test)
     >>> r
-    TestResults(failed=0, attempted=1)
-    >>> post_displayhook is my_displayhook
-    True
+    TestResults(failed=0, attempted=6)
 """
     def optionflags(): r"""
 Tests of `DocTestRunner`'s option flag handling.

--- a/Misc/NEWS.d/next/Library/2021-04-27-08-36-50.bpo-26092.1qLzp5.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-27-08-36-50.bpo-26092.1qLzp5.rst
@@ -1,0 +1,1 @@
+Allow using custom sys.displayhook's with doctest.


### PR DESCRIPTION
This reverts patch from gh-52296.

<!-- gh-issue-number: gh-70280 -->
* Issue: gh-70280
<!-- /gh-issue-number -->
