### PR TITLE
bpo-44089: Allow subclassing of ``csv.Error``

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1237,6 +1237,9 @@ class MiscTestCase(unittest.TestCase):
         extra = {'__doc__', '__version__'}
         support.check__all__(self, csv, ('csv', '_csv'), extra=extra)
 
+    def test_subclassable(self):
+        # issue 44089
+        class Foo(csv.Error): ...
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2021-05-09-22-52-34.bpo-44089.IoANsN.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-09-22-52-34.bpo-44089.IoANsN.rst
@@ -1,1 +1,2 @@
-Allow subclassing ``csv.Error`` in 3.10 (it was allowed in 3.9 and earlier).
+Allow subclassing ``csv.Error`` in 3.10 (it was allowed in 3.9 and earlier but
+was disallowed in early versions of 3.10).

--- a/Misc/NEWS.d/next/Library/2021-05-09-22-52-34.bpo-44089.IoANsN.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-09-22-52-34.bpo-44089.IoANsN.rst
@@ -1,0 +1,1 @@
+Allow subclassing ``csv.Error`` in 3.10 (it was allowed in 3.9 and earlier).

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1515,7 +1515,7 @@ static PyType_Slot error_slots[] = {
 
 PyType_Spec error_spec = {
     .name = "_csv.Error",
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     .slots = error_slots,
 };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44089](https://bugs.python.org/issue44089) -->
https://bugs.python.org/issue44089
<!-- /issue-number -->
