### PR TITLE
Fix typo in library/logging.rst

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -32,7 +32,7 @@ modules.
 
 The module provides a lot of functionality and flexibility.  If you are
 unfamiliar with logging, the best way to get to grips with it is to see the
-tutorials (see the links on the right).
+tutorials (see the links on the left).
 
 The basic classes defined by the module, together with their functions, are
 listed below.


### PR DESCRIPTION
The docs for logging indicated that to get to the docs one should see
the links on the right; however, the sidebar containg the links
is (now?) on the left.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
