### PR TITLE
bpo-44514: Add doctest testcleanup for configparser and bz2

### DIFF
--- a/Doc/library/bz2.rst
+++ b/Doc/library/bz2.rst
@@ -325,3 +325,8 @@ Writing and reading a bzip2-compressed file in binary mode:
     ...     content = f.read()
     >>> content == data  # Check equality to original object after round-trip
     True
+
+.. testcleanup::
+
+   import os
+   os.remove("myfile.bz2")

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -46,6 +46,11 @@ can be customized by end users easily.
 
    import configparser
 
+.. testcleanup::
+
+   import os
+   os.remove("example.ini")
+
 
 Quick Start
 -----------


### PR DESCRIPTION
Add testcleanup section to configparser and bz2 documentation which
removes temporary files created in the filesystem when 'make doctest'
is run.

<!-- issue-number: [bpo-44514](https://bugs.python.org/issue44514) -->
https://bugs.python.org/issue44514
<!-- /issue-number -->
