### PR TITLE
bpo-42830: Update the documentation for tempfile.mkstemp 

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -163,7 +163,7 @@ The module defines the following user-callable items:
 
    Unlike :func:`TemporaryFile`, the user of :func:`mkstemp` is responsible
    for deleting the temporary file when done with it. If a large number of file
-   descriptors are created, your program may run into a per-process limit and crash.
+   descriptors are created, your program may run into a per-process limit and raise an :exc:`OSError`.
    You can avoid this issue by closing file descriptors with :func:`os.close`.
 
    If *suffix* is not ``None``, the file name will end with that suffix,

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -162,7 +162,7 @@ The module defines the following user-callable items:
    by child processes.
 
    Unlike :func:`TemporaryFile`, the user of :func:`mkstemp` is responsible
-   for deleting the temporary file when done with it.If a large number of file
+   for deleting the temporary file when done with it. If a large number of file
    descriptors are created, your program may run into a per-process limit and crash.
    You can avoid this issue by closing file descriptors with :func:`os.close`.
 

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -162,7 +162,9 @@ The module defines the following user-callable items:
    by child processes.
 
    Unlike :func:`TemporaryFile`, the user of :func:`mkstemp` is responsible
-   for deleting the temporary file when done with it.
+   for deleting the temporary file when done with it.If a large number of file
+   descriptors are created, your program may run into a per-process limit and crash.
+   You can avoid this issue by closing file descriptors with :func:`os.close`.
 
    If *suffix* is not ``None``, the file name will end with that suffix,
    otherwise there will be no suffix.  :func:`mkstemp` does not put a dot


### PR DESCRIPTION
[bpo-42830](https://bugs.python.org/issue42830): Update the documentation for tempfile.mkstemp function that user is responsible for closing the file descriptor while closing the created file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42830](https://bugs.python.org/issue42830) -->
https://bugs.python.org/issue42830
<!-- /issue-number -->
