### PR TITLE
Fix typo with missing colon in `try` statement

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -278,7 +278,7 @@ have been incorporated. Some of the most notable ones are as follows:
 
     .. code-block:: python
 
-        >>> try
+        >>> try:
         ...     x = 2
         ... something = 3
           File "<stdin>", line 3


### PR DESCRIPTION
The `try` statement was missing a colon and therefore was not exemplifying the correct `SyntaxError`.

As per the Python Developer's Guide, [6.3 Proofreading](https://devguide.python.org/docquality/#proofreading), this PR is not linked to any bpo issue.
