### PR TITLE
bpo-43916: Remove _disabled_new() function

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -905,11 +905,11 @@ class HashLibTestCase(unittest.TestCase):
     def test_internal_types(self):
         # internal types like _hashlib.HASH are not constructable
         with self.assertRaisesRegex(
-            TypeError, "cannot create 'HASH' instance"
+            TypeError, "cannot create '_hashlib.HASH' instance"
         ):
             HASH()
         with self.assertRaisesRegex(
-            TypeError, "cannot create 'HASHXOF' instance"
+            TypeError, "cannot create '_hashlib.HASHXOF' instance"
         ):
             HASHXOF()
 

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -440,7 +440,7 @@ class ConstructorTestCase(unittest.TestCase):
     def test_internal_types(self):
         # internal types like _hashlib.C_HMAC are not constructable
         with self.assertRaisesRegex(
-            TypeError, "cannot create 'HMAC' instance"
+            TypeError, "cannot create '_hashlib.HMAC' instance"
         ):
             C_HMAC()
 

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -118,15 +118,6 @@ _setException(PyObject *exc)
 }
 /* LCOV_EXCL_STOP */
 
-/* {Py_tp_new, NULL} doesn't block __new__ */
-static PyObject *
-_disabled_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
-{
-    PyErr_Format(PyExc_TypeError,
-        "cannot create '%.100s' instances", _PyType_Name(type));
-    return NULL;
-}
-
 static PyObject*
 py_digest_name(const EVP_MD *md)
 {
@@ -590,7 +581,6 @@ static PyType_Slot EVPtype_slots[] = {
     {Py_tp_doc, (char *)hashtype_doc},
     {Py_tp_methods, EVP_methods},
     {Py_tp_getset, EVP_getseters},
-    {Py_tp_new, _disabled_new},
     {0, 0},
 };
 
@@ -598,7 +588,7 @@ static PyType_Spec EVPtype_spec = {
     "_hashlib.HASH",    /*tp_name*/
     sizeof(EVPobject),  /*tp_basicsize*/
     0,                  /*tp_itemsize*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     EVPtype_slots
 };
 
@@ -740,7 +730,6 @@ static PyType_Slot EVPXOFtype_slots[] = {
     {Py_tp_doc, (char *)hashxoftype_doc},
     {Py_tp_methods, EVPXOF_methods},
     {Py_tp_getset, EVPXOF_getseters},
-    {Py_tp_new, _disabled_new},
     {0, 0},
 };
 
@@ -748,7 +737,7 @@ static PyType_Spec EVPXOFtype_spec = {
     "_hashlib.HASHXOF",    /*tp_name*/
     sizeof(EVPobject),  /*tp_basicsize*/
     0,                  /*tp_itemsize*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     EVPXOFtype_slots
 };
 
@@ -1734,14 +1723,13 @@ static PyType_Slot HMACtype_slots[] = {
     {Py_tp_dealloc,(destructor)_hmac_dealloc},
     {Py_tp_methods, HMAC_methods},
     {Py_tp_getset, HMAC_getset},
-    {Py_tp_new, _disabled_new},
     {0, NULL}
 };
 
 PyType_Spec HMACtype_spec = {
     "_hashlib.HMAC",    /* name */
     sizeof(HMACobject),     /* basicsize */
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = HMACtype_slots,
 };
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -13415,14 +13415,6 @@ typedef struct {
 #endif
 } DirEntry;
 
-static PyObject *
-_disabled_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
-{
-    PyErr_Format(PyExc_TypeError,
-        "cannot create '%.100s' instances", _PyType_Name(type));
-    return NULL;
-}
-
 static void
 DirEntry_dealloc(DirEntry *entry)
 {
@@ -13781,7 +13773,6 @@ static PyMethodDef DirEntry_methods[] = {
 };
 
 static PyType_Slot DirEntryType_slots[] = {
-    {Py_tp_new, _disabled_new},
     {Py_tp_dealloc, DirEntry_dealloc},
     {Py_tp_repr, DirEntry_repr},
     {Py_tp_methods, DirEntry_methods},
@@ -13793,7 +13784,7 @@ static PyType_Spec DirEntryType_spec = {
     MODNAME ".DirEntry",
     sizeof(DirEntry),
     0,
-    Py_TPFLAGS_DEFAULT,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     DirEntryType_slots
 };
 
@@ -14213,7 +14204,6 @@ static PyMethodDef ScandirIterator_methods[] = {
 };
 
 static PyType_Slot ScandirIteratorType_slots[] = {
-    {Py_tp_new, _disabled_new},
     {Py_tp_dealloc, ScandirIterator_dealloc},
     {Py_tp_finalize, ScandirIterator_finalize},
     {Py_tp_iter, PyObject_SelfIter},
@@ -14228,7 +14218,8 @@ static PyType_Spec ScandirIteratorType_spec = {
     0,
     // bpo-40549: Py_TPFLAGS_BASETYPE should not be used, since
     // PyType_GetModule(Py_TYPE(self)) doesn't work on a subclass instance.
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_FINALIZE,
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_FINALIZE
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     ScandirIteratorType_slots
 };
 


### PR DESCRIPTION
Use the new Py_TPFLAGS_DISALLOW_INSTANTIATION flag on posix and
_hashlib types.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43916](https://bugs.python.org/issue43916) -->
https://bugs.python.org/issue43916
<!-- /issue-number -->
