### PR TITLE
bpo-44024: Improve the TypeError message for non-string second arguments passed to the built-in functions getattr and hasattr

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -509,6 +509,9 @@ class BuiltinTest(unittest.TestCase):
         sys.spam = 1
         delattr(sys, 'spam')
         self.assertRaises(TypeError, delattr)
+        self.assertRaises(TypeError, delattr, sys)
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, delattr, sys, 1)
 
     def test_dir(self):
         # dir(wrong number of arguments)
@@ -801,17 +804,21 @@ class BuiltinTest(unittest.TestCase):
 
     def test_getattr(self):
         self.assertTrue(getattr(sys, 'stdout') is sys.stdout)
-        self.assertRaises(TypeError, getattr, sys, 1)
-        self.assertRaises(TypeError, getattr, sys, 1, "foo")
         self.assertRaises(TypeError, getattr)
+        self.assertRaises(TypeError, getattr, sys)
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, getattr, sys, 1)
+        self.assertRaisesRegex(TypeError, msg, getattr, sys, 1, 'spam')
         self.assertRaises(AttributeError, getattr, sys, chr(sys.maxunicode))
         # unicode surrogates are not encodable to the default encoding (utf8)
         self.assertRaises(AttributeError, getattr, 1, "\uDAD1\uD51E")
 
     def test_hasattr(self):
         self.assertTrue(hasattr(sys, 'stdout'))
-        self.assertRaises(TypeError, hasattr, sys, 1)
         self.assertRaises(TypeError, hasattr)
+        self.assertRaises(TypeError, hasattr, sys)
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, hasattr, sys, 1)
         self.assertEqual(False, hasattr(sys, chr(sys.maxunicode)))
 
         # Check that hasattr propagates all exceptions outside of
@@ -1457,8 +1464,11 @@ class BuiltinTest(unittest.TestCase):
     def test_setattr(self):
         setattr(sys, 'spam', 1)
         self.assertEqual(sys.spam, 1)
-        self.assertRaises(TypeError, setattr, sys, 1, 'spam')
         self.assertRaises(TypeError, setattr)
+        self.assertRaises(TypeError, setattr, sys)
+        self.assertRaises(TypeError, setattr, sys, 'spam')
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, setattr, sys, 1, 'spam')
 
     # test_str(): see test_unicode.py and test_bytes.py for str() tests.
 

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -169,6 +169,36 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         msg = r"count\(\) takes no keyword arguments"
         self.assertRaisesRegex(TypeError, msg, [].count, x=2, y=2)
 
+    def test_argtype0(self):
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, getattr, 'foo', 123)
+
+    def test_argtype1(self):
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, hasattr, 'foo', 123)
+
+    def test_argtype2(self):
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, setattr, 'foo', 123, 'bar')
+
+    def test_argtype3(self):
+        msg = r"^attribute name must be string, not 'int'$"
+        self.assertRaisesRegex(TypeError, msg, delattr, 'foo', 123)
+
+    def test_argtype4(self):
+        msg = r"^attribute name must be string, not 'int'$"
+        with self.assertRaisesRegex(TypeError, msg):
+            object.__getattribute__('foo', 123)
+
+    def test_argtype5(self):
+        msg = r"^attribute name must be string, not 'int'$"
+        with self.assertRaisesRegex(TypeError, msg):
+            object.__setattr__('foo', 123, 'bar')
+
+    def test_argtype6(self):
+        msg = r"^attribute name must be string, not 'int'$"
+        with self.assertRaisesRegex(TypeError, msg):
+            object.__delattr__('foo', 123)
 
 
 class TestCallingConventions(unittest.TestCase):

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -170,6 +170,7 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         self.assertRaisesRegex(TypeError, msg, [].count, x=2, y=2)
 
 
+
 class TestCallingConventions(unittest.TestCase):
     """Test calling using various C calling conventions (METH_*) from Python
 

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -169,37 +169,6 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         msg = r"count\(\) takes no keyword arguments"
         self.assertRaisesRegex(TypeError, msg, [].count, x=2, y=2)
 
-    def test_argtype0(self):
-        msg = r"^attribute name must be string, not 'int'$"
-        self.assertRaisesRegex(TypeError, msg, getattr, 'foo', 123)
-
-    def test_argtype1(self):
-        msg = r"^attribute name must be string, not 'int'$"
-        self.assertRaisesRegex(TypeError, msg, hasattr, 'foo', 123)
-
-    def test_argtype2(self):
-        msg = r"^attribute name must be string, not 'int'$"
-        self.assertRaisesRegex(TypeError, msg, setattr, 'foo', 123, 'bar')
-
-    def test_argtype3(self):
-        msg = r"^attribute name must be string, not 'int'$"
-        self.assertRaisesRegex(TypeError, msg, delattr, 'foo', 123)
-
-    def test_argtype4(self):
-        msg = r"^attribute name must be string, not 'int'$"
-        with self.assertRaisesRegex(TypeError, msg):
-            object.__getattribute__('foo', 123)
-
-    def test_argtype5(self):
-        msg = r"^attribute name must be string, not 'int'$"
-        with self.assertRaisesRegex(TypeError, msg):
-            object.__setattr__('foo', 123, 'bar')
-
-    def test_argtype6(self):
-        msg = r"^attribute name must be string, not 'int'$"
-        with self.assertRaisesRegex(TypeError, msg):
-            object.__delattr__('foo', 123)
-
 
 class TestCallingConventions(unittest.TestCase):
     """Test calling using various C calling conventions (METH_*) from Python

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
@@ -1,3 +1,2 @@
-Improve the error message for non-string second arguments
-passed to the built-in functions :func:`getattr` and :func:`hasattr`. Patch
-by Géry Ogam.
+Improve the exc:`TypeError` message for non-string second arguments passed to 
+the built-in functions :func:`getattr` and :func:`hasattr`. Patch by Géry Ogam.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
@@ -1,0 +1,3 @@
+Use the common :exc:`TypeError` message for non-string second arguments
+passed to the built-in functions :func:`getattr` and :func:`hasattr`. Patch
+by Géry Ogam.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
@@ -1,2 +1,2 @@
-Improve the exc:`TypeError` message for non-string second arguments passed to 
+Improve the exc:`TypeError` message for non-string second arguments passed to
 the built-in functions :func:`getattr` and :func:`hasattr`. Patch by Géry Ogam.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-04-21-55-49.bpo-44024.M9m8Qd.rst
@@ -1,3 +1,3 @@
-Use the common :exc:`TypeError` message for non-string second arguments
+Improve the error message for non-string second arguments
 passed to the built-in functions :func:`getattr` and :func:`hasattr`. Patch
 by Géry Ogam.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1099,11 +1099,6 @@ builtin_getattr(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
 
     v = args[0];
     name = args[1];
-    if (!PyUnicode_Check(name)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "getattr(): attribute name must be string");
-        return NULL;
-    }
     if (nargs > 2) {
         if (_PyObject_LookupAttr(v, name, &result) == 0) {
             PyObject *dflt = args[2];
@@ -1164,11 +1159,6 @@ builtin_hasattr_impl(PyObject *module, PyObject *obj, PyObject *name)
 {
     PyObject *v;
 
-    if (!PyUnicode_Check(name)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "hasattr(): attribute name must be string");
-        return NULL;
-    }
     if (_PyObject_LookupAttr(obj, name, &v) < 0) {
         return NULL;
     }


### PR DESCRIPTION
Problem
-------

Actual behaviour:

```python
>>> getattr('foobar', 123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: getattr(): attribute name must be string
>>> hasattr('foobar', 123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: hasattr(): attribute name must be string
```

Expected behaviour:

```python
>>> getattr('foobar', 123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: attribute name must be string, not 'int'
>>> hasattr('foobar', 123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: attribute name must be string, not 'int'
```

Motivation:

```python
>>> setattr('foobar', 123, 'baz')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: attribute name must be string, not 'int'
>>> delattr('foobar', 123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: attribute name must be string, not 'int'
```

Solution
--------

In the function [`builtin_getattr`](https://github.com/python/cpython/blob/3.10/Python/bltinmodule.c#L1083-L1109) defined in Python/bltinmodule.c, we remove the following lines:

```c
    if (!PyUnicode_Check(name)) {
        PyErr_SetString(PyExc_TypeError,
                        "getattr(): attribute name must be string");
        return NULL;
    }
```

because the expected `TypeError` message is already implemented in the subsequent call to the functions [`_PyObject_LookupAttr`](https://github.com/python/cpython/blob/3.10/Objects/object.c#L943-L990) and [`PyObject_GetAttr`](https://github.com/python/cpython/blob/3.10/Objects/object.c#L909-L941) defined in Objects/object.c:

```c
PyObject *
PyObject_GetAttr(PyObject *v, PyObject *name)
{
    PyTypeObject *tp = Py_TYPE(v);
    if (!PyUnicode_Check(name)) {
        PyErr_Format(PyExc_TypeError,
                     "attribute name must be string, not '%.200s'",
                     Py_TYPE(name)->tp_name);
        return NULL;
    }

[…]

int
_PyObject_LookupAttr(PyObject *v, PyObject *name, PyObject **result)
{
    PyTypeObject *tp = Py_TYPE(v);

    if (!PyUnicode_Check(name)) {
        PyErr_Format(PyExc_TypeError,
                     "attribute name must be string, not '%.200s'",
                     Py_TYPE(name)->tp_name);
        *result = NULL;
        return -1;
    }

[…]
```

Likewise, in the function [`builtin_hasattr_impl`](https://github.com/python/cpython/blob/3.10/Python/bltinmodule.c#L1152-L1171) defined in Python/bltinmodule.c, we remove the following lines:

```c
    if (!PyUnicode_Check(name)) {
        PyErr_SetString(PyExc_TypeError,
                        "hasattr(): attribute name must be string");
        return NULL;
    }
```

because the expected `TypeError` message is already implemented in the subsequent call to the function [`_PyObject_LookupAttr`](https://github.com/python/cpython/blob/3.10/Objects/object.c#L943-L990) defined in Objects/object.c.

<!-- issue-number: [bpo-44024](https://bugs.python.org/issue44024) -->
https://bugs.python.org/issue44024
<!-- /issue-number -->
