### PR TITLE
bpo-43864: Silence deprecation warning in test_importlib.test_module_found and test_importlib.test_module_not_found

### DIFF
--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -92,14 +92,18 @@ class WindowsRegistryFinderTests:
 
     def test_module_found(self):
         with setup_module(self.machinery, self.test_module):
-            loader = self.machinery.WindowsRegistryFinder.find_module(self.test_module)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                loader = self.machinery.WindowsRegistryFinder.find_module(self.test_module)
             spec = self.machinery.WindowsRegistryFinder.find_spec(self.test_module)
             self.assertIsNot(loader, None)
             self.assertIsNot(spec, None)
 
     def test_module_not_found(self):
         with setup_module(self.machinery, self.test_module, path="."):
-            loader = self.machinery.WindowsRegistryFinder.find_module(self.test_module)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                loader = self.machinery.WindowsRegistryFinder.find_module(self.test_module)
             spec = self.machinery.WindowsRegistryFinder.find_spec(self.test_module)
             self.assertIsNone(loader)
             self.assertIsNone(spec)


### PR DESCRIPTION


<!-- issue-number: [bpo-43864](https://bugs.python.org/issue43864) -->
https://bugs.python.org/issue43864
<!-- /issue-number -->
