### PR TITLE
bpo-44523: [doc] Document that proxy objects return the has of their referent

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -131,18 +131,22 @@ Extension types can easily be made to support weak references; see
 
 .. function:: proxy(object[, callback])
 
+
    Return a proxy to *object* which uses a weak reference.  This supports use of
    the proxy in most contexts instead of requiring the explicit dereferencing used
    with weak reference objects.  The returned object will have a type of either
    ``ProxyType`` or ``CallableProxyType``, depending on whether *object* is
-   callable.  Proxy objects are not :term:`hashable` regardless of the referent; this
-   avoids a number of problems related to their fundamentally mutable nature, and
-   prevent their use as dictionary keys.  *callback* is the same as the parameter
-   of the same name to the :func:`ref` function.
+   callable.  Proxy objects are :term:`hashable` if the referent is hashable.
+   However, the fundamentally mutable nature of proxies means that their hashes
+   are not guaranteed to remain the same.  *callback* is the same as the
+   parameter of the same name to the :func:`ref` function.
 
    .. versionchanged:: 3.8
       Extended the operator support on proxy objects to include the matrix
       multiplication operators ``@`` and ``@=``.
+
+   .. versionchanged:: 3.9
+      Hashing proxy objects returns the hash of their referent.
 
 
 .. function:: getweakrefcount(object)

--- a/Misc/NEWS.d/next/Documentation/2021-06-28-11-53-27.bpo-44523.I1hj9S.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-06-28-11-53-27.bpo-44523.I1hj9S.rst
@@ -1,0 +1,2 @@
+Document that proxy objects return the has of their referent. This behavior
+was introduced in ``96074de573f82fc66a2bd73c36905141a3f1d5c1``.


### PR DESCRIPTION
I am a little bit unsure about this fix. It seems to me that hashing proxy
objects has been hidden to the user because the hashes are not reliable, and
I'm not sure if @pablogsal intended for it to be documented, or to be
documented in this way.

I might also not be striking the right tone with how I describe the hashes
coming back from proxy objects as "unreliable." Feel free to let me know
if that is the case. Thanks!

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44523](https://bugs.python.org/issue44523) -->
https://bugs.python.org/issue44523
<!-- /issue-number -->
