### PR TITLE
bpo-44032: Move pointer to code object from frame-object to frame specials array.

### DIFF
--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -22,7 +22,6 @@ typedef signed char PyFrameState;
 struct _frame {
     PyObject_HEAD
     struct _frame *f_back;      /* previous frame, or NULL */
-    PyCodeObject *f_code;       /* code segment */
     PyObject **f_valuestack;    /* points after the last local */
     PyObject *f_trace;          /* Trace function */
     /* Borrowed reference to a generator, or NULL */

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -8,7 +8,8 @@ enum {
     FRAME_SPECIALS_GLOBALS_OFFSET = 0,
     FRAME_SPECIALS_BUILTINS_OFFSET = 1,
     FRAME_SPECIALS_LOCALS_OFFSET = 2,
-    FRAME_SPECIALS_SIZE = 3
+    FRAME_SPECIALS_CODE_OFFSET = 3,
+    FRAME_SPECIALS_SIZE = 4
 };
 
 static inline PyObject **
@@ -28,6 +29,13 @@ static inline PyObject *
 _PyFrame_GetBuiltins(PyFrameObject *f)
 {
     return _PyFrame_Specials(f)[FRAME_SPECIALS_BUILTINS_OFFSET];
+}
+
+/* Returns a *borrowed* reference. */
+static inline PyCodeObject *
+_PyFrame_GetCode(PyFrameObject *f)
+{
+    return (PyCodeObject *)_PyFrame_Specials(f)[FRAME_SPECIALS_CODE_OFFSET];
 }
 
 int _PyFrame_TakeLocals(PyFrameObject *f);

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1275,7 +1275,7 @@ class SizeofTest(unittest.TestCase):
         # frame
         import inspect
         x = inspect.currentframe()
-        check(x, size('5P3i4cP'))
+        check(x, size('4P3i4cP'))
         # function
         def func(): pass
         check(func, size('14P'))

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -856,6 +856,8 @@ class PyNoneStructPtr(PyObjectPtr):
 
 FRAME_SPECIALS_GLOBAL_OFFSET = 0
 FRAME_SPECIALS_BUILTINS_OFFSET = 1
+FRAME_SPECIALS_CODE_OFFSET = 3
+FRAME_SPECIALS_SIZE = 4
 
 class PyFrameObjectPtr(PyObjectPtr):
     _typename = 'PyFrameObject'
@@ -864,7 +866,7 @@ class PyFrameObjectPtr(PyObjectPtr):
         PyObjectPtr.__init__(self, gdbval, cast_to)
 
         if not self.is_optimized_out():
-            self.co = PyCodeObjectPtr.from_pyobject_ptr(self.field('f_code'))
+            self.co = self._f_code()
             self.co_name = self.co.pyop_field('co_name')
             self.co_filename = self.co.pyop_field('co_filename')
 
@@ -890,11 +892,18 @@ class PyFrameObjectPtr(PyObjectPtr):
             pyop_name = PyObjectPtr.from_pyobject_ptr(self.co_localsplusnames[i])
             yield (pyop_name, pyop_value)
 
+    def _f_specials(self, index):
+        f_valuestack = self.field('f_valuestack')
+        return PyObjectPtr.from_pyobject_ptr(f_valuestack[index - FRAME_SPECIALS_SIZE])
+
+
     def _f_globals(self):
-        f_localsplus = self.field('f_localsptr')
-        nlocalsplus = int_from_int(self.co.field('co_nlocalsplus'))
-        index = nlocalsplus + FRAME_SPECIALS_GLOBAL_OFFSET
-        return PyObjectPtr.from_pyobject_ptr(f_localsplus[index])
+        return self._f_specials(FRAME_SPECIALS_GLOBAL_OFFSET)
+
+    def _f_code(self):
+        f_valuestack = self.field('f_valuestack')
+        code = f_valuestack[FRAME_SPECIALS_CODE_OFFSET - FRAME_SPECIALS_SIZE]
+        return PyCodeObjectPtr.from_pyobject_ptr(code)
 
     def iter_globals(self):
         '''
@@ -908,10 +917,7 @@ class PyFrameObjectPtr(PyObjectPtr):
         return pyop_globals.iteritems()
 
     def _f_builtins(self):
-        f_localsplus = self.field('f_localsptr')
-        nlocalsplus = int_from_int(self.co.field('co_nlocalsplus'))
-        index = nlocalsplus + FRAME_SPECIALS_BUILTINS_OFFSET
-        return PyObjectPtr.from_pyobject_ptr(f_localsplus[index])
+        return self._f_specials(FRAME_SPECIALS_BUILTINS_OFFSET)
 
     def iter_builtins(self):
         '''

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -892,18 +892,18 @@ class PyFrameObjectPtr(PyObjectPtr):
             pyop_name = PyObjectPtr.from_pyobject_ptr(self.co_localsplusnames[i])
             yield (pyop_name, pyop_value)
 
-    def _f_specials(self, index):
+    def _f_specials(self, index, cls=PyObjectPtr):
         f_valuestack = self.field('f_valuestack')
-        return PyObjectPtr.from_pyobject_ptr(f_valuestack[index - FRAME_SPECIALS_SIZE])
-
+        return cls.from_pyobject_ptr(f_valuestack[index - FRAME_SPECIALS_SIZE])
 
     def _f_globals(self):
         return self._f_specials(FRAME_SPECIALS_GLOBAL_OFFSET)
 
+    def _f_builtins(self):
+        return self._f_specials(FRAME_SPECIALS_BUILTINS_OFFSET)
+
     def _f_code(self):
-        f_valuestack = self.field('f_valuestack')
-        code = f_valuestack[FRAME_SPECIALS_CODE_OFFSET - FRAME_SPECIALS_SIZE]
-        return PyCodeObjectPtr.from_pyobject_ptr(code)
+        return self._f_specials(FRAME_SPECIALS_CODE_OFFSET, PyCodeObjectPtr)
 
     def iter_globals(self):
         '''
@@ -915,9 +915,6 @@ class PyFrameObjectPtr(PyObjectPtr):
 
         pyop_globals = self._f_globals()
         return pyop_globals.iteritems()
-
-    def _f_builtins(self):
-        return self._f_specials(FRAME_SPECIALS_BUILTINS_OFFSET)
 
     def iter_builtins(self):
         '''


### PR DESCRIPTION
The `f_code` field is the last field in the frame object that cannot be lazily evaluated if we want to lazily create frame objects, or ignore them in the interpreter.

<!-- issue-number: [bpo-44032](https://bugs.python.org/issue44032) -->
https://bugs.python.org/issue44032
<!-- /issue-number -->
