### PR TITLE
[3.9] bpo-37741: make importlib.metadata docs discoverable through a module directive. (GH-25415)

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -7,6 +7,8 @@
 .. module:: importlib.metadata
    :synopsis: The implementation of the importlib metadata.
 
+**Source code:** :source:`Lib/importlib/metadata.py`
+
 .. versionadded:: 3.8
 
 .. note::


### PR DESCRIPTION


<!-- issue-number: [bpo-37741](https://bugs.python.org/issue37741) -->
https://bugs.python.org/issue37741
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco