### PR TITLE
gh-88574: Handle extra blank response line in imaplib

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -1128,6 +1128,9 @@ class IMAP4:
                 # Read trailer - possibly containing another literal
 
                 dat = self._get_line()
+                # ignore blank line some servers send after the counted data
+                if dat == b'':
+                    dat = self._get_line()
 
             self._append_untagged(typ, dat)
 


### PR DESCRIPTION
Some (buggy) IMAP servers add an extra blank line after a literal value, which makes imaplib throw an exception. This ignores the blank line.
MacOS mail and T'bird can deal with the blank line so it seems to be a somewhat common server bug.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44408](https://bugs.python.org/issue44408) -->
https://bugs.python.org/issue44408
<!-- /issue-number -->


<!-- gh-issue-number: gh-88574 -->
* Issue: gh-88574
<!-- /gh-issue-number -->
