### PR TITLE
bpo-44003: expose default args on the wrapped functools.lru_cache function

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -476,6 +476,8 @@ def _make_key(args, kwds, typed,
         return key[0]
     return _HashedSeq(key)
 
+_LRU_CACHE_WRAPPER_ASSIGNMENTS = frozenset(WRAPPER_ASSIGNMENTS).union(
+        ('__defaults__', '__kwdefaults__'))
 def lru_cache(maxsize=128, typed=False):
     """Least-recently-used cache decorator.
 
@@ -510,7 +512,7 @@ def lru_cache(maxsize=128, typed=False):
         user_function, maxsize = maxsize, 128
         wrapper = _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo)
         wrapper.cache_parameters = lambda : {'maxsize': maxsize, 'typed': typed}
-        return update_wrapper(wrapper, user_function)
+        return update_wrapper(wrapper, user_function, assigned=_LRU_CACHE_WRAPPER_ASSIGNMENTS)
     elif maxsize is not None:
         raise TypeError(
             'Expected first argument to be an integer, a callable, or None')
@@ -518,7 +520,7 @@ def lru_cache(maxsize=128, typed=False):
     def decorating_function(user_function):
         wrapper = _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo)
         wrapper.cache_parameters = lambda : {'maxsize': maxsize, 'typed': typed}
-        return update_wrapper(wrapper, user_function)
+        return update_wrapper(wrapper, user_function, assigned=_LRU_CACHE_WRAPPER_ASSIGNMENTS)
 
     return decorating_function
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1730,11 +1730,13 @@ class TestLRU:
 
     def test_lru_defaults_bug44003(self):
         @self.module.lru_cache(maxsize=None)
-        def func(arg='ARG', *, kw='KW'):
+        def func(arg='ARG', *, kw: str = 'KW'):
             return arg, kw
 
+        self.assertEqual(func.__wrapped__.__annotations__, {'kw': str})
         self.assertEqual(func.__wrapped__.__defaults__, ('ARG',))
         self.assertEqual(func.__wrapped__.__kwdefaults__, {'kw': 'KW'})
+        self.assertEqual(func.__annotations__, {'kw': str})
         self.assertEqual(func.__defaults__, ('ARG',))
         self.assertEqual(func.__kwdefaults__, {'kw': 'KW'})
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1728,6 +1728,16 @@ class TestLRU:
         for ref in refs:
             self.assertIsNone(ref())
 
+    def test_lru_defaults_bug44003(self):
+        @self.module.lru_cache(maxsize=None)
+        def func(arg='ARG', *, kw='KW'):
+            return arg, kw
+
+        self.assertEqual(func.__wrapped__.__defaults__, ('ARG',))
+        self.assertEqual(func.__wrapped__.__kwdefaults__, {'kw': 'KW'})
+        self.assertEqual(func.__defaults__, ('ARG',))
+        self.assertEqual(func.__kwdefaults__, {'kw': 'KW'})
+
 
 @py_functools.lru_cache()
 def py_cached_func(x, y):

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1208,8 +1208,7 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         }
         PyObject *attr = PyObject_GetAttr(func, attr_name);
         if (attr != NULL) {
-            int err = PyDict_SetItem(obj_dict, attr_name, attr);
-            if (err != 0) {
+            if (PyDict_SetItem(obj_dict, attr_name, attr) != 0) {
                 Py_DECREF(attr);
                 Py_DECREF(cachedict);
                 Py_DECREF(obj_dict);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1462,9 +1462,6 @@ _functools_exec(PyObject *module)
     {
         PyObject *tmp;
         PyObject *lru_attrs = state->lru_obj_attrs_to_clone;
-        if (lru_attrs == NULL) {
-            return -1;
-        }
         tmp = PyUnicode_InternFromString("__defaults__");
         if (tmp == NULL || PyTuple_SetItem(lru_attrs, 0, tmp) != 0) {
             return -1;

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -19,7 +19,7 @@ typedef struct _functools_state {
     PyTypeObject *partial_type;
     PyTypeObject *keyobject_type;
     PyTypeObject *lru_list_elem_type;
-    PyObject *list_of_lru_obj_attrs_to_clone;
+    PyObject *lru_obj_attrs_to_clone;
 } _functools_state;
 
 static inline _functools_state *
@@ -1198,9 +1198,9 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 
     /* Copy special attributes from the original function over to ours. */
     {
-        Py_ssize_t n_attrs = PyTuple_GET_SIZE(state->list_of_lru_obj_attrs_to_clone);
+        Py_ssize_t n_attrs = PyTuple_GET_SIZE(state->lru_obj_attrs_to_clone);
         for (Py_ssize_t idx = 0; idx < n_attrs; ++idx) {
-            PyObject *attr_name = PyTuple_GET_ITEM(state->list_of_lru_obj_attrs_to_clone, idx);
+            PyObject *attr_name = PyTuple_GET_ITEM(state->lru_obj_attrs_to_clone, idx);
             if (attr_name == NULL) {
                 Py_DECREF(cachedict);
                 Py_DECREF(obj_dict);
@@ -1457,13 +1457,13 @@ static int
 _functools_exec(PyObject *module)
 {
     _functools_state *state = get_functools_state(module);
-    state->list_of_lru_obj_attrs_to_clone = PyTuple_New(2);
-    if (state->list_of_lru_obj_attrs_to_clone == NULL) {
+    state->lru_obj_attrs_to_clone = PyTuple_New(2);
+    if (state->lru_obj_attrs_to_clone == NULL) {
         return -1;
     }
     {
         PyObject *tmp;
-        PyObject *lru_attrs = state->list_of_lru_obj_attrs_to_clone;
+        PyObject *lru_attrs = state->lru_obj_attrs_to_clone;
         if (lru_attrs == NULL) {
             return -1;
         }
@@ -1533,7 +1533,7 @@ _functools_traverse(PyObject *module, visitproc visit, void *arg)
     Py_VISIT(state->partial_type);
     Py_VISIT(state->keyobject_type);
     Py_VISIT(state->lru_list_elem_type);
-    Py_VISIT(state->list_of_lru_obj_attrs_to_clone);
+    Py_VISIT(state->lru_obj_attrs_to_clone);
     return 0;
 }
 
@@ -1545,7 +1545,7 @@ _functools_clear(PyObject *module)
     Py_CLEAR(state->partial_type);
     Py_CLEAR(state->keyobject_type);
     Py_CLEAR(state->lru_list_elem_type);
-    Py_CLEAR(state->list_of_lru_obj_attrs_to_clone);
+    Py_CLEAR(state->lru_obj_attrs_to_clone);
     return 0;
 }
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1463,15 +1463,13 @@ _functools_exec(PyObject *module)
         PyObject *tmp;
         PyObject *lru_attrs = state->lru_obj_attrs_to_clone;
         tmp = PyUnicode_InternFromString("__defaults__");
-        if (tmp == NULL || PyTuple_SetItem(lru_attrs, 0, tmp) != 0) {
+        if (tmp == NULL || PyTuple_SetItem(lru_attrs, 0, tmp) != 0) {  // steal
             return -1;
         }
-        Py_DECREF(tmp);
         tmp = PyUnicode_InternFromString("__kwdefaults__");
-        if (tmp == NULL || PyTuple_SetItem(lru_attrs, 1, tmp) != 0) {
+        if (tmp == NULL || PyTuple_SetItem(lru_attrs, 1, tmp) != 0) {  // steal
             return -1;
         }
-        Py_DECREF(tmp);
     }
 
     state->kwd_mark = _PyObject_CallNoArg((PyObject *)&PyBaseObject_Type);


### PR DESCRIPTION
See bug for details.  Basically the lru_cache wrapped function is lacking `__defaults__` and `__kwdefaults__` or they are incorrect (depending on existing implementation).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-44003](https://bugs.python.org/issue44003) -->
https://bugs.python.org/issue44003
<!-- /issue-number -->
