### PR TITLE
bpo-44180: Report generic syntax errors in the furthest position reached in the first parser pass

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -213,6 +213,7 @@ class ExceptionTests(unittest.TestCase):
         check('[file for str(file) in []\n])', 2, 2)
         check('[\nfile\nfor str(file)\nin\n[]\n]', 3, 5)
         check('[file for\n str(file) in []]', 2, 2)
+        check("ages = {'Alice'=22, 'Bob'=23}", 1, 16)
 
         # Errors thrown by compile.c
         check('class foo:return 1', 1, 11)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-19-20-33-36.bpo-44180.mQVaAs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-19-20-33-36.bpo-44180.mQVaAs.rst
@@ -1,0 +1,3 @@
+The parser doesn't report generic syntax errors that happen in a position
+further away that the one it reached in the first pass. Patch by Pablo
+Galindo

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1281,6 +1281,7 @@ _PyPegen_run_parser(Parser *p)
 {
     void *res = _PyPegen_parse(p);
     if (res == NULL) {
+        Token *last_token = p->tokens[p->fill - 1];
         reset_parser_state(p);
         _PyPegen_parse(p);
         if (PyErr_Occurred()) {
@@ -1307,7 +1308,11 @@ _PyPegen_run_parser(Parser *p)
                 RAISE_INDENTATION_ERROR("unexpected unindent");
             }
             else {
-                RAISE_SYNTAX_ERROR("invalid syntax");
+                // Use the last token we found on the first pass to avoid reporting
+                // incorrect locations for generic syntax errors just because we reached
+                // further away when trying to find specific syntax errors in the second
+                // pass.
+                RAISE_SYNTAX_ERROR_KNOWN_LOCATION(last_token, "invalid syntax");
                 // _PyPegen_check_tokenizer_errors will override the existing
                 // generic SyntaxError we just raised if errors are found.
                 _PyPegen_check_tokenizer_errors(p);


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44180](https://bugs.python.org/issue44180) -->
https://bugs.python.org/issue44180
<!-- /issue-number -->
