### PR TITLE
bpo-44062: Fix PYTHON_FOR_BUILD interpreter lookup for cross-compile …

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-08-09-21-05-16.bpo-44062._FgDh-.rst
+++ b/Misc/NEWS.d/next/Build/2021-08-09-21-05-16.bpo-44062._FgDh-.rst
@@ -1,0 +1,1 @@
+Fail appropriately in cross-compile scenarios if no proper python interpreter is found in PATH.

--- a/configure
+++ b/configure
@@ -2997,12 +2997,11 @@ if test "$cross_compiling" = yes; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for python interpreter for cross build" >&5
 $as_echo_n "checking for python interpreter for cross build... " >&6; }
     if test -z "$PYTHON_FOR_BUILD"; then
-        for interp in python$PACKAGE_VERSION python3 python; do
+        for interp in python$PACKAGE_VERSION python3 python ''; do
 	    which $interp >/dev/null 2>&1 || continue
 	    if $interp -c "import sys;sys.exit(not '.'.join(str(n) for n in sys.version_info[:2]) == '$PACKAGE_VERSION')"; then
 	        break
 	    fi
-            interp=
 	done
         if test x$interp = x; then
 	    as_fn_error $? "python$PACKAGE_VERSION interpreter not found" "$LINENO" 5

--- a/configure.ac
+++ b/configure.ac
@@ -71,12 +71,11 @@ AC_SUBST(PYTHON_FOR_REGEN)
 if test "$cross_compiling" = yes; then
     AC_MSG_CHECKING([for python interpreter for cross build])
     if test -z "$PYTHON_FOR_BUILD"; then
-        for interp in python$PACKAGE_VERSION python3 python; do
+        for interp in python$PACKAGE_VERSION python3 python ''; do
 	    which $interp >/dev/null 2>&1 || continue
 	    if $interp -c "import sys;sys.exit(not '.'.join(str(n) for n in sys.version_info@<:@:2@:>@) == '$PACKAGE_VERSION')"; then
 	        break
 	    fi
-            interp=
 	done
         if test x$interp = x; then
 	    AC_MSG_ERROR([python$PACKAGE_VERSION interpreter not found])


### PR DESCRIPTION
…builds

Previously, when running configure in a cross-compile scenario, the
PYTHON_FOR_BUILD interpreter could be set to python even if no python
is availble in PATH.

Now, configure will properly set PYTHON_FOR_BUILD based on what is
available in PATH or fail.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44062](https://bugs.python.org/issue44062) -->
https://bugs.python.org/issue44062
<!-- /issue-number -->
