### PR TITLE
bpo-44401: Make kwlist const in PyArg_ParseTupleAndKeywords

### DIFF
--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -39,10 +39,10 @@ PyAPI_FUNC(PyObject **) _Py_VaBuildStack_SizeT(
 PyAPI_FUNC(int) PyArg_Parse(PyObject *, const char *, ...);
 PyAPI_FUNC(int) PyArg_ParseTuple(PyObject *, const char *, ...);
 PyAPI_FUNC(int) PyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
-                                                  const char *, char **, ...);
+                                                  const char *, const char **, ...);
 PyAPI_FUNC(int) PyArg_VaParse(PyObject *, const char *, va_list);
 PyAPI_FUNC(int) PyArg_VaParseTupleAndKeywords(PyObject *, PyObject *,
-                                                  const char *, char **, va_list);
+                                                  const char *, const char **, va_list);
 #endif
 PyAPI_FUNC(int) PyArg_ValidateKeywordArguments(PyObject *);
 PyAPI_FUNC(int) PyArg_UnpackTuple(PyObject *, const char *, Py_ssize_t, Py_ssize_t, ...);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -638,7 +638,7 @@ SimpleExtendsException(PyExc_BaseException, KeyboardInterrupt,
 static int
 ImportError_init(PyImportErrorObject *self, PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"name", "path", 0};
+    static const char *kwlist[] = {"name", "path", 0};
     PyObject *empty_tuple;
     PyObject *msg = NULL;
     PyObject *name = NULL;
@@ -1330,7 +1330,7 @@ SimpleExtendsException(PyExc_RuntimeError, NotImplementedError,
 static int
 NameError_init(PyNameErrorObject *self, PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"name", NULL};
+    static const char *kwlist[] = {"name", NULL};
     PyObject *name = NULL;
 
     if (BaseException_init((PyBaseExceptionObject *)self, args, NULL) == -1) {
@@ -1404,7 +1404,7 @@ MiddlingExtendsException(PyExc_NameError, UnboundLocalError, NameError,
 static int
 AttributeError_init(PyAttributeErrorObject *self, PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"name", "obj", NULL};
+    static const char *kwlist[] = {"name", "obj", NULL};
     PyObject *name = NULL;
     PyObject *obj = NULL;
 

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -16,9 +16,9 @@ int PyArg_ParseTuple(PyObject *, const char *, ...);
 int PyArg_VaParse(PyObject *, const char *, va_list);
 
 int PyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
-                                const char *, char **, ...);
+                                const char *, const char **, ...);
 int PyArg_VaParseTupleAndKeywords(PyObject *, PyObject *,
-                                const char *, char **, va_list);
+                                const char *, const char **, va_list);
 
 int _PyArg_ParseTupleAndKeywordsFast(PyObject *, PyObject *,
                                             struct _PyArg_Parser *, ...);
@@ -1375,7 +1375,7 @@ int
 PyArg_ParseTupleAndKeywords(PyObject *args,
                             PyObject *keywords,
                             const char *format,
-                            char **kwlist, ...)
+                            const char **kwlist, ...)
 {
     int retval;
     va_list va;
@@ -1399,7 +1399,7 @@ PyAPI_FUNC(int)
 _PyArg_ParseTupleAndKeywords_SizeT(PyObject *args,
                                   PyObject *keywords,
                                   const char *format,
-                                  char **kwlist, ...)
+                                  const char **kwlist, ...)
 {
     int retval;
     va_list va;
@@ -1425,7 +1425,7 @@ int
 PyArg_VaParseTupleAndKeywords(PyObject *args,
                               PyObject *keywords,
                               const char *format,
-                              char **kwlist, va_list va)
+                              const char **kwlist, va_list va)
 {
     int retval;
     va_list lva;


### PR DESCRIPTION
Also in PyArg_VaParseTupleAndKeywords.

Apply const to arrays being passed in.

<!-- issue-number: [bpo-44401](https://bugs.python.org/issue44401) -->
https://bugs.python.org/issue44401
<!-- /issue-number -->
