### PR TITLE
bpo-38291: Remove mention of typing.io and typing.re again

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1488,7 +1488,7 @@ Other concrete types
    Generic type ``IO[AnyStr]`` and its subclasses ``TextIO(IO[str])``
    and ``BinaryIO(IO[bytes])``
    represent the types of I/O streams such as returned by
-   :func:`open`. These types are also in the ``typing.io`` namespace.
+   :func:`open`.
 
 .. class:: Pattern
            Match
@@ -1498,7 +1498,7 @@ Other concrete types
    :func:`re.match`.  These types (and the corresponding functions)
    are generic in ``AnyStr`` and can be made specific by writing
    ``Pattern[str]``, ``Pattern[bytes]``, ``Match[str]``, or
-   ``Match[bytes]``. These types are also in the ``typing.re`` namespace.
+   ``Match[bytes]``.
 
    .. deprecated:: 3.9
       Classes ``Pattern`` and ``Match`` from :mod:`re` now support ``[]``.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1490,6 +1490,10 @@ Other concrete types
    represent the types of I/O streams such as returned by
    :func:`open`.
 
+   .. deprecated-removed:: 3.8 3.12
+      These types are also in the ``typing.io`` namespace, which was
+      never supported by type checkers and will be removed.
+
 .. class:: Pattern
            Match
 
@@ -1499,6 +1503,10 @@ Other concrete types
    are generic in ``AnyStr`` and can be made specific by writing
    ``Pattern[str]``, ``Pattern[bytes]``, ``Match[str]``, or
    ``Match[bytes]``.
+
+   .. deprecated-removed:: 3.8 3.12
+      These types are also in the ``typing.re`` namespace, which was
+      never supported by type checkers and will be removed.
 
    .. deprecated:: 3.9
       Classes ``Pattern`` and ``Match`` from :mod:`re` now support ``[]``.

--- a/Misc/NEWS.d/next/Documentation/2021-06-14-09-20-37.bpo-38291.VMYa_Q.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-14-09-20-37.bpo-38291.VMYa_Q.rst
@@ -1,0 +1,2 @@
+Mark ``typing.io`` and ``typing.re`` as deprecated since Python 3.8 in the
+documentation. They were never properly supported by type checkers.


### PR DESCRIPTION
They were originally removed in GH-10173 per [bpo-35089](https://bugs.python.org/issue35089), but then
readded in GH-21574. Cf. [bpo-38291](https://bugs.python.org/issue38291) for decision to remove. This PR
only partly addresses this bug, as the modules should be deprecated as
well (as they were never properly supported.)


<!-- issue-number: [bpo-38291](https://bugs.python.org/issue38291) -->
https://bugs.python.org/issue38291
<!-- /issue-number -->
