### PR TITLE
bpo-43988: Use check disallow instantiation helper

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1993,5 +1993,9 @@ def check_disallow_instantiation(testcase, tp, *args, **kwds):
     """
     mod = tp.__module__
     name = tp.__name__
-    msg = fr"cannot create '{mod if mod != 'builtins' else ''}.?{name}' instances"
+    if mod != 'builtins':
+        qualname = f"{mod}.{name}"
+    else:
+        qualname = f"{name}"
+    msg = f"cannot create '{re.escape(qualname)}' instances"
     testcase.assertRaisesRegex(TypeError, msg, tp, *args, **kwds)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1993,5 +1993,5 @@ def check_disallow_instantiation(testcase, tp, *args, **kwds):
     """
     mod = tp.__module__
     name = tp.__name__
-    msg = f"cannot create '{mod if mod != 'builtins' else ''}.?{name}' instances"
+    msg = fr"cannot create '{mod if mod != 'builtins' else ''}.?{name}' instances"
     testcase.assertRaisesRegex(TypeError, msg, tp, *args, **kwds)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1991,5 +1991,7 @@ def check_disallow_instantiation(testcase, tp, *args, **kwds):
 
     See bpo-43916.
     """
-    msg = f"cannot create '{tp.__module__}\.{tp.__name__}' instances"
+    mod = tp.__module__
+    name = tp.__name__
+    msg = f"cannot create '{mod if mod != 'builtins' else ''}.?{name}' instances"
     testcase.assertRaisesRegex(TypeError, msg, tp, *args, **kwds)

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -43,8 +43,9 @@ class MiscTest(unittest.TestCase):
     @support.cpython_only
     def test_disallow_instantiation(self):
         my_array = array.array("I")
-        tp = type(iter(my_array))
-        support.check_disallow_instantiation(self, tp, my_array)
+        support.check_disallow_instantiation(
+            self, type(iter(my_array)), my_array
+        )
 
     @support.cpython_only
     def test_immutable(self):

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -6,7 +6,8 @@ import sys
 import tempfile
 import unittest
 
-from test.support import requires, verbose, SaveSignals, cpython_only
+from test.support import (requires, verbose, SaveSignals, cpython_only,
+                          check_disallow_instantiation)
 from test.support.import_helper import import_module
 
 # Optionally test curses module.  This currently requires that the
@@ -1052,7 +1053,8 @@ class TestCurses(unittest.TestCase):
         # Ensure that the type disallows instantiation (bpo-43916)
         w = curses.newwin(10, 10)
         panel = curses.panel.new_panel(w)
-        self.assertRaises(TypeError, type(panel))
+        tp = type(panel)
+        check_disallow_instantiation(self, tp)
 
     @requires_curses_func('is_term_resized')
     def test_is_term_resized(self):

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1053,8 +1053,7 @@ class TestCurses(unittest.TestCase):
         # Ensure that the type disallows instantiation (bpo-43916)
         w = curses.newwin(10, 10)
         panel = curses.panel.new_panel(w)
-        tp = type(panel)
-        check_disallow_instantiation(self, tp)
+        check_disallow_instantiation(self, type(panel))
 
     @requires_curses_func('is_term_resized')
     def test_is_term_resized(self):

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -31,8 +31,7 @@ class TestGdbm(unittest.TestCase):
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)
         self.g = gdbm.open(filename, 'c')
-        tp = type(self.g)
-        support.check_disallow_instantiation(self, tp)
+        support.check_disallow_instantiation(self, type(self.g))
 
     def test_key_methods(self):
         self.g = gdbm.open(filename, 'c')

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -32,7 +32,7 @@ class TestGdbm(unittest.TestCase):
         # Ensure that the type disallows instantiation (bpo-43916)
         self.g = gdbm.open(filename, 'c')
         tp = type(self.g)
-        self.assertRaises(TypeError, tp)
+        support.check_disallow_instantiation(self, tp)
 
     def test_key_methods(self):
         self.g = gdbm.open(filename, 'c')

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1550,8 +1550,7 @@ class StdPrinterTests(EmbeddingTestsMixin, unittest.TestCase):
         fd = self.get_stdout_fd()
         printer = self.create_printer(fd)
         PyStdPrinter_Type = type(printer)
-        with self.assertRaises(TypeError):
-            PyStdPrinter_Type(fd)
+        support.check_disallow_instantiation(self, PyStdPrinter_Type)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1549,8 +1549,7 @@ class StdPrinterTests(EmbeddingTestsMixin, unittest.TestCase):
     def test_disallow_instantiation(self):
         fd = self.get_stdout_fd()
         printer = self.create_printer(fd)
-        PyStdPrinter_Type = type(printer)
-        support.check_disallow_instantiation(self, PyStdPrinter_Type)
+        support.check_disallow_instantiation(self, type(printer))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -951,8 +951,9 @@ class TestCmpToKeyC(TestCmpToKey, unittest.TestCase):
     @support.cpython_only
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)
-        tp = type(c_functools.cmp_to_key(None))
-        support.check_disallow_instantiation(self, tp)
+        support.check_disallow_instantiation(
+            self, type(c_functools.cmp_to_key(None))
+        )
 
 
 class TestCmpToKeyPy(TestCmpToKey, unittest.TestCase):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -952,7 +952,7 @@ class TestCmpToKeyC(TestCmpToKey, unittest.TestCase):
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)
         tp = type(c_functools.cmp_to_key(None))
-        self.assertRaises(TypeError, tp)
+        support.check_disallow_instantiation(self, tp)
 
 
 class TestCmpToKeyPy(TestCmpToKey, unittest.TestCase):

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -911,8 +911,7 @@ class HashLibTestCase(unittest.TestCase):
             for constructor in constructors:
                 h = constructor()
                 with self.subTest(constructor=constructor):
-                    hash_type = type(h)
-                    support.check_disallow_instantiation(self, hash_type)
+                    support.check_disallow_instantiation(self, type(h))
 
     @unittest.skipUnless(HASH is not None, 'need _hashlib')
     def test_hash_disallow_instantiation(self):

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -912,19 +912,13 @@ class HashLibTestCase(unittest.TestCase):
                 h = constructor()
                 with self.subTest(constructor=constructor):
                     hash_type = type(h)
-                    self.assertRaises(TypeError, hash_type)
+                    support.check_disallow_instantiation(self, hash_type)
 
     @unittest.skipUnless(HASH is not None, 'need _hashlib')
-    def test_hash_disallow_instanciation(self):
+    def test_hash_disallow_instantiation(self):
         # internal types like _hashlib.HASH are not constructable
-        with self.assertRaisesRegex(
-            TypeError, "cannot create '_hashlib.HASH' instance"
-        ):
-            HASH()
-        with self.assertRaisesRegex(
-            TypeError, "cannot create '_hashlib.HASHXOF' instance"
-        ):
-            HASHXOF()
+        support.check_disallow_instantiation(self, HASH)
+        support.check_disallow_instantiation(self, HASHOF)
 
     def test_readonly_types(self):
         for algorithm, constructors in self.constructors_to_test.items():

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -918,7 +918,7 @@ class HashLibTestCase(unittest.TestCase):
     def test_hash_disallow_instantiation(self):
         # internal types like _hashlib.HASH are not constructable
         support.check_disallow_instantiation(self, HASH)
-        support.check_disallow_instantiation(self, HASHOF)
+        support.check_disallow_instantiation(self, HASHXOF)
 
     def test_readonly_types(self):
         for algorithm, constructors in self.constructors_to_test.items():

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -6,7 +6,7 @@ import unittest
 import unittest.mock
 import warnings
 
-from test.support import hashlib_helper
+from test.support import hashlib_helper, check_disallow_instantiation
 
 from _operator import _compare_digest as operator_compare_digest
 
@@ -439,7 +439,7 @@ class ConstructorTestCase(unittest.TestCase):
     @unittest.skipUnless(C_HMAC is not None, 'need _hashlib')
     def test_internal_types(self):
         # internal types like _hashlib.C_HMAC are not constructable
-        support.check_disallow_instantiation(self, C_HMAC)
+        check_disallow_instantiation(self, C_HMAC)
         with self.assertRaisesRegex(TypeError, "immutable type"):
             C_HMAC.value = None
 

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -439,11 +439,7 @@ class ConstructorTestCase(unittest.TestCase):
     @unittest.skipUnless(C_HMAC is not None, 'need _hashlib')
     def test_internal_types(self):
         # internal types like _hashlib.C_HMAC are not constructable
-        with self.assertRaisesRegex(
-            TypeError, "cannot create '_hashlib.HMAC' instance"
-        ):
-            C_HMAC()
-
+        support.check_disallow_instantiation(self, C_HMAC)
         with self.assertRaisesRegex(TypeError, "immutable type"):
             C_HMAC.value = None
 

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2228,8 +2228,7 @@ class ImplementationTest(unittest.TestCase):
         check_disallow_instantiation(self, re.Match)
         check_disallow_instantiation(self, re.Pattern)
         pat = re.compile("")
-        tp = type(pat.scanner(""))
-        check_disallow_instantiation(self, tp)
+        check_disallow_instantiation(self, type(pat.scanner("")))
 
 
 class ExternalTests(unittest.TestCase):

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1,5 +1,6 @@
 from test.support import (gc_collect, bigmemtest, _2G,
-                          cpython_only, captured_stdout)
+                          cpython_only, captured_stdout,
+                          check_disallow_instantiation)
 import locale
 import re
 import sre_compile
@@ -2224,11 +2225,11 @@ class ImplementationTest(unittest.TestCase):
     @cpython_only
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)
-        self.assertRaises(TypeError, re.Match)
-        self.assertRaises(TypeError, re.Pattern)
+        check_disallow_instantiation(self, re.Match)
+        check_disallow_instantiation(self, re.Pattern)
         pat = re.compile("")
         tp = type(pat.scanner(""))
-        self.assertRaises(TypeError, tp)
+        check_disallow_instantiation(self, tp)
 
 
 class ExternalTests(unittest.TestCase):

--- a/Lib/test/test_select.py
+++ b/Lib/test/test_select.py
@@ -88,12 +88,10 @@ class SelectTestCase(unittest.TestCase):
         self.assertEqual(select.select([], a, []), ([], a[:5], []))
 
     def test_disallow_instantiation(self):
-        tp = type(select.poll())
-        support.check_disallow_instantiation(self, tp)
+        support.check_disallow_instantiation(self, type(select.poll()))
 
         if hasattr(select, 'devpoll'):
-            tp = type(select.devpoll())
-            support.check_disallow_instantiation(self, tp)
+            support.check_disallow_instantiation(self, type(select.devpoll()))
 
 def tearDownModule():
     support.reap_children()

--- a/Lib/test/test_select.py
+++ b/Lib/test/test_select.py
@@ -89,11 +89,11 @@ class SelectTestCase(unittest.TestCase):
 
     def test_disallow_instantiation(self):
         tp = type(select.poll())
-        self.assertRaises(TypeError, tp)
+        support.check_disallow_instantiation(self, tp)
 
         if hasattr(select, 'devpoll'):
             tp = type(select.devpoll())
-            self.assertRaises(TypeError, tp)
+            support.check_disallow_instantiation(self, tp)
 
 def tearDownModule():
     support.reap_children()

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -358,11 +358,7 @@ class BasicSocketTests(unittest.TestCase):
             with self.subTest(ssl_type=ssl_type):
                 with self.assertRaisesRegex(TypeError, "immutable type"):
                     ssl_type.value = None
-        with self.assertRaisesRegex(
-            TypeError,
-            "cannot create '_ssl.Certificate' instances"
-        ):
-            _ssl.Certificate()
+        support.check_disallow_instantiation(self, _ssl.Certificate)
 
     def test_private_init(self):
         with self.assertRaisesRegex(TypeError, "public constructor"):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -124,8 +124,7 @@ class ThreadTests(BaseTestCase):
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)
         lock = threading.Lock()
-        tp = type(lock)
-        test.support.check_disallow_instantiation(self, tp)
+        test.support.check_disallow_instantiation(self, type(lock))
 
     # Create a bunch of threads, let each do some work, wait until all are
     # done.

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -125,7 +125,7 @@ class ThreadTests(BaseTestCase):
         # Ensure that the type disallows instantiation (bpo-43916)
         lock = threading.Lock()
         tp = type(lock)
-        self.assertRaises(TypeError, tp)
+        test.support.check_disallow_instantiation(self, tp)
 
     # Create a bunch of threads, let each do some work, wait until all are
     # done.

--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -12,7 +12,7 @@ import sys
 import unicodedata
 import unittest
 from test.support import (open_urlresource, requires_resource, script_helper,
-                          cpython_only)
+                          cpython_only, check_disallow_instantiation)
 
 
 class UnicodeMethodsTest(unittest.TestCase):
@@ -229,7 +229,7 @@ class UnicodeMiscTest(UnicodeDatabaseTest):
     @cpython_only
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)
-        self.assertRaises(TypeError, unicodedata.UCD)
+        check_disallow_instantiation(self, unicodedata.UCD)
 
     def test_failed_import_during_compiling(self):
         # Issue 4367

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -134,8 +134,8 @@ class ExceptionTestCase(unittest.TestCase):
         # Ensure that the type disallows instantiation (bpo-43916)
         comp_type = type(zlib.compressobj())
         decomp_type = type(zlib.decompressobj())
-        self.assertRaises(TypeError, comp_type)
-        self.assertRaises(TypeError, decomp_type)
+        support.check_disallow_instantiation(self, comp_type)
+        support.check_disallow_instantiation(self, decomp_type)
 
 
 class BaseCompressTestCase(object):

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -132,10 +132,8 @@ class ExceptionTestCase(unittest.TestCase):
     @support.cpython_only
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)
-        comp_type = type(zlib.compressobj())
-        decomp_type = type(zlib.decompressobj())
-        support.check_disallow_instantiation(self, comp_type)
-        support.check_disallow_instantiation(self, decomp_type)
+        support.check_disallow_instantiation(self, type(zlib.compressobj()))
+        support.check_disallow_instantiation(self, type(zlib.decompressobj()))
 
 
 class BaseCompressTestCase(object):


### PR DESCRIPTION
- Use test.support.check_disallow_instantiation
- Fix exception message regex for builtins

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43988](https://bugs.python.org/issue43988) -->
https://bugs.python.org/issue43988
<!-- /issue-number -->
