### PR TITLE
bpo-44378: Fix a compiler warning in Py_IS_TYPE()

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -141,7 +141,9 @@ static inline Py_ssize_t _Py_REFCNT(const PyObject *ob) {
 
 
 static inline int _Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
-    return Py_TYPE(ob) == type;
+    // bpo-44378: Don't use Py_TYPE() since Py_TYPE() requires a non-const
+    // object.
+    return ob->ob_type == type;
 }
 #define Py_IS_TYPE(ob, type) _Py_IS_TYPE(_PyObject_CAST_CONST(ob), type)
 

--- a/Misc/NEWS.d/next/C API/2021-06-10-15-22-31.bpo-44378.jGYakF.rst
+++ b/Misc/NEWS.d/next/C API/2021-06-10-15-22-31.bpo-44378.jGYakF.rst
@@ -1,0 +1,3 @@
+:c:func:`Py_IS_TYPE` no longer uses :c:func:`Py_TYPE` to avoid a compiler
+warning: no longer cast ``const PyObject*`` to ``PyObject*``.
+Patch by Victor Stinner.


### PR DESCRIPTION
Py_IS_TYPE() no longer uses Py_TYPE() to avoid a compiler when
casting "const PyObject*" to "PyObject*".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44378](https://bugs.python.org/issue44378) -->
https://bugs.python.org/issue44378
<!-- /issue-number -->
