### PR TITLE
bpo-16866 Fix make libainstall.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1688,7 +1688,7 @@ LIBPL=		@LIBPL@
 LIBPC=		$(LIBDIR)/pkgconfig
 
 libainstall:	@DEF_MAKE_RULE@ python-config
-	@for i in $(LIBDIR) $(LIBPL) $(LIBPC); \
+	@for i in $(LIBDIR) $(LIBPL) $(LIBPC) $(BINDIR); \
 	do \
 		if test ! -d $(DESTDIR)$$i; then \
 			echo "Creating directory $$i"; \


### PR DESCRIPTION
```
make libainstall 
```
target is broken.

```
./configure --prefix=/home/senthil/foobar
make libainstall

failed with 

/usr/bin/install: cannot create regular file '/home/senthil/foobar/bin/python3.11-config': No such file or directory
make: *** [Makefile:1715: libainstall] Error 1
```

Looks like the BINDIR dependency was added here - https://github.com/python/cpython/commit/49fd7fa4431da299196d74087df4a04f99f9c46f#diff-1f0a8db227d22005511b0d90f5339b97db345917b863954b3b3ccb9ec308767cR833 but we didn't add the directory creation dependency then.

A simple fix of add BINDIR as dependency seems _OK_ to me. At least it wont break the libainstall standalone target.

---- 

With the fix, `make libainstall` works fine.

```
Creating directory /home/senthil/foobar2/lib
Creating directory /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu
Creating directory /home/senthil/foobar2/lib/pkgconfig
Creating directory /home/senthil/foobar2/bin
/usr/bin/install -c -m 644 Modules/config.c /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/config.c
/usr/bin/install -c -m 644 ./Modules/config.c.in /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/config.c.in
/usr/bin/install -c -m 644 Makefile /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/Makefile
/usr/bin/install -c -m 644 ./Modules/Setup /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/Setup
/usr/bin/install -c -m 644 Modules/Setup.local /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/Setup.local
/usr/bin/install -c -m 644 Misc/python.pc /home/senthil/foobar2/lib/pkgconfig/python-3.11.pc
/usr/bin/install -c -m 644 Misc/python-embed.pc /home/senthil/foobar2/lib/pkgconfig/python-3.11-embed.pc
/usr/bin/install -c ./Modules/makesetup /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/makesetup
/usr/bin/install -c ./install-sh /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/install-sh
/usr/bin/install -c python-config.py /home/senthil/foobar2/lib/python3.11/config-3.11-x86_64-linux-gnu/python-config.py
/usr/bin/install -c python-config /home/senthil/foobar2/bin/python3.11-config
```
<!-- issue-number: [bpo-16866](https://bugs.python.org/issue16866) -->
https://bugs.python.org/issue16866
<!-- /issue-number -->
