### PR TITLE
bpo-43813: Fixing DOS on http.server by limiting the characters getting logged.

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -545,7 +545,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
         if isinstance(code, HTTPStatus):
             code = code.value
         self.log_message('"%s" %s %s',
-                         self.requestline, str(code), str(size))
+                         self.get_method(self.requestline), str(code), str(size))
 
     def log_error(self, format, *args):
         """Log an error.

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -407,6 +407,9 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                 return
             mname = 'do_' + self.command
             if not hasattr(self, mname):
+                if len(self.command) > 10:
+                    self.command = self.command[:10] + "..."
+                
                 self.send_error(
                     HTTPStatus.NOT_IMPLEMENTED,
                     "Unsupported method (%r)" % self.command)
@@ -579,6 +582,26 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                          (self.address_string(),
                           self.log_date_time_string(),
                           format%args))
+        
+    def get_method(self, requestline):
+        methodCharacters = []
+        lastCharacter = ""
+
+        for singleCharacter in str(requestline):
+            if singleCharacter == "/" and lastCharacter == " ":
+                break
+            else:
+                lastCharacter = singleCharacter
+                methodCharacters.append(singleCharacter)
+
+        request_method = ''.join(methodCharacters)
+        if len(request_method) > 10:
+            new_request_method = request_method[:10] + "..." + " "
+        else:
+            new_request_method = request_method
+
+        fixed_requestline = requestline.replace(request_method, new_request_method)
+        return fixed_requestline
 
     def version_string(self):
         """Return the server software version string."""


### PR DESCRIPTION
Due to the large characters limit on the first line of the request, Remote users was able to submit a huge method name and endpoint on the request that they can keep sending until python uses a large amount of memory until it freezes that could be achieved on a strong machine with almost 1000 requests.

The logging part was the most part that's using memory during the attack. so I think limiting the data getting passed into the output functions: `log_request` and `log_message` that uses: `sys.stderr.write` will be more fine to keep http.server handling the requests without stop.

The fix limits the request method characters getting logged into 10 characters only. if the request method is 60k `A` characters for example. it will just print out: `AAAAAAAAAA...` that doesn't consume memory.

Before the fix the memory usage kept increasing. after it the memory usage doesn't pass 6.0% using 5k requests. 

<!-- issue-number: [bpo-43813](https://bugs.python.org/issue43813) -->
https://bugs.python.org/issue43813
<!-- /issue-number -->
