### PR TITLE
[3.10] bpo-25479: add unit test for __subclasshook__ in test_abc.py (…

### DIFF
--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -459,6 +459,24 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             with self.assertRaisesRegex(Exception, exc_msg):
                 issubclass(int, S)
 
+        def test_subclasshook(self):
+            class A(metaclass=abc.ABCMeta):
+                @classmethod
+                def __subclasshook__(cls, C):
+                    if cls is A:
+                        return 'foo' in C.__dict__
+                    return NotImplemented
+            self.assertFalse(issubclass(A, A))
+            self.assertFalse(issubclass(A, (A,)))
+            class B:
+                foo = 42
+            self.assertTrue(issubclass(B, A))
+            self.assertTrue(issubclass(B, (A,)))
+            class C:
+                spam = 42
+            self.assertFalse(issubclass(C, A))
+            self.assertFalse(issubclass(C, (A,)))
+
         def test_all_new_methods_are_called(self):
             class A(metaclass=abc_ABCMeta):
                 pass


### PR DESCRIPTION
…GH-24034)

Co-authored-by: Szymon Trapp
(cherry picked from commit 5010c044c73ee55d0fd578cfecd3f4c3f01a4140)

Co-authored-by: Karl Dubost <karl+github@la-grange.net>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-25479](https://bugs.python.org/issue25479) -->
https://bugs.python.org/issue25479
<!-- /issue-number -->
