### PR TITLE
bpo-44114: Fix dictkeys_reversed and dictvalues_reversed function signatures

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-12-14-26-16.bpo-44114.p-WfAE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-12-14-26-16.bpo-44114.p-WfAE.rst
@@ -1,0 +1,1 @@
+Fix incorrect dictkeys_reversed and dictitems_reversed function signatures in C code, which broke webassembly builds.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4826,7 +4826,7 @@ static PySequenceMethods dictitems_as_sequence = {
     (objobjproc)dictitems_contains,     /* sq_contains */
 };
 
-static PyObject* dictitems_reversed(_PyDictViewObject *dv);
+static PyObject* dictitems_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reversed_items_doc,
 "Return a reverse iterator over the dict items.");
@@ -4879,7 +4879,7 @@ dictitems_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-dictitems_reversed(_PyDictViewObject *dv)
+dictitems_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 {
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
@@ -4909,7 +4909,7 @@ static PySequenceMethods dictvalues_as_sequence = {
     (objobjproc)0,                      /* sq_contains */
 };
 
-static PyObject* dictvalues_reversed(_PyDictViewObject *dv);
+static PyObject* dictvalues_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reversed_values_doc,
 "Return a reverse iterator over the dict values.");
@@ -4960,7 +4960,7 @@ dictvalues_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-dictvalues_reversed(_PyDictViewObject *dv)
+dictvalues_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 {
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;


### PR DESCRIPTION
Fix for bug number 44114

These are passed and called as PyCFunction, which looks like:

```
PyObject *PyCFunction(PyObject *self,
                      PyObject *args);
```

however they are defined here without the (ignored) args parameter. 

This works fine in some C compilers, but fails in webassembly or anything else that has strict function pointer call type checking.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44114](https://bugs.python.org/issue44114) -->
https://bugs.python.org/issue44114
<!-- /issue-number -->
