### PR TITLE
Do not use Py_ssize_clean_t

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -118,12 +118,8 @@ typedef Py_ssize_t Py_hash_t;
 #define SIZEOF_PY_UHASH_T SIZEOF_SIZE_T
 typedef size_t Py_uhash_t;
 
-/* Only used for compatibility with code that may not be PY_SSIZE_T_CLEAN. */
-#ifdef PY_SSIZE_T_CLEAN
+/* Now PY_SSIZE_T_CLEAN is mandatory. This is just for backward compatibility. */
 typedef Py_ssize_t Py_ssize_clean_t;
-#else
-typedef int Py_ssize_clean_t;
-#endif
 
 /* Largest possible value of size_t. */
 #define PY_SIZE_MAX SIZE_MAX

--- a/Lib/test/clinic.test
+++ b/Lib/test/clinic.test
@@ -1659,9 +1659,9 @@ PyDoc_STRVAR(test_str_converter__doc__,
 static PyObject *
 test_str_converter_impl(PyObject *module, const char *a, const char *b,
                         const char *c, const char *d, const char *e,
-                        const char *f, Py_ssize_clean_t f_length,
-                        const char *g, Py_ssize_clean_t g_length,
-                        const char *h, Py_ssize_clean_t h_length);
+                        const char *f, Py_ssize_t f_length, const char *g,
+                        Py_ssize_t g_length, const char *h,
+                        Py_ssize_t h_length);
 
 static PyObject *
 test_str_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
@@ -1673,11 +1673,11 @@ test_str_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     const char *d = "cef";
     const char *e = "gh";
     const char *f = "ij";
-    Py_ssize_clean_t f_length;
+    Py_ssize_t f_length;
     const char *g = "kl";
-    Py_ssize_clean_t g_length;
+    Py_ssize_t g_length;
     const char *h = "mn";
-    Py_ssize_clean_t h_length;
+    Py_ssize_t h_length;
 
     if (!_PyArg_ParseStack(args, nargs, "|sssyzy#s#z#:test_str_converter",
         &a, &b, &c, &d, &e, &f, &f_length, &g, &g_length, &h, &h_length)) {
@@ -1692,10 +1692,10 @@ exit:
 static PyObject *
 test_str_converter_impl(PyObject *module, const char *a, const char *b,
                         const char *c, const char *d, const char *e,
-                        const char *f, Py_ssize_clean_t f_length,
-                        const char *g, Py_ssize_clean_t g_length,
-                        const char *h, Py_ssize_clean_t h_length)
-/*[clinic end generated code: output=ad868ad94a488e32 input=8afe9da8185cd38c]*/
+                        const char *f, Py_ssize_t f_length, const char *g,
+                        Py_ssize_t g_length, const char *h,
+                        Py_ssize_t h_length)
+/*[clinic end generated code: output=5def009caa2fd1ac input=8afe9da8185cd38c]*/
 
 
 /*[clinic input]
@@ -1720,8 +1720,8 @@ PyDoc_STRVAR(test_str_converter_encoding__doc__,
 
 static PyObject *
 test_str_converter_encoding_impl(PyObject *module, char *a, char *b, char *c,
-                                 char *d, Py_ssize_clean_t d_length, char *e,
-                                 Py_ssize_clean_t e_length);
+                                 char *d, Py_ssize_t d_length, char *e,
+                                 Py_ssize_t e_length);
 
 static PyObject *
 test_str_converter_encoding(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
@@ -1731,9 +1731,9 @@ test_str_converter_encoding(PyObject *module, PyObject *const *args, Py_ssize_t 
     char *b = NULL;
     char *c = NULL;
     char *d = NULL;
-    Py_ssize_clean_t d_length;
+    Py_ssize_t d_length;
     char *e = NULL;
-    Py_ssize_clean_t e_length;
+    Py_ssize_t e_length;
 
     if (!_PyArg_ParseStack(args, nargs, "esesetes#et#:test_str_converter_encoding",
         "idna", &a, "idna", &b, "idna", &c, "idna", &d, &d_length, "idna", &e, &e_length)) {
@@ -1768,9 +1768,9 @@ exit:
 
 static PyObject *
 test_str_converter_encoding_impl(PyObject *module, char *a, char *b, char *c,
-                                 char *d, Py_ssize_clean_t d_length, char *e,
-                                 Py_ssize_clean_t e_length)
-/*[clinic end generated code: output=f579dd9e795a364e input=eb4c38e1f898f402]*/
+                                 char *d, Py_ssize_t d_length, char *e,
+                                 Py_ssize_t e_length)
+/*[clinic end generated code: output=5cae635c092334cb input=eb4c38e1f898f402]*/
 
 
 /*[clinic input]
@@ -1796,10 +1796,8 @@ PyDoc_STRVAR(test_Py_UNICODE_converter__doc__,
 static PyObject *
 test_Py_UNICODE_converter_impl(PyObject *module, const Py_UNICODE *a,
                                const Py_UNICODE *b, const Py_UNICODE *c,
-                               const Py_UNICODE *d,
-                               Py_ssize_clean_t d_length,
-                               const Py_UNICODE *e,
-                               Py_ssize_clean_t e_length);
+                               const Py_UNICODE *d, Py_ssize_t d_length,
+                               const Py_UNICODE *e, Py_ssize_t e_length);
 
 static PyObject *
 test_Py_UNICODE_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
@@ -1809,9 +1807,9 @@ test_Py_UNICODE_converter(PyObject *module, PyObject *const *args, Py_ssize_t na
     const Py_UNICODE *b;
     const Py_UNICODE *c;
     const Py_UNICODE *d;
-    Py_ssize_clean_t d_length;
+    Py_ssize_t d_length;
     const Py_UNICODE *e;
-    Py_ssize_clean_t e_length;
+    Py_ssize_t e_length;
 
     if (!_PyArg_ParseStack(args, nargs, "O&O&O&u#Z#:test_Py_UNICODE_converter",
         _PyUnicode_WideCharString_Converter, &a, _PyUnicode_WideCharString_Converter, &b, _PyUnicode_WideCharString_Opt_Converter, &c, &d, &d_length, &e, &e_length)) {
@@ -1839,11 +1837,9 @@ exit:
 static PyObject *
 test_Py_UNICODE_converter_impl(PyObject *module, const Py_UNICODE *a,
                                const Py_UNICODE *b, const Py_UNICODE *c,
-                               const Py_UNICODE *d,
-                               Py_ssize_clean_t d_length,
-                               const Py_UNICODE *e,
-                               Py_ssize_clean_t e_length)
-/*[clinic end generated code: output=ef45e982fedf0b3d input=064a3b68ad7f04b0]*/
+                               const Py_UNICODE *d, Py_ssize_t d_length,
+                               const Py_UNICODE *e, Py_ssize_t e_length)
+/*[clinic end generated code: output=65d6607da302afd0 input=064a3b68ad7f04b0]*/
 
 
 /*[clinic input]

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -299,8 +299,8 @@ Return the value for key if present, otherwise default.
 
 static PyObject *
 _dbm_dbm_get_impl(dbmobject *self, PyTypeObject *cls, const char *key,
-                  Py_ssize_clean_t key_length, PyObject *default_value)
-/*[clinic end generated code: output=34851b5dc1c664dc input=66b993b8349fa8c1]*/
+                  Py_ssize_t key_length, PyObject *default_value)
+/*[clinic end generated code: output=b4e55f8b6d482bc4 input=66b993b8349fa8c1]*/
 {
     datum dbm_key, val;
     _dbm_state *state = PyType_GetModuleState(cls);
@@ -331,9 +331,8 @@ If key is not in the database, it is inserted with default as the value.
 
 static PyObject *
 _dbm_dbm_setdefault_impl(dbmobject *self, PyTypeObject *cls, const char *key,
-                         Py_ssize_clean_t key_length,
-                         PyObject *default_value)
-/*[clinic end generated code: output=d5c68fe673886767 input=126a3ff15c5f8232]*/
+                         Py_ssize_t key_length, PyObject *default_value)
+/*[clinic end generated code: output=9c2f6ea6d0fb576c input=126a3ff15c5f8232]*/
 {
     datum dbm_key, val;
     Py_ssize_t tmp_size;

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -448,8 +448,8 @@ to create a list in memory that contains them all:
 
 static PyObject *
 _gdbm_gdbm_nextkey_impl(gdbmobject *self, PyTypeObject *cls, const char *key,
-                        Py_ssize_clean_t key_length)
-/*[clinic end generated code: output=204964441fdbaf02 input=fcf6a51a96ce0172]*/
+                        Py_ssize_t key_length)
+/*[clinic end generated code: output=c81a69300ef41766 input=fcf6a51a96ce0172]*/
 {
     PyObject *v;
     datum dbm_key, nextkey;

--- a/Modules/clinic/_dbmmodule.c.h
+++ b/Modules/clinic/_dbmmodule.c.h
@@ -60,7 +60,7 @@ PyDoc_STRVAR(_dbm_dbm_get__doc__,
 
 static PyObject *
 _dbm_dbm_get_impl(dbmobject *self, PyTypeObject *cls, const char *key,
-                  Py_ssize_clean_t key_length, PyObject *default_value);
+                  Py_ssize_t key_length, PyObject *default_value);
 
 static PyObject *
 _dbm_dbm_get(dbmobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -69,7 +69,7 @@ _dbm_dbm_get(dbmobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize
     static const char * const _keywords[] = {"", "", NULL};
     static _PyArg_Parser _parser = {"s#|O:get", _keywords, 0};
     const char *key;
-    Py_ssize_clean_t key_length;
+    Py_ssize_t key_length;
     PyObject *default_value = Py_None;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
@@ -95,8 +95,7 @@ PyDoc_STRVAR(_dbm_dbm_setdefault__doc__,
 
 static PyObject *
 _dbm_dbm_setdefault_impl(dbmobject *self, PyTypeObject *cls, const char *key,
-                         Py_ssize_clean_t key_length,
-                         PyObject *default_value);
+                         Py_ssize_t key_length, PyObject *default_value);
 
 static PyObject *
 _dbm_dbm_setdefault(dbmobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -105,7 +104,7 @@ _dbm_dbm_setdefault(dbmobject *self, PyTypeObject *cls, PyObject *const *args, P
     static const char * const _keywords[] = {"", "", NULL};
     static _PyArg_Parser _parser = {"s#|O:setdefault", _keywords, 0};
     const char *key;
-    Py_ssize_clean_t key_length;
+    Py_ssize_t key_length;
     PyObject *default_value = NULL;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
@@ -187,4 +186,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6947b1115df66f7c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=13b6d821416be228 input=a9049054013a1b77]*/

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -170,7 +170,7 @@ PyDoc_STRVAR(_gdbm_gdbm_nextkey__doc__,
 
 static PyObject *
 _gdbm_gdbm_nextkey_impl(gdbmobject *self, PyTypeObject *cls, const char *key,
-                        Py_ssize_clean_t key_length);
+                        Py_ssize_t key_length);
 
 static PyObject *
 _gdbm_gdbm_nextkey(gdbmobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -179,7 +179,7 @@ _gdbm_gdbm_nextkey(gdbmobject *self, PyTypeObject *cls, PyObject *const *args, P
     static const char * const _keywords[] = {"", NULL};
     static _PyArg_Parser _parser = {"s#:nextkey", _keywords, 0};
     const char *key;
-    Py_ssize_clean_t key_length;
+    Py_ssize_t key_length;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &key, &key_length)) {
@@ -340,4 +340,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e84bc6ac82fcb6d4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c3ee3ad64a2f331f input=a9049054013a1b77]*/

--- a/Modules/clinic/unicodedata.c.h
+++ b/Modules/clinic/unicodedata.c.h
@@ -542,14 +542,14 @@ PyDoc_STRVAR(unicodedata_UCD_lookup__doc__,
 
 static PyObject *
 unicodedata_UCD_lookup_impl(PyObject *self, const char *name,
-                            Py_ssize_clean_t name_length);
+                            Py_ssize_t name_length);
 
 static PyObject *
 unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
     const char *name;
-    Py_ssize_clean_t name_length;
+    Py_ssize_t name_length;
 
     if (!PyArg_Parse(arg, "s#:lookup", &name, &name_length)) {
         goto exit;
@@ -559,4 +559,4 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=10c23477dbe8a202 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a3c0eb84eda47b2d input=a9049054013a1b77]*/

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1389,8 +1389,8 @@ corresponding character.  If not found, KeyError is raised.
 
 static PyObject *
 unicodedata_UCD_lookup_impl(PyObject *self, const char *name,
-                            Py_ssize_clean_t name_length)
-/*[clinic end generated code: output=765cb8186788e6be input=a557be0f8607a0d6]*/
+                            Py_ssize_t name_length)
+/*[clinic end generated code: output=7f03fc4959b242f6 input=a557be0f8607a0d6]*/
 {
     Py_UCS4 code;
     unsigned int index;

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2534,7 +2534,7 @@ class CConverter(metaclass=CConverterAutoRegister):
         # impl_parameters
         data.impl_parameters.append(self.simple_declaration(by_reference=self.impl_by_reference))
         if self.length:
-            data.impl_parameters.append("Py_ssize_clean_t " + self.length_name())
+            data.impl_parameters.append("Py_ssize_t " + self.length_name())
 
     def _render_non_self(self, parameter, data):
         self.parameter = parameter
@@ -2640,7 +2640,7 @@ class CConverter(metaclass=CConverterAutoRegister):
             declaration.append(default)
         declaration.append(";")
         if self.length:
-            declaration.append('\nPy_ssize_clean_t ')
+            declaration.append('\nPy_ssize_t ')
             declaration.append(self.length_name())
             declaration.append(';')
         return "".join(declaration)


### PR DESCRIPTION
PY_SSIZE_T_CLEAN is mandatory now.
So Py_ssize_clean_t is not needed anymore.