### PR TITLE
bpo-44285: Assert that the env_file variable in getpath.c is NULL during an error check

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -1263,6 +1263,7 @@ calculate_read_pyenv(PyCalculatePath *calculate)
 
     status = calculate_open_pyenv(calculate, &env_file);
     if (_PyStatus_EXCEPTION(status)) {
+        assert(env_file == NULL);
         return status;
     }
     if (env_file == NULL) {


### PR DESCRIPTION


<!-- issue-number: [bpo-44285](https://bugs.python.org/issue44285) -->
https://bugs.python.org/issue44285
<!-- /issue-number -->
