### PR TITLE
bpo-44437: Add `multimap(function, iterable, workers)`

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -956,6 +956,16 @@ Miscellaneous
    .. seealso::
       :func:`os.cpu_count`
 
+.. function:: multimap(function, iterable, workers=None)
+
+   Return an iterator that applies function to every item of iterable, yielding the results.
+   
+   The operation is applied in a multiprocessing pool with the specified number of workers.
+   
+   If *workers* is ``None`` then it will default to the number of CPUs
+   detected on the system.  :exc:`NotImplementedError` is raised if *workers*
+   is not explicitly specified and the CPU count failed to be detected.
+   
 .. function:: current_process()
 
    Return the :class:`Process` object corresponding to the current process.

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -956,14 +956,14 @@ Miscellaneous
    .. seealso::
       :func:`os.cpu_count`
 
-.. function:: multimap(function, iterable, workers=None)
+.. function:: multimap(function, iterable, processes=None)
 
    Return an iterator that applies function to every item of iterable, yielding the results.
    
    The operation is applied in a multiprocessing pool with the specified number of workers.
    
-   If *workers* is ``None`` then it will default to the number of CPUs
-   detected on the system.  :exc:`NotImplementedError` is raised if *workers*
+   If *processes* is ``None`` then it will default to the number of CPUs
+   detected on the system.  :exc:`NotImplementedError` is raised if *processes*
    is not explicitly specified and the CPU count failed to be detected.
    
 .. function:: current_process()

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -1,10 +1,10 @@
 import os
 import sys
 import threading
-import multiprocessing
 
 from . import process
 from . import reduction
+from . import pool
 
 __all__ = ()
 
@@ -47,9 +47,11 @@ class BaseContext(object):
         else:
             return num
         
-    def multimap(self, function, iterable, workers=self.cpu_count()):
-        with multiprocessing.Pool(workers) as pool:
-            return list(pool.map(function, iterable))
+    def multimap(self, function, iterable, workers=None):
+        if workers is None:
+            workers = self.cpu_count()
+        with pool.Pool(workers) as p:
+            return list(p.map(function, iterable))
 
     def Manager(self):
         '''Returns a manager associated with a running server process

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -4,7 +4,6 @@ import threading
 
 from . import process
 from . import reduction
-from . import pool
 
 __all__ = ()
 
@@ -48,9 +47,10 @@ class BaseContext(object):
             return num
         
     def multimap(self, function, iterable, processes=None):
+        from .pool import Pool
         if processes is None:
             processes = self.cpu_count()
-        with pool.Pool(processes) as p:
+        with Pool(processes) as p:
             return p.imap(function, iterable)
 
     def Manager(self):

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+import multiprocessing
 
 from . import process
 from . import reduction
@@ -45,6 +46,10 @@ class BaseContext(object):
             raise NotImplementedError('cannot determine number of cpus')
         else:
             return num
+        
+    def multimap(self, function, iterable, workers=self.cpu_count()):
+        with multiprocessing.Pool(workers) as pool:
+            return list(pool.map(function, iterable))
 
     def Manager(self):
         '''Returns a manager associated with a running server process

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -47,11 +47,11 @@ class BaseContext(object):
         else:
             return num
         
-    def multimap(self, function, iterable, workers=None):
-        if workers is None:
-            workers = self.cpu_count()
-        with pool.Pool(workers) as p:
-            return list(p.map(function, iterable))
+    def multimap(self, function, iterable, processes=None):
+        if processes is None:
+            processes = self.cpu_count()
+        with pool.Pool(processes) as p:
+            return p.imap(function, iterable)
 
     def Manager(self):
         '''Returns a manager associated with a running server process

--- a/Misc/NEWS.d/next/Library/2021-06-16-19-36-14.bpo-44437.zeu4pl.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-16-19-36-14.bpo-44437.zeu4pl.rst
@@ -1,0 +1,24 @@
+`multimap(function, iterable, workers)` can be used identically to `map(function, iterable)`, but an additional argument, workers, may be specified as well, whose value defaults to the CPU count of the device. This function maps `function` onto `iterable` in a multiprocessing pool with the specified number of workers.
+
+It is implemented as follows:
+```python
+def multimap(function, iterable, workers=multiprocessing.cpu_count()):
+    with multiprocessing.Pool(workers) as pool:
+        return list(pool.map(function, iterable))
+```
+
+It is implemented in `BaseContext`, and thus it can be imported like so:
+```python
+from multiprocessing import multimap
+```
+
+It can then be used like this, for example:
+```python
+def function(data):
+    output = ___ # PERFORM SOME OPERATION ON DATA
+    return output
+
+output = multimap(function, range(100))
+# or if specifying the number of workers explicitly
+output = multimap(function, range(100), workers = 4)
+```


### PR DESCRIPTION
`multimap(function, iterable, workers)` can be used identically to `map(function, iterable)`, but an additional argument, workers, may be specified as well, whose value defaults to the CPU count of the device. This function maps `function` onto `iterable` in a multiprocessing pool with the specified number of workers.

It is implemented as follows:
```python
def multimap(function, iterable, workers=multiprocessing.cpu_count()):
    with multiprocessing.Pool(workers) as pool:
        return list(pool.map(function, iterable))
```

It is implemented in `BaseContext`, and thus it can be imported like so:
```python
from multiprocessing import multimap
```

It can then be used like this, for example:
```python
def function(data):
    output = ___ # PERFORM SOME OPERATION ON DATA
    return output

output = multimap(function, range(100))
# or if specifying the number of workers explicitly
output = multimap(function, range(100), workers = 4)
```

<!-- issue-number: [bpo-44437](https://bugs.python.org/issue44437) -->
https://bugs.python.org/issue44437
<!-- /issue-number -->
