### PR TITLE
Fix for httpretty SSL mocking

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1001,7 +1001,7 @@ class SSLSocket(socket):
             fileno=sock.fileno()
         )
         self = cls.__new__(cls, **kwargs)
-        super(SSLSocket, self).__init__(**kwargs)
+        super(cls, self).__init__(**kwargs)
         self.settimeout(sock.gettimeout())
         sock.detach()
 


### PR DESCRIPTION
A fix for HTTPretty SSL mocking (and maybe other patching solutions):

```
ERROR    django.request:log.py:224 Internal Server Error: /api/v1/auth/facebook/
Traceback (most recent call last):
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/dmugtasimov/.pyenv/versions/3.9.4/lib/python3.9/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/django/utils/decorators.py", line 43, in _wrapper
    return bound_method(*args, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/django/views/decorators/debug.py", line 89, in sensitive_post_parameters_wrapper
    return view(request, *args, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/dj_rest_auth/views.py", line 48, in dispatch
    return super(LoginView, self).dispatch(*args, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/dj_rest_auth/views.py", line 113, in post
    self.serializer.is_valid(raise_exception=True)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/rest_framework/serializers.py", line 220, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/rest_framework/serializers.py", line 422, in run_validation
    value = self.validate(value)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/dj_rest_auth/registration/serializers.py", line 134, in validate
    login = self.get_social_login(adapter, app, social_token, token)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/dj_rest_auth/registration/serializers.py", line 56, in get_social_login
    social_login = adapter.complete_login(request, app, token, response=response)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/allauth/socialaccount/providers/facebook/views.py", line 66, in complete_login
    return fb_complete_login(request, app, access_token)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/allauth/socialaccount/providers/facebook/views.py", line 39, in fb_complete_login
    resp = requests.get(
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/requests/api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 382, in _make_request
    self._validate_conn(conn)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 1010, in _validate_conn
    conn.connect()
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/urllib3/connection.py", line 411, in connect
    self.sock = ssl_wrap_socket(
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/httpretty/core.py", line 716, in fake_wrap_socket
    return orig_wrap_socket_fn(*args, **kw)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 428, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 472, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "/home/dmugtasimov/.virtualenvs/convenience-server-I7VkMQJZ-py3.9/lib/python3.9/site-packages/httpretty/core.py", line 716, in fake_wrap_socket
    return orig_wrap_socket_fn(*args, **kw)
  File "/home/dmugtasimov/.pyenv/versions/3.9.4/lib/python3.9/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/home/dmugtasimov/.pyenv/versions/3.9.4/lib/python3.9/ssl.py", line 1004, in _create
    super(SSLSocket, self).__init__(**kwargs)
TypeError: super(type, obj): obj must be an instance or subtype of type
```