### PR TITLE
bpo-43742: Mention server example in asyncio stream docs

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -39,7 +39,7 @@ streams::
     asyncio.run(tcp_echo_client('Hello World!'))
 
 
-See also the `Examples`_ section below.
+See the **server** and other examples in the `Examples`_ section below.
 
 
 .. rubric:: Stream Functions

--- a/Misc/NEWS.d/next/Documentation/2021-05-05-08-55-29.bpo-43742.pMxwKf.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-05-05-08-55-29.bpo-43742.pMxwKf.rst
@@ -1,0 +1,1 @@
+Mention server example in asyncio stream page


### PR DESCRIPTION
Minor addition to [asyncio-stream](https://docs.python.org/3.10/library/asyncio-stream.html) documentation to mention that the server example is in the Examples sections.

This comes from [issue43821](https://bugs.python.org/issue43821) where the person was not sure if the example would handle the client and server part simultaneously in the example.



<!-- issue-number: [bpo-43742](https://bugs.python.org/issue43742) -->
https://bugs.python.org/issue43742
<!-- /issue-number -->
