### PR TITLE
bpo-38908: [docs] Add changes to 3.10 whatsnew and fix some minor inaccuracies in news

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1298,6 +1298,14 @@ Add new function :func:`typing.is_typeddict` to introspect if an annotation
 is a :class:`typing.TypedDict`.
 (Contributed by Patrick Reader in :issue:`41792`)
 
+Subclassses of ``typing.Protocol`` will now raise a ``TypeError`` when used as
+the second argument of :func:`isinstance` checks unless decorated with the
+``@runtime_checkable`` decorator. This conforms more strictly with :pep:`544`.
+Previously this passed silently without any errors. Users should decorate their
+subclasses with the ``@runtime_checkable`` decorator in 3.10 and higher
+if they want runtime protocols.
+(Contributed by Patch provided by Yurii Karabas in :issue:`38908`)
+
 unittest
 --------
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1302,8 +1302,8 @@ Subclasses of ``typing.Protocol`` which only have data variables declared
 will now raise a ``TypeError`` when checked with ``isinstance`` unless they
 are decorated with :func:`runtime_checkable`.  Previously, these checks
 passed silently.  Users should decorate their
-subclasses with the :func:`runtime_checkable` decorator in Python 3.10 and
-higher if they want runtime protocols.
+subclasses with the :func:`runtime_checkable` decorator
+if they want runtime protocols.
 (Contributed by Yurii Karabas in :issue:`38908`)
 
 unittest

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1298,13 +1298,13 @@ Add new function :func:`typing.is_typeddict` to introspect if an annotation
 is a :class:`typing.TypedDict`.
 (Contributed by Patrick Reader in :issue:`41792`)
 
-Subclassses of ``typing.Protocol`` will now raise a ``TypeError`` when used as
-the second argument of :func:`isinstance` checks unless decorated with the
-``@runtime_checkable`` decorator. This conforms more strictly with :pep:`544`.
-Previously this passed silently without any errors. Users should decorate their
-subclasses with the ``@runtime_checkable`` decorator in Python 3.10 and higher
-if they want runtime protocols.
-(Contributed by Patch provided by Yurii Karabas in :issue:`38908`)
+Subclasses of ``typing.Protocol`` which only have data variables declared
+will now raise a ``TypeError`` when checked with ``isinstance`` unless they
+are decorated with :func:`runtime_checkable`.  Previously, these checks
+passed silently.  Users should decorate their
+subclasses with the :func:`runtime_checkable` decorator in Python 3.10 and
+higher if they want runtime protocols.
+(Contributed by Yurii Karabas in :issue:`38908`)
 
 unittest
 --------

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1302,7 +1302,7 @@ Subclassses of ``typing.Protocol`` will now raise a ``TypeError`` when used as
 the second argument of :func:`isinstance` checks unless decorated with the
 ``@runtime_checkable`` decorator. This conforms more strictly with :pep:`544`.
 Previously this passed silently without any errors. Users should decorate their
-subclasses with the ``@runtime_checkable`` decorator in 3.10 and higher
+subclasses with the ``@runtime_checkable`` decorator in Python 3.10 and higher
 if they want runtime protocols.
 (Contributed by Patch provided by Yurii Karabas in :issue:`38908`)
 

--- a/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
@@ -1,5 +1,5 @@
-Fix issue where :mod:`typing` protocols without the  ``@runtime_checkable``
-decorator did not raise a ``TypeError`` when used with
-``isinstance``.  Now, subclassses of ``typing.Protocol`` will raise a
-``TypeError`` when checked with ``isinstance``.
+Subclasses of ``typing.Protocol`` which only have data variables declared
+will now raise a ``TypeError`` when checked with ``isinstance`` unless they
+are decorated with :func:`runtime_checkable`.  Previously, these checks
+passed silently.
 Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-12-16-43-21.bpo-38908.nM2_rO.rst
@@ -1,5 +1,5 @@
 Fix issue where :mod:`typing` protocols without the  ``@runtime_checkable``
-decorator did not raise a ``TypeError`` when used with ``issubclass`` and
+decorator did not raise a ``TypeError`` when used with
 ``isinstance``.  Now, subclassses of ``typing.Protocol`` will raise a
-``TypeError`` when used with with those checks.
+``TypeError`` when checked with ``isinstance``.
 Patch provided by Yurii Karabas.


### PR DESCRIPTION
The fix only applies to ``isinstance``. ``issubclass`` isn't affected (because it was always working to begin with). So I also fixed the news to reflect that.

<!-- issue-number: [bpo-38908](https://bugs.python.org/issue38908) -->
https://bugs.python.org/issue38908
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum