### PR TITLE
bpo-42362: use clang name on 10.9 builds as well

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -163,7 +163,6 @@ def getTargetCompilers():
         '10.6': ('gcc', 'g++'),
         '10.7': ('gcc', 'g++'),
         '10.8': ('gcc', 'g++'),
-        '10.9': ('gcc', 'g++'),
     }
     return target_cc_map.get(DEPTARGET, ('clang', 'clang++') )
 


### PR DESCRIPTION


<!-- issue-number: [bpo-42362](https://bugs.python.org/issue42362) -->
https://bugs.python.org/issue42362
<!-- /issue-number -->
