### PR TITLE
bpo-44061: Fix pkgutil.iter_modules regression

### DIFF
--- a/Lib/pkgutil.py
+++ b/Lib/pkgutil.py
@@ -413,6 +413,7 @@ def get_importer(path_item):
     The cache (or part of it) can be cleared manually if a
     rescan of sys.path_hooks is necessary.
     """
+    path_item = os.fsdecode(path_item)
     try:
         importer = sys.path_importer_cache[path_item]
     except KeyError:

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -111,9 +111,9 @@ class PkgutilTests(unittest.TestCase):
         z.writestr(pkg + '/res.txt', RESOURCE_DATA)
         z.close()
 
+        # Check we can read the resources
+        sys.path.insert(0, zip_file)
         try:
-            # Check we can read the resources
-            sys.path.insert(0, zip_file)
             res = pkgutil.get_data(pkg, 'res.txt')
             self.assertEqual(res, RESOURCE_DATA)
 

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -111,20 +111,21 @@ class PkgutilTests(unittest.TestCase):
         z.writestr(pkg + '/res.txt', RESOURCE_DATA)
         z.close()
 
-        # Check we can read the resources
-        sys.path.insert(0, zip_file)
-        res = pkgutil.get_data(pkg, 'res.txt')
-        self.assertEqual(res, RESOURCE_DATA)
+        try:
+            # Check we can read the resources
+            sys.path.insert(0, zip_file)
+            res = pkgutil.get_data(pkg, 'res.txt')
+            self.assertEqual(res, RESOURCE_DATA)
 
-        # make sure iter_modules accepts Path objects
-        names = []
-        for moduleinfo in pkgutil.iter_modules([Path(zip_file)]):
-            self.assertIsInstance(moduleinfo, pkgutil.ModuleInfo)
-            names.append(moduleinfo.name)
-        self.assertEqual(names, [pkg])
-
-        del sys.path[0]
-        del sys.modules[pkg]
+            # make sure iter_modules accepts Path objects
+            names = []
+            for moduleinfo in pkgutil.iter_modules([Path(zip_file)]):
+                self.assertIsInstance(moduleinfo, pkgutil.ModuleInfo)
+                names.append(moduleinfo.name)
+            self.assertEqual(names, [pkg])
+        finally:
+            del sys.path[0]
+            del sys.modules[pkg]
 
         # assert path must be None or list of paths
         expected_msg = "path must be None or list of paths to look for modules in"

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -125,7 +125,7 @@ class PkgutilTests(unittest.TestCase):
             self.assertEqual(names, [pkg])
         finally:
             del sys.path[0]
-            del sys.modules[pkg]
+            sys.modules.pop(pkg, None)
 
         # assert path must be None or list of paths
         expected_msg = "path must be None or list of paths to look for modules in"

--- a/Misc/NEWS.d/next/Library/2021-05-07-08-39-23.bpo-44061.MvElG6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-07-08-39-23.bpo-44061.MvElG6.rst
@@ -1,0 +1,2 @@
+Fix regression when calling :func:`pkgutil.iter_modules` with a list of
+:class:`pathlib.Path` objects

--- a/Misc/NEWS.d/next/Library/2021-05-07-08-39-23.bpo-44061.MvElG6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-07-08-39-23.bpo-44061.MvElG6.rst
@@ -1,2 +1,2 @@
-Fix regression when calling :func:`pkgutil.iter_modules` with a list of
-:class:`pathlib.Path` objects
+Fix regression in previous release when calling :func:`pkgutil.iter_modules`
+with a list of :class:`pathlib.Path` objects


### PR DESCRIPTION
<!-- issue-number: [bpo-44061](https://bugs.python.org/issue44061) -->
https://bugs.python.org/issue44061
<!-- /issue-number -->
