### PR TITLE
bpo-37179: Support asyncio loop.start_tls() for TLS in TLS

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -283,6 +283,7 @@ class _SSLPipe(object):
 class _SSLProtocolTransport(transports._FlowControlMixin,
                             transports.Transport):
 
+    _start_tls_compatible = True
     _sendfile_compatible = constants._SendfileMode.FALLBACK
 
     def __init__(self, loop, ssl_protocol):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-11-04-34-41.bpo-37179.7Gs2-B.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-11-04-34-41.bpo-37179.7Gs2-B.rst
@@ -1,0 +1,1 @@
+Allow asyncio StartTLS in an existing TLS connection.


### PR DESCRIPTION
Adds the `_start_tls_compatible` attribute that [start_tls](https://github.com/python/cpython/blob/14ba761078b5ae83519e34d66ab883743912c45b/Lib/asyncio/base_events.py#L1210-L1212) checks. This is required to support using a HTTPS proxy when targeting a HTTPS endpoint.

_This is my first PR to CPython so I'm unsure what the full process is, let me know if there is anything I'm missing._

<!-- issue-number: [bpo-37179](https://bugs.python.org/issue37179) -->
https://bugs.python.org/issue37179
<!-- /issue-number -->
