### PR TITLE
[3.9] bpo-44409: Fix error location in tokenizer errors that happen during initialization (GH-26712).

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -235,6 +235,7 @@ class ExceptionTests(unittest.TestCase):
             """, 9, 20)
         check("pass\npass\npass\n(1+)\npass\npass\npass", 4, 4)
         check("(1+)", 1, 4)
+        check(b"\xef\xbb\xbf#coding: utf8\nprint('\xe6\x88\x91')\n", 0, -1)
 
         # Errors thrown by symtable.c
         check('x = [(yield i) for i in range(3)]', 1, 5)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-13-23-12-18.bpo-44409.eW4LS-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-13-23-12-18.bpo-44409.eW4LS-.rst
@@ -1,0 +1,2 @@
+Fix error location information for tokenizer errors raised on initialization
+of the tokenizer. Patch by Pablo Galindo.

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -269,6 +269,7 @@ static void
 raise_tokenizer_init_error(PyObject *filename)
 {
     if (!(PyErr_ExceptionMatches(PyExc_LookupError)
+          || PyErr_ExceptionMatches(PyExc_SyntaxError)
           || PyErr_ExceptionMatches(PyExc_ValueError)
           || PyErr_ExceptionMatches(PyExc_UnicodeDecodeError))) {
         return;


### PR DESCRIPTION


<!-- issue-number: [bpo-44409](https://bugs.python.org/issue44409) -->
https://bugs.python.org/issue44409
<!-- /issue-number -->
