### PR TITLE
bpo-41963: document that ConfigParser strips off comments

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -1153,6 +1153,13 @@ ConfigParser Objects
       *space_around_delimiters* is true, delimiters between
       keys and values are surrounded by spaces.
 
+   .. note::
+
+      Comments in the original configuration file are not preserved when
+      writing the configuration back.
+      What is considered a comment, depends on the given values for
+      *comment_prefix* and *inline_comment_prefix*.
+
 
    .. method:: remove_option(section, option)
 

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -908,6 +908,9 @@ class RawConfigParser(MutableMapping):
 
         If `space_around_delimiters' is True (the default), delimiters
         between keys and values are surrounded by spaces.
+
+        Please note that comments in the original configuration file are not
+        preserved when writing the configuration back.
         """
         if space_around_delimiters:
             d = " {} ".format(self._delimiters[0])
@@ -1006,7 +1009,7 @@ class RawConfigParser(MutableMapping):
         Configuration files may include comments, prefixed by specific
         characters (`#' and `;' by default). Comments may appear on their own
         in an otherwise empty line or may be entered in lines holding values or
-        section names.
+        section names. Please note that comments gets stripped off on reading.
         """
         elements_added = set()
         cursect = None                        # None, or a dictionary

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1009,7 +1009,7 @@ class RawConfigParser(MutableMapping):
         Configuration files may include comments, prefixed by specific
         characters (`#' and `;' by default). Comments may appear on their own
         in an otherwise empty line or may be entered in lines holding values or
-        section names. Please note that comments gets stripped off on reading.
+        section names. Please note that comments get stripped off on reading.
         """
         elements_added = set()
         cursect = None                        # None, or a dictionary

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1009,7 +1009,7 @@ class RawConfigParser(MutableMapping):
         Configuration files may include comments, prefixed by specific
         characters (`#' and `;' by default). Comments may appear on their own
         in an otherwise empty line or may be entered in lines holding values or
-        section names. Please note that comments get stripped off on reading.
+        section names. Please note that comments get stripped off when reading configuration files.
         """
         elements_added = set()
         cursect = None                        # None, or a dictionary

--- a/Misc/NEWS.d/next/Documentation/2021-05-17-20-03-47.bpo-41963.eUz9_o.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-05-17-20-03-47.bpo-41963.eUz9_o.rst
@@ -1,0 +1,1 @@
+Document that ``ConfigParser`` strips off comments when reading configuration files.


### PR DESCRIPTION
... when reading a configuration file.

<!-- issue-number: [bpo-41963](https://bugs.python.org/issue41963) -->
https://bugs.python.org/issue41963
<!-- /issue-number -->
