### PR TITLE
bpo-40222: Mention zero-cost exceptions in whats-new for 3.11

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -95,6 +95,8 @@ Optimizations
   fast as corresponding f-string expression.
   (Contributed by Serhiy Storchaka in :issue:`28307`.)
 
+* "Zero-cost" exceptions are implemented. The cost of ``try`` statements is
+  almost eliminated when no exception is raised.
 
 Build and C API Changes
 =======================

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -97,6 +97,7 @@ Optimizations
 
 * "Zero-cost" exceptions are implemented. The cost of ``try`` statements is
   almost eliminated when no exception is raised.
+  (Contributed by Mark Shannon in :issue:`40222`.)
 
 Build and C API Changes
 =======================


### PR DESCRIPTION



<!-- issue-number: [bpo-40222](https://bugs.python.org/issue40222) -->
https://bugs.python.org/issue40222
<!-- /issue-number -->
