### PR TITLE
bpo-44115: improve duck-typing of fractions

### DIFF
--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -25,17 +25,20 @@ another rational number, or from a string.
 
    The first version requires that *numerator* and *denominator* are instances
    of :class:`numbers.Rational` and returns a new :class:`Fraction` instance
-   with value ``numerator/denominator``. If *denominator* is :const:`0`, it
-   raises a :exc:`ZeroDivisionError`. The second version requires that
-   *other_fraction* is an instance of :class:`numbers.Rational` and returns a
-   :class:`Fraction` instance with the same value.  The next two versions accept
-   either a :class:`float` or a :class:`decimal.Decimal` instance, and return a
-   :class:`Fraction` instance with exactly the same value.  Note that due to the
-   usual issues with binary floating-point (see :ref:`tut-fp-issues`), the
-   argument to ``Fraction(1.1)`` is not exactly equal to 11/10, and so
-   ``Fraction(1.1)`` does *not* return ``Fraction(11, 10)`` as one might expect.
-   (But see the documentation for the :meth:`limit_denominator` method below.)
-   The last version of the constructor expects a string or unicode instance.
+   with value ``numerator/denominator``.  If *denominator* is :const:`0`, it
+   raises a :exc:`ZeroDivisionError`.  The following versions require
+   that the parameter has an `as_integer_ratio` method which returns a
+   pair (numerator, denominator).  This assures that for instances
+   of :class:`numbers.Rational`, :class:`float`, or :class:`decimal.Decimal`, a
+   :class:`Fraction` instance with exactly the same value is returned.
+
+   Note that due to the usual issues with binary floating-point
+   (see :ref:`tut-fp-issues`), the argument to ``Fraction(1.1)`` is not exactly
+   equal to 11/10, and so ``Fraction(1.1)`` does *not* return
+   ``Fraction(11, 10)`` as one might expect. (But see the documentation for the
+   :meth:`limit_denominator` method below.)
+
+   The last version of the constructor expects a string instance.
    The usual form for this instance is::
 
       [sign] numerator ['/' denominator]
@@ -83,6 +86,10 @@ another rational number, or from a string.
    .. versionchanged:: 3.2
       The :class:`Fraction` constructor now accepts :class:`float` and
       :class:`decimal.Decimal` instances.
+
+   .. versionchanged:: 3.11
+      The :class:`Fraction` constructor now accepts anything that
+      defines `as_integer_ratio`.
 
    .. versionchanged:: 3.9
       The :func:`math.gcd` function is now used to normalize the *numerator*

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -27,7 +27,7 @@ another rational number, or from a string.
    of :class:`numbers.Rational` and returns a new :class:`Fraction` instance
    with value ``numerator/denominator``.  If *denominator* is :const:`0`, it
    raises a :exc:`ZeroDivisionError`.  The following versions require
-   that the parameter has an `as_integer_ratio` method which returns a
+   that the parameter has an :meth:`as_integer_ratio` method which returns a
    pair (numerator, denominator).  This assures that for instances
    of :class:`numbers.Rational`, :class:`float`, or :class:`decimal.Decimal`, a
    :class:`Fraction` instance with exactly the same value is returned.

--- a/Doc/library/numbers.rst
+++ b/Doc/library/numbers.rst
@@ -61,7 +61,7 @@ The numeric tower
    Subtypes :class:`Real` and adds
    :attr:`~Rational.numerator` and :attr:`~Rational.denominator` properties, which
    should be in lowest terms. With these, it provides a default for
-   :func:`float`.
+   :func:`float` and :meth:`~Rational.as_integer_ratio`.
 
    .. attribute:: numerator
 
@@ -71,6 +71,9 @@ The numeric tower
 
       Abstract.
 
+   .. method:: as_integer_ratio()
+
+      return a pair (numerator, denominator).
 
 .. class:: Integral
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -3,7 +3,6 @@
 
 """Fraction, infinite-precision, real numbers."""
 
-from decimal import Decimal
 import math
 import numbers
 import operator
@@ -103,11 +102,6 @@ class Fraction(numbers.Rational):
                 self._denominator = numerator.denominator
                 return self
 
-            elif isinstance(numerator, (float, Decimal)):
-                # Exact conversion
-                self._numerator, self._denominator = numerator.as_integer_ratio()
-                return self
-
             elif isinstance(numerator, str):
                 # Handle construction from strings.
                 m = _RATIONAL_FORMAT.match(numerator)
@@ -136,8 +130,13 @@ class Fraction(numbers.Rational):
                     numerator = -numerator
 
             else:
-                raise TypeError("argument should be a string "
-                                "or a Rational instance")
+                as_integer_ratio = getattr(numerator, "as_integer_ratio", None)
+                if as_integer_ratio is not None:
+                     self._numerator, self._denominator = as_integer_ratio()
+                     return self
+                else:
+                    raise TypeError("argument should be a string "
+                                    "or a Rational instance")
 
         elif type(numerator) is int is type(denominator):
             pass # *very* normal case

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -53,6 +53,9 @@ class Fraction(numbers.Rational):
 
       - other Rational instances (including integers)
 
+      - or anything else that has an `as_integer_ratio` method that
+        returns a pair (numerator, denominator)
+
     """
 
     __slots__ = ('_numerator', '_denominator')

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -132,8 +132,8 @@ class Fraction(numbers.Rational):
             else:
                 as_integer_ratio = getattr(numerator, "as_integer_ratio", None)
                 if as_integer_ratio is not None:
-                     self._numerator, self._denominator = as_integer_ratio()
-                     return self
+                    self._numerator, self._denominator = as_integer_ratio()
+                    return self
                 else:
                     raise TypeError("argument should be a string "
                                     "or a Rational instance")

--- a/Lib/numbers.py
+++ b/Lib/numbers.py
@@ -269,6 +269,14 @@ class Rational(Real):
 
     __slots__ = ()
 
+    def as_integer_ratio(self):
+        """Return the integer ratio as a tuple.
+
+        Return a tuple of two integers, whose ratio is equal to the
+        Fraction and with a positive denominator.
+        """
+        return (self.numerator, self.denominator)
+
     @property
     @abstractmethod
     def numerator(self):

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -157,6 +157,13 @@ class FractionTest(unittest.TestCase):
         self.assertRaises(OverflowError, F, Decimal('inf'))
         self.assertRaises(OverflowError, F, Decimal('-inf'))
 
+    def testInitFromGeneric(self):
+        class TwoThirds:
+            def as_integer_ratio(self):
+                return 2, 3
+
+        self.assertEqual(F(TwoThirds()), F(2, 3))
+
     def testFromString(self):
         self.assertEqual((5, 1), _components(F("5")))
         self.assertEqual((3, 2), _components(F("3/2")))

--- a/Misc/NEWS.d/next/Library/2021-05-12-13-18-28.bpo-44115.Y11_u8.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-12-13-18-28.bpo-44115.Y11_u8.rst
@@ -1,1 +1,1 @@
-improve conversions to fractions
+objects defining as_integer_ratio can be converted to fractions

--- a/Misc/NEWS.d/next/Library/2021-05-12-13-18-28.bpo-44115.Y11_u8.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-12-13-18-28.bpo-44115.Y11_u8.rst
@@ -1,0 +1,1 @@
+improve conversions to fractions


### PR DESCRIPTION
allow any object that has an as_integer_ratio method to be
converted to fractions.

This is helpful especially for numpy types, which have said method
but do not inherit from the classes that can currently be converted
to fractions.


<!-- issue-number: [bpo-44115](https://bugs.python.org/issue44115) -->
https://bugs.python.org/issue44115
<!-- /issue-number -->
