### PR TITLE
bpo-44030: Fix formatting error in exceptions docs

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -96,7 +96,7 @@ The following exceptions are used mostly as base classes for other exceptions.
       instance of ``OtherException`` while preserving the traceback.  Once
       raised, the current frame is pushed onto the traceback of the
       ``OtherException``, as would have happened to the traceback of the
-      original ``SomeException`` had we allowed it to propagate to the caller.
+      original ``SomeException`` had we allowed it to propagate to the caller. ::
 
          try:
              ...


### PR DESCRIPTION
https://bugs.python.org/issue44030


Before fix: https://imgur.com/a/uLdJ3v5
Screenshot After Fix: https://imgur.com/a/g2vsqf2

<!-- issue-number: [bpo-44030](https://bugs.python.org/issue44030) -->
https://bugs.python.org/issue44030
<!-- /issue-number -->