### PR TITLE
[3.10] bpo-38671: Add test that `pathlib.Path.resolve()` returns an absolute path. (GH-26184)

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1799,6 +1799,16 @@ class _BasePathTest(object):
         # Non-strict
         self.assertEqual(r.resolve(strict=False), p / '3' / '4')
 
+    def test_resolve_nonexist_relative_issue38671(self):
+        p = self.cls('non', 'exist')
+
+        old_cwd = os.getcwd()
+        os.chdir(BASE)
+        try:
+            self.assertEqual(p.resolve(), self.cls(BASE, p))
+        finally:
+            os.chdir(old_cwd)
+
     def test_with(self):
         p = self.cls(BASE)
         it = p.iterdir()


### PR DESCRIPTION
Issue should be fixed in [bpo-43757](https://bugs.python.org/issue43757)

Co-Authored-by: Tzu-ping Chung <uranusjr@gmail.com>
(cherry picked from commit 18f41c04ff4161531f4d08631059fd3ed37c0218)

Co-authored-by: Barney Gale <barney.gale@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-38671](https://bugs.python.org/issue38671) -->
https://bugs.python.org/issue38671
<!-- /issue-number -->

Automerge-Triggered-By: GH:encukou