### PR TITLE
bpo-44113: Update __xxtestfuzz not to use Py_SetProgramName

### DIFF
--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -413,6 +413,7 @@ int __lsan_is_turned_off(void) { return 1; }
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
     PyConfig config;
     PyConfig_InitPythonConfig(&config);
+    config.install_signal_handlers = 0;
     PyStatus status;
     status = PyConfig_SetBytesString(&config, &config.program_name, *argv[0]);
     if (PyStatus_Exception(status)) {

--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -411,8 +411,17 @@ int __lsan_is_turned_off(void) { return 1; }
 
 
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    PyConfig config;
+    PyConfig_InitIsolatedConfig(&config);
+    PyStatus status;
     wchar_t* wide_program_name = Py_DecodeLocale(*argv[0], NULL);
-    Py_SetProgramName(wide_program_name);
+    status = PyConfig_SetString(&config, &config.program_name,
+                                wide_program_name);
+    if (PyStatus_Exception(status)) {
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
     return 0;
 }
 

--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -425,7 +425,9 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
         goto fail;
     }
     PyConfig_Clear(&config);
+
     return 0;
+
 fail:
     PyConfig_Clear(&config);
     Py_ExitStatusException(status);

--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -438,6 +438,8 @@ fail:
    (And we bitwise or when running multiple tests to verify that normally we
    only return 0.) */
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    assert(Py_IsInitialized());
+
     int rv = 0;
 
 #if !defined(_Py_FUZZ_ONE) || defined(_Py_FUZZ_fuzz_builtin_float)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44113](https://bugs.python.org/issue44113) -->
https://bugs.python.org/issue44113
<!-- /issue-number -->
