### PR TITLE
bpo-44045: fix spelling of uppercase vs upper-case

### DIFF
--- a/Doc/library/builtins.rst
+++ b/Doc/library/builtins.rst
@@ -25,7 +25,7 @@ that wants to implement an :func:`open` function that wraps the built-in
        return UpperCaser(f)
 
    class UpperCaser:
-       '''Wrapper around a file that converts output to upper-case.'''
+       '''Wrapper around a file that converts output to uppercase.'''
 
        def __init__(self, f):
            self._f = f

--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -119,7 +119,7 @@ structures.
 .. function:: gen_uuid()
 
    Return a new UUID, in the format that MSI typically requires (i.e. in curly
-   braces, and with all hexdigits in upper-case).
+   braces, and with all hexdigits in uppercase).
 
 
 .. seealso::

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -118,7 +118,7 @@ One exception is defined as an attribute of the :mod:`poplib` module:
 POP3 Objects
 ------------
 
-All POP3 commands are represented by methods of the same name, in lower-case;
+All POP3 commands are represented by methods of the same name, in lowercase;
 most return the response text sent by the server.
 
 An :class:`POP3` instance has the following methods:

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -145,7 +145,7 @@ class IMAP4:
                       the global default socket timeout is used
 
     All IMAP4rev1 commands are supported by methods of the same
-    name (in lower-case).
+    name (in lowercase).
 
     All arguments to commands are converted to strings, except for
     AUTHENTICATE, and the last argument to APPEND which is passed as

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -280,7 +280,7 @@ CertificateError = SSLCertVerificationError
 def _dnsname_match(dn, hostname):
     """Matching according to RFC 6125, section 6.4.3
 
-    - Hostnames are compared lower case.
+    - Hostnames are compared lower-case.
     - For IDNA, both dn and hostname must be encoded as IDN A-label (ACE).
     - Partial wildcards like 'www*.example.org', multiple wildcards, sole
       wildcard or wildcards in labels other then the left-most label are not


### PR DESCRIPTION
And also of lowercase vs lower-case.

The `-` notation should only be used for adjectives.

<!-- issue-number: [bpo-44045](https://bugs.python.org/issue44045) -->
https://bugs.python.org/issue44045
<!-- /issue-number -->
