### PR TITLE
bpo-43795 - Update Stable ABI dat.

### DIFF
--- a/Doc/data/stable_abi.dat
+++ b/Doc/data/stable_abi.dat
@@ -286,9 +286,6 @@ PyFrame_GetLineNumber
 PyFrozenSet_New
 PyFrozenSet_Type
 PyGC_Collect
-PyGC_Disable
-PyGC_Enable
-PyGC_IsEnabled
 PyGILState_Ensure
 PyGILState_GetThisThreadState
 PyGILState_Release


### PR DESCRIPTION
PRs were failing with the check if generated files are up to date. For e.g [this one](https://github.com/python/cpython/pull/25595/checks?check_run_id=2465880233).

The Stable ABI was updated here in this PR - https://github.com/python/cpython/pull/25315
The change in this diff was introduced here - 3cc481b9de43c234889c8010e7da3af7c0f42319 

I had  run `make regen-limited-abi` to recrete the stable abi manifest.
<!-- issue-number: [bpo-43774](https://bugs.python.org/issue43774) -->
https://bugs.python.org/issue43774
<!-- /issue-number -->
