### PR TITLE
bpo-26110: Document `CALL_METHOD_KW`

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1176,6 +1176,18 @@ All of the following opcodes use their arguments.
    .. versionadded:: 3.7
 
 
+.. opcode:: CALL_METHOD_KW (argc)
+
+   Similar to :opcode:`CALL_METHOD` but also supports keyword arguments.
+   Calls a method.  *argc* is the number of positional and keyword arguments.
+   This opcode is designed to be used with :opcode:`LOAD_METHOD`.  TOS is a
+   tuple of keyword argument names.  Argument values are below that.
+   Below them, the two items described in :opcode:`LOAD_METHOD` are on the
+   stack (either ``self`` and an unbound method object or ``NULL`` and an
+   arbitrary callable).  All of them are popped and the return value is pushed.
+
+   .. versionadded:: 3.11
+
 .. opcode:: MAKE_FUNCTION (flags)
 
    Pushes a new function object on the stack.  From bottom to top, the consumed

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1178,13 +1178,13 @@ All of the following opcodes use their arguments.
 
 .. opcode:: CALL_METHOD_KW (argc)
 
-   Similar to :opcode:`CALL_METHOD` but also supports keyword arguments.
-   Calls a method.  *argc* is the number of positional and keyword arguments.
+   Calls a method in a similar fashion as :opcode:`CALL_METHOD`, but also supports keyword arguments.
+   *argc* is the number of positional and keyword arguments.
    This opcode is designed to be used with :opcode:`LOAD_METHOD`.  TOS is a
    tuple of keyword argument names.  Argument values are below that.
    Below them, the two items described in :opcode:`LOAD_METHOD` are on the
    stack (either ``self`` and an unbound method object or ``NULL`` and an
-   arbitrary callable).  All of them are popped and the return value is pushed.
+   arbitrary callable).  All of them are popped from the stack and the return value is pushed.
 
    .. versionadded:: 3.11
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -90,7 +90,7 @@ Improved Modules
 Optimizations
 =============
 
-* Compiler optimizes now simple C-style formatting with literal format
+* Compiler now optimizes simple C-style formatting with literal format
   containing only format codes ``%s``, ``%r`` and ``%a`` and makes it as
   fast as corresponding f-string expression.
   (Contributed by Serhiy Storchaka in :issue:`28307`.)
@@ -99,6 +99,17 @@ Optimizations
   almost eliminated when no exception is raised.
   (Contributed by Mark Shannon in :issue:`40222`.)
 
+* Method calls with keywords are now up to 20% faster due to bytecode
+  changes which avoid creating bound method instances. Previously, this
+  optimization was applied only to method calls with purely positional
+  arguments.
+  (Contributed by Ken Jin and Mark Shannon in :issue:`26110`, based on ideas
+  implemented in PyPy.)
+
+CPython bytecode changes
+========================
+
+* Added a new :opcode:`CALL_METHOD_KW` opcode.
 
 Build Changes
 =============

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -110,7 +110,8 @@ CPython bytecode changes
 ========================
 
 * Added a new :opcode:`CALL_METHOD_KW` opcode.  Calls a method in a similar
-fashion as :opcode:`CALL_METHOD`, but also supports keyword arguments.
+fashion as :opcode:`CALL_METHOD`, but also supports keyword arguments.  Works
+in tandem with :opcode:`LOAD_METHOD`.
 
 Build Changes
 =============

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -110,8 +110,8 @@ CPython bytecode changes
 ========================
 
 * Added a new :opcode:`CALL_METHOD_KW` opcode.  Calls a method in a similar
-fashion as :opcode:`CALL_METHOD`, but also supports keyword arguments.  Works
-in tandem with :opcode:`LOAD_METHOD`.
+  fashion as :opcode:`CALL_METHOD`, but also supports keyword arguments.  Works
+  in tandem with :opcode:`LOAD_METHOD`.
 
 
 Build Changes

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -99,7 +99,7 @@ Optimizations
   almost eliminated when no exception is raised.
   (Contributed by Mark Shannon in :issue:`40222`.)
 
-* Method calls with keywords are now up to 20% faster due to bytecode
+* Method calls with keywords are now faster due to bytecode
   changes which avoid creating bound method instances. Previously, this
   optimization was applied only to method calls with purely positional
   arguments.
@@ -109,7 +109,8 @@ Optimizations
 CPython bytecode changes
 ========================
 
-* Added a new :opcode:`CALL_METHOD_KW` opcode.
+* Added a new :opcode:`CALL_METHOD_KW` opcode.  Calls a method in a similar
+fashion as :opcode:`CALL_METHOD`, but also supports keyword arguments.
 
 Build Changes
 =============

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -113,6 +113,7 @@ CPython bytecode changes
 fashion as :opcode:`CALL_METHOD`, but also supports keyword arguments.  Works
 in tandem with :opcode:`LOAD_METHOD`.
 
+
 Build Changes
 =============
 


### PR DESCRIPTION
* Added CALL_METHOD_KW to whatsnew in 3.11 and dis docs.
* Fixed 1 minor nit in the 3.11 whatsnew too.

<!-- issue-number: [bpo-26110](https://bugs.python.org/issue26110) -->
https://bugs.python.org/issue26110
<!-- /issue-number -->
