### PR TITLE
bpo-44289: Keep argument file object's current position in tarfile.is_tarfile

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2484,7 +2484,9 @@ def is_tarfile(name):
     """
     try:
         if hasattr(name, "read"):
+            pos = name.tell()
             t = open(fileobj=name)
+            name.seek(pos)
         else:
             t = open(name)
         t.close()

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -352,6 +352,18 @@ class CommonReadTest(ReadTest):
         with open(self.tarname, "rb") as fobj:
             self.assertTrue(tarfile.is_tarfile(io.BytesIO(fobj.read())))
 
+    def test_is_tarfile_keeps_position(self):
+        # Test for issue44289: tarfile.is_tarfile() modifies
+        # file object's current position
+        with open(self.tarname, "rb") as fobj:
+            tarfile.is_tarfile(fobj)
+            self.assertEqual(fobj.tell(), 0)
+
+        with open(self.tarname, "rb") as fobj:
+            file_like = io.BytesIO(fobj.read())
+            tarfile.is_tarfile(file_like)
+            self.assertEqual(file_like.tell(), 0)
+
     def test_empty_tarfile(self):
         # Test for issue6123: Allow opening empty archives.
         # This test checks if tarfile.open() is able to open an empty tar

--- a/Misc/NEWS.d/next/Library/2021-06-02-19-47-46.bpo-44289.xC5kuV.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-02-19-47-46.bpo-44289.xC5kuV.rst
@@ -1,0 +1,1 @@
+Keep argument file object's current position in tarfile.is_tarifle method.

--- a/Misc/NEWS.d/next/Library/2021-06-02-19-47-46.bpo-44289.xC5kuV.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-02-19-47-46.bpo-44289.xC5kuV.rst
@@ -1,1 +1,1 @@
-Keep argument file object's current position in tarfile.is_tarifle method.
+Fix an issue with :meth:`~tarfile.is_tarfile` method when using _fileobj_ argument: position in the _fileobj_ was advanced forward which made it unreadable with :meth:`tarfile.TarFile.open`.

--- a/Misc/NEWS.d/next/Library/2021-06-02-19-47-46.bpo-44289.xC5kuV.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-02-19-47-46.bpo-44289.xC5kuV.rst
@@ -1,1 +1,1 @@
-Fix an issue with :meth:`~tarfile.is_tarfile` method when using _fileobj_ argument: position in the _fileobj_ was advanced forward which made it unreadable with :meth:`tarfile.TarFile.open`.
+Fix an issue with :meth:`~tarfile.is_tarfile` method when using *fileobj* argument: position in the *fileobj* was advanced forward which made it unreadable with :meth:`tarfile.TarFile.open`.


### PR DESCRIPTION
Since Python 3.9 tarfile.is_tarfile accepts not only paths but also files and file-like objects #18090.

Verification if a file or file-like object is a tar file modifies file object's current position.

https://bugs.python.org/issue44289

<!-- issue-number: [bpo-44289](https://bugs.python.org/issue44289) -->
https://bugs.python.org/issue44289
<!-- /issue-number -->
