### PR TITLE
[3.10] bpo-44056: Fix syntax error lineno in try-except

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -218,7 +218,7 @@ class ExceptionTests(unittest.TestCase):
         check('class foo:return 1', 1, 11)
         check('def f():\n  continue', 2, 3)
         check('def f():\n  break', 2, 3)
-        check('try:\n  pass\nexcept:\n  pass\nexcept ValueError:\n  pass', 2, 3)
+        check('try:\n  pass\nexcept:\n  pass\nexcept ValueError:\n  pass', 3, 1)
 
         # Errors thrown by tokenizer.c
         check('(0x+1)', 1, 3)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-06-12-43-04.bpo-44056.4LWcJW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-06-12-43-04.bpo-44056.4LWcJW.rst
@@ -1,0 +1,2 @@
+Syntax errors when default ``except`` is not the last ``except``  are
+reported with the correct location. Patch by Mark Shannon.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3165,9 +3165,9 @@ compiler_try_except(struct compiler *c, stmt_ty s)
     for (i = 0; i < n; i++) {
         excepthandler_ty handler = (excepthandler_ty)asdl_seq_GET(
             s->v.Try.handlers, i);
+        SET_LOC(c, handler);
         if (!handler->v.ExceptHandler.type && i < n-1)
             return compiler_error(c, "default 'except:' must be last");
-        SET_LOC(c, handler);
         except = compiler_new_block(c);
         if (except == NULL)
             return 0;


### PR DESCRIPTION


<!-- issue-number: [bpo-44056](https://bugs.python.org/issue44056) -->
https://bugs.python.org/issue44056
<!-- /issue-number -->
