### PR TITLE
Simple typo

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -692,7 +692,7 @@ Running in Threads
 
    This coroutine function is primarily intended to be used for executing
    IO-bound functions/methods that would otherwise block the event loop if
-   they were ran in the main thread. For example::
+   they were run in the main thread. For example::
 
        def blocking_io():
            print(f"start blocking_io at {time.strftime('%X')}")


### PR DESCRIPTION
Hi!

I could be wrong, but I believe "they were run" is the correct use of run in this case 😊

Thanks!