### PR TITLE
bpo-44116: Add GC support to _csv heap types

### DIFF
--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1530,31 +1530,13 @@ csv_field_size_limit(PyObject *module, PyObject *args)
     return PyLong_FromLong(old_limit);
 }
 
-static void
-error_dealloc(PyObject *self)
-{
-    PyObject_GC_UnTrack(self);
-    PyTypeObject *tp = Py_TYPE(self);
-    tp->tp_free((PyObject *)self);
-    Py_DECREF(tp);
-}
-
-static int
-error_traverse(PyObject *self, visitproc visit, void *arg)
-{
-    Py_VISIT(Py_TYPE(self));
-    return 0;
-}
-
 static PyType_Slot error_slots[] = {
-    {Py_tp_traverse, error_traverse},
-    {Py_tp_dealloc, error_dealloc},
     {0, NULL},
 };
 
 PyType_Spec error_spec = {
     .name = "_csv.Error",
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     .slots = error_slots,
 };
 

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -897,6 +897,10 @@ Reader_dealloc(ReaderObj *self)
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     tp->tp_clear((PyObject *)self);
+    if (self->field != NULL) {
+        PyMem_Free(self->field);
+        self->field = NULL;
+    }
     PyObject_GC_Del(self);
     Py_DECREF(tp);
 }
@@ -917,10 +921,6 @@ Reader_clear(ReaderObj *self)
     Py_CLEAR(self->dialect);
     Py_CLEAR(self->input_iter);
     Py_CLEAR(self->fields);
-    if (self->field != NULL) {
-        PyMem_Free(self->field);
-        self->field = NULL;
-    }
     return 0;
 }
 
@@ -1346,9 +1346,6 @@ Writer_clear(WriterObj *self)
     Py_CLEAR(self->dialect);
     Py_CLEAR(self->write);
     Py_CLEAR(self->error_obj);
-    if (self->rec != NULL) {
-        PyMem_Free(self->rec);
-    }
     return 0;
 }
 
@@ -1358,6 +1355,9 @@ Writer_dealloc(WriterObj *self)
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     tp->tp_clear((PyObject *)self);
+    if (self->rec != NULL) {
+        PyMem_Free(self->rec);
+    }
     PyObject_GC_Del(self);
     Py_DECREF(tp);
 }


### PR DESCRIPTION
- Implement full GC protocol support for _csv heap types
- Use tp_clear iso. tp_finalize to clear type contexts


Petr's reproducer now outputs the following:
```
$ ./python.exe bug.py
73166
73168
73168
73168
73168
73168
73166
73168
73168
73168
```

~However, the _csv test suite now leaks (**EDIT**: updated output after b8772d6d405c4160d8ce19f58074c92e1d4ab7c0)~
**UPDATE**: No leaks after 19e2952e43e013f1d49fd0437878e4b1c7f0ce66

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44116](https://bugs.python.org/issue44116) -->
https://bugs.python.org/issue44116
<!-- /issue-number -->
