### PR TITLE
[3.8] bpo-43434: Move sqlite3.connect audit event to sqlite3.Connection.__init__ (GH-25818)

### DIFF
--- a/Misc/NEWS.d/next/Security/2021-05-02-17-50-23.bpo-43434.cy7xz6.rst
+++ b/Misc/NEWS.d/next/Security/2021-05-02-17-50-23.bpo-43434.cy7xz6.rst
@@ -1,0 +1,4 @@
+Creating a :class:`sqlite3.Connection` object now also produces
+a ``sqlite3.connect`` :ref:`auditing event <auditing>`.
+Previously this event was only produced by :func:`sqlite3.connect`
+calls. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -98,6 +98,10 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
         return -1;
     }
 
+    if (PySys_Audit("sqlite3.connect", "O", database_obj) < 0) {
+        return -1;
+    }
+
     database = PyBytes_AsString(database_obj);
 
     self->initialized = 1;

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -71,8 +71,6 @@ static PyObject* module_connect(PyObject* self, PyObject* args, PyObject*
     int uri = 0;
     double timeout = 5.0;
 
-    PyObject* result;
-
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|diOiOip", kwlist,
                                      &database, &timeout, &detect_types,
                                      &isolation_level, &check_same_thread,
@@ -85,13 +83,7 @@ static PyObject* module_connect(PyObject* self, PyObject* args, PyObject*
         factory = (PyObject*)&pysqlite_ConnectionType;
     }
 
-    if (PySys_Audit("sqlite3.connect", "O", database) < 0) {
-        return NULL;
-    }
-
-    result = PyObject_Call(factory, args, kwargs);
-
-    return result;
+    return PyObject_Call(factory, args, kwargs);
 }
 
 PyDoc_STRVAR(module_connect_doc,


### PR DESCRIPTION
(cherry picked from commit c96cc089f60d2bf7e003c27413c3239ee9de2990)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@innova.no>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43434](https://bugs.python.org/issue43434) -->
https://bugs.python.org/issue43434
<!-- /issue-number -->
