### PR TITLE
bpo-44128: Refactor ZipExtFile init and re-init after seek

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-05-14-04-37-51.bpo-44128.cxicgo.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-14-04-37-51.bpo-44128.cxicgo.rst
@@ -1,0 +1,1 @@
+Minor refactor of zipfile.ZipExtFile


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44128](https://bugs.python.org/issue44128) -->
https://bugs.python.org/issue44128
<!-- /issue-number -->
