### PR TITLE
bpo-24132: Direct sub-classing of pathlib.Path

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -536,6 +536,14 @@ class _PurePathBase(object):
         '_str', '_hash', '_pparts', '_cached_cparts',
     )
 
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        mro_names = [class_.__name__ for class_ in cls.mro()[:-1]]
+        if "PurePath" not in mro_names:
+            is_posix = os.name == "posix"
+            cls._flavour = _posix_flavour if is_posix else _windows_flavour
+        return cls
+
     def __new__(cls, *args):
         # Utilize __new__ rather __init__ in order to provide a setup
         # method in common with PurePath and Path which are derived from
@@ -1489,10 +1497,16 @@ class WindowsPath(Path, PureWindowsPath):
         raise NotImplementedError("Path.is_mount() is unsupported on this system")
 
 
-class SimplePath:
-    # Stub for class which will, aside from name, match the class instantiated
-    # by PurePath, however unlike PurePath, will be able to be subclassed
-    # normally.
+class SimplePath(_PurePathBase):
+    """
+    Class for manipulating paths without I/O.
+
+    SimplePath represents a filesystem path and offers operations
+    which don't perform any actual filesystem I/O. The methods in this
+    class will return values that are appropriate for your system
+    flavour, be that Windows or Posix, though the return values are not
+    guaranteed to be the same for both platforms.
+    """
     pass
 
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -660,7 +660,7 @@ class _PurePathBase(object):
             return self._cached_cparts
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, _PurePathBase):
             return NotImplemented
         return (
             self._cparts == other._cparts
@@ -676,7 +676,7 @@ class _PurePathBase(object):
 
     def __lt__(self, other):
         if (
-            not isinstance(other, self.__class__)
+            not isinstance(other, _PurePathBase)
             or self._flavour is not other._flavour
         ):
             return NotImplemented
@@ -684,7 +684,7 @@ class _PurePathBase(object):
 
     def __le__(self, other):
         if (
-            not isinstance(other, self.__class__)
+            not isinstance(other, _PurePathBase)
             or self._flavour is not other._flavour
         ):
             return NotImplemented
@@ -692,7 +692,7 @@ class _PurePathBase(object):
 
     def __gt__(self, other):
         if (
-            not isinstance(other, self.__class__)
+            not isinstance(other, _PurePathBase)
             or self._flavour is not other._flavour
         ):
             return NotImplemented
@@ -700,7 +700,7 @@ class _PurePathBase(object):
 
     def __ge__(self, other):
         if (
-            not isinstance(other, self.__class__)
+            not isinstance(other, _PurePathBase)
             or self._flavour is not other._flavour
         ):
             return NotImplemented

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -35,6 +35,7 @@ _IGNORED_WINERRORS = (
     _WINERROR_INVALID_NAME,
     _WINERROR_CANT_RESOLVE_FILENAME)
 
+
 def _ignore_error(exception):
     return (getattr(exception, 'errno', None) in _IGNORED_ERROS or
             getattr(exception, 'winerror', None) in _IGNORED_WINERRORS)
@@ -902,6 +903,7 @@ class PurePath(object):
                 return False
         return True
 
+
 # Can't subclass os.PathLike from PurePath and keep the constructor
 # optimizations in PurePath._parse_args().
 os.PathLike.register(PurePath)
@@ -1438,6 +1440,7 @@ class PosixPath(Path, PurePosixPath):
     """
     __slots__ = ()
 
+
 class WindowsPath(Path, PureWindowsPath):
     """Path subclass for Windows systems.
 
@@ -1447,3 +1450,16 @@ class WindowsPath(Path, PureWindowsPath):
 
     def is_mount(self):
         raise NotImplementedError("Path.is_mount() is unsupported on this system")
+
+
+class SimplePath:
+    # Stub for class which will, aside from name, match the class instantiated
+    # by PurePath, however unlike PurePath, will be able to be subclassed
+    # normally.
+    pass
+
+
+class FilePath:
+    # Stub for class which will, aside from name, match the class instantiated
+    # by Path, however unlike Path, will be able to be subclassed normally.
+    pass

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -561,7 +561,7 @@ class PurePath(object):
         # canonicalize some constructor arguments.
         parts = []
         for a in args:
-            if isinstance(a, PurePath):
+            if isinstance(a, cls):
                 parts += a._parts
             else:
                 a = os.fspath(a)
@@ -650,9 +650,12 @@ class PurePath(object):
             return self._cached_cparts
 
     def __eq__(self, other):
-        if not isinstance(other, PurePath):
+        if not isinstance(other, self.__class__):
             return NotImplemented
-        return self._cparts == other._cparts and self._flavour is other._flavour
+        return (
+            self._cparts == other._cparts
+            and self._flavour is other._flavour
+        )
 
     def __hash__(self):
         try:
@@ -662,22 +665,34 @@ class PurePath(object):
             return self._hash
 
     def __lt__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if (
+            not isinstance(other, self.__class__)
+            or self._flavour is not other._flavour
+        ):
             return NotImplemented
         return self._cparts < other._cparts
 
     def __le__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if (
+            not isinstance(other, self.__class__)
+            or self._flavour is not other._flavour
+        ):
             return NotImplemented
         return self._cparts <= other._cparts
 
     def __gt__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if (
+            not isinstance(other, self.__class__)
+            or self._flavour is not other._flavour
+        ):
             return NotImplemented
         return self._cparts > other._cparts
 
     def __ge__(self, other):
-        if not isinstance(other, PurePath) or self._flavour is not other._flavour:
+        if (
+            not isinstance(other, self.__class__)
+            or self._flavour is not other._flavour
+        ):
             return NotImplemented
         return self._cparts >= other._cparts
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -17,6 +17,8 @@ from urllib.parse import quote_from_bytes as urlquote_from_bytes
 __all__ = [
     "PurePath", "PurePosixPath", "PureWindowsPath",
     "Path", "PosixPath", "WindowsPath",
+    "SimplePath", "SimplePosixPath", "SimpleWindowsPath",
+    "FilePath", "PathIOMixin",
     ]
 
 #

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1510,7 +1510,14 @@ class SimplePath(_PurePathBase):
     pass
 
 
-class FilePath:
-    # Stub for class which will, aside from name, match the class instantiated
-    # by Path, however unlike Path, will be able to be subclassed normally.
+class FilePath(SimplePath):
+    """
+    SimplePath subclass that can make system calls.
+
+    FilePath represents a filesystem path but unlike SimplePath, also
+    offers methods to do system calls on path objects. The methods in
+    this class will return values that are appropriate for your system
+    flavour, be that Windows or Posix, though the return values are not
+    guaranteed to be the same for both platforms.
+    """
     pass

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1369,6 +1369,9 @@ class Path(PurePath):
         """
         Check if this path is a POSIX mount point
         """
+        if os.name != "posix":
+            raise NotImplementedError("Path.is_mount() is "
+                                      "unsupported on this system")
         # Need to exist and be a dir
         if not self.exists() or not self.is_dir():
             return False
@@ -1492,9 +1495,6 @@ class WindowsPath(Path, PureWindowsPath):
     On a Windows system, instantiating a Path should return this object.
     """
     __slots__ = ()
-
-    def is_mount(self):
-        raise NotImplementedError("Path.is_mount() is unsupported on this system")
 
 
 class SimplePath(_PurePathBase):

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -326,21 +326,24 @@ class _NormalAccessor(_Accessor):
         readlink = os.readlink
     else:
         def readlink(self, path):
-            raise NotImplementedError("os.readlink() not available on this system")
+            raise NotImplementedError("os.readlink() is not available "
+                                      "on this system")
 
     def owner(self, path):
         try:
             import pwd
             return pwd.getpwuid(self.stat(path).st_uid).pw_name
         except ImportError:
-            raise NotImplementedError("Path.owner() is unsupported on this system")
+            raise NotImplementedError(f"{self.__class__.__name__}.owner() "
+                                      f"is unsupported on this system")
 
     def group(self, path):
         try:
             import grp
             return grp.getgrgid(self.stat(path).st_gid).gr_name
         except ImportError:
-            raise NotImplementedError("Path.group() is unsupported on this system")
+            raise NotImplementedError(f"{self.__class__.__name__}.group() "
+                                      f"is unsupported on this system")
 
     getcwd = os.getcwd
 
@@ -1012,7 +1015,7 @@ class Path(PurePath):
         # In previous versions of pathlib, this method marked this path as
         # closed; subsequent attempts to perform I/O would raise an IOError.
         # This functionality was never documented, and had the effect of
-        # making Path objects mutable, contrary to PEP 428. In Python 3.9 the
+        # making path objects mutable, contrary to PEP 428. In Python 3.9 the
         # _closed attribute was removed, and this method made a no-op.
         # This method and __enter__()/__exit__() should be deprecated and
         # removed in the future.
@@ -1059,7 +1062,7 @@ class Path(PurePath):
         """Iterate over this subtree and yield all existing files (of any
         kind, including directories) matching the given relative pattern.
         """
-        sys.audit("pathlib.Path.glob", self, pattern)
+        sys.audit(f"pathlib.{self.__class__.__name__}.glob", self, pattern)
         if not pattern:
             raise ValueError("Unacceptable pattern: {!r}".format(pattern))
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
@@ -1074,7 +1077,7 @@ class Path(PurePath):
         directories) matching the given relative pattern, anywhere in
         this subtree.
         """
-        sys.audit("pathlib.Path.rglob", self, pattern)
+        sys.audit(f"pathlib.{self.__class__.__name__}.rglob", self, pattern)
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
         if drv or root:
             raise NotImplementedError("Non-relative patterns are unsupported")
@@ -1262,9 +1265,9 @@ class Path(PurePath):
 
         The target path may be absolute or relative. Relative paths are
         interpreted relative to the current working directory, *not* the
-        directory of the Path object.
+        directory of this object.
 
-        Returns the new Path instance pointing to the target path.
+        Returns the new class instance pointing to the target path.
         """
         self._accessor.rename(self, target)
         return self.__class__(target)
@@ -1275,9 +1278,9 @@ class Path(PurePath):
 
         The target path may be absolute or relative. Relative paths are
         interpreted relative to the current working directory, *not* the
-        directory of the Path object.
+        directory of this object.
 
-        Returns the new Path instance pointing to the target path.
+        Returns the new class instance pointing to the target path.
         """
         self._accessor.replace(self, target)
         return self.__class__(target)
@@ -1303,15 +1306,16 @@ class Path(PurePath):
 
         Note this function does not make this path a hard link to *target*,
         despite the implication of the function and argument names. The order
-        of arguments (target, link) is the reverse of Path.symlink_to, but
+        of arguments (target, link) is the reverse of symlink_to, but
         matches that of os.link.
 
         Deprecated since Python 3.10 and scheduled for removal in Python 3.12.
         Use `hardlink_to()` instead.
         """
-        warnings.warn("pathlib.Path.link_to() is deprecated and is scheduled "
-                      "for removal in Python 3.12. "
-                      "Use pathlib.Path.hardlink_to() instead.",
+        classname = self.__class__.__name__
+        warnings.warn(f"pathlib.{classname}.link_to() is deprecated and is "
+                      f"scheduled for removal in Python 3.12. "
+                      f"Use pathlib.{classname}.hardlink_to() instead.",
                       DeprecationWarning, stacklevel=2)
         self._accessor.link(self, target)
 
@@ -1370,8 +1374,8 @@ class Path(PurePath):
         Check if this path is a POSIX mount point
         """
         if os.name != "posix":
-            raise NotImplementedError("Path.is_mount() is "
-                                      "unsupported on this system")
+            raise NotImplementedError(f"{self.__class__.__name__}.is_mount() "
+                                      f"is unsupported on this system")
         # Need to exist and be a dir
         if not self.exists() or not self.is_dir():
             return False

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2730,7 +2730,17 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
             check()
 
 
-class FilePathTest(unittest.TestCase, SubclassTestMixin):
+class FilePathTest(_BasePathTest, SubclassTestMixin, unittest.TestCase):
+    cls = pathlib.FilePath
+
+
+@only_posix
+class FilePathAsPosixPathTest(PosixPathTest):
+    cls = pathlib.FilePath
+
+
+@only_nt
+class FilePathAsWindowsPathTest(WindowsPathTest):
     cls = pathlib.FilePath
 
 

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -354,7 +354,9 @@ class _BasePurePathTest(object):
         # Ordering is tuple-alike.
         def assertLess(a, b):
             self.assertLess(a, b)
+            self.assertLessEqual(a, b)
             self.assertGreater(b, a)
+            self.assertGreaterEqual(b, a)
         P = self.cls
         a = P('a')
         b = P('a/b')

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1405,6 +1405,20 @@ class WindowsPathAsPureTest(PureWindowsPathTest):
             P('c:/').group()
 
 
+@only_posix
+class FilePathAsPurePosixTest(PurePosixPathTest):
+    cls = pathlib.FilePath
+
+
+@only_nt
+class FilePathAsPureWindowsTest(PureWindowsPathTest):
+    cls = pathlib.FilePath
+
+
+class FilePathAsPureTest(_BasePurePathTest, unittest.TestCase):
+    cls = pathlib.FilePath
+
+
 class _BasePathTest(object):
     """Tests for the FS-accessing functionalities of the Path classes."""
 

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1296,6 +1296,7 @@ class PureWindowsPathTest(_BasePurePathTest, unittest.TestCase):
         # UNC paths are never reserved.
         self.assertIs(False, P('//my/share/nul/con/aux').is_reserved())
 
+
 class PurePathTest(_BasePurePathTest, unittest.TestCase):
     cls = pathlib.PurePath
 
@@ -1322,6 +1323,30 @@ class PurePathTest(_BasePurePathTest, unittest.TestCase):
             p >= q
 
 
+class SubclassTestMixin:
+
+    def test_can_subclass(self):
+        P = self.cls
+        try:
+            class Derived(P):
+                pass
+        except Exception as e:
+            self.fail(f"Failed to subclass {P}: {e}")
+        else:
+            self.assertTrue(issubclass(Derived, P))
+            try:
+                derived = Derived()
+            except Exception as e:
+                self.fail("Failed to be able to instantiate a class "
+                          f"derived from {P}: {e}")
+            else:
+                self.assertIsInstance(derived, Derived)
+
+
+class SimplePathTest(unittest.TestCase, SubclassTestMixin):
+    cls = pathlib.SimplePath
+
+
 #
 # Tests for the concrete classes.
 #
@@ -1336,9 +1361,11 @@ only_nt = unittest.skipIf(os.name != 'nt',
 only_posix = unittest.skipIf(os.name == 'nt',
                              'test requires a POSIX-compatible system')
 
+
 @only_posix
 class PosixPathAsPureTest(PurePosixPathTest):
     cls = pathlib.PosixPath
+
 
 @only_nt
 class WindowsPathAsPureTest(PureWindowsPathTest):
@@ -2664,6 +2691,10 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
             # bpo-38883: ignore `HOME` when set on windows
             env['HOME'] = 'C:\\Users\\eve'
             check()
+
+
+class FilePathTest(unittest.TestCase, SubclassTestMixin):
+    cls = pathlib.FilePath
 
 
 class CompatiblePathTest(unittest.TestCase):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -21,6 +21,12 @@ except ImportError:
     grp = pwd = None
 
 
+only_nt = unittest.skipIf(os.name != 'nt',
+                          'test requires a Windows-compatible system')
+only_posix = unittest.skipIf(os.name == 'nt',
+                             'test requires a POSIX-compatible system')
+
+
 class _BaseFlavourTest(object):
 
     def _check_parse_parts(self, arg, expected):
@@ -703,6 +709,11 @@ class _BasePurePathTest(object):
 class PurePosixPathTest(_BasePurePathTest, unittest.TestCase):
     cls = pathlib.PurePosixPath
 
+    def test_flavour(self):
+        P = self.cls
+        self.assertEqual(P._flavour.__class__,
+                         pathlib._PosixFlavour)
+
     def test_root(self):
         P = self.cls
         self.assertEqual(P('/a/b').root, '/')
@@ -791,6 +802,11 @@ class PureWindowsPathTest(_BasePurePathTest, unittest.TestCase):
             ('//a/b', 'c'), ('//a/b/', 'c'),
             ],
     })
+
+    def test_flavour(self):
+        P = self.cls
+        self.assertEqual(P._flavour.__class__,
+                         pathlib._WindowsFlavour)
 
     def test_str(self):
         p = self.cls('a/b/c')
@@ -1345,7 +1361,17 @@ class SubclassTestMixin:
                 self.assertIsInstance(derived, Derived)
 
 
-class SimplePathTest(unittest.TestCase, SubclassTestMixin):
+class SimplePathTest(_BasePurePathTest, SubclassTestMixin, unittest.TestCase):
+    cls = pathlib.SimplePath
+
+
+@only_posix
+class SimplePathAsPurePosixPathTest(PurePosixPathTest, unittest.TestCase):
+    cls = pathlib.SimplePath
+
+
+@only_nt
+class SimplePathAsPureWindowsPathTest(PureWindowsPathTest, unittest.TestCase):
     cls = pathlib.SimplePath
 
 
@@ -1357,11 +1383,6 @@ class SimplePathTest(unittest.TestCase, SubclassTestMixin):
 BASE = os.path.realpath(TESTFN)
 join = lambda *x: os.path.join(BASE, *x)
 rel_join = lambda *x: os.path.join(TESTFN, *x)
-
-only_nt = unittest.skipIf(os.name != 'nt',
-                          'test requires a Windows-compatible system')
-only_posix = unittest.skipIf(os.name == 'nt',
-                             'test requires a POSIX-compatible system')
 
 
 @only_posix

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1375,6 +1375,18 @@ class SimplePathAsPureWindowsPathTest(PureWindowsPathTest, unittest.TestCase):
     cls = pathlib.SimplePath
 
 
+class SimplePosixPathAsPurePosixPathTest(
+    PurePosixPathTest, SubclassTestMixin, unittest.TestCase
+):
+    cls = pathlib.SimplePosixPath
+
+
+class SimpleWindowsPathAsPureWindowsPathTest(
+    PureWindowsPathTest, SubclassTestMixin, unittest.TestCase
+):
+    cls = pathlib.SimpleWindowsPath
+
+
 #
 # Tests for the concrete classes.
 #

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -545,6 +545,7 @@ Matt Fleming
 Hernán Martínez Foffani
 Benjamin Fogle
 Artem Fokin
+Kevin Follstad
 Arnaud Fontaine
 Michael Foord
 Amaury Forgeot d'Arc

--- a/Misc/NEWS.d/next/Library/2021-05-25-21-25-39.bpo-24132.37mJNj.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-25-21-25-39.bpo-24132.37mJNj.rst
@@ -1,0 +1,5 @@
+Add a drop-in, extensible alternative to :class:`pathlib.PurePath` named
+:class:`pathlib.SimplePath`, which has accompanying classes
+:class:`pathlib.SimplePosixPath` and :class:`pathlib.SimpleWindowsPath`.
+Also add extensible alternative to :class:`pathlib.Path` named
+:class:`pathlib.FilePath`.


### PR DESCRIPTION
**Updated based on feedback - currently marked as draft**

I submit for your consideration what I believe is the first working version (with documentation) of an extensible, subclassable PurePath/Path to close [bpo-24132](https://bugs.python.org/issue24132), a 6-year-old bug. I have also [posted a more detailed version of this explanation on discuss.python.org](https://discuss.python.org/t/fixing-subclassing-in-pathlib/8983) because this fix involves adding classes to pathlib and understanding why that is required takes a significant explanation.

These classes are a complete set of alternatives to PurePath and Path which omit the factory design but instead attach the flavour to the class at the time of instantiation. These newly designed classes still pass all of the test cases that are run against PurePath and Path on both Windows and Linux. Because they omit the factory design, they don't have inverted dependencies and therefore are naively subclassable and extensible in any way you see fit.

To this end I give you:

**SimplePath** (subclassable alternative to PurePath)
**SimplePosixPath** (subclassable alternative to PurePosixPath)
**SimpleWindowsPath** (subclassable alternative to PureWindowsPath)
**FilePath** (subclassable alternative to Path/PosixPath/WindowsPath)

On Windows, SimplePath behaves as if it were PureWindowsPath. On Posix, it behaves as PurePosixPath. Similarly, FilePath behaves like WindowsPath on Windows and PosixPath on Posix. These four classes combined could, if one were so inclined, act as a complete replacement for the existing six Path/PurePath classes.

Despite being 11 commits, it's essentially just two refactors. The first splits the two responsibilities PurePath has, separating the base class methods into _PurePathBase. The second does the same with Path, moving the base class methods into PathIOMixin. The other commits are just minor tweaks and documentation to account for all of that.


<!-- issue-number: [bpo-24132](https://bugs.python.org/issue24132) -->
https://bugs.python.org/issue24132
<!-- /issue-number -->
