### PR TITLE
bpo-44321: Added `os.EX_OK` for Windows

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3656,7 +3656,8 @@ written in Python, such as a mail server's external command delivery program.
 
 .. data:: EX_OK
 
-   Exit code that means no error occurred.
+   Exit code that means no error occurred. May be taken from the defined value of
+   `EXIT_SUCCESS` on some platforms. Generally has a value of zero.
 
    .. availability:: Unix, Windows.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3658,7 +3658,7 @@ written in Python, such as a mail server's external command delivery program.
 
    Exit code that means no error occurred.
 
-   .. availability:: Unix.
+   .. availability:: Unix, Windows.
 
 
 .. data:: EX_USAGE

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3657,7 +3657,7 @@ written in Python, such as a mail server's external command delivery program.
 .. data:: EX_OK
 
    Exit code that means no error occurred. May be taken from the defined value of
-   `EXIT_SUCCESS` on some platforms. Generally has a value of zero.
+   ``EXIT_SUCCESS`` on some platforms. Generally has a value of zero.
 
    .. availability:: Unix, Windows.
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -21,6 +21,9 @@
       FSCTL_GET_REPARSE_POINT is not exported with WIN32_LEAN_AND_MEAN. */
 #  include <windows.h>
 #  include <pathcch.h>
+#endif
+
+#if !defined(EX_OK) && defined(EXIT_SUCCESS)
 #define EX_OK EXIT_SUCCESS
 #endif
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -21,6 +21,7 @@
       FSCTL_GET_REPARSE_POINT is not exported with WIN32_LEAN_AND_MEAN. */
 #  include <windows.h>
 #  include <pathcch.h>
+#define EX_OK EXIT_SUCCESS
 #endif
 
 #ifdef __VXWORKS__


### PR DESCRIPTION
> [Modules/posixmodule.c] Added `os.EX_OK` for Windows; [Doc/library/os.rst] Reflect Windows `os.EX_OK` support in doc

`EXIT_SUCCESS` is defined in `stdlib.h`, as per https://docs.microsoft.com/en-us/cpp/c-runtime-library/exit-success-exit-failure (following the standard https://pubs.opengroup.org/onlinepubs/009695399/basedefs/stdlib.h.html)

> Since Python 2.3 alpha 2 [19-Feb-2003] `EX_OK` has existed… but only for Unix. This adds support for Windows.

There are also https://docs.microsoft.com/en-us/cpp/c-runtime-library/errno-constants which has many equivalents to the `<sysexits.h>` (in `<errno.h>`).

Kinda related: https://bugs.python.org/issue24053

<!-- issue-number: [bpo-44321](https://bugs.python.org/issue44321) -->
https://bugs.python.org/issue44321
<!-- /issue-number -->
