### PR TITLE
bpo-43972: Set content-length to 0 for http.server.SimpleHTTPRequestHandler 301s

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -689,6 +689,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                              parts[3], parts[4])
                 new_url = urllib.parse.urlunsplit(new_parts)
                 self.send_header("Location", new_url)
+                self.send_header("Content-Length", "0")
                 self.end_headers()
                 return None
             for index in "index.html", "index.htm":

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -428,6 +428,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.check_status_and_reason(response, HTTPStatus.OK)
         response = self.request(self.base_url)
         self.check_status_and_reason(response, HTTPStatus.MOVED_PERMANENTLY)
+        self.assertEqual(response.getheader("Content-Length"), "0")
         response = self.request(self.base_url + '/?hi=2')
         self.check_status_and_reason(response, HTTPStatus.OK)
         response = self.request(self.base_url + '?hi=1')

--- a/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
@@ -1,3 +1,3 @@
-When :class:`http.server.SimpleHTTPRequestHandler` sends a ``301 (Moved
-Permanently)`` for a path ending with `/`, add a ``Content-Length: 0`` 
-header. This improves the behavior for certain clients.
+When :class:`http.server.SimpleHTTPRequestHandler` sends a
+``301 (Moved Permanently)`` for a path ending with `/`, add a
+``Content-Length: 0`` header.

--- a/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
@@ -1,3 +1,3 @@
 When :class:`http.server.SimpleHTTPRequestHandler` sends a ``301 (Moved
-Permanently)``, add a ``Content-Length: 0`` header. This improves the
-behavior for certain clients.
+Permanently)`` for a path ending with `/`, add a ``Content-Length: 0`` 
+header. This improves the behavior for certain clients.

--- a/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
@@ -1,0 +1,3 @@
+When :class:`http.server.SimpleHTTPRequestHandler` sends a ``301 (Moved
+Permanently)``, add a ``Content-Length: 0`` header. This improves the
+behavior for certain clients.

--- a/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
+++ b/Misc/NEWS.d/next/Library/2021-04-30-16-58-24.bpo-43972.Y2r9lg.rst
@@ -1,3 +1,3 @@
 When :class:`http.server.SimpleHTTPRequestHandler` sends a
-``301 (Moved Permanently)`` for a path ending with `/`, add a
-``Content-Length: 0`` header.
+``301 (Moved Permanently)`` for a directory path not ending with `/`, add a
+``Content-Length: 0`` header. This improves the behavior for certain clients.


### PR DESCRIPTION
When `http.server.SimpleHTTPRequestHandler` sends a 301 (Moved Permanently) due to a missing file, add a Content-Length of 0. This improves the behavior for certain clients.

<!-- issue-number: [bpo-43972](https://bugs.python.org/issue43972) -->
https://bugs.python.org/issue43972
<!-- /issue-number -->
