### PR TITLE
bpo-43892: Validate the first term of complex literal value patterns

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -276,12 +276,21 @@ literal_expr[expr_ty]:
     | 'False' { _PyAST_Constant(Py_False, NULL, EXTRA) }
 
 complex_number[expr_ty]:
-    | real=signed_number '+' imag=imaginary_number { _PyAST_BinOp(real, Add, imag, EXTRA) }
-    | real=signed_number '-' imag=imaginary_number  { _PyAST_BinOp(real, Sub, imag, EXTRA) }
+    | real=signed_real_number '+' imag=imaginary_number {
+        _PyAST_BinOp(real, Add, imag, EXTRA) }
+    | real=signed_real_number '-' imag=imaginary_number  {
+        _PyAST_BinOp(real, Sub, imag, EXTRA) }
 
 signed_number[expr_ty]:
     | NUMBER
     | '-' number=NUMBER { _PyAST_UnaryOp(USub, number, EXTRA) }
+
+signed_real_number[expr_ty]:
+    | real_number
+    | '-' real=real_number { _PyAST_UnaryOp(USub, real, EXTRA) }
+
+real_number[expr_ty]:
+    | real=NUMBER { _PyPegen_ensure_real(p, real) }
 
 imaginary_number[expr_ty]:
     | imag=NUMBER { _PyPegen_ensure_imaginary(p, imag) }
@@ -954,12 +963,12 @@ invalid_finally_stmt:
     | a='finally' ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'finally' statement on line %d", a->lineno) }
 invalid_except_stmt_indent:
-    | a='except' expression ['as' NAME ] ':' NEWLINE !INDENT { 
+    | a='except' expression ['as' NAME ] ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'except' statement on line %d", a->lineno) }
     | a='except' ':' NEWLINE !INDENT { RAISE_SYNTAX_ERROR("expected an indented block after except statement on line %d", a->lineno) }
 invalid_match_stmt:
     | "match" subject_expr !':' { CHECK_VERSION(void*, 10, "Pattern matching is", RAISE_SYNTAX_ERROR("expected ':'") ) }
-    | a="match" subject=subject_expr ':' NEWLINE !INDENT { 
+    | a="match" subject=subject_expr ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'match' statement on line %d", a->lineno) }
 invalid_case_block:
     | "case" patterns guard? !':' { RAISE_SYNTAX_ERROR("expected ':'") }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -352,7 +352,7 @@ mapping_pattern[pattern_ty]:
             NULL,
             EXTRA) }
 items_pattern[asdl_seq*]:
-    | items=','.key_value_pattern+ { items }
+    | ','.key_value_pattern+
 key_value_pattern[KeyPatternPair*]:
     | key=(literal_expr | attr) ':' pattern=pattern {
         _PyPegen_key_pattern_pair(p, key, pattern) }
@@ -382,7 +382,7 @@ class_pattern[pattern_ty]:
 positional_patterns[asdl_pattern_seq*]:
     | args[asdl_pattern_seq*]=','.pattern+ { args }
 keyword_patterns[asdl_seq*]:
-    | keywords[asdl_seq*]=','.keyword_pattern+ { keywords }
+    | ','.keyword_pattern+
 keyword_pattern[KeyPatternPair*]:
     | arg=NAME '=' value=pattern { _PyPegen_key_pattern_pair(p, arg, value) }
 

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2873,6 +2873,38 @@ class TestPatma(unittest.TestCase):
                 pass
         """)
 
+    @no_perf
+    def test_patma_285(self):
+        self.assert_syntax_error("""
+        match ...:
+            case 0j+0:
+                pass
+        """)
+
+    @no_perf
+    def test_patma_286(self):
+        self.assert_syntax_error("""
+        match ...:
+            case 0j+0j:
+                pass
+        """)
+
+    @no_perf
+    def test_patma_287(self):
+        self.assert_syntax_error("""
+        match ...:
+            case {0j+0: _}:
+                pass
+        """)
+
+    @no_perf
+    def test_patma_288(self):
+        self.assert_syntax_error("""
+        match ...:
+            case {0j+0j: _}:
+                pass
+        """)
+
 
 class PerfPatma(TestPatma):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-04-29-16-00-28.bpo-43892.WXIehI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-04-29-16-00-28.bpo-43892.WXIehI.rst
@@ -1,0 +1,2 @@
+Restore proper validation of complex literal value patterns when parsing
+:keyword:`!match` blocks.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -122,374 +122,376 @@ static char *soft_keywords[] = {
 #define literal_expr_type 1048
 #define complex_number_type 1049
 #define signed_number_type 1050
-#define imaginary_number_type 1051
-#define capture_pattern_type 1052
-#define pattern_capture_target_type 1053
-#define wildcard_pattern_type 1054
-#define value_pattern_type 1055
-#define attr_type 1056  // Left-recursive
-#define name_or_attr_type 1057  // Left-recursive
-#define group_pattern_type 1058
-#define sequence_pattern_type 1059
-#define open_sequence_pattern_type 1060
-#define maybe_sequence_pattern_type 1061
-#define maybe_star_pattern_type 1062
-#define star_pattern_type 1063
-#define mapping_pattern_type 1064
-#define items_pattern_type 1065
-#define key_value_pattern_type 1066
-#define double_star_pattern_type 1067
-#define class_pattern_type 1068
-#define positional_patterns_type 1069
-#define keyword_patterns_type 1070
-#define keyword_pattern_type 1071
-#define return_stmt_type 1072
-#define raise_stmt_type 1073
-#define function_def_type 1074
-#define function_def_raw_type 1075
-#define func_type_comment_type 1076
-#define params_type 1077
-#define parameters_type 1078
-#define slash_no_default_type 1079
-#define slash_with_default_type 1080
-#define star_etc_type 1081
-#define kwds_type 1082
-#define param_no_default_type 1083
-#define param_with_default_type 1084
-#define param_maybe_default_type 1085
-#define param_type 1086
-#define annotation_type 1087
-#define default_type 1088
-#define decorators_type 1089
-#define class_def_type 1090
-#define class_def_raw_type 1091
-#define block_type 1092
-#define star_expressions_type 1093
-#define star_expression_type 1094
-#define star_named_expressions_type 1095
-#define star_named_expression_type 1096
-#define named_expression_type 1097
-#define direct_named_expression_type 1098
-#define annotated_rhs_type 1099
-#define expressions_type 1100
-#define expression_type 1101
-#define lambdef_type 1102
-#define lambda_params_type 1103
-#define lambda_parameters_type 1104
-#define lambda_slash_no_default_type 1105
-#define lambda_slash_with_default_type 1106
-#define lambda_star_etc_type 1107
-#define lambda_kwds_type 1108
-#define lambda_param_no_default_type 1109
-#define lambda_param_with_default_type 1110
-#define lambda_param_maybe_default_type 1111
-#define lambda_param_type 1112
-#define disjunction_type 1113
-#define conjunction_type 1114
-#define inversion_type 1115
-#define comparison_type 1116
-#define compare_op_bitwise_or_pair_type 1117
-#define eq_bitwise_or_type 1118
-#define noteq_bitwise_or_type 1119
-#define lte_bitwise_or_type 1120
-#define lt_bitwise_or_type 1121
-#define gte_bitwise_or_type 1122
-#define gt_bitwise_or_type 1123
-#define notin_bitwise_or_type 1124
-#define in_bitwise_or_type 1125
-#define isnot_bitwise_or_type 1126
-#define is_bitwise_or_type 1127
-#define bitwise_or_type 1128  // Left-recursive
-#define bitwise_xor_type 1129  // Left-recursive
-#define bitwise_and_type 1130  // Left-recursive
-#define shift_expr_type 1131  // Left-recursive
-#define sum_type 1132  // Left-recursive
-#define term_type 1133  // Left-recursive
-#define factor_type 1134
-#define power_type 1135
-#define await_primary_type 1136
-#define primary_type 1137  // Left-recursive
-#define slices_type 1138
-#define slice_type 1139
-#define atom_type 1140
-#define strings_type 1141
-#define list_type 1142
-#define listcomp_type 1143
-#define tuple_type 1144
-#define group_type 1145
-#define genexp_type 1146
-#define set_type 1147
-#define setcomp_type 1148
-#define dict_type 1149
-#define dictcomp_type 1150
-#define double_starred_kvpairs_type 1151
-#define double_starred_kvpair_type 1152
-#define kvpair_type 1153
-#define for_if_clauses_type 1154
-#define for_if_clause_type 1155
-#define yield_expr_type 1156
-#define arguments_type 1157
-#define args_type 1158
-#define kwargs_type 1159
-#define starred_expression_type 1160
-#define kwarg_or_starred_type 1161
-#define kwarg_or_double_starred_type 1162
-#define star_targets_type 1163
-#define star_targets_list_seq_type 1164
-#define star_targets_tuple_seq_type 1165
-#define star_target_type 1166
-#define target_with_star_atom_type 1167
-#define star_atom_type 1168
-#define single_target_type 1169
-#define single_subscript_attribute_target_type 1170
-#define del_targets_type 1171
-#define del_target_type 1172
-#define del_t_atom_type 1173
-#define targets_type 1174
-#define target_type 1175
-#define t_primary_type 1176  // Left-recursive
-#define t_lookahead_type 1177
-#define t_atom_type 1178
-#define invalid_arguments_type 1179
-#define invalid_kwarg_type 1180
-#define invalid_expression_type 1181
-#define invalid_named_expression_type 1182
-#define invalid_assignment_type 1183
-#define invalid_ann_assign_target_type 1184
-#define invalid_del_stmt_type 1185
-#define invalid_block_type 1186
-#define invalid_primary_type 1187  // Left-recursive
-#define invalid_comprehension_type 1188
-#define invalid_dict_comprehension_type 1189
-#define invalid_parameters_type 1190
-#define invalid_parameters_helper_type 1191
-#define invalid_lambda_parameters_type 1192
-#define invalid_lambda_parameters_helper_type 1193
-#define invalid_star_etc_type 1194
-#define invalid_lambda_star_etc_type 1195
-#define invalid_double_type_comments_type 1196
-#define invalid_with_item_type 1197
-#define invalid_for_target_type 1198
-#define invalid_group_type 1199
-#define invalid_import_from_targets_type 1200
-#define invalid_with_stmt_type 1201
-#define invalid_with_stmt_indent_type 1202
-#define invalid_try_stmt_type 1203
-#define invalid_except_stmt_type 1204
-#define invalid_finally_stmt_type 1205
-#define invalid_except_stmt_indent_type 1206
-#define invalid_match_stmt_type 1207
-#define invalid_case_block_type 1208
-#define invalid_if_stmt_type 1209
-#define invalid_elif_stmt_type 1210
-#define invalid_else_stmt_type 1211
-#define invalid_while_stmt_type 1212
-#define invalid_for_stmt_type 1213
-#define invalid_def_raw_type 1214
-#define invalid_class_def_raw_type 1215
-#define invalid_double_starred_kvpairs_type 1216
-#define invalid_kvpair_type 1217
-#define _loop0_1_type 1218
-#define _loop0_2_type 1219
-#define _loop0_4_type 1220
-#define _gather_3_type 1221
-#define _loop0_6_type 1222
-#define _gather_5_type 1223
-#define _loop0_8_type 1224
-#define _gather_7_type 1225
-#define _loop0_10_type 1226
-#define _gather_9_type 1227
-#define _loop1_11_type 1228
-#define _loop0_13_type 1229
-#define _gather_12_type 1230
-#define _tmp_14_type 1231
-#define _tmp_15_type 1232
-#define _tmp_16_type 1233
-#define _tmp_17_type 1234
-#define _tmp_18_type 1235
-#define _tmp_19_type 1236
-#define _tmp_20_type 1237
-#define _tmp_21_type 1238
-#define _loop1_22_type 1239
-#define _tmp_23_type 1240
-#define _tmp_24_type 1241
-#define _loop0_26_type 1242
-#define _gather_25_type 1243
-#define _loop0_28_type 1244
-#define _gather_27_type 1245
-#define _tmp_29_type 1246
-#define _tmp_30_type 1247
-#define _loop0_31_type 1248
-#define _loop1_32_type 1249
-#define _loop0_34_type 1250
-#define _gather_33_type 1251
-#define _tmp_35_type 1252
-#define _loop0_37_type 1253
-#define _gather_36_type 1254
-#define _tmp_38_type 1255
-#define _loop0_40_type 1256
-#define _gather_39_type 1257
-#define _loop0_42_type 1258
-#define _gather_41_type 1259
-#define _loop0_44_type 1260
-#define _gather_43_type 1261
-#define _loop0_46_type 1262
-#define _gather_45_type 1263
-#define _tmp_47_type 1264
-#define _loop1_48_type 1265
-#define _tmp_49_type 1266
-#define _loop1_50_type 1267
-#define _loop0_52_type 1268
-#define _gather_51_type 1269
-#define _tmp_53_type 1270
-#define _tmp_54_type 1271
-#define _tmp_55_type 1272
-#define _tmp_56_type 1273
-#define _loop0_58_type 1274
-#define _gather_57_type 1275
-#define _loop0_60_type 1276
-#define _gather_59_type 1277
-#define _tmp_61_type 1278
-#define _loop0_63_type 1279
-#define _gather_62_type 1280
-#define _loop0_65_type 1281
-#define _gather_64_type 1282
-#define _tmp_66_type 1283
-#define _tmp_67_type 1284
-#define _tmp_68_type 1285
-#define _tmp_69_type 1286
-#define _loop0_70_type 1287
-#define _loop0_71_type 1288
-#define _loop0_72_type 1289
-#define _loop1_73_type 1290
-#define _loop0_74_type 1291
-#define _loop1_75_type 1292
-#define _loop1_76_type 1293
-#define _loop1_77_type 1294
-#define _loop0_78_type 1295
-#define _loop1_79_type 1296
-#define _loop0_80_type 1297
-#define _loop1_81_type 1298
-#define _loop0_82_type 1299
-#define _loop1_83_type 1300
-#define _loop1_84_type 1301
-#define _tmp_85_type 1302
-#define _loop1_86_type 1303
-#define _loop0_88_type 1304
-#define _gather_87_type 1305
-#define _loop1_89_type 1306
-#define _loop0_90_type 1307
-#define _loop0_91_type 1308
-#define _loop0_92_type 1309
-#define _loop1_93_type 1310
-#define _loop0_94_type 1311
-#define _loop1_95_type 1312
-#define _loop1_96_type 1313
-#define _loop1_97_type 1314
-#define _loop0_98_type 1315
-#define _loop1_99_type 1316
-#define _loop0_100_type 1317
-#define _loop1_101_type 1318
-#define _loop0_102_type 1319
-#define _loop1_103_type 1320
-#define _loop1_104_type 1321
-#define _loop1_105_type 1322
-#define _loop1_106_type 1323
-#define _tmp_107_type 1324
-#define _loop0_109_type 1325
-#define _gather_108_type 1326
-#define _tmp_110_type 1327
-#define _tmp_111_type 1328
-#define _tmp_112_type 1329
-#define _tmp_113_type 1330
-#define _loop1_114_type 1331
-#define _tmp_115_type 1332
-#define _tmp_116_type 1333
-#define _loop0_118_type 1334
-#define _gather_117_type 1335
-#define _loop1_119_type 1336
-#define _loop0_120_type 1337
-#define _loop0_121_type 1338
-#define _loop0_123_type 1339
-#define _gather_122_type 1340
-#define _tmp_124_type 1341
-#define _loop0_126_type 1342
-#define _gather_125_type 1343
-#define _loop0_128_type 1344
-#define _gather_127_type 1345
-#define _loop0_130_type 1346
-#define _gather_129_type 1347
-#define _loop0_132_type 1348
-#define _gather_131_type 1349
-#define _loop0_133_type 1350
-#define _loop0_135_type 1351
-#define _gather_134_type 1352
-#define _loop1_136_type 1353
-#define _tmp_137_type 1354
-#define _loop0_139_type 1355
-#define _gather_138_type 1356
-#define _loop0_141_type 1357
-#define _gather_140_type 1358
-#define _tmp_142_type 1359
-#define _tmp_143_type 1360
-#define _tmp_144_type 1361
-#define _tmp_145_type 1362
-#define _tmp_146_type 1363
-#define _loop0_147_type 1364
-#define _loop0_148_type 1365
-#define _loop0_149_type 1366
-#define _tmp_150_type 1367
-#define _tmp_151_type 1368
-#define _tmp_152_type 1369
-#define _tmp_153_type 1370
-#define _loop0_154_type 1371
-#define _loop1_155_type 1372
-#define _loop0_156_type 1373
-#define _loop1_157_type 1374
-#define _tmp_158_type 1375
-#define _tmp_159_type 1376
-#define _tmp_160_type 1377
-#define _loop0_162_type 1378
-#define _gather_161_type 1379
-#define _loop0_164_type 1380
-#define _gather_163_type 1381
-#define _loop0_166_type 1382
-#define _gather_165_type 1383
-#define _loop0_168_type 1384
-#define _gather_167_type 1385
-#define _tmp_169_type 1386
-#define _tmp_170_type 1387
-#define _tmp_171_type 1388
-#define _tmp_172_type 1389
-#define _tmp_173_type 1390
-#define _loop0_175_type 1391
-#define _gather_174_type 1392
-#define _tmp_176_type 1393
-#define _tmp_177_type 1394
-#define _tmp_178_type 1395
-#define _tmp_179_type 1396
-#define _tmp_180_type 1397
-#define _tmp_181_type 1398
-#define _tmp_182_type 1399
-#define _tmp_183_type 1400
-#define _tmp_184_type 1401
-#define _tmp_185_type 1402
-#define _tmp_186_type 1403
-#define _tmp_187_type 1404
-#define _tmp_188_type 1405
-#define _tmp_189_type 1406
-#define _tmp_190_type 1407
-#define _tmp_191_type 1408
-#define _tmp_192_type 1409
-#define _tmp_193_type 1410
-#define _tmp_194_type 1411
-#define _tmp_195_type 1412
-#define _tmp_196_type 1413
-#define _tmp_197_type 1414
-#define _tmp_198_type 1415
-#define _tmp_199_type 1416
-#define _tmp_200_type 1417
-#define _tmp_201_type 1418
+#define signed_real_number_type 1051
+#define real_number_type 1052
+#define imaginary_number_type 1053
+#define capture_pattern_type 1054
+#define pattern_capture_target_type 1055
+#define wildcard_pattern_type 1056
+#define value_pattern_type 1057
+#define attr_type 1058  // Left-recursive
+#define name_or_attr_type 1059  // Left-recursive
+#define group_pattern_type 1060
+#define sequence_pattern_type 1061
+#define open_sequence_pattern_type 1062
+#define maybe_sequence_pattern_type 1063
+#define maybe_star_pattern_type 1064
+#define star_pattern_type 1065
+#define mapping_pattern_type 1066
+#define items_pattern_type 1067
+#define key_value_pattern_type 1068
+#define double_star_pattern_type 1069
+#define class_pattern_type 1070
+#define positional_patterns_type 1071
+#define keyword_patterns_type 1072
+#define keyword_pattern_type 1073
+#define return_stmt_type 1074
+#define raise_stmt_type 1075
+#define function_def_type 1076
+#define function_def_raw_type 1077
+#define func_type_comment_type 1078
+#define params_type 1079
+#define parameters_type 1080
+#define slash_no_default_type 1081
+#define slash_with_default_type 1082
+#define star_etc_type 1083
+#define kwds_type 1084
+#define param_no_default_type 1085
+#define param_with_default_type 1086
+#define param_maybe_default_type 1087
+#define param_type 1088
+#define annotation_type 1089
+#define default_type 1090
+#define decorators_type 1091
+#define class_def_type 1092
+#define class_def_raw_type 1093
+#define block_type 1094
+#define star_expressions_type 1095
+#define star_expression_type 1096
+#define star_named_expressions_type 1097
+#define star_named_expression_type 1098
+#define named_expression_type 1099
+#define direct_named_expression_type 1100
+#define annotated_rhs_type 1101
+#define expressions_type 1102
+#define expression_type 1103
+#define lambdef_type 1104
+#define lambda_params_type 1105
+#define lambda_parameters_type 1106
+#define lambda_slash_no_default_type 1107
+#define lambda_slash_with_default_type 1108
+#define lambda_star_etc_type 1109
+#define lambda_kwds_type 1110
+#define lambda_param_no_default_type 1111
+#define lambda_param_with_default_type 1112
+#define lambda_param_maybe_default_type 1113
+#define lambda_param_type 1114
+#define disjunction_type 1115
+#define conjunction_type 1116
+#define inversion_type 1117
+#define comparison_type 1118
+#define compare_op_bitwise_or_pair_type 1119
+#define eq_bitwise_or_type 1120
+#define noteq_bitwise_or_type 1121
+#define lte_bitwise_or_type 1122
+#define lt_bitwise_or_type 1123
+#define gte_bitwise_or_type 1124
+#define gt_bitwise_or_type 1125
+#define notin_bitwise_or_type 1126
+#define in_bitwise_or_type 1127
+#define isnot_bitwise_or_type 1128
+#define is_bitwise_or_type 1129
+#define bitwise_or_type 1130  // Left-recursive
+#define bitwise_xor_type 1131  // Left-recursive
+#define bitwise_and_type 1132  // Left-recursive
+#define shift_expr_type 1133  // Left-recursive
+#define sum_type 1134  // Left-recursive
+#define term_type 1135  // Left-recursive
+#define factor_type 1136
+#define power_type 1137
+#define await_primary_type 1138
+#define primary_type 1139  // Left-recursive
+#define slices_type 1140
+#define slice_type 1141
+#define atom_type 1142
+#define strings_type 1143
+#define list_type 1144
+#define listcomp_type 1145
+#define tuple_type 1146
+#define group_type 1147
+#define genexp_type 1148
+#define set_type 1149
+#define setcomp_type 1150
+#define dict_type 1151
+#define dictcomp_type 1152
+#define double_starred_kvpairs_type 1153
+#define double_starred_kvpair_type 1154
+#define kvpair_type 1155
+#define for_if_clauses_type 1156
+#define for_if_clause_type 1157
+#define yield_expr_type 1158
+#define arguments_type 1159
+#define args_type 1160
+#define kwargs_type 1161
+#define starred_expression_type 1162
+#define kwarg_or_starred_type 1163
+#define kwarg_or_double_starred_type 1164
+#define star_targets_type 1165
+#define star_targets_list_seq_type 1166
+#define star_targets_tuple_seq_type 1167
+#define star_target_type 1168
+#define target_with_star_atom_type 1169
+#define star_atom_type 1170
+#define single_target_type 1171
+#define single_subscript_attribute_target_type 1172
+#define del_targets_type 1173
+#define del_target_type 1174
+#define del_t_atom_type 1175
+#define targets_type 1176
+#define target_type 1177
+#define t_primary_type 1178  // Left-recursive
+#define t_lookahead_type 1179
+#define t_atom_type 1180
+#define invalid_arguments_type 1181
+#define invalid_kwarg_type 1182
+#define invalid_expression_type 1183
+#define invalid_named_expression_type 1184
+#define invalid_assignment_type 1185
+#define invalid_ann_assign_target_type 1186
+#define invalid_del_stmt_type 1187
+#define invalid_block_type 1188
+#define invalid_primary_type 1189  // Left-recursive
+#define invalid_comprehension_type 1190
+#define invalid_dict_comprehension_type 1191
+#define invalid_parameters_type 1192
+#define invalid_parameters_helper_type 1193
+#define invalid_lambda_parameters_type 1194
+#define invalid_lambda_parameters_helper_type 1195
+#define invalid_star_etc_type 1196
+#define invalid_lambda_star_etc_type 1197
+#define invalid_double_type_comments_type 1198
+#define invalid_with_item_type 1199
+#define invalid_for_target_type 1200
+#define invalid_group_type 1201
+#define invalid_import_from_targets_type 1202
+#define invalid_with_stmt_type 1203
+#define invalid_with_stmt_indent_type 1204
+#define invalid_try_stmt_type 1205
+#define invalid_except_stmt_type 1206
+#define invalid_finally_stmt_type 1207
+#define invalid_except_stmt_indent_type 1208
+#define invalid_match_stmt_type 1209
+#define invalid_case_block_type 1210
+#define invalid_if_stmt_type 1211
+#define invalid_elif_stmt_type 1212
+#define invalid_else_stmt_type 1213
+#define invalid_while_stmt_type 1214
+#define invalid_for_stmt_type 1215
+#define invalid_def_raw_type 1216
+#define invalid_class_def_raw_type 1217
+#define invalid_double_starred_kvpairs_type 1218
+#define invalid_kvpair_type 1219
+#define _loop0_1_type 1220
+#define _loop0_2_type 1221
+#define _loop0_4_type 1222
+#define _gather_3_type 1223
+#define _loop0_6_type 1224
+#define _gather_5_type 1225
+#define _loop0_8_type 1226
+#define _gather_7_type 1227
+#define _loop0_10_type 1228
+#define _gather_9_type 1229
+#define _loop1_11_type 1230
+#define _loop0_13_type 1231
+#define _gather_12_type 1232
+#define _tmp_14_type 1233
+#define _tmp_15_type 1234
+#define _tmp_16_type 1235
+#define _tmp_17_type 1236
+#define _tmp_18_type 1237
+#define _tmp_19_type 1238
+#define _tmp_20_type 1239
+#define _tmp_21_type 1240
+#define _loop1_22_type 1241
+#define _tmp_23_type 1242
+#define _tmp_24_type 1243
+#define _loop0_26_type 1244
+#define _gather_25_type 1245
+#define _loop0_28_type 1246
+#define _gather_27_type 1247
+#define _tmp_29_type 1248
+#define _tmp_30_type 1249
+#define _loop0_31_type 1250
+#define _loop1_32_type 1251
+#define _loop0_34_type 1252
+#define _gather_33_type 1253
+#define _tmp_35_type 1254
+#define _loop0_37_type 1255
+#define _gather_36_type 1256
+#define _tmp_38_type 1257
+#define _loop0_40_type 1258
+#define _gather_39_type 1259
+#define _loop0_42_type 1260
+#define _gather_41_type 1261
+#define _loop0_44_type 1262
+#define _gather_43_type 1263
+#define _loop0_46_type 1264
+#define _gather_45_type 1265
+#define _tmp_47_type 1266
+#define _loop1_48_type 1267
+#define _tmp_49_type 1268
+#define _loop1_50_type 1269
+#define _loop0_52_type 1270
+#define _gather_51_type 1271
+#define _tmp_53_type 1272
+#define _tmp_54_type 1273
+#define _tmp_55_type 1274
+#define _tmp_56_type 1275
+#define _loop0_58_type 1276
+#define _gather_57_type 1277
+#define _loop0_60_type 1278
+#define _gather_59_type 1279
+#define _tmp_61_type 1280
+#define _loop0_63_type 1281
+#define _gather_62_type 1282
+#define _loop0_65_type 1283
+#define _gather_64_type 1284
+#define _tmp_66_type 1285
+#define _tmp_67_type 1286
+#define _tmp_68_type 1287
+#define _tmp_69_type 1288
+#define _loop0_70_type 1289
+#define _loop0_71_type 1290
+#define _loop0_72_type 1291
+#define _loop1_73_type 1292
+#define _loop0_74_type 1293
+#define _loop1_75_type 1294
+#define _loop1_76_type 1295
+#define _loop1_77_type 1296
+#define _loop0_78_type 1297
+#define _loop1_79_type 1298
+#define _loop0_80_type 1299
+#define _loop1_81_type 1300
+#define _loop0_82_type 1301
+#define _loop1_83_type 1302
+#define _loop1_84_type 1303
+#define _tmp_85_type 1304
+#define _loop1_86_type 1305
+#define _loop0_88_type 1306
+#define _gather_87_type 1307
+#define _loop1_89_type 1308
+#define _loop0_90_type 1309
+#define _loop0_91_type 1310
+#define _loop0_92_type 1311
+#define _loop1_93_type 1312
+#define _loop0_94_type 1313
+#define _loop1_95_type 1314
+#define _loop1_96_type 1315
+#define _loop1_97_type 1316
+#define _loop0_98_type 1317
+#define _loop1_99_type 1318
+#define _loop0_100_type 1319
+#define _loop1_101_type 1320
+#define _loop0_102_type 1321
+#define _loop1_103_type 1322
+#define _loop1_104_type 1323
+#define _loop1_105_type 1324
+#define _loop1_106_type 1325
+#define _tmp_107_type 1326
+#define _loop0_109_type 1327
+#define _gather_108_type 1328
+#define _tmp_110_type 1329
+#define _tmp_111_type 1330
+#define _tmp_112_type 1331
+#define _tmp_113_type 1332
+#define _loop1_114_type 1333
+#define _tmp_115_type 1334
+#define _tmp_116_type 1335
+#define _loop0_118_type 1336
+#define _gather_117_type 1337
+#define _loop1_119_type 1338
+#define _loop0_120_type 1339
+#define _loop0_121_type 1340
+#define _loop0_123_type 1341
+#define _gather_122_type 1342
+#define _tmp_124_type 1343
+#define _loop0_126_type 1344
+#define _gather_125_type 1345
+#define _loop0_128_type 1346
+#define _gather_127_type 1347
+#define _loop0_130_type 1348
+#define _gather_129_type 1349
+#define _loop0_132_type 1350
+#define _gather_131_type 1351
+#define _loop0_133_type 1352
+#define _loop0_135_type 1353
+#define _gather_134_type 1354
+#define _loop1_136_type 1355
+#define _tmp_137_type 1356
+#define _loop0_139_type 1357
+#define _gather_138_type 1358
+#define _loop0_141_type 1359
+#define _gather_140_type 1360
+#define _tmp_142_type 1361
+#define _tmp_143_type 1362
+#define _tmp_144_type 1363
+#define _tmp_145_type 1364
+#define _tmp_146_type 1365
+#define _loop0_147_type 1366
+#define _loop0_148_type 1367
+#define _loop0_149_type 1368
+#define _tmp_150_type 1369
+#define _tmp_151_type 1370
+#define _tmp_152_type 1371
+#define _tmp_153_type 1372
+#define _loop0_154_type 1373
+#define _loop1_155_type 1374
+#define _loop0_156_type 1375
+#define _loop1_157_type 1376
+#define _tmp_158_type 1377
+#define _tmp_159_type 1378
+#define _tmp_160_type 1379
+#define _loop0_162_type 1380
+#define _gather_161_type 1381
+#define _loop0_164_type 1382
+#define _gather_163_type 1383
+#define _loop0_166_type 1384
+#define _gather_165_type 1385
+#define _loop0_168_type 1386
+#define _gather_167_type 1387
+#define _tmp_169_type 1388
+#define _tmp_170_type 1389
+#define _tmp_171_type 1390
+#define _tmp_172_type 1391
+#define _tmp_173_type 1392
+#define _loop0_175_type 1393
+#define _gather_174_type 1394
+#define _tmp_176_type 1395
+#define _tmp_177_type 1396
+#define _tmp_178_type 1397
+#define _tmp_179_type 1398
+#define _tmp_180_type 1399
+#define _tmp_181_type 1400
+#define _tmp_182_type 1401
+#define _tmp_183_type 1402
+#define _tmp_184_type 1403
+#define _tmp_185_type 1404
+#define _tmp_186_type 1405
+#define _tmp_187_type 1406
+#define _tmp_188_type 1407
+#define _tmp_189_type 1408
+#define _tmp_190_type 1409
+#define _tmp_191_type 1410
+#define _tmp_192_type 1411
+#define _tmp_193_type 1412
+#define _tmp_194_type 1413
+#define _tmp_195_type 1414
+#define _tmp_196_type 1415
+#define _tmp_197_type 1416
+#define _tmp_198_type 1417
+#define _tmp_199_type 1418
+#define _tmp_200_type 1419
+#define _tmp_201_type 1420
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -542,6 +544,8 @@ static pattern_ty literal_pattern_rule(Parser *p);
 static expr_ty literal_expr_rule(Parser *p);
 static expr_ty complex_number_rule(Parser *p);
 static expr_ty signed_number_rule(Parser *p);
+static expr_ty signed_real_number_rule(Parser *p);
+static expr_ty real_number_rule(Parser *p);
 static expr_ty imaginary_number_rule(Parser *p);
 static pattern_ty capture_pattern_rule(Parser *p);
 static expr_ty pattern_capture_target_rule(Parser *p);
@@ -6318,7 +6322,9 @@ literal_expr_rule(Parser *p)
     return _res;
 }
 
-// complex_number: signed_number '+' imaginary_number | signed_number '-' imaginary_number
+// complex_number:
+//     | signed_real_number '+' imaginary_number
+//     | signed_real_number '-' imaginary_number
 static expr_ty
 complex_number_rule(Parser *p)
 {
@@ -6338,24 +6344,24 @@ complex_number_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
-    { // signed_number '+' imaginary_number
+    { // signed_real_number '+' imaginary_number
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number '+' imaginary_number"));
+        D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_real_number '+' imaginary_number"));
         Token * _literal;
         expr_ty imag;
         expr_ty real;
         if (
-            (real = signed_number_rule(p))  // signed_number
+            (real = signed_real_number_rule(p))  // signed_real_number
             &&
             (_literal = _PyPegen_expect_token(p, 14))  // token='+'
             &&
             (imag = imaginary_number_rule(p))  // imaginary_number
         )
         {
-            D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number '+' imaginary_number"));
+            D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_real_number '+' imaginary_number"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -6375,26 +6381,26 @@ complex_number_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s complex_number[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number '+' imaginary_number"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_real_number '+' imaginary_number"));
     }
-    { // signed_number '-' imaginary_number
+    { // signed_real_number '-' imaginary_number
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_number '-' imaginary_number"));
+        D(fprintf(stderr, "%*c> complex_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "signed_real_number '-' imaginary_number"));
         Token * _literal;
         expr_ty imag;
         expr_ty real;
         if (
-            (real = signed_number_rule(p))  // signed_number
+            (real = signed_real_number_rule(p))  // signed_real_number
             &&
             (_literal = _PyPegen_expect_token(p, 15))  // token='-'
             &&
             (imag = imaginary_number_rule(p))  // imaginary_number
         )
         {
-            D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_number '-' imaginary_number"));
+            D(fprintf(stderr, "%*c+ complex_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "signed_real_number '-' imaginary_number"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 D(p->level--);
@@ -6414,7 +6420,7 @@ complex_number_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s complex_number[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_number '-' imaginary_number"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "signed_real_number '-' imaginary_number"));
     }
     _res = NULL;
   done:
@@ -6496,6 +6502,128 @@ signed_number_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s signed_number[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'-' NUMBER"));
+    }
+    _res = NULL;
+  done:
+    D(p->level--);
+    return _res;
+}
+
+// signed_real_number: real_number | '-' real_number
+static expr_ty
+signed_real_number_rule(Parser *p)
+{
+    D(p->level++);
+    if (p->error_indicator) {
+        D(p->level--);
+        return NULL;
+    }
+    expr_ty _res = NULL;
+    int _mark = p->mark;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        D(p->level--);
+        return NULL;
+    }
+    int _start_lineno = p->tokens[_mark]->lineno;
+    UNUSED(_start_lineno); // Only used by EXTRA macro
+    int _start_col_offset = p->tokens[_mark]->col_offset;
+    UNUSED(_start_col_offset); // Only used by EXTRA macro
+    { // real_number
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> signed_real_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "real_number"));
+        expr_ty real_number_var;
+        if (
+            (real_number_var = real_number_rule(p))  // real_number
+        )
+        {
+            D(fprintf(stderr, "%*c+ signed_real_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "real_number"));
+            _res = real_number_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s signed_real_number[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "real_number"));
+    }
+    { // '-' real_number
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> signed_real_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'-' real_number"));
+        Token * _literal;
+        expr_ty real;
+        if (
+            (_literal = _PyPegen_expect_token(p, 15))  // token='-'
+            &&
+            (real = real_number_rule(p))  // real_number
+        )
+        {
+            D(fprintf(stderr, "%*c+ signed_real_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'-' real_number"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_UnaryOp ( USub , real , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s signed_real_number[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'-' real_number"));
+    }
+    _res = NULL;
+  done:
+    D(p->level--);
+    return _res;
+}
+
+// real_number: NUMBER
+static expr_ty
+real_number_rule(Parser *p)
+{
+    D(p->level++);
+    if (p->error_indicator) {
+        D(p->level--);
+        return NULL;
+    }
+    expr_ty _res = NULL;
+    int _mark = p->mark;
+    { // NUMBER
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> real_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NUMBER"));
+        expr_ty real;
+        if (
+            (real = _PyPegen_number_token(p))  // NUMBER
+        )
+        {
+            D(fprintf(stderr, "%*c+ real_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NUMBER"));
+            _res = _PyPegen_ensure_real ( p , real );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s real_number[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NUMBER"));
     }
     _res = NULL;
   done:

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -7663,18 +7663,13 @@ items_pattern_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> items_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.key_value_pattern+"));
-        asdl_seq * items;
+        asdl_seq * _gather_59_var;
         if (
-            (items = _gather_59_rule(p))  // ','.key_value_pattern+
+            (_gather_59_var = _gather_59_rule(p))  // ','.key_value_pattern+
         )
         {
             D(fprintf(stderr, "%*c+ items_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.key_value_pattern+"));
-            _res = items;
-            if (_res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                D(p->level--);
-                return NULL;
-            }
+            _res = _gather_59_var;
             goto done;
         }
         p->mark = _mark;
@@ -8049,18 +8044,13 @@ keyword_patterns_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> keyword_patterns[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "','.keyword_pattern+"));
-        asdl_seq* keywords;
+        asdl_seq * _gather_64_var;
         if (
-            (keywords = (asdl_seq*)_gather_64_rule(p))  // ','.keyword_pattern+
+            (_gather_64_var = _gather_64_rule(p))  // ','.keyword_pattern+
         )
         {
             D(fprintf(stderr, "%*c+ keyword_patterns[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "','.keyword_pattern+"));
-            _res = keywords;
-            if (_res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                D(p->level--);
-                return NULL;
-            }
+            _res = _gather_64_var;
             goto done;
         }
         p->mark = _mark;

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -2352,7 +2352,17 @@ expr_ty
 _PyPegen_ensure_imaginary(Parser *p, expr_ty exp)
 {
     if (exp->kind != Constant_kind || !PyComplex_CheckExact(exp->v.Constant.value)) {
-        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(exp, "Imaginary number required in complex literal");
+        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(exp, "imaginary number required in complex literal");
+        return NULL;
+    }
+    return exp;
+}
+
+expr_ty
+_PyPegen_ensure_real(Parser *p, expr_ty exp)
+{
+    if (exp->kind != Constant_kind || PyComplex_CheckExact(exp->v.Constant.value)) {
+        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(exp, "real number required in complex literal");
         return NULL;
     }
     return exp;

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -153,7 +153,7 @@ void * _PyPegen_seq_last_item(asdl_seq *seq);
 Py_LOCAL_INLINE(void *)
 RAISE_ERROR_KNOWN_LOCATION(Parser *p, PyObject *errtype,
                            Py_ssize_t lineno, Py_ssize_t col_offset,
-                           Py_ssize_t end_lineno, Py_ssize_t end_col_offset, 
+                           Py_ssize_t end_lineno, Py_ssize_t end_col_offset,
                            const char *errmsg, ...)
 {
     va_list va;
@@ -284,6 +284,7 @@ expr_ty _PyPegen_collect_call_seqs(Parser *, asdl_expr_seq *, asdl_seq *,
                      int end_col_offset, PyArena *arena);
 expr_ty _PyPegen_concatenate_strings(Parser *p, asdl_seq *);
 expr_ty _PyPegen_ensure_imaginary(Parser *p, expr_ty);
+expr_ty _PyPegen_ensure_real(Parser *p, expr_ty);
 asdl_seq *_PyPegen_join_sequences(Parser *, asdl_seq *, asdl_seq *);
 int _PyPegen_check_barry_as_flufl(Parser *, Token *);
 mod_ty _PyPegen_make_module(Parser *, asdl_stmt_seq *);

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -825,7 +825,7 @@ astfold_pattern(pattern_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
             break;
         case MatchAs_kind:
             if (node_->v.MatchAs.pattern) {
-                CALL(astfold_pattern, expr_ty, node_->v.MatchAs.pattern);
+                CALL(astfold_pattern, pattern_ty, node_->v.MatchAs.pattern);
             }
             break;
         case MatchOr_kind:

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6188,7 +6188,7 @@ compiler_pattern_value(struct compiler *c, pattern_ty p, pattern_context *pc)
 }
 
 static int
-compiler_pattern_constant(struct compiler *c, pattern_ty p, pattern_context *pc)
+compiler_pattern_singleton(struct compiler *c, pattern_ty p, pattern_context *pc)
 {
     assert(p->kind == MatchSingleton_kind);
     ADDOP_LOAD_CONST(c, p->v.MatchSingleton.value);
@@ -6204,7 +6204,7 @@ compiler_pattern(struct compiler *c, pattern_ty p, pattern_context *pc)
         case MatchValue_kind:
             return compiler_pattern_value(c, p, pc);
         case MatchSingleton_kind:
-            return compiler_pattern_constant(c, p, pc);
+            return compiler_pattern_singleton(c, p, pc);
         case MatchSequence_kind:
             return compiler_pattern_sequence(c, p, pc);
         case MatchMapping_kind:

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5609,6 +5609,10 @@ compiler_slice(struct compiler *c, expr_ty s)
 static int
 pattern_helper_store_name(struct compiler *c, identifier n, pattern_context *pc)
 {
+    if (n == NULL) {
+        ADDOP(c, POP_TOP);
+        return 1;
+    }
     if (forbidden_name(c, n, Store)) {
         return 0;
     }
@@ -5783,41 +5787,22 @@ compiler_pattern_subpattern(struct compiler *c, pattern_ty p, pattern_context *p
 }
 
 static int
-compiler_pattern_capture(struct compiler *c, identifier n, pattern_context *pc)
-{
-    RETURN_IF_FALSE(pattern_helper_store_name(c, n, pc));
-    ADDOP_LOAD_CONST(c, Py_True);
-    return 1;
-}
-
-static int
-compiler_pattern_wildcard(struct compiler *c, pattern_ty p, pattern_context *pc)
-{
-    assert(p->kind == MatchAs_kind);
-    if (!pc->allow_irrefutable) {
-        // Whoops, can't have a wildcard here!
-        const char *e = "wildcard makes remaining patterns unreachable";
-        return compiler_error(c, e);
-    }
-    ADDOP(c, POP_TOP);
-    ADDOP_LOAD_CONST(c, Py_True);
-    return 1;
-}
-
-static int
 compiler_pattern_as(struct compiler *c, pattern_ty p, pattern_context *pc)
 {
     assert(p->kind == MatchAs_kind);
-    if (p->v.MatchAs.name == NULL) {
-        return compiler_pattern_wildcard(c, p, pc);
-    }
     if (p->v.MatchAs.pattern == NULL) {
+        // An irrefutable match:
         if (!pc->allow_irrefutable) {
-            // Whoops, can't have a name capture here!
-            const char *e = "name capture %R makes remaining patterns unreachable";
-            return compiler_error(c, e, p->v.MatchAs.name);
+            if (p->v.MatchAs.name) {
+                const char *e = "name capture %R makes remaining patterns unreachable";
+                return compiler_error(c, e, p->v.MatchAs.name);
+            }
+            const char *e = "wildcard makes remaining patterns unreachable";
+            return compiler_error(c, e);
         }
-        return compiler_pattern_capture(c, p->v.MatchAs.name, pc);
+        RETURN_IF_FALSE(pattern_helper_store_name(c, p->v.MatchAs.name, pc));
+        ADDOP_LOAD_CONST(c, Py_True);
+        return 1;
     }
     basicblock *end, *fail_pop_1;
     RETURN_IF_FALSE(end = compiler_new_block(c));
@@ -5842,12 +5827,9 @@ static int
 compiler_pattern_star(struct compiler *c, pattern_ty p, pattern_context *pc)
 {
     assert(p->kind == MatchStar_kind);
-    if (!pc->allow_irrefutable) {
-        // Whoops, can't have a star capture here!
-        const char *e = "star captures are only allowed as part of sequence patterns";
-        return compiler_error(c, e);
-    }
-    return compiler_pattern_capture(c, p->v.MatchStar.name, pc);
+    RETURN_IF_FALSE(pattern_helper_store_name(c, p->v.MatchStar.name, pc));
+    ADDOP_LOAD_CONST(c, Py_True);
+    return 1;
 }
 
 static int


### PR DESCRIPTION
This fixes validation of complex literal value patterns in the parser and factors out the old `compiler_pattern_capture` and `compiler_pattern_wildcard` routines to better match the current AST.

(A few other cleanups, too.)


<!-- issue-number: [bpo-43892](https://bugs.python.org/issue43892) -->
https://bugs.python.org/issue43892
<!-- /issue-number -->
