### PR TITLE
bpo-43757: Document os.path.realpath(strict=True) in 3.10 whatsnew

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1089,6 +1089,14 @@ Add :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK`
 and :data:`~os.O_NOFOLLOW_ANY` for macOS.
 (Contributed by Dong-hee Na in :issue:`43106`.)
 
+os.path
+-------
+
+:func:`os.path.realpath` now accepts a *strict* keyword-only argument. When set
+to ``True``, :exc:`OSError` is raised if a path doesn't exist or a symlink loop
+is encountered.
+(Contributed by Barney Gale in :issue:`43757`.)
+
 pathlib
 -------
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43757](https://bugs.python.org/issue43757) -->
https://bugs.python.org/issue43757
<!-- /issue-number -->
