### PR TITLE
[3.9] bpo-44108: sqlite3 test suite now works with SQLITE_DQS=0 (GH-26032)

### DIFF
--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -242,7 +242,7 @@ class TraceCallbackTests(unittest.TestCase):
         # Can't execute bound parameters as their values don't appear
         # in traced statements before SQLite 3.6.21
         # (cf. http://www.sqlite.org/draft/releaselog/3_6_21.html)
-        con.execute('insert into foo(x) values ("%s")' % unicode_value)
+        con.execute("insert into foo(x) values ('%s')" % unicode_value)
         con.commit()
         self.assertTrue(any(unicode_value in stmt for stmt in traced_statements),
                         "Unicode data %s garbled in trace callback: %s"


### PR DESCRIPTION
(cherry picked from commit be7e467bcf5e419302d887904ef3e8fd310c68e7)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@innova.no>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44108](https://bugs.python.org/issue44108) -->
https://bugs.python.org/issue44108
<!-- /issue-number -->
