### PR TITLE
FIX random range with parentheses

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -273,7 +273,7 @@ be found in any statistics text.
 
 .. function:: random()
 
-   Return the next random floating point number in the range [0.0, 1.0).
+   Return the next random floating point number in the range (0.0, 1.0).
 
 
 .. function:: uniform(a, b)


### PR DESCRIPTION
Really trivial issue, just a typo in the random library documentation.
