### PR TITLE
bpo-44464: Remove special exclusion for flake8 in the deprecation warnings. Sync with importlib_metadata 4.6.

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1071,7 +1071,7 @@ and will be incorrect in some rare cases, including some ``_``-s in
 importlib.metadata
 ------------------
 
-Feature parity with ``importlib_metadata`` 4.4
+Feature parity with ``importlib_metadata`` 4.6
 (`history <https://importlib-metadata.readthedocs.io/en/latest/history.html>`_).
 
 :ref:`importlib.metadata entry points <entry-points>`

--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -362,14 +362,6 @@ class EntryPoints(DeprecatedList):
         )
 
 
-def flake8_bypass(func):
-    # defer inspect import as performance optimization.
-    import inspect
-
-    is_flake8 = any('flake8' in str(frame.filename) for frame in inspect.stack()[:5])
-    return func if not is_flake8 else lambda: None
-
-
 class Deprecated:
     """
     Compatibility add-in for mapping to indicate that
@@ -405,7 +397,7 @@ class Deprecated:
         return super().__getitem__(name)
 
     def get(self, name, default=None):
-        flake8_bypass(self._warn)()
+        self._warn()
         return super().get(name, default)
 
     def __iter__(self):

--- a/Misc/NEWS.d/next/Library/2021-06-19-21-52-27.bpo-44464.U2oa-a.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-19-21-52-27.bpo-44464.U2oa-a.rst
@@ -1,0 +1,2 @@
+Remove exception for flake8 in deprecated importlib.metadata interfaces.
+Sync with importlib_metadata 4.6.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44464](https://bugs.python.org/issue44464) -->
https://bugs.python.org/issue44464
<!-- /issue-number -->
