### PR TITLE
bpo-44395: Fix MIMEPart.as_string to pass unixfrom properly

### DIFF
--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -948,7 +948,7 @@ class MIMEPart(Message):
         if policy is None:
             from email.policy import default
             policy = default
-        Message.__init__(self, policy)
+        super().__init__(policy)
 
 
     def as_string(self, unixfrom=False, maxheaderlen=None, policy=None):
@@ -965,7 +965,7 @@ class MIMEPart(Message):
         policy = self.policy if policy is None else policy
         if maxheaderlen is None:
             maxheaderlen = policy.max_line_length
-        return super().as_string(maxheaderlen=maxheaderlen, policy=policy)
+        return super().as_string(unixfrom, maxheaderlen, policy)
 
     def __str__(self):
         return self.as_string(policy=self.policy.clone(utf8=True))

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -775,6 +775,13 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         self.assertEqual(len(m.as_string(maxheaderlen=34).strip().splitlines()),
                          6)
 
+    def test_as_string_unixform(self):
+        m = self._str_msg('test')
+        m.set_unixfrom('From foo@bar Thu Jan  1 00:00:00 1970')
+        self.assertEqual(m.as_string(unixfrom=True),
+                        'From foo@bar Thu Jan  1 00:00:00 1970\n\ntest')
+        self.assertEqual(m.as_string(unixfrom=False), '\ntest')
+
     def test_str_defaults_to_policy_max_line_length(self):
         m = self._str_msg('Subject: long line' + ' ab'*50 + '\n\n')
         self.assertEqual(len(str(m).strip().splitlines()), 3)

--- a/Misc/NEWS.d/next/Library/2021-06-12-10-08-14.bpo-44395.PcW6Sx.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-12-10-08-14.bpo-44395.PcW6Sx.rst
@@ -1,0 +1,2 @@
+Fix :meth:`~email.message.MIMEPart.as_string` to pass unixfrom properly.
+Patch by Dong-hee Na.


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44395](https://bugs.python.org/issue44395) -->
https://bugs.python.org/issue44395
<!-- /issue-number -->
