### PR TITLE
bpo-40943: Fix skipitem() didn't raise SystemError

### DIFF
--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -874,6 +874,13 @@ class String_TestCase(unittest.TestCase):
         self.assertRaises(TypeError, getargs_s_hash, memoryview(b'memoryview'))
         self.assertRaises(TypeError, getargs_s_hash, None)
 
+    def test_s_hash_int(self):
+        # "s#" without PY_SSIZE_T_CLEAN defined.
+        from _testcapi import getargs_s_hash_int
+        self.assertRaises(SystemError, getargs_s_hash_int, "abc")
+        self.assertRaises(SystemError, getargs_s_hash_int, x=42)
+        # getargs_s_hash_int() don't raise SystemError because skipitem() is not called.
+
     def test_z(self):
         from _testcapi import getargs_z
         self.assertEqual(getargs_z('abc\xe9'), b'abc\xc3\xa9')

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5455,9 +5455,6 @@ pynumber_tobase(PyObject *module, PyObject *args)
 }
 
 
-static PyObject *test_buildvalue_issue38913(PyObject *, PyObject *);
-
-
 static PyObject*
 test_set_type_size(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
@@ -5596,6 +5593,8 @@ test_fatal_error(PyObject *self, PyObject *args)
 }
 
 
+static PyObject *test_buildvalue_issue38913(PyObject *, PyObject *);
+static PyObject *getargs_s_hash_int(PyObject *, PyObject *, PyObject*);
 
 static PyMethodDef TestMethods[] = {
     {"raise_exception",         raise_exception,                 METH_VARARGS},
@@ -5703,6 +5702,8 @@ static PyMethodDef TestMethods[] = {
     {"getargs_s",               getargs_s,                       METH_VARARGS},
     {"getargs_s_star",          getargs_s_star,                  METH_VARARGS},
     {"getargs_s_hash",          getargs_s_hash,                  METH_VARARGS},
+    {"getargs_s_hash_int",      (PyCFunction)(void(*)(void))getargs_s_hash_int,
+      METH_VARARGS|METH_KEYWORDS},
     {"getargs_z",               getargs_z,                       METH_VARARGS},
     {"getargs_z_star",          getargs_z_star,                  METH_VARARGS},
     {"getargs_z_hash",          getargs_z_hash,                  METH_VARARGS},
@@ -7373,5 +7374,21 @@ test_buildvalue_issue38913(PyObject *self, PyObject *Py_UNUSED(ignored))
     PyErr_Clear();
 
 
+    Py_RETURN_NONE;
+}
+
+#undef PyArg_ParseTupleAndKeywords
+PyAPI_FUNC(int) PyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
+                                            const char *, char **, ...);
+
+static PyObject *
+getargs_s_hash_int(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    static char *keywords[] = {"", "x", NULL};
+    const char *s;
+    int len;
+    int i = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|s#i", keywords, &s, &len, &i))
+        return NULL;
     Py_RETURN_NONE;
 }

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2535,11 +2535,9 @@ skipitem(const char **p_format, va_list *p_va, int flags)
                     if (flags & FLAG_SIZE_T)
                         (void) va_arg(*p_va, Py_ssize_t *);
                     else {
-                        if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                                    "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
-                            return NULL;
-                        }
-                        (void) va_arg(*p_va, int *);
+                        PyErr_SetString(PyExc_SystemError,
+                                "PY_SSIZE_T_CLEAN macro must be defined for '#' formats");
+                        return NULL;
                     }
                 }
                 format++;

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2532,13 +2532,12 @@ skipitem(const char **p_format, va_list *p_va, int flags)
             }
             if (*format == '#') {
                 if (p_va != NULL) {
-                    if (flags & FLAG_SIZE_T)
-                        (void) va_arg(*p_va, Py_ssize_t *);
-                    else {
+                    if (!(flags & FLAG_SIZE_T)) {
                         PyErr_SetString(PyExc_SystemError,
                                 "PY_SSIZE_T_CLEAN macro must be defined for '#' formats");
                         return NULL;
                     }
+                    (void) va_arg(*p_va, Py_ssize_t *);
                 }
                 format++;
             } else if ((c == 's' || c == 'z' || c == 'y' || c == 'w')


### PR DESCRIPTION
`convertitem()` raises SystemError when '#' is used without `PY_SSIZE_T_CLEAN` defined.
`skipitem()` should do it too.

<!-- issue-number: [bpo-40943](https://bugs.python.org/issue40943) -->
https://bugs.python.org/issue40943
<!-- /issue-number -->
