### PR TITLE
gh-88321: Add backlog arg for multiprocessing manager server

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2517,7 +2517,7 @@ multiple connections at the same time.
    ``'AF_UNIX'`` and address is ``None`` then the socket will be created in a
    private temporary directory created using :func:`tempfile.mkstemp`.
 
-   If the listener object uses a socket then *backlog* (1 by default) is passed
+   If the listener object uses a socket then *backlog* (None by default) is passed
    to the :meth:`~socket.socket.listen` method of the socket once it has been
    bound.
 

--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -452,7 +452,7 @@ class Listener(object):
     This is a wrapper for a bound socket which is 'listening' for
     connections, or for a Windows named pipe.
     '''
-    def __init__(self, address=None, family=None, backlog=1, authkey=None):
+    def __init__(self, address=None, family=None, backlog=None, authkey=None):
         family = family or (address and address_type(address)) \
                  or default_family
         address = address or arbitrary_address(family)
@@ -597,7 +597,7 @@ class SocketListener(object):
     '''
     Representation of a socket which is bound to an address and listening
     '''
-    def __init__(self, address, family, backlog=1):
+    def __init__(self, address, family, backlog=None):
         self._socket = socket.socket(getattr(socket, family))
         try:
             # SO_REUSEADDR has different semantics on Windows (issue #2550).
@@ -606,7 +606,10 @@ class SocketListener(object):
                                         socket.SO_REUSEADDR, 1)
             self._socket.setblocking(True)
             self._socket.bind(address)
-            self._socket.listen(backlog)
+            if backlog is None:
+                self._socket.listen()
+            else:
+                self._socket.listen(backlog)
             self._address = self._socket.getsockname()
         except OSError:
             self._socket.close()

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -146,7 +146,7 @@ class Server(object):
     public = ['shutdown', 'create', 'accept_connection', 'get_methods',
               'debug_info', 'number_of_objects', 'dummy', 'incref', 'decref']
 
-    def __init__(self, registry, address, authkey, serializer):
+    def __init__(self, registry, address, authkey, serializer, backlog=None):
         if not isinstance(authkey, bytes):
             raise TypeError(
                 "Authkey {0!r} is type {1!s}, not bytes".format(
@@ -156,7 +156,7 @@ class Server(object):
         Listener, Client = listener_client[serializer]
 
         # do authentication later
-        self.listener = Listener(address=address, backlog=128)
+        self.listener = Listener(address=address, backlog=backlog)
         self.address = self.listener.address
 
         self.id_to_obj = {'0': (None, ())}

--- a/Misc/NEWS.d/next/Library/2024-07-22-02-19-16.gh-issue-88321.G42EBO.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-22-02-19-16.gh-issue-88321.G42EBO.rst
@@ -1,0 +1,1 @@
+Add backlog arg for multiprocessing manager server


### PR DESCRIPTION
In addition, set listener backlog default to None like https://github.com/python/cpython/pull/12735.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44155](https://bugs.python.org/issue44155) -->
https://bugs.python.org/issue44155
<!-- /issue-number -->


<!-- gh-issue-number: gh-88321 -->
* Issue: gh-88321
<!-- /gh-issue-number -->
