### PR TITLE
bpo-40320: Added support for manipulating context in asyncio tasks

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -847,9 +847,10 @@ Task Object
    APIs except :meth:`Future.set_result` and
    :meth:`Future.set_exception`.
 
-   Tasks support the :mod:`contextvars` module.  When a Task
-   is created it copies the current context and later runs its
-   coroutine in the copied context.
+   Tasks support the :mod:`contextvars` module.  Tasks can be run under
+   any context, defaulting to a copy of the context that created them. This
+   context will later be used to run its coroutines.  The context associated
+   with a task can be modified using `:meth:`asyncio.run_in_context`.
 
    .. versionchanged:: 3.7
       Added support for the :mod:`contextvars` module.

--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -5,7 +5,7 @@ from . import events
 from . import tasks
 
 
-def run(main, *, debug=None):
+def run(main, *, debug=None, **task_kwargs):
     """Execute the coroutine and return the result.
 
     This function runs the passed coroutine, taking care of
@@ -41,7 +41,7 @@ def run(main, *, debug=None):
         events.set_event_loop(loop)
         if debug is not None:
             loop.set_debug(debug)
-        return loop.run_until_complete(main)
+        return loop.run_until_complete(tasks.Task(main, loop=loop, **task_kwargs))
     finally:
         try:
             _cancel_all_tasks(loop)

--- a/Modules/clinic/_asynciomodule.c.h
+++ b/Modules/clinic/_asynciomodule.c.h
@@ -310,28 +310,29 @@ _asyncio_Future__repr_info(FutureObj *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(_asyncio_Task___init____doc__,
-"Task(coro, *, loop=None, name=None)\n"
+"Task(coro, *, loop=None, name=None, context=None)\n"
 "--\n"
 "\n"
 "A coroutine wrapped in a Future.");
 
 static int
 _asyncio_Task___init___impl(TaskObj *self, PyObject *coro, PyObject *loop,
-                            PyObject *name);
+                            PyObject *name, PyObject *context);
 
 static int
 _asyncio_Task___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     int return_value = -1;
-    static const char * const _keywords[] = {"coro", "loop", "name", NULL};
+    static const char * const _keywords[] = {"coro", "loop", "name", "context", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "Task", 0};
-    PyObject *argsbuf[3];
+    PyObject *argsbuf[4];
     PyObject * const *fastargs;
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 1;
     PyObject *coro;
     PyObject *loop = Py_None;
     PyObject *name = Py_None;
+    PyObject *context = Py_None;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser, 1, 1, 0, argsbuf);
     if (!fastargs) {
@@ -347,9 +348,15 @@ _asyncio_Task___init__(PyObject *self, PyObject *args, PyObject *kwargs)
             goto skip_optional_kwonly;
         }
     }
-    name = fastargs[2];
+    if (fastargs[2]) {
+        name = fastargs[2];
+        if (!--noptargs) {
+            goto skip_optional_kwonly;
+        }
+    }
+    context = fastargs[3];
 skip_optional_kwonly:
-    return_value = _asyncio_Task___init___impl((TaskObj *)self, coro, loop, name);
+    return_value = _asyncio_Task___init___impl((TaskObj *)self, coro, loop, name, context);
 
 exit:
     return return_value;
@@ -611,6 +618,41 @@ PyDoc_STRVAR(_asyncio_Task_set_name__doc__,
 #define _ASYNCIO_TASK_SET_NAME_METHODDEF    \
     {"set_name", (PyCFunction)_asyncio_Task_set_name, METH_O, _asyncio_Task_set_name__doc__},
 
+PyDoc_STRVAR(_asyncio_Task__set_context__doc__,
+"_set_context($self, /, context)\n"
+"--\n"
+"\n"
+"Set the context associated with the task.\n"
+"\n"
+"This does not change the current thread context and only affects the thread\n"
+"context of later callbacks. Returns the previously context attached to the task.");
+
+#define _ASYNCIO_TASK__SET_CONTEXT_METHODDEF    \
+    {"_set_context", (PyCFunction)(void(*)(void))_asyncio_Task__set_context, METH_FASTCALL|METH_KEYWORDS, _asyncio_Task__set_context__doc__},
+
+static PyObject *
+_asyncio_Task__set_context_impl(TaskObj *self, PyObject *context);
+
+static PyObject *
+_asyncio_Task__set_context(TaskObj *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"context", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "_set_context", 0};
+    PyObject *argsbuf[1];
+    PyObject *context;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    context = args[0];
+    return_value = _asyncio_Task__set_context_impl(self, context);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_asyncio__get_running_loop__doc__,
 "_get_running_loop($module, /)\n"
 "--\n"
@@ -871,4 +913,4 @@ _asyncio__leave_task(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0d127162ac92e0c0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=02e21cc39188c337 input=a9049054013a1b77]*/


### PR DESCRIPTION
Proposal and sample implementation to address https://bugs.python.org/issue40320 and extend behavior a bit to get parity with what's available in synchronous code.

Makes three public API changes

1. Adds a `context` keyword parameter to the asyncio.Task constructor. When given this will be the contextvars.Context the task will be run in. When not specified the existing default of copying the callers context will still be used.
2. Updates `asyncio.run` to pass additional keyword arguments to the task constructor. This isn't really necessary but seemed like a nice (and it also seemed like it would be nice if you could specify the name of the task created by `asyncio.run`).
3. Created coroutine `asyncio.run_in_context` that functions in an analagous manner to `contextvars.Context.run`. It will manage swapping out the coroutine associated with the task while the passed coroutine is executing within the task.

`asyncio.run_in_context` is implemented by assing an additional private method `Task._set_context` that can change the context associated with a task (although a yield out of the task step function is required before the new context is active).

This is all to better support contextvars in an asyncio context. Without this support it was impossible to run async code in a different context without creating a new task. It was also impossible to create a task using any context other than a copy of the calling context (i.e. the context used was always a copy).

Example Usage

```
import asyncio
import contextvars

var = contextvars.ContextVar("var", default=123)

async def foo():
  val = var.get()
  var.set(val + 1)
  return val

async def main():
  assert await foo() == 123
  assert await asyncio.run_in_context(contextvars.copy_context(), foo()) == 124
  assert var.get() == 124

var.set(-1)
ctx = contextvars.Context()
asyncio.run(main(), name='main', context=ctx)
```

<!-- issue-number: [bpo-40320](https://bugs.python.org/issue40320) -->
https://bugs.python.org/issue40320
<!-- /issue-number -->
