### PR TITLE
bpo-44523: Remove the pass-through for hash() in weakref proxy objects

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -422,14 +422,20 @@ class ReferencesTestCase(TestBase):
         self.assertEqual("".join(reversed(weakref.proxy(obj))), "cba")
 
     def test_proxy_hash(self):
-        cool_hash = 299_792_458
-
         class MyObj:
             def __hash__(self):
-                return cool_hash
+                return 42
 
         obj = MyObj()
-        self.assertEqual(hash(weakref.proxy(obj)), cool_hash)
+        with self.assertRaises(TypeError):
+            hash(weakref.proxy(obj))
+
+        class MyObj:
+            __hash__ = None
+
+        obj = MyObj()
+        with self.assertRaises(TypeError):
+            hash(weakref.proxy(obj))
 
     def test_getweakrefcount(self):
         o = C()

--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-29-11-49-29.bpo-44523.67-ZIP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-29-11-49-29.bpo-44523.67-ZIP.rst
@@ -1,3 +1,3 @@
 Remove the pass-through for :func:`hash` of :class:`weakref.proxy` objects
-due to prevent unintended consecuences when the original referred object
+to prevent unintended consequences when the original referred object
 dies while the proxy is part of a hashable object. Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-06-29-11-49-29.bpo-44523.67-ZIP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-06-29-11-49-29.bpo-44523.67-ZIP.rst
@@ -1,0 +1,3 @@
+Remove the pass-through for :func:`hash` of :class:`weakref.proxy` objects
+due to prevent unintended consecuences when the original referred object
+dies while the proxy is part of a hashable object. Patch by Pablo Galindo.

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -732,21 +732,6 @@ static PyMappingMethods proxy_as_mapping = {
 };
 
 
-static Py_hash_t
-proxy_hash(PyObject *self)
-{
-    PyWeakReference *proxy = (PyWeakReference *)self;
-    if (!proxy_checkref(proxy)) {
-        return -1;
-    }
-    PyObject *obj = PyWeakref_GET_OBJECT(proxy);
-    Py_INCREF(obj);
-    Py_hash_t res = PyObject_Hash(obj);
-    Py_DECREF(obj);
-    return res;
-}
-
-
 PyTypeObject
 _PyWeakref_ProxyType = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -763,7 +748,7 @@ _PyWeakref_ProxyType = {
     &proxy_as_number,                   /* tp_as_number */
     &proxy_as_sequence,                 /* tp_as_sequence */
     &proxy_as_mapping,                  /* tp_as_mapping */
-    proxy_hash,                         /* tp_hash */
+    0,                                  /* tp_hash */
     0,                                  /* tp_call */
     proxy_str,                          /* tp_str */
     proxy_getattr,                      /* tp_getattro */

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -748,6 +748,7 @@ _PyWeakref_ProxyType = {
     &proxy_as_number,                   /* tp_as_number */
     &proxy_as_sequence,                 /* tp_as_sequence */
     &proxy_as_mapping,                  /* tp_as_mapping */
+// Notice that tp_hash is intentionally omitted as proxies are "mutable" (when the reference dies).
     0,                                  /* tp_hash */
     0,                                  /* tp_call */
     proxy_str,                          /* tp_str */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44523](https://bugs.python.org/issue44523) -->
https://bugs.python.org/issue44523
<!-- /issue-number -->
