### PR TITLE
bpo-43961: Fix test_logging.test_namer_rotator_inheritance()

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5219,7 +5219,7 @@ class RotatingFileHandlerTest(BaseFileTest):
 
             def rotator(self, source, dest):
                 if os.path.exists(source):
-                    os.rename(source, dest + ".rotated")
+                    os.replace(source, dest + ".rotated")
 
         rh = HandlerWithNamerAndRotator(
             self.fn, encoding="utf-8", backupCount=2, maxBytes=1)

--- a/Misc/NEWS.d/next/Tests/2021-04-28-13-21-52.bpo-43961.gNchls.rst
+++ b/Misc/NEWS.d/next/Tests/2021-04-28-13-21-52.bpo-43961.gNchls.rst
@@ -1,0 +1,2 @@
+Fix test_logging.test_namer_rotator_inheritance() on Windows: use
+:func:`os.replace` rather than :func:`os.rename`. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_logging.test_namer_rotator_inheritance() on Windows: use
os.replace() rather than os.rename().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43961](https://bugs.python.org/issue43961) -->
https://bugs.python.org/issue43961
<!-- /issue-number -->
