### PR TITLE
bpo-31299: Make it possible to filter out frames from tracebacks

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -363,7 +363,7 @@ capture data for later printing in a lightweight fashion.
 
       Returns a string for printing one of the frames involved in the stack.
       This method gets called for each frame object to be printed in the
-      :class:`StackSummary`. If it returns ``none``, the frame is omitted
+      :class:`StackSummary`. If it returns ``None``, the frame is omitted
       from the output.
 
       .. versionadded:: 3.11

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -212,7 +212,7 @@ The module also defines the following classes:
 :class:`TracebackException` objects are created from actual exceptions to
 capture data for later printing in a lightweight fashion.
 
-.. class:: TracebackException(exc_type, exc_value, exc_traceback, *, limit=None, lookup_lines=True, capture_locals=False, compact=False)
+.. class:: TracebackException(exc_type, exc_value, exc_traceback, *, limit=None, lookup_lines=True, capture_locals=False, compact=False, stack_summary_cls=None)
 
    Capture an exception for later rendering. *limit*, *lookup_lines* and
    *capture_locals* are as for the :class:`StackSummary` class.
@@ -221,6 +221,10 @@ capture data for later printing in a lightweight fashion.
    ``format`` method is saved in the class attributes. In particular, the
    ``__context__`` field is calculated only if ``__cause__`` is ``None`` and
    ``__suppress_context__`` is false.
+
+   If *stack_summary_cls* is not ``None``, it is a class to be used instead of
+   the default :class:`~traceback.StackSummary` to format the stack (typically
+   a subclass that overrides :meth:`~traceback.StackSummary.format_frame`).
 
    Note that when locals are captured, they are also shown in the traceback.
 
@@ -309,6 +313,8 @@ capture data for later printing in a lightweight fashion.
    .. versionchanged:: 3.10
       Added the *compact* parameter.
 
+   .. versionchanged:: 3.11
+      Added the *stack_summary_cls* paramter.
 
 :class:`StackSummary` Objects
 -----------------------------
@@ -357,7 +363,8 @@ capture data for later printing in a lightweight fashion.
 
       Returns a string for printing one of the frames involved in the stack.
       This method gets called for each frame object to be printed in the
-      :class:`StackSummary`.
+      :class:`StackSummary`. If it returns ``none``, the frame is omitted
+      from the output.
 
       .. versionadded:: 3.11
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1473,7 +1473,8 @@ class TestStack(unittest.TestCase):
             default.remove(l)
         # Only the lines for g's frame should remain:
         self.assertEqual(len(default), 3)
-        self.assertRegex(default[0], ', line [0-9]*, in g')
+        lno = g.__code__.co_firstlineno + 2
+        self.assertEqual(default[0], f'  File "{__file__}", line {lno}, in g')
         self.assertEqual(default[1], '    f()')
         self.assertEqual(default[2], '    ^^^')
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1782,11 +1782,11 @@ class TestTracebackException(unittest.TestCase):
 
 class TestTracebackException_CustomStackSummary(unittest.TestCase):
     def _get_output(self, *exc_info, stack_summary_cls=None):
-            output = StringIO()
-            traceback.TracebackException(
-                *exc_info, stack_summary_cls=stack_summary_cls,
-            ).print(file=output)
-            return output.getvalue().split('\n')
+        output = StringIO()
+        traceback.TracebackException(
+            *exc_info, stack_summary_cls=stack_summary_cls,
+        ).print(file=output)
+        return output.getvalue().split('\n')
 
     class MyStackSummary(traceback.StackSummary):
         def format_frame(self, frame):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -453,7 +453,8 @@ class StackSummary(list):
         """Format the lines for a single frame.
 
         Returns a string representing one frame involved in the stack. This
-        gets called for every frame to be printed in the stack summary.
+        gets called for every frame to be printed in the stack summary. If
+        it returns ``None``, the frame is omitted from the output.
         """
         row = []
         row.append('  File "{}", line {}, in {}\n'.format(

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -537,10 +537,11 @@ class StackSummary(list):
 
         if count > _RECURSIVE_CUTOFF:
             count -= _RECURSIVE_CUTOFF
-            result.append(
-                f'  [Previous line repeated {count} more '
-                f'time{"s" if count > 1 else ""}]\n'
-            )
+            if last_line_displayed:
+                result.append(
+                    f'  [Previous line repeated {count} more '
+                    f'time{"s" if count > 1 else ""}]\n'
+                )
         return result
 
 
@@ -674,6 +675,7 @@ class TracebackException:
                         limit=limit,
                         lookup_lines=lookup_lines,
                         capture_locals=capture_locals,
+                        stack_summary_cls=stack_summary_cls,
                         _seen=_seen)
                 else:
                     cause = None
@@ -693,6 +695,7 @@ class TracebackException:
                         limit=limit,
                         lookup_lines=lookup_lines,
                         capture_locals=capture_locals,
+                        stack_summary_cls=stack_summary_cls,
                         _seen=_seen)
                 else:
                     context = None

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -508,40 +508,34 @@ class StackSummary(list):
         last_file = None
         last_line = None
         last_name = None
-        last_line_displayed = False
         count = 0
         for frame in self:
-            if (last_file is None or last_file != frame.filename or
-                last_line is None or last_line != frame.lineno or
-                last_name is None or last_name != frame.name):
-                if count > _RECURSIVE_CUTOFF:
-                    count -= _RECURSIVE_CUTOFF
-                    if last_line_displayed:
+            formatted_frame = self.format_frame(frame)
+            if formatted_frame is not None:
+                if (last_file is None or last_file != frame.filename or
+                    last_line is None or last_line != frame.lineno or
+                    last_name is None or last_name != frame.name):
+                    if count > _RECURSIVE_CUTOFF:
+                        count -= _RECURSIVE_CUTOFF
                         result.append(
                             f'  [Previous line repeated {count} more '
                             f'time{"s" if count > 1 else ""}]\n'
                         )
-                last_file = frame.filename
-                last_line = frame.lineno
-                last_name = frame.name
-                count = 0
-            count += 1
-            if count > _RECURSIVE_CUTOFF:
-                continue
-            formatted_frame = self.format_frame(frame)
-            if formatted_frame is not None:
-                last_line_displayed = True
+                    last_file = frame.filename
+                    last_line = frame.lineno
+                    last_name = frame.name
+                    count = 0
+                count += 1
+                if count > _RECURSIVE_CUTOFF:
+                    continue
                 result.append(formatted_frame)
-            else:
-                last_line_displayed = False
 
         if count > _RECURSIVE_CUTOFF:
             count -= _RECURSIVE_CUTOFF
-            if last_line_displayed:
-                result.append(
-                    f'  [Previous line repeated {count} more '
-                    f'time{"s" if count > 1 else ""}]\n'
-                )
+            result.append(
+                f'  [Previous line repeated {count} more '
+                f'time{"s" if count > 1 else ""}]\n'
+            )
         return result
 
 

--- a/Misc/NEWS.d/next/Library/2021-06-17-16-16-33.bpo-31299.d4WDz7.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-17-16-16-33.bpo-31299.d4WDz7.rst
@@ -1,0 +1,1 @@
+Added the ``stack_summary_cls`` parameter to :class:`TracebackException`, to allow fine-grained control over the content of a formatted traceback.  Added option to completely drop frames from the output by returning ``None`` from a :meth:`~StackSummary.format_frame` override.


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-31299](https://bugs.python.org/issue31299) -->
https://bugs.python.org/issue31299
<!-- /issue-number -->
