### PR TITLE
bpo-44143: Fix crash in the parser when raising tokenizer errors with an exception set

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -242,6 +242,7 @@ class ExceptionTests(unittest.TestCase):
             """, 9, 24)
         check("pass\npass\npass\n(1+)\npass\npass\npass", 4, 4)
         check("(1+)", 1, 4)
+        check("[interesting\nfoo()\n", 1, 1)
 
         # Errors thrown by symtable.c
         check('x = [(yield i) for i in range(3)]', 1, 5)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-15-17-30-57.bpo-44143.7UTS6H.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-15-17-30-57.bpo-44143.7UTS6H.rst
@@ -1,0 +1,2 @@
+Fixed a crash in the parser that manifest when raising tokenizer errors when
+an existing exception was present. Patch by Pablo Galindo.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1259,6 +1259,7 @@ _PyPegen_check_tokenizer_errors(Parser *p) {
                 if (p->tok->level != 0) {
                     int error_lineno = p->tok->parenlinenostack[p->tok->level-1];
                     if (current_err_line > error_lineno) {
+                        PyErr_Clear();
                         raise_unclosed_parentheses_error(p);
                         return -1;
                     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44143](https://bugs.python.org/issue44143) -->
https://bugs.python.org/issue44143
<!-- /issue-number -->
