### PR TITLE
bpo-44048: Fix two hashlib test cases under FIPS mode

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -909,7 +909,11 @@ class HashLibTestCase(unittest.TestCase):
                 continue
             # all other types have DISALLOW_INSTANTIATION
             for constructor in constructors:
-                h = constructor()
+                # In FIPS mode some algorithms are not available raising ValueError
+                try:
+                    h = constructor()
+                except ValueError:
+                    continue
                 with self.subTest(constructor=constructor):
                     support.check_disallow_instantiation(self, type(h))
 
@@ -923,7 +927,11 @@ class HashLibTestCase(unittest.TestCase):
         for algorithm, constructors in self.constructors_to_test.items():
             # all other types have DISALLOW_INSTANTIATION
             for constructor in constructors:
-                hash_type = type(constructor())
+                # In FIPS mode some algorithms are not available raising ValueError
+                try:
+                    hash_type = type(constructor())
+                except ValueError:
+                    continue
                 with self.subTest(hash_type=hash_type):
                     with self.assertRaisesRegex(TypeError, "immutable type"):
                         hash_type.value = False


### PR DESCRIPTION
test_disallow_instantiation and test_readonly_types try to test all the available
digests, however under FIPS mode, while the algorithms are available, trying to use
them will fail with a ValueError.

<!-- issue-number: [bpo-44048](https://bugs.python.org/issue44048) -->
https://bugs.python.org/issue44048
<!-- /issue-number -->
