### PR TITLE
bpo-43908: check_set_special_type_attr() and type_set_annotations() now check for immutable flag

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4763,12 +4763,14 @@ order (MRO) for bases """
             "elephant"
         X.__doc__ = "banana"
         self.assertEqual(X.__doc__, "banana")
+
         with self.assertRaises(TypeError) as cm:
             type(list).__dict__["__doc__"].__set__(list, "blah")
-        self.assertIn("can't set list.__doc__", str(cm.exception))
+        self.assertIn("cannot set '__doc__' attribute of immutable type 'list'", str(cm.exception))
+
         with self.assertRaises(TypeError) as cm:
             type(X).__dict__["__doc__"].__delete__(X)
-        self.assertIn("can't delete X.__doc__", str(cm.exception))
+        self.assertIn("cannot delete '__doc__' attribute of immutable type 'X'", str(cm.exception))
         self.assertEqual(X.__doc__, "banana")
 
     def test_qualname(self):

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -463,12 +463,14 @@ check_set_special_type_attr(PyTypeObject *type, PyObject *value, const char *nam
 {
     if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_Format(PyExc_TypeError,
-                     "can't set '%r' attribute of immutable type %s", name, type->tp_name);
+                     "cannot set '%r' attribute of immutable type '%s'",
+                     name, type->tp_name);
         return 0;
     }
     if (!value) {
         PyErr_Format(PyExc_TypeError,
-                     "can't delete %s.%s", type->tp_name, name);
+                     "cannot delete '%r' attribute of immutable type '%s'",
+                     name, type->tp_name);
         return 0;
     }
 
@@ -974,7 +976,9 @@ static int
 type_set_annotations(PyTypeObject *type, PyObject *value, void *context)
 {
     if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
-        PyErr_Format(PyExc_TypeError, "can't set attributes of built-in/extension type '%s'", type->tp_name);
+        PyErr_Format(PyExc_TypeError,
+                     "cannot set '__annotations__' attribute of immutable type '%s'",
+                     type->tp_name);
         return -1;
     }
 
@@ -3947,7 +3951,7 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
     if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
         PyErr_Format(
             PyExc_TypeError,
-            "can't set attributes of built-in/extension type '%s'",
+            "cannot set attributes of immutable type '%s'",
             type->tp_name);
         return -1;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -463,13 +463,13 @@ check_set_special_type_attr(PyTypeObject *type, PyObject *value, const char *nam
 {
     if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot set '%R' attribute of immutable type '%s'",
+                     "cannot set %R attribute of immutable type '%s'",
                      name, type->tp_name);
         return 0;
     }
     if (!value) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot delete '%R' attribute of immutable type '%s'",
+                     "cannot delete %R attribute of immutable type '%s'",
                      name, type->tp_name);
         return 0;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -463,13 +463,13 @@ check_set_special_type_attr(PyTypeObject *type, PyObject *value, const char *nam
 {
     if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot set %R attribute of immutable type '%s'",
+                     "cannot set '%s' attribute of immutable type '%s'",
                      name, type->tp_name);
         return 0;
     }
     if (!value) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot delete %R attribute of immutable type '%s'",
+                     "cannot delete '%s' attribute of immutable type '%s'",
                      name, type->tp_name);
         return 0;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -973,7 +973,7 @@ type_get_annotations(PyTypeObject *type, void *context)
 static int
 type_set_annotations(PyTypeObject *type, PyObject *value, void *context)
 {
-    if (!(type->tp_flags & Py_TPFLAGS_HEAPTYPE)) {
+    if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_Format(PyExc_TypeError, "can't set attributes of built-in/extension type '%s'", type->tp_name);
         return -1;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -461,7 +461,7 @@ static PyMemberDef type_members[] = {
 static int
 check_set_special_type_attr(PyTypeObject *type, PyObject *value, const char *name)
 {
-    if (!(type->tp_flags & Py_TPFLAGS_HEAPTYPE)) {
+    if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_Format(PyExc_TypeError,
                      "can't set %s.%s", type->tp_name, name);
         return 0;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -463,13 +463,13 @@ check_set_special_type_attr(PyTypeObject *type, PyObject *value, const char *nam
 {
     if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot set '%r' attribute of immutable type '%s'",
+                     "cannot set '%R' attribute of immutable type '%s'",
                      name, type->tp_name);
         return 0;
     }
     if (!value) {
         PyErr_Format(PyExc_TypeError,
-                     "cannot delete '%r' attribute of immutable type '%s'",
+                     "cannot delete '%R' attribute of immutable type '%s'",
                      name, type->tp_name);
         return 0;
     }
@@ -3951,8 +3951,8 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
     if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
         PyErr_Format(
             PyExc_TypeError,
-            "cannot set attributes of immutable type '%s'",
-            type->tp_name);
+            "cannot set '%R' attribute of immutable type '%s'",
+            name, type->tp_name);
         return -1;
     }
     if (PyUnicode_Check(name)) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3951,7 +3951,7 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
     if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
         PyErr_Format(
             PyExc_TypeError,
-            "cannot set '%R' attribute of immutable type '%s'",
+            "cannot set %R attribute of immutable type '%s'",
             name, type->tp_name);
         return -1;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -463,7 +463,7 @@ check_set_special_type_attr(PyTypeObject *type, PyObject *value, const char *nam
 {
     if (_PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE)) {
         PyErr_Format(PyExc_TypeError,
-                     "can't set %s.%s", type->tp_name, name);
+                     "can't set '%r' attribute of immutable type %s", name, type->tp_name);
         return 0;
     }
     if (!value) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43908](https://bugs.python.org/issue43908) -->
https://bugs.python.org/issue43908
<!-- /issue-number -->
