### PR TITLE
Clarify the order of a stacked `abstractmethod`

### DIFF
--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -30,11 +30,11 @@ class abstractclassmethod(classmethod):
 
     Deprecated, use 'classmethod' with 'abstractmethod' instead:
 
-    class C(ABC):
-        @classmethod
-        @abstractmethod
-        def my_abstract_classmethod(cls, ...):
-            ...
+        class C(ABC):
+            @classmethod
+            @abstractmethod
+            def my_abstract_classmethod(cls, ...):
+                ...
 
     """
 
@@ -50,10 +50,11 @@ class abstractstaticmethod(staticmethod):
 
     Deprecated, use 'staticmethod' with 'abstractmethod' instead:
 
-        @staticmethod
-        @abstractmethod
-        def my_abstract_staticmethod(...):
-            ...
+        class C(ABC):
+            @staticmethod
+            @abstractmethod
+            def my_abstract_staticmethod(...):
+                ...
 
     """
 
@@ -69,10 +70,11 @@ class abstractproperty(property):
 
     Deprecated, use 'property' with 'abstractmethod' instead:
 
-        @property
-        @abstractmethod
-        def my_abstract_property(self):
-            ...
+        class C(ABC):
+            @property
+            @abstractmethod
+            def my_abstract_property(self):
+                ...
 
     """
 

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -28,11 +28,11 @@ def abstractmethod(funcobj):
 class abstractclassmethod(classmethod):
     """A decorator indicating abstract classmethods.
 
-    Deprecated, instead use `classmethod` on top of `abstractmethod`:
+    Deprecated, use 'classmethod' with 'abstractmethod' instead:
 
         @classmethod
         @abstractmethod
-        def your_function(cls):
+        def my_abstract_classmethod(cls, ...):
             ...
 
     """
@@ -51,7 +51,7 @@ class abstractstaticmethod(staticmethod):
 
         @staticmethod
         @abstractmethod
-        def your_function():
+        def my_abstract_staticmethod(...):
             ...
 
     """
@@ -70,7 +70,7 @@ class abstractproperty(property):
 
         @property
         @abstractmethod
-        def your_function(self):
+        def my_abstract_property(self):
             ...
 
     """

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -30,6 +30,7 @@ class abstractclassmethod(classmethod):
 
     Deprecated, use 'classmethod' with 'abstractmethod' instead:
 
+    class C(ABC):
         @classmethod
         @abstractmethod
         def my_abstract_classmethod(cls, ...):

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -28,7 +28,13 @@ def abstractmethod(funcobj):
 class abstractclassmethod(classmethod):
     """A decorator indicating abstract classmethods.
 
-    Deprecated, use 'classmethod' with 'abstractmethod' instead.
+    Deprecated, instead use `classmethod` on top of `abstractmethod`:
+
+        @classmethod
+        @abstractmethod
+        def your_function(cls):
+            ...
+
     """
 
     __isabstractmethod__ = True
@@ -41,7 +47,13 @@ class abstractclassmethod(classmethod):
 class abstractstaticmethod(staticmethod):
     """A decorator indicating abstract staticmethods.
 
-    Deprecated, use 'staticmethod' with 'abstractmethod' instead.
+    Deprecated, instead use `staticmethod` on top of `abstractmethod`:
+
+        @staticmethod
+        @abstractmethod
+        def your_function():
+            ...
+
     """
 
     __isabstractmethod__ = True
@@ -54,7 +66,13 @@ class abstractstaticmethod(staticmethod):
 class abstractproperty(property):
     """A decorator indicating abstract properties.
 
-    Deprecated, use 'property' with 'abstractmethod' instead.
+    Deprecated, instead use `property` on top of `abstractmethod`:
+
+        @property
+        @abstractmethod
+        def your_function(self):
+            ...
+
     """
 
     __isabstractmethod__ = True

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -47,7 +47,7 @@ class abstractclassmethod(classmethod):
 class abstractstaticmethod(staticmethod):
     """A decorator indicating abstract staticmethods.
 
-    Deprecated, instead use `staticmethod` on top of `abstractmethod`:
+    Deprecated, use 'staticmethod' with 'abstractmethod' instead:
 
         @staticmethod
         @abstractmethod
@@ -66,7 +66,7 @@ class abstractstaticmethod(staticmethod):
 class abstractproperty(property):
     """A decorator indicating abstract properties.
 
-    Deprecated, instead use `property` on top of `abstractmethod`:
+    Deprecated, use 'property' with 'abstractmethod' instead:
 
         @property
         @abstractmethod


### PR DESCRIPTION
Hey, I hope we can do without an issue number for this one. Every time I see the text "Deprecated, use 'property' with 'abstractmethod' instead" I have to scratch my head and think which one of the two decorators goes on top. This way it's clearer.