### PR TITLE
bpo-44165: optimise sqlite3 statement preparation by passing string size

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -172,6 +172,9 @@ pysqlite_connection_init(pysqlite_Connection *self, PyObject *args,
         return -1;
     }
 
+    // Fetch the maximum length of an SQL string or BLOB
+    self->max_length = sqlite3_limit(self->db, SQLITE_LIMIT_LENGTH, -1);
+
     self->Warning               = pysqlite_Warning;
     self->Error                 = pysqlite_Error;
     self->InterfaceError        = pysqlite_InterfaceError;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -428,7 +428,7 @@ pysqlite_connection_commit_impl(pysqlite_Connection *self)
     if (!sqlite3_get_autocommit(self->db)) {
 
         Py_BEGIN_ALLOW_THREADS
-        rc = sqlite3_prepare_v2(self->db, "COMMIT", -1, &statement, NULL);
+        rc = sqlite3_prepare_v2(self->db, "COMMIT", 7, &statement, NULL);
         Py_END_ALLOW_THREADS
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->db);
@@ -478,7 +478,7 @@ pysqlite_connection_rollback_impl(pysqlite_Connection *self)
         pysqlite_do_all_statements(self, ACTION_RESET, 1);
 
         Py_BEGIN_ALLOW_THREADS
-        rc = sqlite3_prepare_v2(self->db, "ROLLBACK", -1, &statement, NULL);
+        rc = sqlite3_prepare_v2(self->db, "ROLLBACK", 9, &statement, NULL);
         Py_END_ALLOW_THREADS
         if (rc != SQLITE_OK) {
             _pysqlite_seterror(self->db);

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -172,9 +172,6 @@ pysqlite_connection_init(pysqlite_Connection *self, PyObject *args,
         return -1;
     }
 
-    // Fetch the maximum length of an SQL string or BLOB
-    self->max_length = sqlite3_limit(self->db, SQLITE_LIMIT_LENGTH, -1);
-
     self->Warning               = pysqlite_Warning;
     self->Error                 = pysqlite_Error;
     self->InterfaceError        = pysqlite_InterfaceError;

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -45,6 +45,9 @@ typedef struct
     /* the timeout value in seconds for database locks */
     double timeout;
 
+    /* the maximum length of an SQL string or BLOB */
+    int max_length;
+
     /* for internal use in the timeout handler: when did the timeout handler
      * first get called with count=0? */
     double timeout_started;

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -45,9 +45,6 @@ typedef struct
     /* the timeout value in seconds for database locks */
     double timeout;
 
-    /* the maximum length of an SQL string or BLOB */
-    int max_length;
-
     /* for internal use in the timeout handler: when did the timeout handler
      * first get called with count=0? */
     double timeout_started;

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -696,7 +696,7 @@ pysqlite_cursor_executescript(pysqlite_Cursor *self, PyObject *script_obj)
             return NULL;
         }
         if (sql_len >= self->connection->max_length) {
-            PyErr_SetString(PyExc_OverflowError, "query string is too large");
+            PyErr_SetString(pysqlite_DataError, "query string is too large");
             return NULL;
         }
     } else {

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -695,6 +695,10 @@ pysqlite_cursor_executescript(pysqlite_Cursor *self, PyObject *script_obj)
         if (!script_cstr) {
             return NULL;
         }
+        if (sql_len >= self->connection->max_length) {
+            PyErr_SetString(PyExc_OverflowError, "query string is too large");
+            return NULL;
+        }
     } else {
         PyErr_SetString(PyExc_ValueError, "script argument must be unicode.");
         return NULL;
@@ -713,7 +717,7 @@ pysqlite_cursor_executescript(pysqlite_Cursor *self, PyObject *script_obj)
         Py_BEGIN_ALLOW_THREADS
         rc = sqlite3_prepare_v2(self->connection->db,
                                 script_cstr,
-                                (sql_len >= INT_MAX) ? -1 : (int)sql_len + 1,
+                                (int)sql_len + 1,
                                 &statement,
                                 &tail);
         Py_END_ALLOW_THREADS

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -695,7 +695,10 @@ pysqlite_cursor_executescript(pysqlite_Cursor *self, PyObject *script_obj)
         if (!script_cstr) {
             return NULL;
         }
-        if (sql_len >= self->connection->max_length) {
+
+        int max_length = sqlite3_limit(self->connection->db,
+                                       SQLITE_LIMIT_LENGTH, -1);
+        if (sql_len >= max_length) {
             PyErr_SetString(pysqlite_DataError, "query string is too large");
             return NULL;
         }

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -66,7 +66,9 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
         rc = PYSQLITE_SQL_WRONG_TYPE;
         return rc;
     }
-    if (sql_cstr_len >= connection->max_length) {
+
+    int max_length = sqlite3_limit(connection->db, SQLITE_LIMIT_LENGTH, -1);
+    if (sql_cstr_len >= max_length) {
         PyErr_SetString(pysqlite_DataError, "query string is too large");
         return PYSQLITE_TOO_MUCH_SQL;
     }

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -96,7 +96,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_prepare_v2(connection->db,
                             sql_cstr,
-                            -1,
+                            sql_cstr_len + 1,
                             &self->st,
                             &tail);
     Py_END_ALLOW_THREADS

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -67,7 +67,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
         return rc;
     }
     if (sql_cstr_len >= connection->max_length) {
-        PyErr_SetString(PyExc_OverflowError, "query string is too large");
+        PyErr_SetString(pysqlite_DataError, "query string is too large");
         return PYSQLITE_TOO_MUCH_SQL;
     }
     if (strlen(sql_cstr) != (size_t)sql_cstr_len) {

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -93,10 +93,16 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
         break;
     }
 
+    if (sql_cstr_len >= INT_MAX) {
+        sql_cstr_len = -1;
+    }
+    else {
+        sql_cstr_len += 1;
+    }
     Py_BEGIN_ALLOW_THREADS
     rc = sqlite3_prepare_v2(connection->db,
                             sql_cstr,
-                            sql_cstr_len + 1,
+                            (int)sql_cstr_len,
                             &self->st,
                             &tail);
     Py_END_ALLOW_THREADS


### PR DESCRIPTION
Quoting the SQLite docs, https://sqlite.org/c3ref/prepare.html:
"If the caller knows that the supplied string is nul-terminated, then
there is a small performance advantage to passing an nByte parameter
that is the number of bytes in the input string including the
nul-terminator."

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44165](https://bugs.python.org/issue44165) -->
https://bugs.python.org/issue44165
<!-- /issue-number -->
