### PR TITLE
bpo-45505: ZipFile file header optimization

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1564,7 +1564,7 @@ class ZipFile:
 
             fname = zef_file.read(fheader[_FH_FILENAME_LENGTH])
             if fheader[_FH_EXTRA_FIELD_LENGTH]:
-                zef_file.read(fheader[_FH_EXTRA_FIELD_LENGTH])
+                zef_file.seek(fheader[_FH_EXTRA_FIELD_LENGTH], whence=1)
 
             if zinfo.flag_bits & _MASK_COMPRESSED_PATCH:
                 # Zip 2.7: compressed patched data


### PR DESCRIPTION
# ZipFile file header optimization

The return value from read() is never used, so we can just seek() to avoid unneeded IO.

_SharedFile.read() implementation already assumes the file is seekable, so should be ok?

The change helps performance in use cases where the fileobject given to ZipFile is backed by high latency IO, eg. HTTP range requests.


<!-- issue-number: [bpo-45505](https://bugs.python.org/issue45505) -->
https://bugs.python.org/issue45505
<!-- /issue-number -->

closes: gh-89668