### PR TITLE
bpo-44213: Add missing arg to DICT_MERGE opcode

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -933,7 +933,7 @@ All of the following opcodes use their arguments.
    .. versionadded:: 3.9
 
 
-.. opcode:: DICT_MERGE
+.. opcode:: DICT_MERGE (i)
 
    Like :opcode:`DICT_UPDATE` but raises an exception for duplicate keys.
 


### PR DESCRIPTION
Based on report by 'glubs9' in BPO.

<!-- issue-number: [bpo-44213](https://bugs.python.org/issue44213) -->
https://bugs.python.org/issue44213
<!-- /issue-number -->
