### PR TITLE
bpo-11105: use a lower recursion limit for infinite recursion tests

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1999,3 +1999,12 @@ def check_disallow_instantiation(testcase, tp, *args, **kwds):
         qualname = f"{name}"
     msg = f"cannot create '{re.escape(qualname)}' instances"
     testcase.assertRaisesRegex(TypeError, msg, tp, *args, **kwds)
+
+@contextlib.contextmanager
+def infinite_recursion(max_depth=75):
+    original_depth = sys.getrecursionlimit()
+    try:
+        sys.setrecursionlimit(max_depth)
+        yield
+    finally:
+        sys.setrecursionlimit(original_depth)

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1102,7 +1102,8 @@ Module(
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
         e.operand = e
         with self.assertRaises(RecursionError):
-            compile(ast.Expression(e), "<test>", "eval")
+            with support.infinite_recursion():
+                compile(ast.Expression(e), "<test>", "eval")
 
     def test_recursion_indirect(self):
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
@@ -1110,7 +1111,8 @@ Module(
         e.operand = f
         f.operand = e
         with self.assertRaises(RecursionError):
-            compile(ast.Expression(e), "<test>", "eval")
+            with support.infinite_recursion():
+                compile(ast.Expression(e), "<test>", "eval")
 
 
 class ASTValidatorTests(unittest.TestCase):


### PR DESCRIPTION


<!-- issue-number: [bpo-11105](https://bugs.python.org/issue11105) -->
https://bugs.python.org/issue11105
<!-- /issue-number -->
