### PR TITLE
bpo-43126: Expand docs on io.IOBase.readlines() method

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -391,7 +391,8 @@ I/O Base Classes
       to control the number of lines read: no more lines will be read if the
       total size (in bytes/characters) of all lines so far exceeds *hint*.
 
-      *hint* values of 0 or less, as well as ``None`` value, are treated as no hint.
+      *hint* values of ``0`` or less, as well as ``None`` value, are treated as no
+      hint.
 
       Note that it's already possible to iterate on file objects using ``for
       line in file: ...`` without calling ``file.readlines()``.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -391,7 +391,7 @@ I/O Base Classes
       to control the number of lines read: no more lines will be read if the
       total size (in bytes/characters) of all lines so far exceeds *hint*.
 
-      *hint* values of ``0`` or less, as well as ``None`` value, are treated as no
+      *hint* values of ``0`` or less, as well as ``None``, are treated as no
       hint.
 
       Note that it's already possible to iterate on file objects using ``for

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -391,7 +391,7 @@ I/O Base Classes
       to control the number of lines read: no more lines will be read if the
       total size (in bytes/characters) of all lines so far exceeds *hint*.
 
-      *hint* values of 0 or less are treated as no hint.
+      *hint* values of 0 or less, as well as ``None`` value, are treated as no hint.
 
       Note that it's already possible to iterate on file objects using ``for
       line in file: ...`` without calling ``file.readlines()``.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -391,6 +391,8 @@ I/O Base Classes
       to control the number of lines read: no more lines will be read if the
       total size (in bytes/characters) of all lines so far exceeds *hint*.
 
+      *hint* values of 0 or less are treated as no hint.
+
       Note that it's already possible to iterate on file objects using ``for
       line in file: ...`` without calling ``file.readlines()``.
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43126](https://bugs.python.org/issue43126) -->
https://bugs.python.org/issue43126
<!-- /issue-number -->
