### PR TITLE
Fix broken name in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
       run: xvfb-run make buildbottest TESTOPTS="-j4 -uall,-cpu"
 
   build_ubuntu_ssltests:
-    name: 'Ubuntu SSL tests with OpenSSL ${{ matrix.openssl_ver }}'
+    name: 'Ubuntu SSL tests with OpenSSL'
     runs-on: ubuntu-20.04
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true' && needs.check_source.outputs.run_ssl_tests == 'true'


### PR DESCRIPTION
This check is skipped for most PRs. When skipped, the job currently displays as `Ubuntu SSL tests with OpenSSL ${{ matrix.openssl_ver }}` (since the matrix is not actually populated, interpolating the name fails).

This changes the display name to just `Ubuntu SSL tests with OpenSSL`. For PRs that don't skip the check, GitHub automatically adds the value of `matrix.openssl_ver` to the job name (as you can see below).