### PR TITLE
bpo-44208: Make argparse accept option names regardless of '-' and '_'

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2230,10 +2230,12 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         # if the arg_string is undeniably formatted as an option
         # check to see if there are similar option names where _ and - are used interchangeably
         if _re.search(r'^--.', arg_string):
+            explicit_arg = None
+            if '=' in arg_string:
+                arg_string, explicit_arg = arg_string.split('=', 1)
             for option, action in self._option_string_actions.items():
                 if _re.findall(r'([^\W_]+)', arg_string) == _re.findall(r'([^\W_]+)', option):
-                    action = self._option_string_actions[option]
-                    return action, arg_string, None
+                    return action, arg_string, explicit_arg
 
         # it was meant to be an optional but there is no such option
         # in this parser (though it might be a valid option in a subparser)

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2227,6 +2227,14 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         if ' ' in arg_string:
             return None
 
+        # if the arg_string is undeniably formatted as an option
+        # check to see if there are similar option names where _ and - are used interchangeably
+        if _re.search(r'^--.', arg_string):
+            for option, action in self._option_string_actions.items():
+                if _re.findall(r'([^\W_]+)', arg_string) == _re.findall(r'([^\W_]+)', option):
+                    action = self._option_string_actions[option]
+                    return action, arg_string, None
+
         # it was meant to be an optional but there is no such option
         # in this parser (though it might be a valid option in a subparser)
         return None, arg_string, None

--- a/Misc/NEWS.d/next/Library/2021-05-21-18-23-22.bpo-44208.5gvp2f.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-21-18-23-22.bpo-44208.5gvp2f.rst
@@ -1,0 +1,1 @@
+Adding a feature to argparse to accept option names in case "_" is provided in the name inadvertently instead of "-" and vice versa.


### PR DESCRIPTION
[bpo-44208](https://bugs.python.org/issue44208): Make argparse accept option names regardless of '-' and '_'

I wanted to add a feature so that if I use argparse to make a script, a typo in an option name where "-" or "_" gets typed such as if I make a call like `python3 test.py --please-work True` or `python3 test.py --please_work True` could both be used.

<!-- issue-number: [bpo-44208](https://bugs.python.org/issue44208) -->
https://bugs.python.org/issue44208
<!-- /issue-number -->
