### PR TITLE
bpo-44125: Fix "make patchcheck" on non-English locale

### DIFF
--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -78,11 +78,14 @@ def get_git_remote_default_branch(remote_name):
     It is typically called 'main', but may differ
     """
     cmd = "git remote show {}".format(remote_name).split()
+    env = os.environ.copy()
+    env['LANG'] = 'C'
     try:
         remote_info = subprocess.check_output(cmd,
                                               stderr=subprocess.DEVNULL,
                                               cwd=SRCDIR,
-                                              encoding='UTF-8')
+                                              encoding='UTF-8',
+                                              env=env)
     except subprocess.CalledProcessError:
         return None
     for line in remote_info.splitlines():


### PR DESCRIPTION
The patch from [bpo-44074](https://bugs.python.org/issue44074) does not account for a possibly non-English locale and blindly greps for "HEAD branch" in a possibly localized text.

<!-- issue-number: [bpo-44125](https://bugs.python.org/issue44125) -->
https://bugs.python.org/issue44125
<!-- /issue-number -->

Automerge-Triggered-By: GH:pitrou