### PR TITLE
bpo-36027: Fix a potential refcount bug in long_pow

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4185,6 +4185,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
                 goto Error;
             Py_DECREF(a);
             a = temp;
+            temp = NULL;
         }
 
         /* Reduce base by modulus in some cases:


### PR DESCRIPTION
This PR fixes a reference counting bug introduced in #13266 and identified by @tim-one in #26662: if we don't set `temp` to `NULL`, and if the value it has at this point is retained until the end of the function, then we end up doing an extra decref. I spent some time trying to identify a test-case that exercises this bug, and failed - I couldn't find a code path where `temp` isn't re-used at some point. Nevertheless, it's a potential point of fragility for maintenance of this code.

<!-- issue-number: [bpo-36027](https://bugs.python.org/issue36027) -->
https://bugs.python.org/issue36027
<!-- /issue-number -->
