### PR TITLE
fix enum and backslash warnings

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -663,7 +663,7 @@ class FaultHandlerTests(unittest.TestCase):
             import sys
 
             all_threads = {all_threads}
-            signum = {signum}
+            signum = {signum:d}
             unregister = {unregister}
             chain = {chain}
             filename = {filename!r}

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -97,7 +97,7 @@ class CommonTestMixin_v4(CommonTestMixin):
 
     def test_leading_zeros(self):
         # bpo-36384: no leading zeros to avoid ambiguity with octal notation
-        msg = "Leading zeros are not permitted in '\d+'"
+        msg = "Leading zeros are not permitted in '\\d+'"
         addresses = [
             "000.000.000.000",
             "192.168.000.001",


### PR DESCRIPTION
- Enum warning in test_faulthandler
- backslash warning in test_ipaddress