### PR TITLE
bpo-43693: Silence some compiler warnings.

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -26,7 +26,6 @@ typedef uint16_t _Py_CODEUNIT;
 typedef struct _PyOpcache _PyOpcache;
 
 
-// These are duplicated from pycore_code.h.
 typedef unsigned char _PyLocalsPlusKind;
 typedef _PyLocalsPlusKind *_PyLocalsPlusKinds;
 

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -167,16 +167,14 @@ extern Py_ssize_t _Py_QuickenedCount;
  * "free" kind is mutually exclusive with both.
  */
 
-// We would use an enum if C let us specify the storage type.
-typedef unsigned char _PyLocalsPlusKind;
+// For now _PyLocalsPlusKind and _PyLocalsPlusKinds are defined
+// in Include/cpython/code.h.
 /* Note that these all fit within _PyLocalsPlusKind, as do combinations. */
 // Later, we will use the smaller numbers to differentiate the different
 // kinds of locals (e.g. pos-only arg, varkwargs, local-only).
 #define CO_FAST_LOCAL   0x20
 #define CO_FAST_CELL    0x40
 #define CO_FAST_FREE    0x80
-
-typedef _PyLocalsPlusKind *_PyLocalsPlusKinds;
 
 static inline int
 _PyCode_InitLocalsPlusKinds(int num, _PyLocalsPlusKinds *pkinds)


### PR DESCRIPTION
The plan is to eventually make `PyCodeObject` opaque in the public C-API, with the full struct moved to Include/internal/pycore_code.h.  `_PyLocalsPlusKinds` and `_PyLocalsPlusKind` started off there but were needed on `PyCodeObject`, hence the duplication.  This led to warnings with some compilers.  (Apparently it does not trigger a warning on my install of GCC.)

This change eliminates the superfluous typedef.

<!-- issue-number: [bpo-43693](https://bugs.python.org/issue43693) -->
https://bugs.python.org/issue43693
<!-- /issue-number -->
