### PR TITLE
[3.10] bpo-36027: Fix a potential reference-counting bug in long_pow (GH-26690)

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4185,6 +4185,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
                 goto Error;
             Py_DECREF(a);
             a = temp;
+            temp = NULL;
         }
 
         /* Reduce base by modulus in some cases:


### PR DESCRIPTION
(cherry picked from commit 59242431991794064824cf2ab70886367613f29e)

Co-authored-by: Mark Dickinson <mdickinson@enthought.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-36027](https://bugs.python.org/issue36027) -->
https://bugs.python.org/issue36027
<!-- /issue-number -->
