### PR TITLE
bpo-42972: Fix sqlite3 traverse/clear

### DIFF
--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -47,9 +47,9 @@ pysqlite_new_node(PyObject *key, PyObject *data)
 static int
 node_traverse(pysqlite_Node *self, visitproc visit, void *arg)
 {
+    Py_VISIT(Py_TYPE(self));
     Py_VISIT(self->key);
     Py_VISIT(self->data);
-    Py_VISIT(Py_TYPE(self));
     return 0;
 }
 
@@ -106,22 +106,28 @@ pysqlite_cache_init(pysqlite_Cache *self, PyObject *args, PyObject *kwargs)
 static int
 cache_traverse(pysqlite_Cache *self, visitproc visit, void *arg)
 {
+    Py_VISIT(Py_TYPE(self));
+    Py_VISIT(self->mapping);
+    if (self->decref_factory) {
+        Py_VISIT(self->factory);
+    }
+
     pysqlite_Node *node = self->first;
     while (node) {
         Py_VISIT(node);
         node = node->next;
     }
-    Py_VISIT(self->mapping);
-    if (self->decref_factory) {
-        Py_VISIT(self->factory);
-    }
-    Py_VISIT(Py_TYPE(self));
     return 0;
 }
 
 static int
 cache_clear(pysqlite_Cache *self)
 {
+    Py_CLEAR(self->mapping);
+    if (self->decref_factory) {
+        Py_CLEAR(self->factory);
+    }
+
     /* iterate over all nodes and deallocate them */
     pysqlite_Node *node = self->first;
     self->first = NULL;
@@ -130,10 +136,6 @@ cache_clear(pysqlite_Cache *self)
         node = node->next;
         Py_CLEAR(delete_node);
     }
-    if (self->decref_factory) {
-        Py_CLEAR(self->factory);
-    }
-    Py_CLEAR(self->mapping);
     return 0;
 }
 

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -228,33 +228,33 @@ pysqlite_do_all_statements(pysqlite_Connection *self, int action,
 static int
 connection_traverse(pysqlite_Connection *self, visitproc visit, void *arg)
 {
-    Py_VISIT(self->statement_cache);
+    Py_VISIT(Py_TYPE(self));
     Py_VISIT(self->isolation_level);
+    Py_VISIT(self->statement_cache);
+    Py_VISIT(self->statements);
+    Py_VISIT(self->cursors);
+    Py_VISIT(self->row_factory);
+    Py_VISIT(self->text_factory);
     Py_VISIT(self->function_pinboard_trace_callback);
     Py_VISIT(self->function_pinboard_progress_handler);
     Py_VISIT(self->function_pinboard_authorizer_cb);
-    Py_VISIT(self->row_factory);
-    Py_VISIT(self->text_factory);
     Py_VISIT(self->collations);
-    Py_VISIT(self->statements);
-    Py_VISIT(self->cursors);
-    Py_VISIT(Py_TYPE(self));
     return 0;
 }
 
 static int
 connection_clear(pysqlite_Connection *self)
 {
-    Py_CLEAR(self->statement_cache);
     Py_CLEAR(self->isolation_level);
+    Py_CLEAR(self->statement_cache);
+    Py_CLEAR(self->statements);
+    Py_CLEAR(self->cursors);
+    Py_CLEAR(self->row_factory);
+    Py_CLEAR(self->text_factory);
     Py_CLEAR(self->function_pinboard_trace_callback);
     Py_CLEAR(self->function_pinboard_progress_handler);
     Py_CLEAR(self->function_pinboard_authorizer_cb);
-    Py_CLEAR(self->row_factory);
-    Py_CLEAR(self->text_factory);
     Py_CLEAR(self->collations);
-    Py_CLEAR(self->statements);
-    Py_CLEAR(self->cursors);
     return 0;
 }
 

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -93,7 +93,7 @@ typedef struct
     /* a dictionary of registered collation name => collation callable mappings */
     PyObject* collations;
 
-    /* Exception objects */
+    /* Exception objects: borrowed refs. */
     PyObject* Warning;
     PyObject* Error;
     PyObject* InterfaceError;

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -84,43 +84,44 @@ pysqlite_cursor_init_impl(pysqlite_Cursor *self,
 static int
 cursor_traverse(pysqlite_Cursor *self, visitproc visit, void *arg)
 {
-    Py_VISIT(self->connection);
-    Py_VISIT(self->row_cast_map);
-    Py_VISIT(self->row_factory);
-    Py_VISIT(self->next_row);
     Py_VISIT(Py_TYPE(self));
+    Py_VISIT(self->connection);
+    Py_VISIT(self->description);
+    Py_VISIT(self->row_cast_map);
+    Py_VISIT(self->lastrowid);
+    Py_VISIT(self->row_factory);
+    Py_VISIT(self->statement);
+    Py_VISIT(self->next_row);
     return 0;
 }
 
 static int
 cursor_clear(pysqlite_Cursor *self)
 {
-    /* Reset the statement if the user has not closed the cursor */
+    Py_CLEAR(self->connection);
+    Py_CLEAR(self->description);
+    Py_CLEAR(self->row_cast_map);
+    Py_CLEAR(self->lastrowid);
+    Py_CLEAR(self->row_factory);
     if (self->statement) {
+        /* Reset the statement if the user has not closed the cursor */
         pysqlite_statement_reset(self->statement);
         Py_CLEAR(self->statement);
     }
-
-    Py_CLEAR(self->connection);
-    Py_CLEAR(self->row_cast_map);
-    Py_CLEAR(self->description);
-    Py_CLEAR(self->lastrowid);
-    Py_CLEAR(self->row_factory);
     Py_CLEAR(self->next_row);
-
-    if (self->in_weakreflist != NULL) {
-        PyObject_ClearWeakRefs((PyObject*)self);
-    }
 
     return 0;
 }
 
 static void
-cursor_dealloc(PyObject *self)
+cursor_dealloc(pysqlite_Cursor *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
-    tp->tp_clear(self);
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
+    tp->tp_clear((PyObject *)self);
     tp->tp_free(self);
     Py_DECREF(tp);
 }

--- a/Modules/_sqlite/row.c
+++ b/Modules/_sqlite/row.c
@@ -42,9 +42,9 @@ row_clear(pysqlite_Row *self)
 static int
 row_traverse(pysqlite_Row *self, visitproc visit, void *arg)
 {
+    Py_VISIT(Py_TYPE(self));
     Py_VISIT(self->data);
     Py_VISIT(self->description);
-    Py_VISIT(Py_TYPE(self));
     return 0;
 }
 

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -373,6 +373,9 @@ stmt_dealloc(pysqlite_Statement *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
     tp->tp_clear((PyObject *)self);
     tp->tp_free(self);
     Py_DECREF(tp);
@@ -389,17 +392,14 @@ stmt_clear(pysqlite_Statement *self)
     }
 
     Py_CLEAR(self->sql);
-    if (self->in_weakreflist != NULL) {
-        PyObject_ClearWeakRefs((PyObject*)self);
-    }
     return 0;
 }
 
 static int
 stmt_traverse(pysqlite_Statement *self, visitproc visit, void *arg)
 {
-    Py_VISIT(self->sql);
     Py_VISIT(Py_TYPE(self));
+    Py_VISIT(self->sql);
     return 0;
 }
 


### PR DESCRIPTION
GH-26104 had some issues:
- members were not visited/cleared in correct order
- weak refs were cleared in `Py_tp_clear` iso. `Py_tp_dealloc`
- some cursor members were not visited

This PR fixes these issues.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42972](https://bugs.python.org/issue42972) -->
https://bugs.python.org/issue42972
<!-- /issue-number -->
