### PR TITLE
bpo-40620: Clarify tutorial controlflow.rst ``range`` examples

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -110,14 +110,14 @@ The given end point is never part of the generated sequence; ``range(10)`` gener
 is possible to let the range start at another number, or to specify a different
 increment (even negative; sometimes this is called the 'step')::
 
-    range(5, 10)
-       5, 6, 7, 8, 9
+    >>> list(range(5, 10))
+    [5, 6, 7, 8, 9]
 
-    range(0, 10, 3)
-       0, 3, 6, 9
+    >>> list(range(0, 10, 3))
+    [0, 3, 6, 9]
 
-    range(-10, -100, -30)
-      -10, -40, -70
+    >>> list(range(-10, -100, -30))
+    [-10, -40, -70]
 
 To iterate over the indices of a sequence, you can combine :func:`range` and
 :func:`len` as follows::
@@ -137,7 +137,7 @@ function, see :ref:`tut-loopidioms`.
 
 A strange thing happens if you just print a range::
 
-   >>> print(range(10))
+   >>> range(10)
    range(0, 10)
 
 In many ways the object returned by :func:`range` behaves as if it is a list,
@@ -155,13 +155,7 @@ that takes an iterable is :func:`sum`::
     6
 
 Later we will see more functions that return iterables and take iterables as
-arguments.  Lastly, maybe you are curious about how to get a list from a range.
-Here is the solution::
-
-   >>> list(range(4))
-   [0, 1, 2, 3]
-
-In chapter :ref:`tut-structures`, we will discuss in more detail about
+arguments.  In chapter :ref:`tut-structures`, we will discuss in more detail about
 :func:`list`.
 
 .. _tut-break:

--- a/Misc/NEWS.d/next/Documentation/2021-06-26-17-41-06.bpo-40620.PAYDrB.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-26-17-41-06.bpo-40620.PAYDrB.rst
@@ -1,2 +1,2 @@
-Convert examples in controlflow.rst section 4.3 to be interpreter-demo
+Convert examples in tutorial controlflow.rst section 4.3 to be interpreter-demo
 style.

--- a/Misc/NEWS.d/next/Documentation/2021-06-26-17-41-06.bpo-40620.PAYDrB.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-26-17-41-06.bpo-40620.PAYDrB.rst
@@ -1,0 +1,2 @@
+Convert examples in controlflow.rst section 4.3 to be interpreter-demo
+style.


### PR DESCRIPTION
The former examples showed results that the interpreter would not  produce.  Use interactive style instead,
 introducing list here instead of later.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-40620](https://bugs.python.org/issue40620) -->
https://bugs.python.org/issue40620
<!-- /issue-number -->
