### PR TITLE
Revert "bpo-43989: Temporarily disable warnings in ssltests (GH-25780)"

### DIFF
--- a/Lib/test/ssltests.py
+++ b/Lib/test/ssltests.py
@@ -16,7 +16,7 @@ def run_regrtests(*extra_args):
     print(ssl.OPENSSL_VERSION)
     args = [
         sys.executable,
-        # '-Werror', '-bb',  # turn warnings into exceptions
+        '-Werror', '-bb',  # turn warnings into exceptions
         '-m', 'test',
     ]
     if not extra_args:


### PR DESCRIPTION
Reverts python/cpython#25780

<!-- issue-number: [bpo-43989](https://bugs.python.org/issue43989) -->
https://bugs.python.org/issue43989
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran