### PR TITLE
bpo-44113: Update fromzenmain not to use Py_SetProgramName

### DIFF
--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -78,8 +78,14 @@ Py_FrozenMain(int argc, char **argv)
 #ifdef MS_WINDOWS
     PyInitFrozenExtensions();
 #endif /* MS_WINDOWS */
-    if (argc >= 1)
-        Py_SetProgramName(argv_copy[0]);
+    if (argc >= 1) {
+        status = PyConfig_SetString(&config, &config.program_name,
+                                    argv_copy[0]);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            Py_ExitStatusException(status);
+        }
+    }
 
     status = Py_InitializeFromConfig(&config);
     PyConfig_Clear(&config);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44113](https://bugs.python.org/issue44113) -->
https://bugs.python.org/issue44113
<!-- /issue-number -->
