### PR TITLE
[3.10] bpo-44295: ensure deprecation warning from assertDictContainsSubset points at actual test code

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1146,7 +1146,8 @@ class TestCase(object):
     def assertDictContainsSubset(self, subset, dictionary, msg=None):
         """Checks whether dictionary is a superset of subset."""
         warnings.warn('assertDictContainsSubset is deprecated',
-                      DeprecationWarning)
+                      DeprecationWarning,
+                      stacklevel=2)
         missing = []
         mismatched = []
         for key, value in subset.items():

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -706,6 +706,10 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             with self.assertRaises(self.failureException):
                 self.assertDictContainsSubset({'foo': one}, {'foo': '\uFFFD'})
 
+        with self.assertWarns(DeprecationWarning) as warninfo:
+            self.assertDictContainsSubset({}, {})
+        self.assertEqual(warninfo.warnings[0].filename, __file__)
+
     def testAssertEqual(self):
         equal_pairs = [
                 ((), ()),

--- a/Misc/NEWS.d/next/Library/2021-06-02-16-39-42.bpo-44295.erg01m.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-02-16-39-42.bpo-44295.erg01m.rst
@@ -1,0 +1,2 @@
+Ensure deprecation warning from :func:`assertDictContainsSubset` points at
+calling code - by Anthony Sottile.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44295](https://bugs.python.org/issue44295) -->
https://bugs.python.org/issue44295
<!-- /issue-number -->
