### PR TITLE
Revert test for Tix deprecation warning

### DIFF
--- a/Lib/test/test_tix.py
+++ b/Lib/test/test_tix.py
@@ -26,12 +26,9 @@ class TestTix(unittest.TestCase):
         else:
             self.addCleanup(self.root.destroy)
 
-    def test_tix_deprecation(self):
-        with self.assertWarns(DeprecationWarning):
-            import_helper.import_fresh_module(
-                'tkinter.tix',
-                fresh=('tkinter.tix',),
-                )
+    def test_tix_available(self):
+        # this test is just here to make setUp run
+        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added in [bpo-41730](https://bugs.python.org/issue41730) (GH-22186), the test apparently causes refleaks.  The
test isn't worth hunting them down, so it's simply reverted.

This partially reverts commit 4a2d98a1e98de25c5114d11fcb0f9fedbb057e51.