### PR TITLE
bpo-44347: [doc] clarify meaning of shutil.copytree's dirs_exist_ok kwarg

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -230,9 +230,9 @@ Directory and files operations
               dirs_exist_ok=False)
 
    Recursively copy an entire directory tree rooted at *src* to a directory
-   named *dst* and return the destination directory. *dirs_exist_ok* dictates
-   whether to raise an exception in case *dst* or any missing parent directory
-   already exists.
+   named *dst* and return the destination directory. If *dirs_exist_ok* is
+   False (the default), a :exc:`FileExistsError` is raised if *dst* already
+   exists.
 
    Permissions and times of directories are copied with :func:`copystat`,
    individual files are copied using :func:`~shutil.copy2`.

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -509,8 +509,8 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
              ignore_dangling_symlinks=False, dirs_exist_ok=False):
     """Recursively copy a directory tree and return the destination directory.
 
-    dirs_exist_ok dictates whether to raise an exception in case dst or any
-    missing parent directory already exists.
+    If dirs_exist_ok is False (the default), a FileExistsError is
+    raised if dst already exists.
 
     If exception(s) occur, an Error is raised with a list of reasons.
 


### PR DESCRIPTION
* It now mirrors the documentation for os.makedirs
* Docstring in python source file was correspondingly updated

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44347](https://bugs.python.org/issue44347) -->
https://bugs.python.org/issue44347
<!-- /issue-number -->
