### PR TITLE
bpo-44458: Ensure BUFFER_BLOCK_SIZE symbol is statically allocated.

### DIFF
--- a/Include/internal/pycore_blocks_output_buffer.h
+++ b/Include/internal/pycore_blocks_output_buffer.h
@@ -57,7 +57,7 @@ static const char unable_allocate_msg[] = "Unable to allocate output buffer.";
 /* Block size sequence */
 #define KB (1024)
 #define MB (1024*1024)
-const Py_ssize_t BUFFER_BLOCK_SIZE[] =
+static const Py_ssize_t BUFFER_BLOCK_SIZE[] =
     { 32*KB, 64*KB, 256*KB, 1*MB, 4*MB, 8*MB, 16*MB, 16*MB,
       32*MB, 32*MB, 32*MB, 32*MB, 64*MB, 64*MB, 128*MB, 128*MB,
       OUTPUT_BUFFER_MAX_BLOCK_SIZE };

--- a/Misc/NEWS.d/next/Library/2021-06-20-07-14-46.bpo-44458.myqCQ0.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-20-07-14-46.bpo-44458.myqCQ0.rst
@@ -1,0 +1,1 @@
+``BUFFER_BLOCK_SIZE`` is now declared static, to avoid linking collisions when bz2, lmza or zlib are statically linked.


### PR DESCRIPTION
Modifies the declaration of `BUFFER_BLOCK_SIZE` to be static, so that if multiple modules include the `pycore_blocks_output_buffer.h` header file, the resulting Python executable is able to link.

Without this declaration, if two or more of the bz2, lzma or zlib modules are compiled as statically linked modules (i.e., added to Lib/Setup.local), linking the Python executable results in a duplicate symbol error:

```
duplicate symbol '_BUFFER_BLOCK_SIZE' in:
    libpython3.10.a(_bz2module.o)
    libpython3.10.a(_lzmamodule.o)
duplicate symbol '_BUFFER_BLOCK_SIZE' in:
    libpython3.10.a(_bz2module.o)
    libpython3.10.a(zlibmodule.o)
```

<!-- issue-number: [bpo-44458](https://bugs.python.org/issue44458) -->
https://bugs.python.org/issue44458
<!-- /issue-number -->
