### PR TITLE
[3.10] bpo-43475: Add what's new entry for NaN hash changes (GH-26725)

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -836,6 +836,13 @@ Other Language Changes
   effectless under ``from __future__ import annotations``.
   (Contributed by Batuhan Taskaya in :issue:`42725`.)
 
+* Hashes of NaN values of both :class:`float` type and
+  :class:`decimal.Decimal` type now depend on object identity. Formerly, they
+  always hashed to ``0`` even though NaN values are not equal to one another.
+  This caused potentially quadratic runtime behavior due to excessive hash
+  collisions when creating dictionaries and sets containing multiple NaNs.
+  (Contributed by Raymond Hettinger in :issue:`43475`.)
+
 New Modules
 ===========
 


### PR DESCRIPTION
(cherry picked from commit 1d10bf0bb9409a406c56b0de8870df998637fd0f)

Co-authored-by: Mark Dickinson <mdickinson@enthought.com>


<!-- issue-number: [bpo-43475](https://bugs.python.org/issue43475) -->
https://bugs.python.org/issue43475
<!-- /issue-number -->
