### PR TITLE
[3.9] bpo-44434: Don't call PyThread_exit_thread() explicitly (GH-26758)

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-06-16-16-52-14.bpo-44434.SQS4Pg.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-16-16-52-14.bpo-44434.SQS4Pg.rst
@@ -1,0 +1,4 @@
+_thread.start_new_thread() no longer calls PyThread_exit_thread() explicitly
+at the thread exit, the call was redundant. On Linux with the glibc,
+pthread_exit() aborts the whole process if dlopen() fails to open
+libgcc_s.so file (ex: EMFILE error). Patch by Victor Stinner.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1056,7 +1056,10 @@ t_bootstrap(void *boot_raw)
     tstate->interp->num_threads--;
     PyThreadState_Clear(tstate);
     _PyThreadState_DeleteCurrent(tstate);
-    PyThread_exit_thread();
+
+    // bpo-44434: Don't call explicitly PyThread_exit_thread(). On Linux with
+    // the glibc, pthread_exit() can abort the whole process if dlopen() fails
+    // to open the libgcc_s.so library (ex: EMFILE error).
 }
 
 static PyObject *


### PR DESCRIPTION
_thread.start_new_thread() no longer calls PyThread_exit_thread()
explicitly at the thread exit, the call was redundant.

On Linux with the glibc, pthread_cancel() loads dynamically the
libgcc_s.so.1 library. dlopen() can fail if there is no more
available file descriptor to open the file. In this case, the process
aborts with the error message:

"libgcc_s.so.1 must be installed for pthread_cancel to work"

pthread_cancel() unwinds back to the thread's wrapping function that
calls the thread entry point.

The unwind function is dynamically loaded from the libgcc_s library
since it is tightly coupled to the C compiler (GCC). The unwinder
depends on DWARF, the compiler generates DWARF, so the unwinder
belongs to the compiler.

Thanks Florian Weimer and Carlos O'Donell for their help on
investigating this issue.

(cherry picked from commit 45a78f906d2d5fe5381d78466b11763fc56d57ba)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44434](https://bugs.python.org/issue44434) -->
https://bugs.python.org/issue44434
<!-- /issue-number -->
