### PR TITLE
bpo-4928: Document NamedTemporaryFile non-deletion after SIGKILL

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -87,6 +87,9 @@ The module defines the following user-callable items:
    attribute is the underlying true file object. This file-like object can
    be used in a :keyword:`with` statement, just like a normal file.
 
+   On POSIX (only), a process that is terminated abruptly with SIGKILL
+   cannot automatically delete :func:`NamedTemporaryFile`s it created.
+
    .. audit-event:: tempfile.mkstemp fullpath tempfile.NamedTemporaryFile
 
    .. versionchanged:: 3.8

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -88,7 +88,7 @@ The module defines the following user-callable items:
    be used in a :keyword:`with` statement, just like a normal file.
 
    On POSIX (only), a process that is terminated abruptly with SIGKILL
-   cannot automatically delete :func:`NamedTemporaryFile`s it created.
+   cannot automatically delete any NamedTemporaryFiles it created.
 
    .. audit-event:: tempfile.mkstemp fullpath tempfile.NamedTemporaryFile
 

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -532,6 +532,10 @@ def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
     Returns an object with a file-like interface; the name of the file
     is accessible as its 'name' attribute.  The file will be automatically
     deleted when it is closed unless the 'delete' argument is set to False.
+
+    On POSIX, NamedTemporaryFiles cannot be automatically deleted if
+    the creating process is terminated abruptly with a SIGKILL signal.
+    Windows can delete the file even in this case.
     """
 
     prefix, suffix, dir, output_type = _sanitize_params(prefix, suffix, dir)

--- a/Misc/NEWS.d/next/Library/2021-05-17-21-05-06.bpo-4928.Ot2yjO.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-17-21-05-06.bpo-4928.Ot2yjO.rst
@@ -1,0 +1,1 @@
+Documented existing behavior on POSIX: NamedTemporaryFiles are not deleted when creating process is killed with SIGKILL


### PR DESCRIPTION
Consensus on https://bugs.python.org/issue4928 seems to be that documenting the behavior is all we can really do.  Submitting this as suggested wording.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-4928](https://bugs.python.org/issue4928) -->
https://bugs.python.org/issue4928
<!-- /issue-number -->
