### PR TITLE
gh-88315: Add `key` argument to difflib.get_close_matches()

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -205,11 +205,19 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    Optional argument *cutoff* (default ``0.6``) is a float in the range [0, 1].
    Possibilities that don't score at least that similar to *word* are ignored.
 
+   Optional arg *key* (default ``None``) specifies a function of one argument that
+   is used to extract a comparison key from each element in *possibilities*
+   (for example, ``key=str.lower``). If the value is ``None``, the elements are
+   compared with *word* directly.
+
    The best (no more than *n*) matches among the possibilities are returned in a
    list, sorted by similarity score, most similar first.
 
       >>> get_close_matches('appel', ['ape', 'apple', 'peach', 'puppy'])
       ['apple', 'ape']
+      >>> get_close_matches("appel", [("aple", 9), ("peach", 8), ("puppy", 7)],
+      ...                   key=lambda x: x[0])
+      [('aple', 9)]
       >>> import keyword
       >>> get_close_matches('wheel', keyword.kwlist)
       ['while']

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -710,8 +710,8 @@ def get_close_matches(word, possibilities, n=3, cutoff=0.6, key=None):
     Optional arg cutoff (default 0.6) is a float in [0, 1].  Possibilities
     that don't score at least that similar to word are ignored.
 
-    Optional arg key specifies a function of one argument that is used to 
-    extract a comparison key from each element in iterable (for example, 
+    Optional arg key specifies a function of one argument that is used to
+    extract a comparison key from each element in iterable (for example,
     key=str.lower). The default value is None (compare the elements directly).
 
     The best (no more than n) matches among the possibilities are returned

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1,7 +1,7 @@
 """
 Module difflib -- helpers for computing deltas between objects.
 
-Function get_close_matches(word, possibilities, n=3, cutoff=0.6):
+Function get_close_matches(word, possibilities, n=3, cutoff=0.6, key=None):
     Use SequenceMatcher to return list of the best "good enough" matches.
 
 Function context_diff(a, b):
@@ -695,7 +695,7 @@ class SequenceMatcher:
     __class_getitem__ = classmethod(GenericAlias)
 
 
-def get_close_matches(word, possibilities, n=3, cutoff=0.6):
+def get_close_matches(word, possibilities, n=3, cutoff=0.6, key=None):
     """Use SequenceMatcher to return list of the best "good enough" matches.
 
     word is a sequence for which close matches are desired (typically a
@@ -710,11 +710,18 @@ def get_close_matches(word, possibilities, n=3, cutoff=0.6):
     Optional arg cutoff (default 0.6) is a float in [0, 1].  Possibilities
     that don't score at least that similar to word are ignored.
 
+    Optional arg key specifies a function of one argument that is used to 
+    extract a comparison key from each element in iterable (for example, 
+    key=str.lower). The default value is None (compare the elements directly).
+
     The best (no more than n) matches among the possibilities are returned
     in a list, sorted by similarity score, most similar first.
 
     >>> get_close_matches("appel", ["ape", "apple", "peach", "puppy"])
     ['apple', 'ape']
+    >>> get_close_matches("appel", [("aple", 9), ("peach", 8), ("puppy", 7)],
+    ...                   key=lambda x: x[0])
+    [('aple', 9)]
     >>> import keyword as _keyword
     >>> get_close_matches("wheel", _keyword.kwlist)
     ['while']
@@ -732,7 +739,10 @@ def get_close_matches(word, possibilities, n=3, cutoff=0.6):
     s = SequenceMatcher()
     s.set_seq2(word)
     for x in possibilities:
-        s.set_seq1(x)
+        if key is None:
+            s.set_seq1(x)
+        else:
+            s.set_seq1(key(x))
         if s.real_quick_ratio() >= cutoff and \
            s.quick_ratio() >= cutoff and \
            s.ratio() >= cutoff:

--- a/Misc/NEWS.d/next/Library/2021-05-16-16-46-01.bpo-44149.2MUHbG.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-16-16-46-01.bpo-44149.2MUHbG.rst
@@ -1,0 +1,1 @@
+Add a ``key`` argument to :func:`difflib.get_close_matches`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
https://bugs.python.org/issue44149

This features allows you to specify a key function to extract the correct value from an element to be able to find close matches. Currently the only way to do it without re-implementing the function is to extract all the strings into a list, find the close matches and then once again go through the objects to find the corresponding ones.

A simple test case has also been added, and documentation within the file updated as well.

<!-- issue-number: [bpo-44149](https://bugs.python.org/issue44149) -->
https://bugs.python.org/issue44149
<!-- /issue-number -->

<!-- gh-issue-number: gh-88315 -->
* Issue: gh-88315
<!-- /gh-issue-number -->
