### PR TITLE
[3.8] bpo-42589: Change URL for 'from' link when used in a raised exc…

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -42,12 +42,12 @@ include the originating exception(s) and the final exception.
 
 When raising a new exception (rather than using a bare ``raise`` to re-raise
 the exception currently being handled), the implicit exception context can be
-supplemented with an explicit cause by using :keyword:`from` with
+supplemented with an explicit cause by using :keyword:`from<raise>` with
 :keyword:`raise`::
 
    raise new_exc from original_exc
 
-The expression following :keyword:`from` must be an exception or ``None``. It
+The expression following :keyword:`from<raise>` must be an exception or ``None``. It
 will be set as :attr:`__cause__` on the raised exception. Setting
 :attr:`__cause__` also implicitly sets the :attr:`__suppress_context__`
 attribute to ``True``, so that using ``raise new_exc from None``


### PR DESCRIPTION
…eption (GH-23872)

Links for 'raise Exception from x' target to 'The raise statement' (7.8) section instead of 'The import statement' (7.11) section.

There are more modified links than in the bug report because I searched some other ones which can get the same improvement..
(cherry picked from commit 2fd928c8c1328424130cb9c51fc02ad5f9a66328)

This PR is a cherry pick to python 3.8 from https://github.com/python/cpython/pull/23872. The fix was the removal of the change in the other file because the fixed section was introduced in 3.9. So the file does not need to be fixed in 3.8.


Co-authored-by: sblondon <sblondon@users.noreply.github.com>


<!-- issue-number: [bpo-42589](https://bugs.python.org/issue42589) -->
https://bugs.python.org/issue42589
<!-- /issue-number -->

Automerge-Triggered-By: GH:Mariatta