### PR TITLE
bpo-43913: Fix unittest module cleanup

### DIFF
--- a/Lib/unittest/suite.py
+++ b/Lib/unittest/suite.py
@@ -268,7 +268,7 @@ class TestSuite(BaseTestSuite):
             case.doModuleCleanups()
         except Exception as e:
             self._createClassOrModuleLevelException(result, e,
-                                                    'tearDownModule',
+                                                    'doModuleCleanups',
                                                     previousModule)
 
     def _tearDownPreviousClass(self, test, result):

--- a/Lib/unittest/suite.py
+++ b/Lib/unittest/suite.py
@@ -264,12 +264,12 @@ class TestSuite(BaseTestSuite):
                                                         previousModule)
             finally:
                 _call_if_exists(result, '_restoreStdout')
-                try:
-                    case.doModuleCleanups()
-                except Exception as e:
-                    self._createClassOrModuleLevelException(result, e,
-                                                            'tearDownModule',
-                                                            previousModule)
+        try:
+            case.doModuleCleanups()
+        except Exception as e:
+            self._createClassOrModuleLevelException(result, e,
+                                                    'tearDownModule',
+                                                    previousModule)
 
     def _tearDownPreviousClass(self, test, result):
         previousClass = getattr(result, '_previousTestClass', None)

--- a/Lib/unittest/test/test_runner.py
+++ b/Lib/unittest/test/test_runner.py
@@ -440,6 +440,32 @@ class TestModuleCleanUp(unittest.TestCase):
         self.assertEqual(ordering, ['setUpClass', 'test', 'tearDownClass'])
         self.assertEqual(unittest.case._module_cleanups, [])
 
+    def test_run_module_cleanUp_when_teardown_exception(self):
+        ordering = []
+
+        class Module(object):
+            unittest.addModuleCleanup(print, 'module cleanup')
+
+            @staticmethod
+            def tearDownModule():
+                raise Exception('CleanUpExc')
+
+        class TestableTest(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                ordering.append('setUpClass')
+            def testNothing(self):
+                ordering.append('test')
+            @classmethod
+            def tearDownClass(cls):
+                ordering.append('tearDownClass')
+
+        TestableTest.__module__ = 'Module'
+        sys.modules['Module'] = Module
+        runTests(TestableTest)
+        self.assertEqual(ordering, ['setUpClass', 'test', 'tearDownClass'])
+        self.assertEqual(unittest.case._module_cleanups, [])
+
     def test_run_module_cleanUp(self):
         blowUp = True
         ordering = []

--- a/Lib/unittest/test/test_runner.py
+++ b/Lib/unittest/test/test_runner.py
@@ -418,6 +418,28 @@ class TestModuleCleanUp(unittest.TestCase):
         self.assertEqual(cleanups,
                          [((1, 2), {'function': 'hello'})])
 
+    def test_run_module_cleanUp_without_teardown(self):
+        ordering = []
+
+        class Module(object):
+            unittest.addModuleCleanup(print, 'module cleanup')
+
+        class TestableTest(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                ordering.append('setUpClass')
+            def testNothing(self):
+                ordering.append('test')
+            @classmethod
+            def tearDownClass(cls):
+                ordering.append('tearDownClass')
+
+        TestableTest.__module__ = 'Module'
+        sys.modules['Module'] = Module
+        runTests(TestableTest)
+        self.assertEqual(ordering, ['setUpClass', 'test', 'tearDownClass'])
+        self.assertEqual(unittest.case._module_cleanups, [])
+
     def test_run_module_cleanUp(self):
         blowUp = True
         ordering = []

--- a/Misc/NEWS.d/next/Library/2021-04-29-07-08-47.bpo-43913.wcTUA5.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-29-07-08-47.bpo-43913.wcTUA5.rst
@@ -1,0 +1,1 @@
+Fix the :func:`unittest.addModuleCleanup` behavior. It is now called even if :meth:`tearDownModule` is not defined.


### PR DESCRIPTION
This is my my attempt to fix the bug described in https://bugs.python.org/issue43913

<!-- issue-number: [bpo-43913](https://bugs.python.org/issue43913) -->
https://bugs.python.org/issue43913
<!-- /issue-number -->
