### PR TITLE
bpo-44279: revert 'exceptions are raised' back to 'exceptions occur'

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -267,7 +267,7 @@ Functions and classes provided:
 .. function:: suppress(*exceptions)
 
    Return a context manager that suppresses any of the specified exceptions
-   if they are raised in the body of a :keyword:`!with` statement and then
+   if they occur in the body of a :keyword:`!with` statement and then
    resumes execution with the first statement following the end of the
    :keyword:`!with` statement.
 


### PR DESCRIPTION
The previous commit had some makrup changes that are worth keeping, so I'm not reverting the whole change.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44279](https://bugs.python.org/issue44279) -->
https://bugs.python.org/issue44279
<!-- /issue-number -->
