### PR TITLE
Remove unnecessary reversed() from random.shuffle().

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -389,7 +389,7 @@ class Random(_random.Random):
 
         if random is None:
             randbelow = self._randbelow
-            for i in reversed(range(1, len(x))):
+            for i in range(1, len(x)):
                 # pick an element in x[:i+1] with which to exchange x[i]
                 j = randbelow(i + 1)
                 x[i], x[j] = x[j], x[i]
@@ -399,7 +399,7 @@ class Random(_random.Random):
                   'version.',
                   DeprecationWarning, 2)
             floor = _floor
-            for i in reversed(range(1, len(x))):
+            for i in range(1, len(x)):
                 # pick an element in x[:i+1] with which to exchange x[i]
                 j = floor(random() * (i + 1))
                 x[i], x[j] = x[j], x[i]


### PR DESCRIPTION
Originally, I was going to just add a comment, but then thought we might as well remove the unnecessary code.

    # The use of reversed() in the code below isn't necessary.
    # The algorithm works equally well when running forward.
    # We run in reverse only because "we've always done it this way".

In CPython, a reversed range runs as fast a forward range:

```
$ python3.10 -m timeit 'sum(range(10000))'
1000 loops, best of 5: 199 usec per loop
$ python3.10 -m timeit 'sum(reversed(range(10000)))'
2000 loops, best of 5: 199 usec per loop 
```

With PyPy, *reversed()* does add some overhead:
```
$ pypy3 -m timeit 'sum(range(10000))'
50000 loops, average of 7: 9.66 +- 0.0393 usec per loop
$ pypy3 -m timeit 'sum(reversed(range(10000)))'
10000 loops, average of 7: 25.9 +- 0.321 usec per loop
```