### PR TITLE
bpo-44558: Make the implementation consistency of operator.indexOf

### DIFF
--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -173,7 +173,7 @@ def getitem(a, b):
 def indexOf(a, b):
     "Return the first index of b in a."
     for i, j in enumerate(a):
-        if j == b:
+        if j is b or j == b:
             return i
     else:
         raise ValueError('sequence.index(x): x not in sequence')

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -190,6 +190,7 @@ class OperatorTestCase:
         self.assertRaises(ValueError, operator.indexOf, [4, 3, 2, 1], 0)
         nan = float("nan")
         self.assertEqual(operator.indexOf([nan, nan, 21], nan), 0)
+        self.assertEqual(operator.indexOf([{}, 1, {}, 2], {}), 0)
 
     def test_invert(self):
         operator = self.module

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -188,6 +188,8 @@ class OperatorTestCase:
         self.assertRaises(ZeroDivisionError, operator.indexOf, BadIterable(), 1)
         self.assertEqual(operator.indexOf([4, 3, 2, 1], 3), 1)
         self.assertRaises(ValueError, operator.indexOf, [4, 3, 2, 1], 0)
+        nan = float("nan")
+        self.assertEqual(operator.indexOf([nan, nan, 21], nan), 0)
 
     def test_invert(self):
         operator = self.module

--- a/Misc/NEWS.d/next/Library/2021-07-04-21-16-53.bpo-44558.cm7Slv.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-04-21-16-53.bpo-44558.cm7Slv.rst
@@ -1,0 +1,2 @@
+Make the implementation consistency of :func:`~operator.indexOf` between
+C and Python versions. Patch by Dong-hee Na.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44558](https://bugs.python.org/issue44558) -->
https://bugs.python.org/issue44558
<!-- /issue-number -->
