### PR TITLE
[3.9] bpo-11105: reduce the recursion limit for tests (GH-26550).

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3199,3 +3199,13 @@ def skip_if_broken_multiprocessing_synchronize():
             synchronize.Lock(ctx=None)
         except OSError as exc:
             raise unittest.SkipTest(f"broken multiprocessing SemLock: {exc!r}")
+
+
+@contextlib.contextmanager
+def infinite_recursion(max_depth=75):
+    original_depth = sys.getrecursionlimit()
+    try:
+        sys.setrecursionlimit(max_depth)
+        yield
+    finally:
+        sys.setrecursionlimit(original_depth)

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1031,7 +1031,8 @@ Module(
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
         e.operand = e
         with self.assertRaises(RecursionError):
-            compile(ast.Expression(e), "<test>", "eval")
+            with support.infinite_recursion():
+                compile(ast.Expression(e), "<test>", "eval")
 
     def test_recursion_indirect(self):
         e = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
@@ -1039,7 +1040,8 @@ Module(
         e.operand = f
         f.operand = e
         with self.assertRaises(RecursionError):
-            compile(ast.Expression(e), "<test>", "eval")
+            with support.infinite_recursion():
+                compile(ast.Expression(e), "<test>", "eval")
 
 
 class ASTValidatorTests(unittest.TestCase):


### PR DESCRIPTION
(cherry picked from commit e58d762c1fb4ad5e021d016c80c2bc4513632d2f)

Co-authored-by: Batuhan Taskaya <batuhan@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-11105](https://bugs.python.org/issue11105) -->
https://bugs.python.org/issue11105
<!-- /issue-number -->
