### PR TITLE
bpo-44148: Raise a SystemError if frame is NULL in PyEval_GetGlobals

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-16-15-47-23.bpo-44148.l_uEME.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-16-15-47-23.bpo-44148.l_uEME.rst
@@ -1,0 +1,1 @@
+PyEval_GetGlobals will now raise a SystemError and return NULL if frame is NULL.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5838,6 +5838,7 @@ PyEval_GetGlobals(void)
     PyThreadState *tstate = _PyThreadState_GET();
     PyFrameObject *current_frame = tstate->frame;
     if (current_frame == NULL) {
+        _PyErr_SetString(tstate, PyExc_SystemError, "frame does not exist");
         return NULL;
     }
 


### PR DESCRIPTION
PyEval_GetGlobals will now raise a SystemError and return NULL if frame is NULL.

<!-- issue-number: [bpo-44148](https://bugs.python.org/issue44148) -->
https://bugs.python.org/issue44148
<!-- /issue-number -->
