### PR TITLE
bpo-44287: asyncio test_popen() uses longer timeout

### DIFF
--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -107,7 +107,8 @@ class PopenTests(unittest.TestCase):
 
         events = [ovin.event, ovout.event, overr.event]
         # Super-long timeout for slow buildbots.
-        res = _winapi.WaitForMultipleObjects(events, True, 10000)
+        res = _winapi.WaitForMultipleObjects(events, True,
+                                             int(support.SHORT_TIMEOUT * 1000))
         self.assertEqual(res, _winapi.WAIT_OBJECT_0)
         self.assertFalse(ovout.pending)
         self.assertFalse(overr.pending)

--- a/Misc/NEWS.d/next/Tests/2021-06-21-17-53-41.bpo-44287.YON57s.rst
+++ b/Misc/NEWS.d/next/Tests/2021-06-21-17-53-41.bpo-44287.YON57s.rst
@@ -1,0 +1,4 @@
+Fix asyncio test_popen() of test_windows_utils by using a longer timeout.
+Use military grade battle-tested :data:`test.support.SHORT_TIMEOUT` timeout
+rather than a hardcoded timeout of 10 seconds: it's 30 seconds by default, but
+it is made longer on slow buildbots. Patch by Victor Stinner.


### PR DESCRIPTION
Fix asyncio test_popen() of test_windows_utils by using a longer
timeout.  Use battle-tested test.support.SHORT_TIMEOUT timeout rather
than a hardcoded timeout of 10 seconds: it's 30 seconds by default,
but it is made longer on slow buildbots.

WaitForMultipleObjects() timeout argument is in milliseconds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44287](https://bugs.python.org/issue44287) -->
https://bugs.python.org/issue44287
<!-- /issue-number -->
