### PR TITLE
bpo-44014: Fix error in Enum documentation.

### DIFF
--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -286,7 +286,7 @@ overridden::
     ...     EAST = auto()
     ...     WEST = auto()
     ...
-    >>> [member.value for member in Color]
+    >>> [member.value for member in Ordinal]
     ['NORTH', 'SOUTH', 'EAST', 'WEST']
 
 .. note::


### PR DESCRIPTION
Fix error in Enum documentation.

The example code was referring to the wrong enum `Color`, instead of `Ordinal`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-44014](https://bugs.python.org/issue44014) -->
https://bugs.python.org/issue44014
<!-- /issue-number -->
