### PR TITLE
bpo-44309: Add support for yescrypt in crypt.

### DIFF
--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -43,7 +43,8 @@ are available on all platforms):
 .. data:: METHOD_SHA512
 
    A Modular Crypt Format method with 16 character salt and 86 character
-   hash based on the SHA-512 hash function.  This is the strongest method.
+   hash based on the SHA-512 hash function.  This is the strongest method
+   supported on all UNIX-based operating systems.
 
 .. data:: METHOD_SHA256
 
@@ -66,6 +67,14 @@ are available on all platforms):
 
    The traditional method with a 2 character salt and 13 characters of
    hash.  This is the weakest method.
+
+   .. versionadded:: 3.10
+
+.. data:: METHOD_YESCRYPT
+
+   Another Modular Crypt Format method with 24 character salt and 43
+   character hash based on the yescrypt hash function.  This is the
+   strongest method supported on Linux distributions using libxcrypt.
 
 
 Module Attributes

--- a/Lib/crypt.py
+++ b/Lib/crypt.py
@@ -51,12 +51,7 @@ def mksalt(method=None, *, rounds=None):
                 raise ValueError('rounds out of the range 1 to 11')
         else:
             rounds = 5
-        if rounds < 3:
-            s += 'j' + chr(54 + rounds) + '5$'
-        elif rounds < 6:
-            s += 'j' + chr(52 + rounds) + 'T$'
-        elif rounds < 12:
-            s += 'j' + chr(59 + rounds) + 'T$'
+        s += 'j' + ('75', '85', '7T', '8T', '9T', 'AT', 'BT', 'CT', 'DT', 'ET', 'FT')[rounds - 1] + '$'
     elif method.ident and method.ident[0] == '2':  # Blowfish variants
         if rounds is None:
             log_rounds = 12

--- a/Lib/crypt.py
+++ b/Lib/crypt.py
@@ -45,7 +45,19 @@ def mksalt(method=None, *, rounds=None):
     else:  # modular
         s = f'${method.ident}$'
 
-    if method.ident and method.ident[0] == '2':  # Blowfish variants
+    if method.ident and method.ident == 'y':  # yescrypt
+        if rounds is not None:
+            if not 1 <= rounds <= 11:
+                raise ValueError('rounds out of the range 1 to 11')
+        else:
+            rounds = 5
+        if rounds < 3:
+            s += 'j' + chr(54 + rounds) + '5$'
+        elif rounds < 6:
+            s += 'j' + chr(52 + rounds) + 'T$'
+        elif rounds < 12:
+            s += 'j' + chr(59 + rounds) + 'T$'
+    elif method.ident and method.ident[0] == '2':  # Blowfish variants
         if rounds is None:
             log_rounds = 12
         else:
@@ -102,6 +114,10 @@ def _add_method(name, *args, rounds=None):
         return True
     return False
 
+# Supported by libxcrypt.  Strongest hashing method currently supported.
+_add_method('YESCRYPT', 'y', 24, 75, rounds=1)
+
+# SHA-2 based methods.
 _add_method('SHA512', '6', 16, 106)
 _add_method('SHA256', '5', 16, 63)
 

--- a/Lib/test/test_crypt.py
+++ b/Lib/test/test_crypt.py
@@ -93,12 +93,7 @@ class CryptTestCase(unittest.TestCase):
     )
     def test_yescrypt_rounds(self):
         for rounds in range(1, 11):
-            if rounds < 3:
-                enc_rounds = 'j' + chr(54 + rounds) + '5'
-            elif rounds < 6:
-                enc_rounds = 'j' + chr(52 + rounds) + 'T'
-            elif rounds < 12:
-                enc_rounds = 'j' + chr(59 + rounds) + 'T'
+            enc_rounds = 'j' + ('75', '85', '7T', '8T', '9T', 'AT', 'BT', 'CT', 'DT', 'ET', 'FT')[rounds - 1]
             salt = crypt.mksalt(crypt.METHOD_YESCRYPT, rounds=rounds)
             self.assertIn('$%s$' % enc_rounds, salt)
             self.assertEqual(len(salt) - crypt.METHOD_YESCRYPT.salt_chars, 7)

--- a/Misc/NEWS.d/next/Library/2021-06-04-11-19-28.bpo-44309.PBcd1f.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-04-11-19-28.bpo-44309.PBcd1f.rst
@@ -1,0 +1,1 @@
+Add support for the yescrypt hashing method in the crypt module.


### PR DESCRIPTION
Proposed PR adds support for a new method in the crypt module:

yescrypt. It is considered stronger as SHA512 or blowfish and as strong as argon2 for crypt() purpose.  The hashing method was developed by the author of the blowfish crypt method, and was based on scrypt.  It is supported on most Linux distributions, that ship with libxcrypt as a replacement for the glibc crypt library: Fedora, Debian, Ubuntu, OpenSUSE and many others.

<!-- issue-number: [bpo-44309](https://bugs.python.org/issue44309) -->
https://bugs.python.org/issue44309
<!-- /issue-number -->
