### PR TITLE
bpo-44135: issubclass documentation doesn't explain tuple semantic

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -916,9 +916,9 @@ are always available.  They are listed here in alphabetical order.
    Return ``True`` if *class* is a subclass (direct, indirect or :term:`virtual
    <abstract base class>`) of *classinfo*.  A
    class is considered a subclass of itself. *classinfo* may be a tuple of class
-   objects or a :ref:`types-union`, in which case every entry in *classinfo*
-   will be checked. In any other
-   case, a :exc:`TypeError` exception is raised.
+   objects or a :ref:`types-union`, in which case return True if *class* is a
+   subclass of any entry in *classinfo*.  In any other case, a :exc:`TypeError`
+   exception is raised.
 
    .. versionchanged:: 3.10
       *classinfo* can be a :ref:`types-union`.


### PR DESCRIPTION
# [bpo-44135](https://bugs.python.org/issue44135): issubclass documentation doesn't explain tuple semantic

```
[bpo-44135](https://bugs.python.org/issue44135): issubclass documentation doesn't explain tuple semantic
```

https://bugs.python.org/issue44135

<!-- issue-number: [bpo-44135](https://bugs.python.org/issue44135) -->
https://bugs.python.org/issue44135
<!-- /issue-number -->
