### PR TITLE
bpo-42130: Fix swallowing of cancellation by wait_for

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -433,15 +433,12 @@ async def wait_for(fut, timeout):
         try:
             await waiter
         except exceptions.CancelledError:
-            if fut.done():
-                return fut.result()
-            else:
-                fut.remove_done_callback(cb)
-                # We must ensure that the task is not running
-                # after wait_for() returns.
-                # See https://bugs.python.org/issue32751
-                await _cancel_and_wait(fut, loop=loop)
-                raise
+            fut.remove_done_callback(cb)
+            # We must ensure that the task is not running
+            # after wait_for() returns.
+            # See https://bugs.python.org/issue32751
+            await _cancel_and_wait(fut, loop=loop)
+            raise
 
         if fut.done():
             return fut.result()

--- a/Lib/test/test_asyncio/test_asyncio_waitfor.py
+++ b/Lib/test/test_asyncio/test_asyncio_waitfor.py
@@ -28,6 +28,7 @@ class SlowTask:
 
         self.exited = True
 
+
 class AsyncioWaitForTest(unittest.TestCase):
 
     async def atest_asyncio_wait_for_cancelled(self):
@@ -55,6 +56,38 @@ class AsyncioWaitForTest(unittest.TestCase):
 
     def test_asyncio_wait_for_timeout(self):
         asyncio.run(self.atest_asyncio_wait_for_timeout())
+
+    async def atest_asyncio_wait_for_hang(self, inner_steps, outer_steps):
+        # bpo-42130: wait_for can swallow cancellation causing task to hang
+        async def inner(steps):
+            for _ in range(steps):
+                await asyncio.sleep(0)
+
+        finished = False
+
+        async def wait_for_coro(steps):
+            nonlocal finished
+            await asyncio.wait_for(inner(steps), timeout=1)
+            await asyncio.sleep(0.1)
+            finished = True
+
+        task = asyncio.create_task(wait_for_coro(inner_steps))
+        for _ in range(outer_steps):
+            await asyncio.sleep(0)
+        assert not task.done()
+
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        self.assertFalse(finished)
+
+    def test_asyncio_wait_for_hang(self):
+        # Test with different number of inner/outer steps to weaken dependence
+        # on implementation details
+        for inner_steps in range(3):
+            for outer_steps in range(3):
+                with self.subTest(inner_steps=inner_steps, outer_steps=outer_steps):
+                    asyncio.run(self.atest_asyncio_wait_for_hang(inner_steps, outer_steps))
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1147,22 +1147,6 @@ class BaseTaskTests:
         res = loop.run_until_complete(task)
         self.assertEqual(res, "ok")
 
-    def test_wait_for_cancellation_race_condition(self):
-        def gen():
-            yield 0.1
-            yield 0.1
-            yield 0.1
-            yield 0.1
-
-        loop = self.new_test_loop(gen)
-
-        fut = self.new_future(loop)
-        loop.call_later(0.1, fut.set_result, "ok")
-        task = loop.create_task(asyncio.wait_for(fut, timeout=1))
-        loop.call_later(0.1, task.cancel)
-        res = loop.run_until_complete(task)
-        self.assertEqual(res, "ok")
-
     def test_wait_for_waits_for_task_cancellation(self):
         loop = asyncio.new_event_loop()
         self.addCleanup(loop.close)

--- a/Misc/NEWS.d/next/Library/2021-05-13-11-16-06.bpo-42130.ez0TO5.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-13-11-16-06.bpo-42130.ez0TO5.rst
@@ -1,0 +1,1 @@
+:meth:`asyncio.wait_for` fix swallowing of cancellation


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Related:
* [bpo-37658: In some cases asyncio.wait_for can lead to socket leak.](https://bugs.python.org/issue37658) (PR: #21894)
* [MagicStack/asyncpg#548: Ensure pool connection is released in acquire when cancelled](https://github.com/MagicStack/asyncpg/pull/548)

<!-- issue-number: [bpo-42130](https://bugs.python.org/issue42130) -->
https://bugs.python.org/issue42130
<!-- /issue-number -->
