### PR TITLE
bpo-42972: _thread.RLock type implements tp_traverse

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-06-15-13-51-25.bpo-42972.UnyYo1.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-15-13-51-25.bpo-42972.UnyYo1.rst
@@ -1,0 +1,2 @@
+The _thread.RLock type now fully implement the GC protocol: add a traverse
+function and the :const:`Py_TPFLAGS_HAVE_GC` flag. Patch by Victor Stinner.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -327,6 +327,14 @@ typedef struct {
     PyObject *in_weakreflist;
 } rlockobject;
 
+static int
+rlock_traverse(rlockobject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(self));
+    return 0;
+}
+
+
 static void
 rlock_dealloc(rlockobject *self)
 {
@@ -579,13 +587,14 @@ static PyType_Slot rlock_type_slots[] = {
     {Py_tp_alloc, PyType_GenericAlloc},
     {Py_tp_new, rlock_new},
     {Py_tp_members, rlock_type_members},
+    {Py_tp_traverse, rlock_traverse},
     {0, 0},
 };
 
 static PyType_Spec rlock_type_spec = {
     .name = "_thread.RLock",
     .basicsize = sizeof(rlockobject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
     .slots = rlock_type_slots,
 };
 


### PR DESCRIPTION
The _thread.RLock type now fully implement the GC protocol: add a
traverse function and the the Py_TPFLAGS_HAVE_GC flag.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42972](https://bugs.python.org/issue42972) -->
https://bugs.python.org/issue42972
<!-- /issue-number -->
