### PR TITLE
gh-88354: Fix ThreadPoolExecutor unbalanced semaphore count

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-08-31-20-43-30.bpo-44188.JB6g3G.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-31-20-43-30.bpo-44188.JB6g3G.rst
@@ -1,0 +1,1 @@
+Fix ThreadPoolExecutor unbalanced semaphore count.

--- a/Tools/c-analyzer/c_parser/_state_machine.py
+++ b/Tools/c-analyzer/c_parser/_state_machine.py
@@ -23,7 +23,7 @@ def parse(srclines):
     if isinstance(srclines, str):  # a filename
         raise NotImplementedError
 
-    
+
 
 # This only handles at most 10 nested levels.
 #MATCHED_PARENS = textwrap.dedent(rf'''

--- a/Tools/c-analyzer/c_parser/preprocessor/__init__.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/__init__.py
@@ -91,7 +91,7 @@ def get_preprocessor(*,
             macros = list(_resolve_file_values(filename, file_macros))
         if file_incldirs:
             incldirs = [v for v, in _resolve_file_values(filename, file_incldirs)]
-    
+
         def preprocess(**kwargs):
             if file_macros and 'macros' not in kwargs:
                 kwargs['macros'] = macros


### PR DESCRIPTION
Previously when the worker pool was over-saturated, the idle count would
increment after each completed job whereas it would only decrement when
it was already greater than 0.

<!-- issue-number: [bpo-44188](https://bugs.python.org/issue44188) -->
https://bugs.python.org/issue44188
<!-- /issue-number -->

<!-- gh-issue-number: gh-88354 -->
* Issue: gh-88354
<!-- /gh-issue-number -->
