### PR TITLE
bpo-44263: Py_TPFLAGS_HAVE_GC requires tp_traverse

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -144,6 +144,11 @@ New Features
 Porting to Python 3.11
 ----------------------
 
+* The :c:func:`PyType_Ready` function now raises an error if a type is defined
+  with the :const:`Py_TPFLAGS_HAVE_GC` flag set but has no traverse function
+  (:c:member:`PyTypeObject.tp_traverse`).
+  (Contributed by Victor Stinner in :issue:`44263`.)
+
 Deprecated
 ----------
 

--- a/Misc/NEWS.d/next/C API/2021-05-31-11-31-13.bpo-44263.8mIOfV.rst
+++ b/Misc/NEWS.d/next/C API/2021-05-31-11-31-13.bpo-44263.8mIOfV.rst
@@ -1,0 +1,4 @@
+The :c:func:`PyType_Ready` function now raises an error if a type is defined
+with the :const:`Py_TPFLAGS_HAVE_GC` flag set but has no traverse function
+(:c:member:`PyTypeObject.tp_traverse`).
+Patch by Victor Stinner.


### PR DESCRIPTION
The PyType_Ready() function now raises an error if a type is defined
with the Py_TPFLAGS_HAVE_GC flag set but has no traverse function
(PyTypeObject.tp_traverse).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44263](https://bugs.python.org/issue44263) -->
https://bugs.python.org/issue44263
<!-- /issue-number -->
