### PR TITLE
[3.9] bpo-43568: Relax distutils MACOSX_DEPLOYMENT_TARGET check (GH-25827)

### DIFF
--- a/Lib/distutils/spawn.py
+++ b/Lib/distutils/spawn.py
@@ -59,13 +59,17 @@ def spawn(cmd, search_path=1, verbose=0, dry_run=0):
             if _cfg_target:
                 _cfg_target_split = [int(x) for x in _cfg_target.split('.')]
         if _cfg_target:
-            # ensure that the deployment target of build process is not less
-            # than that used when the interpreter was built. This ensures
-            # extension modules are built with correct compatibility values
+            # Ensure that the deployment target of the build process is not
+            # less than 10.3 if the interpreter was built for 10.3 or later.
+            # This ensures extension modules are built with correct
+            # compatibility values, specifically LDSHARED which can use
+            # '-undefined dynamic_lookup' which only works on >= 10.3.
             cur_target = os.environ.get('MACOSX_DEPLOYMENT_TARGET', _cfg_target)
-            if _cfg_target_split > [int(x) for x in cur_target.split('.')]:
+            cur_target_split = [int(x) for x in cur_target.split('.')]
+            if _cfg_target_split[:2] >= [10, 3] and cur_target_split[:2] < [10, 3]:
                 my_msg = ('$MACOSX_DEPLOYMENT_TARGET mismatch: '
-                          'now "%s" but "%s" during configure'
+                          'now "%s" but "%s" during configure;'
+                          'must use 10.3 or later'
                                 % (cur_target, _cfg_target))
                 raise DistutilsPlatformError(my_msg)
             env = dict(os.environ,

--- a/Misc/NEWS.d/next/macOS/2021-06-02-19-21-13.bpo-43568.viomLm.rst
+++ b/Misc/NEWS.d/next/macOS/2021-06-02-19-21-13.bpo-43568.viomLm.rst
@@ -1,0 +1,2 @@
+Relax unnecessarily restrictive MACOSX_DEPLOYMENT_TARGET check when building
+extension modules for macOS. Patch by Joshua Root.


### PR DESCRIPTION
Only complain if the config target is >= 10.3 and the current target is
< 10.3. The check was originally added to ensure that incompatible
LDSHARED flags are not used, because '-undefined dynamic_lookup' is
used when building for 10.3 and later, and is not supported on older OS
versions. Apart from that, there should be no problem in general
with using an older target. In particular, this allows targeting macOS
11.0 when Python was built for a newer minor version like 11.3.

(manually cherry picked from part of commit 8703178)


<!-- issue-number: [bpo-43568](https://bugs.python.org/issue43568) -->
https://bugs.python.org/issue43568
<!-- /issue-number -->
