### PR TITLE
bpo-43822: When reporting parser custom errors, check first for tokenizer errors

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -210,7 +210,7 @@ class ExceptionTests(unittest.TestCase):
         check('x = "a', 1, 5)
         check('lambda x: x = 2', 1, 1)
         check('f{a + b + c}', 1, 2)
-        check('[file for str(file) in []\n])', 1, 11)
+        check('[file for str(file) in []\n])', 2, 2)
         check('[\nfile\nfor str(file)\nin\n[]\n]', 3, 5)
         check('[file for\n str(file) in []]', 2, 2)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-04-01-01-04.bpo-43822.9VeCg0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-04-01-01-04.bpo-43822.9VeCg0.rst
@@ -1,0 +1,2 @@
+The parser will prioritize tokenizer errors over custom syntax errors when
+raising exceptions. Patch by Pablo Galindo.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1283,6 +1283,9 @@ _PyPegen_run_parser(Parser *p)
         reset_parser_state(p);
         _PyPegen_parse(p);
         if (PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_SyntaxError)) {
+                _PyPegen_check_tokenizer_errors(p);
+            }
             return NULL;
         }
         if (p->fill == 0) {


### PR DESCRIPTION


<!-- issue-number: [bpo-43822](https://bugs.python.org/issue43822) -->
https://bugs.python.org/issue43822
<!-- /issue-number -->
