### PR TITLE
Speed up test_urlsplit_normalization

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1079,7 +1079,8 @@ class UrlParseTestCase(unittest.TestCase):
         hex_chars = {'{:04X}'.format(ord(c)) for c in illegal_chars}
         denorm_chars = [
             c for c in map(chr, range(128, sys.maxunicode))
-            if (hex_chars & set(unicodedata.decomposition(c).split()))
+            if unicodedata.decomposition(c)
+            and (hex_chars & set(unicodedata.decomposition(c).split()))
             and c not in illegal_chars
         ]
         # Sanity check that we found at least one such character


### PR DESCRIPTION
Noticed while working on #26687 that one of the tests in `test_urlparse` took ~7s. Here I've short-circuited the filtering of a massive list comprehension (`sys.maxunicode` for me is 1,114,111) by checking if not empty before running split(), set(), &, etc.

LMK if this needs a ticket.

***

$ ./python.exe -m unittest test.test_urlparse.UrlParseTestCase.test_urlsplit_normalization

**Before**
Ran 1 test in 6.981s

**After**
Ran 1 test in 2.459s