### PR TITLE
bpo-44082: Add a method to check interpolation errors in configparser

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -317,7 +317,10 @@ Interpolation of values
 
 On top of the core functionality, :class:`ConfigParser` supports
 interpolation.  This means values can be preprocessed before returning them
-from ``get()`` calls.
+from ``get()`` calls. The preprocessing is done during the get call and
+not while reading the input. To check for any interpolation errors
+after reading the input, use the
+:meth:`ConfigParser.check_interpolation_errors`.
 
 .. index:: single: % (percent); interpolation in configuration files
 
@@ -1186,6 +1189,13 @@ ConfigParser Objects
 
       Note that when reading configuration files, whitespace around the option
       names is stripped before :meth:`optionxform` is called.
+
+
+   .. method:: check_interpolation_errors()
+
+      Check for errors with interpolation of values in the input. Returns a
+      list of interpolation errors found. If no errors are found, an empty
+      list is returned.
 
 
    .. method:: readfp(fp, filename=None)

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -956,6 +956,20 @@ class RawConfigParser(MutableMapping):
             del self._proxies[section]
         return existed
 
+    def check_interpolation_errors(self):
+        """Check the configuration for interpolation errors.
+
+        Returns a list of the errors detected
+        """
+        errors = []
+        for section in self._sections:
+            for option in self._sections[section]:
+                try:
+                    _ = self[section][option]
+                except (TypeError, InterpolationError) as e:
+                   errors.append(e)
+        return errors
+
     def __getitem__(self, key):
         if key != self.default_section and not self.has_section(key):
             raise KeyError(key)

--- a/Misc/NEWS.d/next/Library/2021-05-19-03-49-45.bpo-44082.1CMwjs.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-19-03-49-45.bpo-44082.1CMwjs.rst
@@ -1,0 +1,1 @@
+Add a method in ``ConfigParser`` to verify the loaded config files for any interpolation errors.


### PR DESCRIPTION
The method is meant to check for errors in configuration file due to
missing or incorrect interpolation options. Currently, reading the
configuration file does not generate any error due to interpolation.
The documentation for this behaviour is also not very clear.

The method here provides a means to check for interpolation errors in
the configuration file. It can be used in unit tests or to create an
early failure in an application.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44082](https://bugs.python.org/issue44082) -->
https://bugs.python.org/issue44082
<!-- /issue-number -->
