### PR TITLE
bpo-44225: Fix bug with asyncio BaseEventLoop.run_forever()

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -589,8 +589,10 @@ class BaseEventLoop(events.AbstractEventLoop):
         old_agen_hooks = sys.get_asyncgen_hooks()
         sys.set_asyncgen_hooks(firstiter=self._asyncgen_firstiter_hook,
                                finalizer=self._asyncgen_finalizer_hook)
+
         try:
             events._set_running_loop(self)
+            self._stopping = False              # set inital value to false [fix bpo-44225]
             while True:
                 self._run_once()
                 if self._stopping:

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -918,6 +918,26 @@ class BaseEventLoopTests(test_utils.TestCase):
         test_utils.run_once(self.loop)
         self.assertEqual(count, 1)
 
+    def test_run_forever_iteration_break(self):
+        # Pre stopping makes it execute without errors but only once 
+        # This test validates if it isn't breaking out before it should 
+        arr = []
+        loop = asyncio.new_event_loop()
+
+        async def coro(x):
+            arr.append(x)
+            if x < 2:
+                asyncio.create_task(coro(x+1))
+            else:
+                loop.stop()
+
+        loop.create_task(coro(0))
+        loop.stop()
+        loop.run_forever()
+        loop.close()
+
+        self.assertEqual(len(arr), 3)
+
     def test_run_forever_pre_stopped(self):
         # Test that the old idiom for pre-stopping the loop works.
         self.loop._process_events = mock.Mock()

--- a/Misc/NEWS.d/next/Library/2021-06-02-10-42-06.bpo-44225.oxc3OT.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-02-10-42-06.bpo-44225.oxc3OT.rst
@@ -1,1 +1,1 @@
-Fix ``asyncio`` bug in ``BaseEventLoop.run_forever()`` which only ran once if the initial value of ``_stopping``  was ``False``
+Fix ``asyncio`` bug in ``BaseEventLoop.run_forever()`` which only ran once if the initial value of ``_stopping``  was ``True``

--- a/Misc/NEWS.d/next/Library/2021-06-02-10-42-06.bpo-44225.oxc3OT.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-02-10-42-06.bpo-44225.oxc3OT.rst
@@ -1,0 +1,1 @@
+Fix bug ``asyncio`` bug in ``BaseEventLoop.run_forever()`` which only ran once if the initial value of ``_stopping``  was ``False``

--- a/Misc/NEWS.d/next/Library/2021-06-02-10-42-06.bpo-44225.oxc3OT.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-02-10-42-06.bpo-44225.oxc3OT.rst
@@ -1,1 +1,1 @@
-Fix bug ``asyncio`` bug in ``BaseEventLoop.run_forever()`` which only ran once if the initial value of ``_stopping``  was ``False``
+Fix ``asyncio`` bug in ``BaseEventLoop.run_forever()`` which only ran once if the initial value of ``_stopping``  was ``False``


### PR DESCRIPTION


<!-- issue-number: [bpo-44225](https://bugs.python.org/issue44225) -->
https://bugs.python.org/issue44225
<!-- /issue-number -->
