### PR TITLE
bpo-39950: Fix deprecation warning in test for `pathlib.Path.link_to()`

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1265,7 +1265,7 @@ class Path(PurePath):
         warnings.warn("pathlib.Path.link_to() is deprecated and is scheduled "
                       "for removal in Python 3.12. "
                       "Use pathlib.Path.hardlink_to() instead.",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         self._accessor.link(self, target)
 
     # Convenience functions for querying the stat results

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1934,7 +1934,8 @@ class _BasePathTest(object):
         self.assertTrue(p.stat)
         # Linking to a str of a relative path.
         r = rel_join('fileAAA')
-        q.link_to(r)
+        with self.assertWarns(DeprecationWarning):
+            q.link_to(r)
         self.assertEqual(os.stat(r).st_size, size)
         self.assertTrue(q.stat)
 


### PR DESCRIPTION
Raised by Karthikeyan Singaravelan (xtreak) in msg392779

Will need backporting to 3.10.

<!-- issue-number: [bpo-39950](https://bugs.python.org/issue39950) -->
https://bugs.python.org/issue39950
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead