### PR TITLE
bpo-44254: On Mac, remove disfunctional colors from turtledemo buttons

### DIFF
--- a/Lib/turtledemo/__main__.py
+++ b/Lib/turtledemo/__main__.py
@@ -172,11 +172,11 @@ class DemoWindow(object):
                                 relief=RIDGE)
         if darwin:  # Leave Mac button colors alone - #44254.
             self.start_btn = Button(root, text=" START ", font=btnfont,
-                                    command=self.startDemo)
+                                    fg='#00cc22', command=self.startDemo)
             self.stop_btn = Button(root, text=" STOP ", font=btnfont,
-                                   command=self.stopIt)
+                                   fg='#00cc22', command=self.stopIt)
             self.clear_btn = Button(root, text=" CLEAR ", font=btnfont,
-                                    command = self.clearCanvas)
+                                    fg='#00cc22', command = self.clearCanvas)
         else:
             self.start_btn = Button(root, text=" START ", font=btnfont,
                                     fg="white", disabledforeground = "#fed",

--- a/Lib/turtledemo/__main__.py
+++ b/Lib/turtledemo/__main__.py
@@ -124,7 +124,6 @@ help_entries = (  # (help_label,  help_doc)
     )
 
 
-
 class DemoWindow(object):
 
     def __init__(self, filename=None):
@@ -171,15 +170,23 @@ class DemoWindow(object):
         self.output_lbl = Label(root, height= 1, text=" --- ", bg="#ddf",
                                 font=("Arial", 16, 'normal'), borderwidth=2,
                                 relief=RIDGE)
-        self.start_btn = Button(root, text=" START ", font=btnfont,
-                                fg="white", disabledforeground = "#fed",
-                                command=self.startDemo)
-        self.stop_btn = Button(root, text=" STOP ", font=btnfont,
-                               fg="white", disabledforeground = "#fed",
-                               command=self.stopIt)
-        self.clear_btn = Button(root, text=" CLEAR ", font=btnfont,
-                                fg="white", disabledforeground="#fed",
-                                command = self.clearCanvas)
+        if darwin:  # Leave Mac button colors alone - #44254.
+            self.start_btn = Button(root, text=" START ", font=btnfont,
+                                    command=self.startDemo)
+            self.stop_btn = Button(root, text=" STOP ", font=btnfont,
+                                   command=self.stopIt)
+            self.clear_btn = Button(root, text=" CLEAR ", font=btnfont,
+                                    command = self.clearCanvas)
+        else:
+            self.start_btn = Button(root, text=" START ", font=btnfont,
+                                    fg="white", disabledforeground = "#fed",
+                                    command=self.startDemo)
+            self.stop_btn = Button(root, text=" STOP ", font=btnfont,
+                                   fg="white", disabledforeground = "#fed",
+                                   command=self.stopIt)
+            self.clear_btn = Button(root, text=" CLEAR ", font=btnfont,
+                                    fg="white", disabledforeground="#fed",
+                                    command = self.clearCanvas)
         self.output_lbl.grid(row=1, column=0, sticky='news', padx=(0,5))
         self.start_btn.grid(row=1, column=1, sticky='ew')
         self.stop_btn.grid(row=1, column=2, sticky='ew')
@@ -267,12 +274,17 @@ class DemoWindow(object):
             return self.increase_size()
 
     def configGUI(self, start, stop, clear, txt="", color="blue"):
-        self.start_btn.config(state=start,
-                              bg="#d00" if start == NORMAL else "#fca")
-        self.stop_btn.config(state=stop,
-                             bg="#d00" if stop == NORMAL else "#fca")
-        self.clear_btn.config(state=clear,
-                              bg="#d00" if clear == NORMAL else "#fca")
+        if darwin:  # Leave Mac button colors alone - #44254.
+            self.start_btn.config(state=start)
+            self.stop_btn.config(state=stop)
+            self.clear_btn.config(state=clear)
+        else:
+            self.start_btn.config(state=start,
+                                  bg="#d00" if start == NORMAL else "#fca")
+            self.stop_btn.config(state=stop,
+                                 bg="#d00" if stop == NORMAL else "#fca")
+            self.clear_btn.config(state=clear,
+                                  bg="#d00" if clear == NORMAL else "#fca")
         self.output_lbl.config(text=txt, fg=color)
 
     def makeLoadDemoMenu(self, master):

--- a/Misc/NEWS.d/next/Library/2021-05-29-01-05-43.bpo-44254.f06xDm.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-29-01-05-43.bpo-44254.f06xDm.rst
@@ -1,2 +1,2 @@
-On Mac, give turtledemo button text a color that works on light and
-dark background.  Programmers cannot control the latter.
+On Mac, give turtledemo button text a color that works on both light
+or dark background.  Programmers cannot control the latter.

--- a/Misc/NEWS.d/next/Library/2021-05-29-01-05-43.bpo-44254.f06xDm.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-29-01-05-43.bpo-44254.f06xDm.rst
@@ -1,1 +1,2 @@
-On Mac, remove disfunctional colors from turtledemo buttons.
+On Mac, give turtledemo button text a color that works on light and
+dark background.  Programmers cannot control the latter.

--- a/Misc/NEWS.d/next/Library/2021-05-29-01-05-43.bpo-44254.f06xDm.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-29-01-05-43.bpo-44254.f06xDm.rst
@@ -1,0 +1,1 @@
+On Mac, remove disfunctional colors from turtledemo buttons.


### PR DESCRIPTION
On macOS, tk partly defers to system settings.  Custom white
on system white meant unreadable text.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44254](https://bugs.python.org/issue44254) -->
https://bugs.python.org/issue44254
<!-- /issue-number -->
