### PR TITLE
bpo-44426: Use of 'complex' as a variable name confuses recent Sphinx; change to 'num'

### DIFF
--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -46,9 +46,9 @@ pointers.  This is consistent throughout the API.
    :c:type:`Py_complex` representation.
 
 
-.. c:function:: Py_complex _Py_c_neg(Py_complex complex)
+.. c:function:: Py_complex _Py_c_neg(Py_complex num)
 
-   Return the negation of the complex number *complex*, using the C
+   Return the negation of the complex number *num*, using the C
    :c:type:`Py_complex` representation.
 
 


### PR DESCRIPTION
Sphinx 4.0.2 misidentifies the name 'complex' as a C keyword, and issues a warning as a result.  Sphinx is wrong here: `complex` is not a keyword (it's a macro), and `Py_complex _Py_c_neg(Py_complex complex);` is a valid C declaration (unless `complex.h` has been included). Nevertheless, it's not a great name. This PR changes it to `num`, which is already used elsewhere in the same file.

<!-- issue-number: [bpo-44426](https://bugs.python.org/issue44426) -->
https://bugs.python.org/issue44426
<!-- /issue-number -->
