### PR TITLE
bpo-38323, asyncio: Fix MultiLoopChildWatcher race condition

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-06-04-23-07-25.bpo-38323.dL7knT.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-04-23-07-25.bpo-38323.dL7knT.rst
@@ -1,0 +1,6 @@
+Fix a race condition in asyncio MultiLoopChildWatcher: call the loop
+add_signal_handler() rather than calling directly signal.signal(), so
+signal.set_wakeup_fd() is used to wake up the event loop when the SIGCHLD
+signal is received. Previously, the event loop could block forever if the
+signal was received while the loop was idle. The signal was only proceed
+when another event woke up the event loop. Patch by Victor Stinner.


### PR DESCRIPTION
Fix a race condition in asyncio MultiLoopChildWatcher: call the loop
add_signal_handler() rather than calling directly signal.signal(), so
signal.set_wakeup_fd() is used to wake up the event loop when the
SIGCHLD signal is received. Previously, the event loop could block
forever if the signal was received while the loop was idle. The
signal was only proceed when another event woke up the event loop.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-38323](https://bugs.python.org/issue38323) -->
https://bugs.python.org/issue38323
<!-- /issue-number -->
