### PR TITLE
bpo-44227: documentation fix (bisect_left returns index OF leftmost target if it exists)

### DIFF
--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -199,8 +199,7 @@ _bisect.bisect_left -> Py_ssize_t
 Return the index where to insert item x in list a, assuming a is sorted.
 
 The return value i is such that all e in a[:i] have e < x, and all e in
-a[i:] have e >= x.  So if x already appears in the list, i points just
-before the leftmost x already there.
+a[i:] have e >= x.  So if x already appears in the list, i points at the leftmost x already there.
 
 Optional args lo (default 0) and hi (default len(a)) bound the
 slice of a to be searched.

--- a/Modules/clinic/_bisectmodule.c.h
+++ b/Modules/clinic/_bisectmodule.c.h
@@ -172,8 +172,8 @@ PyDoc_STRVAR(_bisect_bisect_left__doc__,
 "Return the index where to insert item x in list a, assuming a is sorted.\n"
 "\n"
 "The return value i is such that all e in a[:i] have e < x, and all e in\n"
-"a[i:] have e >= x.  So if x already appears in the list, i points just\n"
-"before the leftmost x already there.\n"
+"a[i:] have e >= x.  So if x already appears in the list, i points at the\n"
+"leftmost x already there.\n"
 "\n"
 "Optional args lo (default 0) and hi (default len(a)) bound the\n"
 "slice of a to be searched.");


### PR DESCRIPTION
not "just before the leftmost x already there."

<!-- issue-number: [bpo-44227](https://bugs.python.org/issue44227) -->
https://bugs.python.org/issue44227
<!-- /issue-number -->
