### PR TITLE
An issue in 'Introducing Positional arguments documentation.'

### DIFF
--- a/Doc/howto/argparse.rst
+++ b/Doc/howto/argparse.rst
@@ -181,7 +181,7 @@ Now, how about doing something even more useful::
    parser = argparse.ArgumentParser()
    parser.add_argument("square", help="display a square of a given number")
    args = parser.parse_args()
-   print(args.square**2)
+   print(int(args.square)**2)
 
 Following is a result of running the code:
 


### PR DESCRIPTION
URL - https://docs.python.org/3/howto/argparse.html

The following code will return a type error:

import argparse
parser = argparse.ArgumentParser()
parser.add_argument("square", help="display a square of a given number")
args = parser.parse_args()
print(args.square**2)

This should be changed to:

import argparse
parser = argparse.ArgumentParser()
parser.add_argument("square", help="display a square of a given number")
args = parser.parse_args()
print(int(args.square)**2)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
