### PR TITLE
bpo-44558: Match countOf `is`/`==` treatment to c

### DIFF
--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -155,10 +155,10 @@ def contains(a, b):
     return b in a
 
 def countOf(a, b):
-    "Return the number of times b occurs in a."
+    "Return the number of items in a which are, or which equal, b."
     count = 0
     for i in a:
-        if i == b:
+        if i is b or i == b:
             count += 1
     return count
 

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -153,6 +153,11 @@ class OperatorTestCase:
         self.assertRaises(ZeroDivisionError, operator.countOf, BadIterable(), 1)
         self.assertEqual(operator.countOf([1, 2, 1, 3, 1, 4], 3), 1)
         self.assertEqual(operator.countOf([1, 2, 1, 3, 1, 4], 5), 0)
+        # is but not ==
+        nan = float("nan")
+        self.assertEqual(operator.countOf([nan, nan, 21], nan), 2)
+        # == but not is
+        self.assertEqual(operator.countOf([{}, 1, {}, 2], {}), 2)
 
     def test_delitem(self):
         operator = self.module

--- a/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
@@ -1,2 +1,3 @@
-Match the docstring and python implementation of :func:countOf to the behaviour
+Match the docstring and python implementation of :func:`~operator.countOf` to the behavior
+
 of its c implementation.

--- a/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
@@ -1,2 +1,2 @@
-Match the docstring and python implementation of :func:countOf to the behaviour 
+Match the docstring and python implementation of :func:countOf to the behaviour
 of its c implementation.

--- a/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
@@ -1,3 +1,2 @@
 Match the docstring and python implementation of :func:`~operator.countOf` to the behavior
-
 of its c implementation.

--- a/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
@@ -1,0 +1,2 @@
+Match the docstring and python implementation of :func:countOf to the behaviour 
+of its c implementation.

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -507,7 +507,7 @@ _operator_indexOf_impl(PyObject *module, PyObject *a, PyObject *b)
 /*[clinic input]
 _operator.countOf = _operator.indexOf
 
-Return the number of times b occurs in a.
+Return the number of items in a which are, or which equal, b.
 [clinic start generated code]*/
 
 static Py_ssize_t

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -512,7 +512,7 @@ Return the number of items in a which are, or which equal, b.
 
 static Py_ssize_t
 _operator_countOf_impl(PyObject *module, PyObject *a, PyObject *b)
-/*[clinic end generated code: output=9e1623197daf3382 input=0c3a2656add252db]*/
+/*[clinic end generated code: output=9e1623197daf3382 input=93ea57f170f3f0bb]*/
 {
     return PySequence_Count(a, b);
 }

--- a/Modules/clinic/_operator.c.h
+++ b/Modules/clinic/_operator.c.h
@@ -957,7 +957,7 @@ PyDoc_STRVAR(_operator_countOf__doc__,
 "countOf($module, a, b, /)\n"
 "--\n"
 "\n"
-"Return the number of times b occurs in a.");
+"Return the number of items in a which are, or which equal, b.");
 
 #define _OPERATOR_COUNTOF_METHODDEF    \
     {"countOf", (PyCFunction)(void(*)(void))_operator_countOf, METH_FASTCALL, _operator_countOf__doc__},
@@ -1486,4 +1486,4 @@ _operator__compare_digest(PyObject *module, PyObject *const *args, Py_ssize_t na
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=eae5d08f971a65fd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=16749e11fda51785 input=a9049054013a1b77]*/


### PR DESCRIPTION
The python implementation and docstrings currently treat these comparisons differently.

This change preserves the existing behaviour of the c implementation.

Add tests for cases where `is` and `==` differ.

<!-- issue-number: [bpo-44558](https://bugs.python.org/issue44558) -->
https://bugs.python.org/issue44558
<!-- /issue-number -->
