### PR TITLE
bpo-44094: Remove deprecated PyErr_ APIs.

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -91,14 +91,6 @@ PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, Py
 
 PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
 
-/* Convenience functions */
-
-#ifdef MS_WINDOWS
-Py_DEPRECATED(3.3)
-PyAPI_FUNC(PyObject *) PyErr_SetFromErrnoWithUnicodeFilename(
-    PyObject *, const Py_UNICODE *);
-#endif /* MS_WINDOWS */
-
 /* Like PyErr_Format(), but saves current exception as __context__ and
    __cause__.
  */
@@ -107,16 +99,6 @@ PyAPI_FUNC(PyObject *) _PyErr_FormatFromCause(
     const char *format,   /* ASCII-encoded string  */
     ...
     );
-
-#ifdef MS_WINDOWS
-/* XXX redeclare to use WSTRING */
-Py_DEPRECATED(3.3)
-PyAPI_FUNC(PyObject *) PyErr_SetFromWindowsErrWithUnicodeFilename(
-    int, const Py_UNICODE *);
-Py_DEPRECATED(3.3)
-PyAPI_FUNC(PyObject *) PyErr_SetExcFromWindowsErrWithUnicodeFilename(
-    PyObject *,int, const Py_UNICODE *);
-#endif
 
 /* In exceptions.c */
 

--- a/Misc/NEWS.d/next/C API/2021-05-10-14-34-22.bpo-44094.HayXZO.rst
+++ b/Misc/NEWS.d/next/C API/2021-05-10-14-34-22.bpo-44094.HayXZO.rst
@@ -1,0 +1,4 @@
+Remove ``PyErr_SetFromErrnoWithUnicodeFilename()``,
+``PyErr_SetFromWindowsErrWithUnicodeFilename()``, and
+``PyErr_SetExcFromWindowsErrWithUnicodeFilename()``. They are not documented
+and have been deprecated since Python 3.3.

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -776,17 +776,6 @@ PyErr_SetFromErrnoWithFilename(PyObject *exc, const char *filename)
     return result;
 }
 
-#ifdef MS_WINDOWS
-PyObject *
-PyErr_SetFromErrnoWithUnicodeFilename(PyObject *exc, const Py_UNICODE *filename)
-{
-    PyObject *name = filename ? PyUnicode_FromWideChar(filename, -1) : NULL;
-    PyObject *result = PyErr_SetFromErrnoWithFilenameObjects(exc, name, NULL);
-    Py_XDECREF(name);
-    return result;
-}
-#endif /* MS_WINDOWS */
-
 PyObject *
 PyErr_SetFromErrno(PyObject *exc)
 {
@@ -887,20 +876,6 @@ PyObject *PyErr_SetExcFromWindowsErrWithFilename(
     return ret;
 }
 
-PyObject *PyErr_SetExcFromWindowsErrWithUnicodeFilename(
-    PyObject *exc,
-    int ierr,
-    const Py_UNICODE *filename)
-{
-    PyObject *name = filename ? PyUnicode_FromWideChar(filename, -1) : NULL;
-    PyObject *ret = PyErr_SetExcFromWindowsErrWithFilenameObjects(exc,
-                                                                 ierr,
-                                                                 name,
-                                                                 NULL);
-    Py_XDECREF(name);
-    return ret;
-}
-
 PyObject *PyErr_SetExcFromWindowsErr(PyObject *exc, int ierr)
 {
     return PyErr_SetExcFromWindowsErrWithFilename(exc, ierr, NULL);
@@ -924,17 +899,6 @@ PyObject *PyErr_SetFromWindowsErrWithFilename(
     return result;
 }
 
-PyObject *PyErr_SetFromWindowsErrWithUnicodeFilename(
-    int ierr,
-    const Py_UNICODE *filename)
-{
-    PyObject *name = filename ? PyUnicode_FromWideChar(filename, -1) : NULL;
-    PyObject *result = PyErr_SetExcFromWindowsErrWithFilenameObjects(
-                                                  PyExc_OSError,
-                                                  ierr, name, NULL);
-    Py_XDECREF(name);
-    return result;
-}
 #endif /* MS_WINDOWS */
 
 PyObject *


### PR DESCRIPTION
These APIs are deprecated since Python 3.3. They are not documented too.

<!-- issue-number: [bpo-44094](https://bugs.python.org/issue44094) -->
https://bugs.python.org/issue44094
<!-- /issue-number -->

Automerge-Triggered-By: GH:pitrou