### PR TITLE
bpo-44110: Improve string's __getitem__ error message

### DIFF
--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -1195,6 +1195,12 @@ class MixinStrUnicodeUserStringTest:
 
         self.checkraises(TypeError, 'abc', '__getitem__', 'def')
 
+        for idx in ('def', object()):
+            with self.assertRaises(TypeError) as cm:
+                getattr('abc', '__getitem__')(idx)
+            self.assertEqual(str(cm.exception),
+                             "string indices must be integers, not '{}'".format(type(idx).__name__))
+
     def test_slice(self):
         self.checkequal('abc', 'abc', '__getitem__', slice(0, 1000))
         self.checkequal('abc', 'abc', '__getitem__', slice(0, 3))

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -80,12 +80,14 @@ class BaseTest:
                 self.assertIsNot(obj, realresult)
 
     # check that obj.method(*args) raises exc
-    def checkraises(self, exc, obj, methodname, *args):
+    def checkraises(self, exc, obj, methodname, *args, **kwargs):
         obj = self.fixtype(obj)
         args = self.fixtype(args)
         with self.assertRaises(exc) as cm:
             getattr(obj, methodname)(*args)
         self.assertNotEqual(str(cm.exception), '')
+        if 'expected_msg' in kwargs:
+            self.assertEqual(str(cm.exception), kwargs['expected_msg'])
 
     # call obj.method(*args) without any checks
     def checkcall(self, obj, methodname, *args):
@@ -1195,11 +1197,9 @@ class MixinStrUnicodeUserStringTest:
 
         self.checkraises(TypeError, 'abc', '__getitem__', 'def')
 
-        for idx in ('def', object()):
-            with self.assertRaises(TypeError) as cm:
-                getattr('abc', '__getitem__')(idx)
-            self.assertEqual(str(cm.exception),
-                             "string indices must be integers, not '{}'".format(type(idx).__name__))
+        for idx_type in ('def', object()):
+            expected_msg = "string indices must be integers, not '{}'".format(type(idx_type).__name__)
+            self.checkraises(TypeError, 'abc', '__getitem__', idx_type, expected_msg=expected_msg)
 
     def test_slice(self):
         self.checkequal('abc', 'abc', '__getitem__', slice(0, 1000))

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -80,14 +80,14 @@ class BaseTest:
                 self.assertIsNot(obj, realresult)
 
     # check that obj.method(*args) raises exc
-    def checkraises(self, exc, obj, methodname, *args, **kwargs):
+    def checkraises(self, exc, obj, methodname, *args, expected_msg=None):
         obj = self.fixtype(obj)
         args = self.fixtype(args)
         with self.assertRaises(exc) as cm:
             getattr(obj, methodname)(*args)
         self.assertNotEqual(str(cm.exception), '')
-        if 'expected_msg' in kwargs:
-            self.assertEqual(str(cm.exception), kwargs['expected_msg'])
+        if expected_msg is not None:
+            self.assertEqual(str(cm.exception), expected_msg)
 
     # call obj.method(*args) without any checks
     def checkcall(self, obj, methodname, *args):

--- a/Lib/test/test_userstring.py
+++ b/Lib/test/test_userstring.py
@@ -27,14 +27,14 @@ class UserStringTest(
             realresult
         )
 
-    def checkraises(self, exc, obj, methodname, *args, **kwargs):
+    def checkraises(self, exc, obj, methodname, *args, expected_msg=None):
         obj = self.fixtype(obj)
         # we don't fix the arguments, because UserString can't cope with it
         with self.assertRaises(exc) as cm:
             getattr(obj, methodname)(*args)
         self.assertNotEqual(str(cm.exception), '')
-        if 'expected_msg' in kwargs:
-            self.assertEqual(str(cm.exception), kwargs['expected_msg'])
+        if expected_msg is not None:
+            self.assertEqual(str(cm.exception), expected_msg)
 
     def checkcall(self, object, methodname, *args):
         object = self.fixtype(object)

--- a/Lib/test/test_userstring.py
+++ b/Lib/test/test_userstring.py
@@ -27,12 +27,14 @@ class UserStringTest(
             realresult
         )
 
-    def checkraises(self, exc, obj, methodname, *args):
+    def checkraises(self, exc, obj, methodname, *args, **kwargs):
         obj = self.fixtype(obj)
         # we don't fix the arguments, because UserString can't cope with it
         with self.assertRaises(exc) as cm:
             getattr(obj, methodname)(*args)
         self.assertNotEqual(str(cm.exception), '')
+        if 'expected_msg' in kwargs:
+            self.assertEqual(str(cm.exception), kwargs['expected_msg'])
 
     def checkcall(self, object, methodname, *args):
         object = self.fixtype(object)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-11-21-52-44.bpo-44110.VqbAsB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-11-21-52-44.bpo-44110.VqbAsB.rst
@@ -1,0 +1,1 @@
+Improve :func:`str.__getitem__` error message

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -14564,7 +14564,8 @@ unicode_subscript(PyObject* self, PyObject* item)
         assert(_PyUnicode_CheckConsistency(result, 1));
         return result;
     } else {
-        PyErr_SetString(PyExc_TypeError, "string indices must be integers");
+        PyErr_Format(PyExc_TypeError, "string indices must be integers, not '%.200s'",
+                     Py_TYPE(item)->tp_name);
         return NULL;
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44110](https://bugs.python.org/issue44110) -->
https://bugs.python.org/issue44110
<!-- /issue-number -->
