### PR TITLE
bpo-44173: better approach for seeking in non-compressed ZipExtFile

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -833,10 +833,10 @@ class ZipExtFile(io.BufferedIOBase):
         self.name = zipinfo.filename
 
         if hasattr(zipinfo, 'CRC'):
-            self._expected_crc = zipinfo.CRC
+            self._expected_crc = self._orig_crc = zipinfo.CRC
             self._running_crc = crc32(b'')
         else:
-            self._expected_crc = None
+            self._expected_crc = self._orig_crc = None
 
         self._seekable = False
         try:
@@ -1067,17 +1067,17 @@ class ZipExtFile(io.BufferedIOBase):
             raise ValueError("I/O operation on closed file.")
         return self._seekable
 
-    def seek(self, offset, whence=0):
+    def seek(self, offset, whence=os.SEEK_SET):
         if self.closed:
             raise ValueError("seek on closed file.")
         if not self._seekable:
             raise io.UnsupportedOperation("underlying stream is not seekable")
         curr_pos = self.tell()
-        if whence == 0: # Seek from start of file
+        if whence == os.SEEK_SET:
             new_pos = offset
-        elif whence == 1: # Seek from current position
+        elif whence == os.SEEK_CUR:
             new_pos = curr_pos + offset
-        elif whence == 2: # Seek from EOF
+        elif whence == os.SEEK_END:
             new_pos = self._orig_file_size + offset
         else:
             raise ValueError("whence must be os.SEEK_SET (0), "
@@ -1100,6 +1100,7 @@ class ZipExtFile(io.BufferedIOBase):
             # Position is before the current position. Reset the ZipExtFile
             self._fileobj.seek(self._orig_compress_start)
             self._running_crc = self._orig_start_crc
+            self._expected_crc = self._orig_crc
             self._compress_left = self._orig_compress_size
             self._left = self._orig_file_size
             self._readbuffer = b''
@@ -1109,6 +1110,14 @@ class ZipExtFile(io.BufferedIOBase):
             read_offset = new_pos
             if self._decrypter is not None:
                 self._init_decrypter()
+
+        if read_offset > 0 and self._compress_type == ZIP_STORED:
+            # disable CRC checking after first seeking - it would be invalid
+            self._expected_crc = None
+
+            self._fileobj.seek(read_offset, os.SEEK_CUR)
+            self._left -= read_offset
+            self._offset = read_offset = 0
 
         while read_offset > 0:
             read_len = min(self.MAX_SEEK_READ, read_offset)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

At the moment stored ZipExtFile is being read to the place of seek like all other compressed variants.
It's not needed as it's possible to freely seek uncompressed file inside zip without this penalty.

Lots of apps depend on ZipExtFile seeking ability and this patch would increase performance and lower IO penalty significantly.

It disables CRC checking after first seek as it's impossible to check CRC if we are not reading whole file.

I've been using patched zipfile for almost a year now and I can say it works good ;)

<!-- issue-number: [bpo-44173](https://bugs.python.org/issue44173) -->
https://bugs.python.org/issue44173
<!-- /issue-number -->
