### PR TITLE
bpo-43933: Show frame.f_lineno as None, rather than -1, if there is no line number.

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2081,7 +2081,10 @@ class PEP626Tests(unittest.TestCase):
             while t.tb_next:
                 t = t.tb_next
             frame = t.tb_frame
-            self.assertEqual(frame.f_lineno-frame.f_code.co_firstlineno, line)
+            if line is None:
+                self.assertEqual(frame.f_lineno, line)
+            else:
+                self.assertEqual(frame.f_lineno-frame.f_code.co_firstlineno, line)
 
     def test_lineno_after_raise_simple(self):
         def simple():
@@ -2153,6 +2156,12 @@ class PEP626Tests(unittest.TestCase):
                 pass
         self.lineno_after_raise(after_with, 2)
 
+    def test_missing_lineno_shows_as_none(self):
+        def f():
+            1/0
+        self.lineno_after_raise(f, 1)
+        f.__code__ = f.__code__.replace(co_linetable=b'\x04\x80\xff\x80')
+        self.lineno_after_raise(f, None)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-29-13-11-44.bpo-43933.mvoV6O.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-29-13-11-44.bpo-43933.mvoV6O.rst
@@ -1,0 +1,3 @@
+If the current position in a frame has no line number then set the f_lineno
+attribute to None, instead of -1, to conform to PEP 626. This should not
+normally be possible, but might occur in some unusual circumstances.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -58,7 +58,7 @@ frame_getlineno(PyFrameObject *f, void *closure)
         Py_RETURN_NONE;
     }
     else {
-        return PyLong_FromLong(PyFrame_GetLineNumber(f));
+        return PyLong_FromLong(lineno);
     }
 }
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -53,7 +53,13 @@ PyFrame_GetLineNumber(PyFrameObject *f)
 static PyObject *
 frame_getlineno(PyFrameObject *f, void *closure)
 {
-    return PyLong_FromLong(PyFrame_GetLineNumber(f));
+    int lineno = PyFrame_GetLineNumber(f);
+    if (lineno < 0) {
+        Py_RETURN_NONE;
+    }
+    else {
+        return PyLong_FromLong(PyFrame_GetLineNumber(f));
+    }
 }
 
 static PyObject *


### PR DESCRIPTION
As specified by PEP 626.
This should not be observable unless `frame.f_trace_opcodes` is set, or some other oddity.


<!-- issue-number: [bpo-43933](https://bugs.python.org/issue43933) -->
https://bugs.python.org/issue43933
<!-- /issue-number -->
