### PR TITLE
bpo-33433 Fix private address checking for IPv4 mapped IPv6.

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -16,6 +16,7 @@ import functools
 IPV4LENGTH = 32
 IPV6LENGTH = 128
 
+
 class AddressValueError(ValueError):
     """A Value Error related to the address."""
 
@@ -2005,6 +2006,9 @@ class IPv6Address(_BaseV6, _BaseAddress):
             iana-ipv6-special-registry.
 
         """
+        ipv4_mapped = self.ipv4_mapped
+        if ipv4_mapped is not None:
+            return ipv4_mapped.is_private
         return any(self in net for net in self._constants._private_networks)
 
     @property

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2003,7 +2003,8 @@ class IPv6Address(_BaseV6, _BaseAddress):
 
         Returns:
             A boolean, True if the address is reserved per
-            iana-ipv6-special-registry.
+            iana-ipv6-special-registry, or is ipv4_mapped and is
+            reserved in the iana-ipv4-special-registry.
 
         """
         ipv4_mapped = self.ipv4_mapped

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2339,6 +2339,12 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(ipaddress.ip_address('::ffff:c0a8:101').ipv4_mapped,
                          ipaddress.ip_address('192.168.1.1'))
 
+    def testIpv4MappedPrivateCheck(self):
+        self.assertEqual(
+                True, ipaddress.ip_address('::ffff:192.168.1.1').is_private)
+        self.assertEqual(
+                False, ipaddress.ip_address('::ffff:172.32.0.0').is_private)
+
     def testAddrExclude(self):
         addr1 = ipaddress.ip_network('10.1.1.0/24')
         addr2 = ipaddress.ip_network('10.1.1.0/26')

--- a/Misc/NEWS.d/next/Library/2021-05-16-17-48-24.bpo-33433.MyzO71.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-16-17-48-24.bpo-33433.MyzO71.rst
@@ -1,0 +1,1 @@
+For IPv4 mapped IPv6 addresses, privacy check is deferred to the mapped IPv4 address. Solves bug where public mapped IPv4 addresses are considered private by the IPv6 check.

--- a/Misc/NEWS.d/next/Library/2021-05-16-17-48-24.bpo-33433.MyzO71.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-16-17-48-24.bpo-33433.MyzO71.rst
@@ -1,1 +1,1 @@
-For IPv4 mapped IPv6 addresses, privacy check is deferred to the mapped IPv4 address. Solves bug where public mapped IPv4 addresses are considered private by the IPv6 check.
+For IPv4 mapped IPv6 addresses (:rfc:`4291` Section 2.5.5.2), the :mod:`ipaddress.IPv6Address.is_private` check is deferred to the mapped IPv4 address. This solves a bug where public mapped IPv4 addresses were considered private by the IPv6 check.


### PR DESCRIPTION
For IPv4 mapped IPv6 addresses, defer privacy check to the mapped IPv4 address. Solves bug where public mapped IPv4 addresses are considered private by the IPv6 check.


<!-- issue-number: [bpo-33433](https://bugs.python.org/issue33433) -->
https://bugs.python.org/issue33433
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead