### PR TITLE
bpo-43921: Fix test_ssl.test_wrong_cert_tls13() on Windows

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3190,7 +3190,8 @@ class ThreadedTests(unittest.TestCase):
         )
         with server, \
              client_context.wrap_socket(socket.socket(),
-                                        server_hostname=hostname) as s:
+                                        server_hostname=hostname,
+                                        suppress_ragged_eofs=False) as s:
             # TLS 1.3 perform client cert exchange after handshake
             s.connect((HOST, server.port))
             try:
@@ -3207,13 +3208,7 @@ class ThreadedTests(unittest.TestCase):
                 if support.verbose:
                     sys.stdout.write("\nsocket.error is %r\n" % e)
             else:
-                if sys.platform == "win32":
-                    self.skipTest(
-                        "Ignoring failed test_wrong_cert_tls13 test case. "
-                        "The test is flaky on Windows, see bpo-43921."
-                    )
-                else:
-                    self.fail("Use of invalid cert should have failed!")
+                self.fail("Use of invalid cert should have failed!")
 
     def test_rude_shutdown(self):
         """A brutal shutdown of an SSL server should raise an OSError
@@ -4450,7 +4445,8 @@ class TestPostHandshakeAuth(unittest.TestCase):
         server = ThreadedEchoServer(context=server_context, chatty=True)
         with server:
             with client_context.wrap_socket(socket.socket(),
-                                            server_hostname=hostname) as s:
+                                            server_hostname=hostname,
+                                            suppress_ragged_eofs=False) as s:
                 s.connect((HOST, server.port))
                 s.write(b'PHA')
                 # test sometimes fails with EOF error. Test passes as long as
@@ -4461,17 +4457,13 @@ class TestPostHandshakeAuth(unittest.TestCase):
                 ):
                     # receive CertificateRequest
                     data = s.recv(1024)
-                    if not data:
-                        raise ssl.SSLError(1, "EOF occurred")
                     self.assertEqual(data, b'OK\n')
 
                     # send empty Certificate + Finish
                     s.write(b'HASCERT')
 
                     # receive alert
-                    data = s.recv(1024)
-                    if not data:
-                        raise ssl.SSLError(1, "EOF occurred")
+                    s.recv(1024)
 
     def test_pha_optional(self):
         if support.verbose:

--- a/Misc/NEWS.d/next/Tests/2021-06-03-03-29-34.bpo-43921.nwH1FS.rst
+++ b/Misc/NEWS.d/next/Tests/2021-06-03-03-29-34.bpo-43921.nwH1FS.rst
@@ -1,0 +1,3 @@
+Fix test_ssl.test_wrong_cert_tls13(): use ``suppress_ragged_eofs=False``,
+since ``read()`` can raise :exc:`ssl.SSLEOFError` on Windows. Patch by
+Victor Stinner.


### PR DESCRIPTION
Fix test_ssl.test_wrong_cert_tls13(): use suppress_ragged_eofs=False,
since read() can raise ssl.SSLEOFError on Windows.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43921](https://bugs.python.org/issue43921) -->
https://bugs.python.org/issue43921
<!-- /issue-number -->
