### PR TITLE
bpo-43963: import _signal in subinterpreter has no side effect

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-28-01-23-38.bpo-43963.u5Y6bS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-28-01-23-38.bpo-43963.u5Y6bS.rst
@@ -1,0 +1,2 @@
+Importing the :mod:`_signal` module in a subinterpreter has no longer side
+effects.


### PR DESCRIPTION
Importing the _signal module in a subinterpreter has no longer side
effects.

signal_module_exec() no longer modify Handlers and no longer attempt
to set SIGINT signal handler in subinterpreters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43963](https://bugs.python.org/issue43963) -->
https://bugs.python.org/issue43963
<!-- /issue-number -->
