### PR TITLE
bpo-44316: add `keep_curdir` and `keep_pardir` arguments to `os.path.normpath()`

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -332,15 +332,18 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: normpath(path, *, strict=False)
+.. function:: normpath(path, *, keep_curdir=False, keep_pardir=False)
 
-   Normalize a pathname by collapsing redundant separators so that ``A//B``,
-   ``A/B/`` and ``A/./B`` all become ``A/B``.
+   Normalize a pathname by collapsing redundant separators so that ``A//B`` and
+   ``A/B/`` become ``A/B``.
 
-   In non-strict mode (the default), up-level references are collapsed so that
-   ``A/foo/../B`` also becomes ``A/B``.  This string manipulation may change
-   the meaning of a path that contains symbolic links. In strict mode, ``..``
-   entries are retained, and so the path's meaning is always preserved.
+   Unless *keep_curdir* is ``True``, references to the current directory are
+   collapsed so that ``./A/./B`` becomes ``A/B``. This may change how the path
+   is interpreted by a shell.
+
+   Unless *keep_pardir* is ``True``, references to the parent directory are
+   collapsed so that ``A/foo/../B`` becomes ``A/B``. This string manipulation
+   may change the meaning of a path that contains symbolic links.
 
    On Windows, this function converts forward slashes to backward slashes. To
    normalize case, use :func:`normcase`.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -332,16 +332,24 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. function:: normpath(path)
+.. function:: normpath(path, *, strict=False)
 
-   Normalize a pathname by collapsing redundant separators and up-level
-   references so that ``A//B``, ``A/B/``, ``A/./B`` and ``A/foo/../B`` all
-   become ``A/B``.  This string manipulation may change the meaning of a path
-   that contains symbolic links.  On Windows, it converts forward slashes to
-   backward slashes. To normalize case, use :func:`normcase`.
+   Normalize a pathname by collapsing redundant separators so that ``A//B``,
+   ``A/B/`` and ``A/./B`` all become ``A/B``.
+
+   In non-strict mode (the default), up-level references are collapsed so that
+   ``A/foo/../B`` also becomes ``A/B``.  This string manipulation may change
+   the meaning of a path that contains symbolic links. In strict mode, ``..``
+   entries are retained, and so the path's meaning is always preserved.
+
+   On Windows, this function converts forward slashes to backward slashes. To
+   normalize case, use :func:`normcase`.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
+
+   .. versionchanged:: 3.11
+      The *strict* parameter was added.
 
 
 .. function:: realpath(path, *, strict=False)

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -456,11 +456,10 @@ def expandvars(path):
     return res
 
 
-# Normalize a path, e.g. A//B, A/./B and A/foo/../B all become A\B.
-# Previously, this function also truncated pathnames to 8+3 format,
-# but as this module is called "ntpath", that's obviously wrong!
+# Normalize a path, e.g. A//B, A/./B and A/foo/../B all become A\B in
+# non-strict mode.
 
-def normpath(path):
+def normpath(path, *, strict=False):
     """Normalize path, eliminating double slashes, etc."""
     path = os.fspath(path)
     if isinstance(path, bytes):
@@ -482,6 +481,8 @@ def normpath(path):
         # do not do any normalization, but return the path
         # unchanged apart from the call to os.fspath()
         return path
+    if strict:
+        pardir = object()
     path = path.replace(altsep, sep)
     prefix, path = splitdrive(path)
 

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -330,11 +330,12 @@ def expandvars(path):
     return path
 
 
-# Normalize a path, e.g. A//B, A/./B and A/foo/../B all become A/B.
+# Normalize a path, e.g. A//B, A/./B and A/foo/../B all become A/B in
+# non-strict mode.
 # It should be understood that this may change the meaning of the path
 # if it contains symbolic links!
 
-def normpath(path):
+def normpath(path, *, strict=False):
     """Normalize path, eliminating double slashes, etc."""
     path = os.fspath(path)
     if isinstance(path, bytes):
@@ -349,6 +350,8 @@ def normpath(path):
         dotdot = '..'
     if path == empty:
         return dot
+    if strict:
+        dotdot = object()
     initial_slashes = path.startswith(sep)
     # POSIX allows one or two initial slashes, but treats three or more
     # as single slash.

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -330,12 +330,11 @@ def expandvars(path):
     return path
 
 
-# Normalize a path, e.g. A//B, A/./B and A/foo/../B all become A/B in
-# non-strict mode.
+# Normalize a path, e.g. A//B, A/./B and A/foo/../B all become A/B.
 # It should be understood that this may change the meaning of the path
 # if it contains symbolic links!
 
-def normpath(path, *, strict=False):
+def normpath(path, *, keep_curdir=False, keep_pardir=False):
     """Normalize path, eliminating double slashes, etc."""
     path = os.fspath(path)
     if isinstance(path, bytes):
@@ -350,8 +349,8 @@ def normpath(path, *, strict=False):
         dotdot = '..'
     if path == empty:
         return dot
-    if strict:
-        dotdot = object()
+    curdir = object() if keep_curdir else dot
+    pardir = object() if keep_pardir else dotdot
     initial_slashes = path.startswith(sep)
     # POSIX allows one or two initial slashes, but treats three or more
     # as single slash.
@@ -361,10 +360,10 @@ def normpath(path, *, strict=False):
     comps = path.split(sep)
     new_comps = []
     for comp in comps:
-        if comp in (empty, dot):
+        if comp in (empty, curdir):
             continue
-        if (comp != dotdot or (not initial_slashes and not new_comps) or
-             (new_comps and new_comps[-1] == dotdot)):
+        if (comp != pardir or (not initial_slashes and not new_comps) or
+             (new_comps and new_comps[-1] == pardir)):
             new_comps.append(comp)
         elif new_comps:
             new_comps.pop()

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -236,6 +236,33 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.normpath('\\\\.\\NUL')", r'\\.\NUL')
         tester("ntpath.normpath('\\\\?\\D:/XY\\Z')", r'\\?\D:/XY\Z')
 
+    def test_normpath_strict(self):
+        tester("ntpath.normpath('A//////././//.//B', strict=True)", r'A\B')
+        tester("ntpath.normpath('A/./B', strict=True)", r'A\B')
+        tester("ntpath.normpath('A/foo/../B', strict=True)", r'A\foo\..\B')
+        tester("ntpath.normpath('C:A//B', strict=True)", r'C:A\B')
+        tester("ntpath.normpath('D:A/./B', strict=True)", r'D:A\B')
+        tester("ntpath.normpath('e:A/foo/../B', strict=True)", r'e:A\foo\..\B')
+
+        tester("ntpath.normpath('C:///A//B', strict=True)", r'C:\A\B')
+        tester("ntpath.normpath('D:///A/./B', strict=True)", r'D:\A\B')
+        tester("ntpath.normpath('e:///A/foo/../B', strict=True)", r'e:\A\foo\..\B')
+
+        tester("ntpath.normpath('..', strict=True)", r'..')
+        tester("ntpath.normpath('.', strict=True)", r'.')
+        tester("ntpath.normpath('', strict=True)", r'.')
+        tester("ntpath.normpath('/', strict=True)", '\\')
+        tester("ntpath.normpath('c:/', strict=True)", 'c:\\')
+        tester("ntpath.normpath('/../.././..', strict=True)", '\\..\\..\\..')
+        tester("ntpath.normpath('c:/../../..', strict=True)", 'c:\\..\\..\\..')
+        tester("ntpath.normpath('../.././..', strict=True)", r'..\..\..')
+        tester("ntpath.normpath('K:../.././..', strict=True)", r'K:..\..\..')
+        tester("ntpath.normpath('C:////a/b', strict=True)", r'C:\a\b')
+        tester("ntpath.normpath('//machine/share//a/b', strict=True)", r'\\machine\share\a\b')
+
+        tester("ntpath.normpath('\\\\.\\NUL', strict=True)", r'\\.\NUL')
+        tester("ntpath.normpath('\\\\?\\D:/XY\\Z', strict=True)", r'\\?\D:/XY\Z')
+
     def test_realpath_curdir(self):
         expected = ntpath.normpath(os.getcwd())
         tester("ntpath.realpath('.')", expected)

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -236,32 +236,130 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.normpath('\\\\.\\NUL')", r'\\.\NUL')
         tester("ntpath.normpath('\\\\?\\D:/XY\\Z')", r'\\?\D:/XY\Z')
 
-    def test_normpath_strict(self):
-        tester("ntpath.normpath('A//////././//.//B', strict=True)", r'A\B')
-        tester("ntpath.normpath('A/./B', strict=True)", r'A\B')
-        tester("ntpath.normpath('A/foo/../B', strict=True)", r'A\foo\..\B')
-        tester("ntpath.normpath('C:A//B', strict=True)", r'C:A\B')
-        tester("ntpath.normpath('D:A/./B', strict=True)", r'D:A\B')
-        tester("ntpath.normpath('e:A/foo/../B', strict=True)", r'e:A\foo\..\B')
+    def test_normpath_keep_curdir(self):
+        tester("ntpath.normpath('A//////././//.//B', keep_curdir=True)", r'A\.\.\.\B')
+        tester("ntpath.normpath('A/./B', keep_curdir=True)", r'A\.\B')
+        tester("ntpath.normpath('A/foo/../B', keep_curdir=True)", r'A\B')
+        tester("ntpath.normpath('C:A//B', keep_curdir=True)", r'C:A\B')
+        tester("ntpath.normpath('D:A/./B', keep_curdir=True)", r'D:A\.\B')
+        tester("ntpath.normpath('e:A/foo/../B', keep_curdir=True)", r'e:A\B')
 
-        tester("ntpath.normpath('C:///A//B', strict=True)", r'C:\A\B')
-        tester("ntpath.normpath('D:///A/./B', strict=True)", r'D:\A\B')
-        tester("ntpath.normpath('e:///A/foo/../B', strict=True)", r'e:\A\foo\..\B')
+        tester("ntpath.normpath('C:///A//B', keep_curdir=True)", r'C:\A\B')
+        tester("ntpath.normpath('D:///A/./B', keep_curdir=True)", r'D:\A\.\B')
+        tester("ntpath.normpath('e:///A/foo/../B', keep_curdir=True)", r'e:\A\B')
 
-        tester("ntpath.normpath('..', strict=True)", r'..')
-        tester("ntpath.normpath('.', strict=True)", r'.')
-        tester("ntpath.normpath('', strict=True)", r'.')
-        tester("ntpath.normpath('/', strict=True)", '\\')
-        tester("ntpath.normpath('c:/', strict=True)", 'c:\\')
-        tester("ntpath.normpath('/../.././..', strict=True)", '\\..\\..\\..')
-        tester("ntpath.normpath('c:/../../..', strict=True)", 'c:\\..\\..\\..')
-        tester("ntpath.normpath('../.././..', strict=True)", r'..\..\..')
-        tester("ntpath.normpath('K:../.././..', strict=True)", r'K:..\..\..')
-        tester("ntpath.normpath('C:////a/b', strict=True)", r'C:\a\b')
-        tester("ntpath.normpath('//machine/share//a/b', strict=True)", r'\\machine\share\a\b')
+        tester("ntpath.normpath('..', keep_curdir=True)", r'..')
+        tester("ntpath.normpath('.', keep_curdir=True)", r'.')
+        tester("ntpath.normpath('', keep_curdir=True)", r'.')
+        tester("ntpath.normpath('/', keep_curdir=True)", '\\')
+        tester("ntpath.normpath('c:/', keep_curdir=True)", 'c:\\')
+        tester("ntpath.normpath('/../.././..', keep_curdir=True)", '\\')
+        tester("ntpath.normpath('c:/../../..', keep_curdir=True)", 'c:\\')
+        tester("ntpath.normpath('../.././..', keep_curdir=True)", r'..\..')
+        tester("ntpath.normpath('K:../.././..', keep_curdir=True)", r'K:..\..')
+        tester("ntpath.normpath('C:////a/b', keep_curdir=True)", r'C:\a\b')
+        tester("ntpath.normpath('//machine/share//a/b', keep_curdir=True)", r'\\machine\share\a\b')
 
-        tester("ntpath.normpath('\\\\.\\NUL', strict=True)", r'\\.\NUL')
-        tester("ntpath.normpath('\\\\?\\D:/XY\\Z', strict=True)", r'\\?\D:/XY\Z')
+        tester("ntpath.normpath('\\\\.\\NUL', keep_curdir=True)", r'\\.\NUL')
+        tester("ntpath.normpath('\\\\?\\D:/XY\\Z', keep_curdir=True)", r'\\?\D:/XY\Z')
+
+    def test_normpath_keep_pardir(self):
+        tester("ntpath.normpath('A//////././//.//B', keep_pardir=True)", r'A\B')
+        tester("ntpath.normpath('A/./B', keep_pardir=True)", r'A\B')
+        tester("ntpath.normpath('A/foo/../B', keep_pardir=True)", r'A\foo\..\B')
+        tester("ntpath.normpath('C:A//B', keep_pardir=True)", r'C:A\B')
+        tester("ntpath.normpath('D:A/./B', keep_pardir=True)", r'D:A\B')
+        tester("ntpath.normpath('e:A/foo/../B', keep_pardir=True)", r'e:A\foo\..\B')
+
+        tester("ntpath.normpath('C:///A//B', keep_pardir=True)", r'C:\A\B')
+        tester("ntpath.normpath('D:///A/./B', keep_pardir=True)", r'D:\A\B')
+        tester("ntpath.normpath('e:///A/foo/../B', keep_pardir=True)", r'e:\A\foo\..\B')
+
+        tester("ntpath.normpath('..', keep_pardir=True)", r'..')
+        tester("ntpath.normpath('.', keep_pardir=True)", r'.')
+        tester("ntpath.normpath('', keep_pardir=True)", r'.')
+        tester("ntpath.normpath('/', keep_pardir=True)", '\\')
+        tester("ntpath.normpath('c:/', keep_pardir=True)", 'c:\\')
+        tester("ntpath.normpath('/../.././..', keep_pardir=True)", '\\..\\..\\..')
+        tester("ntpath.normpath('c:/../../..', keep_pardir=True)", 'c:\\..\\..\\..')
+        tester("ntpath.normpath('../.././..', keep_pardir=True)", r'..\..\..')
+        tester("ntpath.normpath('K:../.././..', keep_pardir=True)", r'K:..\..\..')
+        tester("ntpath.normpath('C:////a/b', keep_pardir=True)", r'C:\a\b')
+        tester("ntpath.normpath('//machine/share//a/b', keep_pardir=True)", r'\\machine\share\a\b')
+
+        tester("ntpath.normpath('\\\\.\\NUL', keep_pardir=True)", r'\\.\NUL')
+        tester("ntpath.normpath('\\\\?\\D:/XY\\Z', keep_pardir=True)", r'\\?\D:/XY\Z')
+
+    def test_normpath_keep_curdir_and_pardir(self):
+        tester("ntpath.normpath("
+               "'A//////././//.//B', keep_curdir=True, keep_pardir=True)",
+               r'A\.\.\.\B')
+        tester("ntpath.normpath("
+               "'A/./B', keep_curdir=True, keep_pardir=True)",
+               r'A\.\B')
+        tester("ntpath.normpath("
+               "'A/foo/../B', keep_curdir=True, keep_pardir=True)",
+               r'A\foo\..\B')
+        tester("ntpath.normpath("
+               "'C:A//B', keep_curdir=True, keep_pardir=True)",
+               r'C:A\B')
+        tester("ntpath.normpath("
+               "'D:A/./B', keep_curdir=True, keep_pardir=True)",
+               r'D:A\.\B')
+        tester("ntpath.normpath("
+               "'e:A/foo/../B', keep_curdir=True, keep_pardir=True)",
+               r'e:A\foo\..\B')
+
+        tester("ntpath.normpath("
+               "'C:///A//B', keep_curdir=True, keep_pardir=True)",
+               r'C:\A\B')
+        tester("ntpath.normpath("
+               "'D:///A/./B', keep_curdir=True, keep_pardir=True)",
+               r'D:\A\.\B')
+        tester("ntpath.normpath("
+               "'e:///A/foo/../B', keep_curdir=True, keep_pardir=True)",
+               r'e:\A\foo\..\B')
+
+        tester("ntpath.normpath("
+               "'..', keep_curdir=True, keep_pardir=True)",
+               r'..')
+        tester("ntpath.normpath("
+               "'.', keep_curdir=True, keep_pardir=True)",
+               r'.')
+        tester("ntpath.normpath("
+               "'', keep_curdir=True, keep_pardir=True)",
+               r'.')
+        tester("ntpath.normpath("
+               "'/', keep_curdir=True, keep_pardir=True)",
+               '\\')
+        tester("ntpath.normpath("
+               "'c:/', keep_curdir=True, keep_pardir=True)",
+               'c:\\')
+        tester("ntpath.normpath("
+               "'/../.././..', keep_curdir=True, keep_pardir=True)",
+               '\\..\\..\\.\\..')
+        tester("ntpath.normpath("
+               "'c:/../../..', keep_curdir=True, keep_pardir=True)",
+               'c:\\..\\..\\..')
+        tester("ntpath.normpath("
+               "'../.././..', keep_curdir=True, keep_pardir=True)",
+               r'..\..\.\..')
+        tester("ntpath.normpath("
+               "'K:../.././..', keep_curdir=True, keep_pardir=True)",
+               r'K:..\..\.\..')
+        tester("ntpath.normpath("
+               "'C:////a/b', keep_curdir=True, keep_pardir=True)",
+               r'C:\a\b')
+        tester("ntpath.normpath("
+               "'//machine/share//a/b', keep_curdir=True, keep_pardir=True)",
+               r'\\machine\share\a\b')
+
+        tester("ntpath.normpath("
+               "'\\\\.\\NUL', keep_curdir=True, keep_pardir=True)",
+               r'\\.\NUL')
+        tester("ntpath.normpath("
+               "'\\\\?\\D:/XY\\Z', keep_curdir=True, keep_pardir=True)",
+               r'\\?\D:/XY\Z')
 
     def test_realpath_curdir(self):
         expected = ntpath.normpath(os.getcwd())

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -324,34 +324,108 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(posixpath.normpath(b"///..//./foo/.//bar"),
                          b"/foo/bar")
 
-    def test_normpath_strict(self):
-        self.assertEqual(posixpath.normpath("", strict=True), ".")
-        self.assertEqual(posixpath.normpath("/", strict=True), "/")
-        self.assertEqual(posixpath.normpath("//", strict=True), "//")
-        self.assertEqual(posixpath.normpath("///", strict=True), "/")
+    def test_normpath_keep_curdir(self):
+        self.assertEqual(posixpath.normpath("", keep_curdir=True), ".")
+        self.assertEqual(posixpath.normpath("/", keep_curdir=True), "/")
+        self.assertEqual(posixpath.normpath("//", keep_curdir=True), "//")
+        self.assertEqual(posixpath.normpath("///", keep_curdir=True), "/")
         self.assertEqual(posixpath.normpath(
-            "///foo/.//bar//", strict=True),
+            "///foo/.//bar//", keep_curdir=True),
+            "/foo/./bar")
+        self.assertEqual(posixpath.normpath(
+            "///foo/.//bar//.//..//.//baz", keep_curdir=True),
+            "/foo/./bar/./baz")
+        self.assertEqual(posixpath.normpath(
+            "///..//./foo/.//bar", keep_curdir=True),
+            "/./foo/./bar")
+
+        self.assertEqual(posixpath.normpath(b"", keep_curdir=True), b".")
+        self.assertEqual(posixpath.normpath(b"/", keep_curdir=True), b"/")
+        self.assertEqual(posixpath.normpath(b"//", keep_curdir=True), b"//")
+        self.assertEqual(posixpath.normpath(b"///", keep_curdir=True), b"/")
+        self.assertEqual(posixpath.normpath(
+            b"///foo/.//bar//", keep_curdir=True),
+            b"/foo/./bar")
+        self.assertEqual(posixpath.normpath(
+            b"///foo/.//bar//.//..//.//baz", keep_curdir=True),
+            b"/foo/./bar/./baz")
+        self.assertEqual(posixpath.normpath(
+            b"///..//./foo/.//bar", keep_curdir=True),
+            b"/./foo/./bar")
+
+    def test_normpath_keep_pardir(self):
+        self.assertEqual(posixpath.normpath("", keep_pardir=True), ".")
+        self.assertEqual(posixpath.normpath("/", keep_pardir=True), "/")
+        self.assertEqual(posixpath.normpath("//", keep_pardir=True), "//")
+        self.assertEqual(posixpath.normpath("///", keep_pardir=True), "/")
+        self.assertEqual(posixpath.normpath(
+            "///foo/.//bar//", keep_pardir=True),
             "/foo/bar")
         self.assertEqual(posixpath.normpath(
-            "///foo/.//bar//.//..//.//baz", strict=True),
+            "///foo/.//bar//.//..//.//baz", keep_pardir=True),
             "/foo/bar/../baz")
         self.assertEqual(posixpath.normpath(
-            "///..//./foo/.//bar", strict=True),
+            "///..//./foo/.//bar", keep_pardir=True),
             "/../foo/bar")
 
-        self.assertEqual(posixpath.normpath(b"", strict=True), b".")
-        self.assertEqual(posixpath.normpath(b"/", strict=True), b"/")
-        self.assertEqual(posixpath.normpath(b"//", strict=True), b"//")
-        self.assertEqual(posixpath.normpath(b"///", strict=True), b"/")
+        self.assertEqual(posixpath.normpath(b"", keep_pardir=True), b".")
+        self.assertEqual(posixpath.normpath(b"/", keep_pardir=True), b"/")
+        self.assertEqual(posixpath.normpath(b"//", keep_pardir=True), b"//")
+        self.assertEqual(posixpath.normpath(b"///", keep_pardir=True), b"/")
         self.assertEqual(posixpath.normpath(
-            b"///foo/.//bar//", strict=True),
+            b"///foo/.//bar//", keep_pardir=True),
             b"/foo/bar")
         self.assertEqual(posixpath.normpath(
-            b"///foo/.//bar//.//..//.//baz", strict=True),
+            b"///foo/.//bar//.//..//.//baz", keep_pardir=True),
             b"/foo/bar/../baz")
         self.assertEqual(posixpath.normpath(
-            b"///..//./foo/.//bar", strict=True),
+            b"///..//./foo/.//bar", keep_pardir=True),
             b"/../foo/bar")
+
+    def test_normpath_keep_curdir_and_pardir(self):
+        self.assertEqual(posixpath.normpath(
+            "", keep_curdir=True, keep_pardir=True),
+            ".")
+        self.assertEqual(posixpath.normpath(
+            "/", keep_curdir=True, keep_pardir=True),
+            "/")
+        self.assertEqual(posixpath.normpath(
+            "//", keep_curdir=True, keep_pardir=True),
+            "//")
+        self.assertEqual(posixpath.normpath(
+            "///", keep_curdir=True, keep_pardir=True),
+            "/")
+        self.assertEqual(posixpath.normpath(
+            "///foo/.//bar//", keep_curdir=True, keep_pardir=True),
+            "/foo/./bar")
+        self.assertEqual(posixpath.normpath(
+            "///foo/.//bar//.//..//.//baz", keep_curdir=True, keep_pardir=True),
+            "/foo/./bar/./.././baz")
+        self.assertEqual(posixpath.normpath(
+            "///..//./foo/.//bar", keep_curdir=True, keep_pardir=True),
+            "/.././foo/./bar")
+
+        self.assertEqual(posixpath.normpath(
+            b"", keep_curdir=True, keep_pardir=True),
+            b".")
+        self.assertEqual(posixpath.normpath(
+            b"/", keep_curdir=True, keep_pardir=True),
+            b"/")
+        self.assertEqual(posixpath.normpath(
+            b"//", keep_curdir=True, keep_pardir=True),
+            b"//")
+        self.assertEqual(posixpath.normpath(
+            b"///", keep_curdir=True, keep_pardir=True),
+            b"/")
+        self.assertEqual(posixpath.normpath(
+            b"///foo/.//bar//", keep_curdir=True, keep_pardir=True),
+            b"/foo/./bar")
+        self.assertEqual(posixpath.normpath(
+            b"///foo/.//bar//.//..//.//baz", keep_curdir=True, keep_pardir=True),
+            b"/foo/./bar/./.././baz")
+        self.assertEqual(posixpath.normpath(
+            b"///..//./foo/.//bar", keep_curdir=True, keep_pardir=True),
+            b"/.././foo/./bar")
 
     @skip_if_ABSTFN_contains_backslash
     def test_realpath_curdir(self):

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -324,6 +324,35 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(posixpath.normpath(b"///..//./foo/.//bar"),
                          b"/foo/bar")
 
+    def test_normpath_strict(self):
+        self.assertEqual(posixpath.normpath("", strict=True), ".")
+        self.assertEqual(posixpath.normpath("/", strict=True), "/")
+        self.assertEqual(posixpath.normpath("//", strict=True), "//")
+        self.assertEqual(posixpath.normpath("///", strict=True), "/")
+        self.assertEqual(posixpath.normpath(
+            "///foo/.//bar//", strict=True),
+            "/foo/bar")
+        self.assertEqual(posixpath.normpath(
+            "///foo/.//bar//.//..//.//baz", strict=True),
+            "/foo/bar/../baz")
+        self.assertEqual(posixpath.normpath(
+            "///..//./foo/.//bar", strict=True),
+            "/../foo/bar")
+
+        self.assertEqual(posixpath.normpath(b"", strict=True), b".")
+        self.assertEqual(posixpath.normpath(b"/", strict=True), b"/")
+        self.assertEqual(posixpath.normpath(b"//", strict=True), b"//")
+        self.assertEqual(posixpath.normpath(b"///", strict=True), b"/")
+        self.assertEqual(posixpath.normpath(
+            b"///foo/.//bar//", strict=True),
+            b"/foo/bar")
+        self.assertEqual(posixpath.normpath(
+            b"///foo/.//bar//.//..//.//baz", strict=True),
+            b"/foo/bar/../baz")
+        self.assertEqual(posixpath.normpath(
+            b"///..//./foo/.//bar", strict=True),
+            b"/../foo/bar")
+
     @skip_if_ABSTFN_contains_backslash
     def test_realpath_curdir(self):
         self.assertEqual(realpath('.'), os.getcwd())

--- a/Misc/NEWS.d/next/Library/2021-06-12-18-36-31.bpo-44316.XaUjsk.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-12-18-36-31.bpo-44316.XaUjsk.rst
@@ -1,3 +1,3 @@
-:func:`os.path.normpath` now accepts a *strict* keyword-only argument. When
-set to ``True``, ``..`` entries are retained, which ensures the path's
-meaning is preserved in the presence of symlinks.
+:func:`os.path.normpath` now accepts *keep_curdir* and *keep_pardir*
+keyword-only arguments. When set to ``True``, references to the current or
+parent directory (``.`` or ``..``) are retained respectively.

--- a/Misc/NEWS.d/next/Library/2021-06-12-18-36-31.bpo-44316.XaUjsk.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-12-18-36-31.bpo-44316.XaUjsk.rst
@@ -1,0 +1,3 @@
+:func:`os.path.normpath` now accepts a *strict* keyword-only argument. When
+set to ``True``, ``..`` entries are retained, which ensures the path's
+meaning is preserved in the presence of symlinks.


### PR DESCRIPTION
Retaining '..' entries ensures the path's meaning is preserved in the presence of symlinks. This functionality was previously available only in pathlib.

Retaining '.' entries helps ensure shells don't interpret paths differently (compare `./python` and `python`). Thanks to @eryksun for the suggestion.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44316](https://bugs.python.org/issue44316) -->
https://bugs.python.org/issue44316
<!-- /issue-number -->
