### PR TITLE
bpo-22167: Updated glob.iglob doc with details on memory use

### DIFF
--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -80,8 +80,12 @@ For example, ``'[?]'`` matches the character ``'?'``.
 
 .. function:: iglob(pathname, *, root_dir=None, dir_fd=None, recursive=False)
 
-   Return an :term:`iterator` which yields the same values as :func:`glob`
-   without actually storing them all simultaneously.
+   Return an :term:`iterator` which yields the same values as :func:`glob.glob` without
+   actually storing them all simultaneously. Internally, :func:`iglob` uses
+   :func:`os.listdir` which may result in large amount of memory being consumed if a
+   single directory contains a large number of files. Unlike :func:`glob.glob`, the case
+   with large number of subdirectories but with small number of files per each
+   subdirectory, should not result in large amount of memory consumption.
 
    .. audit-event:: glob.glob pathname,recursive glob.iglob
    .. audit-event:: glob.glob/2 pathname,recursive,root_dir,dir_fd glob.iglob

--- a/Misc/NEWS.d/next/Documentation/2021-05-01-00-08-04.bpo-22167.2i15sR.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-05-01-00-08-04.bpo-22167.2i15sR.rst
@@ -1,0 +1,1 @@
+:func:`glob.iglob` documentation updated with details on memory use.


### PR DESCRIPTION
(also fixed the link to `glob.glob()` in the same paragraph.)

<!-- issue-number: [bpo-22167](https://bugs.python.org/issue22167) -->
https://bugs.python.org/issue22167
<!-- /issue-number -->
