### PR TITLE
bpo-44136: remove `pathlib._Flavour`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -57,8 +57,6 @@ class _WindowsFlavour(_Flavour):
 
     has_drv = True
 
-    is_supported = (os.name == 'nt')
-
     def casefold(self, s):
         return s.lower()
 
@@ -68,8 +66,6 @@ class _WindowsFlavour(_Flavour):
 
 class _PosixFlavour(_Flavour):
     has_drv = False
-
-    is_supported = (os.name != 'nt')
 
     def casefold(self, s):
         return s
@@ -788,6 +784,7 @@ class PurePosixPath(PurePath):
     """
     _flavour = _posix_flavour
     _pathmod = posixpath
+    _supported = (os.name != 'nt')
     _case_insensitive = False
     __slots__ = ()
 
@@ -828,6 +825,7 @@ class PureWindowsPath(PurePath):
     """
     _flavour = _windows_flavour
     _pathmod = ntpath
+    _supported = (os.name == 'nt')
     _case_insensitive = True
     _drive_letters = set('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
     _ext_namespace_prefix = '\\\\?\\'
@@ -940,11 +938,10 @@ class Path(PurePath):
     def __new__(cls, *args, **kwargs):
         if cls is Path:
             cls = WindowsPath if os.name == 'nt' else PosixPath
-        self = cls._from_parts(args)
-        if not self._flavour.is_supported:
+        elif not cls._supported:
             raise NotImplementedError("cannot instantiate %r on your system"
                                       % (cls.__name__,))
-        return self
+        return cls._from_parts(args)
 
     def _make_child_relpath(self, part):
         # This is an optimization used for dir walking.  `part` must be

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -88,23 +88,6 @@ class _Flavour(object):
         parsed.reverse()
         return drv, root, parsed
 
-    def join_parsed_parts(self, drv, root, parts, drv2, root2, parts2):
-        """
-        Join the two paths represented by the respective
-        (drive, root, parts) tuples.  Return a new (drive, root, parts) tuple.
-        """
-        if root2:
-            if not drv2 and drv:
-                return drv, root2, [drv + root2] + parts2[1:]
-        elif drv2:
-            if drv2 == drv or self.casefold(drv2) == self.casefold(drv):
-                # Same drive => second path is relative to the first
-                return drv, root, parts + parts2[1:]
-        else:
-            # Second path is non-anchored (common case)
-            return drv, root, parts + parts2
-        return drv2, root2, parts2
-
 
 class _WindowsFlavour(_Flavour):
     # Reference for Windows paths can be found at
@@ -558,9 +541,26 @@ class PurePath(object):
 
     def _make_child(self, args):
         drv, root, parts = self._parse_args(args)
-        drv, root, parts = self._flavour.join_parsed_parts(
+        drv, root, parts = self._join_parsed_parts(
             self._drv, self._root, self._parts, drv, root, parts)
         return self._from_parsed_parts(drv, root, parts)
+
+    def _join_parsed_parts(self, drv, root, parts, drv2, root2, parts2):
+        """
+        Join the two paths represented by the respective
+        (drive, root, parts) tuples.  Return a new (drive, root, parts) tuple.
+        """
+        if root2:
+            if not drv2 and drv:
+                return drv, root2, [drv + root2] + parts2[1:]
+        elif drv2:
+            if drv2 == drv or self._flavour.casefold(drv2) == self._flavour.casefold(drv):
+                # Same drive => second path is relative to the first
+                return drv, root, parts + parts2[1:]
+        else:
+            # Second path is non-anchored (common case)
+            return drv, root, parts + parts2
+        return drv2, root2, parts2
 
     def __str__(self):
         """Return the string representation of the path, suitable for

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -768,7 +768,6 @@ class PurePosixPath(PurePath):
     However, you can also instantiate it directly on any system.
     """
     _pathmod = posixpath
-    _supported = (os.name != 'nt')
     _case_insensitive = False
     __slots__ = ()
 
@@ -813,7 +812,6 @@ class PureWindowsPath(PurePath):
     # Reference for Windows paths can be found at
     # http://msdn.microsoft.com/en-us/library/aa365247%28v=vs.85%29.aspx
     _pathmod = ntpath
-    _supported = (os.name == 'nt')
     _case_insensitive = True
     __slots__ = ()
 
@@ -922,7 +920,8 @@ class Path(PurePath):
     def __new__(cls, *args, **kwargs):
         if cls is Path:
             cls = WindowsPath if os.name == 'nt' else PosixPath
-        elif not cls._supported:
+        elif (issubclass(cls, PosixPath) and os.name == 'nt') or \
+             (issubclass(cls, WindowsPath) and os.name != 'nt'):
             raise NotImplementedError("cannot instantiate %r on your system"
                                       % (cls.__name__,))
         return cls._from_parts(args)

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -55,8 +55,6 @@ class _WindowsFlavour(_Flavour):
     # Reference for Windows paths can be found at
     # http://msdn.microsoft.com/en-us/library/aa365247%28v=vs.85%29.aspx
 
-    has_drv = True
-
     def casefold(self, s):
         return s.lower()
 
@@ -65,8 +63,6 @@ class _WindowsFlavour(_Flavour):
 
 
 class _PosixFlavour(_Flavour):
-    has_drv = False
-
     def casefold(self, s):
         return s
 
@@ -737,9 +733,7 @@ class PurePath(object):
     def is_absolute(self):
         """True if the path is absolute (has both a root and, if applicable,
         a drive)."""
-        if not self._root:
-            return False
-        return not self._flavour.has_drv or bool(self._drv)
+        raise NotImplementedError
 
     def is_reserved(self):
         """Return True if the path contains one of the special names reserved
@@ -804,6 +798,9 @@ class PurePosixPath(PurePath):
                 return '', sep, stripped_part
         else:
             return '', '', part
+
+    def is_absolute(self):
+        return bool(self._root)
 
     def is_reserved(self):
         return False
@@ -893,6 +890,9 @@ class PureWindowsPath(PurePath):
                 prefix += s[:3]
                 s = '\\' + s[3:]
         return prefix, s
+
+    def is_absolute(self):
+        return bool(self._root) and bool(self._drv)
 
     def is_reserved(self):
         # NOTE: the rules for reserved names seem somewhat complicated

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -46,25 +46,6 @@ def _is_wildcard_pattern(pat):
     return "*" in pat or "?" in pat or "[" in pat
 
 
-class _Flavour(object):
-    """A flavour implements a particular (platform-specific) set of path
-    semantics."""
-
-
-class _WindowsFlavour(_Flavour):
-    # Reference for Windows paths can be found at
-    # http://msdn.microsoft.com/en-us/library/aa365247%28v=vs.85%29.aspx
-    pass
-
-
-class _PosixFlavour(_Flavour):
-    pass
-
-
-_windows_flavour = _WindowsFlavour()
-_posix_flavour = _PosixFlavour()
-
-
 class _Accessor:
     """An accessor implements a particular (system-specific or not) way of
     accessing paths on the filesystem."""
@@ -516,9 +497,9 @@ class PurePath(object):
             return self._cached_cparts
 
     def __eq__(self, other):
-        if not isinstance(other, PurePath):
+        if not isinstance(other, type(self)):
             return NotImplemented
-        return self._cparts == other._cparts and self._flavour is other._flavour
+        return self._cparts == other._cparts
 
     def __hash__(self):
         try:
@@ -528,22 +509,22 @@ class PurePath(object):
             return self._hash
 
     def __lt__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if not isinstance(other, type(self)):
             return NotImplemented
         return self._cparts < other._cparts
 
     def __le__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if not isinstance(other, type(self)):
             return NotImplemented
         return self._cparts <= other._cparts
 
     def __gt__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if not isinstance(other, type(self)):
             return NotImplemented
         return self._cparts > other._cparts
 
     def __ge__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if not isinstance(other, type(self)):
             return NotImplemented
         return self._cparts >= other._cparts
 
@@ -779,7 +760,6 @@ class PurePosixPath(PurePath):
     On a POSIX system, instantiating a PurePath should return this object.
     However, you can also instantiate it directly on any system.
     """
-    _flavour = _posix_flavour
     _pathmod = posixpath
     _supported = (os.name != 'nt')
     _case_insensitive = False
@@ -823,7 +803,8 @@ class PureWindowsPath(PurePath):
     On a Windows system, instantiating a PurePath should return this object.
     However, you can also instantiate it directly on any system.
     """
-    _flavour = _windows_flavour
+    # Reference for Windows paths can be found at
+    # http://msdn.microsoft.com/en-us/library/aa365247%28v=vs.85%29.aspx
     _pathmod = ntpath
     _supported = (os.name == 'nt')
     _case_insensitive = True

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2400,7 +2400,7 @@ class PathTest(_BasePathTest, unittest.TestCase):
         self.assertIs(type(p),
             pathlib.WindowsPath if os.name == 'nt' else pathlib.PosixPath)
 
-    def test_unsupported_flavour(self):
+    def test_unsupported_type(self):
         if os.name == 'nt':
             self.assertRaises(NotImplementedError, pathlib.PosixPath)
         else:

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -45,7 +45,6 @@ class _BasePurePathTest(object):
 
     def setUp(self):
         p = self.cls('a')
-        self.flavour = p._flavour
         self.sep = p._pathmod.sep
         self.altsep = p._pathmod.altsep
 
@@ -1290,12 +1289,12 @@ class PurePathTest(_BasePurePathTest, unittest.TestCase):
         self.assertIs(type(p),
             pathlib.PureWindowsPath if os.name == 'nt' else pathlib.PurePosixPath)
 
-    def test_different_flavours_unequal(self):
+    def test_different_types_unequal(self):
         p = pathlib.PurePosixPath('a')
         q = pathlib.PureWindowsPath('a')
         self.assertNotEqual(p, q)
 
-    def test_different_flavours_unordered(self):
+    def test_different_types_unordered(self):
         p = pathlib.PurePosixPath('a')
         q = pathlib.PureWindowsPath('a')
         with self.assertRaises(TypeError):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -25,8 +25,8 @@ class _BaseFlavourTest(object):
 
     def _check_parse_parts(self, arg, expected):
         f = self.flavour.parse_parts
-        sep = self.flavour.sep
-        altsep = self.flavour.altsep
+        sep = self.flavour.pathmod.sep
+        altsep = self.flavour.pathmod.altsep
         actual = f([x.replace('/', sep) for x in arg])
         self.assertEqual(actual, expected)
         if altsep:
@@ -35,7 +35,7 @@ class _BaseFlavourTest(object):
 
     def test_parse_parts_common(self):
         check = self._check_parse_parts
-        sep = self.flavour.sep
+        sep = self.flavour.pathmod.sep
         # Unanchored parts.
         check([],                   ('', '', []))
         check(['a'],                ('', '', ['a']))
@@ -186,8 +186,8 @@ class _BasePurePathTest(object):
     def setUp(self):
         p = self.cls('a')
         self.flavour = p._flavour
-        self.sep = self.flavour.sep
-        self.altsep = self.flavour.altsep
+        self.sep = self.flavour.pathmod.sep
+        self.altsep = self.flavour.pathmod.altsep
 
     def test_constructor_common(self):
         P = self.cls
@@ -615,7 +615,7 @@ class _BasePurePathTest(object):
         self.assertRaises(ValueError, P('a/b').with_suffix, './.d')
         self.assertRaises(ValueError, P('a/b').with_suffix, '.d/.')
         self.assertRaises(ValueError, P('a/b').with_suffix,
-                          (self.flavour.sep, 'd'))
+                          (self.sep, 'd'))
 
     def test_relative_to_common(self):
         P = self.cls


### PR DESCRIPTION
For [bpo-24132](https://bugs.python.org/issue24132), we'd like subclasses of `AbstractPath` to be able to customize flavour behaviour (like `as_uri()`) without needing to promote `_Flavour` to a public class.

(Copy-pasted bug description:)

Following #18841, #25264 and #25701, `pathlib._Flavour` and its subclasses are looking a bit pointless.

The implementations of `is_reserved()` and `make_uri()` (~`as_uri()`) can be readily moved to into `PurePosixPath` and `PureWindowsPath`, which removes some indirection. This follows the pattern of OS-specific stuff in `PosixPath` and `WindowsPath`.

The remaining methods, such as `splitroot()`, can be pulled into `Pure*Path` with an underscore prefix.

I'm generally a believer in composition over inheritance, but in this case `_Flavour` seems too small and too similar to `PurePath` to separate out into 3 extra classes.

There should be no impact on public APIs or performance.

I've tried to split the changes up across commits; it may be easier to browse the diff that way.

<!-- issue-number: [bpo-44136](https://bugs.python.org/issue44136) -->
https://bugs.python.org/issue44136
<!-- /issue-number -->
