### PR TITLE
bpo-43989: Temporarily disable warnings in ssltests (GH-25780)

### DIFF
--- a/Lib/test/ssltests.py
+++ b/Lib/test/ssltests.py
@@ -16,7 +16,7 @@ def run_regrtests(*extra_args):
     print(ssl.OPENSSL_VERSION)
     args = [
         sys.executable,
-        '-Werror', '-bb',  # turn warnings into exceptions
+        # '-Werror', '-bb',  # turn warnings into exceptions
         '-m', 'test',
     ]
     if not extra_args:


### PR DESCRIPTION
-Werror is currently broken.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43989](https://bugs.python.org/issue43989) -->
https://bugs.python.org/issue43989
<!-- /issue-number -->
