### PR TITLE
 [3.9] bpo-44558: Match countOf is/== treatment to c (GH-27007) #27053 

### DIFF
--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -155,10 +155,10 @@ def contains(a, b):
     return b in a
 
 def countOf(a, b):
-    "Return the number of times b occurs in a."
+    "Return the number of items in a which are, or which equal, b."
     count = 0
     for i in a:
-        if i == b:
+        if i is b or i == b:
             count += 1
     return count
 

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -149,6 +149,11 @@ class OperatorTestCase:
         self.assertRaises(ZeroDivisionError, operator.countOf, BadIterable(), 1)
         self.assertEqual(operator.countOf([1, 2, 1, 3, 1, 4], 3), 1)
         self.assertEqual(operator.countOf([1, 2, 1, 3, 1, 4], 5), 0)
+        # is but not ==
+        nan = float("nan")
+        self.assertEqual(operator.countOf([nan, nan, 21], nan), 2)
+        # == but not is
+        self.assertEqual(operator.countOf([{}, 1, {}, 2], {}), 2)
 
     def test_delitem(self):
         operator = self.module

--- a/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-03-18-25-17.bpo-44558.0pTknl.rst
@@ -1,0 +1,2 @@
+Match the docstring and python implementation of :func:`~operator.countOf` to the behavior
+of its c implementation.

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -494,12 +494,12 @@ _operator_indexOf_impl(PyObject *module, PyObject *a, PyObject *b)
 /*[clinic input]
 _operator.countOf = _operator.indexOf
 
-Return the number of times b occurs in a.
+Return the number of items in a which are, or which equal, b.
 [clinic start generated code]*/
 
 static Py_ssize_t
 _operator_countOf_impl(PyObject *module, PyObject *a, PyObject *b)
-/*[clinic end generated code: output=9e1623197daf3382 input=0c3a2656add252db]*/
+/*[clinic end generated code: output=9e1623197daf3382 input=93ea57f170f3f0bb]*/
 {
     return PySequence_Count(a, b);
 }

--- a/Modules/clinic/_operator.c.h
+++ b/Modules/clinic/_operator.c.h
@@ -957,7 +957,7 @@ PyDoc_STRVAR(_operator_countOf__doc__,
 "countOf($module, a, b, /)\n"
 "--\n"
 "\n"
-"Return the number of times b occurs in a.");
+"Return the number of items in a which are, or which equal, b.");
 
 #define _OPERATOR_COUNTOF_METHODDEF    \
     {"countOf", (PyCFunction)(void(*)(void))_operator_countOf, METH_FASTCALL, _operator_countOf__doc__},
@@ -1491,4 +1491,4 @@ _operator__compare_digest(PyObject *module, PyObject *const *args, Py_ssize_t na
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e7ed71a8c475a901 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ed2bc172e42320d8 input=a9049054013a1b77]*/


### PR DESCRIPTION
(cherry picked from commit 6bd3ecf)

Co-authored-by: Rupert Tombs rupert.tombs@gmail.com

Attempted manual backport (auto attempt message [here](https://github.com/python/cpython/pull/27007#issuecomment-875604225))

Conflict was just in clinic hashes. Cleared the header and re-ran clinic to make this.

<!-- issue-number: [bpo-44558](https://bugs.python.org/issue44558) -->
https://bugs.python.org/issue44558
<!-- /issue-number -->
