### PR TITLE
bpo-44493: Add missing terminated NUL in sockaddr_un's length

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-07-26-10-46-49.bpo-44493.xp3CRH.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-26-10-46-49.bpo-44493.xp3CRH.rst
@@ -1,0 +1,3 @@
+Add missing terminated NUL in sockaddr_un's length
+
+This was potentially observable when using non-abstract AF_UNIX datagram sockets to processes written in another programming language.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1683,6 +1683,8 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
                                 "AF_UNIX path too long");
                 goto unix_out;
             }
+
+            *len_ret = path.len + offsetof(struct sockaddr_un, sun_path);
         }
         else
 #endif /* linux */
@@ -1694,10 +1696,12 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
                 goto unix_out;
             }
             addr->sun_path[path.len] = 0;
+
+            *len_ret = path.len + offsetof(struct sockaddr_un, sun_path) + 1; /* including the tailing NUL */
         }
         addr->sun_family = s->sock_family;
         memcpy(addr->sun_path, path.buf, path.len);
-        *len_ret = path.len + offsetof(struct sockaddr_un, sun_path);
+        
         retval = 1;
     unix_out:
         PyBuffer_Release(&path);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1697,7 +1697,8 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             }
             addr->sun_path[path.len] = 0;
 
-            *len_ret = path.len + offsetof(struct sockaddr_un, sun_path) + 1; /* including the tailing NUL */
+            /* including the tailing NUL */
+            *len_ret = path.len + offsetof(struct sockaddr_un, sun_path) + 1;
         }
         addr->sun_family = s->sock_family;
         memcpy(addr->sun_path, path.buf, path.len);


### PR DESCRIPTION
- Linux: https://man7.org/linux/man-pages/man7/unix.7.html
- *BSD: SUN_LEN

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44493](https://bugs.python.org/issue44493) -->
https://bugs.python.org/issue44493
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead