### PR TITLE
bpo-44544: [doc] list all textwrap func kwargs

### DIFF
--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -99,10 +99,11 @@ functions should be good enough; otherwise, you should use an instance of
    * :attr:`.break_on_hyphens`
    * :attr:`.max_lines`
 
-   Note that :class:`TextWrapper` has some additional options which have **no
-   effect** when passed to :func:`shorten` (:attr:`.tabsize`,
-   :attr:`.expand_tabs`, :attr:`.drop_whitespace`, and
-   :attr:`.replace_whitespace`).
+
+   Note that the whitespace is collapsed before the text is passed to the
+   :class:`TextWrapper` :meth:`fill` function, so changing the value of
+   :attr:`.tabsize`, :attr:`.expand_tabs`, :attr:`.drop_whitespace`, and
+   :attr:`.replace_whitespace` will have no effect.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -17,31 +17,69 @@ If you're just wrapping or filling one or two text strings, the convenience
 functions should be good enough; otherwise, you should use an instance of
 :class:`TextWrapper` for efficiency.
 
-.. function:: wrap(text, width=70, **kwargs)
+.. function:: wrap(text, width=70, initial_indent="", subsequent_indent="", \
+                   expand_tabs=True, replace_whitespace=True, \
+                   fix_sentence_endings=False, \
+                   break_long_words=True, drop_whitespace=True, \
+                   break_on_hyphens=True, tabsize=8, \
+                   *, max_lines=None)
 
    Wraps the single paragraph in *text* (a string) so every line is at most
    *width* characters long.  Returns a list of output lines, without final
-   newlines.
+   newlines.  *width* defaults to ``70``.
 
-   Optional keyword arguments correspond to the instance attributes of
-   :class:`TextWrapper`, documented below.  *width* defaults to ``70``.
+   See :class:`TextWrapper` for documentation on all additional optional
+   arguments:
 
-   See the :meth:`TextWrapper.wrap` method for additional details on how
-   :func:`wrap` behaves.
+   * :attr:`.initial_indent`
+   * :attr:`.subsequent_indent`
+   * :attr:`.expand_tabs`
+   * :attr:`.replace_whitespace`
+   * :attr:`.fix_sentence_endings`
+   * :attr:`.break_long_words`
+   * :attr:`.drop_whitespace`
+   * :attr:`.break_on_hyphens`
+   * :attr:`.tabsize`
+   * :attr:`.max_lines`
+
+   Note that :func:`wrap` accepts exactly the same keyword arguments as
+   :func:`fill`.
 
 
-.. function:: fill(text, width=70, **kwargs)
+.. function:: fill(text, width=70, initial_indent="", \
+                   subsequent_indent="", expand_tabs=True, \
+                   replace_whitespace=True, fix_sentence_endings=False, \
+                   break_long_words=True, drop_whitespace=True, \
+                   break_on_hyphens=True, tabsize=8, \
+                   *, max_lines=None)
 
-   Wraps the single paragraph in *text*, and returns a single string containing the
-   wrapped paragraph.  :func:`fill` is shorthand for  ::
+   Wraps the single paragraph in *text*, and returns a single string containing
+   the wrapped paragraph.  :func:`fill` is shorthand for ::
 
       "\n".join(wrap(text, ...))
 
-   In particular, :func:`fill` accepts exactly the same keyword arguments as
+   See :class:`TextWrapper` for documentation on all additional optional
+   arguments:
+
+   * :attr:`.initial_indent`
+   * :attr:`.subsequent_indent`
+   * :attr:`.expand_tabs`
+   * :attr:`.replace_whitespace`
+   * :attr:`.fix_sentence_endings`
+   * :attr:`.break_long_words`
+   * :attr:`.drop_whitespace`
+   * :attr:`.break_on_hyphens`
+   * :attr:`.tabsize`
+   * :attr:`.max_lines`
+
+   Note that :func:`fill` accepts exactly the same keyword arguments as
    :func:`wrap`.
 
 
-.. function:: shorten(text, width, **kwargs)
+.. function:: shorten(text, width, initial_indent="", \
+                      subsequent_indent="", fix_sentence_endings=False, \
+                      break_long_words=True, break_on_hyphens=True, \
+                      *,  max_lines=None,  placeholder=' [...]')
 
    Collapse and truncate the given *text* to fit in the given *width*.
 
@@ -57,14 +95,22 @@ functions should be good enough; otherwise, you should use an instance of
       >>> textwrap.shorten("Hello world", width=10, placeholder="...")
       'Hello...'
 
-   Optional keyword arguments correspond to the instance attributes of
-   :class:`TextWrapper`, documented below.  Note that the whitespace is
-   collapsed before the text is passed to the :class:`TextWrapper` :meth:`fill`
-   function, so changing the value of :attr:`.tabsize`, :attr:`.expand_tabs`,
-   :attr:`.drop_whitespace`, and :attr:`.replace_whitespace` will have no effect.
+   See :class:`TextWrapper` for documentation on all additional optional
+   arguments:
+
+   * :attr:`.initial_indent`
+   * :attr:`.subsequent_indent`
+   * :attr:`.fix_sentence_endings`
+   * :attr:`.break_long_words`
+   * :attr:`.break_on_hyphens`
+   * :attr:`.max_lines`
+
+   Note that :class:`TextWrapper` has some additional options which have **no
+   effect** when passed to :func:`shorten` (:attr:`.tabsize`,
+   :attr:`.expand_tabs`, :attr:`.drop_whitespace`, and
+   :attr:`.replace_whitespace`).
 
    .. versionadded:: 3.4
-
 
 .. function:: dedent(text)
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -22,7 +22,7 @@ functions should be good enough; otherwise, you should use an instance of
                    fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
                    break_on_hyphens=True, tabsize=8, \
-                   *, max_lines=None)
+                   *, max_lines=None, **kwargs)
 
    Wraps the single paragraph in *text* (a string) so every line is at most
    *width* characters long.  Returns a list of output lines, without final
@@ -48,7 +48,7 @@ functions should be good enough; otherwise, you should use an instance of
                    replace_whitespace=True, fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
                    break_on_hyphens=True, tabsize=8, \
-                   *, max_lines=None)
+                   *, max_lines=None, **kwargs)
 
    Wraps the single paragraph in *text*, and returns a single string containing
    the wrapped paragraph.  :func:`fill` is shorthand for ::
@@ -73,7 +73,7 @@ functions should be good enough; otherwise, you should use an instance of
 .. function:: shorten(text, width, initial_indent="", \
                       subsequent_indent="", fix_sentence_endings=False, \
                       break_long_words=True, break_on_hyphens=True, \
-                      *,  max_lines=None,  placeholder=' [...]')
+                      *,  max_lines=None,  placeholder=' [...]', **kwargs)
 
    Collapse and truncate the given *text* to fit in the given *width*.
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -42,9 +42,6 @@ functions should be good enough; otherwise, you should use an instance of
    * :attr:`.tabsize`
    * :attr:`.max_lines`
 
-   Note that :func:`wrap` accepts exactly the same keyword arguments as
-   :func:`fill`.
-
 
 .. function:: fill(text, width=70, initial_indent="", \
                    subsequent_indent="", expand_tabs=True, \
@@ -71,9 +68,6 @@ functions should be good enough; otherwise, you should use an instance of
    * :attr:`.break_on_hyphens`
    * :attr:`.tabsize`
    * :attr:`.max_lines`
-
-   Note that :func:`fill` accepts exactly the same keyword arguments as
-   :func:`wrap`.
 
 
 .. function:: shorten(text, width, initial_indent="", \

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -17,26 +17,29 @@ If you're just wrapping or filling one or two text strings, the convenience
 functions should be good enough; otherwise, you should use an instance of
 :class:`TextWrapper` for efficiency.
 
-.. function:: wrap(text, width=70, initial_indent="", subsequent_indent="", \
-                   expand_tabs=True, replace_whitespace=True, \
-                   fix_sentence_endings=False, \
+.. function:: wrap(text, width=70, *, initial_indent="", \
+                   subsequent_indent="", expand_tabs=True, \
+                   replace_whitespace=True, fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
-                   break_on_hyphens=True, tabsize=8, \
-                   *, max_lines=None, **kwargs)
+                   break_on_hyphens=True, tabsize=8, *, max_lines=None, \
+                   **kwargs)
 
    Wraps the single paragraph in *text* (a string) so every line is at most
    *width* characters long.  Returns a list of output lines, without final
    newlines.  *width* defaults to ``70``.
 
-   See :class:`TextWrapper` for documentation on all additional optional
+   See :class:`TextWrapper` for documentation on all optional keyword
    arguments: :attr:`.initial_indent`, :attr:`.subsequent_indent`,
    :attr:`.expand_tabs`, :attr:`.replace_whitespace`,
    :attr:`.fix_sentence_endings`, :attr:`.break_long_words`,
    :attr:`.drop_whitespace`, :attr:`.break_on_hyphens` :attr:`.tabsize`, and
-   :attr:`.max_lines`.
+   :attr:`.max_lines`.  Be careful not to misspell keyword arguments.
+   Misspelled keyword arguments will silently have no effect, and an exception
+   will not be raised.
 
 
-.. function:: fill(text, width=70, initial_indent="", \
+
+.. function:: fill(text, width=70, *, initial_indent="", \
                    subsequent_indent="", expand_tabs=True, \
                    replace_whitespace=True, fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
@@ -53,10 +56,9 @@ functions should be good enough; otherwise, you should use an instance of
    above.
 
 
-.. function:: shorten(text, width, initial_indent="", \
-                      subsequent_indent="", fix_sentence_endings=False, \
-                      break_long_words=True, break_on_hyphens=True, \
-                      *,  max_lines=None,  placeholder=' [...]', **kwargs)
+.. function:: shorten(text, width, *, fix_sentence_endings=False, \
+                      break_long_words=True, break_on_hyphens=True, *, \
+                      placeholder=' [...]', **kwargs)
 
    Collapse and truncate the given *text* to fit in the given *width*.
 
@@ -72,7 +74,7 @@ functions should be good enough; otherwise, you should use an instance of
       >>> textwrap.shorten("Hello world", width=10, placeholder="...")
       'Hello...'
 
-   See :class:`TextWrapper` for documentation on all additional optional
+   See :class:`TextWrapper` for documentation on all optional keyword
    arguments: :attr:`.initial_indent`, :attr:`.subsequent_indent`,
    :attr:`.fix_sentence_endings`, :attr:`.break_long_words`,
    :attr:`.break_on_hyphens`, and :attr:`.max_lines`.
@@ -80,7 +82,9 @@ functions should be good enough; otherwise, you should use an instance of
    Note that the whitespace is collapsed before the text is passed to the
    :class:`TextWrapper` :meth:`fill` function, so changing the value of
    :attr:`.tabsize`, :attr:`.expand_tabs`, :attr:`.drop_whitespace`, and
-   :attr:`.replace_whitespace` will have no effect.
+   :attr:`.replace_whitespace` will have no effect.  Be careful not to misspell
+   keyword arguments. Misspelled keyword arguments will silently have no
+   effect, and an exception will not be raised.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -29,18 +29,11 @@ functions should be good enough; otherwise, you should use an instance of
    newlines.  *width* defaults to ``70``.
 
    See :class:`TextWrapper` for documentation on all additional optional
-   arguments:
-
-   * :attr:`.initial_indent`
-   * :attr:`.subsequent_indent`
-   * :attr:`.expand_tabs`
-   * :attr:`.replace_whitespace`
-   * :attr:`.fix_sentence_endings`
-   * :attr:`.break_long_words`
-   * :attr:`.drop_whitespace`
-   * :attr:`.break_on_hyphens`
-   * :attr:`.tabsize`
-   * :attr:`.max_lines`
+   arguments: :attr:`.initial_indent`, :attr:`.subsequent_indent`,
+   :attr:`.expand_tabs`, :attr:`.replace_whitespace`,
+   :attr:`.fix_sentence_endings`, :attr:`.break_long_words`,
+   :attr:`.drop_whitespace`, :attr:`.break_on_hyphens` :attr:`.tabsize`, and
+   :attr:`.max_lines`.
 
 
 .. function:: fill(text, width=70, initial_indent="", \
@@ -56,18 +49,8 @@ functions should be good enough; otherwise, you should use an instance of
       "\n".join(wrap(text, ...))
 
    See :class:`TextWrapper` for documentation on all additional optional
-   arguments:
-
-   * :attr:`.initial_indent`
-   * :attr:`.subsequent_indent`
-   * :attr:`.expand_tabs`
-   * :attr:`.replace_whitespace`
-   * :attr:`.fix_sentence_endings`
-   * :attr:`.break_long_words`
-   * :attr:`.drop_whitespace`
-   * :attr:`.break_on_hyphens`
-   * :attr:`.tabsize`
-   * :attr:`.max_lines`
+   arguments, which are the same as the optional arguments to :func:`wrap`
+   above.
 
 
 .. function:: shorten(text, width, initial_indent="", \
@@ -90,15 +73,9 @@ functions should be good enough; otherwise, you should use an instance of
       'Hello...'
 
    See :class:`TextWrapper` for documentation on all additional optional
-   arguments:
-
-   * :attr:`.initial_indent`
-   * :attr:`.subsequent_indent`
-   * :attr:`.fix_sentence_endings`
-   * :attr:`.break_long_words`
-   * :attr:`.break_on_hyphens`
-   * :attr:`.max_lines`
-
+   arguments: :attr:`.initial_indent`, :attr:`.subsequent_indent`,
+   :attr:`.fix_sentence_endings`, :attr:`.break_long_words`,
+   :attr:`.break_on_hyphens`, and :attr:`.max_lines`.
 
    Note that the whitespace is collapsed before the text is passed to the
    :class:`TextWrapper` :meth:`fill` function, so changing the value of

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -29,14 +29,7 @@ functions should be good enough; otherwise, you should use an instance of
    newlines.  *width* defaults to ``70``.
 
    See :class:`TextWrapper` for documentation on all optional keyword
-   arguments: :attr:`.initial_indent`, :attr:`.subsequent_indent`,
-   :attr:`.expand_tabs`, :attr:`.replace_whitespace`,
-   :attr:`.fix_sentence_endings`, :attr:`.break_long_words`,
-   :attr:`.drop_whitespace`, :attr:`.break_on_hyphens` :attr:`.tabsize`, and
-   :attr:`.max_lines`.  Be careful not to misspell keyword arguments.
-   Misspelled keyword arguments will silently have no effect, and an exception
-   will not be raised.
-
+   arguments.
 
 
 .. function:: fill(text, width=70, *, initial_indent="", \
@@ -75,12 +68,8 @@ functions should be good enough; otherwise, you should use an instance of
       'Hello...'
 
    See :class:`TextWrapper` for documentation on all optional keyword
-   arguments: :attr:`.initial_indent`, :attr:`.subsequent_indent`,
-   :attr:`.fix_sentence_endings`, :attr:`.break_long_words`,
-   :attr:`.break_on_hyphens`, and :attr:`.max_lines`.
-
-   Note that the whitespace is collapsed before the text is passed to the
-   :class:`TextWrapper` :meth:`fill` function, so changing the value of
+   arguments. Note that the whitespace is collapsed before the text is passed
+   to the :class:`TextWrapper` :meth:`fill` function, so changing the value of
    :attr:`.tabsize`, :attr:`.expand_tabs`, :attr:`.drop_whitespace`, and
    :attr:`.replace_whitespace` will have no effect.  Be careful not to misspell
    keyword arguments. Misspelled keyword arguments will silently have no

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -72,8 +72,7 @@ functions should be good enough; otherwise, you should use an instance of
    to the :class:`TextWrapper` :meth:`fill` function, so changing the value of
    :attr:`.tabsize`, :attr:`.expand_tabs`, :attr:`.drop_whitespace`, and
    :attr:`.replace_whitespace` will have no effect.  Be careful not to misspell
-   keyword arguments. Misspelled keyword arguments will silently have no
-   effect, and an exception will not be raised.
+   keyword arguments.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -25,10 +25,13 @@ functions should be good enough; otherwise, you should use an instance of
 
    Wraps the single paragraph in *text* (a string) so every line is at most
    *width* characters long.  Returns a list of output lines, without final
-   newlines.  *width* defaults to ``70``.
+   newlines.
 
-   See :class:`TextWrapper` for documentation on all optional keyword
-   arguments.
+   Optional keyword arguments correspond to the instance attributes of
+   :class:`TextWrapper`, documented below.  *width* defaults to ``70``.
+
+   See the :meth:`TextWrapper.wrap` method for additional details on how
+   :func:`wrap` behaves.
 
 
 .. function:: fill(text, width=70, *, initial_indent="", \
@@ -43,9 +46,8 @@ functions should be good enough; otherwise, you should use an instance of
 
       "\n".join(wrap(text, ...))
 
-   See :class:`TextWrapper` for documentation on all additional optional
-   arguments, which are the same as the optional arguments to :func:`wrap`
-   above.
+   In particular, :func:`fill` accepts exactly the same keyword arguments as
+   :func:`wrap`.
 
 
 .. function:: shorten(text, width, *, fix_sentence_endings=False, \
@@ -66,12 +68,11 @@ functions should be good enough; otherwise, you should use an instance of
       >>> textwrap.shorten("Hello world", width=10, placeholder="...")
       'Hello...'
 
-   See :class:`TextWrapper` for documentation on all optional keyword
-   arguments. Note that the whitespace is collapsed before the text is passed
-   to the :class:`TextWrapper` :meth:`fill` function, so changing the value of
-   :attr:`.tabsize`, :attr:`.expand_tabs`, :attr:`.drop_whitespace`, and
-   :attr:`.replace_whitespace` will have no effect.  Be careful not to misspell
-   keyword arguments.
+   Optional keyword arguments correspond to the instance attributes of
+   :class:`TextWrapper`, documented below.  Note that the whitespace is
+   collapsed before the text is passed to the :class:`TextWrapper` :meth:`fill`
+   function, so changing the value of :attr:`.tabsize`, :attr:`.expand_tabs`,
+   :attr:`.drop_whitespace`, and :attr:`.replace_whitespace` will have no effect.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -21,8 +21,7 @@ functions should be good enough; otherwise, you should use an instance of
                    subsequent_indent="", expand_tabs=True, \
                    replace_whitespace=True, fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
-                   break_on_hyphens=True, tabsize=8, *, max_lines=None, \
-                   **kwargs)
+                   break_on_hyphens=True, tabsize=8, max_lines=None)
 
    Wraps the single paragraph in *text* (a string) so every line is at most
    *width* characters long.  Returns a list of output lines, without final
@@ -37,7 +36,7 @@ functions should be good enough; otherwise, you should use an instance of
                    replace_whitespace=True, fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
                    break_on_hyphens=True, tabsize=8, \
-                   *, max_lines=None, **kwargs)
+                   max_lines=None)
 
    Wraps the single paragraph in *text*, and returns a single string containing the
    wrapped paragraph.  :func:`fill` is shorthand for  ::
@@ -50,8 +49,8 @@ functions should be good enough; otherwise, you should use an instance of
 
 
 .. function:: shorten(text, width, *, fix_sentence_endings=False, \
-                      break_long_words=True, break_on_hyphens=True, *, \
-                      placeholder=' [...]', **kwargs)
+                      break_long_words=True, break_on_hyphens=True, \
+                      placeholder=' [...]')
 
    Collapse and truncate the given *text* to fit in the given *width*.
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -46,8 +46,8 @@ functions should be good enough; otherwise, you should use an instance of
                    break_on_hyphens=True, tabsize=8, \
                    *, max_lines=None, **kwargs)
 
-   Wraps the single paragraph in *text*, and returns a single string containing
-   the wrapped paragraph.  :func:`fill` is shorthand for ::
+   Wraps the single paragraph in *text*, and returns a single string containing the
+   wrapped paragraph.  :func:`fill` is shorthand for  ::
 
       "\n".join(wrap(text, ...))
 

--- a/Misc/NEWS.d/next/Documentation/2021-07-02-14-02-29.bpo-44544._5_aCz.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-02-14-02-29.bpo-44544._5_aCz.rst
@@ -1,0 +1,4 @@
+List all kwargs for :func:`textwrap.wrap`, :func:`textwrap.fill`, and
+:func:`textwrap.shorten`. Now, there are nav links to attributes of
+:class:`TextWrap`, which makes navigation much easier while minimizing
+duplication in the documentation.


### PR DESCRIPTION
- list all kwargs for `textwrap.wrap`, `textwrap.fill`, and
  `textwrap.shorten`
- now, there are nav links to attributes of TextWrap, which makes navigation
  much easier while minimizing duplication
- revised descriptions of those functions accordingly
- _did not_ change actual function signatures; maybe we should?
  - if so, we should continue accepting additional kwargs as to not break
    existing code.
  - now, function signatures do not match the documentation
  - however, I noticed that while using pyright, it still shows all the kwargs
  through introspection. Maybe the mismatch is acceptable?
  <!--
  Thanks for your contribution!
  Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44544](https://bugs.python.org/issue44544) -->
https://bugs.python.org/issue44544
<!-- /issue-number -->
