### PR TITLE
[3.9] Revert "[3.9] bpo-38908: Fix issue when non runtime_protocol does not raise TypeError (GH-26067)"

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1422,14 +1422,6 @@ class ProtocolTests(BaseTestCase):
         class CustomContextManager(typing.ContextManager, Protocol):
             pass
 
-    def test_non_runtime_protocol_isinstance_check(self):
-        class P(Protocol):
-            x: int
-
-        with self.assertRaisesRegex(TypeError, "@runtime_checkable"):
-            isinstance(1, P)
-
-
 class GenericTests(BaseTestCase):
 
     def test_basics(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1079,14 +1079,14 @@ def _no_init(self, *args, **kwargs):
         raise TypeError('Protocols cannot be instantiated')
 
 
-def _allow_reckless_class_checks(depth=3):
+def _allow_reckless_class_cheks():
     """Allow instance and class checks for special stdlib modules.
 
     The abc and functools modules indiscriminately call isinstance() and
     issubclass() on the whole MRO of a user class, which may contain protocols.
     """
     try:
-        return sys._getframe(depth).f_globals['__name__'] in ['abc', 'functools']
+        return sys._getframe(3).f_globals['__name__'] in ['abc', 'functools']
     except (AttributeError, ValueError):  # For platforms without _getframe().
         return True
 
@@ -1106,14 +1106,6 @@ class _ProtocolMeta(ABCMeta):
     def __instancecheck__(cls, instance):
         # We need this method for situations where attributes are
         # assigned in __init__.
-        if (
-            getattr(cls, '_is_protocol', False) and
-            not getattr(cls, '_is_runtime_protocol', False) and
-            not _allow_reckless_class_checks(depth=2)
-        ):
-            raise TypeError("Instance and class checks can only be used with"
-                            " @runtime_checkable protocols")
-
         if ((not getattr(cls, '_is_protocol', False) or
                 _is_callable_members_only(cls)) and
                 issubclass(instance.__class__, cls)):
@@ -1176,12 +1168,12 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
 
             # First, perform various sanity checks.
             if not getattr(cls, '_is_runtime_protocol', False):
-                if _allow_reckless_class_checks():
+                if _allow_reckless_class_cheks():
                     return NotImplemented
                 raise TypeError("Instance and class checks can only be used with"
                                 " @runtime_checkable protocols")
             if not _is_callable_members_only(cls):
-                if _allow_reckless_class_checks():
+                if _allow_reckless_class_cheks():
                     return NotImplemented
                 raise TypeError("Protocols with non-method members"
                                 " don't support issubclass()")

--- a/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
@@ -1,5 +1,0 @@
-Fix issue where :mod:`typing` protocols without the  ``@runtime_checkable``
-decorator did not raise a ``TypeError`` when used with ``issubclass`` and
-``isinstance``.  Now, subclassses of ``typing.Protocol`` will raise a
-``TypeError`` when used with with those checks.
-Patch provided by Yurii Karabas.


### PR DESCRIPTION
Reverts python/cpython#26075

<!-- issue-number: [bpo-38908](https://bugs.python.org/issue38908) -->
https://bugs.python.org/issue38908
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum