### PR TITLE
bpo-43916: Select now uses Py_TPFLAGS_DISALLOW_INSTANTIATION

### DIFF
--- a/Lib/test/test_select.py
+++ b/Lib/test/test_select.py
@@ -87,6 +87,10 @@ class SelectTestCase(unittest.TestCase):
         a[:] = [F()] * 10
         self.assertEqual(select.select([], a, []), ([], a[:5], []))
 
+    def test_disallow_instantiation(self):
+        tp = type(select.poll())
+        self.assertRaises(TypeError, tp)
+
 def tearDownModule():
     support.reap_children()
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -728,13 +728,6 @@ newPollObject(PyObject *module)
     return self;
 }
 
-static PyObject *
-poll_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
-{
-    PyErr_Format(PyExc_TypeError, "Cannot create '%.200s' instances", _PyType_Name(type));
-    return NULL;
-}
-
 static void
 poll_dealloc(pollObject *self)
 {
@@ -2275,16 +2268,14 @@ static PyMethodDef poll_methods[] = {
 static PyType_Slot poll_Type_slots[] = {
     {Py_tp_dealloc, poll_dealloc},
     {Py_tp_methods, poll_methods},
-    {Py_tp_new, poll_new},
     {0, 0},
 };
 
 static PyType_Spec poll_Type_spec = {
-    "select.poll",
-    sizeof(pollObject),
-    0,
-    Py_TPFLAGS_DEFAULT,
-    poll_Type_slots
+    .name = "select.poll",
+    .basicsize = sizeof(pollObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = poll_Type_slots,
 };
 
 #ifdef HAVE_SYS_DEVPOLL_H


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43916](https://bugs.python.org/issue43916) -->
https://bugs.python.org/issue43916
<!-- /issue-number -->
