### PR TITLE
bpo-38193: Add http.client script

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1517,3 +1517,47 @@ class RemoteDisconnected(ConnectionResetError, BadStatusLine):
 
 # for backwards compatibility
 error = HTTPException
+
+def _get_http_version(response_version):
+    if response.version == 10:
+        return '1.0'
+    if response.version == 11:
+        return '1.1'
+    return 'unknown'
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--method', '-m', default='GET',
+                        help='HTTP method used in the request'
+                        '[default:current directory]')
+    parser.add_argument('--output', '-o', default='',
+                        nargs='?',
+                        help='File to save the response body')
+    parser.add_argument('url', help='URL to make the request to')
+    args = parser.parse_args()
+
+    from urllib.parse import urlparse
+    parsed_url = urlparse(args.url)
+
+    http_connection = HTTPConnection(parsed_url.netloc)
+    http_connection.request(method=args.method, url=parsed_url.path)
+    try:
+        response = http_connection.getresponse()
+        response_body = response.read()
+        if args.output:
+            with open(args.output, 'wb+') as output_file:
+                output_file.write(response_body)
+        http_version = _get_http_version(response.version)
+        print('HTTP/%s %d %s' % (http_version, response.status, response.reason))
+        print(response.headers.as_string().strip())
+        print()
+        try:
+            print(response_body.decode('utf-8'))
+        except UnicodeDecodeError:
+            print(response_body.hex())
+    finally:
+        http_connection.close()
+

--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-17-19-18-53.bpo-38193.nAG1AB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-17-19-18-53.bpo-38193.nAG1AB.rst
@@ -1,0 +1,1 @@
+Enabled http.client module script to do simple HTTP requests


### PR DESCRIPTION
Adding http.client script.

Examples:

Handling JSON response:
```
$ ./python -m http.client https://httpbin.org/json
HTTP/1.1 200 OK
Date: Thu, 17 Jun 2021 19:14:38 GMT
Content-Type: application/json
Content-Length: 429
Connection: keep-alive
Server: gunicorn/19.9.0
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true

{
  "slideshow": {
    "author": "Yours Truly",
    "date": "date of publication",
    "slides": [
      {
        "title": "Wake up to WonderWidgets!",
        "type": "all"
      },
      {
        "items": [
          "Why <em>WonderWidgets</em> are great",
          "Who <em>buys</em> WonderWidgets"
        ],
        "title": "Overview",
        "type": "all"
      }
    ],
    "title": "Sample Slide Show"
  }
}
```

Handling binary response:
```
$ ./python -m http.client https://httpbin.org/brotli
HTTP/1.1 200 OK
Date: Thu, 17 Jun 2021 19:15:14 GMT
Content-Type: application/json
Content-Length: 164
Connection: keep-alive
Server: gunicorn/19.9.0
Content-Encoding: br
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true

1bda00001c07ced93cc8c13c0587a0cf06cf918f335f62d72efa1344a42f1592a8e03f77db091f98dcdbdf6e0b5a0b83200ae3dc234bb7f9081e227a6881ac820ee9e8f9a3fa3ede7502f758c25acff5006f54b09e62aae86b28a657cd0e20da9a48eef17dcf5a38146957898aeddbd1400c54abf463fd4b18d2b4a95d2f3992a2eb84d51d6d2bd389c64a26b4925a035c9a30082aed2fc585bc1d8a6341b16fc64deb03
```

Writing response to file:
```
$ ./python -m http.client https://httpbin.org/brotli -o out.brotli
HTTP/1.1 200 OK
Date: Thu, 17 Jun 2021 19:15:55 GMT
Content-Type: application/json
Content-Length: 164
Connection: keep-alive
Server: gunicorn/19.9.0
Content-Encoding: br
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true

1bda00001c07ceb93cc8c19be010f4d9e2b6d49f45318b74cd3b6a091244a42f14e03f77db091f98dcdbdfda82d6c22088c220ca3d91749b8fe021a29015c82ae8908e9e3fc17dbceb84eeb184b59ef341be51c17a8aa990afa118be72768451d644e71adff704e15024bb1a926ddf4e0a203ac95ba51eeb3712c4e606bcde06e238bd911c94ecedd618cf121e340e8d3835611094db5f8a0b79db2c4915a7be3adeb436

$ file out.brotli
out.brotli: data
$ ls -lh out.brotli
-rw-r--r-- 1 jaswdr jaswdr 164 Jun 17 19:15 out.brotli
```

<!-- issue-number: [bpo-38193](https://bugs.python.org/issue38193) -->
https://bugs.python.org/issue38193
<!-- /issue-number -->
