### PR TITLE
[3.7] bpo-43882 - Mention urllib.parse changes in Whats New section for 3.7.11

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2594,3 +2594,13 @@ IPv4 address sent from the remote server when setting up a passive data
 channel.  We reuse the ftp server IP address instead.  For unusual code
 requiring the old behavior, set a ``trust_server_pasv_ipv4_address``
 attribute on your FTP instance to ``True``.  (See :issue:`43285`)
+
+
+The presence of newline or tab characters in parts of a URL allows for some
+forms of attacks. Following the WHATWG specification that updates RFC 3986,
+ASCII newline ``\n``, ``\r`` and tab ``\t`` characters are stripped from the
+URL by the parser :func:`urllib.parse` preventing such attacks. The removal
+characters are controlled by module level variable
+``urllib.parse._UNSAFE_URL_BYTES_TO_REMOVE``. (See :issue:`43882`)
+
+

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2600,7 +2600,7 @@ The presence of newline or tab characters in parts of a URL allows for some
 forms of attacks. Following the WHATWG specification that updates RFC 3986,
 ASCII newline ``\n``, ``\r`` and tab ``\t`` characters are stripped from the
 URL by the parser :func:`urllib.parse` preventing such attacks. The removal
-characters are controlled by module level variable
+characters are controlled by a new module level variable
 ``urllib.parse._UNSAFE_URL_BYTES_TO_REMOVE``. (See :issue:`43882`)
 
 


### PR DESCRIPTION
Related to [bpo-43882](https://bugs.python.org/issue43882) - urllib.parse should sanitize urls containing ASCII newline and tabs

<!-- issue-number: [bpo-43882](https://bugs.python.org/issue43882) -->
https://bugs.python.org/issue43882
<!-- /issue-number -->

--- 

News Entry was added in the initial patch - https://github.com/python/cpython/blob/3.7/Misc/NEWS.d/next/Security/2021-04-25-07-46-37.[bpo-43882](https://bugs.python.org/issue43882).Jpwx85.rst 
