### PR TITLE
bpo-43149: Correct the syntax error message for multiple exception types

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -248,7 +248,7 @@ have been incorporated. Some of the most notable ones:
           File "<stdin>", line 3
             except NotEnoughScienceError, NotEnoughResourcesError:
                    ^
-        SyntaxError: exception group must be parenthesized
+        SyntaxError: multiple exception types must be parenthesized
 
     (Contributed by Pablo Galindo in :issue:`43149`)
 

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -956,7 +956,7 @@ invalid_try_stmt:
         RAISE_INDENTATION_ERROR("expected an indented block after 'try' statement on line %d", a->lineno) }
 invalid_except_stmt:
     | 'except' a=expression ',' expressions ['as' NAME ] ':' {
-        RAISE_SYNTAX_ERROR_STARTING_FROM(a, "exception group must be parenthesized") }
+        RAISE_SYNTAX_ERROR_STARTING_FROM(a, "multiple exception types must be parenthesized") }
     | a='except' expression ['as' NAME ] NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
     | a='except' NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
 invalid_finally_stmt:

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1068,7 +1068,7 @@ Make sure that the old "raise X, Y[, Z]" form is gone:
      ...
    SyntaxError: invalid syntax
 
-Check that an exception group with missing parentheses
+Check that an multiple exception types with missing parentheses
 raise a custom exception
 
    >>> try:
@@ -1076,21 +1076,21 @@ raise a custom exception
    ... except A, B:
    ...   pass
    Traceback (most recent call last):
-   SyntaxError: exception group must be parenthesized
+   SyntaxError: multiple exception types must be parenthesized
 
    >>> try:
    ...   pass
    ... except A, B, C:
    ...   pass
    Traceback (most recent call last):
-   SyntaxError: exception group must be parenthesized
+   SyntaxError: multiple exception types must be parenthesized
 
    >>> try:
    ...   pass
    ... except A, B, C as blech:
    ...   pass
    Traceback (most recent call last):
-   SyntaxError: exception group must be parenthesized
+   SyntaxError: multiple exception types must be parenthesized
 
    >>> try:
    ...   pass
@@ -1099,7 +1099,7 @@ raise a custom exception
    ... finally:
    ...   pass
    Traceback (most recent call last):
-   SyntaxError: exception group must be parenthesized
+   SyntaxError: multiple exception types must be parenthesized
 
 
 >>> f(a=23, a=234)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-08-17-18-37.bpo-43149.Kp5FxD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-08-17-18-37.bpo-43149.Kp5FxD.rst
@@ -1,0 +1,2 @@
+Corrent the syntax error message regarding multiple exception types to not
+refer to "exception groups". Patch by Pablo Galindo

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -19978,7 +19978,7 @@ invalid_except_stmt_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ invalid_except_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' expression ',' expressions ['as' NAME] ':'"));
-            _res = RAISE_SYNTAX_ERROR_STARTING_FROM ( a , "exception group must be parenthesized" );
+            _res = RAISE_SYNTAX_ERROR_STARTING_FROM ( a , "multiple exception types must be parenthesized" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 D(p->level--);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43149](https://bugs.python.org/issue43149) -->
https://bugs.python.org/issue43149
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal