### PR TITLE
[3.6] bpo-43882 - Mention urllib.parse changes in Whats New section for 3.6.14

### DIFF
--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -2485,6 +2485,6 @@ attribute on your FTP instance to ``True``.  (See :issue:`43285`)
 The presence of newline or tab characters in parts of a URL allows for some
 forms of attacks. Following the WHATWG specification that updates RFC 3986,
 ASCII newline \n, \r and tab \t characters are stripped from the URL by the
-parser :func:`urllib.parse` preventing such attacks. The removal characters are
-controlled by module level variable
+parser :func:`urllib.parse` preventing such attacks. The removal characters
+are controlled by a new module level variable
 ``urllib.parse._UNSAFE_URL_BYTES_TO_REMOVE``.  (See :issue:`43882`)

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -2481,3 +2481,10 @@ IPv4 address sent from the remote server when setting up a passive data
 channel.  We reuse the ftp server IP address instead.  For unusual code
 requiring the old behavior, set a ``trust_server_pasv_ipv4_address``
 attribute on your FTP instance to ``True``.  (See :issue:`43285`)
+
+The presence of newline or tab characters in parts of a URL allows for some
+forms of attacks. Following the WHATWG specification that updates RFC 3986,
+ASCII newline \n, \r and tab \t characters are stripped from the URL by the
+parser :func:`urllib.parse` preventing such attacks. The removal characters are
+controlled by module level variable
+``urllib.parse._UNSAFE_URL_BYTES_TO_REMOVE``.  (See :issue:`43882`)

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -2484,7 +2484,7 @@ attribute on your FTP instance to ``True``.  (See :issue:`43285`)
 
 The presence of newline or tab characters in parts of a URL allows for some
 forms of attacks. Following the WHATWG specification that updates RFC 3986,
-ASCII newline \n, \r and tab \t characters are stripped from the URL by the
-parser :func:`urllib.parse` preventing such attacks. The removal characters
-are controlled by a new module level variable
-``urllib.parse._UNSAFE_URL_BYTES_TO_REMOVE``.  (See :issue:`43882`)
+ASCII newline ``\n``, ``\r`` and tab ``\t`` characters are stripped from the
+URL by the parser :func:`urllib.parse` preventing such attacks. The removal
+characters are controlled by a new module level variable
+``urllib.parse._UNSAFE_URL_BYTES_TO_REMOVE``. (See :issue:`43882`)


### PR DESCRIPTION
* [bpo-43882](https://bugs.python.org/issue43882) - Mention urllib.parse changes in Whats New section for 3.6.14

News added https://github.com/python/cpython/blob/3.6/Misc/NEWS.d/next/Security/2021-04-25-07-46-37.[bpo-43882](https://bugs.python.org/issue43882).Jpwx85.rst

<!-- issue-number: [bpo-43882](https://bugs.python.org/issue43882) -->
https://bugs.python.org/issue43882
<!-- /issue-number -->
