### PR TITLE
bpo-44232: Fix type_new crash caused by AssertionError

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-05-25-23-55-02.bpo-44232.KEDM_e.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-05-25-23-55-02.bpo-44232.KEDM_e.rst
@@ -1,0 +1,2 @@
+Fixed a crash caused by bad metaclass bases being passed into :func:`type`.
+This only affected debug builds of Python -- release builds are unaffected.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3310,7 +3310,6 @@ type_new(PyTypeObject *metatype, PyObject *args, PyObject *kwds)
         return NULL;
     }
     if (res == 1) {
-        assert(type != NULL);
         return type;
     }
     assert(ctx.base != NULL);


### PR DESCRIPTION
``type`` can sometimes be NULL due to invalid ``tp_new`` of base classes, so just return ``NULL`` in those cases (the old code prior to refactoring in ecf14e6557c6e4f7af9c0d6460d31fe121c22553 did this).

This only affects debug builds.

<!-- issue-number: [bpo-44232](https://bugs.python.org/issue44232) -->
https://bugs.python.org/issue44232
<!-- /issue-number -->
