### PR TITLE
bpo-44563: Fix error handling in tee.fromiterable()

### DIFF
--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -863,7 +863,7 @@ static PyObject *
 tee_fromiterable(PyObject *iterable)
 {
     teeobject *to;
-    PyObject *it = NULL;
+    PyObject *it;
 
     it = PyObject_GetIter(iterable);
     if (it == NULL)
@@ -873,21 +873,22 @@ tee_fromiterable(PyObject *iterable)
         goto done;
     }
 
-    to = PyObject_GC_New(teeobject, &tee_type);
-    if (to == NULL)
-        goto done;
-    to->dataobj = (teedataobject *)teedataobject_newinternal(it);
+    PyObject *dataobj = teedataobject_newinternal(it);
     if (!to->dataobj) {
-        PyObject_GC_Del(to);
         to = NULL;
         goto done;
     }
-
+    to = PyObject_GC_New(teeobject, &tee_type);
+    if (to == NULL) {
+        Py_DECREF(dataobj);
+        goto done;
+    }
+    to->dataobj = (teedataobject *)dataobj;
     to->index = 0;
     to->weakreflist = NULL;
     PyObject_GC_Track(to);
 done:
-    Py_XDECREF(it);
+    Py_DECREF(it);
     return (PyObject *)to;
 }
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -874,7 +874,7 @@ tee_fromiterable(PyObject *iterable)
     }
 
     PyObject *dataobj = teedataobject_newinternal(it);
-    if (!to->dataobj) {
+    if (!dataobj) {
         to = NULL;
         goto done;
     }


### PR DESCRIPTION
In debug build failed tee.fromiterable() corrupted the linked
list of all GC objects.


<!-- issue-number: [bpo-44563](https://bugs.python.org/issue44563) -->
https://bugs.python.org/issue44563
<!-- /issue-number -->
