### PR TITLE
bpo-41129: Fix check for macOS SDK paths when building Python

### DIFF
--- a/Misc/NEWS.d/next/macOS/2021-05-02-21-03-27.bpo-42119.Y7BSX_.rst
+++ b/Misc/NEWS.d/next/macOS/2021-05-02-21-03-27.bpo-42119.Y7BSX_.rst
@@ -1,0 +1,7 @@
+Fix check for macOS SDK paths when building Python. Narrow search to match
+contents of SDKs, namely only files in ``/System/Library``,
+``/System/IOSSupport``, and ``/usr`` other than ``/usr/local``. Previously,
+anything under ``/System`` was assumed to be in an SDK which causes problems
+with the new file system layout in 10.15+ where user file systems may appear
+to be mounted under ``/System``.  Paths in ``/Library`` were also
+incorrectly treated as SDK locations.

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,9 @@ def is_macosx_sdk_path(path):
     Returns True if 'path' can be located in an OSX SDK
     """
     return ( (path.startswith('/usr/') and not path.startswith('/usr/local'))
-                or path.startswith('/System/')
+                or (path.startswith('/System/') and not path.startswith('/System/Volumes/Data'))
+                or path.startswith('/System/Library')
+                or path.startswith('/System/iOSSupport')
                 or path.startswith('/Library/') )
 
 

--- a/setup.py
+++ b/setup.py
@@ -227,13 +227,11 @@ def macosx_sdk_specified():
 
 def is_macosx_sdk_path(path):
     """
-    Returns True if 'path' can be located in an OSX SDK
+    Returns True if 'path' can be located in a macOS SDK
     """
     return ( (path.startswith('/usr/') and not path.startswith('/usr/local'))
-                or (path.startswith('/System/') and not path.startswith('/System/Volumes/Data'))
                 or path.startswith('/System/Library')
-                or path.startswith('/System/iOSSupport')
-                or path.startswith('/Library/') )
+                or path.startswith('/System/iOSSupport') )
 
 
 def grep_headers_for(function, headers):


### PR DESCRIPTION
Catalina puts files in /System/Volumes/Data, so the CPython sources can
be there.  setup.py shouldn't assume /System means SDK files.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-41129](https://bugs.python.org/issue41129) -->
https://bugs.python.org/issue41129
<!-- /issue-number -->
