### PR TITLE
[3.9] bpo-44562: Remove invalid PyObject_GC_Del from error path of types.GenericAlias … (GH-27016)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-04-23-38-51.bpo-44562.QdeRQo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-04-23-38-51.bpo-44562.QdeRQo.rst
@@ -1,0 +1,2 @@
+Remove uses of :c:func:`PyObject_GC_Del` in error path when initializing
+:class:`types.GenericAlias`.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -641,7 +641,7 @@ PyObject *
 Py_GenericAlias(PyObject *origin, PyObject *args)
 {
     gaobject *alias = (gaobject*) PyType_GenericAlloc(
-            (PyTypeObject *)(&Py_GenericAliasType), 0);
+            (PyTypeObject *)&Py_GenericAliasType, 0);
     if (alias == NULL) {
         return NULL;
     }

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -33,10 +33,7 @@ ga_traverse(PyObject *self, visitproc visit, void *arg)
     gaobject *alias = (gaobject *)self;
     Py_VISIT(alias->origin);
     Py_VISIT(alias->args);
-    // alias->parameters is lazily created, so this might be NULL
-    if (alias->parameters != NULL) {
-        Py_VISIT(alias->parameters);
-    }
+    Py_VISIT(alias->parameters);
     return 0;
 }
 
@@ -643,11 +640,11 @@ PyTypeObject Py_GenericAliasType = {
 PyObject *
 Py_GenericAlias(PyObject *origin, PyObject *args)
 {
-    gaobject *alias = PyObject_GC_New(gaobject, &Py_GenericAliasType);
+    gaobject *alias = (gaobject*) PyType_GenericAlloc(
+            (PyTypeObject *)(&Py_GenericAliasType), 0);
     if (alias == NULL) {
         return NULL;
     }
-    _PyObject_GC_TRACK(alias);
     if (!setup_ga(alias, origin, args)) {
         Py_DECREF(alias);
         return NULL;


### PR DESCRIPTION
(cherry picked from commit d33943a)

<!-- issue-number: [bpo-44562](https://bugs.python.org/issue44562) -->
https://bugs.python.org/issue44562
<!-- /issue-number -->
