### PR TITLE
IDLE: make the config dialog vertically resizable

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -15,7 +15,8 @@ from tkinter import (Toplevel, Listbox, Scale, Canvas, TclError,
                      StringVar, BooleanVar, IntVar, TRUE, FALSE,
                      TOP, BOTTOM, RIGHT, LEFT, SOLID, GROOVE,
                      NONE, BOTH, X, Y, W, E, EW, NS, NSEW, NW,
-                     HORIZONTAL, VERTICAL, ANCHOR, ACTIVE, END)
+                     HORIZONTAL, VERTICAL, ANCHOR, ACTIVE, END,
+                     DISABLED, Text)
 from tkinter.ttk import (Frame, LabelFrame, Button, Checkbutton, Entry, Label,
                          OptionMenu, Notebook, Radiobutton, Scrollbar, Style)
 from tkinter import colorchooser
@@ -111,7 +112,7 @@ class ConfigDialog(Toplevel):
             activate_config_changes: Tell editors to reload.
         """
         self.frame = frame = Frame(self, padding="5px")
-        self.frame.grid(sticky="nwes")
+        self.frame.grid(sticky=NSEW)
 
         vscrollables = []
 
@@ -881,18 +882,18 @@ class HighPage(Frame):
                 StringVar(self), self.var_changed_highlight_target)
 
         # Create widgets:
+        self.scrollable_frame = VerticalScrolledFrame(self)
+
         # body frame and section frames.
-        frame_custom = LabelFrame(self, borderwidth=2, relief=GROOVE,
+        frame_custom = LabelFrame(self.scrollable_frame.interior,
+                                  borderwidth=2, relief=GROOVE,
                                   text=' Custom Highlighting ')
-        frame_theme = LabelFrame(self, borderwidth=2, relief=GROOVE,
+        frame_theme = LabelFrame(self.scrollable_frame.interior,
+                                 borderwidth=2, relief=GROOVE,
                                  text=' Highlighting Theme ')
         # frame_custom.
-        sample_frame = ScrollableTextFrame(
-                frame_custom, relief=SOLID, borderwidth=1)
-        text = self.highlight_sample = sample_frame.text
-        text.configure(
-                font=('courier', 12, ''), cursor='hand2', width=1, height=1,
-                takefocus=FALSE, highlightthickness=0, wrap=NONE)
+        text = self.highlight_sample = Text(frame_custom,
+                                            relief=SOLID, borderwidth=1)
         # Prevent perhaps invisible selection of word or slice.
         text.bind('<Double-Button-1>', lambda e: 'break')
         text.bind('<B1-Motion>', lambda e: 'break')
@@ -927,7 +928,11 @@ class HighPage(Frame):
                 self.highlight_target.set(elem)
             text.tag_bind(
                     self.theme_elements[element][0], '<ButtonPress-1>', tem)
-        text['state'] = 'disabled'
+        text.configure(
+                font=('courier', 12, ''), cursor='hand2',
+                width=1, height=n_lines,
+                takefocus=FALSE, highlightthickness=0, wrap=NONE,
+                state=DISABLED)
         self.style.configure('frame_color_set.TFrame', borderwidth=1,
                              relief='solid')
         self.frame_color_set = Frame(frame_custom, style='frame_color_set.TFrame')
@@ -964,15 +969,16 @@ class HighPage(Frame):
                 frame_theme, text='Delete Custom Theme',
                 command=self.delete_custom)
         self.theme_message = Label(frame_theme, borderwidth=2)
+
         # Pack widgets:
         # body.
+        self.scrollable_frame.pack(side=LEFT, expand=TRUE, fill=BOTH)
         frame_custom.pack(side=LEFT, padx=5, pady=5, expand=TRUE, fill=BOTH)
         frame_theme.pack(side=TOP, padx=5, pady=5, fill=X)
         # frame_custom.
         self.frame_color_set.pack(side=TOP, padx=5, pady=5, fill=X)
         frame_fg_bg_toggle.pack(side=TOP, padx=5, pady=0)
-        sample_frame.pack(
-                side=TOP, padx=5, pady=5, expand=TRUE, fill=BOTH)
+        text.pack(side=TOP, padx=5, pady=5, expand=TRUE, fill=BOTH)
         self.button_set_color.pack(side=TOP, expand=TRUE, fill=X, padx=8, pady=4)
         self.targetlist.pack(side=TOP, expand=TRUE, fill=X, padx=8, pady=3)
         self.fg_on.pack(side=LEFT, anchor=E)

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -77,7 +77,7 @@ class ConfigDialog(Toplevel):
         # The first value of the tuple is the sample area tag name.
         # The second value is the display name list sort index.
         self.create_widgets()
-        self.resizable(height=FALSE, width=FALSE)
+        self.resizable(height=TRUE, width=FALSE)
         self.transient(parent)
         self.protocol("WM_DELETE_WINDOW", self.cancel)
         self.fontpage.fontlist.focus_set()
@@ -112,7 +112,7 @@ class ConfigDialog(Toplevel):
             activate_config_changes: Tell editors to reload.
         """
         self.frame = frame = Frame(self, padding="5px")
-        self.frame.grid(sticky=NSEW)
+        self.frame.pack(side=TOP, expand=TRUE, fill=BOTH)
 
         vscrollables = []
 
@@ -136,7 +136,9 @@ class ConfigDialog(Toplevel):
         note.add(self.extpage, text='Extensions')
         note.enable_traversal()
         note.pack(side=TOP, expand=TRUE, fill=BOTH)
-        self.create_action_buttons().pack(side=BOTTOM)
+        buttons_frame = self.create_action_buttons()
+        buttons_frame.pack(side=BOTTOM, before=note)
+        self.wm_minsize(1, buttons_frame.winfo_reqheight() + 200)
 
         self.bind_all('<MouseWheel>', self.mousewheel_event)
         self.bind_all('<Button-4>', self.mousewheel_event)

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -1490,11 +1490,13 @@ class KeysPage(Frame):
 
         # Create widgets:
         # body and section frames.
-        frame_custom = LabelFrame(
-                self, borderwidth=2, relief=GROOVE,
-                text=' Custom Key Bindings ')
-        frame_key_sets = LabelFrame(
-                self, borderwidth=2, relief=GROOVE, text=' Key Set ')
+        self.scrollable_frame = VerticalScrolledFrame(self)
+        frame_custom = LabelFrame(self.scrollable_frame.interior,
+                                  borderwidth=2, relief=GROOVE,
+                                  text=' Custom Key Bindings ')
+        frame_key_sets = LabelFrame(self.scrollable_frame.interior,
+                                    borderwidth=2, relief=GROOVE,
+                                    text=' Key Set ')
         # frame_custom.
         frame_target = Frame(frame_custom)
         target_title = Label(frame_target, text='Action - Key(s)')
@@ -1502,6 +1504,7 @@ class KeysPage(Frame):
         scroll_target_x = Scrollbar(frame_target, orient=HORIZONTAL)
         self.bindingslist = Listbox(
                 frame_target, takefocus=FALSE, exportselection=FALSE)
+        vscrollables.extend([self.bindingslist, scroll_target_y])
         self.bindingslist.bind('<ButtonRelease-1>',
                                self.on_bindingslist_select)
         scroll_target_y['command'] = self.bindingslist.yview
@@ -1534,6 +1537,7 @@ class KeysPage(Frame):
 
         # Pack widgets:
         # body.
+        self.scrollable_frame.pack(side=LEFT, expand=TRUE, fill=BOTH)
         frame_custom.pack(side=BOTTOM, padx=5, pady=5, expand=TRUE, fill=BOTH)
         frame_key_sets.pack(side=BOTTOM, padx=5, pady=5, fill=BOTH)
         # frame_custom.

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -448,7 +448,11 @@ class ConfigDialog(Toplevel):
         if self._vscrollables_re.match(event.widget._w):
             return
         page = self._nametowidget(self.note.select())
-        if is_child_widget(event.widget, page.scrollable_frame.canvas):
+        scrollable_frame = getattr(page, 'scrollable_frame', None)
+        if (
+                scrollable_frame is not None and
+                is_child_widget(event.widget, page.scrollable_frame.canvas)
+        ):
             page.scrollable_frame.mousewheel_event(event)
             return "break"
 

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -2420,8 +2420,7 @@ class VerticalScrolledFrame(Frame):
         def _configure_interior(event):
             try:
                 # Update the scrollbars to match the size of the inner frame.
-                size = (interior.winfo_reqwidth(), interior.winfo_reqheight())
-                canvas.config(scrollregion="0 0 %s %s" % size)
+                canvas.config(scrollregion=canvas.bbox("all"))
             except TclError:
                 pass
         interior.bind('<Configure>', _configure_interior)

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -204,7 +204,7 @@ class Event:
     following attributes (in braces are the event types for which
     the attribute is valid):
 
-        serial - serial number of event
+    serial - serial number of event
     num - mouse button pressed (ButtonPress, ButtonRelease)
     focus - whether the window has the focus (Enter, Leave)
     height - height of the exposed window (Configure, Expose)


### PR DESCRIPTION
This is achieved by making all of the tab panes vertically scrollable (except for the extensions tab).

Relevant issues:
* [bpo-40468](https://bugs.python.org/issue40468)
* [bpo-37768](https://bugs.python.org/issue37768), because it would require adding another config option, which is currently problematic