### PR TITLE
bpo-30256: Fix rst in news

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-09-25-13-54-41.bpo-30256.wBkzox.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-25-13-54-41.bpo-30256.wBkzox.rst
@@ -1,1 +1,1 @@
-Pass multiprocessing BaseProxy argument ``manager_owned`` through AutoProxy
+Pass multiprocessing BaseProxy argument ``manager_owned`` through AutoProxy.

--- a/Misc/NEWS.d/next/Library/2019-09-25-13-54-41.bpo-30256.wBkzox.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-25-13-54-41.bpo-30256.wBkzox.rst
@@ -1,1 +1,1 @@
-Pass multiprocessing BaseProxy argument `manager_owned` through AutoProxy
+Pass multiprocessing BaseProxy argument ``manager_owned`` through AutoProxy


### PR DESCRIPTION
Unblocks the docs CI. Currently PR CIs fail with the following error:
```
python tools/rstlint.py ../Misc/NEWS.d/next/
[2] ../Misc/NEWS.d/next/Library/2019-09-25-13-54-41.[bpo-30256](https://bugs.python.org/issue30256).wBkzox.rst:1: default role used
1 problem with severity 2 found.
Makefile:204: recipe for target 'check' failed

```

<!-- issue-number: [bpo-30256](https://bugs.python.org/issue30256) -->
https://bugs.python.org/issue30256
<!-- /issue-number -->
