### PR TITLE
bpo-43921: Fix test_ssl.test_pha_required_nocert()

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4460,11 +4460,18 @@ class TestPostHandshakeAuth(unittest.TestCase):
                     '(certificate required|EOF occurred)'
                 ):
                     # receive CertificateRequest
-                    self.assertEqual(s.recv(1024), b'OK\n')
+                    data = s.recv(1024)
+                    if not data:
+                        raise ssl.SSLError(1, "EOF occurred")
+                    self.assertEqual(data, b'OK\n')
+
                     # send empty Certificate + Finish
                     s.write(b'HASCERT')
+
                     # receive alert
-                    s.recv(1024)
+                    data = s.recv(1024)
+                    if not data:
+                        raise ssl.SSLError(1, "EOF occurred")
 
     def test_pha_optional(self):
         if support.verbose:

--- a/Misc/NEWS.d/next/Tests/2021-06-02-17-41-42.bpo-43921.xP7yZ4.rst
+++ b/Misc/NEWS.d/next/Tests/2021-06-02-17-41-42.bpo-43921.xP7yZ4.rst
@@ -1,0 +1,2 @@
+Fix test_pha_required_nocert() of test_ssl: catch two more EOF cases (when
+the ``recv()`` method returns an empty string). Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_pha_required_nocert() of test_ssl: catch two more EOF cases
(when the recv() method returns an empty string).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43921](https://bugs.python.org/issue43921) -->
https://bugs.python.org/issue43921
<!-- /issue-number -->
