### PR TITLE
bpo-43945: [Enum] reduce scope of new format() behavior

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -22,7 +22,7 @@
    * :ref:`Advanced Tutorial <enum-advanced-tutorial>`
    * :ref:`Enum Cookbook <enum-cookbook>`
 
-----------------
+---------------
 
 An enumeration:
 
@@ -58,6 +58,7 @@ are not normal Python classes.  See
      :attr:`Color.RED` is ``RED``, the value of :attr:`Color.BLUE` is
      ``3``, etc.)
 
+---------------
 
 Module Contents
 ---------------
@@ -73,12 +74,12 @@ Module Contents
    :class:`IntEnum`
 
       Base class for creating enumerated constants that are also
-      subclasses of :class:`int`.
+      subclasses of :class:`int`. (`Notes`_)
 
    :class:`StrEnum`
 
       Base class for creating enumerated constants that are also
-      subclasses of :class:`str`.
+      subclasses of :class:`str`. (`Notes`_)
 
    :class:`Flag`
 
@@ -89,7 +90,7 @@ Module Contents
 
       Base class for creating enumerated constants that can be combined using
       the bitwise operators without losing their :class:`IntFlag` membership.
-      :class:`IntFlag` members are also subclasses of :class:`int`.
+      :class:`IntFlag` members are also subclasses of :class:`int`. (`Notes`_)
 
    :class:`EnumCheck`
 
@@ -132,6 +133,7 @@ Module Contents
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 .. versionadded:: 3.10  ``StrEnum``, ``EnumCheck``, ``FlagBoundary``
 
+---------------
 
 Data Types
 ----------
@@ -647,6 +649,7 @@ Data Types
 
 .. versionadded:: 3.10
 
+---------------
 
 Utilites and Decorators
 -----------------------
@@ -710,3 +713,25 @@ Utilites and Decorators
    on the decorated enumeration.
 
 .. versionadded:: 3.10
+
+---------------
+
+Notes
+-----
+
+:class:`IntEnum`, :class:`StrEnum`, and :class:`IntFlag`
+
+    These three enum types are designed to be drop-in replacements for existing
+    integer- and string-based values; as such, they have extra limitations:
+
+    - ``format()`` will use the value of the enum member, unless ``__str__``
+      has been overridden
+
+    - ``StrEnum.__str__`` uses the value and not the name of the enum member
+
+    If you do not need/want those limitations, you can create your own base
+    class by mixing in the ``int`` or ``str`` type yourself::
+
+        >>> from enum import Enum
+        >>> class MyIntEnum(int, Enum):
+        ...     pass

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -126,7 +126,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                     logger.info('set_wakeup_fd(-1) failed: %s', nexc)
 
             if exc.errno == errno.EINVAL:
-                raise RuntimeError(f'sig {sig:d} cannot be caught')
+                raise RuntimeError(f'sig {sig} cannot be caught')
             else:
                 raise
 
@@ -160,7 +160,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
             signal.signal(sig, handler)
         except OSError as exc:
             if exc.errno == errno.EINVAL:
-                raise RuntimeError(f'sig {sig:d} cannot be caught')
+                raise RuntimeError(f'sig {sig} cannot be caught')
             else:
                 raise
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -557,16 +557,27 @@ class TestEnum(unittest.TestCase):
             'mixin-format is still using member.value',
             )
     def test_mixin_format_warning(self):
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(f'{self.Grades.B}', 'Grades.B')
+        class Grades(int, Enum):
+            A = 5
+            B = 4
+            C = 3
+            D = 2
+            F = 0
+        self.assertEqual(f'{self.Grades.B}', 'B')
 
     @unittest.skipIf(
             python_version >= (3, 12),
             'mixin-format now uses member instead of member.value',
             )
     def test_mixin_format_warning(self):
+        class Grades(int, Enum):
+            A = 5
+            B = 4
+            C = 3
+            D = 2
+            F = 0
         with self.assertWarns(DeprecationWarning):
-            self.assertEqual(f'{self.Grades.B}', '4')
+            self.assertEqual(f'{Grades.B}', '4')
 
     def assertFormatIsValue(self, spec, member):
         if python_version < (3, 12) and (not spec or spec in ('{}','{:}')):
@@ -599,7 +610,12 @@ class TestEnum(unittest.TestCase):
         self.assertFormatIsValue('{:f}', Konstants.TAU)
 
     def test_format_enum_int(self):
-        Grades = self.Grades
+        class Grades(int, Enum):
+            A = 5
+            B = 4
+            C = 3
+            D = 2
+            F = 0
         self.assertFormatIsValue('{}', Grades.C)
         self.assertFormatIsValue('{:}', Grades.C)
         self.assertFormatIsValue('{:20}', Grades.C)
@@ -3080,15 +3096,23 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(repr(~(Open.WO | Open.CE)), 'Open.RW')
         self.assertEqual(repr(Open(~4)), '-5')
 
-    @unittest.skipUnless(
-            python_version < (3, 12),
-            'mixin-format now uses member instead of member.value',
-            )
+    # @unittest.skipUnless(
+    #         python_version < (3, 12),
+    #         'mixin-format now uses member instead of member.value',
+    #         )
     def test_format(self):
-        with self.assertWarns(DeprecationWarning):
-            Perm = self.Perm
-            self.assertEqual(format(Perm.R, ''), '4')
-            self.assertEqual(format(Perm.R | Perm.X, ''), '5')
+        Perm = self.Perm
+        self.assertEqual(format(Perm.R, ''), '4')
+        self.assertEqual(format(Perm.R | Perm.X, ''), '5')
+        #
+        class NewPerm(IntFlag):
+            R = 1 << 2  
+            W = 1 << 1
+            X = 1 << 0
+            def __str__(self):
+                return self._name_
+        self.assertEqual(format(NewPerm.R, ''), 'R')
+        self.assertEqual(format(NewPerm.R | Perm.X, ''), 'R|X')
 
     def test_or(self):
         Perm = self.Perm
@@ -3979,10 +4003,6 @@ class TestIntEnumConvert(unittest.TestCase):
                 ('test.test_enum', '__main__')[__name__=='__main__'],
                 filter=lambda x: x.startswith('CONVERT_TEST_'))
 
-    @unittest.skipUnless(
-            python_version < (3, 12),
-            'mixin-format now uses member instead of member.value',
-            )
     def test_convert_repr_and_str(self):
         module = ('test.test_enum', '__main__')[__name__=='__main__']
         test_type = enum.IntEnum._convert_(
@@ -3991,8 +4011,7 @@ class TestIntEnumConvert(unittest.TestCase):
                 filter=lambda x: x.startswith('CONVERT_STRING_TEST_'))
         self.assertEqual(repr(test_type.CONVERT_STRING_TEST_NAME_A), '%s.CONVERT_STRING_TEST_NAME_A' % module)
         self.assertEqual(str(test_type.CONVERT_STRING_TEST_NAME_A), 'CONVERT_STRING_TEST_NAME_A')
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(format(test_type.CONVERT_STRING_TEST_NAME_A), '5')
+        self.assertEqual(format(test_type.CONVERT_STRING_TEST_NAME_A), '5')
 
 # global names for StrEnum._convert_ test
 CONVERT_STR_TEST_2 = 'goodbye'

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3106,7 +3106,7 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(format(Perm.R | Perm.X, ''), '5')
         #
         class NewPerm(IntFlag):
-            R = 1 << 2  
+            R = 1 << 2
             W = 1 << 1
             X = 1 << 0
             def __str__(self):

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -259,7 +259,7 @@ class BaseHTTPServerTestCase(BaseTestCase):
         for code in (HTTPStatus.NO_CONTENT, HTTPStatus.NOT_MODIFIED,
                      HTTPStatus.PROCESSING, HTTPStatus.RESET_CONTENT,
                      HTTPStatus.SWITCHING_PROTOCOLS):
-            self.con.request('SEND_ERROR', '/{:d}'.format(code))
+            self.con.request('SEND_ERROR', '/{}'.format(code))
             res = self.con.getresponse()
             self.assertEqual(code, res.status)
             self.assertEqual(None, res.getheader('Content-Length'))
@@ -276,7 +276,7 @@ class BaseHTTPServerTestCase(BaseTestCase):
         for code in (HTTPStatus.OK, HTTPStatus.NO_CONTENT,
                      HTTPStatus.NOT_MODIFIED, HTTPStatus.RESET_CONTENT,
                      HTTPStatus.SWITCHING_PROTOCOLS):
-            self.con.request('HEAD', '/{:d}'.format(code))
+            self.con.request('HEAD', '/{}'.format(code))
             res = self.con.getresponse()
             self.assertEqual(code, res.status)
             if code == HTTPStatus.OK:


### PR DESCRIPTION
Instead of treating all Enums the same for format(), only user mixed-in
enums will be affected.  In other words, IntEnum and IntFlag will not be
changing the format() behavior, due to the requirement that they be
drop-in replacements of existing integer constants.

If a user creates their own integer-based enum, then the new behavior
will apply:

    class Grades(int, Enum):
        A = 5
        B = 4
        C = 3
        D = 2
        F = 0

Now:  format(Grades.B)  -> DeprecationWarning and '4'
3.12:                   -> no warning, and 'B'



<!-- issue-number: [bpo-43945](https://bugs.python.org/issue43945) -->
https://bugs.python.org/issue43945
<!-- /issue-number -->
