### PR TITLE
bpo-44114: Remove redundant cast.

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4834,7 +4834,7 @@ PyDoc_STRVAR(reversed_items_doc,
 static PyMethodDef dictitems_methods[] = {
     {"isdisjoint",      (PyCFunction)dictviews_isdisjoint,  METH_O,
      isdisjoint_doc},
-    {"__reversed__",    (PyCFunction)(void(*)(void))dictitems_reversed,    METH_NOARGS,
+    {"__reversed__",    (PyCFunction)dictitems_reversed,    METH_NOARGS,
      reversed_items_doc},
     {NULL,              NULL}           /* sentinel */
 };
@@ -4915,7 +4915,7 @@ PyDoc_STRVAR(reversed_values_doc,
 "Return a reverse iterator over the dict values.");
 
 static PyMethodDef dictvalues_methods[] = {
-    {"__reversed__",    (PyCFunction)(void(*)(void))dictvalues_reversed,    METH_NOARGS,
+    {"__reversed__",    (PyCFunction)dictvalues_reversed,    METH_NOARGS,
      reversed_values_doc},
     {NULL,              NULL}           /* sentinel */
 };


### PR DESCRIPTION


<!-- issue-number: [bpo-44114](https://bugs.python.org/issue44114) -->
https://bugs.python.org/issue44114
<!-- /issue-number -->

Automerge-Triggered-By: GH:pitrou