### PR TITLE
bpo-44117: Add C API section to What's New in Python 3.11

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -99,10 +99,10 @@ Optimizations
   almost eliminated when no exception is raised.
   (Contributed by Mark Shannon in :issue:`40222`.)
 
-Build and C API Changes
-=======================
 
-* :c:func:`PyFrame_BlockSetup` and :c:func:`PyFrame_BlockPop` have been removed.
+Build Changes
+=============
+
 
 Deprecated
 ==========
@@ -119,3 +119,23 @@ Porting to Python 3.11
 
 This section lists previously described changes and other bugfixes
 that may require changes to your code.
+
+
+C API Changes
+=============
+
+New Features
+------------
+
+Porting to Python 3.11
+----------------------
+
+Deprecated
+----------
+
+Removed
+-------
+
+* :c:func:`PyFrame_BlockSetup` and :c:func:`PyFrame_BlockPop` have been
+  removed.
+  (Contributed by Mark Shannon in :issue:`40222`.)


### PR DESCRIPTION
Add also references to PyFrame_BlockPop() removal.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44117](https://bugs.python.org/issue44117) -->
https://bugs.python.org/issue44117
<!-- /issue-number -->
