### PR TITLE
bpo-38291: Fix a spurious warning when using help(object)

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2512,7 +2512,7 @@ class TextIO(IO[str]):
 
 class _DeprecatedType(type):
     def __getattribute__(cls, name):
-        if name not in ["__dict__", "__module__"] and name in cls.__dict__:
+        if name not in ("__dict__", "__module__") and name in cls.__dict__:
             warnings.warn(
                 f"{cls.__name__} is deprecated, import directly "
                 f"from typing instead. {cls.__name__} will be removed "

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2512,7 +2512,7 @@ class TextIO(IO[str]):
 
 class _DeprecatedType(type):
     def __getattribute__(cls, name):
-        if name != "__dict__" and name in cls.__dict__:
+        if name not in ["__dict__", "__module__"] and name in cls.__dict__:
             warnings.warn(
                 f"{cls.__name__} is deprecated, import directly "
                 f"from typing instead. {cls.__name__} will be removed "


### PR DESCRIPTION


<!-- issue-number: [bpo-38291](https://bugs.python.org/issue38291) -->
https://bugs.python.org/issue38291
<!-- /issue-number -->

Automerge-Triggered-By: GH:gvanrossum