### PR TITLE
gh-88435: smtplib make AUTH work with non-ASCII user/pw

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -633,7 +633,7 @@ class SMTP:
         mechanism = mechanism.upper()
         initial_response = (authobject() if initial_response_ok else None)
         if initial_response is not None:
-            response = encode_base64(initial_response.encode('ascii'), eol='')
+            response = encode_base64(initial_response.encode(self.command_encoding), eol='')
             (code, resp) = self.docmd("AUTH", mechanism + " " + response)
             self._auth_challenge_count = 1
         else:
@@ -644,7 +644,7 @@ class SMTP:
             self._auth_challenge_count += 1
             challenge = base64.decodebytes(resp)
             response = encode_base64(
-                authobject(challenge).encode('ascii'), eol='')
+                authobject(challenge).encode(self.command_encoding), eol='')
             (code, resp) = self.docmd(response)
             # If server keeps sending challenges, something is wrong.
             if self._auth_challenge_count > _MAXCHALLENGE:
@@ -663,7 +663,7 @@ class SMTP:
         if challenge is None:
             return None
         return self.user + " " + hmac.HMAC(
-            self.password.encode('ascii'), challenge, 'md5').hexdigest()
+            self.password.encode(self.command_encoding), challenge, 'md5').hexdigest()
 
     def auth_plain(self, challenge=None):
         """ Authobject to use with PLAIN authentication. Requires self.user and


### PR DESCRIPTION
EAI mail systems can have UTF-8 usernames and passwords. This makes AUTH use the same encoding as the rest of smtplib

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44269](https://bugs.python.org/issue44269) -->
https://bugs.python.org/issue44269
<!-- /issue-number -->


<!-- gh-issue-number: gh-88435 -->
* Issue: gh-88435
<!-- /gh-issue-number -->
