### PR TITLE
[3.10] bpo-44479: Simplified LICENSE.txt regeneration in Windows build (GH-27056)

### DIFF
--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -96,21 +96,21 @@
     <_LicenseSources Include="$(tcltkDir)tcllicense.terms;
                               $(tcltkDir)tklicense.terms;
                               $(tcltkDir)tixlicense.terms" Condition="$(IncludeTkinter)" />
-    <_LicenseOutputs Include="$(OutDir)LICENSE.txt" />
   </ItemGroup>
 
-  <Target Name="_RegenLicense" Inputs="@(_LicenseSources)" Outputs="@(_LicenseOutputs)">
-    <Message Text="Regenerate @(_LicenseOutputs->'%(Filename)%(Extension)', ' ')" Importance="high" />
+  <Target Name="_RegenLicense">
     <ItemGroup>
-      <_Text Include="@(_LicenseFiles)">
+      <_Text1 Include="@(_LicenseSources)">
         <Content Condition="Exists(%(FullPath))">$([System.IO.File]::ReadAllText(%(FullPath)))</Content>
-      </_Text>
+      </_Text1>
+      <_Text Include="@(_Text1->'%(Content)')" />
     </ItemGroup>
 
-    <WriteLinesToFile File="@(_LicenseOutputs)" Overwrite="true" Lines="@(_Text->'%(Content)')" />
+    <WriteLinesToFile File="$(OutDir)LICENSE.txt" Overwrite="true" Lines="@(_Text)" />
+    <Warning Text="License file %(_LicenseSources.FullPath) is missing"
+             Condition="!Exists(@(_LicenseSources))" />
+    <Message Text="Wrote $(OutDir)LICENSE.txt" Importance="high" />
   </Target>
 
-  <Target Name="PostBuildRegen" DependsOnTargets="_RegenLicense">
-    <Message Text="Other generated files are up to date" Importance="high" />
-  </Target>
+  <Target Name="PostBuildRegen" DependsOnTargets="_RegenLicense" />
 </Project>


### PR DESCRIPTION


<!-- issue-number: [bpo-44479](https://bugs.python.org/issue44479) -->
https://bugs.python.org/issue44479
<!-- /issue-number -->
