### PR TITLE
bpo-44434: Remove useless calls to PyThread_exit_thread()

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4300,8 +4300,6 @@ temporary_c_thread(void *data)
     PyGILState_Release(state);
 
     PyThread_release_lock(test_c_thread->exit_event);
-
-    PyThread_exit_thread();
 }
 
 static PyObject *

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -269,8 +269,6 @@ static void bpo20891_thread(void *lockp)
     PyGILState_Release(state);
 
     PyThread_release_lock(lock);
-
-    PyThread_exit_thread();
 }
 
 static int test_bpo20891(void)


### PR DESCRIPTION
Remove useless calls to PyThread_exit_thread() in two unit tests of
_testcapi and _testembed modules.

Co-authored-by: Alexey Izbyshev <izbyshev@ispras.ru>


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44434](https://bugs.python.org/issue44434) -->
https://bugs.python.org/issue44434
<!-- /issue-number -->
