### PR TITLE
bpo-38671: Add test that `pathlib.Path.resolve()` returns an absolute path.

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1799,6 +1799,16 @@ class _BasePathTest(object):
         # Non-strict
         self.assertEqual(r.resolve(strict=False), p / '3' / '4')
 
+    def test_resolve_nonexist_relative_issue38671(self):
+        p = self.cls('non', 'exist')
+
+        old_cwd = os.getcwd()
+        os.chdir(BASE)
+        try:
+            self.assertEqual(p.resolve(), self.cls(BASE, p))
+        finally:
+            os.chdir(old_cwd)
+
     def test_with(self):
         p = self.cls(BASE)
         it = p.iterdir()


### PR DESCRIPTION
Original code by Tzu-ping Chung (uranusjr) in #17716

Issue should be fixed in #25264

<!-- issue-number: [bpo-38671](https://bugs.python.org/issue38671) -->
https://bugs.python.org/issue38671
<!-- /issue-number -->
