### PR TITLE
bpo-43434: Move sqlite3.connect audit events to sqlite3.Connection.__init__

### DIFF
--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -367,13 +367,14 @@ def test_sqlite3():
             print(event, *args)
 
     sys.addaudithook(hook)
-    cx = sqlite3.connect(":memory:")
+    cx1 = sqlite3.connect(":memory:")
+    cx2 = sqlite3.Connection(":memory:")
 
     # Configured without --enable-loadable-sqlite-extensions
     if hasattr(sqlite3.Connection, "enable_load_extension"):
-        cx.enable_load_extension(False)
+        cx1.enable_load_extension(False)
         try:
-            cx.load_extension("test")
+            cx1.load_extension("test")
         except sqlite3.OperationalError:
             pass
         else:

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -158,7 +158,7 @@ class AuditTest(unittest.TestCase):
         if support.verbose:
             print(*events, sep='\n')
         actual = [ev[0] for ev in events]
-        expected = ["sqlite3.connect", "sqlite3.connect/handle"]
+        expected = ["sqlite3.connect", "sqlite3.connect/handle"] * 2
 
         if hasattr(sqlite3.Connection, "enable_load_extension"):
             expected += [

--- a/Misc/NEWS.d/next/Security/2021-05-02-17-50-23.bpo-43434.cy7xz6.rst
+++ b/Misc/NEWS.d/next/Security/2021-05-02-17-50-23.bpo-43434.cy7xz6.rst
@@ -1,0 +1,4 @@
+Creating :class:`sqlite3.Connection` objects now also produces
+``sqlite3.connect`` and ``sqlite3.connect/handle`` :ref:`auditing events
+<auditing>`. Previously these events were only produced by
+:func:`sqlite3.connect` calls. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -86,6 +86,10 @@ pysqlite_connection_init(pysqlite_Connection *self, PyObject *args,
         return -1;
     }
 
+    if (PySys_Audit("sqlite3.connect", "O", database_obj) < 0) {
+        return -1;
+    }
+
     database = PyBytes_AsString(database_obj);
 
     self->initialized = 1;
@@ -178,6 +182,10 @@ pysqlite_connection_init(pysqlite_Connection *self, PyObject *args,
     self->InternalError         = pysqlite_InternalError;
     self->ProgrammingError      = pysqlite_ProgrammingError;
     self->NotSupportedError     = pysqlite_NotSupportedError;
+
+    if (PySys_Audit("sqlite3.connect/handle", "O", self) < 0) {
+        return -1;
+    }
 
     return 0;
 }

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -91,17 +91,8 @@ static PyObject* module_connect(PyObject* self, PyObject* args, PyObject*
         factory = (PyObject*)pysqlite_ConnectionType;
     }
 
-    if (PySys_Audit("sqlite3.connect", "O", database) < 0) {
-        return NULL;
-    }
-
     result = PyObject_Call(factory, args, kwargs);
     if (result == NULL) {
-        return NULL;
-    }
-
-    if (PySys_Audit("sqlite3.connect/handle", "O", self) < 0) {
-        Py_DECREF(result);
         return NULL;
     }
 


### PR DESCRIPTION
Both sqlite3.connect() and sqlite.Connection() now produce sqlite3.connect* events.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43434](https://bugs.python.org/issue43434) -->
https://bugs.python.org/issue43434
<!-- /issue-number -->
