### PR TITLE
bpo-43858: Add logging.getLevelNamesMapping()

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1111,10 +1111,12 @@ functions.
    .. note:: If you are thinking of defining your own levels, please see the
       section on :ref:`custom-levels`.
 
-.. function:: getLevelNamesDict()
+.. function:: getLevelNamesMapping()
 
-   Returns the dictionary of all available level names and respective logging levels.
-   
+   Returns a mapping from level names to their corresponding logging
+   levels. The returned mapping is copied from internal mapping on each call to this
+   function.
+
    .. versionadded:: 3.11
 
 .. function:: getLevelName(level)

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1113,9 +1113,9 @@ functions.
 
 .. function:: getLevelNamesMapping()
 
-   Returns a mapping from level names to their corresponding logging
-   levels. The returned mapping is copied from internal mapping on each call to this
-   function.
+   Returns a mapping from level names to their corresponding logging levels. For example, the
+   string "CRITICAL" maps to :const:`CRITICAL`. The returned mapping is copied from an internal
+   mapping on each call to this function.
 
    .. versionadded:: 3.11
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1111,6 +1111,12 @@ functions.
    .. note:: If you are thinking of defining your own levels, please see the
       section on :ref:`custom-levels`.
 
+.. function:: getLevelNamesDict()
+
+   Returns the dictionary of all available level names and respective logging levels.
+   
+   .. versionadded:: 3.11
+
 .. function:: getLevelName(level)
 
    Returns the textual or numeric representation of logging level *level*.

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -116,6 +116,9 @@ _nameToLevel = {
     'NOTSET': NOTSET,
 }
 
+def getLevelNamesDict():
+    return _nameToLevel.copy()
+
 def getLevelName(level):
     """
     Return the textual or numeric representation of logging level 'level'.

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -30,14 +30,14 @@ from string import Formatter as StrFormatter
 
 
 __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
-'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
-'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
-'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
-'captureWarnings', 'critical', 'debug', 'disable', 'error',
-'exception', 'fatal', 'getLevelName', 'getLogger',
-'getLoggerClass', 'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
-'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
-'lastResort', 'raiseExceptions', 'getLevelNamesMapping']
+           'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
+           'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
+           'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
+           'captureWarnings', 'critical', 'debug', 'disable', 'error',
+           'exception', 'fatal', 'getLevelName', 'getLogger',
+           'getLoggerClass', 'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
+           'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
+           'lastResort', 'raiseExceptions', 'getLevelNamesMapping']
 
 import threading
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -30,14 +30,14 @@ from string import Formatter as StrFormatter
 
 
 __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
-           'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
-           'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
-           'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
-           'captureWarnings', 'critical', 'debug', 'disable', 'error',
-           'exception', 'fatal', 'getLevelName', 'getLogger', 'getLoggerClass',
-           'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
-           'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
-           'lastResort', 'raiseExceptions']
+'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
+'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
+'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
+'captureWarnings', 'critical', 'debug', 'disable', 'error',
+'exception', 'fatal', 'getLevelNamesDict', 'getLevelName', 'getLogger',
+'getLoggerClass', 'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
+'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
+'lastResort', 'raiseExceptions']
 
 import threading
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -34,10 +34,10 @@ __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
 'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
 'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
 'captureWarnings', 'critical', 'debug', 'disable', 'error',
-'exception', 'fatal', 'getLevelNamesDict', 'getLevelName', 'getLogger',
+'exception', 'fatal', 'getLevelName', 'getLogger',
 'getLoggerClass', 'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
 'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
-'lastResort', 'raiseExceptions']
+'lastResort', 'raiseExceptions', 'getLevelNamesMapping']
 
 import threading
 
@@ -116,7 +116,7 @@ _nameToLevel = {
     'NOTSET': NOTSET,
 }
 
-def getLevelNamesDict():
+def getLevelNamesMapping():
     return _nameToLevel.copy()
 
 def getLevelName(level):

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -34,8 +34,8 @@ __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
            'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
            'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
            'captureWarnings', 'critical', 'debug', 'disable', 'error',
-           'exception', 'fatal', 'getLevelName', 'getLogger',
-           'getLoggerClass', 'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
+           'exception', 'fatal', 'getLevelName', 'getLogger', 'getLoggerClass',
+           'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
            'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
            'lastResort', 'raiseExceptions', 'getLevelNamesMapping']
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4391,13 +4391,12 @@ class ModuleLevelMiscTest(BaseTest):
         self.assertEqual(rc, 1)
 
     def test_get_level_names_mapping(self):
-        def test_get_level_names_mapping(self):
-            mapping = logging.getLevelNamesMapping()
-            self.assertEqual(logging._nameToLevel, mapping)  # value is equivalent
-            self.assertIsNot(logging._nameToLevel, mapping)  # but not the internal data
-            new_mapping = logging.getLevelNamesMapping()     # another call -> another copy
-            self.assertIsNot(mapping, new_mapping)           # verify not the same object as before
-            self.assertEqual(mapping, new_mapping)           # but equivalent in value
+        mapping = logging.getLevelNamesMapping()
+        self.assertEqual(logging._nameToLevel, mapping)  # value is equivalent
+        self.assertIsNot(logging._nameToLevel, mapping)  # but not the internal data
+        new_mapping = logging.getLevelNamesMapping()     # another call -> another copy
+        self.assertIsNot(mapping, new_mapping)           # verify not the same object as before
+        self.assertEqual(mapping, new_mapping)           # but equivalent in value
 
 
 class LogRecordTest(BaseTest):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4391,8 +4391,13 @@ class ModuleLevelMiscTest(BaseTest):
         self.assertEqual(rc, 1)
 
     def test_get_level_names_mapping(self):
-        self.assertEqual(logging._nameToLevel, logging.getLevelNamesMapping())
-        self.assertNotEqual(id(logging._nameToLevel), id(logging.getLevelNamesMapping()))
+        def test_get_level_names_mapping(self):
+            mapping = logging.getLevelNamesMapping()
+            self.assertEqual(logging._nameToLevel, mapping)  # value is equivalent
+            self.assertIsNot(logging._nameToLevel, mapping)  # but not the internal data
+            new_mapping = logging.getLevelNamesMapping()     # another call -> another copy
+            self.assertIsNot(mapping, new_mapping)           # verify not the same object as before
+            self.assertEqual(mapping, new_mapping)           # but equivalent in value
 
 
 class LogRecordTest(BaseTest):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4390,6 +4390,10 @@ class ModuleLevelMiscTest(BaseTest):
         self.assertNotIn("Cannot recover from stack overflow.", err)
         self.assertEqual(rc, 1)
 
+    def test_get_level_names_mapping(self):
+        self.assertEqual(logging._nameToLevel, logging.getLevelNamesMapping())
+        self.assertNotEqual(id(logging._nameToLevel), id(logging.getLevelNamesMapping()))
+
 
 class LogRecordTest(BaseTest):
     def test_str_rep(self):

--- a/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
@@ -1,1 +1,1 @@
-Added a function that returns a copy of a dict of logging levels: func::`logging.getLevelNamesDict()`
+Added a function that returns a copy of a dict of logging levels: func::`logging.getLevelNamesMapping()`

--- a/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
@@ -1,1 +1,1 @@
-Added a function that returns a copy of a dict of logging levels: :func:`logging.getLevelNamesMapping()`
+Added a function that returns a copy of a dict of logging levels: :func:`logging.getLevelNamesMapping`

--- a/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
@@ -1,0 +1,1 @@
+Added a function that returns a copy of a dict of logging levels: func::`logging.getLevelNamesDict()`

--- a/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
@@ -1,1 +1,1 @@
-Added a function that returns a copy of a dict of logging levels: func::`logging.getLevelNamesMapping()`
+Added a function that returns a copy of a dict of logging levels: func:`logging.getLevelNamesMapping()`

--- a/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-31-04-51-02.bpo-43858.r7LOu6.rst
@@ -1,1 +1,1 @@
-Added a function that returns a copy of a dict of logging levels: func:`logging.getLevelNamesMapping()`
+Added a function that returns a copy of a dict of logging levels: :func:`logging.getLevelNamesMapping()`


### PR DESCRIPTION
Added a function that returns a copy of a dict of logging levels.



<!-- issue-number: [bpo-43858](https://bugs.python.org/issue43858) -->
https://bugs.python.org/issue43858
<!-- /issue-number -->
