### PR TITLE
bpo-43733: netrc try to use UTF-8 before using locale encoding.

### DIFF
--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -38,6 +38,10 @@ the Unix :program:`ftp` program and other FTP clients.
       :func:`os.path.expanduser` is used to find the location of the
       :file:`.netrc` file when *file* is not passed as argument.
 
+   .. versionchanged:: 3.10
+      :class:`netrc` try UTF-8 encoding before using locale specific
+      encoding.
+
 
 .. exception:: NetrcParseError
 

--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -26,8 +26,12 @@ class netrc:
             file = os.path.join(os.path.expanduser("~"), ".netrc")
         self.hosts = {}
         self.macros = {}
-        with open(file) as fp:
-            self._parse(file, fp, default_netrc)
+        try:
+            with open(file, encoding="utf-8") as fp:
+                self._parse(file, fp, default_netrc)
+        except UnicodeDecodeError:
+            with open(file, encoding="locale") as fp:
+                self._parse(file, fp, default_netrc)
 
     def _parse(self, file, fp, default_netrc):
         lexer = shlex.shlex(fp)

--- a/Misc/NEWS.d/next/Library/2021-05-01-22-59-20.bpo-43733.gJWwEQ.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-01-22-59-20.bpo-43733.gJWwEQ.rst
@@ -1,0 +1,2 @@
+Change :class:`netrc.netrc` to use UTF-8 encoding before using locale
+encoding.


### PR DESCRIPTION


<!-- issue-number: [bpo-43733](https://bugs.python.org/issue43733) -->
https://bugs.python.org/issue43733
<!-- /issue-number -->
