### PR TITLE
bpo-42972: Fix GC assertion error in _winapi by untracking Overlapped earlier

### DIFF
--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -132,6 +132,7 @@ overlapped_dealloc(OverlappedObject *self)
     DWORD bytes;
     int err = GetLastError();
 
+    PyObject_GC_UnTrack(self);
     if (self->pending) {
         if (check_CancelIoEx() &&
             Py_CancelIoEx(self->handle, &self->overlapped) &&
@@ -164,7 +165,6 @@ overlapped_dealloc(OverlappedObject *self)
 
     CloseHandle(self->overlapped.hEvent);
     SetLastError(err);
-    PyObject_GC_UnTrack(self);
     if (self->write_buffer.obj)
         PyBuffer_Release(&self->write_buffer);
     Py_CLEAR(self->read_buffer);


### PR DESCRIPTION
See https://github.com/python/cpython/pull/26381#discussion_r641478265. This untracks a possible 'bad' object earlier so the GC stops having weird race conditions. Fixes a gc assertion error in debug mode in ``test_httplib``.
```
python_d.exe -m test test_httplib -m test_local_bad_hostname 

...\cpython\Modules\gcmodule.c:446: update_refs: Assertion "gc_get_refs(gc) != 0" failed
Enable tracemalloc to get the memory block allocation traceback

object address  : 000002DADE2A99D0
object refcount : 0
object type     : 000002DADDF72F60
object type name: _winapi.Overlapped
object repr     : <refcnt 0 at 000002DADE2A99D0>

Fatal Python error: _PyObject_AssertFailed: _PyObject_AssertFailed
Python runtime state: initialized
```
<!-- issue-number: [bpo-42972](https://bugs.python.org/issue42972) -->
https://bugs.python.org/issue42972
<!-- /issue-number -->
