### PR TITLE
bpo-40528: fix is_simple(sum)s behavior for attributes

### DIFF
--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -71,16 +71,20 @@ def reflow_lines(s, depth):
 def reflow_c_string(s, depth):
     return '"%s"' % s.replace('\n', '\\n"\n%s"' % (' ' * depth * TABSIZE))
 
-def is_simple(sum):
+def is_simple(sum_type):
     """Return True if a sum is a simple.
 
-    A sum is simple if its types have no fields, e.g.
+    A sum is simple if it's types have no fields and itself
+    doesn't have any attributes. Instances of these types are
+    cached at C level, and they act like singletons when propagating
+    parser generated nodes into Python level, e.g.
     unaryop = Invert | Not | UAdd | USub
     """
-    for t in sum.types:
-        if t.fields:
-            return False
-    return True
+
+    return not (
+        sum_type.attributes or
+        any(constructor.fields for constructor in sum_type.types)
+    )
 
 def asdl_of(name, obj):
     if isinstance(obj, asdl.Product) or isinstance(obj, asdl.Constructor):


### PR DESCRIPTION
This is something I noticed while (now discontinued) experimenting
with the idea of annotating operators with location information. Unfortunately
without this addition, adding any `attributes` to stuff like `unaryop`
doesn't change anything since the code assumes they are singletons and
caches all instances. This patch fixes this assumption with including
the attributes as well as constructor fields.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40528](https://bugs.python.org/issue40528) -->
https://bugs.python.org/issue40528
<!-- /issue-number -->
