### PR TITLE
bpo-44381: Windows build now allows enabling control flow guard

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-06-10-18-08-44.bpo-44381.Xpc1iX.rst
+++ b/Misc/NEWS.d/next/Build/2021-06-10-18-08-44.bpo-44381.Xpc1iX.rst
@@ -1,0 +1,2 @@
+The Windows build now accepts :envvar:`EnableControlFlowGuard` set to
+``guard`` to enable CFG.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -44,11 +44,11 @@
       <CompileAs>Default</CompileAs>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">OnlyExplicitInline</InlineFunctionExpansion>
-      <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">OnlyExplicitInline</InlineFunctionExpansion>
+      <ControlFlowGuard Condition="$(EnableControlFlowGuard) != ''">$(EnableControlFlowGuard)</ControlFlowGuard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ClCompile Condition="$(Configuration) == 'Debug'">
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <Optimization>Disabled</Optimization>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>


### PR DESCRIPTION
Also moves a conditional operation to a neater (and more correct) place.

<!-- issue-number: [bpo-44381](https://bugs.python.org/issue44381) -->
https://bugs.python.org/issue44381
<!-- /issue-number -->
