### PR TITLE
bpo-44205: Ignore out of space errors in shutil.copystat

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -320,6 +320,11 @@ if hasattr(os, 'listxattr'):
                 value = os.getxattr(src, name, follow_symlinks=follow_symlinks)
                 os.setxattr(dst, name, value, follow_symlinks=follow_symlinks)
             except OSError as e:
+                # EINVAL can occur when the destination filesystem does not
+                # support extended attributed
+                # ENOSPC can occur when the destination filesystem has a
+                # smaller limit than the source filesystem for the size of
+                # extended attributes
                 if e.errno not in (errno.EPERM, errno.ENOTSUP, errno.ENODATA,
                                    errno.EINVAL, errno.ENOSPC):
                     raise

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -321,7 +321,7 @@ if hasattr(os, 'listxattr'):
                 os.setxattr(dst, name, value, follow_symlinks=follow_symlinks)
             except OSError as e:
                 if e.errno not in (errno.EPERM, errno.ENOTSUP, errno.ENODATA,
-                                   errno.EINVAL):
+                                   errno.EINVAL, errno.ENOSPC):
                     raise
 else:
     def _copyxattr(*args, **kwargs):

--- a/Misc/NEWS.d/next/Library/2021-05-21-15-17-28.bpo-44205.m0Wjb6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-21-15-17-28.bpo-44205.m0Wjb6.rst
@@ -1,0 +1,1 @@
+Fix :exc:`OSError` in :func:`shutil.copystat` when the destination file system doesn't have sufficient space for the source file's extended attributes.


### PR DESCRIPTION
https://bugs.python.org/issue44205

<!-- issue-number: [bpo-44205](https://bugs.python.org/issue44205) -->
https://bugs.python.org/issue44205
<!-- /issue-number -->
