### PR TITLE
bpo-44206: Add a version number to dictionary keys

### DIFF
--- a/Include/cpython/dictobject.h
+++ b/Include/cpython/dictobject.h
@@ -82,3 +82,7 @@ typedef struct {
 
 PyAPI_FUNC(PyObject *) _PyDictView_New(PyObject *, PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyDictView_Intersect(PyObject* self, PyObject *other);
+
+/* Gets a version number unique to the current state of the keys of dict, if possible.
+ * Returns the version number, or zero if it was not possible to get a version number. */
+uint32_t _PyDictKeys_GetVersionForCurrentState(PyDictObject *dict);

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -752,7 +752,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         check = self.check_sizeof
 
         basicsize = size('nQ2P' + '3PnPn2P')
-        keysize = calcsize('n2B2n')
+        keysize = calcsize('n2BI2n')
 
         entrysize = calcsize('n2P')
         p = calcsize('P')

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -752,7 +752,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         check = self.check_sizeof
 
         basicsize = size('nQ2P' + '3PnPn2P')
-        keysize = calcsize('2nP2n')
+        keysize = calcsize('n2B2n')
 
         entrysize = calcsize('n2P')
         p = calcsize('P')

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1229,9 +1229,9 @@ class SizeofTest(unittest.TestCase):
         # empty dict
         check({}, size('nQ2P'))
         # dict
-        check({"a": 1}, size('nQ2P') + calcsize('2nP2n') + 8 + (8*2//3)*calcsize('n2P'))
+        check({"a": 1}, size('nQ2P') + calcsize('n2B2n') + 8 + (8*2//3)*calcsize('n2P'))
         longdict = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
-        check(longdict, size('nQ2P') + calcsize('2nP2n') + 16 + (16*2//3)*calcsize('n2P'))
+        check(longdict, size('nQ2P') + calcsize('n2B2n') + 16 + (16*2//3)*calcsize('n2P'))
         # dictionary-keyview
         check({}.keys(), size('P'))
         # dictionary-valueview
@@ -1385,13 +1385,13 @@ class SizeofTest(unittest.TestCase):
                   '5P')
         class newstyleclass(object): pass
         # Separate block for PyDictKeysObject with 8 keys and 5 entries
-        check(newstyleclass, s + calcsize("2nP2n0P") + 8 + 5*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("n2B2n0P") + 8 + 5*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 5*self.P)
         o = newstyleclass()
         o.a = o.b = o.c = o.d = o.e = o.f = o.g = o.h = 1
         # Separate block for PyDictKeysObject with 16 keys and 10 entries
-        check(newstyleclass, s + calcsize("2nP2n0P") + 16 + 10*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("n2B2n0P") + 16 + 10*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 10*self.P)
         # unicode

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -22,6 +22,7 @@ import warnings
 # strings to intern in test_intern()
 INTERN_NUMRUNS = 0
 
+DICT_KEY_STRUCT_FORMAT = 'n2BI2n'
 
 class DisplayHookTest(unittest.TestCase):
 
@@ -1229,9 +1230,9 @@ class SizeofTest(unittest.TestCase):
         # empty dict
         check({}, size('nQ2P'))
         # dict
-        check({"a": 1}, size('nQ2P') + calcsize('n2B2n') + 8 + (8*2//3)*calcsize('n2P'))
+        check({"a": 1}, size('nQ2P') + calcsize(DICT_KEY_STRUCT_FORMAT) + 8 + (8*2//3)*calcsize('n2P'))
         longdict = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
-        check(longdict, size('nQ2P') + calcsize('n2B2n') + 16 + (16*2//3)*calcsize('n2P'))
+        check(longdict, size('nQ2P') + calcsize(DICT_KEY_STRUCT_FORMAT) + 16 + (16*2//3)*calcsize('n2P'))
         # dictionary-keyview
         check({}.keys(), size('P'))
         # dictionary-valueview
@@ -1385,13 +1386,13 @@ class SizeofTest(unittest.TestCase):
                   '5P')
         class newstyleclass(object): pass
         # Separate block for PyDictKeysObject with 8 keys and 5 entries
-        check(newstyleclass, s + calcsize("n2B2n0P") + 8 + 5*calcsize("n2P"))
+        check(newstyleclass, s + calcsize(DICT_KEY_STRUCT_FORMAT) + 8 + 5*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 5*self.P)
         o = newstyleclass()
         o.a = o.b = o.c = o.d = o.e = o.f = o.g = o.h = 1
         # Separate block for PyDictKeysObject with 16 keys and 10 entries
-        check(newstyleclass, s + calcsize("n2B2n0P") + 16 + 10*calcsize("n2P"))
+        check(newstyleclass, s + calcsize(DICT_KEY_STRUCT_FORMAT) + 16 + 10*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 10*self.P)
         # unicode

--- a/Objects/dict-common.h
+++ b/Objects/dict-common.h
@@ -23,7 +23,7 @@ struct _dictkeysobject {
     Py_ssize_t dk_refcnt;
 
     /* Size of the hash table (dk_indices). It must be a power of 2. */
-    Py_ssize_t dk_size;
+    uint8_t dk_log2_size;
 
     /* Function to lookup in the hash table (dk_indices):
 

--- a/Objects/dict-common.h
+++ b/Objects/dict-common.h
@@ -8,15 +8,22 @@ typedef struct {
     PyObject *me_value; /* This field is only meaningful for combined tables */
 } PyDictKeyEntry;
 
-/* dict_lookup_func() returns index of entry which can be used like DK_ENTRIES(dk)[index].
+/* _Py_dict_lookup() returns index of entry which can be used like DK_ENTRIES(dk)[index].
  * -1 when no entry found, -3 when compare raises error.
  */
-typedef Py_ssize_t (*dict_lookup_func)
-    (PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
+Py_ssize_t _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
+
 
 #define DKIX_EMPTY (-1)
 #define DKIX_DUMMY (-2)  /* Used internally */
 #define DKIX_ERROR (-3)
+
+typedef enum {
+    DICT_KEYS_GENERAL = 0,
+    DICT_KEYS_UNICODE = 1,
+    DICT_KEYS_UNICODE_NO_DUMMY = 2,
+    DICT_KEYS_SPLIT = 3
+} DictKeysKind;
 
 /* See dictobject.c for actual layout of DictKeysObject */
 struct _dictkeysobject {
@@ -25,20 +32,8 @@ struct _dictkeysobject {
     /* Size of the hash table (dk_indices). It must be a power of 2. */
     uint8_t dk_log2_size;
 
-    /* Function to lookup in the hash table (dk_indices):
-
-       - lookdict(): general-purpose, and may return DKIX_ERROR if (and
-         only if) a comparison raises an exception.
-
-       - lookdict_unicode(): specialized to Unicode string keys, comparison of
-         which can never raise an exception; that function can never return
-         DKIX_ERROR.
-
-       - lookdict_unicode_nodummy(): similar to lookdict_unicode() but further
-         specialized for Unicode string keys that cannot be the <dummy> value.
-
-       - lookdict_split(): Version of lookdict() for split tables. */
-    dict_lookup_func dk_lookup;
+    /* Kind of keys */
+    uint8_t dk_kind;
 
     /* Number of usable entries in dk_entries. */
     Py_ssize_t dk_usable;

--- a/Objects/dict-common.h
+++ b/Objects/dict-common.h
@@ -21,8 +21,7 @@ Py_ssize_t _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyOb
 typedef enum {
     DICT_KEYS_GENERAL = 0,
     DICT_KEYS_UNICODE = 1,
-    DICT_KEYS_UNICODE_NO_DUMMY = 2,
-    DICT_KEYS_SPLIT = 3
+    DICT_KEYS_SPLIT = 2
 } DictKeysKind;
 
 /* See dictobject.c for actual layout of DictKeysObject */

--- a/Objects/dict-common.h
+++ b/Objects/dict-common.h
@@ -35,6 +35,9 @@ struct _dictkeysobject {
     /* Kind of keys */
     uint8_t dk_kind;
 
+    /* Version number -- Reset to 0 by any modification to keys */
+    uint32_t dk_version;
+
     /* Number of usable entries in dk_entries. */
     Py_ssize_t dk_usable;
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -785,10 +785,6 @@ start:
         /* Strings only */
         for (;;) {
             ix = dictkeys_get_index(mp->ma_keys, i);
-            if (ix == DKIX_EMPTY) {
-                *value_addr = NULL;
-                return DKIX_EMPTY;
-            }
             if (ix >= 0) {
                 PyDictKeyEntry *ep = &ep0[ix];
                 assert(ep->me_key != NULL);
@@ -797,6 +793,26 @@ start:
                         (ep->me_hash == hash && unicode_eq(ep->me_key, key))) {
                     goto found;
                 }
+            }
+            else if (ix == DKIX_EMPTY) {
+                *value_addr = NULL;
+                return DKIX_EMPTY;
+            }
+            perturb >>= PERTURB_SHIFT;
+            i = mask & (i*5 + perturb + 1);
+            ix = dictkeys_get_index(mp->ma_keys, i);
+            if (ix >= 0) {
+                PyDictKeyEntry *ep = &ep0[ix];
+                assert(ep->me_key != NULL);
+                assert(PyUnicode_CheckExact(ep->me_key));
+                if (ep->me_key == key ||
+                        (ep->me_hash == hash && unicode_eq(ep->me_key, key))) {
+                    goto found;
+                }
+            }
+            else if (ix == DKIX_EMPTY) {
+                *value_addr = NULL;
+                return DKIX_EMPTY;
             }
             perturb >>= PERTURB_SHIFT;
             i = mask & (i*5 + perturb + 1);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -494,7 +494,6 @@ _PyDict_CheckConsistency(PyObject *op, int check_content)
     Py_ssize_t usable = USABLE_FRACTION(DK_SIZE(keys));
 
     CHECK(0 <= mp->ma_used && mp->ma_used <= usable);
-    CHECK(IS_POWER_OF_2(DK_SIZE(keys)));
     CHECK(0 <= keys->dk_usable && keys->dk_usable <= usable);
     CHECK(0 <= keys->dk_nentries && keys->dk_nentries <= usable);
     CHECK(keys->dk_usable + keys->dk_nentries <= usable);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -597,7 +597,7 @@ new_keys_object(uint8_t log2_size)
     dk->dk_refcnt = 1;
     dk->dk_log2_size = log2_size;
     dk->dk_usable = usable;
-    dk->dk_kind = DICT_KEYS_UNICODE_NO_DUMMY;
+    dk->dk_kind = DICT_KEYS_UNICODE;
     dk->dk_nentries = 0;
     dk->dk_version = 0;
     memset(&dk->dk_indices[0], 0xff, es * (1<<log2_size));
@@ -1223,12 +1223,12 @@ make_keys_shared(PyObject *op)
         if (mp->ma_keys->dk_kind == DICT_KEYS_GENERAL) {
             return NULL;
         }
-        else if (mp->ma_keys->dk_kind == DICT_KEYS_UNICODE) {
+        else if (mp->ma_used > mp->ma_keys->dk_nentries) {
             /* Remove dummy keys */
             if (dictresize(mp, DK_LOG_SIZE(mp->ma_keys)))
                 return NULL;
         }
-        assert(mp->ma_keys->dk_kind == DICT_KEYS_UNICODE_NO_DUMMY);
+        assert(mp->ma_used == mp->ma_keys->dk_nentries);
         /* Copy values into a new array */
         ep0 = DK_ENTRIES(mp->ma_keys);
         size = USABLE_FRACTION(DK_SIZE(mp->ma_keys));

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1324,9 +1324,8 @@ PyDict_GetItem(PyObject *op, PyObject *key)
     /* Ignore any exception raised by the lookup */
     _PyErr_Restore(tstate, exc_type, exc_value, exc_tb);
 
-    if (ix < 0) {
-        return NULL;
-    }
+
+    assert(ix >= 0 || value == NULL);
     return value;
 }
 
@@ -1385,9 +1384,7 @@ _PyDict_GetItem_KnownHash(PyObject *op, PyObject *key, Py_hash_t hash)
     }
 
     ix = _Py_dict_lookup(mp, key, hash, &value);
-    if (ix < 0) {
-        return NULL;
-    }
+    assert(ix >= 0 || value == NULL);
     return value;
 }
 
@@ -1417,8 +1414,7 @@ PyDict_GetItemWithError(PyObject *op, PyObject *key)
     }
 
     ix = _Py_dict_lookup(mp, key, hash, &value);
-    if (ix < 0)
-        return NULL;
+    assert(ix >= 0 || value == NULL);
     return value;
 }
 
@@ -1478,8 +1474,7 @@ _PyDict_LoadGlobal(PyDictObject *globals, PyDictObject *builtins, PyObject *key)
 
     /* namespace 2: builtins */
     ix = _Py_dict_lookup(builtins, key, hash, &value);
-    if (ix < 0)
-        return NULL;
+    assert(ix >= 0 || value == NULL);
     return value;
 }
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -553,7 +553,7 @@ _odict_resize(PyODictObject *od)
     _ODictNode **fast_nodes, *node;
 
     /* Initialize a new "fast nodes" table. */
-    size = ((PyDictObject *)od)->ma_keys->dk_size;
+    size = 1 << (((PyDictObject *)od)->ma_keys->dk_log2_size);
     fast_nodes = PyMem_NEW(_ODictNode *, size);
     if (fast_nodes == NULL) {
         PyErr_NoMemory();
@@ -592,7 +592,7 @@ _odict_get_index(PyODictObject *od, PyObject *key, Py_hash_t hash)
 
     /* Ensure od_fast_nodes and dk_entries are in sync. */
     if (od->od_resize_sentinel != keys ||
-        od->od_fast_nodes_size != keys->dk_size) {
+        od->od_fast_nodes_size != (1 << (keys->dk_log2_size))) {
         int resize_res = _odict_resize(od);
         if (resize_res < 0)
             return -1;

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -41,8 +41,8 @@ we've considered:
 The approach with the least performance impact (time and space) is #2,
 mirroring the key order of dict's dk_entries with an array of node pointers.
 While _Py_dict_lookup() does not give us the index into the array,
-we make use of pointer arithmetic to get that index.  An alternative
-would be to refactor lookdict() to provide the index, explicitly exposing
+we make use of pointer arithmetic to get that index.  An alternative would
+be to refactor _Py_dict_lookup() to provide the index, explicitly exposing
 the implementation detail.  We could even just use a custom lookup function
 for OrderedDict that facilitates our need.  However, both approaches are
 significantly more complicated than just using pointer arithmetic.

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -40,8 +40,8 @@ we've considered:
 
 The approach with the least performance impact (time and space) is #2,
 mirroring the key order of dict's dk_entries with an array of node pointers.
-While lookdict() and friends (dk_lookup) don't give us the index into the
-array, we make use of pointer arithmetic to get that index.  An alternative
+While _Py_dict_lookup() does not give us the index into the array,
+we make use of pointer arithmetic to get that index.  An alternative
 would be to refactor lookdict() to provide the index, explicitly exposing
 the implementation detail.  We could even just use a custom lookup function
 for OrderedDict that facilitates our need.  However, both approaches are
@@ -535,7 +535,7 @@ _odict_get_index_raw(PyODictObject *od, PyObject *key, Py_hash_t hash)
     PyDictKeysObject *keys = ((PyDictObject *)od)->ma_keys;
     Py_ssize_t ix;
 
-    ix = (keys->dk_lookup)((PyDictObject *)od, key, hash, &value);
+    ix = _Py_dict_lookup((PyDictObject *)od, key, hash, &value);
     if (ix == DKIX_EMPTY) {
         return keys->dk_nentries;  /* index of new entry */
     }

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -730,7 +730,7 @@ class PyDictObjectPtr(PyObjectPtr):
 
     def _get_entries(self, keys):
         dk_nentries = int(keys['dk_nentries'])
-        dk_size = int(keys['dk_size'])
+        dk_size = 1<<int(keys['dk_log2_size'])
         try:
             # <= Python 3.5
             return keys['dk_entries'], dk_size


### PR DESCRIPTION
Apart from adding a version number, this PR also:

* Reduces the size of dict keys by 8 bytes on 64 bit systems.
* Reduces the overall code size by ~100 lines

I'll need to run pyperformance before merging, in case this slows things downs.

<!-- issue-number: [bpo-44206](https://bugs.python.org/issue44206) -->
https://bugs.python.org/issue44206
<!-- /issue-number -->
