### PR TITLE
bpo-44116: Work around module unloading refleak to unblock buildbots

### DIFF
--- a/Lib/test/test_tools/test_sundry.py
+++ b/Lib/test/test_tools/test_sundry.py
@@ -10,6 +10,11 @@ import sys
 import unittest
 from test.support import import_helper
 
+# Work around bpo-44116: the csv and urllib.request modules leak
+# references when unloaded using modules_cleanup
+import csv
+import urllib.request
+
 from test.test_tools import scriptsdir, import_tool, skip_if_missing
 
 skip_if_missing()


### PR DESCRIPTION
The `csv` and `urllib.request` modules leak references when unloaded using `test.support.import_helper.modules_cleanup()`.
This should unblock refleak buildbots while the issue is investigated.

<!-- issue-number: [bpo-44116](https://bugs.python.org/issue44116) -->
https://bugs.python.org/issue44116
<!-- /issue-number -->
