### PR TITLE
Doc: http.server: directory is not a class attribute, but an argument.

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -328,7 +328,7 @@ provides three different variants:
       The *directory* parameter.
 
    .. versionchanged:: 3.9
-      The *directory* parameter Accepts a :term:`path-like object`.
+      The *directory* parameter accepts a :term:`path-like object`.
 
    A lot of the work, such as parsing the request, is done by the base class
    :class:`BaseHTTPRequestHandler`.  This class implements the :func:`do_GET`

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -320,8 +320,15 @@ provides three different variants:
 
 .. class:: SimpleHTTPRequestHandler(request, client_address, server, directory=None)
 
-   This class serves files from the current directory and below, directly
+   This class serves files from the directory *directory* and below,
+   or the current directory if *directory* is not provided, directly
    mapping the directory structure to HTTP requests.
+
+   .. versionadded:: 3.7
+      The *directory* parameter.
+
+   .. versionchanged:: 3.9
+      The *directory* parameter Accepts a :term:`path-like object`.
 
    A lot of the work, such as parsing the request, is done by the base class
    :class:`BaseHTTPRequestHandler`.  This class implements the :func:`do_GET`
@@ -344,13 +351,6 @@ provides three different variants:
       .. versionchanged:: 3.9
          This dictionary is no longer filled with the default system mappings,
          but only contains overrides.
-
-   .. attribute:: directory
-
-      If not specified, the directory to serve is the current working directory.
-
-      .. versionchanged:: 3.9
-         Accepts a :term:`path-like object`.
 
    The :class:`SimpleHTTPRequestHandler` class defines the following methods:
 


### PR DESCRIPTION
Also added the fact that this argument was added on 3.7.