### PR TITLE
bpo-39906: Document new follow_symlinks argument to pathlib.Path.stat() and chmod() in 3.10 whatsnew.

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1104,6 +1104,11 @@ supersedes :meth:`~pathlib.Path.link_to`. The new method has the same argument
 order as :meth:`~pathlib.Path.symlink_to`.
 (Contributed by Barney Gale in :issue:`39950`.)
 
+:meth:`pathlib.Path.stat` and :meth:`~pathlib.Path.chmod` now accept a
+*follow_symlinks* keyword-only argument for consistency with corresponding
+functions in the :mod:`os` module.
+(Contributed by Barney Gale in :issue:`39906`.)
+
 platform
 --------
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39906](https://bugs.python.org/issue39906) -->
https://bugs.python.org/issue39906
<!-- /issue-number -->
