### PR TITLE
bpo-44032: Move data stack to thread from FrameObject.

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -40,6 +40,7 @@ struct PyCodeObject {
     PyObject *co_name;          /* unicode (name, for reference) */
     PyObject *co_linetable;     /* string (encoding addr<->lineno mapping) See
                                    Objects/lnotab_notes.txt for details. */
+    int co_nlocalsplus;         /* Number of locals + free + cell variables */
     PyObject *co_exceptiontable; /* Byte string encoding exception handling table */
     PyObject *co_weakreflist;   /* to support weakrefs to code objects */
     /* Scratch space for extra data relating to the code object.

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -41,7 +41,6 @@ struct PyCodeObject {
     PyObject *co_linetable;     /* string (encoding addr<->lineno mapping) See
                                    Objects/lnotab_notes.txt for details. */
     PyObject *co_exceptiontable; /* Byte string encoding exception handling table */
-    void *co_zombieframe;       /* for optimization only (see frameobject.c) */
     PyObject *co_weakreflist;   /* to support weakrefs to code objects */
     /* Scratch space for extra data relating to the code object.
        Type is a void* to keep the format private in codeobject.c to force

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -22,14 +22,14 @@ typedef signed char PyFrameState;
 enum {
     FRAME_SPECIALS_GLOBALS_OFFSET = 0,
     FRAME_SPECIALS_BUILTINS_OFFSET = 1,
-    FRAME_SPECIALS_SIZE = 2
+    FRAME_SPECIALS_LOCALS_OFFSET = 2,
+    FRAME_SPECIALS_SIZE = 3
 };
 
 struct _frame {
     PyObject_HEAD
     struct _frame *f_back;      /* previous frame, or NULL */
     PyCodeObject *f_code;       /* code segment */
-    PyObject *f_locals;         /* local symbol table (any mapping) */
     PyObject **f_valuestack;    /* points after the last local */
     PyObject *f_trace;          /* Trace function */
     /* Borrowed reference to a generator, or NULL */

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -63,7 +63,7 @@ PyAPI_FUNC(PyFrameObject *) PyFrame_New(PyThreadState *, PyCodeObject *,
 
 /* only internal use */
 PyFrameObject*
-_PyFrame_New_NoTrack(PyThreadState *, PyFrameConstructor *, PyObject *);
+_PyFrame_New_NoTrack(PyThreadState *, PyFrameConstructor *, PyObject *, PyObject **);
 
 
 /* The rest of the interface is specific for frame objects */
@@ -78,3 +78,5 @@ PyAPI_FUNC(void) PyFrame_FastToLocals(PyFrameObject *);
 PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
+
+int _PyFrame_MakeCopyOfLocals(PyFrameObject *f);

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -83,7 +83,7 @@ PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
 
-int _PyFrame_StealLocals(PyFrameObject *f);
-
+/** Internal -- Not to be used outside of the interpreter core */
+int _PyFrame_TakeLocals(PyFrameObject *f);
 PyObject *_PyFrame_GetGlobals(PyFrameObject *f);
 PyObject *_PyFrame_GetBuiltins(PyFrameObject *f);

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -19,12 +19,16 @@ enum _framestate {
 
 typedef signed char PyFrameState;
 
+enum {
+    FRAME_SPECIALS_GLOBALS_OFFSET = 0,
+    FRAME_SPECIALS_BUILTINS_OFFSET = 1,
+    FRAME_SPECIALS_SIZE = 2
+};
+
 struct _frame {
     PyObject_HEAD
     struct _frame *f_back;      /* previous frame, or NULL */
     PyCodeObject *f_code;       /* code segment */
-    PyObject *f_builtins;       /* builtin symbol table (PyDictObject) */
-    PyObject *f_globals;        /* global symbol table (PyDictObject) */
     PyObject *f_locals;         /* local symbol table (any mapping) */
     PyObject **f_valuestack;    /* points after the last local */
     PyObject *f_trace;          /* Trace function */
@@ -79,4 +83,7 @@ PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
 
-int _PyFrame_MakeCopyOfLocals(PyFrameObject *f);
+int _PyFrame_StealLocals(PyFrameObject *f);
+
+PyObject *_PyFrame_GetGlobals(PyFrameObject *f);
+PyObject *_PyFrame_GetBuiltins(PyFrameObject *f);

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -20,7 +20,7 @@ enum _framestate {
 typedef signed char PyFrameState;
 
 struct _frame {
-    PyObject_VAR_HEAD
+    PyObject_HEAD
     struct _frame *f_back;      /* previous frame, or NULL */
     PyCodeObject *f_code;       /* code segment */
     PyObject *f_builtins;       /* builtin symbol table (PyDictObject) */
@@ -36,7 +36,8 @@ struct _frame {
     PyFrameState f_state;       /* What state the frame is in */
     char f_trace_lines;         /* Emit per-line trace events? */
     char f_trace_opcodes;       /* Emit per-opcode trace events? */
-    PyObject *f_localsplus[1];  /* locals+stack, dynamically sized */
+    char f_own_locals_memory;   /* This frame owns the memory for the locals */
+    PyObject **f_localsptr;     /* Pointer to locals, cells, free */
 };
 
 static inline int _PyFrame_IsRunnable(struct _frame *f) {

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -19,13 +19,6 @@ enum _framestate {
 
 typedef signed char PyFrameState;
 
-enum {
-    FRAME_SPECIALS_GLOBALS_OFFSET = 0,
-    FRAME_SPECIALS_BUILTINS_OFFSET = 1,
-    FRAME_SPECIALS_LOCALS_OFFSET = 2,
-    FRAME_SPECIALS_SIZE = 3
-};
-
 struct _frame {
     PyObject_HEAD
     struct _frame *f_back;      /* previous frame, or NULL */
@@ -82,8 +75,3 @@ PyAPI_FUNC(void) PyFrame_FastToLocals(PyFrameObject *);
 PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
-
-/** Internal -- Not to be used outside of the interpreter core */
-int _PyFrame_TakeLocals(PyFrameObject *f);
-PyObject *_PyFrame_GetGlobals(PyFrameObject *f);
-PyObject *_PyFrame_GetBuiltins(PyFrameObject *f);

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -57,6 +57,12 @@ typedef struct _err_stackitem {
 
 } _PyErr_StackItem;
 
+typedef struct _stack_chunk {
+    struct _stack_chunk *previous;
+    size_t size;
+    size_t top;
+    PyObject * data[1]; /* Variable sized */
+} _PyStackChunk;
 
 // The PyThreadState typedef is in Include/pystate.h.
 struct _ts {
@@ -149,10 +155,9 @@ struct _ts {
 
     CFrame root_cframe;
 
-    PyObject **datastack_base;
+    _PyStackChunk *datastack_chunk;
     PyObject **datastack_top;
-    PyObject **datastack_soft_limit;
-    PyObject **datastack_hard_limit;
+    PyObject **datastack_limit;
     /* XXX signal handlers should also be here */
 
 };

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -149,6 +149,10 @@ struct _ts {
 
     CFrame root_cframe;
 
+    PyObject **datastack_base;
+    PyObject **datastack_top;
+    PyObject **datastack_soft_limit;
+    PyObject **datastack_hard_limit;
     /* XXX signal handlers should also be here */
 
 };

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -18,7 +18,7 @@ extern "C" {
     /* Note: gi_frame can be NULL if the generator is "finished" */         \
     PyFrameObject *prefix##_frame;                                          \
     /* The code object backing the generator */                             \
-    PyObject *prefix##_code;                                                \
+    PyCodeObject *prefix##_code;                                                \
     /* List of weak reference. */                                           \
     PyObject *prefix##_weakreflist;                                         \
     /* Name of the generator. */                                            \

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -23,6 +23,7 @@ _PyFrame_GetGlobals(PyFrameObject *f)
     return _PyFrame_Specials(f)[FRAME_SPECIALS_GLOBALS_OFFSET];
 }
 
+/* Returns a *borrowed* reference. */
 static inline PyObject *
 _PyFrame_GetBuiltins(PyFrameObject *f)
 {

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -1,0 +1,37 @@
+#ifndef Py_INTERNAL_FRAME_H
+#define Py_INTERNAL_FRAME_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    FRAME_SPECIALS_GLOBALS_OFFSET = 0,
+    FRAME_SPECIALS_BUILTINS_OFFSET = 1,
+    FRAME_SPECIALS_LOCALS_OFFSET = 2,
+    FRAME_SPECIALS_SIZE = 3
+};
+
+static inline PyObject **
+_PyFrame_Specials(PyFrameObject *f) {
+    return &f->f_valuestack[-FRAME_SPECIALS_SIZE];
+}
+
+/* Returns a *borrowed* reference. */
+static inline PyObject *
+_PyFrame_GetGlobals(PyFrameObject *f)
+{
+    return _PyFrame_Specials(f)[FRAME_SPECIALS_GLOBALS_OFFSET];
+}
+
+static inline PyObject *
+_PyFrame_GetBuiltins(PyFrameObject *f)
+{
+    return _PyFrame_Specials(f)[FRAME_SPECIALS_BUILTINS_OFFSET];
+}
+
+int _PyFrame_TakeLocals(PyFrameObject *f);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_FRAME_H */

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -95,6 +95,10 @@ struct _PyTraceMalloc_Config {
 PyAPI_DATA(struct _PyTraceMalloc_Config) _Py_tracemalloc_config;
 
 
+void *_PyObject_VirtualAlloc(size_t size);
+void _PyObject_VirtualFree(void *, size_t size);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -94,7 +94,8 @@ struct _PyTraceMalloc_Config {
 
 PyAPI_DATA(struct _PyTraceMalloc_Config) _Py_tracemalloc_config;
 
-
+/* Allocate memory directly from the O/S virtual memory system,
+ * where supported. Otherwise fallback on malloc */
 void *_PyObject_VirtualAlloc(size_t size);
 void _PyObject_VirtualFree(void *, size_t size);
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -147,6 +147,9 @@ PyAPI_FUNC(int) _PyState_AddModule(
 
 PyAPI_FUNC(int) _PyOS_InterruptOccurred(PyThreadState *tstate);
 
+PyObject **_PyThreadState_PushLocals(PyThreadState *, int size);
+void _PyThreadState_PopLocals(PyThreadState *, PyObject **);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -147,7 +147,7 @@ PyAPI_FUNC(int) _PyState_AddModule(
 
 PyAPI_FUNC(int) _PyOS_InterruptOccurred(PyThreadState *tstate);
 
-PyObject **_PyThreadState_PushLocals(PyThreadState *, int size);
+PyObject **_PyThreadState_PushLocals(PyThreadState *, size_t size);
 void _PyThreadState_PopLocals(PyThreadState *, PyObject **);
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -147,7 +147,7 @@ PyAPI_FUNC(int) _PyState_AddModule(
 
 PyAPI_FUNC(int) _PyOS_InterruptOccurred(PyThreadState *tstate);
 
-PyObject **_PyThreadState_PushLocals(PyThreadState *, size_t size);
+PyObject **_PyThreadState_PushLocals(PyThreadState *, int size);
 void _PyThreadState_PopLocals(PyThreadState *, PyObject **);
 
 #ifdef __cplusplus

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -666,15 +666,16 @@ id(a)''')
 
     def test_frames(self):
         gdb_output = self.get_stack_trace('''
+import sys
 def foo(a, b, c):
-    pass
+    return sys._getframe(0)
 
-foo(3, 4, 5)
-id(foo.__code__)''',
+f = foo(3, 4, 5)
+id(f)''',
                                           breakpoint='builtin_id',
-                                          cmds_after_breakpoint=['print (PyFrameObject*)(((PyCodeObject*)v)->co_zombieframe)']
+                                          cmds_after_breakpoint=['print (PyFrameObject*)v']
                                           )
-        self.assertTrue(re.match(r'.*\s+\$1 =\s+Frame 0x-?[0-9a-f]+, for file <string>, line 3, in foo \(\)\s+.*',
+        self.assertTrue(re.match(r'.*\s+\$1 =\s+Frame 0x-?[0-9a-f]+, for file <string>, line 4, in foo \(a=3.*',
                                  gdb_output,
                                  re.DOTALL),
                         'Unexpected gdb representation: %r\n%s' % (gdb_output, gdb_output))

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1274,7 +1274,7 @@ class SizeofTest(unittest.TestCase):
         # frame
         import inspect
         x = inspect.currentframe()
-        check(x, size('8P3i4cP'))
+        check(x, size('6P3i4cP'))
         # function
         def func(): pass
         check(func, size('14P'))

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1274,7 +1274,7 @@ class SizeofTest(unittest.TestCase):
         # frame
         import inspect
         x = inspect.currentframe()
-        check(x, size('6P3i4cP'))
+        check(x, size('5P3i4cP'))
         # function
         def func(): pass
         check(func, size('14P'))

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1274,11 +1274,7 @@ class SizeofTest(unittest.TestCase):
         # frame
         import inspect
         x = inspect.currentframe()
-        ncells = len(x.f_code.co_cellvars)
-        nfrees = len(x.f_code.co_freevars)
-        localsplus = x.f_code.co_stacksize + x.f_code.co_nlocals +\
-                  ncells + nfrees
-        check(x, vsize('8P3i3c' + localsplus*'P'))
+        check(x, size('8P3i4cP'))
         # function
         def func(): pass
         check(func, size('14P'))

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-14-20-03-32.bpo-44032.OzT1ob.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-14-20-03-32.bpo-44032.OzT1ob.rst
@@ -1,0 +1,2 @@
+Move 'fast' locals and other variables from the frame object to a per-thread
+datastack.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -263,7 +263,6 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
     co->co_linetable = linetable;
     Py_INCREF(exceptiontable);
     co->co_exceptiontable = exceptiontable;
-    co->co_zombieframe = NULL;
     co->co_weakreflist = NULL;
     co->co_extra = NULL;
 
@@ -674,8 +673,6 @@ code_dealloc(PyCodeObject *co)
     Py_XDECREF(co->co_exceptiontable);
     if (co->co_cell2arg != NULL)
         PyMem_Free(co->co_cell2arg);
-    if (co->co_zombieframe != NULL)
-        PyObject_GC_Del(co->co_zombieframe);
     if (co->co_weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject*)co);
     PyObject_Free(co);

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -239,6 +239,8 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
     co->co_posonlyargcount = posonlyargcount;
     co->co_kwonlyargcount = kwonlyargcount;
     co->co_nlocals = nlocals;
+    co->co_nlocalsplus = nlocals +
+        PyTuple_GET_SIZE(freevars) + PyTuple_GET_SIZE(cellvars);
     co->co_stacksize = stacksize;
     co->co_flags = flags;
     Py_INCREF(code);

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -240,7 +240,7 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
     co->co_kwonlyargcount = kwonlyargcount;
     co->co_nlocals = nlocals;
     co->co_nlocalsplus = nlocals +
-        PyTuple_GET_SIZE(freevars) + PyTuple_GET_SIZE(cellvars);
+        (int)PyTuple_GET_SIZE(freevars) + (int)PyTuple_GET_SIZE(cellvars);
     co->co_stacksize = stacksize;
     co->co_flags = flags;
     Py_INCREF(code);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -564,21 +564,8 @@ static PyGetSetDef frame_getsetlist[] = {
    frame is on the free list, only the following members have a meaning:
     ob_type             == &Frametype
     f_back              next item on free list, or NULL
-    f_stacksize         size of value stack
-    ob_size             size of localsplus
-   Note that the value and block stacks are preserved -- this can save
-   another malloc() call or two (and two free() calls as well!).
-   Also note that, unlike for integers, each frame object is a
-   malloc'ed object in its own right -- it is only the actual calls to
-   malloc() that we are trying to save here, not the administration.
-   After all, while a typical program may make millions of calls, a
-   call depth of more than 20 or 30 is probably already exceptional
-   unless the program contains run-away recursion.  I hope.
-
-   Later, PyFrame_MAXFREELIST was added to bound the # of frames saved on
-   free_list.  Else programs creating lots of cyclic trash involving
-   frames could provoke free_list into growing without bound.
 */
+
 /* max value for numfree */
 #define PyFrame_MAXFREELIST 200
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -850,7 +850,7 @@ frame_alloc(PyCodeObject *code, PyObject **localsarray)
 }
 
 int
-_PyFrame_StealLocals(PyFrameObject *f)
+_PyFrame_TakeLocals(PyFrameObject *f)
 {
     assert(f->f_own_locals_memory == 0);
     assert(f->f_stackdepth == 0);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -630,7 +630,7 @@ frame_dealloc(PyFrameObject *f)
     PyCodeObject *co = f->f_code;
 
     /* Kill all local variables */
-    if (f->f_own_locals_memory) {
+    if (f->f_localsptr) {
         for (int i = 0; i < co->co_nlocalsplus+FRAME_SPECIALS_SIZE; i++) {
             Py_CLEAR(f->f_localsptr[i]);
         }
@@ -638,8 +638,10 @@ frame_dealloc(PyFrameObject *f)
         for (int i = 0; i < f->f_stackdepth; i++) {
             Py_XDECREF(f->f_valuestack[i]);
         }
-        PyMem_Free(f->f_localsptr);
-        f->f_own_locals_memory = 0;
+        if (f->f_own_locals_memory) {
+            PyMem_Free(f->f_localsptr);
+            f->f_own_locals_memory = 0;
+        }
     }
     f->f_stackdepth = 0;
     Py_XDECREF(f->f_back);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -6,6 +6,7 @@
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 
 #include "frameobject.h"          // PyFrameObject
+#include "pycore_frame.h"
 #include "opcode.h"               // EXTENDED_ARG
 #include "structmember.h"         // PyMemberDef
 
@@ -23,11 +24,6 @@ get_frame_state(void)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
     return &interp->frame;
-}
-
-static inline PyObject **
-_PyFrame_Specials(PyFrameObject *f) {
-    return &f->f_valuestack[-FRAME_SPECIALS_SIZE];
 }
 
 
@@ -72,20 +68,6 @@ frame_getlasti(PyFrameObject *f, void *closure)
         return PyLong_FromLong(-1);
     }
     return PyLong_FromLong(f->f_lasti*2);
-}
-
-/* Returns a *borrowed* reference. Not part of the API. */
-PyObject *
-_PyFrame_GetGlobals(PyFrameObject *f)
-{
-    return _PyFrame_Specials(f)[FRAME_SPECIALS_GLOBALS_OFFSET];
-}
-
-/* Returns a *borrowed* reference. Not part of the API. */
-PyObject *
-_PyFrame_GetBuiltins(PyFrameObject *f)
-{
-    return _PyFrame_Specials(f)[FRAME_SPECIALS_BUILTINS_OFFSET];
 }
 
 static PyObject *

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -552,6 +552,18 @@ PyObject_GetArenaAllocator(PyObjectArenaAllocator *allocator)
     *allocator = _PyObject_Arena;
 }
 
+void *
+_PyObject_VirtualAlloc(size_t size)
+{
+    return _PyObject_Arena.alloc(_PyObject_Arena.ctx, size);
+}
+
+void
+_PyObject_VirtualFree(void *obj, size_t size)
+{
+    return _PyObject_Arena.free(_PyObject_Arena.ctx, obj, size);
+}
+
 void
 PyObject_SetArenaAllocator(PyObjectArenaAllocator *allocator)
 {
@@ -3035,7 +3047,7 @@ _PyObject_DebugMallocStats(FILE *out)
 
     fputc('\n', out);
 
-    /* Account for what all of those arena bytes are being used for. */ 
+    /* Account for what all of those arena bytes are being used for. */
     total = printone(out, "# bytes in allocated blocks", allocated_bytes);
     total += printone(out, "# bytes in available blocks", available_bytes);
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -561,7 +561,7 @@ _PyObject_VirtualAlloc(size_t size)
 void
 _PyObject_VirtualFree(void *obj, size_t size)
 {
-    return _PyObject_Arena.free(_PyObject_Arena.ctx, obj, size);
+    _PyObject_Arena.free(_PyObject_Arena.ctx, obj, size);
 }
 
 void

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8836,14 +8836,14 @@ super_init_without_args(PyFrameObject *f, PyCodeObject *co,
         return -1;
     }
 
-    PyObject *obj = f->f_localsplus[0];
+    PyObject *obj = f->f_localsptr[0];
     Py_ssize_t i, n;
     if (obj == NULL && co->co_cell2arg) {
         /* The first argument might be a cell. */
         n = PyTuple_GET_SIZE(co->co_cellvars);
         for (i = 0; i < n; i++) {
             if (co->co_cell2arg[i] == 0) {
-                PyObject *cell = f->f_localsplus[co->co_nlocals + i];
+                PyObject *cell = f->f_localsptr[co->co_nlocals + i];
                 assert(PyCell_Check(cell));
                 obj = PyCell_GET(cell);
                 break;
@@ -8871,7 +8871,7 @@ super_init_without_args(PyFrameObject *f, PyCodeObject *co,
         if (_PyUnicode_EqualToASCIIId(name, &PyId___class__)) {
             Py_ssize_t index = co->co_nlocals +
                 PyTuple_GET_SIZE(co->co_cellvars) + i;
-            PyObject *cell = f->f_localsplus[index];
+            PyObject *cell = f->f_localsptr[index];
             if (cell == NULL || !PyCell_Check(cell)) {
                 PyErr_SetString(PyExc_RuntimeError,
                   "super(): bad __class__ cell");

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -853,7 +853,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
         *lineno = 1;
     }
     else {
-        globals = f->f_globals;
+        globals = _PyFrame_GetGlobals(f);
         PyCodeObject *code = PyFrame_GetCode(f);
         *filename = code->co_filename;
         Py_DECREF(code);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -5,6 +5,7 @@
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "frameobject.h"          // PyFrame_GetBack()
+#include "pycore_frame.h"
 #include "clinic/_warnings.c.h"
 
 #define MODULE_NAME "_warnings"

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4775,6 +4775,10 @@ fail:
 
 }
 
+/* Exception table parsing code.
+ * See Objects/exception_table_notes.txt for details.
+ */
+
 static inline unsigned char *
 parse_varint(unsigned char *p, int *result) {
     int val = p[0] & 63;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1641,8 +1641,8 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
 
     names = co->co_names;
     consts = co->co_consts;
-    fastlocals = f->f_localsplus;
-    freevars = f->f_localsplus + co->co_nlocals;
+    fastlocals = f->f_localsptr;
+    freevars = f->f_localsptr + co->co_nlocals;
     assert(PyBytes_Check(co->co_code));
     assert(PyBytes_GET_SIZE(co->co_code) <= INT_MAX);
     assert(PyBytes_GET_SIZE(co->co_code) % sizeof(_Py_CODEUNIT) == 0);
@@ -4879,8 +4879,8 @@ _PyEval_MakeFrameVector(PyThreadState *tstate,
     if (f == NULL) {
         return NULL;
     }
-    PyObject **fastlocals = f->f_localsplus;
-    PyObject **freevars = f->f_localsplus + co->co_nlocals;
+    PyObject **fastlocals = f->f_localsptr;
+    PyObject **freevars = f->f_localsptr + co->co_nlocals;
 
     /* Create a dictionary for keyword parameters (**kwags) */
     PyObject *kwdict;
@@ -6429,14 +6429,14 @@ unicode_concatenate(PyThreadState *tstate, PyObject *v, PyObject *w,
         switch (opcode) {
         case STORE_FAST:
         {
-            PyObject **fastlocals = f->f_localsplus;
+            PyObject **fastlocals = f->f_localsptr;
             if (GETLOCAL(oparg) == v)
                 SETLOCAL(oparg, NULL);
             break;
         }
         case STORE_DEREF:
         {
-            PyObject **freevars = (f->f_localsplus +
+            PyObject **freevars = (f->f_localsptr +
                                    f->f_code->co_nlocals);
             PyObject *c = freevars[oparg];
             if (PyCell_GET(c) ==  v) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5171,6 +5171,9 @@ _PyEval_Vector(PyThreadState *tstate, PyFrameConstructor *con,
         _PyObject_GC_TRACK(f);
         if (_PyFrame_MakeCopyOfLocals(f)) {
             Py_XDECREF(retval);
+            if (!is_coro) {
+                _PyThreadState_PopLocals(tstate, localsarray);
+            }
             return NULL;
         }
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -26,6 +26,7 @@
 #include "code.h"
 #include "dictobject.h"
 #include "frameobject.h"
+#include "pycore_frame.h"
 #include "opcode.h"
 #include "pydtrace.h"
 #include "setobject.h"

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5183,7 +5183,7 @@ _PyEval_Vector(PyThreadState *tstate, PyFrameConstructor *con,
     if (Py_REFCNT(f) > 1) {
         Py_DECREF(f);
         _PyObject_GC_TRACK(f);
-        if (_PyFrame_StealLocals(f)) {
+        if (_PyFrame_TakeLocals(f)) {
             Py_CLEAR(retval);
         }
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5179,7 +5179,6 @@ _PyEval_Vector(PyThreadState *tstate, PyFrameConstructor *con,
     */
     assert (!is_coro);
     assert(f->f_own_locals_memory == 0);
-    assert(f->f_stackdepth == 0);
     if (Py_REFCNT(f) > 1) {
         Py_DECREF(f);
         _PyObject_GC_TRACK(f);
@@ -5188,10 +5187,11 @@ _PyEval_Vector(PyThreadState *tstate, PyFrameConstructor *con,
         }
     }
     else {
+        ++tstate->recursion_depth;
+        f->f_localsptr = NULL;
         for (int i = 0; i < code->co_nlocalsplus + FRAME_SPECIALS_SIZE; i++) {
             Py_XDECREF(localsarray[i]);
         }
-        ++tstate->recursion_depth;
         Py_DECREF(f);
         --tstate->recursion_depth;
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1969,6 +1969,31 @@ _Py_GetConfig(void)
     return _PyInterpreterState_GetConfig(tstate->interp);
 }
 
+/* Dumbest possible (and very inefficient) implementation */
+
+PyObject **
+_PyThreadState_PushLocals(PyThreadState *tstate, int size)
+{
+    (void)tstate;
+    PyObject **res = PyMem_Malloc(sizeof(PyObject **)*size);
+    if (res == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    for (Py_ssize_t i=0; i < size; i++) {
+        res[i] = NULL;
+    }
+    return res;
+}
+
+void
+_PyThreadState_PopLocals(PyThreadState *tstate, PyObject **locals)
+{
+    (void)tstate;
+    PyMem_Free(locals);
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2035,7 +2035,7 @@ _PyThreadState_PopLocals(PyThreadState *tstate, PyObject **locals)
         tstate->datastack_top = &previous->data[previous->top];
         tstate->datastack_chunk = previous;
         _PyObject_VirtualFree(chunk, chunk->size);
-        tstate->datastack_limit = (PyObject **)(((char *)tstate->datastack_chunk) + DATA_STACK_CHUNK_SIZE);
+        tstate->datastack_limit = (PyObject **)(((char *)previous) + previous->size);
     }
     else {
         assert(tstate->datastack_top >= locals);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -607,7 +607,11 @@ PyInterpreterState_GetDict(PyInterpreterState *interp)
     return interp->dict;
 }
 
+/* Size of data stack
+ * Experimentally this can be set as low as 12k and have all the tests
+ * pass (64bit linux). */
 #define DATA_STACK_SIZE (62*1024)
+/* Additional stack space for error recovery */
 #define DATA_STACK_HEADROOM (2*1024)
 
 static PyThreadState *

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2011,7 +2011,6 @@ _PyThreadState_PushLocals(PyThreadState *tstate, size_t size)
            _PyErr_SetString(tstate, PyExc_MemoryError, "Out of memory");
             return NULL;
         }
-        printf("Pushing chunk\n");
         tstate->datastack_chunk->top = tstate->datastack_top - &tstate->datastack_chunk->data[0];
         tstate->datastack_chunk = new;
         tstate->datastack_limit = (PyObject **)(((char *)new) + allocate_size);
@@ -2031,7 +2030,6 @@ void
 _PyThreadState_PopLocals(PyThreadState *tstate, PyObject **locals)
 {
     if (locals == &tstate->datastack_chunk->data[0]) {
-        printf("Popping chunk\n");
         _PyStackChunk *chunk = tstate->datastack_chunk;
         _PyStackChunk *previous = chunk->previous;
         tstate->datastack_top = &previous->data[previous->top];

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2026,7 +2026,7 @@ _PyThreadState_PushLocals(PyThreadState *tstate, int size)
     else {
         tstate->datastack_top = top;
     }
-    for (size_t i=0; i < size; i++) {
+    for (int i=0; i < size; i++) {
         res[i] = NULL;
     }
     return res;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -680,7 +680,7 @@ new_threadstate(PyInterpreterState *interp, int init)
         PyMem_RawFree(tstate);
         return NULL;
     }
-    /* If top points to entry 0, then _PyThreadState_PopLocals willl try to pop this chunk */
+    /* If top points to entry 0, then _PyThreadState_PopLocals will try to pop this chunk */
     tstate->datastack_top = &tstate->datastack_chunk->data[1];
     tstate->datastack_limit = (PyObject **)(((char *)tstate->datastack_chunk) + DATA_STACK_CHUNK_SIZE);
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -897,6 +897,13 @@ PyThreadState_Clear(PyThreadState *tstate)
     if (tstate->on_delete != NULL) {
         tstate->on_delete(tstate->on_delete_data);
     }
+    _PyStackChunk *chunk = tstate->datastack_chunk;
+    tstate->datastack_chunk = NULL;
+    while (chunk != NULL) {
+        _PyStackChunk *prev = chunk->previous;
+        _PyObject_VirtualFree(chunk, chunk->size);
+        chunk = prev;
+    }
 }
 
 
@@ -941,7 +948,6 @@ _PyThreadState_Delete(PyThreadState *tstate, int check_current)
         }
     }
     tstate_delete_common(tstate, gilstate);
-    _PyObject_VirtualFree(tstate->datastack_chunk, tstate->datastack_chunk->size);
     PyMem_RawFree(tstate);
 }
 

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -208,9 +208,10 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
 
     PyFrameObject *frame = traceback->tb_frame;
     assert(frame != NULL);
-    PyCodeObject *code = frame->f_code;
+    PyCodeObject *code = PyFrame_GetCode(frame);
     assert(code != NULL && code->co_varnames != NULL);
     PyObject *dir = PySequence_List(code->co_varnames);
+    Py_DECREF(code);
     if (dir == NULL) {
         return NULL;
     }
@@ -221,7 +222,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_globals);
+    dir = PySequence_List(_PyFrame_GetGlobals(frame));
     if (dir == NULL) {
         return NULL;
     }
@@ -231,7 +232,7 @@ offer_suggestions_for_name_error(PyNameErrorObject *exc)
         return suggestions;
     }
 
-    dir = PySequence_List(frame->f_builtins);
+    dir = PySequence_List(_PyFrame_GetBuiltins(frame));
     if (dir == NULL) {
         return NULL;
     }

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "frameobject.h"
+#include "pycore_frame.h"
 
 #include "pycore_pyerrors.h"
 

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -879,7 +879,7 @@ class PyFrameObjectPtr(PyObjectPtr):
         if self.is_optimized_out():
             return
 
-        f_localsplus = self.field('f_localsplus')
+        f_localsplus = self.field('f_localsptr')
         for i in safe_range(self.co_nlocals):
             pyop_value = PyObjectPtr.from_pyobject_ptr(f_localsplus[i])
             if not pyop_value.is_null():


### PR DESCRIPTION
Move local, cell and free variables, plus the evaluation stack to the thread.
Cuts down the size of frames to under 100 bytes, and enables further optimizations of Python-to-Python calls.


<!-- issue-number: [bpo-44032](https://bugs.python.org/issue44032) -->
https://bugs.python.org/issue44032
<!-- /issue-number -->
