### PR TITLE
bpo-44304: Ensure the sqlite3 destructor callback is always called with the GIL held

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -825,7 +825,12 @@ static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self)
 
 static void _destructor(void* args)
 {
+    // This function may be called without the GIL held, so we need to ensure
+    // that we destroy 'args' with the GIL
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
     Py_DECREF((PyObject*)args);
+    PyGILState_Release(gstate);
 }
 
 /*[clinic input]

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -404,7 +404,9 @@ stmt_dealloc(pysqlite_Statement *self)
         PyObject_ClearWeakRefs((PyObject*)self);
     }
     if (self->st) {
+        Py_BEGIN_ALLOW_THREADS
         sqlite3_finalize(self->st);
+        Py_END_ALLOW_THREADS
         self->st = 0;
     }
     tp->tp_clear((PyObject *)self);


### PR DESCRIPTION


<!-- issue-number: [bpo-44304](https://bugs.python.org/issue44304) -->
https://bugs.python.org/issue44304
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal