### PR TITLE
bpo-42213: Remove redundant cyclic GC hack in sqlite3

### DIFF
--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -25,7 +25,6 @@ import unittest
 import sqlite3 as sqlite
 import sys
 
-from test.support import gc_collect
 from test.support.os_helper import TESTFN, unlink
 
 
@@ -171,16 +170,10 @@ class ConnectionTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.cx.in_transaction = True
 
-
-class OpenTests(unittest.TestCase):
-    def tearDown(self):
-        # bpo-42213: ensure that TESTFN is closed before unlinking
-        gc_collect()
-        unlink(TESTFN)
-
     def test_open_with_path_like_object(self):
         """ Checks that we can successfully connect to a database using an object that
             is PathLike, i.e. has __fspath__(). """
+        self.addCleanup(unlink, TESTFN)
         class Path:
             def __fspath__(self):
                 return TESTFN
@@ -189,6 +182,7 @@ class OpenTests(unittest.TestCase):
             cx.execute('create table test(id integer)')
 
     def test_open_uri(self):
+        self.addCleanup(unlink, TESTFN)
         with sqlite.connect(TESTFN) as cx:
             cx.execute('create table test(id integer)')
         with sqlite.connect('file:' + TESTFN, uri=True) as cx:
@@ -948,7 +942,6 @@ def suite():
         CursorTests,
         ExtensionTests,
         ModuleTests,
-        OpenTests,
         SqliteOnConflictTests,
         ThreadTests,
     ]

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -135,6 +135,25 @@ class ConnectionTests(unittest.TestCase):
     def test_close(self):
         self.cx.close()
 
+    def test_use_after_close(self):
+        sql = "select 1"
+        cu = self.cx.cursor()
+        res = cu.execute(sql)
+        self.cx.close()
+        self.assertRaises(sqlite.ProgrammingError, res.fetchall)
+        self.assertRaises(sqlite.ProgrammingError, cu.execute, sql)
+        self.assertRaises(sqlite.ProgrammingError, cu.executemany, sql, [])
+        self.assertRaises(sqlite.ProgrammingError, cu.executescript, sql)
+        self.assertRaises(sqlite.ProgrammingError, self.cx.execute, sql)
+        self.assertRaises(sqlite.ProgrammingError,
+                          self.cx.executemany, sql, [])
+        self.assertRaises(sqlite.ProgrammingError, self.cx.executescript, sql)
+        self.assertRaises(sqlite.ProgrammingError,
+                          self.cx.create_function, "t", 1, lambda x: x)
+        with self.assertRaises(sqlite.ProgrammingError):
+            with self.cx:
+                pass
+
     def test_exceptions(self):
         # Optional DB-API extension.
         self.assertEqual(self.cx.Warning, sqlite.Warning)

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -173,6 +173,7 @@ class ConnectionTests(unittest.TestCase):
 
 class OpenTests(unittest.TestCase):
     def tearDown(self):
+        # bpo-42213: ensure that TESTFN is closed before unlinking
         import gc
         gc.collect()
         unlink(TESTFN)

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -170,10 +170,16 @@ class ConnectionTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.cx.in_transaction = True
 
+
+class OpenTests(unittest.TestCase):
+    def tearDown(self):
+        import gc
+        gc.collect()
+        unlink(TESTFN)
+
     def test_open_with_path_like_object(self):
         """ Checks that we can successfully connect to a database using an object that
             is PathLike, i.e. has __fspath__(). """
-        self.addCleanup(unlink, TESTFN)
         class Path:
             def __fspath__(self):
                 return TESTFN
@@ -182,7 +188,6 @@ class ConnectionTests(unittest.TestCase):
             cx.execute('create table test(id integer)')
 
     def test_open_uri(self):
-        self.addCleanup(unlink, TESTFN)
         with sqlite.connect(TESTFN) as cx:
             cx.execute('create table test(id integer)')
         with sqlite.connect('file:' + TESTFN, uri=True) as cx:
@@ -942,6 +947,7 @@ def suite():
         CursorTests,
         ExtensionTests,
         ModuleTests,
+        OpenTests,
         SqliteOnConflictTests,
         ThreadTests,
     ]

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -170,26 +170,35 @@ class ConnectionTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.cx.in_transaction = True
 
+
+class OpenTests(unittest.TestCase):
+    def tearDown(self):
+        unlink(TESTFN)
+
     def test_open_with_path_like_object(self):
         """ Checks that we can successfully connect to a database using an object that
             is PathLike, i.e. has __fspath__(). """
-        self.addCleanup(unlink, TESTFN)
         class Path:
             def __fspath__(self):
                 return TESTFN
         path = Path()
         with sqlite.connect(path) as cx:
             cx.execute('create table test(id integer)')
+        cx.close()
 
     def test_open_uri(self):
-        self.addCleanup(unlink, TESTFN)
         with sqlite.connect(TESTFN) as cx:
             cx.execute('create table test(id integer)')
+        cx.close()
+
         with sqlite.connect('file:' + TESTFN, uri=True) as cx:
             cx.execute('insert into test(id) values(0)')
+        cx.close()
+
         with sqlite.connect('file:' + TESTFN + '?mode=ro', uri=True) as cx:
             with self.assertRaises(sqlite.OperationalError):
                 cx.execute('insert into test(id) values(1)')
+        cx.close()
 
 
 class CursorTests(unittest.TestCase):
@@ -942,6 +951,7 @@ def suite():
         CursorTests,
         ExtensionTests,
         ModuleTests,
+        OpenTests,
         SqliteOnConflictTests,
         ThreadTests,
     ]

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -25,6 +25,7 @@ import unittest
 import sqlite3 as sqlite
 import sys
 
+from test.support import gc_collect
 from test.support.os_helper import TESTFN, unlink
 
 
@@ -174,8 +175,7 @@ class ConnectionTests(unittest.TestCase):
 class OpenTests(unittest.TestCase):
     def tearDown(self):
         # bpo-42213: ensure that TESTFN is closed before unlinking
-        import gc
-        gc.collect()
+        gc_collect()
         unlink(TESTFN)
 
     def test_open_with_path_like_object(self):

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -23,6 +23,7 @@
 import unittest
 import sqlite3 as sqlite
 
+from test.support import gc_collect
 from test.support.os_helper import TESTFN, unlink
 
 
@@ -264,8 +265,7 @@ class TraceCallbackTests(unittest.TestCase):
         # bpo-42213: ensure that TESTFN is closed before the cleanup runs
         con1.close()
         con2.close()
-        import gc
-        gc.collect()
+        gc_collect()
 
 
 def suite():

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -261,6 +261,7 @@ class TraceCallbackTests(unittest.TestCase):
         cur.execute(queries[1])
         self.assertEqual(traced_statements, queries)
 
+        # bpo-42213: ensure that TESTFN is closed before the cleanup runs
         con1.close()
         con2.close()
         import gc

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -261,6 +261,11 @@ class TraceCallbackTests(unittest.TestCase):
         cur.execute(queries[1])
         self.assertEqual(traced_statements, queries)
 
+        con1.close()
+        con2.close()
+        import gc
+        gc.collect()
+
 
 def suite():
     tests = [

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -254,13 +254,15 @@ class TraceCallbackTests(unittest.TestCase):
         self.addCleanup(unlink, TESTFN)
         con1 = sqlite.connect(TESTFN, isolation_level=None)
         con2 = sqlite.connect(TESTFN)
-        con1.set_trace_callback(trace)
-        cur = con1.cursor()
-        cur.execute(queries[0])
-        con2.execute("create table bar(x)")
-        cur.execute(queries[1])
-        con1.close()
-        con2.close()
+        try:
+            con1.set_trace_callback(trace)
+            cur = con1.cursor()
+            cur.execute(queries[0])
+            con2.execute("create table bar(x)")
+            cur.execute(queries[1])
+        finally:
+            con1.close()
+            con2.close()
         self.assertEqual(traced_statements, queries)
 
 

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -23,7 +23,6 @@
 import unittest
 import sqlite3 as sqlite
 
-from test.support import gc_collect
 from test.support.os_helper import TESTFN, unlink
 
 
@@ -261,11 +260,6 @@ class TraceCallbackTests(unittest.TestCase):
         con2.execute("create table bar(x)")
         cur.execute(queries[1])
         self.assertEqual(traced_statements, queries)
-
-        # bpo-42213: ensure that TESTFN is closed before the cleanup runs
-        con1.close()
-        con2.close()
-        gc_collect()
 
 
 def suite():

--- a/Lib/sqlite3/test/hooks.py
+++ b/Lib/sqlite3/test/hooks.py
@@ -259,6 +259,8 @@ class TraceCallbackTests(unittest.TestCase):
         cur.execute(queries[0])
         con2.execute("create table bar(x)")
         cur.execute(queries[1])
+        con1.close()
+        con2.close()
         self.assertEqual(traced_statements, queries)
 
 

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -97,9 +97,6 @@ pysqlite_cache_init(pysqlite_Cache *self, PyObject *args, PyObject *kwargs)
     }
 
     self->factory = Py_NewRef(factory);
-
-    self->decref_factory = 1;
-
     return 0;
 }
 
@@ -108,9 +105,7 @@ cache_traverse(pysqlite_Cache *self, visitproc visit, void *arg)
 {
     Py_VISIT(Py_TYPE(self));
     Py_VISIT(self->mapping);
-    if (self->decref_factory) {
-        Py_VISIT(self->factory);
-    }
+    Py_VISIT(self->factory);
 
     pysqlite_Node *node = self->first;
     while (node) {
@@ -124,9 +119,7 @@ static int
 cache_clear(pysqlite_Cache *self)
 {
     Py_CLEAR(self->mapping);
-    if (self->decref_factory) {
-        Py_CLEAR(self->factory);
-    }
+    Py_CLEAR(self->factory);
 
     /* iterate over all nodes and deallocate them */
     pysqlite_Node *node = self->first;

--- a/Modules/_sqlite/cache.h
+++ b/Modules/_sqlite/cache.h
@@ -52,10 +52,6 @@ typedef struct
 
     pysqlite_Node* first;
     pysqlite_Node* last;
-
-    /* if set, decrement the factory function when the Cache is deallocated.
-     * this is almost always desirable, but not in the pysqlite context */
-    int decref_factory;
 } pysqlite_Cache;
 
 extern PyTypeObject *pysqlite_NodeType;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -149,14 +149,6 @@ pysqlite_connection_init(pysqlite_Connection *self, PyObject *args,
         return -1;
     }
 
-    /* By default, the Cache class INCREFs the factory in its initializer, and
-     * decrefs it in its deallocator method. Since this would create a circular
-     * reference here, we're breaking it by decrementing self, and telling the
-     * cache class to not decref the factory (self) in its deallocator.
-     */
-    self->statement_cache->decref_factory = 0;
-    Py_DECREF(self);
-
     self->detect_types = detect_types;
     self->timeout = timeout;
     (void)sqlite3_busy_timeout(self->db, (int)(timeout*1000));

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1815,6 +1815,9 @@ static PyObject *
 pysqlite_connection_enter_impl(pysqlite_Connection *self)
 /*[clinic end generated code: output=457b09726d3e9dcd input=127d7a4f17e86d8f]*/
 {
+    if (!pysqlite_check_connection(self)) {
+        return NULL;
+    }
     return Py_NewRef((PyObject *)self);
 }
 


### PR DESCRIPTION
The sqlite3 module now fully implements the GC protocol; there's no
need for this workaround anymore.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42213](https://bugs.python.org/issue42213) -->
https://bugs.python.org/issue42213
<!-- /issue-number -->
