### PR TITLE
bpo-43954: Fix a missing word in the unittest docs

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -331,8 +331,9 @@ the `load_tests protocol`_.
 
 .. versionchanged:: 3.4
    Test discovery supports :term:`namespace packages <namespace package>`
-   for start directory. Note that you need to the top level directory too.
-   (e.g. ``python -m unittest discover -s root/namespace -t root``).
+   for the start directory. Note that you need to specify the top level
+   directory too (e.g.
+   ``python -m unittest discover -s root/namespace -t root``).
 
 
 .. _organizing-tests:


### PR DESCRIPTION


<!-- issue-number: [bpo-43954](https://bugs.python.org/issue43954) -->
https://bugs.python.org/issue43954
<!-- /issue-number -->
