### PR TITLE
[minor code fix] Remove redundant reset()

### DIFF
--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -457,7 +457,7 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
 
     if (self->statement != NULL) {
         /* There is an active statement */
-        pysqlite_statement_reset(self->statement);
+        (void)pysqlite_statement_reset(self->statement);
     }
 
     /* reset description and rowcount */
@@ -471,10 +471,6 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
     }
     if (PyTuple_SetItem(func_args, 0, Py_NewRef(operation)) != 0) {
         goto error;
-    }
-
-    if (self->statement) {
-        (void)pysqlite_statement_reset(self->statement);
     }
 
     Py_XSETREF(self->statement,


### PR DESCRIPTION
pysqlite_statement_reset() is being called twice. Nuke one, and add a `(void)` to the remaining call to be explicit that we're tossing the result code.

[ note: a bug is not being fixed, so the "skip issue" label is appropriate here ]
