### PR TITLE
bpo-44212: asyncio: store old signal handlers and call them

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-05-22-01-12-14.bpo-44212.RXiAsf.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-22-01-12-14.bpo-44212.RXiAsf.rst
@@ -1,0 +1,2 @@
+asyncio: signal handlers registered by add_signal_handler() now call
+previously registered handlers (if any).


### PR DESCRIPTION
(instead of forgetting about the old callable)

related to #18664

<!-- issue-number: [bpo-44212](https://bugs.python.org/issue44212) -->
https://bugs.python.org/issue44212
<!-- /issue-number -->
