### PR TITLE
bpo-43770: PyObject_GetAttr() calls PyType_Ready()

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -692,13 +692,13 @@ pycore_init_types(PyInterpreterState *interp)
     int is_main_interp = _Py_IsMainInterpreter(interp);
 
     if (is_main_interp) {
-        if (_PyStructSequence_Init() < 0) {
-            return _PyStatus_ERR("can't initialize structseq");
-        }
-
         status = _PyTypes_Init();
         if (_PyStatus_EXCEPTION(status)) {
             return status;
+        }
+
+        if (_PyStructSequence_Init() < 0) {
+            return _PyStatus_ERR("can't initialize structseq");
         }
 
         if (_PyLong_InitTypes() < 0) {


### PR DESCRIPTION
PyObject_GetAttr() and _PyObject_LookupAttr() functions now make the
object type ready before using checking the tp_getattro member of the
type.

Moreover, _PyStructSequence_Init() is now called after _PyTypes_Init().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43770](https://bugs.python.org/issue43770) -->
https://bugs.python.org/issue43770
<!-- /issue-number -->
