### PR TITLE
bpo-29688: document and test `pathlib.Path.absolute()`.

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1052,6 +1052,20 @@ call fails (for example because the path doesn't exist).
       Added return value, return the new Path instance.
 
 
+.. method:: Path.absolute()
+
+   Make the path absolute, without resolving symlinks, and return a new path
+   object.  This is equivalent to prepending the current directory::
+
+      >>> p = Path('..')
+      >>> p
+      PosixPath('..')
+      >>> p.absolute()
+      PosixPath('/home/antoine/pathlib/..')
+      >>> Path.cwd() / p
+      PosixPath('/home/antoine/pathlib/..')
+
+
 .. method:: Path.resolve(strict=False)
 
    Make the path absolute, resolving any symlinks.  A new path object is
@@ -1239,13 +1253,14 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 
    Not all pairs of functions/methods below are equivalent. Some of them,
    despite having some overlapping use-cases, have different semantics. They
-   include :func:`os.path.abspath` and :meth:`Path.resolve`,
+   include :func:`os.path.abspath` and :meth:`Path.absolute`,
    :func:`os.path.relpath` and :meth:`PurePath.relative_to`.
 
 ====================================   ==============================
 :mod:`os` and :mod:`os.path`           :mod:`pathlib`
 ====================================   ==============================
-:func:`os.path.abspath`                :meth:`Path.resolve` [#]_
+:func:`os.path.abspath`                :meth:`Path.absolute` [#]_
+:func:`os.path.realpath`               :meth:`Path.resolve`
 :func:`os.chmod`                       :meth:`Path.chmod`
 :func:`os.mkdir`                       :meth:`Path.mkdir`
 :func:`os.makedirs`                    :meth:`Path.mkdir`
@@ -1278,5 +1293,5 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 
 .. rubric:: Footnotes
 
-.. [#] :func:`os.path.abspath` does not resolve symbolic links while :meth:`Path.resolve` does.
+.. [#] :func:`os.path.abspath` normalizes the resulting path, which may change its meaning in the presence of symlinks.
 .. [#] :meth:`Path.relative_to` requires ``self`` to be the subpath of the argument, but :func:`os.path.relpath` does not.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1293,5 +1293,5 @@ Below is a table mapping various :mod:`os` functions to their corresponding
 
 .. rubric:: Footnotes
 
-.. [#] :func:`os.path.abspath` normalizes the resulting path, which may change its meaning in the presence of symlinks.
+.. [#] :func:`os.path.abspath` normalizes the resulting path, which may change its meaning in the presence of symlinks, while :meth:`Path.absolute` does not.
 .. [#] :meth:`Path.relative_to` requires ``self`` to be the subpath of the argument, but :func:`os.path.relpath` does not.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1054,7 +1054,7 @@ call fails (for example because the path doesn't exist).
 
 .. method:: Path.absolute()
 
-   Make the path absolute, without resolving symlinks, and return a new path
+   Make the path absolute, without normalization or resolving symlinks, and return a new path
    object.  This is equivalent to prepending the current directory::
 
       >>> p = Path('..')

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1054,16 +1054,14 @@ call fails (for example because the path doesn't exist).
 
 .. method:: Path.absolute()
 
-   Make the path absolute, without normalization or resolving symlinks, and return a new path
-   object.  This is equivalent to prepending the current directory::
+   Make the path absolute, without normalization or resolving symlinks.
+   Returns a new path object::
 
-      >>> p = Path('..')
+      >>> p = Path('tests')
       >>> p
-      PosixPath('..')
+      PosixPath('tests')
       >>> p.absolute()
-      PosixPath('/home/antoine/pathlib/..')
-      >>> Path.cwd() / p
-      PosixPath('/home/antoine/pathlib/..')
+      PosixPath('/home/antoine/pathlib/tests')
 
 
 .. method:: Path.resolve(strict=False)

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1046,24 +1046,19 @@ class Path(PurePath):
             yield p
 
     def absolute(self):
-        """Return an absolute version of this path.  This function works
-        even if the path doesn't point to anything.
+        """Return an absolute version of this path by prepending the current
+        working directory. No normalization or symlink resolution is performed.
 
-        No normalization is done, i.e. all '.' and '..' will be kept along.
         Use resolve() to get the canonical path to a file.
         """
-        # XXX untested yet!
         if self.is_absolute():
             return self
-        # FIXME this must defer to the specific flavour (and, under Windows,
-        # use nt._getfullpathname())
         return self._from_parts([self._accessor.getcwd()] + self._parts)
 
     def resolve(self, strict=False):
         """
         Make the path absolute, resolving all symlinks on the way and also
-        normalizing it (for example turning slashes into backslashes under
-        Windows).
+        normalizing it.
         """
 
         def check_eloop(e):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2664,23 +2664,21 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
         self.assertEqualNormCase(str(P('c:\\a\\b').absolute()), 'c:\\a\\b')
 
         # UNC absolute paths
-        share = '\\\\server\\share'
+        share = '\\\\server\\share\\'
         self.assertEqualNormCase(str(P(share).absolute()), share)
-        self.assertEqualNormCase(str(P(share + '\\a').absolute()),
-                                 share + '\\a')
-        self.assertEqualNormCase(str(P(share + '\\a\\b').absolute()),
-                                 share + '\\a\\b')
+        self.assertEqualNormCase(str(P(share + 'a').absolute()), share + 'a')
+        self.assertEqualNormCase(str(P(share + 'a\\b').absolute()), share + 'a\\b')
 
         # UNC relative paths
         with mock.patch("pathlib._normal_accessor.getcwd") as getcwd:
             getcwd.return_value = share
 
-            self.assertEqualNormCase(str(P().absolute()), BASE)
-            self.assertEqualNormCase(str(P('.').absolute()), BASE)
+            self.assertEqualNormCase(str(P().absolute()), share)
+            self.assertEqualNormCase(str(P('.').absolute()), share)
             self.assertEqualNormCase(str(P('a').absolute()),
-                                     os.path.join(BASE, 'a'))
+                                     os.path.join(share, 'a'))
             self.assertEqualNormCase(str(P('a', 'b', 'c').absolute()),
-                                     os.path.join(BASE, 'a', 'b', 'c'))
+                                     os.path.join(share, 'a', 'b', 'c'))
 
 
     def test_glob(self):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1463,20 +1463,20 @@ class _BasePathTest(object):
             getcwd.return_value = BASE
 
             # Simple relative paths
-            self.assertEqualNormCase(str(P().absolute()), BASE)
-            self.assertEqualNormCase(str(P('.').absolute()), BASE)
-            self.assertEqualNormCase(str(P('a').absolute()), os.path.join(BASE, 'a'))
-            self.assertEqualNormCase(str(P('a', 'b', 'c').absolute()), os.path.join(BASE, 'a', 'b', 'c'))
+            self.assertEqual(str(P().absolute()), BASE)
+            self.assertEqual(str(P('.').absolute()), BASE)
+            self.assertEqual(str(P('a').absolute()), os.path.join(BASE, 'a'))
+            self.assertEqual(str(P('a', 'b', 'c').absolute()), os.path.join(BASE, 'a', 'b', 'c'))
 
             # Symlinks should not be resolved
-            self.assertEqualNormCase(str(P('linkB', 'fileB').absolute()), os.path.join(BASE, 'linkB', 'fileB'))
-            self.assertEqualNormCase(str(P('brokenLink').absolute()), os.path.join(BASE, 'brokenLink'))
-            self.assertEqualNormCase(str(P('brokenLinkLoop').absolute()), os.path.join(BASE, 'brokenLinkLoop'))
+            self.assertEqual(str(P('linkB', 'fileB').absolute()), os.path.join(BASE, 'linkB', 'fileB'))
+            self.assertEqual(str(P('brokenLink').absolute()), os.path.join(BASE, 'brokenLink'))
+            self.assertEqual(str(P('brokenLinkLoop').absolute()), os.path.join(BASE, 'brokenLinkLoop'))
 
             # '..' entries should be preserved and not normalised
-            self.assertEqualNormCase(str(P('..').absolute()), os.path.join(BASE, '..'))
-            self.assertEqualNormCase(str(P('a', '..').absolute()), os.path.join(BASE, 'a', '..'))
-            self.assertEqualNormCase(str(P('..', 'b').absolute()), os.path.join(BASE, '..', 'b'))
+            self.assertEqual(str(P('..').absolute()), os.path.join(BASE, '..'))
+            self.assertEqual(str(P('a', '..').absolute()), os.path.join(BASE, 'a', '..'))
+            self.assertEqual(str(P('..', 'b').absolute()), os.path.join(BASE, '..', 'b'))
 
     def _test_home(self, p):
         q = self.cls(os.path.expanduser('~'))
@@ -2481,14 +2481,14 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
 
     def test_absolute(self):
         P = self.cls
-        self.assertEqualNormCase(str(P('/').absolute()), '/')
-        self.assertEqualNormCase(str(P('/a').absolute()), '/a')
-        self.assertEqualNormCase(str(P('/a/b').absolute()), '/a/b')
+        self.assertEqual(str(P('/').absolute()), '/')
+        self.assertEqual(str(P('/a').absolute()), '/a')
+        self.assertEqual(str(P('/a/b').absolute()), '/a/b')
 
         # '//'-prefixed absolute path (supported by POSIX)
-        self.assertEqualNormCase(str(P('//').absolute()), '//')
-        self.assertEqualNormCase(str(P('//a').absolute()), '//a')
-        self.assertEqualNormCase(str(P('//a/b').absolute()), '//a/b')
+        self.assertEqual(str(P('//').absolute()), '//')
+        self.assertEqual(str(P('//a').absolute()), '//a')
+        self.assertEqual(str(P('//a/b').absolute()), '//a/b')
 
     def _check_symlink_loop(self, *args, strict=True):
         path = self.cls(*args)
@@ -2659,26 +2659,25 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
         P = self.cls
 
         # Simple absolute paths
-        self.assertEqualNormCase(str(P('c:\\').absolute()), 'c:\\')
-        self.assertEqualNormCase(str(P('c:\\a').absolute()), 'c:\\a')
-        self.assertEqualNormCase(str(P('c:\\a\\b').absolute()), 'c:\\a\\b')
+        self.assertEqual(str(P('c:\\').absolute()), 'c:\\')
+        self.assertEqual(str(P('c:\\a').absolute()), 'c:\\a')
+        self.assertEqual(str(P('c:\\a\\b').absolute()), 'c:\\a\\b')
 
         # UNC absolute paths
         share = '\\\\server\\share\\'
-        self.assertEqualNormCase(str(P(share).absolute()), share)
-        self.assertEqualNormCase(str(P(share + 'a').absolute()), share + 'a')
-        self.assertEqualNormCase(str(P(share + 'a\\b').absolute()), share + 'a\\b')
+        self.assertEqual(str(P(share).absolute()), share)
+        self.assertEqual(str(P(share + 'a').absolute()), share + 'a')
+        self.assertEqual(str(P(share + 'a\\b').absolute()), share + 'a\\b')
 
         # UNC relative paths
         with mock.patch("pathlib._normal_accessor.getcwd") as getcwd:
             getcwd.return_value = share
 
-            self.assertEqualNormCase(str(P().absolute()), share)
-            self.assertEqualNormCase(str(P('.').absolute()), share)
-            self.assertEqualNormCase(str(P('a').absolute()),
-                                     os.path.join(share, 'a'))
-            self.assertEqualNormCase(str(P('a', 'b', 'c').absolute()),
-                                     os.path.join(share, 'a', 'b', 'c'))
+            self.assertEqual(str(P().absolute()), share)
+            self.assertEqual(str(P('.').absolute()), share)
+            self.assertEqual(str(P('a').absolute()), os.path.join(share, 'a'))
+            self.assertEqual(str(P('a', 'b', 'c').absolute()),
+                             os.path.join(share, 'a', 'b', 'c'))
 
 
     def test_glob(self):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1462,18 +1462,18 @@ class _BasePathTest(object):
         with mock.patch("pathlib._normal_accessor.getcwd") as getcwd:
             getcwd.return_value = BASE
 
-            # Simple relative paths
+            # Simple relative paths.
             self.assertEqual(str(P().absolute()), BASE)
             self.assertEqual(str(P('.').absolute()), BASE)
             self.assertEqual(str(P('a').absolute()), os.path.join(BASE, 'a'))
             self.assertEqual(str(P('a', 'b', 'c').absolute()), os.path.join(BASE, 'a', 'b', 'c'))
 
-            # Symlinks should not be resolved
+            # Symlinks should not be resolved.
             self.assertEqual(str(P('linkB', 'fileB').absolute()), os.path.join(BASE, 'linkB', 'fileB'))
             self.assertEqual(str(P('brokenLink').absolute()), os.path.join(BASE, 'brokenLink'))
             self.assertEqual(str(P('brokenLinkLoop').absolute()), os.path.join(BASE, 'brokenLinkLoop'))
 
-            # '..' entries should be preserved and not normalised
+            # '..' entries should be preserved and not normalised.
             self.assertEqual(str(P('..').absolute()), os.path.join(BASE, '..'))
             self.assertEqual(str(P('a', '..').absolute()), os.path.join(BASE, 'a', '..'))
             self.assertEqual(str(P('..', 'b').absolute()), os.path.join(BASE, '..', 'b'))
@@ -2485,7 +2485,7 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         self.assertEqual(str(P('/a').absolute()), '/a')
         self.assertEqual(str(P('/a/b').absolute()), '/a/b')
 
-        # '//'-prefixed absolute path (supported by POSIX)
+        # '//'-prefixed absolute path (supported by POSIX).
         self.assertEqual(str(P('//').absolute()), '//')
         self.assertEqual(str(P('//a').absolute()), '//a')
         self.assertEqual(str(P('//a/b').absolute()), '//a/b')
@@ -2658,18 +2658,18 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
     def test_absolute(self):
         P = self.cls
 
-        # Simple absolute paths
+        # Simple absolute paths.
         self.assertEqual(str(P('c:\\').absolute()), 'c:\\')
         self.assertEqual(str(P('c:\\a').absolute()), 'c:\\a')
         self.assertEqual(str(P('c:\\a\\b').absolute()), 'c:\\a\\b')
 
-        # UNC absolute paths
+        # UNC absolute paths.
         share = '\\\\server\\share\\'
         self.assertEqual(str(P(share).absolute()), share)
         self.assertEqual(str(P(share + 'a').absolute()), share + 'a')
         self.assertEqual(str(P(share + 'a\\b').absolute()), share + 'a\\b')
 
-        # UNC relative paths
+        # UNC relative paths.
         with mock.patch("pathlib._normal_accessor.getcwd") as getcwd:
             getcwd.return_value = share
 

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1456,38 +1456,27 @@ class _BasePathTest(object):
         p = self.cls.cwd()
         self._test_cwd(p)
 
-    def _test_absolute(self):
+    def test_absolute_common(self):
         P = self.cls
 
-        # Simple absolute paths
-        self.assertEqualNormCase(str(P('/').absolute()), '/')
-        self.assertEqualNormCase(str(P('/a').absolute()), '/a')
-        self.assertEqualNormCase(str(P('/a/b').absolute()), '/a/b')
-        self.assertEqualNormCase(str(P('//a/b').absolute()), '//a/b')
+        with mock.patch("pathlib._normal_accessor.getcwd") as getcwd:
+            getcwd.return_value = BASE
 
-        # Simple relative paths
-        self.assertEqualNormCase(str(P().absolute()), BASE)
-        self.assertEqualNormCase(str(P('.').absolute()), BASE)
-        self.assertEqualNormCase(str(P('a').absolute()), os.path.join(BASE, 'a'))
-        self.assertEqualNormCase(str(P('a', 'b', 'c').absolute()), os.path.join(BASE, 'a', 'b', 'c'))
+            # Simple relative paths
+            self.assertEqualNormCase(str(P().absolute()), BASE)
+            self.assertEqualNormCase(str(P('.').absolute()), BASE)
+            self.assertEqualNormCase(str(P('a').absolute()), os.path.join(BASE, 'a'))
+            self.assertEqualNormCase(str(P('a', 'b', 'c').absolute()), os.path.join(BASE, 'a', 'b', 'c'))
 
-        # Symlinks should not be resolved
-        self.assertEqualNormCase(str(P('linkB', 'fileB').absolute()), os.path.join(BASE, 'linkB', 'fileB'))
-        self.assertEqualNormCase(str(P('brokenLink').absolute()), os.path.join(BASE, 'brokenLink'))
-        self.assertEqualNormCase(str(P('brokenLinkLoop').absolute()), os.path.join(BASE, 'brokenLinkLoop'))
+            # Symlinks should not be resolved
+            self.assertEqualNormCase(str(P('linkB', 'fileB').absolute()), os.path.join(BASE, 'linkB', 'fileB'))
+            self.assertEqualNormCase(str(P('brokenLink').absolute()), os.path.join(BASE, 'brokenLink'))
+            self.assertEqualNormCase(str(P('brokenLinkLoop').absolute()), os.path.join(BASE, 'brokenLinkLoop'))
 
-        # '..' entries should be preserved and not normalised
-        self.assertEqualNormCase(str(P('..').absolute()), os.path.join(BASE, '..'))
-        self.assertEqualNormCase(str(P('a', '..').absolute()), os.path.join(BASE, 'a', '..'))
-        self.assertEqualNormCase(str(P('..', 'b').absolute()), os.path.join(BASE, '..', 'b'))
-
-    def test_absolute(self):
-        old_path = os.getcwd()
-        os.chdir(BASE)
-        try:
-            self._test_absolute()
-        finally:
-            os.chdir(old_path)
+            # '..' entries should be preserved and not normalised
+            self.assertEqualNormCase(str(P('..').absolute()), os.path.join(BASE, '..'))
+            self.assertEqualNormCase(str(P('a', '..').absolute()), os.path.join(BASE, 'a', '..'))
+            self.assertEqualNormCase(str(P('..', 'b').absolute()), os.path.join(BASE, '..', 'b'))
 
     def _test_home(self, p):
         q = self.cls(os.path.expanduser('~'))
@@ -2490,6 +2479,17 @@ class PathTest(_BasePathTest, unittest.TestCase):
 class PosixPathTest(_BasePathTest, unittest.TestCase):
     cls = pathlib.PosixPath
 
+    def test_absolute(self):
+        P = self.cls
+        self.assertEqualNormCase(str(P('/').absolute()), '/')
+        self.assertEqualNormCase(str(P('/a').absolute()), '/a')
+        self.assertEqualNormCase(str(P('/a/b').absolute()), '/a/b')
+
+        # '//'-prefixed absolute path (supported by POSIX)
+        self.assertEqualNormCase(str(P('//').absolute()), '//')
+        self.assertEqualNormCase(str(P('//a').absolute()), '//a')
+        self.assertEqualNormCase(str(P('//a/b').absolute()), '//a/b')
+
     def _check_symlink_loop(self, *args, strict=True):
         path = self.cls(*args)
         with self.assertRaises(RuntimeError):
@@ -2654,6 +2654,34 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
 @only_nt
 class WindowsPathTest(_BasePathTest, unittest.TestCase):
     cls = pathlib.WindowsPath
+
+    def test_absolute(self):
+        P = self.cls
+
+        # Simple absolute paths
+        self.assertEqualNormCase(str(P('c:\\').absolute()), 'c:\\')
+        self.assertEqualNormCase(str(P('c:\\a').absolute()), 'c:\\a')
+        self.assertEqualNormCase(str(P('c:\\a\\b').absolute()), 'c:\\a\\b')
+
+        # UNC absolute paths
+        share = '\\\\server\\share'
+        self.assertEqualNormCase(str(P(share).absolute()), share)
+        self.assertEqualNormCase(str(P(share + '\\a').absolute()),
+                                 share + '\\a')
+        self.assertEqualNormCase(str(P(share + '\\a\\b').absolute()),
+                                 share + '\\a\\b')
+
+        # UNC relative paths
+        with mock.patch("pathlib._normal_accessor.getcwd") as getcwd:
+            getcwd.return_value = share
+
+            self.assertEqualNormCase(str(P().absolute()), BASE)
+            self.assertEqualNormCase(str(P('.').absolute()), BASE)
+            self.assertEqualNormCase(str(P('a').absolute()),
+                                     os.path.join(BASE, 'a'))
+            self.assertEqualNormCase(str(P('a', 'b', 'c').absolute()),
+                                     os.path.join(BASE, 'a', 'b', 'c'))
+
 
     def test_glob(self):
         P = self.cls

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1456,6 +1456,39 @@ class _BasePathTest(object):
         p = self.cls.cwd()
         self._test_cwd(p)
 
+    def _test_absolute(self):
+        P = self.cls
+
+        # Simple absolute paths
+        self.assertEqualNormCase(str(P('/').absolute()), '/')
+        self.assertEqualNormCase(str(P('/a').absolute()), '/a')
+        self.assertEqualNormCase(str(P('/a/b').absolute()), '/a/b')
+        self.assertEqualNormCase(str(P('//a/b').absolute()), '//a/b')
+
+        # Simple relative paths
+        self.assertEqualNormCase(str(P().absolute()), BASE)
+        self.assertEqualNormCase(str(P('.').absolute()), BASE)
+        self.assertEqualNormCase(str(P('a').absolute()), os.path.join(BASE, 'a'))
+        self.assertEqualNormCase(str(P('a', 'b', 'c').absolute()), os.path.join(BASE, 'a', 'b', 'c'))
+
+        # Symlinks should not be resolved
+        self.assertEqualNormCase(str(P('linkB', 'fileB').absolute()), os.path.join(BASE, 'linkB', 'fileB'))
+        self.assertEqualNormCase(str(P('brokenLink').absolute()), os.path.join(BASE, 'brokenLink'))
+        self.assertEqualNormCase(str(P('brokenLinkLoop').absolute()), os.path.join(BASE, 'brokenLinkLoop'))
+
+        # '..' entries should be preserved and not normalised
+        self.assertEqualNormCase(str(P('..').absolute()), os.path.join(BASE, '..'))
+        self.assertEqualNormCase(str(P('a', '..').absolute()), os.path.join(BASE, 'a', '..'))
+        self.assertEqualNormCase(str(P('..', 'b').absolute()), os.path.join(BASE, '..', 'b'))
+
+    def test_absolute(self):
+        old_path = os.getcwd()
+        os.chdir(BASE)
+        try:
+            self._test_absolute()
+        finally:
+            os.chdir(old_path)
+
     def _test_home(self, p):
         q = self.cls(os.path.expanduser('~'))
         self.assertEqual(p, q)

--- a/Misc/NEWS.d/next/Library/2022-01-05-03-21-21.bpo-29688.W06bSH.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-05-03-21-21.bpo-29688.W06bSH.rst
@@ -1,0 +1,2 @@
+:meth:`pathlib.Path.absolute` is now documented. This method has always been
+present in pathlib.

--- a/Misc/NEWS.d/next/Library/2022-01-05-03-21-21.bpo-29688.W06bSH.rst
+++ b/Misc/NEWS.d/next/Library/2022-01-05-03-21-21.bpo-29688.W06bSH.rst
@@ -1,2 +1,1 @@
-:meth:`pathlib.Path.absolute` is now documented. This method has always been
-present in pathlib.
+Document :meth:`pathlib.Path.absolute` (which has always existed).


### PR DESCRIPTION
This method is important and cannot be replaced with `resolve()`! `resolve()` will hit OS APIs to resolve symlinks/etc, and will fail on symlink loops, whereas `absolute()` just prepends the working directory and can never raise an OSError.

Also improved the table showing correspondence with `os.path` methods. The gory details:

- `Path.resolve()` is `os.path.realpath()` in strict mode, with a tweaked exception type for symlink loops (backwards compat)
- `Path.absolute()` is `os.path.abspath()` but _without_ normalizing the path. The pathlib behaviour is better, as `abspath()`'s normlisation changes the meaning of the path in the presence of symlinks!

Happy to expand the tests if anyone has any ideas what else to cover.

<!-- issue-number: [bpo-29688](https://bugs.python.org/issue29688) -->
https://bugs.python.org/issue29688
<!-- /issue-number -->
