### PR TITLE
bpo-38062: [doc] clarify that atexit uses equality comparisons internally.

### DIFF
--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -16,9 +16,35 @@ order in which they were registered; if you register ``A``, ``B``, and ``C``,
 at interpreter termination time they will be run in the order ``C``, ``B``,
 ``A``.
 
-**Note:** The functions registered via this module are not called when the
-program is killed by a signal not handled by Python, when a Python fatal
-internal error is detected, or when :func:`os._exit` is called.
+.. warning::
+
+   The functions registered via this module are not called when the
+   program is killed by a signal not handled by Python, when a Python fatal
+   internal error is detected, or when :func:`os._exit` is called.
+
+.. note::
+
+   Internal comparisons for registration and unregistration are done by
+   equality, not identity; meaning that you can register or unregister a method
+   even when the identity would not match. For example::
+
+       import atexit
+
+       class Saxophone:
+           def play():
+               ...
+
+       sax = Saxophone()
+       p1 = sax.play
+       p2 = sax.play
+       p1 is p2  # False; each bound method is a different object
+       p1 == p2  # True; this is how atexit compares functions internally
+
+   As a result, the code below works exactly as you expect because equality
+   comparisons are internally used::
+
+      atexit.register(sax.play)
+      atexit.unregister(sax.play)
 
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions
@@ -111,3 +137,4 @@ Usage as a :term:`decorator`::
        print('You are now leaving the Python sector.')
 
 This only works with functions that can be called without arguments.
+

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -14,11 +14,11 @@ functions.  Functions thus registered are automatically executed upon normal
 interpreter termination.  :mod:`atexit` runs these functions in the *reverse*
 order in which they were registered; if you register ``A``, ``B``, and ``C``,
 at interpreter termination time they will be run in the order ``C``, ``B``,
-``A``.
-
-**Note:** The functions registered via this module are not called when the
+``A``.  The functions registered via this module are not called when the
 program is killed by a signal not handled by Python, when a Python fatal
-internal error is detected, or when :func:`os._exit` is called.
+internal error is detected, or when :func:`os._exit` is called.  Equality
+comparisons are used internally during registration and unregistration
+operations, so function references do not need to have matching identities.
 
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -14,10 +14,11 @@ functions.  Functions thus registered are automatically executed upon normal
 interpreter termination.  :mod:`atexit` runs these functions in the *reverse*
 order in which they were registered; if you register ``A``, ``B``, and ``C``,
 at interpreter termination time they will be run in the order ``C``, ``B``,
-``A``.  The functions registered via this module are not called when the
+``A``.
+
+**Note:** The functions registered via this module are not called when the
 program is killed by a signal not handled by Python, when a Python fatal
 internal error is detected, or when :func:`os._exit` is called.
-
 
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -16,35 +16,9 @@ order in which they were registered; if you register ``A``, ``B``, and ``C``,
 at interpreter termination time they will be run in the order ``C``, ``B``,
 ``A``.
 
-.. warning::
-
-   The functions registered via this module are not called when the
-   program is killed by a signal not handled by Python, when a Python fatal
-   internal error is detected, or when :func:`os._exit` is called.
-
-.. note::
-
-   Internal comparisons for registration and unregistration are done by
-   equality, not identity; meaning that you can register or unregister a method
-   even when the identity would not match. For example::
-
-       import atexit
-
-       class Saxophone:
-           def play():
-               ...
-
-       sax = Saxophone()
-       p1 = sax.play
-       p2 = sax.play
-       p1 is p2  # False; each bound method is a different object
-       p1 == p2  # True; this is how atexit compares functions internally
-
-   As a result, the code below works exactly as you expect because equality
-   comparisons are internally used::
-
-      atexit.register(sax.play)
-      atexit.unregister(sax.play)
+**Note:** The functions registered via this module are not called when the
+program is killed by a signal not handled by Python, when a Python fatal
+internal error is detected, or when :func:`os._exit` is called.
 
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions
@@ -137,4 +111,3 @@ Usage as a :term:`decorator`::
        print('You are now leaving the Python sector.')
 
 This only works with functions that can be called without arguments.
-

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -50,7 +50,7 @@ internal error is detected, or when :func:`os._exit` is called.
 
    Remove *func* from the list of functions to be run at interpreter shutdown.
    :func:`unregister` silently does nothing if *func* was not previously
-   registered.  If *func* has been registered more than once, every occurance
+   registered.  If *func* has been registered more than once, every occurrence
    of that function in the :mod:`atexit` call stack will be removed.  Equality
    comparisons (``==``) are used internally during unregistration, so function
    references do not need to have matching identities.

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -17,8 +17,8 @@ at interpreter termination time they will be run in the order ``C``, ``B``,
 ``A``.  The functions registered via this module are not called when the
 program is killed by a signal not handled by Python, when a Python fatal
 internal error is detected, or when :func:`os._exit` is called.  Equality
-comparisons are used internally during registration and unregistration
-operations, so function references do not need to have matching identities.
+comparisons are used internally during unregistration operations, so function
+references do not need to have matching identities.
 
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -16,9 +16,8 @@ order in which they were registered; if you register ``A``, ``B``, and ``C``,
 at interpreter termination time they will be run in the order ``C``, ``B``,
 ``A``.  The functions registered via this module are not called when the
 program is killed by a signal not handled by Python, when a Python fatal
-internal error is detected, or when :func:`os._exit` is called.  Equality
-comparisons are used internally during unregistration operations, so function
-references do not need to have matching identities.
+internal error is detected, or when :func:`os._exit` is called.
+
 
 .. versionchanged:: 3.7
     When used with C-API subinterpreters, registered functions
@@ -48,11 +47,11 @@ references do not need to have matching identities.
 
 .. function:: unregister(func)
 
-   Remove *func* from the list of functions to be run at interpreter
-   shutdown.  After calling :func:`unregister`, *func* is guaranteed not to be
-   called when the interpreter shuts down, even if it was registered more than
-   once.  :func:`unregister` silently does nothing if *func* was not previously
-   registered.
+   Remove *func* from the list of functions to be run at interpreter shutdown.
+   :func:`unregister` silently does nothing if *func* was not previously
+   registered.  Equality comparisons (``==``) are used internally during
+   unregistration operations, so function references do not need to have
+   matching identities.
 
 
 .. seealso::

--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -49,9 +49,10 @@ internal error is detected, or when :func:`os._exit` is called.
 
    Remove *func* from the list of functions to be run at interpreter shutdown.
    :func:`unregister` silently does nothing if *func* was not previously
-   registered.  Equality comparisons (``==``) are used internally during
-   unregistration operations, so function references do not need to have
-   matching identities.
+   registered.  If *func* has been registered more than once, every occurance
+   of that function in the :mod:`atexit` call stack will be removed.  Equality
+   comparisons (``==``) are used internally during unregistration, so function
+   references do not need to have matching identities.
 
 
 .. seealso::

--- a/Misc/NEWS.d/next/Documentation/2021-06-28-11-17-42.bpo-38062.9Ehp9O.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-28-11-17-42.bpo-38062.9Ehp9O.rst
@@ -1,0 +1,1 @@
+Clarify that atexit uses equality comparisons internally.

--- a/Misc/NEWS.d/next/Documentation/2021-06-28-11-17-42.bpo-38062.9Ehp9O.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-28-11-17-42.bpo-38062.9Ehp9O.rst
@@ -1,1 +1,0 @@
-Clarify that atexit uses equality comparisons internally.

--- a/Misc/NEWS.d/next/Documentation/2021-06-28-12-13-48.bpo-38062.9Ehp9O.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-28-12-13-48.bpo-38062.9Ehp9O.rst
@@ -1,0 +1,1 @@
+Clarify that atexit uses equality comparisons internally.


### PR DESCRIPTION
I added a note with an example as shown in the bpo. I'm not sure if the
example is too verbose, and I should pair it down to just one sentence;
what do you think?

Also, there is a note about edge cases where registered functions are
not called. I elevated that to a `warning` block to maintain a better visual
hierarchy alongside the new note I added.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-38062](https://bugs.python.org/issue38062) -->
https://bugs.python.org/issue38062
<!-- /issue-number -->
