### PR TITLE
Supress errors from repr/str in specialization stats

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -42,6 +42,9 @@ SpecializationStats _specialization_stats[256] = { 0 };
 
 #define PRINT_STAT(name, field) fprintf(stderr, "    %s." #field " : %" PRIu64 "\n", name, stats->field);
 
+#define SUPPRESS_REPR_ERR if (PyErr_Occurred() && \
+    PyErr_ExceptionMatches(PyExc_TypeError)) { PyErr_Clear(); }
+
 static void
 print_stats(SpecializationStats *stats, const char *name)
 {
@@ -65,8 +68,10 @@ print_stats(SpecializationStats *stats, const char *name)
         PyObject *kind = PyTuple_GetItem(key, 2);
         fprintf(stderr, "        %s.", ((PyTypeObject *)type)->tp_name);
         PyObject_Print(name, stderr, Py_PRINT_RAW);
+        SUPPRESS_REPR_ERR;
         fprintf(stderr, " (");
         PyObject_Print(kind, stderr, Py_PRINT_RAW);
+        SUPPRESS_REPR_ERR;
         fprintf(stderr, "): %ld\n", PyLong_AsLong(count));
     }
 #endif


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
