### PR TITLE
bpo-43625: Enhance csv sniffer has_headers() to be more accurate

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -268,7 +268,20 @@ The :mod:`csv` module defines the following classes:
    .. method:: has_header(sample)
 
       Analyze the sample text (presumed to be in CSV format) and return
-      :const:`True` if the first row appears to be a series of column headers.
+      :const:`True` if the first row appears to be a series of column
+      headers. One of two key criteria will be considered to guess if the sample contains a
+      header:
+
+        - the second through n-th rows contain numeric values
+        - the second through n-th rows contain strings where at least one value's length
+          differs from that of the putative header of that column.
+
+      Twenty rows after the first are sampled, if more than half of columns + rows meet the
+      criteria, :const:`True` is returned.
+
+   .. note::
+
+      This method is a rough heuristic and may produce both false positives and negatives.
 
 An example for :class:`Sniffer` use::
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -268,20 +268,21 @@ The :mod:`csv` module defines the following classes:
    .. method:: has_header(sample)
 
       Analyze the sample text (presumed to be in CSV format) and return
-      :const:`True` if the first row appears to be a series of column
-      headers. One of two key criteria will be considered to guess if the sample contains a
-      header:
+      :const:`True` if the first row appears to be a series of column headers.
+      Inspecting each column, one of two key criteria will be considered to
+      estimate if the sample contains a header:
 
         - the second through n-th rows contain numeric values
-        - the second through n-th rows contain strings where at least one value's length
-          differs from that of the putative header of that column.
+        - the second through n-th rows contain strings where at least one value's
+          length differs from that of the putative header of that column.
 
-      Twenty rows after the first are sampled, if more than half of columns + rows meet the
-      criteria, :const:`True` is returned.
+      Twenty rows after the first row are sampled; if more than half of columns +
+      rows meet the criteria, :const:`True` is returned.
 
    .. note::
 
-      This method is a rough heuristic and may produce both false positives and negatives.
+      This method is a rough heuristic and may produce both false positives and
+      negatives.
 
 An example for :class:`Sniffer` use::
 

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -412,7 +412,7 @@ class Sniffer:
                 thisType = complex
                 try:
                     thisType(row[col])
-                except:
+                except (ValueError, OverflowError):
                     # fallback to length of string
                     thisType = len(row[col])
 

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -410,7 +410,7 @@ class Sniffer:
 
             for col in list(columnTypes.keys()):
 
-                for thisType in [int, float, complex]:
+                for thisType in [complex, float, int]:
                     try:
                         thisType(row[col])
                         break

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -409,14 +409,10 @@ class Sniffer:
                 continue # skip rows that have irregular number of columns
 
             for col in list(columnTypes.keys()):
-
-                for thisType in [complex, float, int]:
-                    try:
-                        thisType(row[col])
-                        break
-                    except (ValueError, OverflowError):
-                        pass
-                else:
+                thisType = complex
+                try:
+                    thisType(row[col])
+                except:
                     # fallback to length of string
                     thisType = len(row[col])
 

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1231,6 +1231,7 @@ class KeyOrderingTest(unittest.TestCase):
              OrderedDict([('fname', 'John'), ('lname', 'Cleese')]),
             ])
 
+
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         extra = {'__doc__', '__version__'}

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1014,6 +1014,42 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
 'Stonecutters ''Seafood'' and Chop House'+ 'Lemont'+ 'IL'+ '12/19/02'+ 'Week Back'
 """
 
+    sample10 = dedent("""
+                        abc,def
+                        ghijkl,mno
+                        ghi,jkl
+                        """)
+
+    sample11 = dedent("""
+                        abc,def
+                        ghijkl,mnop
+                        ghi,jkl
+                         """)
+
+    sample12 = dedent(""""time","forces"
+                        1,1.5
+                        0.5,5+0j
+                        0,0
+                        1+1j,6
+                        """)
+
+    sample13 = dedent(""""time","forces"
+                        0,0
+                        1,2
+                        a,b
+                        """)
+
+    def test_issue43625(self):
+        sniffer = csv.Sniffer()
+        self.assertTrue(sniffer.has_header(self.sample12))
+        self.assertFalse(sniffer.has_header(self.sample13))
+
+    def test_has_header_strings(self):
+        # More to document existing (unexpected?) behavior than anything else.
+        sniffer = csv.Sniffer()
+        self.assertFalse(sniffer.has_header(self.sample10))
+        self.assertFalse(sniffer.has_header(self.sample11))
+
     def test_has_header(self):
         sniffer = csv.Sniffer()
         self.assertIs(sniffer.has_header(self.sample1), False)
@@ -1240,49 +1276,6 @@ class MiscTestCase(unittest.TestCase):
     def test_subclassable(self):
         # issue 44089
         class Foo(csv.Error): ...
-
-class TestSniffer(unittest.TestCase):
-    mixed = dedent(""""time","forces"
-                        1,1.5
-                        0.5,5+0j
-                        0,0
-                        1+1j,6
-                        """)
-
-    mixed2 = dedent(""""time","forces"
-                        0,0
-                        1,2
-                        a,b
-                        """)
-
-    mixed3 = dedent(""""time","forces"
-                        0,0
-                        1,2
-                        a,b
-                        """)
-
-    sample10 = dedent("""
-                        abc,def
-                        ghijkl,mno
-                        ghi,jkl
-                        """)
-
-    sample11 = dedent("""
-                        abc,def
-                        ghijkl,mnop
-                        ghi,jkl
-                         """)
-
-    def test_issue43625(self):
-        sniffer = csv.Sniffer()
-        self.assertTrue(sniffer.has_header(self.mixed))
-        self.assertFalse(sniffer.has_header(self.mixed2))
-
-    def test_has_header_strings(self):
-        # More to document existing (unexpected?) behavior than anything else.
-        sniffer = csv.Sniffer()
-        self.assertFalse(sniffer.has_header(self.sample10))
-        self.assertFalse(sniffer.has_header(self.sample11))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1231,7 +1231,6 @@ class KeyOrderingTest(unittest.TestCase):
              OrderedDict([('fname', 'John'), ('lname', 'Cleese')]),
             ])
 
-
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         extra = {'__doc__', '__version__'}
@@ -1240,6 +1239,20 @@ class MiscTestCase(unittest.TestCase):
     def test_subclassable(self):
         # issue 44089
         class Foo(csv.Error): ...
+
+class TestSniffer(unittest.TestCase):
+    mixed = '''"time","forces"
+0,0
+0.5,0.9
+'''
+    mixed2 = '''"time","forces"
+0.5,0.9
+0,0
+'''
+    def test_issue43625(self):
+        sniffer = csv.Sniffer()
+        self.assertTrue(sniffer.has_header(self.mixed))
+        self.assertTrue(sniffer.has_header(self.mixed2))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1045,7 +1045,7 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
         self.assertFalse(sniffer.has_header(self.sample13))
 
     def test_has_header_strings(self):
-        # More to document existing (unexpected?) behavior than anything else.
+        "More to document existing (unexpected?) behavior than anything else."
         sniffer = csv.Sniffer()
         self.assertFalse(sniffer.has_header(self.sample10))
         self.assertFalse(sniffer.has_header(self.sample11))

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1242,18 +1242,47 @@ class MiscTestCase(unittest.TestCase):
         class Foo(csv.Error): ...
 
 class TestSniffer(unittest.TestCase):
-    mixed = '''"time","forces"
-0,0
-0.5,0.9
-'''
-    mixed2 = '''"time","forces"
-0.5,0.9
-0,0
-'''
+    mixed = dedent(""""time","forces"
+                        1,1.5
+                        0.5,5+0j
+                        0,0
+                        1+1j,6
+                        """)
+
+    mixed2 = dedent(""""time","forces"
+                        0,0
+                        1,2
+                        a,b
+                        """)
+
+    mixed3 = dedent(""""time","forces"
+                        0,0
+                        1,2
+                        a,b
+                        """)
+
+    sample10 = dedent("""
+                        abc,def
+                        ghijkl,mno
+                        ghi,jkl
+                        """)
+
+    sample11 = dedent("""
+                        abc,def
+                        ghijkl,mnop
+                        ghi,jkl
+                         """)
+
     def test_issue43625(self):
         sniffer = csv.Sniffer()
         self.assertTrue(sniffer.has_header(self.mixed))
-        self.assertTrue(sniffer.has_header(self.mixed2))
+        self.assertFalse(sniffer.has_header(self.mixed2))
+
+    def test_has_header_strings(self):
+        # More to document existing (unexpected?) behavior than anything else.
+        sniffer = csv.Sniffer()
+        self.assertFalse(sniffer.has_header(self.sample10))
+        self.assertFalse(sniffer.has_header(self.sample11))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2021-06-29-07-27-08.bpo-43625.ZlAxhp.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-29-07-27-08.bpo-43625.ZlAxhp.rst
@@ -1,0 +1,2 @@
+Fix a bug in the detection of CSV file headers by
+:meth:`csv.Sniffer.has_header` and improve documentation of same.


### PR DESCRIPTION
Based on the patch by @smontanaro , updated by A. Kulakov

<!-- issue-number: [bpo-43625](https://bugs.python.org/issue43625) -->
https://bugs.python.org/issue43625
<!-- /issue-number -->
