### PR TITLE
bpo-44446: support lineno being None in traceback.FrameSummary

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1204,6 +1204,10 @@ class TestFrame(unittest.TestCase):
             '"""Test cases for traceback module"""',
             f.line)
 
+    def test_no_line(self):
+        f = traceback.FrameSummary("f", None, "dummy")
+        self.assertEqual(f.line, None)
+
     def test_explicit_line(self):
         f = traceback.FrameSummary("f", 1, "dummy", line="line")
         self.assertEqual("line", f.line)

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -310,6 +310,8 @@ class FrameSummary:
     @property
     def line(self):
         if self._line is None:
+            if self.lineno is None:
+                return None
             self._line = linecache.getline(self.filename, self.lineno)
         return self._line.strip()
 

--- a/Misc/NEWS.d/next/Library/2021-06-17-22-39-34.bpo-44446.qwdRic.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-17-22-39-34.bpo-44446.qwdRic.rst
@@ -1,0 +1,1 @@
+Take into account that ``lineno`` might be ``None`` in :class:`traceback.FrameSummary`.


### PR DESCRIPTION
As of 088a15c49d99ecb4c3bef93f8f40dd513c6cae3b, lineno is None instead of -1 if there is no line number.

Signed-off-by: Filipe Laíns <lains@riseup.net>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44446](https://bugs.python.org/issue44446) -->
https://bugs.python.org/issue44446
<!-- /issue-number -->
