### PR TITLE
bpo-44320: Fix markup for W3C C14N test suite

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -955,7 +955,7 @@ W3C C14N test suite
 The C14N 2.0 test suite in the :mod:`test` package
 (``Lib/test/xmltestdata/c14n-20/``) was retrieved from the W3C website at
 https://www.w3.org/TR/xml-c14n2-testcases/ and is distributed under the
-3-clause BSD license:
+3-clause BSD license::
 
    Copyright (c) 2013 W3C(R) (MIT, ERCIM, Keio, Beihang),
    All Rights Reserved.


### PR DESCRIPTION
Fixed the rendering result to be as expected.

https://bugs.python.org/issue44320

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:
                       
```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44320](https://bugs.python.org/issue44320) -->
https://bugs.python.org/issue44320
<!-- /issue-number -->
