### PR TITLE
bpo-44246: Update What's New for importlib.metadata.

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1042,7 +1042,7 @@ importlib.metadata
 Feature parity with ``importlib_metadata`` 4.2
 (`history <https://importlib-metadata.readthedocs.io/en/latest/history.html>`_).
 
-`importlib.metadata.entry_points <importlib.metadata#entry_points>`_
+:ref:`importlib.metadata entry points <entry-points>`
 now provides a nicer experience
 for selecting entry points by group and name through a new
 :class:`importlib.metadata.EntryPoints` class. See the Compatibility

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1049,7 +1049,7 @@ for selecting entry points by group and name through a new
 Note in the docs for more info on the deprecation and usage.
 Incidentally, these changes also removed access by index on the
 result of :func:`importlib.metadata.Distribution.entry_points`
-(see :issue:44246 for more detail).
+(see :issue:`44246` for more detail).
 
 Added :func:`importlib.metadata.packages_distributions` for resolving
 top-level Python modules and packages to their

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1039,11 +1039,17 @@ and will be incorrect in some rare cases, including some ``_``-s in
 importlib.metadata
 ------------------
 
-Feature parity with ``importlib_metadata`` 3.7.
+Feature parity with ``importlib_metadata`` 4.2
+(`history <https://importlib-metadata.readthedocs.io/en/latest/history.html>`_).
 
-:func:`importlib.metadata.entry_points` now provides a nicer experience
+`importlib.metadata.entry_points <importlib.metadata#entry_points>`_
+now provides a nicer experience
 for selecting entry points by group and name through a new
-:class:`importlib.metadata.EntryPoints` class.
+:class:`importlib.metadata.EntryPoints` class. See the Compatibility
+Note in the docs for more info on the deprecation and usage.
+Incidentally, these changes also removed access by index on the
+result of :func:`importlib.metadata.Distribution.entry_points`
+(see :issue:44246 for more detail).
 
 Added :func:`importlib.metadata.packages_distributions` for resolving
 top-level Python modules and packages to their


### PR DESCRIPTION
- Bump version of importlib_metadata included.
- Add note about compatibility notice and fix link to entry_points documentation.
- Add note about removal of access by index on Distribution.entry_points.


<!-- issue-number: [bpo-44246](https://bugs.python.org/issue44246) -->
https://bugs.python.org/issue44246
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco