### PR TITLE
Don't duplicate typedef in code.h as is a C11 feature

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -56,7 +56,7 @@ struct PyCodeObject {
     int co_stacksize;           /* #entries needed for evaluation stack */
     int co_firstlineno;         /* first source line number */
     PyObject *co_localsplusnames;  /* tuple mapping offsets to names */
-    unsigned char* co_localspluskinds; /* array mapping to local kinds */
+    unsigned char *co_localspluskinds; /* array mapping to local kinds */
     PyObject *co_filename;      /* unicode (where it was loaded from) */
     PyObject *co_name;          /* unicode (name, for reference) */
     PyObject *co_linetable;     /* string (encoding addr<->lineno mapping) See
@@ -217,5 +217,4 @@ void PyLineTable_InitAddressRange(char *linetable, Py_ssize_t length, int firstl
 /** API for traversing the line number table. */
 int PyLineTable_NextAddressRange(PyCodeAddressRange *range);
 int PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
-
 

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -16,11 +16,6 @@ typedef uint16_t _Py_CODEUNIT;
 
 typedef struct _PyOpcache _PyOpcache;
 
-
-// These are duplicated from pycore_code.h.
-typedef unsigned char _PyLocalsPlusKind;
-typedef _PyLocalsPlusKind *_PyLocalsPlusKinds;
-
 /* Bytecode object */
 struct PyCodeObject {
     PyObject_HEAD
@@ -61,7 +56,7 @@ struct PyCodeObject {
     int co_stacksize;           /* #entries needed for evaluation stack */
     int co_firstlineno;         /* first source line number */
     PyObject *co_localsplusnames;  /* tuple mapping offsets to names */
-    _PyLocalsPlusKinds co_localspluskinds; /* array mapping to local kinds */
+    unsigned char* co_localspluskinds; /* array mapping to local kinds */
     PyObject *co_filename;      /* unicode (where it was loaded from) */
     PyObject *co_name;          /* unicode (name, for reference) */
     PyObject *co_linetable;     /* string (encoding addr<->lineno mapping) See


### PR DESCRIPTION
```
./Include/cpython/code.h:21:23: note: previous definition is here
typedef unsigned char _PyLocalsPlusKind;
                      ^
In file included from Python/marshal.c:16:
./Include/internal/pycore_code.h:54:28: warning: redefinition of typedef '_PyLocalsPlusKinds' is a C11 feature [-Wtypedef-redefinition]
typedef _PyLocalsPlusKind *_PyLocalsPlusKinds;
                           ^
./Include/cpython/code.h:22:28: note: previous definition is here
typedef _PyLocalsPlusKind *_PyLocalsPlusKinds;
                           ^
```