### PR TITLE
bpo-39710: Remove Python 2-specific sentence from calendar documentation

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -279,16 +279,13 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 
    This subclass of :class:`TextCalendar` can be passed a locale name in the
    constructor and will return month and weekday names in the specified locale.
-   If this locale includes an encoding all strings containing month and weekday
-   names will be returned as unicode.
 
 
 .. class:: LocaleHTMLCalendar(firstweekday=0, locale=None)
 
    This subclass of :class:`HTMLCalendar` can be passed a locale name in the
    constructor and will return month and weekday names in the specified
-   locale. If this locale includes an encoding all strings containing month and
-   weekday names will be returned as unicode.
+   locale.
 
 .. note::
 

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -558,9 +558,7 @@ class different_locale:
 class LocaleTextCalendar(TextCalendar):
     """
     This class can be passed a locale name in the constructor and will return
-    month and weekday names in the specified locale. If this locale includes
-    an encoding all strings containing month and weekday names will be returned
-    as unicode.
+    month and weekday names in the specified locale.
     """
 
     def __init__(self, firstweekday=0, locale=None):
@@ -581,9 +579,7 @@ class LocaleTextCalendar(TextCalendar):
 class LocaleHTMLCalendar(HTMLCalendar):
     """
     This class can be passed a locale name in the constructor and will return
-    month and weekday names in the specified locale. If this locale includes
-    an encoding all strings containing month and weekday names will be returned
-    as unicode.
+    month and weekday names in the specified locale.
     """
     def __init__(self, firstweekday=0, locale=None):
         HTMLCalendar.__init__(self, firstweekday)


### PR DESCRIPTION
https://bugs.python.org/issue39710
Duplicate of #18619, but solves issues not resolved by original pull request namely modification in Doc

Co-authored-by: Andrey Doroschenko andrey.daraschenka@gmail.com

https://bugs.python.org/issue39710

<!-- issue-number: [bpo-39710](https://bugs.python.org/issue39710) -->
https://bugs.python.org/issue39710
<!-- /issue-number -->
