### PR TITLE
bpo-43298: Improved error message when building without the Windows SDK installed

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-06-19-11-50-03.bpo-43298.9ircMb.rst
+++ b/Misc/NEWS.d/next/Build/2021-06-19-11-50-03.bpo-43298.9ircMb.rst
@@ -1,0 +1,1 @@
+Improved error message when building without a Windows SDK installed.

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -108,9 +108,18 @@
 
     <!-- The minimum allowed SDK version to use for building -->
     <DefaultWindowsSDKVersion>10.0.10586.0</DefaultWindowsSDKVersion>
-    <DefaultWindowsSDKVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) > $([System.Version]::Parse($(DefaultWindowsSDKVersion)))">$(_RegistryVersion)</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) != '' and $([System.Version]::Parse($(_RegistryVersion))) > $([System.Version]::Parse($(DefaultWindowsSDKVersion)))">$(_RegistryVersion)</DefaultWindowsSDKVersion>
   </PropertyGroup>
-  
+
+  <Target Name="_CheckWindowsSDKFound" BeforeTargets="_CheckWindowsSDKInstalled" Condition="$(_RegistryVersion) == ''">
+    <PropertyGroup>
+      <_Message>Failed to locate a Windows SDK installation.</_Message>
+      <_Message>$(_Message) If the build fails, please use the Visual Studio Installer to install the Windows SDK.</_Message>
+      <_Message>$(_Message) (Ignore the version number specified in the error message and select the latest.)</_Message>
+    </PropertyGroup>
+    <Warning Text="$(_Message)" />
+  </Target>
+
   <PropertyGroup Condition="$(WindowsTargetPlatformVersion) == ''">
     <WindowsTargetPlatformVersion>$(DefaultWindowsSDKVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
@@ -175,7 +184,7 @@
     <ReleaseLevelNumber Condition="$(_ReleaseLevel) == 'b'">11</ReleaseLevelNumber>
     <ReleaseLevelNumber Condition="$(_ReleaseLevel) == 'rc'">12</ReleaseLevelNumber>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <PythonVersionNumber>$(MajorVersionNumber).$(MinorVersionNumber).$(MicroVersionNumber)</PythonVersionNumber>
     <PythonVersion>$(MajorVersionNumber).$(MinorVersionNumber).$(MicroVersionNumber)$(ReleaseLevelName)</PythonVersion>


### PR DESCRIPTION


<!-- issue-number: [bpo-43298](https://bugs.python.org/issue43298) -->
https://bugs.python.org/issue43298
<!-- /issue-number -->
