### PR TITLE
bpo-44222: Improve _removeHandlerRef() for a very long _handlerList

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -845,8 +845,9 @@ def _removeHandlerRef(wr):
     if acquire and release and handlers:
         acquire()
         try:
-            if wr in handlers:
-                handlers.remove(wr)
+            handlers.remove(wr)
+        except ValueError:
+            pass
         finally:
             release()
 

--- a/Misc/NEWS.d/next/Library/2021-05-25-01-43-53.bpo-44222.mwqYlK.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-25-01-43-53.bpo-44222.mwqYlK.rst
@@ -1,2 +1,0 @@
-Improve the performance of _removeHandlerRef() for very long _handlerLists.
-Patch by Yonatan Goldschmidt.

--- a/Misc/NEWS.d/next/Library/2021-05-25-01-43-53.bpo-44222.mwqYlK.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-25-01-43-53.bpo-44222.mwqYlK.rst
@@ -1,0 +1,2 @@
+Improve the performance of _removeHandlerRef() for very long _handlerLists.
+Patch by Yonatan Goldschmidt.


### PR DESCRIPTION
The list lookups become a big burden for very long lists.
This patch changes the "happy flow" path of 2 lookups into 1 lookup.

<!-- issue-number: [bpo-44222](https://bugs.python.org/issue44222) -->
https://bugs.python.org/issue44222
<!-- /issue-number -->

Automerge-Triggered-By: GH:vsajip