### PR TITLE
gh-59170: Proxy `super().x = y` and `del super().x`

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-17-18-47-03.bpo-14965.uU4lZp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-17-18-47-03.bpo-14965.uU4lZp.rst
@@ -1,0 +1,3 @@
+Proxying data descriptor setters with `super().x = y` and deleters with `del super().x` will now follow getter use with `super().x`. Previously, these would unconditionally fail.
+
+Patch written by Daniel Urban.


### PR DESCRIPTION
Arguably this is a bugfix, and therefore should be backported into the 3.10 branch as well.

This patch was originally contributed by Daniel Urban, whose summary
follows:

> I'm attaching a patch implementing `super.__setattr__` (and
> `__delattr__`).
>
> The implementation in the patch only works, if super can find a data
> descriptor in the MRO, otherwise it throws an `AttributeError`. As it
> can be seen in the tests, in some cases this may result in
> counter-intuitive behaviour. But I wasn't able to find another
> behaviour, that is consistent with both `super.__getattr__` and normal
> `__setattr__` semantics.




<!-- issue-number: [bpo-14965](https://bugs.python.org/issue14965) -->
https://bugs.python.org/issue14965
<!-- /issue-number -->

<!-- gh-issue-number: gh-59170 -->
* Issue: gh-59170
<!-- /gh-issue-number -->
