### PR TITLE
bpo-44206: Fix compiler warnings in dictobject.c

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1316,7 +1316,7 @@ PyDict_GetItem(PyObject *op, PyObject *key)
     /* Preserve the existing exception */
     PyObject *exc_type, *exc_value, *exc_tb;
     PyObject *value;
-    Py_ssize_t ix;
+    Py_ssize_t ix; (void)ix;
 
     _PyErr_Fetch(tstate, &exc_type, &exc_value, &exc_tb);
     ix = _Py_dict_lookup(mp, key, hash, &value);
@@ -1374,7 +1374,7 @@ _PyDict_GetItemHint(PyDictObject *mp, PyObject *key,
 PyObject *
 _PyDict_GetItem_KnownHash(PyObject *op, PyObject *key, Py_hash_t hash)
 {
-    Py_ssize_t ix;
+    Py_ssize_t ix; (void)ix;
     PyDictObject *mp = (PyDictObject *)op;
     PyObject *value;
 
@@ -1395,7 +1395,7 @@ _PyDict_GetItem_KnownHash(PyObject *op, PyObject *key, Py_hash_t hash)
 PyObject *
 PyDict_GetItemWithError(PyObject *op, PyObject *key)
 {
-    Py_ssize_t ix;
+    Py_ssize_t ix; (void)ix;
     Py_hash_t hash;
     PyDictObject*mp = (PyDictObject *)op;
     PyObject *value;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44206](https://bugs.python.org/issue44206) -->
https://bugs.python.org/issue44206
<!-- /issue-number -->
