### PR TITLE
bpo-29298: Fixing argparse required subparsers error handling

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -727,6 +727,8 @@ def _get_action_name(argument):
         return argument.metavar
     elif argument.dest not in (None, SUPPRESS):
         return argument.dest
+    elif isinstance(argument, _SubParsersAction):
+        return '{%s}' % ','.join(map(str, argument.choices))
     else:
         return None
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2052,6 +2052,12 @@ class TestAddSubparsers(TestCase):
         subparsers.add_parser('run')
         self._test_required_subparsers(parser)
 
+    def test_required_subparsers_via_kwarg_no_dest(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers(required=True)
+        subparsers.add_parser('run')
+        self.assertArgumentParserError(parser.parse_args, ())
+
     def test_required_subparsers_default(self):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers(dest='command')

--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-21-09-18-14.bpo-33109.s97TSf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-21-09-18-14.bpo-33109.s97TSf.rst
@@ -1,0 +1,1 @@
+Fixing argparse required subparsers error handling


### PR DESCRIPTION
Related issues:

* https://bugs.python.org/issue29298
* https://bugs.python.org/issue33109

<!-- issue-number: [bpo-29298](https://bugs.python.org/issue29298) -->
https://bugs.python.org/issue29298
<!-- /issue-number -->
