### PR TITLE
bpo-44310: added docs to functools to warn for memory leaks

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -144,10 +144,11 @@ The :mod:`functools` module defines the following functions:
    functions with side-effects, functions that need to create distinct mutable
    objects on each call, or impure functions such as time() or random().
 
-   Keep in mind that the LRU cache locks all method arguments in memory and
-   prevents them from being garabage collected, including *self*.
-   This may cause memory leaks.
-
+   The LRU cache takes string references to the arguments provided in the decorated callable
+   as well as the return value. Notice that this means that if a class method is decorated, the cache
+   will keep strong references to all arguments provided, including the instance itself (provided as  the
+   argument of the method, normally called ``self``). This has the consequence that calling the cached
+   method will keep the instances alive until they are discarded by the cache or manually removed.
    Example of an LRU cache for static web content::
 
         @lru_cache(maxsize=32)

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -144,6 +144,10 @@ The :mod:`functools` module defines the following functions:
    functions with side-effects, functions that need to create distinct mutable
    objects on each call, or impure functions such as time() or random().
 
+   Keep in mind that the LRU cache locks all method arguments in memory and
+   prevents them from being garabage collected, including *self*.
+   This may cause memory leaks.
+
    Example of an LRU cache for static web content::
 
         @lru_cache(maxsize=32)


### PR DESCRIPTION
I implemented the easier fix for https://bugs.python.org/issue44310: documenting the unexpected behavior.

To actually change the behavior look a bit too tricky.  [WeakKeyDictionary](https://docs.python.org/3/library/weakref.html#weakref.WeakKeyDictionary) does what is needed, but it doesn't update the LRU linked list, and offers no hook to do so. I could make an attempt to make the change, but I'm not sufficiently familiar with the python codebase to do it without confirmation that I can. 

<!-- issue-number: [bpo-44310](https://bugs.python.org/issue44310) -->
https://bugs.python.org/issue44310
<!-- /issue-number -->
