### PR TITLE
Doc: Fix ambiguous pronoun

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -254,7 +254,7 @@ is found that matches the exception.  An expression-less except clause, if
 present, must be last; it matches any exception.  For an except clause with an
 expression, that expression is evaluated, and the clause matches the exception
 if the resulting object is "compatible" with the exception.  An object is
-compatible with an exception if it is the class or a base class of the exception
+compatible with an exception if the object is the class or a base class of the exception
 object, or a tuple containing an item that is the class or a base class of
 the exception object.
 


### PR DESCRIPTION
Clarify that the word `it` refers not to `an exception` but to `an object`.