### PR TITLE
bpo-44426: Fix use of the C keyword 'default' as a variable name

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -311,12 +311,12 @@ Object Protocol
    returned.  This is the equivalent to the Python expression ``len(o)``.
 
 
-.. c:function:: Py_ssize_t PyObject_LengthHint(PyObject *o, Py_ssize_t default)
+.. c:function:: Py_ssize_t PyObject_LengthHint(PyObject *o, Py_ssize_t defaultvalue)
 
    Return an estimated length for the object *o*. First try to return its
    actual length, then an estimate using :meth:`~object.__length_hint__`, and
    finally return the default value. On error return ``-1``. This is the
-   equivalent to the Python expression ``operator.length_hint(o, default)``.
+   equivalent to the Python expression ``operator.length_hint(o, defaultvalue)``.
 
    .. versionadded:: 3.4
 


### PR DESCRIPTION
The declaration
```
.. c:function:: Py_ssize_t PyObject_LengthHint(PyObject *o, Py_ssize_t default)
```
causes Sphinx >= 4.0 to issue a warning about the use of the C keyword `default` as a variable name. This PR changes `default` to `defaultvalue`, which is what's used in the actual `abstract.c` source.


<!-- issue-number: [bpo-44426](https://bugs.python.org/issue44426) -->
https://bugs.python.org/issue44426
<!-- /issue-number -->
