### PR TITLE
bpo-44039: Eliminate duplicated assignment in _randommodule.c

### DIFF
--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -597,7 +597,7 @@ _random_exec(PyObject *module)
     }
 
     /* Look up and save int.__abs__, which is needed in random_seed(). */
-    PyObject *longval = longval = PyLong_FromLong(0);
+    PyObject *longval = PyLong_FromLong(0);
     if (longval == NULL) {
         return -1;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-44039](https://bugs.python.org/issue44039) -->
https://bugs.python.org/issue44039
<!-- /issue-number -->
