### PR TITLE
fix enum.property reference in docs

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -108,7 +108,7 @@ Module Contents
       :class:`Enum` class decorator to apply the appropriate global `__repr__`,
       and export its members into the global name space.
 
-   :func:`property`
+   :func:`.property`
 
       Allows :class:`Enum` members to have attributes without conflicting with
       other members' names.


### PR DESCRIPTION
In https://docs.python.org/3.10/library/enum.html#module-contents, the link for the new `enum.property` currently links to the docs for `builtins.property` instead. Adding a leading dot makes it a local reference.

Requesting review from @ethanfurman 