### PR TITLE
bpo-44299: Enable control over daemon flag in ThreadPoolExecutor and ProcessPoolExecutor

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -579,7 +579,7 @@ class BrokenProcessPool(_base.BrokenExecutor):
 
 class ProcessPoolExecutor(_base.Executor):
     def __init__(self, max_workers=None, mp_context=None,
-                 initializer=None, initargs=()):
+                 initializer=None, initargs=(), daemon=None):
         """Initializes a new ProcessPoolExecutor instance.
 
         Args:
@@ -658,6 +658,7 @@ class ProcessPoolExecutor(_base.Executor):
         self._call_queue._ignore_epipe = True
         self._result_queue = mp_context.SimpleQueue()
         self._work_ids = queue.Queue()
+        self._daemon = daemon
 
     def _start_executor_manager_thread(self):
         if self._executor_manager_thread is None:
@@ -679,7 +680,8 @@ class ProcessPoolExecutor(_base.Executor):
                 args=(self._call_queue,
                       self._result_queue,
                       self._initializer,
-                      self._initargs))
+                      self._initargs),
+                daemon=self._daemon)
             p.start()
             self._processes[p.pid] = p
 

--- a/Misc/NEWS.d/next/Library/2021-06-03-11-17-29.bpo-44299.-9X6eV.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-03-11-17-29.bpo-44299.-9X6eV.rst
@@ -1,0 +1,1 @@
+Enable control over daemon flag in ThreadPoolExecutor and ProcessPoolExecutor


### PR DESCRIPTION
ThreadPoolExecutor and ProcessPoolExecutor spawn threads and processes with default value of daemon flag, i.e. None.

In some cases it would handful to have control over daemon flag of spawned threads and processes.
Simple 6-line fix to enable it.

<!-- issue-number: [bpo-44299](https://bugs.python.org/issue44299) -->
https://bugs.python.org/issue44299
<!-- /issue-number -->
