### PR TITLE
bpo-44584: Deprecate PYTHONTHREADDEBUG env var

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -962,9 +962,11 @@ Debug-mode variables
 
 .. envvar:: PYTHONTHREADDEBUG
 
-   If set, Python will print threading debug info.
+   If set, Python will print threading debug info into stdout.
 
    Need a :ref:`debug build of Python <debug-build>`.
+
+   .. deprecated-removed:: 3.10 3.12
 
 
 .. envvar:: PYTHONDUMPREFS

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1691,6 +1691,11 @@ Deprecated
   * NPN features like :meth:`ssl.SSLSocket.selected_npn_protocol` and
     :meth:`ssl.SSLContext.set_npn_protocols` are replaced by ALPN.
 
+* The threading debug (:envvar:`PYTHONTHREADDEBUG` environment variable) is
+  deprecated in Python 3.10 and will be removed in Python 3.12. This feature
+  requires a :ref:`debug build of Python <debug-build>`.
+  (Contributed by Victor Stinner in :issue:`44584`.)
+
 .. _whatsnew310-removed:
 
 Removed

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-08-12-18-56.bpo-44584.qKnSqV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-08-12-18-56.bpo-44584.qKnSqV.rst
@@ -1,0 +1,3 @@
+The threading debug (:envvar:`PYTHONTHREADDEBUG` environment variable) is
+deprecated in Python 3.10 and will be removed in Python 3.12. This feature
+requires a debug build of Python. Patch by Victor Stinner.

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -550,6 +550,7 @@ if Python was configured with the
 \fB\--with-pydebug\fP build option.
 .IP PYTHONTHREADDEBUG
 If this environment variable is set, Python will print threading debug info.
+The feature is deprecated in Python 3.10 and will be removed in Python 3.12.
 .IP PYTHONDUMPREFS
 If this environment variable is set, Python will dump objects and reference
 counts still alive after shutting down the interpreter.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1057,6 +1057,8 @@ pyinit_main_reconfigure(PyThreadState *tstate)
 static PyStatus
 init_interp_main(PyThreadState *tstate)
 {
+    extern void _PyThread_debug_deprecation(void);
+
     assert(!_PyErr_Occurred(tstate));
 
     PyStatus status;
@@ -1157,6 +1159,9 @@ init_interp_main(PyThreadState *tstate)
         emit_stderr_warning_for_legacy_locale(interp->runtime);
 #endif
     }
+
+    // Warn about PYTHONTHREADDEBUG deprecation
+    _PyThread_debug_deprecation();
 
     assert(!_PyErr_Occurred(tstate));
 

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -75,6 +75,25 @@ PyThread_init_thread(void)
     PyThread__init_thread();
 }
 
+void
+_PyThread_debug_deprecation(void)
+{
+#ifdef Py_DEBUG
+    if (thread_debug) {
+        // Flush previous dprintf() logs
+        fflush(stdout);
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "The threading debug (PYTHONTHREADDEBUG environment "
+                         "variable) is deprecated and will be removed "
+                         "in Python 3.12",
+                         0))
+        {
+            _PyErr_WriteUnraisableMsg("at Python startup", NULL);
+        }
+    }
+#endif
+}
+
 #if defined(_POSIX_THREADS)
 #   define PYTHREAD_NAME "pthread"
 #   include "thread_pthread.h"


### PR DESCRIPTION
The threading debug (PYTHONTHREADDEBUG environment variable) is now
deprecated in Python 3.10 and will be removed in Python 3.12.
This feature requires a debug build of Python.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44584](https://bugs.python.org/issue44584) -->
https://bugs.python.org/issue44584
<!-- /issue-number -->
