### PR TITLE
bpo-38323: Change MultiLoopChildWatcher to install handlers for all the event loops

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1219,7 +1219,6 @@ class MultiLoopChildWatcher(AbstractChildWatcher):
 
     def __init__(self):
         self._callbacks = {}
-        self._saved_sighandler = {}
         self._handler_added_loops = []
 
     def is_active(self):

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1256,8 +1256,10 @@ class MultiLoopChildWatcher(AbstractChildWatcher):
 
     def add_child_handler(self, pid, callback, *args):
         loop = events.get_running_loop()
-        if loop not in self._handler_added_loops:
-            self.attach_loop(loop)
+        for handler_added_loop in self._handler_added_loops:
+            if loop is handler_added_loop:
+                self.attach_loop(loop)
+                break
 
         self._callbacks[pid] = (loop, callback, args)
 

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1215,7 +1215,7 @@ class MultiLoopChildWatcher(AbstractChildWatcher):
     # The class keeps compatibility with AbstractChildWatcher ABC
     # It retrieves the current loop by get_running_loop() and installs
     # handler on it using add_child_handler()/remove_child_handler()
-    
+
 
     def __init__(self):
         self._callbacks = {}
@@ -1266,18 +1266,18 @@ class MultiLoopChildWatcher(AbstractChildWatcher):
             return False
 
     def attach_loop(self, loop):
-        # Install the handler on the loop and save it in a list. 
+        # Install the handler on the loop and save it in a list.
         # The reason to do it here is to avoid a race condition by
         # indirectly calling set_wakeup_fd. Previously attach_loop
         # installed the handler globally. See bpo-38323 for more
         # details.
         # Main thread is required for installing SIGCHLD handler
-        # on the event loop therefore attach_loop is only callable 
+        # on the event loop therefore attach_loop is only callable
         # from the main thread.
 
 
         assert loop is None or isinstance(loop, events.AbstractEventLoop)
-    
+
         if loop is not None:
             loop.add_signal_handler(signal.SIGCHLD, self._sig_chld)
 

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1265,7 +1265,8 @@ class MultiLoopChildWatcher(AbstractChildWatcher):
 
     def remove_child_handler(self, pid):
         try:
-            del self._callbacks[pid]
+            loop, callback, args = self._callbacks.pop(pid)
+            loop.remove_signal_handler(signal.SIGCHLD)
             return True
         except KeyError:
             return False

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1230,12 +1230,6 @@ class MultiLoopChildWatcher(AbstractChildWatcher):
         if self._handler_added_loops is []:
             return
 
-        if self._handler_added_loops is not [] and self._callbacks:
-            warnings.warn(
-                'Event Loops are being detached '
-                'from a child watcher with pending handlers',
-                RuntimeWarning)
-
         # Remove handler from every event loop we registered the handler
         # on previously
         if self._handler_added_loops is not []:

--- a/Misc/NEWS.d/next/Library/2021-06-07-13-39-16.bpo-38323.FGViHn.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-07-13-39-16.bpo-38323.FGViHn.rst
@@ -1,20 +1,20 @@
-Fix a race condition in `MultiLoopChildWatcher`. The patch does the
+Fix a race condition in ``MultiLoopChildWatcher``. The patch does the
 following -
 
 1) Creates a list that will keep track of the event loops where the handler
-has been installed by `MultiLoopChildWatcher`.
+has been installed by ``MultiLoopChildWatcher``.
 
-2) In `attach_loop` and `add_child_handler`, the handler is installed for the
-loop using `add_signal_handler` and the event loop instance is also added to
+2) In ``attach_loop`` and ``add_child_handler``, the handler is installed for the
+loop using ``add_signal_handler`` and the event loop instance is also added to
 the list.
 
-3) In `remove_child_handler`, the `remove_signal_handler` is called on the
+3) In ``remove_child_handler``, the ``remove_signal_handler`` is called on the
 loop the provided pid is attached to.
 
-4) In `close`, the `remove_signal_handler` is called on every loop and the
+4) In ``close``, the ``remove_signal_handler`` is called on every loop and the
 loop is removed from the list.
 
-The patch changes the behavior of `MultiLoopChildWatcher`. `MultiLoopChildWatcher`
+The patch changes the behavior of ``MultiLoopChildWatcher``. ``MultiLoopChildWatcher``
 can now only be used in the main thread.
 
 Patch by Shreyan Avigyan

--- a/Misc/NEWS.d/next/Library/2021-06-07-13-39-16.bpo-38323.FGViHn.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-07-13-39-16.bpo-38323.FGViHn.rst
@@ -6,7 +6,7 @@ has been installed by `MultiLoopChildWatcher`.
 
 2) In `attach_loop` and `add_child_handler`, the handler is installed for the
 loop using `add_signal_handler` and the event loop instance is also added to
- the list.
+the list.
 
 3) In `remove_child_handler`, the `remove_signal_handler` is called on the
 loop the provided pid is attached to.
@@ -15,6 +15,6 @@ loop the provided pid is attached to.
 loop is removed from the list.
 
 The patch changes the behavior of `MultiLoopChildWatcher`. `MultiLoopChildWatcher`
- can now only be used in the main thread.
+can now only be used in the main thread.
 
 Patch by Shreyan Avigyan

--- a/Misc/NEWS.d/next/Library/2021-06-07-13-39-16.bpo-38323.FGViHn.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-07-13-39-16.bpo-38323.FGViHn.rst
@@ -1,0 +1,20 @@
+Fix a race condition in `MultiLoopChildWatcher`. The patch does the
+following -
+
+1) Creates a list that will keep track of the event loops where the handler
+has been installed by `MultiLoopChildWatcher`.
+
+2) In `attach_loop` and `add_child_handler`, the handler is installed for the
+loop using `add_signal_handler` and the event loop instance is also added to
+ the list.
+
+3) In `remove_child_handler`, the `remove_signal_handler` is called on the
+loop the provided pid is attached to.
+
+4) In `close`, the `remove_signal_handler` is called on every loop and the
+loop is removed from the list.
+
+The patch changes the behavior of `MultiLoopChildWatcher`. `MultiLoopChildWatcher`
+ can now only be used in the main thread.
+
+Patch by Shreyan Avigyan


### PR DESCRIPTION
Fix a race condition in `MultiLoopChildWatcher`. This patch does the following -

1) Creates a list that will keep track of the event loops where the handler has been installed by `MultiLoopChildWatcher`.
2) In `attach_loop` and `add_child_handler`, the handler is installed for the loop using `add_signal_handler` and the event loop instance is also added to the list.
4) In `remove_child_handler`, the `remove_signal_handler` is called on the loop the provided pid is attached to.
3) In `close`, the `remove_signal_handler` is called on every loop and the loop is removed from the list.

This patch changes the behavior of `MultiLoopChildWatcher`. The original idea remains the same but with this patch `MultiLoopChildWatcher` can only be used in the main thread.

<!-- issue-number: [bpo-38323](https://bugs.python.org/issue38323) -->
https://bugs.python.org/issue38323
<!-- /issue-number -->
