### PR TITLE
Fix small typo in description of check_output()

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1158,7 +1158,7 @@ calls these functions.
 
    This is equivalent to::
 
-       run(..., check=True, stdout=PIPE).stdout
+       run(..., check=True, stdout=PIPE.stdout)
 
    The arguments shown above are merely some common ones.
    The full function signature is largely the same as that of :func:`run` -


### PR DESCRIPTION
The current text includes `run(..., check=True, stdout=PIPE).stdout`, this fixes it.

As this is just a typo, I have not created a tracking issue.
