### PR TITLE
bpo-44376 - reduce pow() overhead for small exponents

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-11-17-37-15.bpo-44376.zhM1UW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-11-17-37-15.bpo-44376.zhM1UW.rst
@@ -1,0 +1,1 @@
+Exact integer exponentiation (like ``i**2`` or ``pow(i, 2)``) with a small exponent is much faster, due to reducing overhead in such cases.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4241,6 +4241,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
 
     i = Py_SIZE(b);
     digit bi = i ? b->ob_digit[i-1] : 0;
+    digit bit;
     if (i <= 1 && bi <= 3) {
         /* exponent <= 3 - just do straight multiplies. Note that the multiply
          * 1 * a -> z serves a purpose when bi is 1: if `a` is of an int
@@ -4259,19 +4260,19 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
          * because we're primarily trying to cut overhead for small powers.
          */
         assert(bi);  /* else there is no significant bit */
-        for (j = 2; ; j <<= 1) {
-            if (j > bi) { /* found the first bit */
-                assert((bi & j) == 0);
-                j >>= 1;
+        for (bit = 2; ; bit <<= 1) {
+            if (bit > bi) { /* found the first bit */
+                assert((bi & bit) == 0);
+                bit >>= 1;
                 MULT(z, a, z);
                 break;
             }
         }
-        assert(bi & j);
-        for (--i, j >>= 1;;) {
-            for (; j != 0; j >>= 1) {
+        assert(bi & bit);
+        for (--i, bit >>= 1;;) {
+            for (; bit != 0; bit >>= 1) {
                 MULT(z, z, z);
-                if (bi & j) {
+                if (bi & bit) {
                     MULT(z, a, z);
                 }
             }
@@ -4279,7 +4280,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
                 break;
             }
             bi = b->ob_digit[i];
-            j = (digit)1 << (PyLong_SHIFT-1);
+            bit = (digit)1 << (PyLong_SHIFT-1);
         }
     }
     else {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4250,10 +4250,15 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
             /* Find the first significant exponent bit. */
             for (j = (digit)1 << (PyLong_SHIFT-1); j != 0; j >>= 1) {
                 if (bi & j) {
-                    Py_INCREF(a);
-                    Py_DECREF(z); /* z is currently 1 */
-                    z = a;
-                    REDUCE(z);
+                    /* Found the first bit. We would like to simply set z to
+                     * `a` now. But, if we do, and b is 1, pow() will return
+                     * `a` then. Which is of a wrong type if `a` is an instance
+                     * of an int subclass. test_bool actually griped about
+                     * that, demanding that, e.g., pos(False, 1) is not False.
+                     * The seemingly useless multiplication by 1 is done
+                     * solely to worm around that.
+                     */
+                    MULT(z, a, z);
                     break;
                 }
             }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4254,7 +4254,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
                      * `a` now. But, if we do, and b is 1, pow() will return
                      * `a` then. Which is of a wrong type if `a` is an instance
                      * of an int subclass. test_bool actually griped about
-                     * that, demanding that, e.g., pos(False, 1) is not False.
+                     * that, demanding that, e.g., pow(False, 1) is not False.
                      * The seemingly useless multiplication by 1 is done
                      * solely to worm around that.
                      */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4253,7 +4253,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
         else if (bi == 1) {
             /* Multiplying by 1 serves two purposes: if `a` is of an int
              * subclass, makes the result an int (e.g., pow(False, 1) returns
-             * 0 instead of False), and potetially reduces `a` by the modulus.
+             * 0 instead of False), and potentially reduces `a` by the modulus.
              */
             MULT(a, z, z);
         }


### PR DESCRIPTION

BPO-44376
Reduce pow() overhead for small exponents.
Incidentally fixed a refcount oversight for
negative exponents.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44376](https://bugs.python.org/issue44376) -->
https://bugs.python.org/issue44376
<!-- /issue-number -->
