### PR TITLE
bpo-38352: Add to typing.__all__

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -104,7 +104,7 @@ __all__ = [
     'BinaryIO',
     'IO',
     'Match',
-    'Patern',
+    'Pattern',
     'TextIO',
 
     # One-off things.

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -99,6 +99,13 @@ __all__ = [
     'NamedTuple',  # Not really a type.
     'TypedDict',  # Not really a type.
     'Generator',
+  
+    # Other concrete types.
+    'BinaryIO',
+    'IO',
+    'Match',
+    'Patern',
+    'TextIO',
 
     # One-off things.
     'AnyStr',

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -99,7 +99,7 @@ __all__ = [
     'NamedTuple',  # Not really a type.
     'TypedDict',  # Not really a type.
     'Generator',
-  
+ 
     # Other concrete types.
     'BinaryIO',
     'IO',

--- a/Misc/NEWS.d/next/Library/2021-05-02-13-54-25.bpo-38352.N9MlhV.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-02-13-54-25.bpo-38352.N9MlhV.rst
@@ -1,0 +1,2 @@
+Add ``IO``, ``BinaryIO``, ``TextIO``, ``Match``, and ``Pattern`` to
+``typing.__all__``. Patch by Jelle Zijlstra.


### PR DESCRIPTION
This adds IO, TextIO, BinaryIO, Match, and Pattern.

<!-- issue-number: [bpo-38352](https://bugs.python.org/issue38352) -->
https://bugs.python.org/issue38352
<!-- /issue-number -->
