### PR TITLE
[3.10] bpo-43933: Force RETURN_VALUE bytecodes to have line numbers

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -976,6 +976,26 @@ class TraceTestCase(unittest.TestCase):
              (3, 'return'),
              (1, 'return')])
 
+    def test_try_in_try(self):
+        def func():
+            try:
+                try:
+                    pass
+                except Exception as ex:
+                    pass
+            except Exception:
+                pass
+
+        # This doesn't conform to PEP 626
+        self.run_and_compare(func,
+            [(0, 'call'),
+             (1, 'line'),
+             (2, 'line'),
+             (3, 'line'),
+             (5, 'line'),
+             (5, 'return')])
+
+
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""
 

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1647,6 +1647,7 @@ class JumpTestCase(unittest.TestCase):
         output.append(1)
         async for i in asynciter([1, 2]):
             output.append(3)
+        pass
 
     @jump_test(3, 2, [2, 2], (ValueError, 'into'))
     def test_no_jump_backwards_into_for_block(output):

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6974,8 +6974,6 @@ guarantee_lineno_for_exits(struct assembler *a, int firstlineno) {
         }
         struct instr *last = &b->b_instr[b->b_iused-1];
         if (last->i_lineno < 0) {
-            /* A return in a block by itself can't have a linenumber, or
-             * we can mess up frame.setlineno */
             if (last->i_opcode == RETURN_VALUE)
             {
                 for (int i = 0; i < b->b_iused; i++) {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6960,6 +6960,36 @@ insert_generator_prefix(struct compiler *c, basicblock *entryblock) {
     return 0;
 }
 
+/* Make sure that all returns have a line number, even if early passes
+ * have failed to propagate a correct line number.
+ * The resulting line number may not be correct according to PEP 626,
+ * but should be "good enough", and no worse than in older versions. */
+static void
+guarantee_lineno_for_exits(struct assembler *a, int firstlineno) {
+    int lineno = firstlineno;
+    assert(lineno > 0);
+    for (basicblock *b = a->a_entry; b != NULL; b = b->b_next) {
+        if (b->b_iused == 0) {
+            continue;
+        }
+        struct instr *last = &b->b_instr[b->b_iused-1];
+        if (last->i_lineno < 0) {
+            /* A return in a block by itself can't have a linenumber, or
+             * we can mess up frame.setlineno */
+            if (last->i_opcode == RETURN_VALUE)
+            {
+                for (int i = 0; i < b->b_iused; i++) {
+                    assert(b->b_instr[i].i_lineno < 0);
+                    b->b_instr[i].i_lineno = lineno;
+                }
+            }
+        }
+        else {
+            lineno = last->i_lineno;
+        }
+    }
+}
+
 static PyCodeObject *
 assemble(struct compiler *c, int addNone)
 {
@@ -7022,6 +7052,7 @@ assemble(struct compiler *c, int addNone)
     if (optimize_cfg(c, &a, consts)) {
         goto error;
     }
+    guarantee_lineno_for_exits(&a, c->u->u_firstlineno);
 
     /* Can't modify the bytecode after computing jump offsets. */
     assemble_jump_offsets(&a, c);


### PR DESCRIPTION
Manual backport of https://github.com/python/cpython/pull/26054

<!-- issue-number: [bpo-43933](https://bugs.python.org/issue43933) -->
https://bugs.python.org/issue43933
<!-- /issue-number -->
