### PR TITLE
[3.9] bpo-44070: Clarify NEWS message to specify the version when the behaviour was introduced

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-10-22-30-12.bpo-44070.5bBtKx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-10-22-30-12.bpo-44070.5bBtKx.rst
@@ -1,2 +1,2 @@
 No longer eagerly makes import filenames absolute, except for extension
-modules.
+modules, which was introduced in 3.9.5.


### PR DESCRIPTION


<!-- issue-number: [bpo-44070](https://bugs.python.org/issue44070) -->
https://bugs.python.org/issue44070
<!-- /issue-number -->
