### PR TITLE
bpo-24132: Add direct subclassing of PurePath/Path in pathlib

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -22,6 +22,10 @@ try:
     import _tkinter
 except ImportError:
     _tkinter = None
+from os import name as system_name
+is_posix = system_name == 'posix'
+is_windows = system_name == 'nt'
+del system_name
 '''
 
 manpages_url = 'https://manpages.debian.org/{path}'

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -273,7 +273,7 @@ Methods and properties
 
 .. testsetup::
 
-   from pathlib import PurePath, PurePosixPath, PureWindowsPath
+   from pathlib import PurePath, PurePosixPath, PureWindowsPath, Path
 
 Pure paths provide the following methods and properties:
 
@@ -1228,6 +1228,56 @@ call fails (for example because the path doesn't exist).
 
    .. versionchanged:: 3.10
       The *newline* parameter was added.
+
+Subclassing and Extensibility
+-----------------------------
+
+Both :class:`PurePath` and :class:`Path` are directly subclassable and extensible as you
+see fit:
+
+   >>> class MyPath(Path):
+   ...    def my_method(self, *args, **kwargs):
+   ...        ... # Platform agnostic implementation
+
+.. note::
+   Unlike :class:`PurePath` or :class:`Path`, instantiating the derived
+   class will not generate a differently named class:
+
+   .. doctest::
+      :pyversion: > 3.11
+      :skipif: is_windows
+
+      >>> Path('.')  # On POSIX
+      PosixPath('.')
+      >>> MyPath('.')
+      MyPath('.')
+
+   Despite this, the subclass will otherwise match the class that would be
+   returned by the factory on your particular system type. For instance,
+   when instantiated on a POSIX system:
+
+   .. doctest::
+      :pyversion: > 3.11
+      :skipif: is_windows
+
+      >>> [Path('/dir').is_absolute, MyPath('/dir').is_absolute()]
+      [True, True]
+      >>> [Path().home().drive, MyPath().home().drive]
+      ['', '']
+
+   However on Windows, the *same code* will instead return values which
+   apply to that system:
+
+   .. doctest::
+      :pyversion: > 3.11
+      :skipif: is_posix
+
+      >>> [Path('/dir').is_absolute(), MyPath('/dir').is_absolute()]
+      [False, False]
+      >>> [Path().home().drive, MyPath().home().drive]
+      ['C:', 'C:']
+
+.. versionadded:: 3.11
 
 Correspondence to tools in the :mod:`os` module
 -----------------------------------------------

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1322,6 +1322,9 @@ class Path(PurePath):
         """
         Check if this path is a POSIX mount point
         """
+        if os.name != "posix":
+            raise NotImplementedError("Path.is_mount() is "
+                                      "unsupported on this system")
         # Need to exist and be a dir
         if not self.exists() or not self.is_dir():
             return False
@@ -1444,6 +1447,3 @@ class WindowsPath(Path, PureWindowsPath):
     On a Windows system, instantiating a Path should return this object.
     """
     __slots__ = ()
-
-    def is_mount(self):
-        raise NotImplementedError("Path.is_mount() is unsupported on this system")

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -325,21 +325,24 @@ class _NormalAccessor(_Accessor):
         readlink = os.readlink
     else:
         def readlink(self, path):
-            raise NotImplementedError("os.readlink() not available on this system")
+            raise NotImplementedError("os.readlink() is not available "
+                                      "on this system")
 
     def owner(self, path):
         try:
             import pwd
             return pwd.getpwuid(self.stat(path).st_uid).pw_name
         except ImportError:
-            raise NotImplementedError("Path.owner() is unsupported on this system")
+            raise NotImplementedError(f"{self.__class__.__name__}.owner() "
+                                      f"is unsupported on this system")
 
     def group(self, path):
         try:
             import grp
             return grp.getgrgid(self.stat(path).st_gid).gr_name
         except ImportError:
-            raise NotImplementedError("Path.group() is unsupported on this system")
+            raise NotImplementedError(f"{self.__class__.__name__}.group() "
+                                      f"is unsupported on this system")
 
     getcwd = os.getcwd
 
@@ -965,7 +968,7 @@ class Path(PurePath):
         # In previous versions of pathlib, this method marked this path as
         # closed; subsequent attempts to perform I/O would raise an IOError.
         # This functionality was never documented, and had the effect of
-        # making Path objects mutable, contrary to PEP 428. In Python 3.9 the
+        # making path objects mutable, contrary to PEP 428. In Python 3.9 the
         # _closed attribute was removed, and this method made a no-op.
         # This method and __enter__()/__exit__() should be deprecated and
         # removed in the future.
@@ -1012,7 +1015,7 @@ class Path(PurePath):
         """Iterate over this subtree and yield all existing files (of any
         kind, including directories) matching the given relative pattern.
         """
-        sys.audit("pathlib.Path.glob", self, pattern)
+        sys.audit(f"pathlib.{self.__class__.__name__}.glob", self, pattern)
         if not pattern:
             raise ValueError("Unacceptable pattern: {!r}".format(pattern))
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
@@ -1027,7 +1030,7 @@ class Path(PurePath):
         directories) matching the given relative pattern, anywhere in
         this subtree.
         """
-        sys.audit("pathlib.Path.rglob", self, pattern)
+        sys.audit(f"pathlib.{self.__class__.__name__}.rglob", self, pattern)
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
         if drv or root:
             raise NotImplementedError("Non-relative patterns are unsupported")
@@ -1215,9 +1218,9 @@ class Path(PurePath):
 
         The target path may be absolute or relative. Relative paths are
         interpreted relative to the current working directory, *not* the
-        directory of the Path object.
+        directory of this object.
 
-        Returns the new Path instance pointing to the target path.
+        Returns the new class instance pointing to the target path.
         """
         self._accessor.rename(self, target)
         return self.__class__(target)
@@ -1228,9 +1231,9 @@ class Path(PurePath):
 
         The target path may be absolute or relative. Relative paths are
         interpreted relative to the current working directory, *not* the
-        directory of the Path object.
+        directory of this object.
 
-        Returns the new Path instance pointing to the target path.
+        Returns the new class instance pointing to the target path.
         """
         self._accessor.replace(self, target)
         return self.__class__(target)
@@ -1256,15 +1259,16 @@ class Path(PurePath):
 
         Note this function does not make this path a hard link to *target*,
         despite the implication of the function and argument names. The order
-        of arguments (target, link) is the reverse of Path.symlink_to, but
+        of arguments (target, link) is the reverse of symlink_to, but
         matches that of os.link.
 
         Deprecated since Python 3.10 and scheduled for removal in Python 3.12.
         Use `hardlink_to()` instead.
         """
-        warnings.warn("pathlib.Path.link_to() is deprecated and is scheduled "
-                      "for removal in Python 3.12. "
-                      "Use pathlib.Path.hardlink_to() instead.",
+        classname = self.__class__.__name__
+        warnings.warn(f"pathlib.{classname}.link_to() is deprecated and is "
+                      f"scheduled for removal in Python 3.12. "
+                      f"Use pathlib.{classname}.hardlink_to() instead.",
                       DeprecationWarning, stacklevel=2)
         self._accessor.link(self, target)
 
@@ -1323,8 +1327,8 @@ class Path(PurePath):
         Check if this path is a POSIX mount point
         """
         if os.name != "posix":
-            raise NotImplementedError("Path.is_mount() is "
-                                      "unsupported on this system")
+            raise NotImplementedError(f"{self.__class__.__name__}.is_mount() "
+                                      f"is unsupported on this system")
         # Need to exist and be a dir
         if not self.exists() or not self.is_dir():
             return False

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1341,7 +1341,6 @@ class PurePathTest(
         self.assertClassProperties(p, correct_cls)
         self.assertNonIONewInstancesClassProperties(p, correct_cls)
 
-    @unittest.expectedFailure
     def test_direct_subclassing(self):
         P = self.cls
         try:
@@ -2504,7 +2503,6 @@ class PathTest(_BasePathTest, _PathPurePathCommonTest, unittest.TestCase):
             link = P(BASE, "linkA")
             self.assertClassProperties(link.readlink(), correct_cls)
 
-    @unittest.expectedFailure
     def test_direct_subclassing(self):
         P = self.cls
         try:

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1335,6 +1335,10 @@ class PurePathTest(
         is_posix = os.name == 'posix'
         return pathlib.PurePosixPath if is_posix else pathlib.PureWindowsPath
 
+    def _get_anti_system_flavour_class(self):
+        is_posix = os.name == 'posix'
+        return pathlib.PureWindowsPath if is_posix else pathlib.PurePosixPath
+
     def test_instance_class_properties(self):
         p = self.cls('placeholder')
         correct_cls = self._get_class_to_generate()
@@ -1369,9 +1373,15 @@ class PurePathTest(
         q = pathlib.PureWindowsPath('a')
         self.assertNotEqual(p, q)
 
-    def test_different_flavours_unordered(self):
-        p = pathlib.PurePosixPath('a')
-        q = pathlib.PureWindowsPath('a')
+    def test_subclass_different_flavours_unequal(self):
+        class Derived(pathlib.PurePath):
+            pass
+        p = Derived('a')
+        PureAntiFlavourPath = self._get_anti_system_flavour_class()
+        q = PureAntiFlavourPath('a')
+        self.assertNotEqual(p, q)
+
+    def _test_different_flavours_unordered(self, p, q):
         with self.assertRaises(TypeError):
             p < q
         with self.assertRaises(TypeError):
@@ -1380,6 +1390,19 @@ class PurePathTest(
             p > q
         with self.assertRaises(TypeError):
             p >= q
+
+    def test_different_flavours_unordered(self):
+        p = pathlib.PurePosixPath('a')
+        q = pathlib.PureWindowsPath('a')
+        self._test_different_flavours_unordered(p, q)
+
+    def test_subclass_different_flavours_unordered(self):
+        class Derived(pathlib.PurePath):
+            pass
+        p = Derived('a')
+        PureAntiFlavourPath = self._get_anti_system_flavour_class()
+        q = PureAntiFlavourPath('a')
+        self._test_different_flavours_unordered(p, q)
 
 
 #

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -545,6 +545,7 @@ Matt Fleming
 Hernán Martínez Foffani
 Benjamin Fogle
 Artem Fokin
+Kevin Follstad
 Arnaud Fontaine
 Michael Foord
 Amaury Forgeot d'Arc

--- a/Misc/NEWS.d/next/Library/2021-06-16-17-38-36.bpo-24132.FqsJWY.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-16-17-38-36.bpo-24132.FqsJWY.rst
@@ -1,0 +1,2 @@
+Add a mechanism and support for direct subclassing of :class:`PurePath`
+and :class:`Path` in pathlib.


### PR DESCRIPTION
I submit for your consideration a new working version (with documentation) of an extensible, subclassable PurePath/Path to close [bpo-24132](https://bugs.python.org/issue24132), a 6-year-old bug. I had previously submitted a PR which added classes to pathlib as a path to solving this, but these commits introduce no new public classes, breaking changes, or deviations from PEP 428.

The crux of the issue here is that Path (and PurePath) are factories which generate their subclasses upon instantiation and as such are actually dependent upon their flavoured subclasses. To get around this, we attach _flavour to PurePath/Path (and any _non_ PurePosixPath/PureWindowsPath/PosixPath/WindowsPath class) at time of instantiation. Then any subclass will have the essential _flavour attribute available to it. Moreover, in the case that the class being instantiated is PurePath/Path, instead of instantiating another new instance, we just update the class attributes in place so that it _becomes_ its flavoured subclass. My thanks goes out to Barney Gale for making suggestions that inspired this approach.

In addition, I should mention that @barneygale is working on implementing an AbstractPath interface which will allow for even further extensibility of pathlib. [His idea thread on this is here](https://discuss.python.org/t/make-pathlib-extensible/3428). This was an active consideration as I was writing this, and I specifically chose an implementation which I think works with what he is doing. (Barney, I hope that you find that this to be true - I look forward to your comments.) To verify this, I created a stub version of AbstractPath derived from these commits which I hope further shows the viability of this approach. [That code can be found here.](https://github.com/kfollstad/cpython/commit/903f35fa5d71d57edbdd417982799cc180121c07)

<!-- issue-number: [bpo-24132](https://bugs.python.org/issue24132) -->
https://bugs.python.org/issue24132
<!-- /issue-number -->
