### PR TITLE
Added argument to Path.iterdir to return only directories

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -998,7 +998,7 @@ class Path(PurePath):
             other_st = self._accessor.stat(other_path)
         return os.path.samestat(st, other_st)
 
-    def iterdir(self):
+    def iterdir(self, dirs_only=False):
         """Iterate over the files in this directory.  Does not yield any
         result for the special paths '.' and '..'.
         """
@@ -1006,7 +1006,10 @@ class Path(PurePath):
             if name in {'.', '..'}:
                 # Yielding a path object for these makes little sense
                 continue
-            yield self._make_child_relpath(name)
+            child_path = self._make_child_relpath(name)
+            if dirs_only and not child_path.is_dir():
+                continue
+            yield child_path
 
     def glob(self, pattern):
         """Iterate over this subtree and yield all existing files (of any

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1592,6 +1592,16 @@ class _BasePathTest(object):
         self.assertIn(cm.exception.errno, (errno.ENOTDIR,
                                            errno.ENOENT, errno.EINVAL))
 
+    def test_iterdir(self):
+        P = self.cls
+        p = P(BASE)
+        it = p.iterdir(dirs_only=True)
+        paths = set(it)
+        expected = ['dirA', 'dirB', 'dirC', 'dirE']
+        if os_helper.can_symlink():
+            expected += ['linkB']
+        self.assertEqual(paths, { P(BASE, q) for q in expected })
+
     def test_glob_common(self):
         def _check(glob, expected):
             self.assertEqual(set(glob), { P(BASE, q) for q in expected })


### PR DESCRIPTION
This is useful, for example, when you take turns working with files in several different directories.
Now it looks like `(path for path in root.iterdir() if path.is_dir())`, became `root.iterdir(dirs_only=True)`.
I didn't create bpo issue because it's "trivial issues," it seems to me.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
