### PR TITLE
bpo-37224: Fix the sequence of unlock/lock of MUTEX.

### DIFF
--- a/Python/condvar.h
+++ b/Python/condvar.h
@@ -162,13 +162,13 @@ _PyCOND_WAIT_MS(PyCOND_T *cv, PyMUTEX_T *cs, DWORD ms)
 {
     DWORD wait;
     cv->waiting++;
-    PyMUTEX_UNLOCK(cs);
+    PyMUTEX_LOCK(cs);
     /* "lost wakeup bug" would occur if the caller were interrupted here,
      * but we are safe because we are using a semaphore which has an internal
      * count.
      */
     wait = WaitForSingleObjectEx(cv->sem, ms, FALSE);
-    PyMUTEX_LOCK(cs);
+    PyMUTEX_UNLOCK(cs);
     if (wait != WAIT_OBJECT_0)
         --cv->waiting;
         /* Here we have a benign race condition with PyCOND_SIGNAL.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-37224](https://bugs.python.org/issue37224) -->
https://bugs.python.org/issue37224
<!-- /issue-number -->
