### PR TITLE
bpo-44583: Fix build for OSF1/Tru64.

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -4,6 +4,9 @@
 
 /* Include nearly all Python header files */
 
+#ifdef __osf__
+#include "pyportosf.h"
+#endif
 #include "patchlevel.h"
 #include "pyconfig.h"
 #include "pymacconfig.h"

--- a/Include/exports.h
+++ b/Include/exports.h
@@ -11,12 +11,13 @@
  * as a cross-platform way to determine if visibility is supported. However,
  * we may still need to support gcc >= 4, as some Ubuntu LTS and Centos versions
  * have 4 < gcc < 5.
+ * OSF/1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
  */
     #ifndef __has_attribute
       #define __has_attribute(x) 0  // Compatibility with non-clang compilers.
     #endif
-    #if (defined(__GNUC__) && (__GNUC__ >= 4)) ||\
-        (defined(__clang__) && __has_attribute(visibility))
+    #if !defined(__osf__) && ((defined(__GNUC__) && (__GNUC__ >= 4)) ||\
+        (defined(__clang__) && __has_attribute(visibility)))
         #define Py_IMPORTED_SYMBOL __attribute__ ((visibility ("default")))
         #define Py_EXPORTED_SYMBOL __attribute__ ((visibility ("default")))
         #define Py_LOCAL_SYMBOL  __attribute__ ((visibility ("hidden")))

--- a/Include/pyportosf.h
+++ b/Include/pyportosf.h
@@ -1,0 +1,72 @@
+#if defined(__osf__) && defined(__arch64__)
+
+// Native cc headers require requesting pieces of C99.
+// Native cc support is hypothetical. gcc4 is being used.
+#define __STDC_CONSTANT_MACROS 1
+#define __STDC_LIMIT_MACROS 1
+#define __STDC_FORMAT_MACROS 1
+
+#undef _ISO_C_SOURCE
+#define _ISO_C_SOURCE 199901
+#define _OSF_SOURCE 1
+#define _ANSI_C_SOURCE 1
+#define _XOPEN_SOURCE 700       // highest value in /usr/include is 500 but match Python elsewhere
+#define _POSIX_C_SOURCE 200809L // highest value in /usr/include is 199506L but match Python elsewhere
+// Unfortunately defining _XOPEN_SOURCE_EXTENDED both hides and reveals symbols.
+// _XOPEN_SOURCE_EXTENDED is generally defined by /usr/include/standards.h
+// that /usr/include/all includes*.h first includes.
+// There is no good solution. That it hides symbols is probably an error.
+// On balance it seems the path of less resistance is let
+// _XOPEN_SOURCE_EXTENDED be defined and duplicate the small amount
+// of content that it suppresses.
+#include <sys/types.h>
+#include <stdint.h>
+// sys/types.h defines _XOPEN_SOURCE_EXTENDED
+// pyconfig.h will define it again, producing many warnings
+#undef _XOPEN_SOURCE_EXTENDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// NSIG is in /usr/include/signal.h behind ifndef _XOPEN_SOURCE_EXTENDED; verbatim:
+// TODO: How to evade patchcheck which damaged verbatim copy?
+#define NSIG    (SIGMAX+1)      /* prefer __sys_nsig; see above */
+
+double copysign(double, double); // /usr/include/math.h ifndef _XOPEN_SOURCE_EXTENDED
+int initgroups(char*, gid_t);    // /usr/include/grp.h ifndef _XOPEN_SOURCE_EXTENDED
+int plock(int);                  // documented but not declared anywhere
+#define HAVE_BROKEN_UNSETENV 1   // unsetenv returns void, not int; configure fails because ifdef _BSD
+
+#ifdef __GNUC__
+double round(double); // /usr/include.dtk/math.h and /usr/lib/cmplrs/cc.dtk/EIDF.h, unlikely usable with gcc
+int finite(double);   // /usr/include.dtk/math.h, unlikely usable with gcc
+
+// from /usr/include.dtk/inttypes.h, not likely usable with gcc
+// 32 == int
+// 64 == long == long long == max
+#define PRId32          "d"
+#define PRId64          "ld"
+#define PRIi32          "i"
+#define PRIi64          "li"
+#define PRIu32          "u"
+#define PRIu64          "lu"
+#define PRIx32          "x"
+#define PRIx64          "lx"
+#define PRIX32          "X"
+// incorrect system definition: "X"
+#define PRIX64          "lX"
+#define PRIXPTR         "lX"
+
+#endif // __GNUC__
+
+#define CLOCK_MONOTONIC CLOCK_REALTIME // no known monotonic time source; fake it poorly for py_get_monotonic_clock
+
+int setenv(const char*, const char*, int); // /usr/include/stdlib.h ifdef _BSD
+void unsetenv(const char*);                // /usr/include/stdlib.h ifdef _BSD
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // osf && 64

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -957,6 +957,7 @@ Bob Kras
 Oleg Krasnikov
 Sebastian Kreft
 Holger Krekel
+Jay Krell
 Michael Kremer
 Fabian Kreutz
 Cédric Krier

--- a/Misc/NEWS.d/next/Build/2021-07-08-01-53-39.bpo-44583.h-_iV-.rst
+++ b/Misc/NEWS.d/next/Build/2021-07-08-01-53-39.bpo-44583.h-_iV-.rst
@@ -1,0 +1,1 @@
+Fix to build on OSF/1 (with gcc 4.7.4).

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -914,8 +914,12 @@
 /* Define to 1 if you have the `sem_unlink' function. */
 #undef HAVE_SEM_UNLINK
 
+/* OSF1 documents and implements but does not declare sendfile,
+   and it does not match others. Skip it. */
+#ifndef __osf__
 /* Define to 1 if you have the `sendfile' function. */
 #undef HAVE_SENDFILE
+#endif
 
 /* Define to 1 if you have the `setegid' function. */
 #undef HAVE_SETEGID


### PR DESCRIPTION
This enables building with gcc4 (4.7.4) on OSF1/Tru64.
gcc3 (3.4.6) and native cc are a bit different, and might be handled later.

 - _XOPEN_SOURCE_EXTENDED both hides and reveals content.
   There is no good answer.
   The system headers define it by default.
   Undefine it to avoid warnings about repeated defines.
   Duplicate a few lines of content that are under ifndef _XOPEN_SOURCE_EXTENDED
 - Duplicate a few other troublesome lines, i.e. due to ifdef _BSD
 - Possible duplication summary: round, finite, copysign, NSIG, setenv, unsetenv
 - OSF1 appears to have no monotic timer; fake it badly with realtime
   This is probably the worst part.
 - unsetenv is broken, returns void, not int
   configure fails to detect this, because the
   prototype is under ifdef _BSD and the program compiles without warning or error;
   unprototyped functions are assumed to return int, after all
 - wait4 always takes union wait; cast
 - printf C99 macros are missing with gcc
 - sendfile is implemented and documented, but not declared and does not match other systems; skip it
 - plock is documented and probably implemented, but not declared; declare it
 - cast away const in initgroups call (safe for all systems)

The fixes are a bit spread out between configure.ac, pyconfig.h.in
and new file pyportosf.h. It may be preferable to consolidate, esp. in configure.ac.

Fwiw I got python2 running also.

<!-- issue-number: [bpo-44583](https://bugs.python.org/issue44583) -->
https://bugs.python.org/issue44583
<!-- /issue-number -->
