### PR TITLE
bpo-44389: Fix typo in ssl deprecation warning message

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -605,7 +605,7 @@ class BasicSocketTests(unittest.TestCase):
                 with self.assertWarns(DeprecationWarning) as cm:
                     ctx.options |= option
                 self.assertEqual(
-                    'ssl.OP_NO_SSL*/ssl.SSL_NO_TLS* options are deprecated',
+                    'ssl.OP_NO_SSL*/ssl.OP_NO_TLS* options are deprecated',
                     str(cm.warning)
                 )
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3597,7 +3597,7 @@ set_options(PySSLContext *self, PyObject *arg, void *c)
     set = ~opts & new_opts;
 
     if ((set & opt_no) != 0) {
-        if (_ssl_deprecated("ssl.OP_NO_SSL*/ssl.SSL_NO_TLS* options are "
+        if (_ssl_deprecated("ssl.OP_NO_SSL*/ssl.OP_NO_TLS* options are "
                             "deprecated", 2) < 0) {
             return -1;
         }


### PR DESCRIPTION
`ssl.SSL_NO_TLS` should be `ssl.OP_NO_TLS`.


<!-- issue-number: [bpo-44389](https://bugs.python.org/issue44389) -->
https://bugs.python.org/issue44389
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran