### PR TITLE
bpo-44273: Improve syntax error message for assigning to "..."

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -93,7 +93,7 @@ SyntaxError: cannot assign to literal here. Maybe you meant '==' instead of '='?
 
 >>> ... = 1
 Traceback (most recent call last):
-SyntaxError: cannot assign to Ellipsis here. Maybe you meant '==' instead of '='?
+SyntaxError: cannot assign to ellipsis here. Maybe you meant '==' instead of '='?
 
 >>> `1` = 1
 Traceback (most recent call last):

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -217,7 +217,7 @@ _PyPegen_get_expr_name(expr_ty e)
                 return "True";
             }
             if (value == Py_Ellipsis) {
-                return "Ellipsis";
+                return "ellipsis";
             }
             return "literal";
         }


### PR DESCRIPTION
Use "ellipsis" instead of "Ellipsis" to eliminate confusion with builtin variable Ellipsis.


<!-- issue-number: [bpo-44273](https://bugs.python.org/issue44273) -->
https://bugs.python.org/issue44273
<!-- /issue-number -->
