### PR TITLE
bpo-44483: Fix crash in union object with bad ``__module__``

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -747,6 +747,15 @@ class TypesTests(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     issubclass(list, type_)
 
+    def test_or_type_operator_with_bad_module(self):
+        class TypeVar:
+            @property
+            def __module__(self):
+                1 / 0
+        # Crashes in Issue44483
+        with self.assertRaises(ZeroDivisionError):
+            str | TypeVar()
+
     def test_ellipsis_type(self):
         self.assertIsInstance(Ellipsis, types.EllipsisType)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-22-19-08-19.bpo-44483.eq2f7T.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-22-19-08-19.bpo-44483.eq2f7T.rst
@@ -1,0 +1,2 @@
+Fix a crash in ``types.Union`` objects when creating a union of an object
+with bad ``__module__`` field.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -286,13 +286,10 @@ is_new_type(PyObject *obj)
 
 // Emulates short-circuiting behavior of the ``||`` operator
 // while also checking negative values.
-#define CHECK_RES(obj, check) { \
-    int result = check(obj); \
-    if (result < 0) { \
-        goto fail; \
-    } \
-    else if (result > 0) { \
-        return 1; \
+#define CHECK_RES(res) { \
+    int result = res; \
+    if (result) { \
+       return result; \
     } \
 }
 
@@ -304,17 +301,14 @@ is_unionable(PyObject *obj)
         return 1;
     }
     PyTypeObject *type = Py_TYPE(obj);
-    CHECK_RES(obj, is_typevar);
-    CHECK_RES(obj, is_new_type);
-    CHECK_RES(obj, is_special_form);
+    CHECK_RES(is_typevar(obj));
+    CHECK_RES(is_new_type(obj));
+    CHECK_RES(is_special_form(obj));
     return (
         // The following checks never fail.
         PyType_Check(obj) ||
         PyObject_TypeCheck(obj, &Py_GenericAliasType) ||
         type == &_Py_UnionType);
-
-fail:
-    return -1;
 }
 
 PyObject *


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44483](https://bugs.python.org/issue44483) -->
https://bugs.python.org/issue44483
<!-- /issue-number -->
