### PR TITLE
bpo-44252: Correctly implement gc support for SSLError objects

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -436,8 +436,7 @@ static PyType_Slot sslerror_type_slots[] = {
 static PyType_Spec sslerror_type_spec = {
     .name = "ssl.SSLError",
     .basicsize = sizeof(PyOSErrorObject),
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-              Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HAVE_GC),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE),
     .slots = sslerror_type_slots
 };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44252](https://bugs.python.org/issue44252) -->
https://bugs.python.org/issue44252
<!-- /issue-number -->
