### PR TITLE
bpo-44166: Make IndexError messages for lists more informative

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -124,6 +124,27 @@ class CommonTest(seq_tests.CommonTest):
         with self.assertRaisesRegex(TypeError, msg):
             a['a'] = "python"
 
+        # assert error message when non-empty list positive index
+        idx = 7
+        msg = ("list assignment index out of range, the len is %d"
+               " so index must be in -%d..%d, got %d") % (len(a), len(a), len(a)-1, idx)
+        with self.assertRaisesRegex(IndexError, msg):
+            a[idx] = 9
+
+        # assert error message when non-empty list negative index
+        idx = -7
+        msg = ("list assignment index out of range, the len is %d"
+               " so index must be in -%d..%d, got %d") % (len(a), len(a), len(a)-1, idx)
+        with self.assertRaisesRegex(IndexError, msg):
+            a[idx] = 9
+
+        # assert error message when list is empty
+        idx = 7
+        a = []
+        msg = ("list assignment index out of range, got index %d but the list is empty" % idx)
+        with self.assertRaisesRegex(IndexError, msg):
+            a[idx] = 9
+
     def test_delitem(self):
         a = self.type2test([0, 1])
         del a[1]
@@ -302,6 +323,27 @@ class CommonTest(seq_tests.CommonTest):
         self.assertRaises(IndexError, a.pop)
         self.assertRaises(TypeError, a.pop, 42, 42)
         a = self.type2test([0, 10, 20, 30, 40])
+
+        # assert error message when non-empty list
+        idx = 7
+        msg = ("pop index out of range, the len is %d"
+               " so index must be in -%d..%d, got %d") % (len(a), len(a), len(a)-1, idx)
+        with self.assertRaisesRegex(IndexError, msg):
+            a.pop(idx)
+
+        # assert error message when non-empty list
+        idx = -17
+        msg = ("pop index out of range, the len is %d"
+               " so index must be in -%d..%d, got %d") % (len(a), len(a), len(a)-1, idx)
+        with self.assertRaisesRegex(IndexError, msg):
+            a.pop(idx)
+
+        # assert error message when list is empty
+        idx = 7
+        a = []
+        msg = "pop index out of range, got index %d but the list is empty" % idx
+        with self.assertRaisesRegex(IndexError, msg):
+            a.pop(idx)
 
     def test_remove(self):
         a = self.type2test([0, 0, 1])

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-18-08-38-56.bpo-44166.XU72f8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-18-08-38-56.bpo-44166.XU72f8.rst
@@ -1,0 +1,3 @@
+:exc:`IndexError` messages for :class:`list` are now more informative. They
+provide hints about the current length, the provided index number and the
+allowed range.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -219,7 +219,7 @@ valid_index(Py_ssize_t i, Py_ssize_t limit)
 }
 
 static inline void
-print_error(const char *msg, Py_ssize_t len, Py_ssize_t i)
+index_error(const char *msg, Py_ssize_t len, Py_ssize_t i)
 {
     if (len == 0) {
         PyErr_Format(PyExc_IndexError, "%s index out of range, got index %zd but the list is empty", msg, i);
@@ -241,7 +241,7 @@ PyList_GetItem(PyObject *op, Py_ssize_t i)
         return NULL;
     }
     if (!valid_index(i, Py_SIZE(op))) {
-        print_error("list", Py_SIZE(op), i);
+        index_error("list", Py_SIZE(op), i);
         return NULL;
     }
     return ((PyListObject *)op) -> ob_item[i];
@@ -259,7 +259,7 @@ PyList_SetItem(PyObject *op, Py_ssize_t i,
     }
     if (!valid_index(i, Py_SIZE(op))) {
         Py_XDECREF(newitem);
-        print_error("list assignment", Py_SIZE(op), i);
+        index_error("list assignment", Py_SIZE(op), i);
         return -1;
     }
     p = ((PyListObject *)op) -> ob_item + i;
@@ -445,7 +445,7 @@ static PyObject *
 list_item(PyListObject *a, Py_ssize_t i)
 {
     if (!valid_index(i, Py_SIZE(a))) {
-        print_error("list", Py_SIZE(a), i);
+        index_error("list", Py_SIZE(a), i);
         return NULL;
     }
     Py_INCREF(a->ob_item[i]);
@@ -765,7 +765,7 @@ static int
 list_ass_item(PyListObject *a, Py_ssize_t i, PyObject *v)
 {
     if (!valid_index(i, Py_SIZE(a))) {
-        print_error("list assignment", Py_SIZE(a), i);
+        index_error("list assignment", Py_SIZE(a), i);
         return -1;
     }
     if (v == NULL)
@@ -1005,13 +1005,13 @@ list_pop_impl(PyListObject *self, Py_ssize_t index)
 
     if (Py_SIZE(self) == 0) {
         /* Special-case most common failure cause */
-        PyErr_SetString(PyExc_IndexError, "pop from empty list");
+        index_error("pop", Py_SIZE(self), index);
         return NULL;
     }
     if (index < 0)
         index += Py_SIZE(self);
     if (!valid_index(index, Py_SIZE(self))) {
-        print_error("pop index", Py_SIZE(self), index);
+        index_error("pop", Py_SIZE(self), index);
         return NULL;
     }
     v = self->ob_item[index];


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44166](https://bugs.python.org/issue44166) -->
https://bugs.python.org/issue44166
<!-- /issue-number -->
