### PR TITLE
bpo-44060: Enable TARGET labels even when not using computed gotos.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-06-10-53-47.bpo-44060.ScfYXD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-06-10-53-47.bpo-44060.ScfYXD.rst
@@ -1,0 +1,2 @@
+The TARGET_#op label is now available even when computed gotos aren't
+enabled.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1296,11 +1296,10 @@ eval_frame_handle_pending(PyThreadState *tstate)
     #define USE_COMPUTED_GOTOS 0
 #endif
 
-#if USE_COMPUTED_GOTOS
 #define TARGET(op) op: TARGET_##op
+#if USE_COMPUTED_GOTOS
 #define DISPATCH_GOTO() goto *opcode_targets[opcode]
 #else
-#define TARGET(op) op
 #define DISPATCH_GOTO() goto dispatch_opcode
 #endif
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1296,7 +1296,12 @@ eval_frame_handle_pending(PyThreadState *tstate)
     #define USE_COMPUTED_GOTOS 0
 #endif
 
+#if USE_COMPUTED_GOTOS || defined(Py_DEBUG)
 #define TARGET(op) op: TARGET_##op
+#else
+#define TARGET(op) op
+#endif
+
 #if USE_COMPUTED_GOTOS
 #define DISPATCH_GOTO() goto *opcode_targets[opcode]
 #else


### PR DESCRIPTION
This change enables the TARGET_##op labels even when computed gotos aren't enabled. That generates a bunch of compiler warnings, but the labels allow gdb to break on them.


<!-- issue-number: [bpo-44060](https://bugs.python.org/issue44060) -->
https://bugs.python.org/issue44060
<!-- /issue-number -->
