### PR TITLE
bpo-25251:Adding vcruntime140 support to cygwin

### DIFF
--- a/Lib/distutils/cygwinccompiler.py
+++ b/Lib/distutils/cygwinccompiler.py
@@ -80,6 +80,10 @@ def get_msvcr():
         elif msc_ver == '1600':
             # VS2010 / MSVC 10.0
             return ['msvcr100']
+        elif msc_ver == '1900':
+            # Visual Studio 2015 / Visual C++ 14.0
+            # "msvcr140.dll no longer exists" 
+            return ['vcruntime140']
         else:
             raise ValueError("Unknown MS Compiler version %s " % msc_ver)
 


### PR DESCRIPTION
Fixing the fact that MinGW compilation cygwin will identify it and python as vcruntime140 but there is not a definition for it. Fix taken from: https://www.programmersought.com/article/95064175115/

Noticed it never seems to have been submitted as a pull request to actually apply the fix so submitting my own.


<!-- issue-number: [bpo-25251](https://bugs.python.org/issue25251) -->
https://bugs.python.org/issue25251
<!-- /issue-number -->
