### PR TITLE
bpo-44532: fix _PyStructSequence_InitType_Check

### DIFF
--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -478,8 +478,7 @@ _PyStructSequence_InitType(PyTypeObject *type, PyStructSequence_Desc *desc,
 
     /* PyTypeObject has already been initialized */
     if (Py_REFCNT(type) != 0) {
-        PyErr_BadInternalCall();
-        return -1;
+        return 0;
     }
 
     type->tp_name = desc->name;


### PR DESCRIPTION
In _PyStructSequence_InitType, it will check type is initialized.
but when we have multi subinterpreters, type may be initialized in expected.

when type already been initialized, should return 0 rather than throw exception.
```c
/* PyTypeObject has already been initialized */
if (Py_REFCNT(type) != 0) {
    return 0;
}
```


```c
int
_PyStructSequence_InitType(PyTypeObject *type, PyStructSequence_Desc *desc,
                           unsigned long tp_flags)
{
    PyMemberDef *members;
    Py_ssize_t n_members, n_unnamed_members;

#ifdef Py_TRACE_REFS
    /* if the type object was chained, unchain it first
       before overwriting its storage */
    if (type->ob_base.ob_base._ob_next) {
        _Py_ForgetReference((PyObject *)type);
    }
#endif

    /* PyTypeObject has already been initialized */
    if (Py_REFCNT(type) != 0) {
        PyErr_BadInternalCall();
        return -1;
    }
```

<!-- issue-number: [bpo-44532](https://bugs.python.org/issue44532) -->
https://bugs.python.org/issue44532
<!-- /issue-number -->
