### PR TITLE
bpo-44165: pysqlite_statement_create() returns a PyObject *, not an int

### DIFF
--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -70,7 +70,7 @@ pysqlite_statement_create(pysqlite_Connection *connection, PyObject *sql)
     int max_length = sqlite3_limit(connection->db, SQLITE_LIMIT_LENGTH, -1);
     if (sql_cstr_len >= max_length) {
         PyErr_SetString(pysqlite_DataError, "query string is too large");
-        return PYSQLITE_TOO_MUCH_SQL;
+        return NULL;
     }
     if (strlen(sql_cstr) != (size_t)sql_cstr_len) {
         PyErr_SetString(PyExc_ValueError,


### PR DESCRIPTION
GH-26206 was broken by GH-26475. This PR resolves the issue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44165](https://bugs.python.org/issue44165) -->
https://bugs.python.org/issue44165
<!-- /issue-number -->
