### PR TITLE
bpo-43957: [Enum] deprecate ``TypeError`` from containment checks

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -140,6 +140,12 @@ Data Types
         >>> some_var in Color
         True
 
+      .. note::
+
+         In Python 3.12 it will be possible to check for member values and not
+         just members; until then, a ``TypeError`` will be raised if a
+         non-Enum-member is used in a containment check.
+
    .. method:: EnumType.__dir__(cls)
 
       Returns ``['__class__', '__doc__', '__members__', '__module__']`` and the

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -280,7 +280,8 @@ class _proto_member:
             # linear.
             enum_class._value2member_map_.setdefault(value, enum_member)
         except TypeError:
-            pass
+            # keep track of the value in a list so containment checks are quick
+            enum_class._unhashable_values_.append(value)
 
 
 class _EnumDict(dict):
@@ -440,6 +441,7 @@ class EnumType(type):
         classdict['_member_names_'] = []
         classdict['_member_map_'] = {}
         classdict['_value2member_map_'] = {}
+        classdict['_unhashable_values_'] = []
         classdict['_member_type_'] = member_type
         #
         # Flag structures (will be removed if final class is not a Flag
@@ -622,6 +624,13 @@ class EnumType(type):
 
     def __contains__(cls, member):
         if not isinstance(member, Enum):
+            import warnings
+            warnings.warn(
+                    "in 3.12 __contains__ will no longer raise TypeError, but will return True or\n"
+                    "False depending on whether the value is a member or the value of a member",
+                    DeprecationWarning,
+                    stacklevel=2,
+                    )
             raise TypeError(
                 "unsupported operand type(s) for 'in': '%s' and '%s'" % (
                     type(member).__qualname__, cls.__class__.__qualname__))
@@ -1005,14 +1014,15 @@ class Enum(metaclass=EnumType):
             val = str(self)
         # mix-in branch
         else:
-            import warnings
-            warnings.warn(
-                    "in 3.12 format() will use the enum member, not the enum member's value;\n"
-                    "use a format specifier, such as :d for an IntEnum member, to maintain"
-                    "the current display",
-                    DeprecationWarning,
-                    stacklevel=2,
-                    )
+            if not format_spec or format_spec in ('{}','{:}'):
+                import warnings
+                warnings.warn(
+                        "in 3.12 format() will use the enum member, not the enum member's value;\n"
+                        "use a format specifier, such as :d for an IntEnum member, to maintain"
+                        "the current display",
+                        DeprecationWarning,
+                        stacklevel=2,
+                        )
             cls = self._member_type_
             val = self._value_
         return cls.__format__(val, format_spec)
@@ -1434,6 +1444,7 @@ def _simple_enum(etype=Enum, *, boundary=None, use_args=None):
         body['_member_names_'] = member_names = []
         body['_member_map_'] = member_map = {}
         body['_value2member_map_'] = value2member_map = {}
+        body['_unhashable_values_'] = []
         body['_member_type_'] = member_type = etype._member_type_
         if issubclass(etype, Flag):
             body['_boundary_'] = boundary or etype._boundary_

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1323,7 +1323,7 @@ class StressTest(unittest.TestCase):
                     # race condition, check it.
                     self.assertIsInstance(cm.unraisable.exc_value, OSError)
                     self.assertIn(
-                        f"Signal {signum} ignored due to race condition",
+                        f"Signal {signum:d} ignored due to race condition",
                         str(cm.unraisable.exc_value))
                     ignored = True
 

--- a/Misc/NEWS.d/next/Library/2021-04-27-12-13-51.bpo-43957.6EaPD-.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-27-12-13-51.bpo-43957.6EaPD-.rst
@@ -1,0 +1,4 @@
+[Enum] Deprecate ``TypeError`` when non-member is used in a containment
+check; In 3.12 ``True`` or ``False`` will be returned instead, and
+containment will return ``True`` if the value is either a member of that
+enum or one of its members' value.


### PR DESCRIPTION
In 3.12 ``True`` or ``False`` will be returned for all containment checks,
with ``True`` being returned if the value is either a member of that enum
or one of its members' value.

<!-- issue-number: [bpo-42957](https://bugs.python.org/issue42957) -->
https://bugs.python.org/issue42957
<!-- /issue-number -->
