### PR TITLE
Removed redundant declarations in distutils' `LooseVersion`

### DIFF
--- a/Lib/distutils/version.py
+++ b/Lib/distutils/version.py
@@ -301,10 +301,6 @@ class LooseVersion (Version):
 
     component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
 
-    def __init__ (self, vstring=None):
-        if vstring:
-            self.parse(vstring)
-
 
     def parse (self, vstring):
         # I've given up on thinking I can reconstruct the version string
@@ -324,10 +320,6 @@ class LooseVersion (Version):
 
     def __str__ (self):
         return self.vstring
-
-
-    def __repr__ (self):
-        return "LooseVersion ('%s')" % str(self)
 
 
     def _cmp (self, other):


### PR DESCRIPTION
Removed declarations for methods `__repr__` and `__init__` from `LooseVersion` since they were redundant, already specified in `Version` metaclass.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
