### PR TITLE
bpo-31904: Correct error string in test_file_not_exists() for VxWorks

### DIFF
--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -276,7 +276,11 @@ class PyCompileCLITestCase(unittest.TestCase):
         rc, stdout, stderr = self.pycompilecmd_failure(self.source_path, should_not_exists)
         self.assertEqual(rc, 1)
         self.assertEqual(stdout, b'')
-        self.assertIn(b'No such file or directory', stderr)
+        if sys.platform == 'vxworks':
+            err_str = b'no such file or directory'
+        else:
+            err_str = b'No such file or directory'
+        self.assertIn(err_str, stderr)
 
     def test_file_not_exists_with_quiet(self):
         should_not_exists = os.path.join(os.path.dirname(__file__), 'should_not_exists.py')

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -276,11 +276,7 @@ class PyCompileCLITestCase(unittest.TestCase):
         rc, stdout, stderr = self.pycompilecmd_failure(self.source_path, should_not_exists)
         self.assertEqual(rc, 1)
         self.assertEqual(stdout, b'')
-        if sys.platform == 'vxworks':
-            err_str = b'no such file or directory'
-        else:
-            err_str = b'No such file or directory'
-        self.assertIn(err_str, stderr)
+        self.assertIn(b'no such file or directory', stderr.lower())
 
     def test_file_not_exists_with_quiet(self):
         should_not_exists = os.path.join(os.path.dirname(__file__), 'should_not_exists.py')

--- a/Misc/NEWS.d/next/Tests/2021-05-07-15-46-04.bpo-31904.8dk3la.rst
+++ b/Misc/NEWS.d/next/Tests/2021-05-07-15-46-04.bpo-31904.8dk3la.rst
@@ -1,0 +1,1 @@
+Correct error string in test_file_not_exists() for VxWorks.

--- a/Misc/NEWS.d/next/Tests/2021-05-07-15-46-04.bpo-31904.8dk3la.rst
+++ b/Misc/NEWS.d/next/Tests/2021-05-07-15-46-04.bpo-31904.8dk3la.rst
@@ -1,1 +1,1 @@
-Correct error string in test_file_not_exists() for VxWorks.
+Ignore error string case in test_file_not_exists().


### PR DESCRIPTION
The error string on VxWorks is "no such file or directory" for FileNotFoundError. That is, the 1st letter of the error string has lower case.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead