### PR TITLE
bpo-40128: Fix IDLE autocomplete on macOS

### DIFF
--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -206,6 +206,7 @@ class AutoCompleteWindow:
         scrollbar.config(command=listbox.yview)
         scrollbar.pack(side=RIGHT, fill=Y)
         listbox.pack(side=LEFT, fill=BOTH, expand=True)
+        acw.update_idletasks()
         acw.lift()  # work around bug in Tk 8.5.18+ (issue #24570)
 
         # Initialize the listbox selection

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -206,7 +206,7 @@ class AutoCompleteWindow:
         scrollbar.config(command=listbox.yview)
         scrollbar.pack(side=RIGHT, fill=Y)
         listbox.pack(side=LEFT, fill=BOTH, expand=True)
-        acw.update_idletasks()
+        acw.update_idletasks() # Need for tk8.6.8 on macOS: #40128.
         acw.lift()  # work around bug in Tk 8.5.18+ (issue #24570)
 
         # Initialize the listbox selection

--- a/Misc/NEWS.d/next/IDLE/2021-06-11-17-43-39.bpo-40128.7vDN3U.rst
+++ b/Misc/NEWS.d/next/IDLE/2021-06-11-17-43-39.bpo-40128.7vDN3U.rst
@@ -1,0 +1,3 @@
+Mostly fix completions on macOS when not using tcl/tk 8.6.11 (as with 3.9).
+The added update_idletask call should be harmless and possibly helpful
+otherwise.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR allows autocomplete to work as expected in the MacOS IDLE

<!-- issue-number: [bpo-40128](https://bugs.python.org/issue40128) -->
https://bugs.python.org/issue40128
<!-- /issue-number -->
