### PR TITLE
bpo-44315: Remove unused connection argument from pysqlite_step()

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -432,7 +432,7 @@ pysqlite_connection_commit_impl(pysqlite_Connection *self)
             goto error;
         }
 
-        rc = pysqlite_step(statement, self);
+        rc = pysqlite_step(statement);
         if (rc != SQLITE_DONE) {
             _pysqlite_seterror(self->db);
         }
@@ -482,7 +482,7 @@ pysqlite_connection_rollback_impl(pysqlite_Connection *self)
             goto error;
         }
 
-        rc = pysqlite_step(statement, self);
+        rc = pysqlite_step(statement);
         if (rc != SQLITE_DONE) {
             _pysqlite_seterror(self->db);
         }

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -568,7 +568,7 @@ _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject* operation
             goto error;
         }
 
-        rc = pysqlite_step(self->statement->st, self->connection);
+        rc = pysqlite_step(self->statement->st);
         if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
             if (PyErr_Occurred()) {
                 /* there was an error that occurred in a user-defined callback */
@@ -773,7 +773,7 @@ pysqlite_cursor_executescript(pysqlite_Cursor *self, PyObject *script_obj)
 
         /* execute statement, and ignore results of SELECT statements */
         do {
-            rc = pysqlite_step(statement, self->connection);
+            rc = pysqlite_step(statement);
             if (PyErr_Occurred()) {
                 (void)sqlite3_finalize(statement);
                 goto error;
@@ -847,7 +847,7 @@ pysqlite_cursor_iternext(pysqlite_Cursor *self)
     }
 
     if (self->statement) {
-        rc = pysqlite_step(self->statement->st, self->connection);
+        rc = pysqlite_step(self->statement->st);
         if (PyErr_Occurred()) {
             (void)pysqlite_statement_reset(self->statement);
             Py_DECREF(next_row);

--- a/Modules/_sqlite/util.c
+++ b/Modules/_sqlite/util.c
@@ -24,7 +24,8 @@
 #include "module.h"
 #include "connection.h"
 
-int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection)
+int
+pysqlite_step(sqlite3_stmt *statement)
 {
     int rc;
 

--- a/Modules/_sqlite/util.h
+++ b/Modules/_sqlite/util.h
@@ -29,7 +29,7 @@
 #include "sqlite3.h"
 #include "connection.h"
 
-int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection);
+int pysqlite_step(sqlite3_stmt *statement);
 
 /**
  * Checks the SQLite error code and sets the appropriate DB-API exception.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44315](https://bugs.python.org/issue44315) -->
https://bugs.python.org/issue44315
<!-- /issue-number -->
