### PR TITLE
bpo-43916: _md5.md5 uses Py_TPFLAGS_DISALLOW_INSTANTIATION

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -901,8 +901,39 @@ class HashLibTestCase(unittest.TestCase):
         if fips_mode is not None:
             self.assertIsInstance(fips_mode, int)
 
+    def test_disallow_instanciation(self):
+        constructors = []
+        try:
+            import _md5
+            constructors.append(_md5.md5)
+        except ImportError:
+            pass
+        try:
+            import _sha1
+            constructors.append(_sha1.sha1)
+        except ImportError:
+            pass
+        try:
+            import _sha256
+            constructors.append(_sha256.sha224)
+            constructors.append(_sha256.sha256)
+        except ImportError:
+            pass
+        try:
+            import _sha512
+            constructors.append(_sha512.sha384)
+            constructors.append(_sha512.sha512)
+        except ImportError:
+            pass
+
+        for constructor in constructors:
+            h = constructor()
+            with self.subTest(constructor=constructor):
+                hash_type = type(h)
+                self.assertRaises(TypeError, hash_type)
+
     @unittest.skipUnless(HASH is not None, 'need _hashlib')
-    def test_internal_types(self):
+    def test_hash_disallow_instanciation(self):
         # internal types like _hashlib.HASH are not constructable
         with self.assertRaisesRegex(
             TypeError, "cannot create '_hashlib.HASH' instance"

--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -484,7 +484,7 @@ static PyType_Slot md5_type_slots[] = {
 static PyType_Spec md5_type_spec = {
     .name = "_md5.md5",
     .basicsize =  sizeof(MD5object),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = md5_type_slots
 };
 

--- a/Modules/sha1module.c
+++ b/Modules/sha1module.c
@@ -462,7 +462,7 @@ static PyType_Slot sha1_type_slots[] = {
 static PyType_Spec sha1_type_spec = {
     .name = "_sha1.sha1",
     .basicsize =  sizeof(SHA1object),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = sha1_type_slots
 };
 
@@ -554,7 +554,7 @@ _sha1_exec(PyObject *module)
     }
 
     Py_INCREF(st->sha1_type);
-    if (PyModule_AddObject(module, 
+    if (PyModule_AddObject(module,
                            "SHA1Type",
                            (PyObject *)st->sha1_type) < 0) {
         Py_DECREF(st->sha1_type);

--- a/Modules/sha256module.c
+++ b/Modules/sha256module.c
@@ -544,14 +544,14 @@ static PyType_Slot sha256_types_slots[] = {
 static PyType_Spec sha224_type_spec = {
     .name = "_sha256.sha224",
     .basicsize = sizeof(SHAobject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = sha256_types_slots
 };
 
 static PyType_Spec sha256_type_spec = {
     .name = "_sha256.sha256",
     .basicsize = sizeof(SHAobject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = sha256_types_slots
 };
 

--- a/Modules/sha512module.c
+++ b/Modules/sha512module.c
@@ -602,7 +602,7 @@ static PyType_Slot sha512_sha384_type_slots[] = {
 static PyType_Spec sha512_sha384_type_spec = {
     .name = "_sha512.sha384",
     .basicsize =  sizeof(SHAobject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = sha512_sha384_type_slots
 };
 
@@ -619,7 +619,7 @@ static PyType_Slot sha512_sha512_type_slots[] = {
 static PyType_Spec sha512_sha512_type_spec = {
     .name = "_sha512.sha512",
     .basicsize =  sizeof(SHAobject),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = sha512_sha512_type_slots
 };
 


### PR DESCRIPTION
The following types use Py_TPFLAGS_DISALLOW_INSTANTIATION flag:

* _md5.md5
* _sha1.sha1
* _sha256.sha224
* _sha256.sha256
* _sha512.sha384
* _sha512.sha512

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43916](https://bugs.python.org/issue43916) -->
https://bugs.python.org/issue43916
<!-- /issue-number -->
