### PR TITLE
bpo-44342: [Enum] fix data type search

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -818,7 +818,7 @@ class EnumType(type):
                         data_types.add(candidate or base)
                         break
                     else:
-                        candidate = base
+                        candidate = candidate or base
             if len(data_types) > 1:
                 raise TypeError('%r: too many data types: %r' % (class_name, data_types))
             elif data_types:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -658,6 +658,14 @@ class TestEnum(unittest.TestCase):
             def __repr__(self):
                 return '<%s.%s: %r>' % (self.__class__.__name__, self._name_, self._value_)
         self.assertEqual(repr(MyEnum.A), '<MyEnum.A: 0x1>')
+        #
+        class SillyInt(HexInt):
+            pass
+        class MyOtherEnum(SillyInt, enum.Enum):
+            D = 4
+            E = 5
+            F = 6
+        self.assertIs(MyOtherEnum._member_type_, SillyInt)
 
     def test_too_many_data_types(self):
         with self.assertRaisesRegex(TypeError, 'too many data types'):


### PR DESCRIPTION
In an inheritance chain of

  int -> my_int -> final_int

the data type is now final_int (not my_int)

<!-- issue-number: [bpo-44342](https://bugs.python.org/issue44342) -->
https://bugs.python.org/issue44342
<!-- /issue-number -->
