### PR TITLE
bpo-43951: Two minor fixes for accessing a module's name.

### DIFF
--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -22,7 +22,7 @@ class ModuleTests(unittest.TestCase):
         # and __doc__ is None
         foo = ModuleType.__new__(ModuleType)
         self.assertTrue(foo.__dict__ is None)
-        self.assertRaises(SystemError, dir, foo)
+        self.assertRaises(TypeError, dir, foo)
         try:
             s = foo.__name__
             self.fail("__name__ = %s" % repr(s))

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -478,7 +478,7 @@ PyModule_GetNameObject(PyObject *m)
         return NULL;
     }
     d = ((PyModuleObject *)m)->md_dict;
-    if (d == NULL ||
+    if (d == NULL || !PyDict_Check(d) ||
         (name = _PyDict_GetItemIdWithError(d, &PyId___name__)) == NULL ||
         !PyUnicode_Check(name))
     {
@@ -823,11 +823,7 @@ module_dir(PyObject *self, PyObject *args)
             }
         }
         else {
-            const char *name = PyModule_GetName(self);
-            if (name)
-                PyErr_Format(PyExc_TypeError,
-                             "%.200s.__dict__ is not a dictionary",
-                             name);
+            PyErr_Format(PyExc_TypeError, "<module>.__dict__ is not a dictionary");
         }
     }
 


### PR DESCRIPTION
While working on another issue, I noticed two minor nits in the C implementation of the module object.  Both are related to getting a module's name.

**First,** the C function `module_dir()` (aka `module.__dir__`) starts by ensuring the module dict is valid.  If the module dict is invalid, it wants to format an exception using the name of the module, which it gets from `PyModule_GetName()`.  However, `PyModule_GetName()` gets the name of the module from the dict.  So getting the name in this circumstance will never succeed.

When `module_dir()` wants to format the error but can't get the name, it knows that `PyModule_GetName()` must have already raised an exception.  So it leaves that exception alone and returns an error.  The end result is that the exception raised here is kind of useless and misleading: `dir(module)` on a module with no `__dict__` raises `SystemError("nameless module")`.  I changed the code to actually raise the exception it wanted to raise, just without a real module name: `TypeError("<module>.__dict__ is not a dictionary")`.  This seems more useful, and would do a better job putting the programmer who encountered this on the right track of figuring out what was going on.

**Second,** the C API function `PyModule_GetNameObject()` checks to see if the module has a dict.  If `m->md_dict` is not `NULL`, it calls `_PyDict_GetItemIdWithError()`.  However, it's possible for `m->md_dict` to be `None`.  And if you call `_PyDict_GetItemIdWithError(Py_None, ...)` it will *crash*.

Unfortunately, this crash was due to my own bug in the other branch.  Fixing my code made the crash go away.  I assert that this is still possible at the API level.

The fix is easy: add a `PyDict_Check()` to `PyModule_GetNameObject()`.

Unfortunately, I don't know how to add a unit test for this.  Having changed `module_dir()` above, I can't find any other interfaces callable from Python that eventually call `PyModule_GetNameObject()`.  So I don't know how to trick the runtime into reproducing this error.

<!-- issue-number: [bpo-43951](https://bugs.python.org/issue43951) -->
https://bugs.python.org/issue43951
<!-- /issue-number -->
