### PR TITLE
bpo-44011: Increase test timeout

### DIFF
--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -179,7 +179,7 @@ class TestSSL(test_utils.TestCase):
     def test_create_server_ssl_1(self):
         CNT = 0           # number of clients that were successful
         TOTAL_CNT = 25    # total number of clients that test will create
-        TIMEOUT = 10.0    # timeout for this test
+        TIMEOUT = 60.0    # timeout for this test
 
         A_DATA = b'A' * 1024 * 1024
         B_DATA = b'B' * 1024 * 1024
@@ -238,7 +238,7 @@ class TestSSL(test_utils.TestCase):
 
         async def start_server():
             extras = {}
-            extras = dict(ssl_handshake_timeout=10.0)
+            extras = dict(ssl_handshake_timeout=40.0)
 
             srv = await asyncio.start_server(
                 handle_client,
@@ -303,7 +303,7 @@ class TestSSL(test_utils.TestCase):
 
         async def client(addr):
             extras = {}
-            extras = dict(ssl_handshake_timeout=10.0)
+            extras = dict(ssl_handshake_timeout=40.0)
 
             reader, writer = await asyncio.open_connection(
                 *addr,


### PR DESCRIPTION
"Gentoo with X" buildbot agent fails with timeout.
10 seconds is too short for slow bots, let's increase it.

<!-- issue-number: [bpo-44011](https://bugs.python.org/issue44011) -->
https://bugs.python.org/issue44011
<!-- /issue-number -->
