### PR TITLE
bpo-43916: select.devpoll uses Py_TPFLAGS_DISALLOW_INSTANTIATION

### DIFF
--- a/Lib/test/test_select.py
+++ b/Lib/test/test_select.py
@@ -91,6 +91,10 @@ class SelectTestCase(unittest.TestCase):
         tp = type(select.poll())
         self.assertRaises(TypeError, tp)
 
+        if hasattr(select, 'devpoll'):
+            tp = type(select.devpoll())
+            self.assertRaises(TypeError, tp)
+
 def tearDownModule():
     support.reap_children()
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1110,13 +1110,6 @@ newDevPollObject(PyObject *module)
     return self;
 }
 
-static PyObject *
-devpoll_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
-{
-    PyErr_Format(PyExc_TypeError, "Cannot create '%.200s' instances", _PyType_Name(type));
-    return NULL;
-}
-
 static void
 devpoll_dealloc(devpollObject *self)
 {
@@ -1131,7 +1124,6 @@ static PyType_Slot devpoll_Type_slots[] = {
     {Py_tp_dealloc, devpoll_dealloc},
     {Py_tp_getset, devpoll_getsetlist},
     {Py_tp_methods, devpoll_methods},
-    {Py_tp_new, devpoll_new},
     {0, 0},
 };
 
@@ -1139,7 +1131,7 @@ static PyType_Spec devpoll_Type_spec = {
     "select.devpoll",
     sizeof(devpollObject),
     0,
-    Py_TPFLAGS_DEFAULT,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     devpoll_Type_slots
 };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43916](https://bugs.python.org/issue43916) -->
https://bugs.python.org/issue43916
<!-- /issue-number -->
