### PR TITLE
bpo-44186: prevent TimedRotatingFileHandler overwriting log files

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -382,7 +382,8 @@ timed intervals.
    The system will save old log files by appending extensions to the filename.
    The extensions are date-and-time based, using the strftime format
    ``%Y-%m-%d_%H-%M-%S`` or a leading portion thereof, depending on the
-   rollover interval.
+   rollover interval. In the case that an existing file has the same name,
+   a numbered suffix will be added to the new file to prevent overwriting logs.
 
    When computing the next rollover time for the first time (when the handler
    is created), the last modification time of an existing log file, or else

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -255,7 +255,7 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
             raise ValueError("Invalid rollover interval specified: %s" % self.when)
 
         self.extMatch = re.compile(self.extMatch, re.ASCII)
-        self.file_number = re.compile(r'(\()([0-9])(\))$')
+        self.file_number = re.compile(r'\(([0-9]+)\)$')
         self.interval = self.interval * interval # multiply by units requested
         # The following line added because the filename passed in could be a
         # path object (see Issue #27493), but self.baseFilename will be a string
@@ -404,7 +404,7 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
                                      time.strftime(self.suffix, timeTuple))
         while os.path.exists(dfn):
             if match := re.search(self.file_number, dfn):
-                name = re.sub(self.file_number, f'({int(match.groups()[1]) + 1})', dfn)
+                name = re.sub(self.file_number, f'({int(match.groups()[0]) + 1})', dfn)
                 dfn = self.rotation_filename(name)
             else:
                 dfn = self.rotation_filename(self.baseFilename + '.' + time.strftime(self.suffix, timeTuple) + ' (2)')

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5334,30 +5334,25 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
     def test_overwrite_rollover(self):
         # bpo-44186 test that pre-existing files aren't overwritten by rollover
         now = datetime.datetime.now()
-        handlers = [
-            logging.handlers.TimedRotatingFileHandler(
-                self.fn, 'midnight', atTime=now, encoding='utf-8', backupCount=1),
-            logging.handlers.TimedRotatingFileHandler(
-                self.fn, 'midnight', atTime=now, encoding='utf-8', backupCount=1),
-            logging.handlers.TimedRotatingFileHandler(
-                self.fn, 'midnight', atTime=now, encoding='utf-8', backupCount=1),
-        ]
+        handler = logging.handlers.TimedRotatingFileHandler(
+                self.fn, 'midnight', atTime=now, encoding='utf-8', backupCount=1)
 
         # compute the filename
-        t = handlers[0].rolloverAt - handlers[0].interval
+        t = handler.rolloverAt - handler.interval
         timeTuple = time.gmtime(t)
-        fn = handlers[0].rotation_filename(
-            handlers[0].baseFilename + '.' + time.strftime(handlers[0].suffix, timeTuple))
+        fn = handler.rotation_filename(
+            handler.baseFilename + '.' + time.strftime(handler.suffix, timeTuple))
+
+        # touch a file with the intended filename
+        pathlib.Path(fn).touch()
+        self.rmfiles.append(fn)
 
         r = logging.makeLogRecord({'msg': 'test msg'})
 
-        for handler in handlers:
-            handler.emit(r)
-            handler.close()
+        handler.emit(r)
+        handler.close()
 
-        self.assertLogFile(fn)
         self.assertLogFile(fn + ' (2)')
-        self.assertLogFile(fn + ' (3)')
 
     def test_lowest_filename_generated(self):
         # test that when the filename is generated, the lowest possible suffix is used

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5335,11 +5335,11 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
         # bpo-44186 test that pre-existing files aren't overwritten by rollover
         now = datetime.datetime.now()
         handlers = [
-            logging.handlers.TimedRotatingFileHandler(  
+            logging.handlers.TimedRotatingFileHandler(
                 self.fn, 'midnight', atTime=now, encoding='utf-8', backupCount=1),
-            logging.handlers.TimedRotatingFileHandler(  
+            logging.handlers.TimedRotatingFileHandler(
                 self.fn, 'midnight', atTime=now, encoding='utf-8', backupCount=1),
-            logging.handlers.TimedRotatingFileHandler(  
+            logging.handlers.TimedRotatingFileHandler(
                 self.fn, 'midnight', atTime=now, encoding='utf-8', backupCount=1),
         ]
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1017,6 +1017,7 @@ John J. Lee
 Thomas Lee
 Robert Leenders
 Cooper Ry Lees
+Harry Lees
 Yaron de Leeuw
 Tennessee Leeuwenburg
 Luc Lefebvre


### PR DESCRIPTION
When TimedRotatingFileHandler rotates, it deletes any files with the target name, this is especially noticeable if the rollover time is midnight as it will potentially overwrite an entire days logs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44186](https://bugs.python.org/issue44186) -->
https://bugs.python.org/issue44186
<!-- /issue-number -->
