### PR TITLE
[3.9] bpo-44322: Document more SyntaxError details. (GH-26562)

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -390,14 +390,16 @@ The following exceptions are the exceptions that are usually raised.
 
    .. versionadded:: 3.5
 
-.. exception:: SyntaxError
+.. exception:: SyntaxError(message, details)
 
    Raised when the parser encounters a syntax error.  This may occur in an
-   :keyword:`import` statement, in a call to the built-in functions :func:`exec`
+   :keyword:`import` statement, in a call to the built-in functions
+   :func:`compile`, :func:`exec`,
    or :func:`eval`, or when reading the initial script or standard input
    (also interactively).
 
    The :func:`str` of the exception instance returns only the error message.
+   Details is a tuple whose members are also available as separate attributes.
 
    .. attribute:: filename
 
@@ -416,6 +418,11 @@ The following exceptions are the exceptions that are usually raised.
    .. attribute:: text
 
       The source code text involved in the error.
+
+   For errors in f-string fields, the message is prefixed by "f-string: "
+   and the offsets are offsets in a text constructed from the replacement
+   expression.  For example, compiling f'Bad {a b} field' results in this
+   args attribute: ('f-string: ...', ('', 1, 4, '(a b)\n')).
 
 
 .. exception:: IndentationError

--- a/Misc/NEWS.d/next/Documentation/2021-06-06-14-12-00.bpo-44322.K0PHfE.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-06-14-12-00.bpo-44322.K0PHfE.rst
@@ -1,0 +1,2 @@
+Document that SyntaxError args have a details tuple and that details are
+adjusted for errors in f-string field replacement expressions.


### PR DESCRIPTION
    SyntaxError args have a tuple of other attributes.
    Attributes are adjusted for errors in f-string field expressions.
    Compile() can raise SyntaxErrors.
    (cherry picked from commit 67dfa6f)

Co-authored-by: Terry Jan Reedy tjreedy@udel.edu
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44322](https://bugs.python.org/issue44322) -->
https://bugs.python.org/issue44322
<!-- /issue-number -->
