### PR TITLE
bpo-44388: Update venv EnvBuilder.ensure_directories() docs.

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -170,11 +170,11 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     .. method:: ensure_directories(env_dir)
 
-        Creates the environment directory and all necessary directories, and
-        returns a context object.  This is just a holder for attributes (such as
-        paths), for use by the other methods. The directories are allowed to
-        exist already, as long as either ``clear`` or ``upgrade`` were
-        specified to allow operating on an existing environment directory.
+        Creates the environment directory and all necessary subdirectories that
+        don't already exist, and returns a context object.  This is just a
+        holder for attributes (such as paths), for use by the other methods.
+        Any existing environment directories will remain unaffected as long as
+        ``clear`` was not specified.
 
     .. method:: create_configuration(context)
 

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -173,8 +173,9 @@ creation according to their needs, the :class:`EnvBuilder` class.
         Creates the environment directory and all necessary subdirectories that
         don't already exist, and returns a context object.  This is just a
         holder for attributes (such as paths), for use by the other methods.
-        Any existing environment directories will remain unaffected as long as
-        ``clear`` was not specified.
+        If the :class:`EnvBuilder` is created with the arg ``clear=True``,
+        contents of the environment directory will be cleared and then all
+        necessary subdirectories will be recreated.
 
     .. method:: create_configuration(context)
 

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -171,11 +171,11 @@ creation according to their needs, the :class:`EnvBuilder` class.
     .. method:: ensure_directories(env_dir)
 
         Creates the environment directory and all necessary subdirectories that
-        don't already exist, and returns a context object.  This is just a
-        holder for attributes (such as paths), for use by the other methods.
-        If the :class:`EnvBuilder` is created with the arg ``clear=True``,
-        contents of the environment directory will be cleared and then all
-        necessary subdirectories will be recreated.
+        don't already exist, and returns a context object.  This context object
+        is just a holder for attributes (such as paths) for use by the other
+        methods.  If the :class:`EnvBuilder` is created with the arg
+        ``clear=True``, contents of the environment directory will be cleared
+        and then all necessary subdirectories will be recreated.
 
     .. method:: create_configuration(context)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Ref: https://bugs.python.org/issue44388

This changes the documentation for `EnvBuilder.ensure_directories(env_dir)` to match the actual behavior of that API call.

In particular, `ensure_directories()` is not affected by the state of the `upgrade` attribute, and will not cause an error to have existing directories whether or not the `clear` attribute is set.

This documentation change I believe should be valid to all python versions back to 3.6.

<!-- issue-number: [bpo-44388](https://bugs.python.org/issue44388) -->
https://bugs.python.org/issue44388
<!-- /issue-number -->

Automerge-Triggered-By: GH:vsajip