### PR TITLE
Remove __cleanenv from PEP-657 tests

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -384,7 +384,7 @@ class CodeTest(unittest.TestCase):
             assert f.__code__.co_endlinetable is None
             assert f.__code__.co_columntable is None
             """)
-        assert_python_ok('-X', 'no_debug_ranges', '-c', code, __cleanenv=True)
+        assert_python_ok('-X', 'no_debug_ranges', '-c', code)
 
     def test_endline_and_columntable_none_when_no_debug_ranges_env(self):
         # Same as above but using the environment variable opt out.
@@ -395,7 +395,7 @@ class CodeTest(unittest.TestCase):
             assert f.__code__.co_endlinetable is None
             assert f.__code__.co_columntable is None
             """)
-        assert_python_ok('-c', code, PYTHONNODEBUGRANGES='1', __cleanenv=True)
+        assert_python_ok('-c', code, PYTHONNODEBUGRANGES='1')
 
     # co_positions behavior when info is missing.
 

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -148,8 +148,7 @@ class CodeTestCase(unittest.TestCase):
                 marshal.dump(co, f)
 
             assert_python_ok('-X', 'no_debug_ranges',
-                             '-c', code, os_helper.TESTFN,
-                             __cleanenv=True)
+                             '-c', code, os_helper.TESTFN)
         finally:
             os_helper.unlink(os_helper.TESTFN)
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -84,7 +84,7 @@ class TracebackCases(unittest.TestCase):
                 f.write("x = 1 / 0\n")
 
             _, _, stderr = assert_python_failure(
-                '-X', 'no_debug_ranges', TESTFN, __cleanenv=True)
+                '-X', 'no_debug_ranges', TESTFN)
 
             lines = stderr.splitlines()
             self.assertEqual(len(lines), 4)
@@ -108,7 +108,7 @@ class TracebackCases(unittest.TestCase):
                 f.write(code)
 
             _, _, stderr = assert_python_ok(
-                '-X', 'no_debug_ranges', TESTFN, __cleanenv=True)
+                '-X', 'no_debug_ranges', TESTFN)
 
             lines = stderr.splitlines()
             self.assertEqual(len(lines), 4)


### PR DESCRIPTION
This should help fix the failures in the shared buildbots caused by https://github.com/python/cpython/pull/27023