### PR TITLE
bpo-43908: Types with `Py_TPFLAGS_IMMUTABLETYPE ` can now inherit the vectorcall protocol

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -710,7 +710,7 @@ and :c:type:`PyType_Type` effectively act as defaults.)
 
    .. warning::
 
-      It is not recommended for :ref:`heap types <heap-types>` to implement
+      It is not recommended for :ref:`mutable heap types <heap-types>` to implement
       the vectorcall protocol.
       When a user sets :attr:`__call__` in Python code, only *tp_call* is updated,
       likely making it inconsistent with the vectorcall function.
@@ -734,8 +734,9 @@ and :c:type:`PyType_Type` effectively act as defaults.)
    always inherited. If it's not, then the subclass won't use
    :ref:`vectorcall <vectorcall>`, except when
    :c:func:`PyVectorcall_Call` is explicitly called.
-   This is in particular the case for :ref:`heap types <heap-types>`
-   (including subclasses defined in Python).
+   This is in particular the case for types without the
+   :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set (including subclasses defined in
+   Python).
 
 
 .. c:member:: getattrfunc PyTypeObject.tp_getattr
@@ -1125,9 +1126,9 @@ and :c:type:`PyType_Type` effectively act as defaults.)
 
       **Inheritance:**
 
-      This flag is never inherited by :ref:`heap types <heap-types>`.
-      For extension types, it is inherited whenever
-      :c:member:`~PyTypeObject.tp_descr_get` is inherited.
+      This flag is never inherited by types without the
+      :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set.  For extension types, it is
+      inherited whenever :c:member:`~PyTypeObject.tp_descr_get` is inherited.
 
 
    .. XXX Document more flags here?
@@ -1172,9 +1173,9 @@ and :c:type:`PyType_Type` effectively act as defaults.)
 
       **Inheritance:**
 
-      This bit is inherited for :ref:`static subtypes <static-types>` if
+      This bit is inherited for types with the
+      :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set, if
       :c:member:`~PyTypeObject.tp_call` is also inherited.
-      :ref:`Heap types <heap-types>` do not inherit ``Py_TPFLAGS_HAVE_VECTORCALL``.
 
       .. versionadded:: 3.9
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -2073,6 +2073,11 @@ Porting to Python 3.10
   limited API. The function is mainly useful for custom builds of Python.
   (Contributed by Petr Viktorin in :issue:`26241`)
 
+* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now implement the
+  :pep:`590` vectorcall protocol.  Previously, this was only available for
+  :ref:`static types <static-types>`.
+  (Contributed by Erlend E. Aasland in :issue:`43908`)
+
 Deprecated
 ----------
 

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -2073,11 +2073,6 @@ Porting to Python 3.10
   limited API. The function is mainly useful for custom builds of Python.
   (Contributed by Petr Viktorin in :issue:`26241`)
 
-* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now implement the
-  :pep:`590` vectorcall protocol.  Previously, this was only available for
-  :ref:`static types <static-types>`.
-  (Contributed by Erlend E. Aasland in :issue:`43908`)
-
 Deprecated
 ----------
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -211,10 +211,9 @@ Porting to Python 3.11
   (:c:member:`PyTypeObject.tp_traverse`).
   (Contributed by Victor Stinner in :issue:`44263`.)
 
-* The :const:`Py_TPFLAGS_HAVE_VECTORCALL` and
-  :const:`Py_TPFLAGS_METHOD_DESCRIPTOR` flags can now be inherited if the
-  target type has the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set.  Previously,
-  only :ref:`static types <static-types>` could inherit these flags.
+* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set can now implement
+  the :pep:`590` vectorcall protocol.  Previously, this was only available for
+  :ref:`static types <static-types>`.
   (Contributed by Erlend E.  Aasland in :issue:`43908`)
 
 Deprecated

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -214,7 +214,7 @@ Porting to Python 3.11
 * Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set can now implement
   the :pep:`590` vectorcall protocol.  Previously, this was only available for
   :ref:`static types <static-types>`.
-  (Contributed by Erlend E.  Aasland in :issue:`43908`)
+  (Contributed by Erlend E. Aasland in :issue:`43908`)
 
 Deprecated
 ----------

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -211,8 +211,8 @@ Porting to Python 3.11
   (:c:member:`PyTypeObject.tp_traverse`).
   (Contributed by Victor Stinner in :issue:`44263`.)
 
-* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now implement the
-  :pep:`590` vectorcall protocol.  Previously, this was only available for
+* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now inherit the
+  :pep:`590` vectorcall protocol.  Previously, this was only possible for
   :ref:`static types <static-types>`.
   (Contributed by Erlend E. Aasland in :issue:`43908`)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -211,8 +211,8 @@ Porting to Python 3.11
   (:c:member:`PyTypeObject.tp_traverse`).
   (Contributed by Victor Stinner in :issue:`44263`.)
 
-* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set can now implement
-  the :pep:`590` vectorcall protocol.  Previously, this was only available for
+* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now implement the
+  :pep:`590` vectorcall protocol.  Previously, this was only available for
   :ref:`static types <static-types>`.
   (Contributed by Erlend E. Aasland in :issue:`43908`)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -211,6 +211,11 @@ Porting to Python 3.11
   (:c:member:`PyTypeObject.tp_traverse`).
   (Contributed by Victor Stinner in :issue:`44263`.)
 
+* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set can now implement
+  the :pep:`590` vectorcall protocol.  Previously, this was only available for
+  :ref:`static types <static-types>`.
+  (Contributed by Erlend E. Aasland in :issue:`43908`)
+
 Deprecated
 ----------
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -211,6 +211,12 @@ Porting to Python 3.11
   (:c:member:`PyTypeObject.tp_traverse`).
   (Contributed by Victor Stinner in :issue:`44263`.)
 
+* The :const:`Py_TPFLAGS_HAVE_VECTORCALL` and
+  :const:`Py_TPFLAGS_METHOD_DESCRIPTOR` flags can now be inherited if the
+  target type has the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set.  Previously,
+  only :ref:`static types <static-types>` could inherit these flags.
+  (Contributed by Erlend E.  Aasland in :issue:`43908`)
+
 Deprecated
 ----------
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -211,8 +211,8 @@ Porting to Python 3.11
   (:c:member:`PyTypeObject.tp_traverse`).
   (Contributed by Victor Stinner in :issue:`44263`.)
 
-* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now inherit the
-  :pep:`590` vectorcall protocol.  Previously, this was only possible for
+* Heap types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now inherit
+  the :pep:`590` vectorcall protocol.  Previously, this was only possible for
   :ref:`static types <static-types>`.
   (Contributed by Erlend E. Aasland in :issue:`43908`)
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -211,11 +211,6 @@ Porting to Python 3.11
   (:c:member:`PyTypeObject.tp_traverse`).
   (Contributed by Victor Stinner in :issue:`44263`.)
 
-* Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set can now implement
-  the :pep:`590` vectorcall protocol.  Previously, this was only available for
-  :ref:`static types <static-types>`.
-  (Contributed by Erlend E. Aasland in :issue:`43908`)
-
 Deprecated
 ----------
 

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -563,7 +563,7 @@ class TestPEP590(unittest.TestCase):
         self.assertTrue(_testcapi.MethodDescriptorDerived.__flags__ & Py_TPFLAGS_METHOD_DESCRIPTOR)
         self.assertFalse(_testcapi.MethodDescriptorNopGet.__flags__ & Py_TPFLAGS_METHOD_DESCRIPTOR)
 
-        # Heap type should not inherit Py_TPFLAGS_METHOD_DESCRIPTOR
+        # Mutable heap types should not inherit Py_TPFLAGS_METHOD_DESCRIPTOR
         class MethodDescriptorHeap(_testcapi.MethodDescriptorBase):
             pass
         self.assertFalse(MethodDescriptorHeap.__flags__ & Py_TPFLAGS_METHOD_DESCRIPTOR)
@@ -574,7 +574,7 @@ class TestPEP590(unittest.TestCase):
         self.assertFalse(_testcapi.MethodDescriptorNopGet.__flags__ & Py_TPFLAGS_HAVE_VECTORCALL)
         self.assertTrue(_testcapi.MethodDescriptor2.__flags__ & Py_TPFLAGS_HAVE_VECTORCALL)
 
-        # Heap type should not inherit Py_TPFLAGS_HAVE_VECTORCALL
+        # Mutable heap types should not inherit Py_TPFLAGS_HAVE_VECTORCALL
         class MethodDescriptorHeap(_testcapi.MethodDescriptorBase):
             pass
         self.assertFalse(MethodDescriptorHeap.__flags__ & Py_TPFLAGS_HAVE_VECTORCALL)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
@@ -1,3 +1,3 @@
-Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set can now implement
-the :pep:`590` vectorcall protocol.  Previously, this was only available for
+Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now inherit the
+:pep:`590` vectorcall protocol.  Previously, this was only possible for
 :ref:`static types <static-types>`.  Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
@@ -1,3 +1,3 @@
-Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now inherit the
+Heap types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag can now inherit the
 :pep:`590` vectorcall protocol.  Previously, this was only possible for
 :ref:`static types <static-types>`.  Patch by Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
@@ -1,0 +1,5 @@
+The :const:`Py_TPFLAGS_HAVE_VECTORCALL` and
+:const:`Py_TPFLAGS_METHOD_DESCRIPTOR` flags can now be inherited if the
+target type has the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set. Previously,
+only :ref:`static types <static-types>` could inherit these flags. Patch by
+Erlend E. Aasland.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-03-00-20-39.bpo-43908.YHuV_s.rst
@@ -1,5 +1,3 @@
-The :const:`Py_TPFLAGS_HAVE_VECTORCALL` and
-:const:`Py_TPFLAGS_METHOD_DESCRIPTOR` flags can now be inherited if the
-target type has the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set. Previously,
-only :ref:`static types <static-types>` could inherit these flags. Patch by
-Erlend E. Aasland.
+Types with the :const:`Py_TPFLAGS_IMMUTABLETYPE` flag set can now implement
+the :pep:`590` vectorcall protocol.  Previously, this was only available for
+:ref:`static types <static-types>`.  Patch by Erlend E. Aasland.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5915,8 +5915,8 @@ inherit_slots(PyTypeObject *type, PyTypeObject *base)
          * but only for extension types */
         if (base->tp_descr_get &&
             type->tp_descr_get == base->tp_descr_get &&
-            !(type->tp_flags & Py_TPFLAGS_HEAPTYPE) &&
-            (base->tp_flags & Py_TPFLAGS_METHOD_DESCRIPTOR))
+            _PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE) &&
+            _PyType_HasFeature(base, Py_TPFLAGS_METHOD_DESCRIPTOR))
         {
             type->tp_flags |= Py_TPFLAGS_METHOD_DESCRIPTOR;
         }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5881,8 +5881,8 @@ inherit_slots(PyTypeObject *type, PyTypeObject *base)
         /* Inherit Py_TPFLAGS_HAVE_VECTORCALL for non-heap types
         * if tp_call is not overridden */
         if (!type->tp_call &&
-            (base->tp_flags & Py_TPFLAGS_HAVE_VECTORCALL) &&
-            !(type->tp_flags & Py_TPFLAGS_HEAPTYPE))
+            _PyType_HasFeature(base, Py_TPFLAGS_HAVE_VECTORCALL) &&
+            _PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE))
         {
             type->tp_flags |= Py_TPFLAGS_HAVE_VECTORCALL;
         }


### PR DESCRIPTION
`Py_TPFLAGS_HAVE_VECTORCALL` and `Py_TPFLAGS_METHOD_DESCRIPTOR`
inheritance is now ruled by the `Py_TPFLAGS_IMMUTABLETYPE` flag instead
of the `Py_TPFLAGS_HEAPTYPE` flag.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43908](https://bugs.python.org/issue43908) -->
https://bugs.python.org/issue43908
<!-- /issue-number -->
