### PR TITLE
Correcting hyphenation in various locations in documentation

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -173,8 +173,8 @@ And::
 
    .. versionchanged:: 3.8
       Default value of *max_workers* is changed to ``min(32, os.cpu_count() + 4)``.
-      This default value preserves at least 5 workers for I/O bound tasks.
-      It utilizes at most 32 CPU cores for CPU bound tasks which release the GIL.
+      This default value preserves at least 5 workers for I/O-bound tasks.
+      It utilizes at most 32 CPU cores for CPU-bound tasks which release the GIL.
       And it avoids using very large resources implicitly on many-core machines.
 
       ThreadPoolExecutor now reuses idle worker threads before starting

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -137,7 +137,7 @@ The :mod:`functools` module defines the following functions:
                lru_cache(maxsize=128, typed=False)
 
    Decorator to wrap a function with a memoizing callable that saves up to the
-   *maxsize* most recent calls.  It can save time when an expensive or I/O bound
+   *maxsize* most recent calls.  It can save time when an expensive or I/O-bound
    function is periodically called with the same arguments.
 
    Since a dictionary is used to cache results, the positional and keyword

--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -34,7 +34,7 @@ that lets you have nearly all the advantages of multi-threading, without
 actually using multiple threads. it's really only practical if your program
 is largely I/O bound. If your program is CPU bound, then pre-emptive
 scheduled threads are probably what you really need. Network servers are
-rarely CPU-bound, however.
+rarely CPU bound, however.
 
 If your operating system supports the select() system call in its I/O
 library (and nearly all do), then you can use it to juggle multiple

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -127,8 +127,8 @@ class ThreadPoolExecutor(_base.Executor):
         """
         if max_workers is None:
             # ThreadPoolExecutor is often used to:
-            # * CPU bound task which releases GIL
-            # * I/O bound task (which releases GIL, of course)
+            # * CPU-bound task which releases GIL
+            # * I/O-bound task (which releases GIL, of course)
             #
             # We use cpu_count + 4 for both types of tasks.
             # But we limit it to 32 to avoid consuming surprisingly large resource


### PR DESCRIPTION
Since these are trivial documentation changes, I did not create an issue.

There are two things this PR fixes

[When two or more words form an adjective that describe some noun, and the descriptor words precede the noun, the descriptors should be hyphenated](https://www.grammarly.com/blog/hyphen/).  In this case specifically, I corrected some usages of `IO bound` and `CPU bound` to be `IO-bound` and `CPU-bound`, respectively.  There are already places in Python documentation that already do this, such as ["However, threading is still an appropriate model if you want to run multiple I/O-bound tasks simultaneously"](https://github.com/python/cpython/blob/main/Doc/library/threading.rst#L4).

It should be noted that there are places where these words shouldn't be hyphenated, such as when the descriptor words come after the noun; I've corrected a case like this as well.