### PR TITLE
bpo-41546: make pprint (like print) not write to stdout when it is None

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -46,6 +46,8 @@ The :mod:`pprint` module defines one class:
 
    *stream* (default ``sys.stdout``) is a :term:`file-like object` to
    which the output will be written by calling its :meth:`write` method.
+   If both *stream* and ``sys.stdout`` are ``None``, then
+   :meth:`~PrettyPrinter.pprint` silently returns.
 
    Other values configure the manner in which nesting of complex data
    structures is displayed.
@@ -84,6 +86,9 @@ The :mod:`pprint` module defines one class:
    .. versionchanged:: 3.10
       Added the *underscore_numbers* parameter.
 
+   .. versionchanged:: 3.11
+      No longer attempts to write to ``sys.stdout`` if it is None.
+
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
       >>> stuff.insert(0, stuff[:])
@@ -107,24 +112,13 @@ The :mod:`pprint` module defines one class:
       >>> pp.pprint(tup)
       ('spam', ('eggs', ('lumberjack', ('knights', ('ni', ('dead', (...)))))))
 
-
-The :mod:`pprint` module also provides several shortcut functions:
-
 .. function:: pformat(object, indent=1, width=80, depth=None, *, \
                       compact=False, sort_dicts=True, underscore_numbers=False)
 
    Return the formatted representation of *object* as a string.  *indent*,
-   *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* will be passed to the
-   :class:`PrettyPrinter` constructor as formatting parameters.
-
-   .. versionchanged:: 3.4
-      Added the *compact* parameter.
-
-   .. versionchanged:: 3.8
-      Added the *sort_dicts* parameter.
-
-   .. versionchanged:: 3.10
-      Added the *underscore_numbers* parameter.
+   *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* are
+   passed to the :class:`PrettyPrinter` constructor as formatting parameters
+   and their meanings are as described in its documentation above.
 
 
 .. function:: pp(object, *args, sort_dicts=False, **kwargs)
@@ -142,20 +136,15 @@ The :mod:`pprint` module also provides several shortcut functions:
                      compact=False, sort_dicts=True, underscore_numbers=False)
 
    Prints the formatted representation of *object* on *stream*, followed by a
-   newline.  If *stream* is ``None``, ``sys.stdout`` is used.  This may be used
+   newline.  If *stream* is ``None``, ``sys.stdout`` is used. This may be used
    in the interactive interpreter instead of the :func:`print` function for
    inspecting values (you can even reassign ``print = pprint.pprint`` for use
-   within a scope).  *indent*, *width*, *depth*, *compact*, *sort_dicts* and *underscore_numbers* will
-   be passed to the :class:`PrettyPrinter` constructor as formatting parameters.
+   within a scope).
 
-   .. versionchanged:: 3.4
-      Added the *compact* parameter.
-
-   .. versionchanged:: 3.8
-      Added the *sort_dicts* parameter.
-
-   .. versionchanged:: 3.10
-      Added the *underscore_numbers* parameter.
+   The configuration parameters *stream*, *indent*, *width*, *depth*,
+   *compact*, *sort_dicts* and *underscore_numbers* are passed to the
+   :class:`PrettyPrinter` constructor and their meanings are as
+   described in its documentation above.
 
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']
@@ -167,7 +156,6 @@ The :mod:`pprint` module also provides several shortcut functions:
        'lumberjack',
        'knights',
        'ni']
-
 
 .. function:: isreadable(object)
 

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -87,7 +87,7 @@ The :mod:`pprint` module defines one class:
       Added the *underscore_numbers* parameter.
 
    .. versionchanged:: 3.11
-      No longer attempts to write to ``sys.stdout`` if it is None.
+      No longer attempts to write to ``sys.stdout`` if it is ``None``.
 
       >>> import pprint
       >>> stuff = ['spam', 'eggs', 'lumberjack', 'knights', 'ni']

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -141,20 +141,16 @@ class PrettyPrinter:
         self._width = width
         if stream is not None:
             self._stream = stream
-        elif _sys.stdout is not None:
-            self._stream = _sys.stdout
         else:
-            class _NullStdout:
-                def write(self, s):
-                    return 0
-            self._stream = _NullStdout()
+            self._stream = _sys.stdout
         self._compact = bool(compact)
         self._sort_dicts = sort_dicts
         self._underscore_numbers = underscore_numbers
 
     def pprint(self, object):
-        self._format(object, self._stream, 0, 0, {}, 0)
-        self._stream.write("\n")
+        if self._stream is not None:
+            self._format(object, self._stream, 0, 0, {}, 0)
+            self._stream.write("\n")
 
     def pformat(self, object):
         sio = _StringIO()

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -141,8 +141,13 @@ class PrettyPrinter:
         self._width = width
         if stream is not None:
             self._stream = stream
-        else:
+        elif _sys.stdout is not None:
             self._stream = _sys.stdout
+        else:
+            class _NullStdout:
+                def write(self, s):
+                    return 0
+            self._stream = _NullStdout()
         self._compact = bool(compact)
         self._sort_dicts = sort_dicts
         self._underscore_numbers = underscore_numbers

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -249,9 +249,6 @@ class QueryTestCase(unittest.TestCase):
                              .replace('\n', ' '), native)
             self.assertEqual(pprint.pformat(simple, underscore_numbers=True), native)
             self.assertEqual(pprint.saferepr(simple), native)
-            with contextlib.redirect_stdout(None):
-                # smoke test - there is no output to check
-                pprint.pprint(simple)
 
     def test_container_repr_override_called(self):
         N = 1000

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import collections
+import contextlib
 import dataclasses
 import io
 import itertools
@@ -159,6 +160,10 @@ class QueryTestCase(unittest.TestCase):
             self.assertTrue(pp.isreadable(safe),
                             "expected isreadable for %r" % (safe,))
 
+    def test_stdout_is_None(self):
+        with contextlib.redirect_stdout(None):
+            pprint.pprint('this should not fail')
+
     def test_knotted(self):
         # Verify .isrecursive() and .isreadable() w/ recursion
         # Tie a knot.
@@ -241,6 +246,9 @@ class QueryTestCase(unittest.TestCase):
                              .replace('\n', ' '), native)
             self.assertEqual(pprint.pformat(simple, underscore_numbers=True), native)
             self.assertEqual(pprint.saferepr(simple), native)
+            with contextlib.redirect_stdout(None):
+                # smoke test - there is no output to check
+                pprint.pprint(simple)
 
     def test_container_repr_override_called(self):
         N = 1000

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -162,7 +162,10 @@ class QueryTestCase(unittest.TestCase):
 
     def test_stdout_is_None(self):
         with contextlib.redirect_stdout(None):
-            pprint.pprint('this should not fail')
+            # smoke test - there is no output to check
+            value = 'this should not fail'
+            pprint.pprint(value)
+            pprint.PrettyPrinter().pprint(value)
 
     def test_knotted(self):
         # Verify .isrecursive() and .isreadable() w/ recursion

--- a/Misc/NEWS.d/next/Library/2021-06-20-14-03-18.bpo-41546.lO1jXU.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-20-14-03-18.bpo-41546.lO1jXU.rst
@@ -1,1 +1,1 @@
-Make :mod:`pprint` (like the builtin ``print``) not write to ``stdout`` when it is ``None``.
+Make :mod:`pprint` (like the builtin ``print``) not attempt to write to ``stdout`` when it is ``None``.

--- a/Misc/NEWS.d/next/Library/2021-06-20-14-03-18.bpo-41546.lO1jXU.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-20-14-03-18.bpo-41546.lO1jXU.rst
@@ -1,0 +1,1 @@
+Make :mod:`pprint` (like the builtin ``print``) not write to ``stdout`` when it is ``None``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-41546](https://bugs.python.org/issue41546) -->
https://bugs.python.org/issue41546
<!-- /issue-number -->
