### PR TITLE
bpo-43553: Improve `sqlite3` test coverage

### DIFF
--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -597,6 +597,11 @@ class CursorTests(unittest.TestCase):
         new_count = len(res.description)
         self.assertEqual(new_count - old_count, 1)
 
+    def test_same_query_in_multiple_cursors(self):
+        cursors = [self.cx.execute("select 1") for _ in range(3)]
+        for cu in cursors:
+            self.assertEqual(cu.fetchall(), [(1,)])
+
 
 class ThreadTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -26,9 +26,8 @@ import sys
 import threading
 import unittest
 
-from test.support import check_disallow_instantiation
+from test.support import check_disallow_instantiation, threading_helper
 from test.support.os_helper import TESTFN, unlink
-from test.support import threading_helper
 
 
 # Helper for tests using TESTFN
@@ -109,6 +108,10 @@ class ModuleTests(unittest.TestCase):
     def test_disallow_instantiation(self):
         cx = sqlite.connect(":memory:")
         check_disallow_instantiation(self, type(cx("select 1")))
+
+    def test_complete_statement(self):
+        self.assertFalse(sqlite.complete_statement("select t"))
+        self.assertTrue(sqlite.complete_statement("create table t(t);"))
 
 
 class ConnectionTests(unittest.TestCase):

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -237,6 +237,11 @@ class ConnectionTests(unittest.TestCase):
     def test_interrupt(self):
         self.assertIsNone(self.cx.interrupt())
 
+    def test_drop_unused_refs(self):
+        for n in range(500):
+            cu = self.cx.execute(f"select {n}")
+            self.assertEqual(cu.fetchone()[0], n)
+
 
 class OpenTests(unittest.TestCase):
     _sql = "create table test(id integer)"

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -228,6 +228,15 @@ class ConnectionTests(unittest.TestCase):
                 self.assertTrue(hasattr(self.cx, exc))
                 self.assertIs(getattr(sqlite, exc), getattr(self.cx, exc))
 
+    def test_interrupt_on_closed_db(self):
+        cx = sqlite.connect(":memory:")
+        cx.close()
+        with self.assertRaises(sqlite.ProgrammingError):
+            cx.interrupt()
+
+    def test_interrupt(self):
+        self.assertIsNone(self.cx.interrupt())
+
 
 class OpenTests(unittest.TestCase):
     _sql = "create table test(id integer)"

--- a/Lib/sqlite3/test/factory.py
+++ b/Lib/sqlite3/test/factory.py
@@ -123,6 +123,8 @@ class RowFactoryTests(unittest.TestCase):
             row[-3]
         with self.assertRaises(IndexError):
             row[2**1000]
+        with self.assertRaises(IndexError):
+            row[complex()]  # index must be int or string
 
     def test_sqlite_row_index_unicode(self):
         self.con.row_factory = sqlite.Row

--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -21,10 +21,35 @@
 #    misrepresented as being the original software.
 # 3. This notice may not be removed or altered from any source distribution.
 
+import contextlib
+import functools
+import io
 import unittest
 import unittest.mock
 import gc
 import sqlite3 as sqlite
+
+def with_tracebacks(strings):
+    """Convenience decorator for testing callback tracebacks."""
+    strings.append('Traceback')
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            # First, run the test with traceback enabled.
+            sqlite.enable_callback_tracebacks(True)
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                func(self, *args, **kwargs)
+            tb = buf.getvalue()
+            for s in strings:
+                self.assertIn(s, tb)
+
+            # Then run the test with traceback disabled.
+            sqlite.enable_callback_tracebacks(False)
+            func(self, *args, **kwargs)
+        return wrapper
+    return decorator
 
 def func_returntext():
     return "foo"
@@ -228,6 +253,7 @@ class FunctionTests(unittest.TestCase):
         val = cur.fetchone()[0]
         self.assertEqual(val, 1<<31)
 
+    @with_tracebacks(['func_raiseexception', '5/0', 'ZeroDivisionError'])
     def test_func_exception(self):
         cur = self.con.cursor()
         with self.assertRaises(sqlite.OperationalError) as cm:
@@ -387,6 +413,7 @@ class AggregateTests(unittest.TestCase):
             val = cur.fetchone()[0]
         self.assertEqual(str(cm.exception), "user-defined aggregate's 'finalize' method raised error")
 
+    @with_tracebacks(['__init__', '5/0', 'ZeroDivisionError'])
     def test_aggr_exception_in_init(self):
         cur = self.con.cursor()
         with self.assertRaises(sqlite.OperationalError) as cm:
@@ -394,6 +421,7 @@ class AggregateTests(unittest.TestCase):
             val = cur.fetchone()[0]
         self.assertEqual(str(cm.exception), "user-defined aggregate's '__init__' method raised error")
 
+    @with_tracebacks(['step', '5/0', 'ZeroDivisionError'])
     def test_aggr_exception_in_step(self):
         cur = self.con.cursor()
         with self.assertRaises(sqlite.OperationalError) as cm:
@@ -401,6 +429,7 @@ class AggregateTests(unittest.TestCase):
             val = cur.fetchone()[0]
         self.assertEqual(str(cm.exception), "user-defined aggregate's 'step' method raised error")
 
+    @with_tracebacks(['finalize', '5/0', 'ZeroDivisionError'])
     def test_aggr_exception_in_finalize(self):
         cur = self.con.cursor()
         with self.assertRaises(sqlite.OperationalError) as cm:
@@ -501,6 +530,14 @@ class AuthorizerRaiseExceptionTests(AuthorizerTests):
         if arg2 == 'c2' or arg1 == 't2':
             raise ValueError
         return sqlite.SQLITE_OK
+
+    @with_tracebacks(['authorizer_cb', 'ValueError'])
+    def test_table_access(self):
+        super().test_table_access()
+
+    @with_tracebacks(['authorizer_cb', 'ValueError'])
+    def test_column_access(self):
+        super().test_table_access()
 
 class AuthorizerIllegalTypeTests(AuthorizerTests):
     @staticmethod


### PR DESCRIPTION
`llvm-cov` report _after_ this PR:
```
Filename                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
prepare_protocol.c                 20                17    15.00%           4                 3    25.00%          22                15    31.82%
util.c                             65                21    67.69%           3                 0   100.00%          80                26    67.50%
module.c                          313                52    83.39%          11                 1    90.91%         245                51    79.18%
row.c                             214                44    79.44%          13                 1    92.31%         158                19    87.97%
microprotocols.c                   79                 8    89.87%           3                 0   100.00%          98                15    84.69%
connection.c                     1250               163    86.96%          46                 0   100.00%        1332               175    86.86%
module.h                            1                 0   100.00%           1                 0   100.00%           3                 0   100.00%
cursor.c                          875               114    86.97%          23                 0   100.00%         835               124    85.15%
statement.c                       355                26    92.68%          11                 0   100.00%         421                36    91.45%
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                            3172               445    85.97%         115                 5    95.65%        3194               461    85.57%
```

For comparison; coverage _before_ this PR:
```
Filename                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
prepare_protocol.c                 20                17    15.00%           4                 3    25.00%          22                15    31.82%
util.c                             65                21    67.69%           3                 0   100.00%          80                26    67.50%
module.c                          313                65    79.23%          11                 4    63.64%         245                66    73.06%
row.c                             214                45    78.97%          13                 1    92.31%         158                23    85.44%
microprotocols.c                   79                24    69.62%           3                 0   100.00%          98                31    68.37%
connection.c                     1250               209    83.28%          46                 1    97.83%        1332               224    83.18%
module.h                            1                 0   100.00%           1                 0   100.00%           3                 0   100.00%
cursor.c                          875               122    86.06%          23                 0   100.00%         835               127    84.79%
statement.c                       355                26    92.68%          11                 0   100.00%         421                36    91.45%
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                            3172               529    83.32%         115                 9    92.17%        3194               548    82.84%
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43553](https://bugs.python.org/issue43553) -->
https://bugs.python.org/issue43553
<!-- /issue-number -->
