### PR TITLE
bpo-44570: Fix line tracing for forwards jumps to duplicated tails

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1041,6 +1041,41 @@ class TraceTestCase(unittest.TestCase):
              (-8, 'return'),
              (1, 'return')])
 
+    def test_flow_converges_on_same_line(self):
+
+        def foo(x):
+            if x:
+                try:
+                    1/(x - 1)
+                except ZeroDivisionError:
+                    pass
+            return x
+
+        def func():
+            for i in range(2):
+                foo(i)
+
+        self.run_and_compare(func,
+            [(0, 'call'),
+             (1, 'line'),
+             (2, 'line'),
+             (-8, 'call'),
+             (-7, 'line'),
+             (-2, 'line'),
+             (-2, 'return'),
+             (1, 'line'),
+             (2, 'line'),
+             (-8, 'call'),
+             (-7, 'line'),
+             (-6, 'line'),
+             (-5, 'line'),
+             (-5, 'exception'),
+             (-4, 'line'),
+             (-3, 'line'),
+             (-2, 'line'),
+             (-2, 'return'),
+             (1, 'line'),
+             (1, 'return')])
 
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""


### PR DESCRIPTION
Handle forward jumps where the target has the same line number as the physically preceding instruction.

This doesn't seem to be strictly necessary for 3.10 due to the change in exception handling, but I'm adding anyway mainly for the regression test.




<!-- issue-number: [bpo-44570](https://bugs.python.org/issue44570) -->
https://bugs.python.org/issue44570
<!-- /issue-number -->
