### PR TITLE
bpo-33140: skip defining shutil.chown() on windows

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -54,8 +54,7 @@ __all__ = ["copyfileobj", "copyfile", "copymode", "copystat", "copy", "copy2",
            "register_archive_format", "unregister_archive_format",
            "get_unpack_formats", "register_unpack_format",
            "unregister_unpack_format", "unpack_archive",
-           "ignore_patterns", "which", "get_terminal_size",
-           "SameFileError"]
+           "ignore_patterns", "which", "get_terminal_size", "SameFileError"]
            # disk_usage is added later, if available on the platform
 
 if not _WINDOWS:

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -54,9 +54,12 @@ __all__ = ["copyfileobj", "copyfile", "copymode", "copystat", "copy", "copy2",
            "register_archive_format", "unregister_archive_format",
            "get_unpack_formats", "register_unpack_format",
            "unregister_unpack_format", "unpack_archive",
-           "ignore_patterns", "chown", "which", "get_terminal_size",
+           "ignore_patterns", "which", "get_terminal_size",
            "SameFileError"]
            # disk_usage is added later, if available on the platform
+
+if not _WINDOWS:
+    __all__.append("chown")
 
 class Error(OSError):
     pass

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1298,8 +1298,8 @@ if not _WINDOWS:
     def chown(path, user=None, group=None):
         """Change owner user and group of the given path.
 
-        user and group can be the uid/gid or the user/group names, and in that case,
-        they are converted to their respective uid/gid.
+        user and group can be the uid/gid or the user/group names, and in that
+        case, they are converted to their respective uid/gid.
         """
         sys.audit('shutil.chown', path, user, group)
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1292,37 +1292,38 @@ elif _WINDOWS:
         return _ntuple_diskusage(total, used, free)
 
 
-def chown(path, user=None, group=None):
-    """Change owner user and group of the given path.
+if not _WINDOWS:
+    def chown(path, user=None, group=None):
+        """Change owner user and group of the given path.
 
-    user and group can be the uid/gid or the user/group names, and in that case,
-    they are converted to their respective uid/gid.
-    """
-    sys.audit('shutil.chown', path, user, group)
+        user and group can be the uid/gid or the user/group names, and in that case,
+        they are converted to their respective uid/gid.
+        """
+        sys.audit('shutil.chown', path, user, group)
 
-    if user is None and group is None:
-        raise ValueError("user and/or group must be set")
+        if user is None and group is None:
+            raise ValueError("user and/or group must be set")
 
-    _user = user
-    _group = group
+        _user = user
+        _group = group
 
-    # -1 means don't change it
-    if user is None:
-        _user = -1
-    # user can either be an int (the uid) or a string (the system username)
-    elif isinstance(user, str):
-        _user = _get_uid(user)
-        if _user is None:
-            raise LookupError("no such user: {!r}".format(user))
+        # -1 means don't change it
+        if user is None:
+            _user = -1
+        # user can either be an int (the uid) or a string (the system username)
+        elif isinstance(user, str):
+            _user = _get_uid(user)
+            if _user is None:
+                raise LookupError("no such user: {!r}".format(user))
 
-    if group is None:
-        _group = -1
-    elif not isinstance(group, int):
-        _group = _get_gid(group)
-        if _group is None:
-            raise LookupError("no such group: {!r}".format(group))
+        if group is None:
+            _group = -1
+        elif not isinstance(group, int):
+            _group = _get_gid(group)
+            if _group is None:
+                raise LookupError("no such group: {!r}".format(group))
 
-    os.chown(path, _user, _group)
+        os.chown(path, _user, _group)
 
 def get_terminal_size(fallback=(80, 24)):
     """Get the size of the terminal window.

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2612,7 +2612,7 @@ class PublicAPITests(unittest.TestCase):
                       'get_terminal_size', 'SameFileError']
         if hasattr(os, 'statvfs') or os.name == 'nt':
             target_api.append('disk_usage')
-        if os.name == 'nt':
+        if os.name != 'nt':
             target_api.append('chown')
         self.assertEqual(set(shutil.__all__), set(target_api))
 

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2608,10 +2608,12 @@ class PublicAPITests(unittest.TestCase):
                       'get_archive_formats', 'register_archive_format',
                       'unregister_archive_format', 'get_unpack_formats',
                       'register_unpack_format', 'unregister_unpack_format',
-                      'unpack_archive', 'ignore_patterns', 'chown', 'which',
+                      'unpack_archive', 'ignore_patterns', 'which',
                       'get_terminal_size', 'SameFileError']
         if hasattr(os, 'statvfs') or os.name == 'nt':
             target_api.append('disk_usage')
+        if os.name == 'nt':
+            target_api.append('chown')
         self.assertEqual(set(shutil.__all__), set(target_api))
 
 


### PR DESCRIPTION


<!-- issue-number: [bpo-33140](https://bugs.python.org/issue33140) -->
https://bugs.python.org/issue33140
<!-- /issue-number -->
