### PR TITLE
Fix ref to protocol class in code example

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1197,7 +1197,7 @@ These are not used in annotations. They are building blocks for creating generic
           def meth(self) -> int:
               return 0
 
-      def func(x: Proto) -> int:
+      def func(x: C) -> int:
           return x.meth()
 
       func(C())  # Passes static type check


### PR DESCRIPTION
In code example for typing.Protocol, reference to the previous example is used, instead it should reference the `C` class used in current example. As it is now, it's confusing and code sample is not runnable.