### PR TITLE
bpo-44389: Fix deprecation of OP_NO_TLSv1_3 (GH-26700)

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -580,6 +580,54 @@ class BasicSocketTests(unittest.TestCase):
             with test_wrap_socket(s) as ss:
                 self.assertEqual(timeout, ss.gettimeout())
 
+    def test_openssl111_deprecations(self):
+        options = [
+            ssl.OP_NO_TLSv1,
+            ssl.OP_NO_TLSv1_1,
+            ssl.OP_NO_TLSv1_2,
+            ssl.OP_NO_TLSv1_3
+        ]
+        protocols = [
+            ssl.PROTOCOL_TLSv1,
+            ssl.PROTOCOL_TLSv1_1,
+            ssl.PROTOCOL_TLSv1_2,
+            ssl.PROTOCOL_TLS
+        ]
+        versions = [
+            ssl.TLSVersion.SSLv3,
+            ssl.TLSVersion.TLSv1,
+            ssl.TLSVersion.TLSv1_1,
+        ]
+
+        for option in options:
+            with self.subTest(option=option):
+                ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                with self.assertWarns(DeprecationWarning) as cm:
+                    ctx.options |= option
+                self.assertEqual(
+                    'ssl.OP_NO_SSL*/ssl.SSL_NO_TLS* options are deprecated',
+                    str(cm.warning)
+                )
+
+        for protocol in protocols:
+            with self.subTest(protocol=protocol):
+                with self.assertWarns(DeprecationWarning) as cm:
+                    ssl.SSLContext(protocol)
+                self.assertEqual(
+                    f'{protocol!r} is deprecated',
+                    str(cm.warning)
+                )
+
+        for version in versions:
+            with self.subTest(version=version):
+                ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                with self.assertWarns(DeprecationWarning) as cm:
+                    ctx.minimum_version = version
+                self.assertEqual(
+                    f'ssl.{version!r} is deprecated',
+                    str(cm.warning)
+                )
+
     @ignore_deprecation
     def test_errors_sslwrap(self):
         sock = socket.socket()
@@ -3067,7 +3115,7 @@ class ThreadedTests(unittest.TestCase):
         client_context.load_verify_locations(SIGNING_CA)
         # TODO: fix TLSv1.3 once SSLContext can restrict signature
         #       algorithms.
-        client_context.options |= ssl.OP_NO_TLSv1_3
+        client_context.maximum_version = ssl.TLSVersion.TLSv1_2
         # only ECDSA certs
         client_context.set_ciphers('ECDHE:ECDSA:!NULL:!aRSA')
         hostname = SIGNED_CERTFILE_ECC_HOSTNAME
@@ -3806,7 +3854,7 @@ class ThreadedTests(unittest.TestCase):
     def test_no_shared_ciphers(self):
         client_context, server_context, hostname = testing_context()
         # OpenSSL enables all TLS 1.3 ciphers, enforce TLS 1.2 for test
-        client_context.options |= ssl.OP_NO_TLSv1_3
+        client_context.maximum_version = ssl.TLSVersion.TLSv1_2
         # Force different suites on client and server
         client_context.set_ciphers("AES128")
         server_context.set_ciphers("AES256")
@@ -4021,10 +4069,10 @@ class ThreadedTests(unittest.TestCase):
         # Check we can get a connection with ephemeral Diffie-Hellman
         client_context, server_context, hostname = testing_context()
         # test scenario needs TLS <= 1.2
-        client_context.options |= ssl.OP_NO_TLSv1_3
+        client_context.maximum_version = ssl.TLSVersion.TLSv1_2
         server_context.load_dh_params(DHFILE)
         server_context.set_ciphers("kEDH")
-        server_context.options |= ssl.OP_NO_TLSv1_3
+        server_context.maximum_version = ssl.TLSVersion.TLSv1_2
         stats = server_params_test(client_context, server_context,
                                    chatty=True, connectionchatty=True,
                                    sni_name=hostname)
@@ -4270,7 +4318,7 @@ class ThreadedTests(unittest.TestCase):
     def test_session(self):
         client_context, server_context, hostname = testing_context()
         # TODO: sessions aren't compatible with TLSv1.3 yet
-        client_context.options |= ssl.OP_NO_TLSv1_3
+        client_context.maximum_version = ssl.TLSVersion.TLSv1_2
 
         # first connection without session
         stats = server_params_test(client_context, server_context,
@@ -4329,8 +4377,8 @@ class ThreadedTests(unittest.TestCase):
         client_context2, _, _ = testing_context()
 
         # TODO: session reuse does not work with TLSv1.3
-        client_context.options |= ssl.OP_NO_TLSv1_3
-        client_context2.options |= ssl.OP_NO_TLSv1_3
+        client_context.maximum_version = ssl.TLSVersion.TLSv1_2
+        client_context2.maximum_version = ssl.TLSVersion.TLSv1_2
 
         server = ThreadedEchoServer(context=server_context, chatty=False)
         with server:
@@ -4754,7 +4802,7 @@ class TestSSLDebug(unittest.TestCase):
 
     def test_msg_callback_tls12(self):
         client_context, server_context, hostname = testing_context()
-        client_context.options |= ssl.OP_NO_TLSv1_3
+        client_context.maximum_version = ssl.TLSVersion.TLSv1_2
 
         msg = []
 

--- a/Misc/NEWS.d/next/Library/2021-06-12-22-58-20.bpo-44389.WTRnoC.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-12-22-58-20.bpo-44389.WTRnoC.rst
@@ -1,0 +1,1 @@
+Fix deprecation of :data:`ssl.OP_NO_TLSv1_3`

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3587,7 +3587,7 @@ set_options(PySSLContext *self, PyObject *arg, void *c)
     long new_opts, opts, set, clear;
     long opt_no = (
         SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 |
-        SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2
+        SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3
     );
 
     if (!PyArg_Parse(arg, "l", &new_opts))


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44389](https://bugs.python.org/issue44389) -->
https://bugs.python.org/issue44389
<!-- /issue-number -->
