### PR TITLE
bpo-43950: Specialize tracebacks for subscripts/binary ops

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -473,7 +473,7 @@ The output for the example would look similar to this:
    ['Traceback (most recent call last):\n',
     '  File "<doctest default[0]>", line 10, in <module>\n    lumberjack()\n    ^^^^^^^^^^^^\n',
     '  File "<doctest default[0]>", line 4, in lumberjack\n    bright_side_of_death()\n    ^^^^^^^^^^^^^^^^^^^^^^\n',
-    '  File "<doctest default[0]>", line 7, in bright_side_of_death\n    return tuple()[0]\n           ^^^^^^^^^^\n',
+    '  File "<doctest default[0]>", line 7, in bright_side_of_death\n    return tuple()[0]\n           ~~~~~~~^^^\n',
     'IndexError: tuple index out of range\n']
    *** extract_tb:
    [<FrameSummary file <doctest...>, line 10 in <module>>,
@@ -482,7 +482,7 @@ The output for the example would look similar to this:
    *** format_tb:
    ['  File "<doctest default[0]>", line 10, in <module>\n    lumberjack()\n    ^^^^^^^^^^^^\n',
     '  File "<doctest default[0]>", line 4, in lumberjack\n    bright_side_of_death()\n    ^^^^^^^^^^^^^^^^^^^^^^\n',
-    '  File "<doctest default[0]>", line 7, in bright_side_of_death\n    return tuple()[0]\n           ^^^^^^^^^^\n']
+    '  File "<doctest default[0]>", line 7, in bright_side_of_death\n    return tuple()[0]\n           ~~~~~~~^^^\n']
    *** tb_lineno: 10
 
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -464,16 +464,15 @@ class TracebackErrorLocationCaretTests(unittest.TestCase):
         self.assertEqual(result_lines, expected_error.splitlines())
 
     def test_traceback_specialization_with_syntax_error(self):
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as file:
-            bytecode = compile("1 / 0 / 1 / 2\n", file.name, "exec")
+        bytecode = compile("1 / 0 / 1 / 2\n", TESTFN, "exec")
 
-            # make the file invalid
+        with open(TESTFN, "w") as file:
+            # make the file's contents invalid
             file.write("1 $ 0 / 1 / 2\n")
-            file.flush()
+        self.addCleanup(unlink, TESTFN)
 
         func = partial(exec, bytecode)
         result_lines = self.get_exception(func)
-        os.unlink(file.name)
 
         lineno_f = bytecode.co_firstlineno
         expected_error = (
@@ -481,7 +480,7 @@ class TracebackErrorLocationCaretTests(unittest.TestCase):
             f'  File "{__file__}", line {self.callable_line}, in get_exception\n'
             '    callable()\n'
             '    ^^^^^^^^^^\n'
-            f'  File "{file.name}", line {lineno_f}, in <module>\n'
+            f'  File "{TESTFN}", line {lineno_f}, in <module>\n'
             "    1 $ 0 / 1 / 2\n"
             '    ^^^^^\n'
         )

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -6,7 +6,6 @@ import linecache
 import sys
 import inspect
 import unittest
-import tempfile
 import re
 from test import support
 from test.support import (Error, captured_output, cpython_only, ALWAYS_EQ,

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -494,9 +494,23 @@ class StackSummary(list):
                     colno = _byte_offset_to_character_offset(frame._original_line, frame.colno)
                     end_colno = _byte_offset_to_character_offset(frame._original_line, frame.end_colno)
 
+                    try:
+                        anchors = _extract_caret_anchors_from_line_segment(
+                            frame._original_line[colno - 1:end_colno]
+                        )
+                    except Exception:
+                        anchors = None
+
                     row.append('    ')
                     row.append(' ' * (colno - stripped_characters))
-                    row.append('^' * (end_colno - colno))
+
+                    if anchors:
+                        row.append('~' * (anchors[0]))
+                        row.append('^' * (anchors[1] - anchors[0]))
+                        row.append('~' * (end_colno - colno - anchors[1]))
+                    else:
+                        row.append('^' * (end_colno - colno))
+
                     row.append('\n')
 
             if frame.locals:
@@ -518,6 +532,39 @@ def _byte_offset_to_character_offset(str, offset):
         offset = len(as_utf8)
 
     return len(as_utf8[:offset + 1].decode("utf-8"))
+
+
+def _extract_caret_anchors_from_line_segment(segment):
+    import ast
+
+    try:
+        tree = ast.parse(segment)
+    except SyntaxError:
+        return None
+
+    if len(tree.body) != 1:
+        return None
+
+    statement = tree.body[0]
+    match statement:
+        case ast.Expr(expr):
+            match expr:
+                case ast.BinOp():
+                    operator_str = segment[expr.left.end_col_offset:expr.right.col_offset]
+                    operator_offset = len(operator_str) - len(operator_str.lstrip())
+
+                    left_anchor = expr.left.end_col_offset + operator_offset
+                    right_anchor = left_anchor + 1
+                    if (
+                        operator_offset + 1 < len(operator_str)
+                        and not operator_str[operator_offset + 1].isspace()
+                    ):
+                        right_anchor += 1
+                    return left_anchor, right_anchor
+                case ast.Subscript():
+                    return expr.value.end_col_offset, expr.slice.end_col_offset + 1
+
+    return None
 
 
 class TracebackException:

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -539,7 +539,7 @@ static int
 extract_anchors_from_expr(const char *segment_str, expr_ty expr, Py_ssize_t *left_anchor, Py_ssize_t *right_anchor,
                           char** primary_error_char, char** secondary_error_char)
 {
-switch (expr->kind) {
+    switch (expr->kind) {
         case BinOp_kind: {
             expr_ty left = expr->v.BinOp.left;
             expr_ty right = expr->v.BinOp.right;
@@ -743,23 +743,20 @@ tb_displayline(PyTracebackObject* tb, PyObject *f, PyObject *filename, int linen
     // right_end_offset will be set to -1.
 
     // Convert the utf-8 byte offset to the actual character offset so we print the right number of carets.
-    Py_ssize_t start_offset = (Py_ssize_t)start_col_byte_offset;
-    Py_ssize_t end_offset = (Py_ssize_t)end_col_byte_offset;
+    assert(source_line);
+    Py_ssize_t start_offset = _PyPegen_byte_offset_to_character_offset(source_line, start_col_byte_offset);
+    Py_ssize_t end_offset = _PyPegen_byte_offset_to_character_offset(source_line, end_col_byte_offset);
     Py_ssize_t left_end_offset = -1;
     Py_ssize_t right_start_offset = -1;
 
     char *primary_error_char = "^";
     char *secondary_error_char = primary_error_char;
 
-    if (source_line) {
-        start_offset = _PyPegen_byte_offset_to_character_offset(source_line, start_col_byte_offset);
-        end_offset = _PyPegen_byte_offset_to_character_offset(source_line, end_col_byte_offset);
-        int res = extract_anchors_from_line(filename, source_line, start_offset, end_offset,
-                                            &left_end_offset, &right_start_offset,
-                                            &primary_error_char, &secondary_error_char);
-        if (res < 0 && ignore_source_errors() < 0) {
-            goto done;
-        }
+    int res = extract_anchors_from_line(filename, source_line, start_offset, end_offset,
+                                        &left_end_offset, &right_start_offset,
+                                        &primary_error_char, &secondary_error_char);
+    if (res < 0 && ignore_source_errors() < 0) {
+        goto done;
     }
 
     err = print_error_location_carets(f, truncation, start_offset, end_offset,


### PR DESCRIPTION
Examples;

```
 $ ./python t.py
Traceback (most recent call last):
  File "/home/isidentical/cpython/cpython/t.py", line 10, in <module>
    add_values(1, 2, 'x', 3, 4)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/isidentical/cpython/cpython/t.py", line 2, in add_values
    return a + b + c + d + e
           ~~~~~~^~~
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```

```
Traceback (most recent call last):
  File "/home/isidentical/cpython/cpython/t2.py", line 10, in <module>
    response['data']['segment1']['segment2']['segment3']
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

<!-- issue-number: [bpo-43950](https://bugs.python.org/issue43950) -->
https://bugs.python.org/issue43950
<!-- /issue-number -->
