### PR TITLE
bpo-43989: Add signal format specifier for unix_events.py

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -126,7 +126,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                     logger.info('set_wakeup_fd(-1) failed: %s', nexc)
 
             if exc.errno == errno.EINVAL:
-                raise RuntimeError(f'sig {sig} cannot be caught')
+                raise RuntimeError(f'sig {sig:d} cannot be caught')
             else:
                 raise
 
@@ -160,7 +160,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
             signal.signal(sig, handler)
         except OSError as exc:
             if exc.errno == errno.EINVAL:
-                raise RuntimeError(f'sig {sig} cannot be caught')
+                raise RuntimeError(f'sig {sig:d} cannot be caught')
             else:
                 raise
 


### PR DESCRIPTION
This adds a format specifier for `IntEnum` so that we can avoid 3.12 deprecation warning.

I'm a new contributor so any extra comments/suggestions are welcome :smile: 

<!-- issue-number: [bpo-43989](https://bugs.python.org/issue43989) -->
https://bugs.python.org/issue43989
<!-- /issue-number -->
