### PR TITLE
[3.10] bpo-44446: support lineno being None in traceback.FrameSummary (GH-26781)

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -1001,6 +1001,10 @@ class TestFrame(unittest.TestCase):
             '"""Test cases for traceback module"""',
             f.line)
 
+    def test_no_line(self):
+        f = traceback.FrameSummary("f", None, "dummy")
+        self.assertEqual(f.line, None)
+
     def test_explicit_line(self):
         f = traceback.FrameSummary("f", 1, "dummy", line="line")
         self.assertEqual("line", f.line)

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -301,9 +301,10 @@ class FrameSummary:
     @property
     def line(self):
         if self._line is None:
-            self._line = linecache.getline(self.filename, self.lineno).strip()
-        return self._line
-
+            if self.lineno is None:
+                return None
+            self._line = linecache.getline(self.filename, self.lineno)
+        return self._line.strip()
 
 def walk_stack(f):
     """Walk a stack yielding the frame and line number for each frame.

--- a/Misc/NEWS.d/next/Library/2021-06-17-22-39-34.bpo-44446.qwdRic.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-17-22-39-34.bpo-44446.qwdRic.rst
@@ -1,0 +1,1 @@
+Take into account that ``lineno`` might be ``None`` in :class:`traceback.FrameSummary`.


### PR DESCRIPTION
As of 088a15c49d99ecb4c3bef93f8f40dd513c6cae3b, lineno is None instead
of -1 if there is no line number.

Signed-off-by: Filipe Laíns <lains@riseup.net>.
(cherry picked from commit 91a8f8c16ca9a7e2466a8241d9b41769ef97d094)

Co-authored-by: Filipe Laíns <lains@riseup.net>


<!-- issue-number: [bpo-44446](https://bugs.python.org/issue44446) -->
https://bugs.python.org/issue44446
<!-- /issue-number -->
