### PR TITLE
bpo-43565: Document PyUnicode_KIND's return type as an unsigned int

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -149,7 +149,7 @@ access internal read-only data of Unicode objects:
       ``PyUnicode_WCHAR_KIND`` is deprecated.
 
 
-.. c:function:: int PyUnicode_KIND(PyObject *o)
+.. c:function:: unsigned int PyUnicode_KIND(PyObject *o)
 
    Return one of the PyUnicode kind constants (see above) that indicate how many
    bytes per character this Unicode object uses to store its data.  *o* has to


### PR DESCRIPTION
It looks like people are already using this enum within their code: https://github.com/search?p=1&q=enum+PyUnicode_Kind&type=Code

So as the bpo ticket suggests, we may as well document this type properly as an enum and correct the return type for `PyUnicode_KIND`

<!-- issue-number: [bpo-43565](https://bugs.python.org/issue43565) -->
https://bugs.python.org/issue43565
<!-- /issue-number -->
