### PR TITLE
bpo-42369: Fix thread safety of zipfile._SharedFile.tell

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -721,7 +721,9 @@ class _SharedFile:
         self._lock = lock
         self._writing = writing
         self.seekable = file.seekable
-        self.tell = file.tell
+
+    def tell(self):
+        return self._pos
 
     def seek(self, offset, whence=0):
         with self._lock:

--- a/Misc/NEWS.d/next/Library/2022-03-19-19-56-04.bpo-42369.Ok828t.rst
+++ b/Misc/NEWS.d/next/Library/2022-03-19-19-56-04.bpo-42369.Ok828t.rst
@@ -1,0 +1,1 @@
+Fix thread safety of :meth:`zipfile._SharedFile.tell` to avoid a "zipfile.BadZipFile: Bad CRC-32 for file" exception when reading a :class:`ZipFile` from multiple threads.


### PR DESCRIPTION
The `_SharedFile` tracks its own virtual position into the file as `self._pos` and updates it after reading or seeking. `tell()` should return this position instead of calling into the underlying file object, since if multiple `_SharedFile` instances are being used concurrently on the same file, another one may have moved the real file position. Additionally, calling into the underlying `tell` may expose thread safety issues in the underlying file object because it was called without taking the lock.

Prior to this fix, the test case in https://bugs.python.org/issue42369#msg381212 reliably caused a `zipfile.BadZipFile: Bad CRC-32 for file 'file1'` in less than a second; with this fix I have not seen this error.


<!-- issue-number: [bpo-42369](https://bugs.python.org/issue42369) -->
https://bugs.python.org/issue42369
<!-- /issue-number -->
