### PR TITLE
docs: add the word 'official'

### DIFF
--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -5,7 +5,7 @@
 {% block body %}
   <h1>{{ docstitle|e }}</h1>
   <p>
-  {% trans %}Welcome! This is the documentation for Python {{ release }}.{% endtrans %}
+  {% trans %}Welcome! This is the official documentation for Python {{ release }}.{% endtrans %}
   </p>
   <p><strong>{% trans %}Parts of the documentation:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I have been told that some people have trouble getting Python accepted into strict environments because some people don't believe these docs are "official".  This seems like a harmless addition, and these are the official docs.