### PR TITLE
bpo-30274: Rename 'name' to 'fullname' argument to ExtensionFileLoader.

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1162,18 +1162,9 @@ class ExtensionFileLoader(FileLoader, _LoaderBasics):
 
     """
 
-    def __init__(self, fullname, path, name=None):
+    def __init__(self, fullname, path):
+        self.name = fullname
         self.path = path
-
-        if name is None:
-            self.name = fullname
-        else:
-            _warnings.warn("the 'name' parameter is deprecated; use "
-                           "'fullname' instead", DeprecationWarning)
-            if fullname is not None:
-                raise TypeError("'name' and 'fullname' cannot be used "
-                                "simultaneously")
-
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__ and

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1163,8 +1163,17 @@ class ExtensionFileLoader(FileLoader, _LoaderBasics):
     """
 
     def __init__(self, fullname, path, name=None):
-        self.name = name
         self.path = path
+
+        if name is None:
+            self.name = fullname
+        else:
+            _warnings.warn("the 'name' parameter is deprecated; use "
+                           "'fullname' instead", DeprecationWarning)
+            if fullname is not None:
+                raise TypeError("'name' and 'fullname' cannot be used "
+                                "simultaneously")
+
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__ and

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1162,7 +1162,7 @@ class ExtensionFileLoader(FileLoader, _LoaderBasics):
 
     """
 
-    def __init__(self, name, path):
+    def __init__(self, fullname, path, name=None):
         self.name = name
         self.path = path
 


### PR DESCRIPTION
# [bpo-30274](https://bugs.python.org/issue30274): Rename `name` to `fullname` argument to ExtensionFileLoader.

This PR replaces the positional argument `name` for the ExtensionFileLoader class with the positional argument `fullname`.


Old: `__init__(self, name, path):`
New: `__init__(self, fullname, path):`

`name` is not added as a kwarg, unlike in https://github.com/python/cpython/pull/1735

In PR #1735:
1. An error would be raised if both a `fullname` arg and `name` kwarg (and `path` arg) were passed.
2. If only a `path` arg and `name` kwarg were passed, `path` would be the first positional argument, acting as `fullname`, and this would raise an error


bpo: https://bugs.python.org/issue30274




<!-- issue-number: [bpo-30274](https://bugs.python.org/issue30274) -->
https://bugs.python.org/issue30274
<!-- /issue-number -->
