### PR TITLE
bpo-41299: fix 16ms jitter in Windows threading timeouts

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-06-06-16-36-13.bpo-41299.Rg-vb_.rst
+++ b/Misc/NEWS.d/next/Windows/2021-06-06-16-36-13.bpo-41299.Rg-vb_.rst
@@ -1,0 +1,1 @@
+Fix 16ms jitter when using timeouts in :mod:`threading`, such as with :meth:`threading.Lock.acquire` or :meth:`threading.Condition.wait`.


### PR DESCRIPTION
GetTickCount64() is quantized to 16ms, which makes it unsuitable for measuring short timeouts.

QueryPerformanceCounter() has been guaranteed to work since Windows XP. It should only return an error if you pass in an unaligned pointer, which should only happen if your compiler doesn't align the stack.

<!-- issue-number: [bpo-41299](https://bugs.python.org/issue41299) -->
https://bugs.python.org/issue41299
<!-- /issue-number -->
