### PR TITLE
bpo-44304: Fix crash in the sqlite3 module when the GC clears Statement objects

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-05-02-34-57.bpo-44304._MAoPc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-05-02-34-57.bpo-44304._MAoPc.rst
@@ -1,0 +1,2 @@
+Fix a crash in the :mod:`sqlite3` module that happened when the garbage
+collector clears :class:`sqlite.Statement` objects. Patch by Pablo Galindo

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -403,6 +403,10 @@ stmt_dealloc(pysqlite_Statement *self)
     if (self->in_weakreflist != NULL) {
         PyObject_ClearWeakRefs((PyObject*)self);
     }
+    if (self->st) {
+        sqlite3_finalize(self->st);
+        self->st = 0;
+    }
     tp->tp_clear((PyObject *)self);
     tp->tp_free(self);
     Py_DECREF(tp);
@@ -411,13 +415,6 @@ stmt_dealloc(pysqlite_Statement *self)
 static int
 stmt_clear(pysqlite_Statement *self)
 {
-    if (self->st) {
-        Py_BEGIN_ALLOW_THREADS
-        sqlite3_finalize(self->st);
-        Py_END_ALLOW_THREADS
-        self->st = 0;
-    }
-
     Py_CLEAR(self->sql);
     return 0;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44304](https://bugs.python.org/issue44304) -->
https://bugs.python.org/issue44304
<!-- /issue-number -->
