### PR TITLE
bpo-44543: remove "warn" methods and functions from logging

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -763,7 +763,7 @@ for the handler class. If not provided, it defaults to ``{}``.
 
    [handler_hand04]
    class=handlers.DatagramHandler
-   level=WARN
+   level=WARNING
    formatter=form04
    args=('localhost', handlers.DEFAULT_UDP_LOGGING_PORT)
 
@@ -781,7 +781,7 @@ for the handler class. If not provided, it defaults to ``{}``.
 
    [handler_hand07]
    class=handlers.SMTPHandler
-   level=WARN
+   level=WARNING
    formatter=form07
    args=('localhost', 'from@abc', ['user1@abc', 'user2@xyz'], 'Logger Subject')
    kwargs={'timeout': 10.0}

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -676,7 +676,7 @@ supports sending logging messages to a remote or local Unix syslog.
       +--------------------------+---------------+
       | ``notice``               | LOG_NOTICE    |
       +--------------------------+---------------+
-      | ``warn`` or ``warning``  | LOG_WARNING   |
+      | ``warning``              | LOG_WARNING   |
       +--------------------------+---------------+
 
       **Facilities**
@@ -724,6 +724,10 @@ supports sending logging messages to a remote or local Unix syslog.
       +---------------+---------------+
       | ``local7``    | LOG_LOCAL7    |
       +---------------+---------------+
+
+   .. versionchanged:: 3.11
+
+      The deprecated keyword ``"WARN"`` was removed. Use ``"WARNING"`` instead.
 
    .. method:: mapPriority(levelname)
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -256,7 +256,7 @@ is the module's name in the Python package namespace.
 
       .. versionchanged:: 3.11
 
-      The deprecated ``logging.warn`` method, a duplicate of this method,
+      The deprecated method ``logging.Logger.warn``, a duplicate of this method,
       was removed. Use this method instead.
 
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -254,9 +254,11 @@ is the module's name in the Python package namespace.
       Logs a message with level :const:`WARNING` on this logger. The arguments are
       interpreted as for :meth:`debug`.
 
-      .. note:: There is an obsolete method ``warn`` which is functionally
-         identical to ``warning``. As ``warn`` is deprecated, please do not use
-         it - use ``warning`` instead.
+      .. versionchanged:: 3.11
+
+      The deprecated ``logging.warn`` method, a duplicate of this method,
+      was removed. Use this method instead.
+
 
    .. method:: Logger.error(msg, *args, **kwargs)
 
@@ -1039,9 +1041,10 @@ functions.
    Logs a message with level :const:`WARNING` on the root logger. The arguments
    are interpreted as for :func:`debug`.
 
-   .. note:: There is an obsolete function ``warn`` which is functionally
-      identical to ``warning``. As ``warn`` is deprecated, please do not use
-      it - use ``warning`` instead.
+   .. versionchanged:: 3.11
+
+   The deprecated ``logging.warn`` function, a duplicate of this function, was
+   removed. Use this function instead.
 
 
 .. function:: error(msg, *args, **kwargs)

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -32,11 +32,11 @@ from string import Formatter as StrFormatter
 __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
            'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
            'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
-           'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
+           'StreamHandler', 'WARNING', 'addLevelName', 'basicConfig',
            'captureWarnings', 'critical', 'debug', 'disable', 'error',
            'exception', 'fatal', 'getLevelName', 'getLogger', 'getLoggerClass',
            'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
-           'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
+           'warning', 'getLogRecordFactory', 'setLogRecordFactory',
            'lastResort', 'raiseExceptions', 'getLevelNamesMapping']
 
 import threading
@@ -92,7 +92,6 @@ CRITICAL = 50
 FATAL = CRITICAL
 ERROR = 40
 WARNING = 30
-WARN = WARNING
 INFO = 20
 DEBUG = 10
 NOTSET = 0
@@ -109,7 +108,6 @@ _nameToLevel = {
     'CRITICAL': CRITICAL,
     'FATAL': FATAL,
     'ERROR': ERROR,
-    'WARN': WARNING,
     'WARNING': WARNING,
     'INFO': INFO,
     'DEBUG': DEBUG,
@@ -1483,11 +1481,6 @@ class Logger(Filterer):
         if self.isEnabledFor(WARNING):
             self._log(WARNING, msg, args, **kwargs)
 
-    def warn(self, msg, *args, **kwargs):
-        warnings.warn("The 'warn' method is deprecated, "
-            "use 'warning' instead", DeprecationWarning, 2)
-        self.warning(msg, *args, **kwargs)
-
     def error(self, msg, *args, **kwargs):
         """
         Log 'msg % args' with severity 'ERROR'.
@@ -1841,11 +1834,6 @@ class LoggerAdapter(object):
         """
         self.log(WARNING, msg, *args, **kwargs)
 
-    def warn(self, msg, *args, **kwargs):
-        warnings.warn("The 'warn' method is deprecated, "
-            "use 'warning' instead", DeprecationWarning, 2)
-        self.warning(msg, *args, **kwargs)
-
     def error(self, msg, *args, **kwargs):
         """
         Delegate an error call to the underlying logger.
@@ -2116,11 +2104,6 @@ def warning(msg, *args, **kwargs):
     if len(root.handlers) == 0:
         basicConfig()
     root.warning(msg, *args, **kwargs)
-
-def warn(msg, *args, **kwargs):
-    warnings.warn("The 'warn' function is deprecated, "
-        "use 'warning' instead", DeprecationWarning, 2)
-    warning(msg, *args, **kwargs)
 
 def info(msg, *args, **kwargs):
     """

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -773,7 +773,6 @@ class SysLogHandler(logging.Handler):
         "info":     LOG_INFO,
         "notice":   LOG_NOTICE,
         "panic":    LOG_EMERG,      #  DEPRECATED
-        "warn":     LOG_WARNING,    #  DEPRECATED
         "warning":  LOG_WARNING,
         }
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4235,7 +4235,7 @@ class ModuleLevelMiscTest(BaseTest):
 
         self.assertRaises(TypeError, logging.disable, _NotAnIntOrString())
 
-        logging.disable("WARN")
+        logging.disable("WARNING")
 
         # test the default value introduced in 3.7
         # (Issue #28524)

--- a/Misc/NEWS.d/next/Library/2021-07-01-13-15-18.bpo-44543.1VLXFU.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-01-13-15-18.bpo-44543.1VLXFU.rst
@@ -1,0 +1,2 @@
+From the :mod:`logging` module, remove depricated :func:`logging.warn`,
+:meth:`logging.Logger.warn`, and :meth:`logger.LoggerAdapter.warn`.


### PR DESCRIPTION
- remove logging.warn
- remove logging.Logger.warn
- remove logging.LoggerAdapter.warn
- these methods/functions have been emitting deprication warnings since
  version 3.4

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44543](https://bugs.python.org/issue44543) -->
https://bugs.python.org/issue44543
<!-- /issue-number -->
