### PR TITLE
bpo-44120: Fix class resolver in logging.config

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -617,7 +617,7 @@ fails.
 Import resolution and custom importers
 """"""""""""""""""""""""""""""""""""""
 
-Import resolution, by default, uses the builtin :func:`__import__` function
+Import resolution, by default, uses the :func:`importlib.import_module` function
 to do its importing. You may want to replace this with your own importing
 mechanism: if so, you can replace the :attr:`importer` attribute of the
 :class:`DictConfigurator` or its superclass, the

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1188,6 +1188,7 @@ Dom Mitchell
 Dustin J. Mitchell
 Tim Mitchell
 Zubin Mithra
+Hiroaki Mizuguchi
 Florian Mladitsch
 Doug Moen
 Jakub Molinski

--- a/Misc/NEWS.d/next/Library/2021-05-18-17-42-38.bpo-44120.eE3ovs.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-18-17-42-38.bpo-44120.eE3ovs.rst
@@ -1,0 +1,2 @@
+The BaseConfigurator of :mod:`logging.config` module no longer use the
+built-in :func:`__import__`, use :func:`importlib.import_module`


### PR DESCRIPTION
Use importlib.import_module instead of __import__ to avoid import error.

ImportError is happend when import class `foo.logging.BarFormatter` if `foo` module has `import logging` directive because `getattr(found, name)` return `logging` module not `bar.logging` module when `_resolve()` traverse module from `bar` to `bar.logging`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44120](https://bugs.python.org/issue44120) -->
https://bugs.python.org/issue44120
<!-- /issue-number -->
