### PR TITLE
bpo-44453: Fix return type documentation for sysconfig.get_path()

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -175,7 +175,7 @@ identifier.  Python currently uses eight paths:
    If *expand* is set to ``False``, the path will not be expanded using the
    variables.
 
-   If *name* is not found, return ``None``.
+   If *name* is not found, raise a :exc:`KeyError`.
 
 
 .. function:: get_paths([scheme, [vars, [expand]]])

--- a/Misc/NEWS.d/next/Documentation/2021-06-18-06-44-45.bpo-44453.3PIkj2.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-18-06-44-45.bpo-44453.3PIkj2.rst
@@ -1,0 +1,1 @@
+Fix documentation for the return type of :func:`sysconfig.get_path`.


### PR DESCRIPTION
The current documentation says it returns None if the name is not found, but
the implementation uses [] and will raise KeyError instead.

Noticed by @srittau in python/typeshed#5659.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44453](https://bugs.python.org/issue44453) -->
https://bugs.python.org/issue44453
<!-- /issue-number -->
