### PR TITLE
bpo-44451: Reset DeprecationWarning filters in test_importlib.test_entry_points_by_index

### DIFF
--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -139,6 +139,7 @@ class APITests(
         """
         eps = distribution('distinfo-pkg').entry_points
         with warnings.catch_warnings(record=True) as caught:
+            warnings.filterwarnings("default", category=DeprecationWarning)
             eps[0]
 
         # check warning

--- a/Misc/NEWS.d/next/Tests/2021-06-18-15-19-35.bpo-44451.aj5pqE.rst
+++ b/Misc/NEWS.d/next/Tests/2021-06-18-15-19-35.bpo-44451.aj5pqE.rst
@@ -1,0 +1,3 @@
+Reset ``DeprecationWarning`` filters in
+``test.test_importlib.test_metadata_api.APITests.test_entry_points_by_index``
+to avoid ``StopIteration`` error if ``DeprecationWarnings`` are ignored.


### PR DESCRIPTION
This avoids the following error if DeprecationWarnings are ignored.

    ======================================================================
    ERROR: test_entry_points_by_index (test.test_importlib.test_metadata_api.APITests)
    Prior versions of Distribution.entry_points would return a
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/Python-3.10.0b3/Lib/test/test_importlib/test_metadata_api.py", line 145, in test_entry_points_by_index
        expected = next(iter(caught))
    StopIteration
    ----------------------------------------------------------------------
    Ran 1402 tests in 2.125s
    FAILED (errors=1, skipped=18, expected failures=1)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44451](https://bugs.python.org/issue44451) -->
https://bugs.python.org/issue44451
<!-- /issue-number -->
