### PR TITLE
bpo-38908: Fix issue when non runtime_protocol does not raise TypeError

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1424,7 +1424,7 @@ class ProtocolTests(BaseTestCase):
 
     def test_non_runtime_protocol_isinstance_check(self):
         class P(Protocol):
-            pass
+            x: int
 
         class A:
             pass

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1426,11 +1426,8 @@ class ProtocolTests(BaseTestCase):
         class P(Protocol):
             x: int
 
-        class A:
-            pass
-
-        with self.assertRaises(TypeError):
-            isinstance(A(), P)
+        with self.assertRaisesRegex(TypeError, "@runtime_checkable"):
+            isinstance(1, P)
 
 
 class GenericTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1422,6 +1422,17 @@ class ProtocolTests(BaseTestCase):
         class CustomContextManager(typing.ContextManager, Protocol):
             pass
 
+    def test_non_runtime_protocol_isinstance_check(self):
+        class P(Protocol):
+            pass
+
+        class A:
+            pass
+
+        with self.assertRaises(TypeError):
+            isinstance(A(), P)
+
+
 class GenericTests(BaseTestCase):
 
     def test_basics(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1343,14 +1343,14 @@ def _no_init(self, *args, **kwargs):
         raise TypeError('Protocols cannot be instantiated')
 
 
-def _allow_reckless_class_checks():
+def _allow_reckless_class_checks(depth=3):
     """Allow instance and class checks for special stdlib modules.
 
     The abc and functools modules indiscriminately call isinstance() and
     issubclass() on the whole MRO of a user class, which may contain protocols.
     """
     try:
-        return sys._getframe(3).f_globals['__name__'] in ['abc', 'functools']
+        return sys._getframe(depth).f_globals['__name__'] in ['abc', 'functools']
     except (AttributeError, ValueError):  # For platforms without _getframe().
         return True
 
@@ -1370,6 +1370,14 @@ class _ProtocolMeta(ABCMeta):
     def __instancecheck__(cls, instance):
         # We need this method for situations where attributes are
         # assigned in __init__.
+        if (
+            getattr(cls, '_is_protocol', False) and
+            not getattr(cls, '_is_runtime_protocol', False) and
+            not _allow_reckless_class_checks(depth=2)
+        ):
+            raise TypeError("Instance and class checks can only be used with"
+                            " @runtime_checkable protocols")
+
         if ((not getattr(cls, '_is_protocol', False) or
                 _is_callable_members_only(cls)) and
                 issubclass(instance.__class__, cls)):

--- a/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
@@ -1,0 +1,2 @@
+Fix issue when non runtime_protocol does not raise TypeError and return
+False instead. Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
@@ -1,2 +1,5 @@
-Fix issue when non runtime_protocol does not raise TypeError and return
-False instead. Patch provided by Yurii Karabas.
+Fix issue where :mod:`typing` protocols without the  ``@runtime_checkable``
+decorator did not raise a ``TypeError`` when used with ``issubclass`` and
+``isinstance``.  Now, subclassses of ``typing.Protocol`` will raise a
+``TypeError`` when used with with those checks.
+Patch provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-38908](https://bugs.python.org/issue38908) -->
https://bugs.python.org/issue38908
<!-- /issue-number -->
