### PR TITLE
bpo-44001: improve Literal documentation

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -799,10 +799,10 @@ These can be used as types in annotations using ``[]``, each having a unique syn
    .. versionadded:: 3.8
 
    .. versionchanged:: 3.9.1
-      ``Literal`` now de-duplicates parameters.  Equality comparison of
+      ``Literal`` now de-duplicates parameters.  Equality comparisons of
       ``Literal`` objects are no longer order dependent. ``Literal`` objects
       will now raise a :exc:`TypeError` exception during equality comparisons
-      if one of their parameters are not :term:`immutable`.
+      if one of their parameters are not :term:`hashable`.
 
 .. data:: ClassVar
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1271,8 +1271,8 @@ and to match the behavior of static type checkers specified in the PEP.
    now ``False``.  To support this change, the internally used type cache now
    supports differentiating types.
 4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
-   equality comparisons if one of their parameters are not :term:`immutable`.
-   Note that declaring ``Literal`` with mutable parameters will not throw
+   equality comparisons if any of their parameters are not :term:`hashable`.
+   Note that declaring ``Literal`` with unhashable parameters will not throw
    an error::
 
       >>> from typing import Literal

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -1494,7 +1494,7 @@ and to match the behavior of static type checkers specified in the PEP.
    now ``False``.  To support this change, the internally used type cache now
    supports differentiating types.
 4. ``Literal`` objects will now raise a :exc:`TypeError` exception during
-   equality comparisons if one of their parameters are not :term:`immutable`.
+   equality comparisons if any of their parameters are not :term:`hashable`.
    Note that declaring ``Literal`` with mutable parameters will not throw
    an error::
 


### PR DESCRIPTION
Mutable but hashable objects (such as function objects) work fine.

<!-- issue-number: [bpo-44001](https://bugs.python.org/issue44001) -->
https://bugs.python.org/issue44001
<!-- /issue-number -->
