### PR TITLE
[3.9] bpo-44562: Revert "Remove invalid PyObject_GC_Del from error path of types.GenericAlias … (GH-27016)"

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-04-23-38-51.bpo-44562.QdeRQo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-04-23-38-51.bpo-44562.QdeRQo.rst
@@ -1,2 +1,0 @@
-Remove uses of :c:func:`PyObject_GC_Del` in error path when initializing
-:class:`types.GenericAlias`.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -602,7 +602,7 @@ ga_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     if (!setup_ga(self, origin, arguments)) {
-        Py_DECREF(self);
+        type->tp_free((PyObject *)self);
         return NULL;
     }
     return (PyObject *)self;
@@ -644,10 +644,10 @@ Py_GenericAlias(PyObject *origin, PyObject *args)
     if (alias == NULL) {
         return NULL;
     }
-    _PyObject_GC_TRACK(alias);
     if (!setup_ga(alias, origin, args)) {
-        Py_DECREF(alias);
+        PyObject_GC_Del((PyObject *)alias);
         return NULL;
     }
+    _PyObject_GC_TRACK(alias);
     return (PyObject *)alias;
 }


### PR DESCRIPTION
Reverts python/cpython#27018

<!-- issue-number: [bpo-44562](https://bugs.python.org/issue44562) -->
https://bugs.python.org/issue44562
<!-- /issue-number -->
