### PR TITLE
bpo-44404: tkinter `after` support callable classes

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -841,7 +841,11 @@ class Misc:
                         self.deletecommand(name)
                     except TclError:
                         pass
-            callit.__name__ = func.__name__
+            try:
+                callit.__name__ = func.__name__
+            except AttributeError:
+                # Required for callable classes (bpo-44404)
+                callit.__name__ = type(func).__name__
             name = self._register(callit)
             return self.tk.call('after', ms, name)
 

--- a/Lib/tkinter/test/test_tkinter/test_misc.py
+++ b/Lib/tkinter/test/test_tkinter/test_misc.py
@@ -1,3 +1,4 @@
+import functools
 import unittest
 import tkinter
 import enum
@@ -100,12 +101,7 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
 
         # Call with a callable class
         count = 0
-        timer1 = root.after(
-            0,
-            type("callback", (),
-                 {"__call__": staticmethod(callback)})(),
-            42,
-            11)
+        timer1 = root.after(0, functools.partial(callback, 42, 11))
         root.update()  # Process all pending events.
         self.assertEqual(count, 53)
 

--- a/Lib/tkinter/test/test_tkinter/test_misc.py
+++ b/Lib/tkinter/test/test_tkinter/test_misc.py
@@ -98,6 +98,17 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         with self.assertRaises(tkinter.TclError):
             root.tk.call(script)
 
+        # Call with a callable class
+        count = 0
+        timer1 = root.after(
+            0,
+            type("callback", (),
+                 {"__call__": staticmethod(callback)})(),
+            42,
+            11)
+        root.update()  # Process all pending events.
+        self.assertEqual(count, 53)
+
     def test_after_idle(self):
         root = self.root
 

--- a/Misc/NEWS.d/next/Library/2021-06-20-19-01-11.bpo-44404.McfrYB.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-20-19-01-11.bpo-44404.McfrYB.rst
@@ -1,1 +1,1 @@
-tkinter ``after`` now supports callable classes
+:mod:`tkinter`'s ``after()`` method now supports callables without the ``__name__`` attribute.

--- a/Misc/NEWS.d/next/Library/2021-06-20-19-01-11.bpo-44404.McfrYB.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-20-19-01-11.bpo-44404.McfrYB.rst
@@ -1,0 +1,1 @@
+tkinter ``after`` now supports callable classes


### PR DESCRIPTION


<!-- issue-number: [bpo-44404](https://bugs.python.org/issue44404) -->
https://bugs.python.org/issue44404
<!-- /issue-number -->
