### PR TITLE
bpo-44196:  document that Traversable's methods should raise FileNotFoundError

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -810,10 +810,71 @@ ABC hierarchy::
 
 .. class:: Traversable
 
-    An object with a subset of pathlib.Path methods suitable for
-    traversing directories and opening files.
+   An object with a subset of pathlib.Path methods suitable for
+   traversing directories and opening files.
 
-    .. versionadded:: 3.9
+   .. versionadded:: 3.9
+
+   .. abstractmethod:: name()
+
+      The base name of this object without any parent references.
+
+   .. abstractmethod:: iterdir()
+
+      Yield Traversable objects in self
+
+   .. abstractmethod:: is_dir()
+
+      Return True if self is a dir
+
+      If the directory/file cannot be found, :exc:`FileNotFoundError` should be raised,
+      although this is not guaranteed for compatibility reasons.
+
+   .. abstractmethod:: is_file()
+
+      Return True if self is a file
+
+      If the directory/file cannot be found, :exc:`FileNotFoundError` should be raised,
+      although this is not guaranteed for compatibility reasons.
+
+   .. abstractmethod:: joinpath(child)
+
+      Return Traversable child in self
+
+      If the file cannot be found, :exc:`FileNotFoundError` should be raised,
+      although this is not guaranteed for compatibility reasons.
+
+   .. abstractmethod:: __truediv__(child)
+
+      Return Traversable child in self
+
+      If the file cannot be found, :exc:`FileNotFoundError` should be raised,
+      although this is not guaranteed for compatibility reasons.
+
+   .. abstractmethod:: open(mode='r', *args, **kwargs)
+
+      *mode* may be 'r' or 'rb' to open as text or binary. Return a handle
+      suitable for reading (same as :attr:`pathlib.Path.open`).
+
+      When opening as text, accepts encoding parameters such as those
+      accepted by :attr:`io.TextIOWrapper`.
+
+      If the file cannot be found, :exc:`FileNotFoundError` should be raised,
+      although this is not guaranteed for compatibility reasons.
+
+   .. method:: read_bytes()
+
+      Read contents of self as bytes
+
+      If the file cannot be found, :exc:`FileNotFoundError` should be raised,
+      although this is not guaranteed for compatibility reasons.
+
+   .. method:: read_text(encoding=None)
+
+      Read contents of self as text
+
+      If the file cannot be found, :exc:`FileNotFoundError` should be raised,
+      although this is not guaranteed for compatibility reasons.
 
 
 .. class:: TraversableReader

--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -367,6 +367,9 @@ class Traversable(Protocol):
     def read_bytes(self):
         """
         Read contents of self as bytes
+
+        If the file cannot be found, FileNotFoundError should be raised,
+        although this is not guaranteed for compatibility reasons.
         """
         with self.open('rb') as strm:
             return strm.read()
@@ -374,6 +377,9 @@ class Traversable(Protocol):
     def read_text(self, encoding=None):
         """
         Read contents of self as text
+
+        If the file cannot be found, FileNotFoundError should be raised,
+        although this is not guaranteed for compatibility reasons.
         """
         with self.open(encoding=encoding) as strm:
             return strm.read()
@@ -382,23 +388,35 @@ class Traversable(Protocol):
     def is_dir(self) -> bool:
         """
         Return True if self is a dir
+
+        If the directory/file cannot be found, FileNotFoundError should be raised,
+        although this is not guaranteed for compatibility reasons.
         """
 
     @abc.abstractmethod
     def is_file(self) -> bool:
         """
         Return True if self is a file
+
+        If the directory/file cannot be found, FileNotFoundError should be raised,
+        although this is not guaranteed for compatibility reasons.
         """
 
     @abc.abstractmethod
     def joinpath(self, child):
         """
         Return Traversable child in self
+
+        If the file cannot be found, FileNotFoundError should be raised,
+        although this is not guaranteed for compatibility reasons.
         """
 
     def __truediv__(self, child):
         """
         Return Traversable child in self
+
+        If the file cannot be found, FileNotFoundError should be raised,
+        although this is not guaranteed for compatibility reasons.
         """
         return self.joinpath(child)
 
@@ -410,6 +428,9 @@ class Traversable(Protocol):
 
         When opening as text, accepts encoding parameters such as those
         accepted by io.TextIOWrapper.
+
+        If the file cannot be found, FileNotFoundError should be raised,
+        although this is not guaranteed for compatibility reasons.
         """
 
     @abc.abstractproperty

--- a/Misc/NEWS.d/next/Documentation/2021-05-20-21-04-34.bpo-44196.KAbNb8.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-05-20-21-04-34.bpo-44196.KAbNb8.rst
@@ -1,0 +1,2 @@
+Document that importlib.abc.Traversable methods should raise
+FileNotFoundError.


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>


<!-- issue-number: [[bpo-44196](https://bugs.python.org/issue44196)](https://bugs.python.org/issue44195) -->
https://bugs.python.org/issue44196
<!-- /issue-number -->
