### PR TITLE
bpo-40645: Fix reference leak in the _hashopenssl extension

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -2109,6 +2109,7 @@ hashlib_init_constructors(PyObject *module)
     if (PyModule_AddObjectRef(module, "_constructors", proxy) < 0) {
         return -1;
     }
+    Py_DECREF(proxy);
     return 0;
 }
 


### PR DESCRIPTION
The `PyModule_AddObjectRef` function doesn't steal a reference, so an extra `Py_DECREF` is needed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40645](https://bugs.python.org/issue40645) -->
https://bugs.python.org/issue40645
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran