### PR TITLE
bpo-43754: Fix compiler warning in Python/compile.c

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6144,7 +6144,7 @@ compiler_pattern_or(struct compiler *c, pattern_ty p, pattern_context *pc)
     // - A copy of the subject.
     // - Anything else that may be on top of the stack.
     // - Any previous stores we've already stashed away on the stack.
-    int nrots = nstores + 1 + pc->on_top + PyList_GET_SIZE(pc->stores);
+    Py_ssize_t nrots = nstores + 1 + pc->on_top + PyList_GET_SIZE(pc->stores);
     for (Py_ssize_t i = 0; i < nstores; i++) {
         // Rotate this capture to its proper place on the stack:
         if (!compiler_addop_i(c, ROT_N, nrots)) {


### PR DESCRIPTION
This fixes the following warning:

'initializing': conversion from 'Py_ssize_t' to 'int', possible loss of data [D:\a\cpython\cpython\PCbuild\pythoncore.vcxproj]

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43754](https://bugs.python.org/issue43754) -->
https://bugs.python.org/issue43754
<!-- /issue-number -->
