### PR TITLE
bpo-43901: Upgrade test to use cool  module reloading tech.

### DIFF
--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -2,6 +2,7 @@
 import unittest
 import weakref
 from test.support import gc_collect
+from test.support import import_helper
 from test.support.script_helper import assert_python_ok
 
 import sys
@@ -334,10 +335,11 @@ a = A(destroyed)"""
             del foo.__annotations__
 
     def test_annotations_are_created_correctly(self):
-        from test import ann_module4
-        self.assertTrue("__annotations__" in ann_module4.__dict__)
-        del ann_module4.__annotations__
-        self.assertFalse("__annotations__" in ann_module4.__dict__)
+        for i in range(3):
+            ann_module4 = import_helper.import_fresh_module("test.ann_module4")
+            self.assertTrue("__annotations__" in ann_module4.__dict__)
+            del ann_module4.__annotations__
+            self.assertFalse("__annotations__" in ann_module4.__dict__)
 
 
     # frozen and namespace module reprs are tested in importlib.


### PR DESCRIPTION
One of my new tests is broken on the Windows buildbot.  Pablo suggested I modify the test to use `import_helper.import_fresh_module()`, so... here goes!

<!-- issue-number: [bpo-43901](https://bugs.python.org/issue43901) -->
https://bugs.python.org/issue43901
<!-- /issue-number -->
