### PR TITLE
bpo-44279: [doc] reword contextlib.suppress documentation

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -267,7 +267,7 @@ Functions and classes provided:
 .. function:: suppress(*exceptions)
 
    Return a context manager that suppresses any of the specified exceptions
-   if they occur in the body of a with statement and then resumes execution
+   if they are raised in the body of a with statement and then resumes execution
    with the first statement following the end of the with statement.
 
    As with any other mechanism that completely suppresses exceptions, this

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -267,8 +267,9 @@ Functions and classes provided:
 .. function:: suppress(*exceptions)
 
    Return a context manager that suppresses any of the specified exceptions
-   if they are raised in the body of a with statement and then resumes execution
-   with the first statement following the end of the with statement.
+   if they are raised in the body of a :keyword:`with` statement and then
+   resumes execution with the first statement following the end of the
+   :keyword:`with` statement.
 
    As with any other mechanism that completely suppresses exceptions, this
    context manager should be used only to cover very specific errors where

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -267,9 +267,9 @@ Functions and classes provided:
 .. function:: suppress(*exceptions)
 
    Return a context manager that suppresses any of the specified exceptions
-   if they are raised in the body of a :keyword:`with` statement and then
+   if they are raised in the body of a :keyword:`!with` statement and then
    resumes execution with the first statement following the end of the
-   :keyword:`with` statement.
+   :keyword:`!with` statement.
 
    As with any other mechanism that completely suppresses exceptions, this
    context manager should be used only to cover very specific errors where


### PR DESCRIPTION
The document of `contextlib.suppress` does make it sound like it would suppress any specified exception. It would be better if we inform the user that the overarching promise doesn't include warnings, which are also exceptions, albeit special.

<!-- issue-number: [bpo-44279](https://bugs.python.org/issue44279) -->
https://bugs.python.org/issue44279
<!-- /issue-number -->
