### PR TITLE
bpo-30511: Add note on thread safety to shutil.make_archive()

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -596,6 +596,7 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
    .. audit-event:: shutil.make_archive base_name,format,root_dir,base_dir shutil.make_archive
 
    .. note::
+
       This function is not thread-safe.
 
    .. versionchanged:: 3.8

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -595,6 +595,9 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
 
    .. audit-event:: shutil.make_archive base_name,format,root_dir,base_dir shutil.make_archive
 
+   .. note::
+      This function is not thread-safe.
+
    .. versionchanged:: 3.8
       The modern pax (POSIX.1-2001) format is now used instead of
       the legacy GNU format for archives created with ``format="tar"``.

--- a/Misc/NEWS.d/next/Documentation/2021-07-20-21-03-18.bpo-30511.eMFkRi.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-20-21-03-18.bpo-30511.eMFkRi.rst
@@ -1,0 +1,2 @@
+Clarify that :func:`shutil.make_archive` is not thread-safe due to
+reliance on changing the current working directory.


### PR DESCRIPTION


<!-- issue-number: [bpo-30511](https://bugs.python.org/issue30511) -->
https://bugs.python.org/issue30511
<!-- /issue-number -->
