### PR TITLE
bpo-44422: Fix threading.enumerate() reentrant call

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -775,8 +775,11 @@ _counter = _count(1).__next__
 def _newname(name_template):
     return name_template % _counter()
 
-# Active thread administration
-_active_limbo_lock = _allocate_lock()
+# Active thread administration.
+#
+# bpo-44422: Use a reentrant lock to allocate reentrant calls to functions like
+# threading.enumerate().
+_active_limbo_lock = RLock()
 _active = {}    # maps thread id to Thread object
 _limbo = {}
 _dangling = WeakSet()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -777,7 +777,7 @@ def _newname(name_template):
 
 # Active thread administration.
 #
-# bpo-44422: Use a reentrant lock to allocate reentrant calls to functions like
+# bpo-44422: Use a reentrant lock to allow reentrant calls to functions like
 # threading.enumerate().
 _active_limbo_lock = RLock()
 _active = {}    # maps thread id to Thread object

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1567,7 +1567,7 @@ def _after_fork():
     # by another (non-forked) thread.  http://bugs.python.org/issue874900
     global _active_limbo_lock, _main_thread
     global _shutdown_locks_lock, _shutdown_locks
-    _active_limbo_lock = _allocate_lock()
+    _active_limbo_lock = RLock()
 
     # fork() only copied the current thread; clear references to others.
     new_active = {}

--- a/Misc/NEWS.d/next/Library/2021-06-14-23-28-17.bpo-44422.BlWOgv.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-14-23-28-17.bpo-44422.BlWOgv.rst
@@ -1,0 +1,2 @@
+The :func:`threading.enumerate` function now uses a reentrant lock to
+prevent a hang on reentrant call.

--- a/Misc/NEWS.d/next/Library/2021-06-14-23-28-17.bpo-44422.BlWOgv.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-14-23-28-17.bpo-44422.BlWOgv.rst
@@ -1,2 +1,3 @@
 The :func:`threading.enumerate` function now uses a reentrant lock to
 prevent a hang on reentrant call.
+Patch by Victor Stinner.


### PR DESCRIPTION
The threading.enumerate() function now uses a reentrant lock to
prevent a hang on reentrant call.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44422](https://bugs.python.org/issue44422) -->
https://bugs.python.org/issue44422
<!-- /issue-number -->
