### PR TITLE
bpo-44018: random.seed() no longer mutates its inputs

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -154,8 +154,7 @@ class Random(_random.Random):
         elif version == 2 and isinstance(a, (str, bytes, bytearray)):
             if isinstance(a, str):
                 a = a.encode()
-            a += _sha512(a).digest()
-            a = int.from_bytes(a, 'big')
+            a = int.from_bytes(a + _sha512(a).digest(), 'big')
 
         elif not isinstance(a, (type(None), int, float, str, bytes, bytearray)):
             _warn('Seeding based on hashing is deprecated\n'

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -57,6 +57,11 @@ class TestBasicOps:
         self.assertRaises(TypeError, self.gen.seed, 1, 2, 3, 4)
         self.assertRaises(TypeError, type(self.gen), [])
 
+    def test_seed_no_mutate_bug_44018(self):
+        a = bytearray(b'1234')
+        self.gen.seed(a)
+        self.assertEqual(a, bytearray(b'1234'))
+
     @unittest.mock.patch('random._urandom') # os.urandom
     def test_seed_when_randomness_source_not_found(self, urandom_mock):
         # Random.seed() uses time.time() when an operating system specific

--- a/Misc/NEWS.d/next/Library/2021-05-03-10-07-43.bpo-44018.VDyW8f.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-03-10-07-43.bpo-44018.VDyW8f.rst
@@ -1,0 +1,1 @@
+random.seed() no longer mutates bytearray inputs.


### PR DESCRIPTION


<!-- issue-number: [bpo-44018](https://bugs.python.org/issue44018) -->
https://bugs.python.org/issue44018
<!-- /issue-number -->
