### PR TITLE
bpo-43905: Expand dataclasses.astuple() and asdict() docs

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -355,6 +355,12 @@ Module contents
 
      assert astuple(p) == (10, 20)
      assert astuple(c) == ([(0, 0), (10, 4)],)
+     
+   The tuple is a :func:`copy.deepcopy` of contained objects, which may
+   be an issue in some corner cases. To create a shallow copy, the
+   following workaround may be used::
+   
+     tuple(getattr(instance, field.name) for field in dataclasses.fields(instance))
 
    Raises :exc:`TypeError` if ``instance`` is not a dataclass instance.
 

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -349,16 +349,15 @@ Module contents
    Converts the dataclass ``instance`` to a tuple (by using the
    factory function ``tuple_factory``).  Each dataclass is converted
    to a tuple of its field values.  dataclasses, dicts, lists, and
-   tuples are recursed into.
+   tuples are recursed into. Other objects are copied with 
+   :func:`copy.deepcopy`.
 
    Continuing from the previous example::
 
      assert astuple(p) == (10, 20)
      assert astuple(c) == ([(0, 0), (10, 4)],)
      
-   The tuple is a :func:`copy.deepcopy` of contained objects, which may
-   be an issue in some corner cases. To create a shallow copy, the
-   following workaround may be used::
+   To create a shallow copy, the following workaround may be used::
    
      tuple(getattr(instance, field.name) for field in dataclasses.fields(instance))
 

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -356,9 +356,9 @@ Module contents
 
      assert astuple(p) == (10, 20)
      assert astuple(c) == ([(0, 0), (10, 4)],)
-     
+
    To create a shallow copy, the following workaround may be used::
-   
+
      tuple(getattr(instance, field.name) for field in dataclasses.fields(instance))
 
    Raises :exc:`TypeError` if ``instance`` is not a dataclass instance.

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -328,7 +328,7 @@ Module contents
    lists, and tuples are recursed into.  Other objects are copied with
    :func:`copy.deepcopy`.
 
-   Example of using :func:`~asdict` on nested dataclasses::
+   Example of using :func:`asdict` on nested dataclasses::
 
      @dataclass
      class Point:
@@ -349,7 +349,7 @@ Module contents
 
      dict((field.name, getattr(instance, field.name)) for field in fields(instance))
 
-   :func:`~asdict` raises :exc:`TypeError` if ``instance`` is not a dataclass
+   :func:`asdict` raises :exc:`TypeError` if ``instance`` is not a dataclass
    instance.
 
 .. function:: astuple(instance, *, tuple_factory=tuple)
@@ -369,7 +369,7 @@ Module contents
 
      tuple(getattr(instance, field.name) for field in dataclasses.fields(instance))
 
-   :func:`~astuple` raises :exc:`TypeError` if ``instance`` is not a dataclass
+   :func:`astuple` raises :exc:`TypeError` if ``instance`` is not a dataclass
    instance.
 
 .. function:: make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False, match_args=True, kw_only=False, slots=False)

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -349,7 +349,7 @@ Module contents
    Converts the dataclass ``instance`` to a tuple (by using the
    factory function ``tuple_factory``).  Each dataclass is converted
    to a tuple of its field values.  dataclasses, dicts, lists, and
-   tuples are recursed into. Other objects are copied with 
+   tuples are recursed into. Other objects are copied with
    :func:`copy.deepcopy`.
 
    Continuing from the previous example::

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -325,7 +325,10 @@ Module contents
    Converts the dataclass ``instance`` to a dict (by using the
    factory function ``dict_factory``).  Each dataclass is converted
    to a dict of its fields, as ``name: value`` pairs.  dataclasses, dicts,
-   lists, and tuples are recursed into.  For example::
+   lists, and tuples are recursed into.  Other objects are copied with
+   :func:`copy.deepcopy`.
+
+   Example of using :func:`~asdict` on nested dataclasses::
 
      @dataclass
      class Point:
@@ -342,7 +345,12 @@ Module contents
      c = C([Point(0, 0), Point(10, 4)])
      assert asdict(c) == {'mylist': [{'x': 0, 'y': 0}, {'x': 10, 'y': 4}]}
 
-   Raises :exc:`TypeError` if ``instance`` is not a dataclass instance.
+   To create a shallow copy, the following workaround may be used::
+
+     dict((field.name, getattr(instance, field.name)) for field in fields(instance))
+
+   :func:`~asdict` raises :exc:`TypeError` if ``instance`` is not a dataclass
+   instance.
 
 .. function:: astuple(instance, *, tuple_factory=tuple)
 
@@ -361,7 +369,8 @@ Module contents
 
      tuple(getattr(instance, field.name) for field in dataclasses.fields(instance))
 
-   Raises :exc:`TypeError` if ``instance`` is not a dataclass instance.
+   :func:`~astuple` raises :exc:`TypeError` if ``instance`` is not a dataclass
+   instance.
 
 .. function:: make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False, match_args=True, kw_only=False, slots=False)
 

--- a/Misc/NEWS.d/next/Documentation/2021-05-24-05-00-12.bpo-43905.tBIndE.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-05-24-05-00-12.bpo-43905.tBIndE.rst
@@ -1,0 +1,2 @@
+Expanded ``dataclasses.astuple()`` docs, warning about deepcopy being applied
+and providing a workaround.

--- a/Misc/NEWS.d/next/Documentation/2021-05-24-05-00-12.bpo-43905.tBIndE.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-05-24-05-00-12.bpo-43905.tBIndE.rst
@@ -1,2 +1,2 @@
-Expanded ``dataclasses.astuple()`` docs, warning about deepcopy being applied
-and providing a workaround.
+Expanded :func:`~dataclasses.astuple` and :func:`~dataclasses.asdict` docs,
+warning about deepcopy being applied and providing a workaround.


### PR DESCRIPTION
Expanded ``astuple()`` docs, warning about deepcopy being applied 
and providing a workaround.



<!-- issue-number: [bpo-43905](https://bugs.python.org/issue43905) -->
https://bugs.python.org/issue43905
<!-- /issue-number -->

Automerge-Triggered-By: GH:ericvsmith