### PR TITLE
bpo-38693: Prefer f-strings in importlib.resources (importlib_resources 5.0.6).

### DIFF
--- a/Lib/importlib/_common.py
+++ b/Lib/importlib/_common.py
@@ -31,7 +31,7 @@ def normalize_path(path):
     str_path = str(path)
     parent, file_name = os.path.split(str_path)
     if parent:
-        raise ValueError('{!r} must be only a file name'.format(path))
+        raise ValueError(f'{path!r} must be only a file name')
     return file_name
 
 
@@ -65,7 +65,7 @@ def get_package(package):
     """
     resolved = resolve(package)
     if wrap_spec(resolved).submodule_search_locations is None:
-        raise TypeError('{!r} is not a package'.format(package))
+        raise TypeError(f'{package!r} is not a package')
     return resolved
 
 

--- a/Lib/importlib/readers.py
+++ b/Lib/importlib/readers.py
@@ -94,16 +94,15 @@ class MultiplexedPath(abc.Traversable):
     __truediv__ = joinpath
 
     def open(self, *args, **kwargs):
-        raise FileNotFoundError('{} is not a file'.format(self))
+        raise FileNotFoundError(f'{self} is not a file')
 
     @property
     def name(self):
         return self._paths[0].name
 
     def __repr__(self):
-        return 'MultiplexedPath({})'.format(
-            ', '.join("'{}'".format(path) for path in self._paths)
-        )
+        paths = ', '.join(f"'{path}'" for path in self._paths)
+        return f'MultiplexedPath({paths})'
 
 
 class NamespaceReader(abc.TraversableResources):

--- a/Lib/importlib/resources.py
+++ b/Lib/importlib/resources.py
@@ -68,9 +68,7 @@ def open_binary(package: Package, resource: Resource) -> BinaryIO:
             if data is not None:
                 return BytesIO(data)
 
-    raise FileNotFoundError(
-        '{!r} resource not found in {!r}'.format(resource, spec.name)
-    )
+    raise FileNotFoundError(f'{resource!r} resource not found in {spec.name!r}')
 
 
 def open_text(

--- a/Lib/test/test_importlib/test_reader.py
+++ b/Lib/test/test_importlib/test_reader.py
@@ -79,7 +79,7 @@ class MultiplexedPathTest(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(
             repr(MultiplexedPath(self.folder)),
-            "MultiplexedPath('{}')".format(self.folder),
+            f"MultiplexedPath('{self.folder}')",
         )
 
     def test_name(self):
@@ -121,7 +121,7 @@ class NamespaceReaderTest(unittest.TestCase):
         reader = NamespaceReader(namespacedata01.__spec__.submodule_search_locations)
         root = os.path.abspath(os.path.join(__file__, '..', 'namespacedata01'))
         self.assertIsInstance(reader.files(), MultiplexedPath)
-        self.assertEqual(repr(reader.files()), "MultiplexedPath('{}')".format(root))
+        self.assertEqual(repr(reader.files()), f"MultiplexedPath('{root}')")
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_importlib/test_resource.py
+++ b/Lib/test/test_importlib/test_resource.py
@@ -152,7 +152,7 @@ class DeletingZipsTest(unittest.TestCase):
         data_path = pathlib.Path(self.ZIP_MODULE.__file__)
         data_dir = data_path.parent
         self.source_zip_path = data_dir / 'ziptestdata.zip'
-        self.zip_path = pathlib.Path('{}.zip'.format(uuid.uuid4())).absolute()
+        self.zip_path = pathlib.Path(f'{uuid.uuid4()}.zip').absolute()
         self.zip_path.write_bytes(self.source_zip_path.read_bytes())
         sys.path.append(str(self.zip_path))
         self.data = import_module('ziptestdata')

--- a/Misc/NEWS.d/next/Library/2021-05-26-14-50-06.bpo-38693.NkMacJ.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-26-14-50-06.bpo-38693.NkMacJ.rst
@@ -1,0 +1,1 @@
+Prefer f-strings to ``.format`` in importlib.resources.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-38693](https://bugs.python.org/issue38693) -->
https://bugs.python.org/issue38693
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco