### PR TITLE
bpo-43453: Update and re-add example to typing runtime_checkable

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1234,7 +1234,7 @@ These are not used in annotations. They are building blocks for creating generic
 
         :func:`runtime_checkable` will check only the presence of the required
         methods, not their type signatures. For example, :class:`ssl.SSLObject`
-        implements :func:`__init__`, therefore it passes an :func:`issubclass`
+        implements :meth:`__init__`, therefore it passes an :func:`issubclass`
         check against :data:`Callable`.  However, the
         :meth:`ssl.SSLObject.__init__` method exists only to raise a
         :exc:`TypeError` with a more informative message.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1232,11 +1232,12 @@ These are not used in annotations. They are building blocks for creating generic
 
    .. note::
 
-        :func:`runtime_checkable` will check only the presence of the required methods,
-        not their type signatures. For example, :class:`ssl.SSLObject` implements `__init__()`,
-        therefore it passes an :func:`builtins.issubclass()` check against :data:`Callable`.
-        However, the :meth:`ssl.SSLObject.__float__` method exists only to raise a TypeError
-        with a more informative message.
+        :func:`runtime_checkable` will check only the presence of the required
+        methods, not their type signatures. For example, :class:`ssl.SSLObject`
+        implements :func:`__init__`, therefore it passes an :func:`issubclass`
+        check against :data:`Callable`.  However, the
+        :meth:`ssl.SSLObject.__init__` method exists only to raise a
+        :exc:`TypeError` with a more informative message.
 
    .. versionadded:: 3.8
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1233,7 +1233,10 @@ These are not used in annotations. They are building blocks for creating generic
    .. note::
 
         :func:`runtime_checkable` will check only the presence of the required methods,
-        not their type signatures.
+        not their type signatures. For example, :class:`ssl.SSLObject` implements `__init__()`,
+        therefore it passes an :func:`builtins.issubclass()` check against :data:`Callable`.
+        However, the :meth:`ssl.SSLObject.__float__` method exists only to raise a TypeError
+        with a more informative message.
 
    .. versionadded:: 3.8
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1234,10 +1234,11 @@ These are not used in annotations. They are building blocks for creating generic
 
         :func:`runtime_checkable` will check only the presence of the required
         methods, not their type signatures. For example, :class:`ssl.SSLObject`
-        implements :meth:`__init__`, therefore it passes an :func:`issubclass`
+        is a class, therefore it passes an :func:`issubclass`
         check against :data:`Callable`.  However, the
         :meth:`ssl.SSLObject.__init__` method exists only to raise a
-        :exc:`TypeError` with a more informative message.
+        :exc:`TypeError` with a more informative message, therefore making
+        it impossible to call (instantiate) :class:`ssl.SSLObject`.
 
    .. versionadded:: 3.8
 


### PR DESCRIPTION
This example was outdated and removed in 3.10, I've found a similar example that can be used to clarify this function.

<!-- issue-number: [bpo-43453](https://bugs.python.org/issue43453) -->
https://bugs.python.org/issue43453
<!-- /issue-number -->
