### PR TITLE
bpo-44468: Never skip base classes in `typing.get_type_hints()`, even with invalid `.__module__`.

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2282,7 +2282,18 @@ class ClassVarTests(BaseTestCase):
         class BadModule:
             pass
         BadModule.__module__ = 'bad' # Something not in sys.modules
+        self.assertNotIn('bad', sys.modules)
         self.assertEqual(get_type_hints(BadModule), {})
+
+    def test_annotated_bad_module(self):
+        # See https://bugs.python.org/issue44468
+        class BadBase:
+            foo: tuple
+        class BadType(BadBase):
+            bar: list
+        BadType.__module__ = BadBase.__module__ = 'bad'
+        self.assertNotIn('bad', sys.modules)
+        self.assertEqual(get_type_hints(BadType), {'foo': tuple, 'bar': list})
 
 class FinalTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2277,24 +2277,6 @@ class ClassVarTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(int, ClassVar)
 
-    def test_bad_module(self):
-        # bpo-41515
-        class BadModule:
-            pass
-        BadModule.__module__ = 'bad' # Something not in sys.modules
-        self.assertNotIn('bad', sys.modules)
-        self.assertEqual(get_type_hints(BadModule), {})
-
-    def test_annotated_bad_module(self):
-        # See https://bugs.python.org/issue44468
-        class BadBase:
-            foo: tuple
-        class BadType(BadBase):
-            bar: list
-        BadType.__module__ = BadBase.__module__ = 'bad'
-        self.assertNotIn('bad', sys.modules)
-        self.assertEqual(get_type_hints(BadType), {'foo': tuple, 'bar': list})
-
 class FinalTests(BaseTestCase):
 
     def test_basics(self):
@@ -3043,6 +3025,24 @@ class GetTypeHintTests(BaseTestCase):
             x: 'y'
         # This previously raised an error under PEP 563.
         self.assertEqual(get_type_hints(Foo), {'x': str})
+
+    def test_get_type_hints_bad_module(self):
+        # bpo-41515
+        class BadModule:
+            pass
+        BadModule.__module__ = 'bad' # Something not in sys.modules
+        self.assertNotIn('bad', sys.modules)
+        self.assertEqual(get_type_hints(BadModule), {})
+
+    def test_get_type_hints_annotated_bad_module(self):
+        # See https://bugs.python.org/issue44468
+        class BadBase:
+            foo: tuple
+        class BadType(BadBase):
+            bar: list
+        BadType.__module__ = BadBase.__module__ = 'bad'
+        self.assertNotIn('bad', sys.modules)
+        self.assertEqual(get_type_hints(BadType), {'foo': tuple, 'bar': list})
 
 
 class GetUtilitiesTestCase(TestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1701,10 +1701,7 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False):
         hints = {}
         for base in reversed(obj.__mro__):
             if globalns is None:
-                try:
-                    base_globals = sys.modules[base.__module__].__dict__
-                except KeyError:
-                    continue
+                base_globals = getattr(sys.modules.get(base.__module__, None), '__dict__', {})
             else:
                 base_globals = globalns
             ann = base.__dict__.get('__annotations__', {})

--- a/Misc/NEWS.d/next/Library/2021-06-23-19-02-00.bpo-44468.-klV5-.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-23-19-02-00.bpo-44468.-klV5-.rst
@@ -1,1 +1,2 @@
-:func:`typing.get_type_hints` now finds annotations in classes and base classes with unexpected ``__module__``. Previously, it skip those MRO elements.
+:func:`typing.get_type_hints` now finds annotations in classes and base classes
+with unexpected ``__module__``. Previously, it skipped those MRO elements.

--- a/Misc/NEWS.d/next/Library/2021-06-23-19-02-00.bpo-44468.-klV5-.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-23-19-02-00.bpo-44468.-klV5-.rst
@@ -1,0 +1,1 @@
+:func:`typing.get_type_hints` now finds annotations in classes and base classes with unexpected ``__module__``. Previously, it skip those MRO elements.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

https://bugs.python.org/issue44468

* Added test to make sure base classes with invalid modules still get their annotations picked up in `get_type_hints()`.

* Moved tests to right place (was originally under `class ClassVarTests`, are now under `class GetTypeHintTests`).

* Used empty `dict` for `globalsn` instead of skipping class if its `.__module__` is invalid.

---

I'm using default values for `sys.modules.get()` and then `getattr()`, to default to an empty dict.

I would probably actually personally consider it cleaner and clearer (with fewer function calls and objects) to either keep the `try/except KeyError` and just replace the `continue` with an assignment to an empty `dict`, or do an `if/else` check for containment in `sys.modules`.

But this approach is what I linked to on BPO-44468, and it does have the (somewhat dubious) additional benefit that it will still work and default to an empty `dict` even if someone adds a matching fake module to `sys.modules` that doesn't have a `.__dict__` attribute.

I'm sure it's a minute detail that no one else necessarily cares about. But this is pretty much my second time ever contributing code to an outside project, and also the biggest chance I've had to accidentally break software that other people rely on (however small of a part of that software it may be)— So I just want to make sure I mention that to be considered.

<!-- issue-number: [bpo-44468](https://bugs.python.org/issue44468) -->
https://bugs.python.org/issue44468
<!-- /issue-number -->
