### PR TITLE
bpo-44340: Add support for building with clang thin lto via --with-lto=thin

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-44340.1xHAZP.rst
+++ b/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-44340.1xHAZP.rst
@@ -1,0 +1,2 @@
+Add support for building with clang's "thin" link time optimization using
+``--with-lto=thin``.

--- a/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-bpo-44340.1xHAZP.rst
+++ b/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-bpo-44340.1xHAZP.rst
@@ -1,1 +1,1 @@
-Add support for building with clang's "thin" link time optimization using `--with-lto=thin`.
+Add support for building with clang's "thin" link time optimization using ``--with-lto=thin``.

--- a/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-bpo-44340.1xHAZP.rst
+++ b/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-bpo-44340.1xHAZP.rst
@@ -1,0 +1,1 @@
+Add support for building with clang's "thin" link time optimization using `--with-lto=thin`.

--- a/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-bpo-44340.1xHAZP.rst
+++ b/Misc/NEWS.d/next/Build/2021-07-18-05-35-33.bpo-bpo-44340.1xHAZP.rst
@@ -1,1 +1,0 @@
-Add support for building with clang's "thin" link time optimization using ``--with-lto=thin``.

--- a/configure
+++ b/configure
@@ -1545,7 +1545,7 @@ Optional Packages:
   --with-trace-refs       enable tracing references for debugging purpose
                           (default is no)
   --with-assertions       build with C assertions enabled (default is no)
-  --with-lto              enable Link-Time-Optimization in any build (default
+  --with-lto[=no|thin]    enable Link-Time-Optimization in any build (default
                           is no)
   --with-hash-algorithm=[fnv|siphash24]
                           select hash algorithm for use in Python/pyhash.c
@@ -6585,16 +6585,23 @@ $as_echo_n "checking for --with-lto... " >&6; }
 # Check whether --with-lto was given.
 if test "${with_lto+set}" = set; then :
   withval=$with_lto;
-if test "$withval" != no
-then
-  Py_LTO='true'
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; };
-else
-  Py_LTO='false'
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+  LTO_ARG=''
+  if test "$withval" = no
+  then
+    Py_LTO='false'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; };
-fi
+  elif test "$withval" = yes
+  then
+    Py_LTO='true'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; };
+  else
+    Py_LTO='true'
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: \"$withval\"" >&5
+$as_echo "\"$withval\"" >&6; };
+    LTO_ARG="=$withval"
+  fi
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -6732,11 +6739,11 @@ $as_echo "$as_me: llvm-ar found via xcrun: ${LLVM_AR}" >&6;}
       case $ac_sys_system in
         Darwin*)
           # Any changes made here should be reflected in the GCC+Darwin case below
-          LTOFLAGS="-flto -Wl,-export_dynamic"
-          LTOCFLAGS="-flto"
+          LTOFLAGS="-flto$LTO_ARG -Wl,-export_dynamic"
+          LTOCFLAGS="-flto$LTO_ARG"
           ;;
         *)
-          LTOFLAGS="-flto"
+          LTOFLAGS="-flto$LTO_ARG"
           ;;
       esac
       ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1360,16 +1360,23 @@ fi
 
 # Enable LTO flags
 AC_MSG_CHECKING(for --with-lto)
-AC_ARG_WITH(lto, AS_HELP_STRING([--with-lto], [enable Link-Time-Optimization in any build (default is no)]),
+AC_ARG_WITH(lto, AS_HELP_STRING([--with-lto@<:@=no|thin@:>@], [enable Link-Time-Optimization in any build (default is no)]),
+
 [
-if test "$withval" != no
-then
-  Py_LTO='true'
-  AC_MSG_RESULT(yes);
-else
-  Py_LTO='false'
-  AC_MSG_RESULT(no);
-fi],
+  LTO_ARG=''
+  if test "$withval" = no
+  then
+    Py_LTO='false'
+    AC_MSG_RESULT(no);
+  elif test "$withval" = yes
+  then
+    Py_LTO='true'
+    AC_MSG_RESULT(yes);
+  else
+    Py_LTO='true'
+    AC_MSG_RESULT("$withval");
+    LTO_ARG="=$withval"
+  fi],
 [AC_MSG_RESULT(no)])
 if test "$Py_LTO" = 'true' ; then
   case $CC in
@@ -1405,11 +1412,11 @@ if test "$Py_LTO" = 'true' ; then
       case $ac_sys_system in
         Darwin*)
           # Any changes made here should be reflected in the GCC+Darwin case below
-          LTOFLAGS="-flto -Wl,-export_dynamic"
-          LTOCFLAGS="-flto"
+          LTOFLAGS="-flto$LTO_ARG -Wl,-export_dynamic"
+          LTOCFLAGS="-flto$LTO_ARG"
           ;;
         *)
-          LTOFLAGS="-flto"
+          LTOFLAGS="-flto$LTO_ARG"
           ;;
       esac
       ;;


### PR DESCRIPTION
This adds support for building cpython with clang's `--flto=thin` option.  Existing `--with-lto` behavior remains unchanged (default to no, with `--with-lto` currently using the default compiler lto option).

The tests (`make test`) currently pass for clang 11.1.0 for each of `--with-lto` and `--with-lto=thin`.

<!-- issue-number: [bpo-44340](https://bugs.python.org/issue44340) -->
https://bugs.python.org/issue44340
<!-- /issue-number -->
