### PR TITLE
fix: use unambiguous punction in 'invalid escape sequence' message

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -651,7 +651,7 @@ class CmdLineTest(unittest.TestCase):
                 stderr.splitlines()[-3:],
                 [   b'    foo = """\\q"""',
                     b'          ^^^^^^^^',
-                    b'SyntaxError: invalid escape sequence \\q'
+                    b'SyntaxError: invalid escape sequence \'\\q\''
                 ],
             )
 

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -12,7 +12,7 @@ static int
 warn_invalid_escape_sequence(Parser *p, unsigned char first_invalid_escape_char, Token *t)
 {
     PyObject *msg =
-        PyUnicode_FromFormat("invalid escape sequence \\%c", first_invalid_escape_char);
+        PyUnicode_FromFormat("invalid escape sequence '\\%c'", first_invalid_escape_char);
     if (msg == NULL) {
         return -1;
     }
@@ -27,7 +27,7 @@ warn_invalid_escape_sequence(Parser *p, unsigned char first_invalid_escape_char,
                since _PyPegen_raise_error uses p->tokens[p->fill - 1] for the
                error location, if p->known_err_token is not set. */
             p->known_err_token = t;
-            RAISE_SYNTAX_ERROR("invalid escape sequence \\%c", first_invalid_escape_char);
+            RAISE_SYNTAX_ERROR("invalid escape sequence '\\%c'", first_invalid_escape_char);
         }
         Py_DECREF(msg);
         return -1;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This adds quotes around the syntax error for invalid escape sequences.  This matches the messages in bytesobject.c and unicodeobject.c.  My invalid escape sequence was backslash-space.  This change made it easier to understand what I was being told.