### PR TITLE
bpo-44207: Add an internal version number to function objects.

### DIFF
--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -42,6 +42,13 @@ typedef struct {
     PyObject *func_module;      /* The __module__ attribute, can be anything */
     PyObject *func_annotations; /* Annotations, a dict or NULL */
     vectorcallfunc vectorcall;
+    /* Version number for use by specializer.
+     * Can set to non-zero when we want to specialize.
+     * Will be set to zero if any of these change:
+     *     defaults
+     *     kwdefaults (only if the object changes, not the contents of the dict)
+     *     code
+     *     annotations */
     uint32_t func_version;
 
     /* Invariant:

--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -42,6 +42,7 @@ typedef struct {
     PyObject *func_module;      /* The __module__ attribute, can be anything */
     PyObject *func_annotations; /* Annotations, a dict or NULL */
     vectorcallfunc vectorcall;
+    uint32_t func_version;
 
     /* Invariant:
      *     func_closure contains the bindings for func_code->co_freevars, so
@@ -74,6 +75,8 @@ PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
     PyObject *const *stack,
     size_t nargsf,
     PyObject *kwnames);
+
+uint32_t _PyFunction_GetVersionForCurrentState(PyFunctionObject *func);
 #endif
 
 /* Macros for direct access to these values. Type checks are *not*

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1278,7 +1278,7 @@ class SizeofTest(unittest.TestCase):
         check(x, size('4P3i4cP'))
         # function
         def func(): pass
-        check(func, size('14P'))
+        check(func, size('14Pi'))
         class c():
             @staticmethod
             def foo():

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -171,6 +171,7 @@ PyFunction_SetDefaults(PyObject *op, PyObject *defaults)
         PyErr_SetString(PyExc_SystemError, "non-tuple default args");
         return -1;
     }
+    ((PyFunctionObject *)op)->func_version = 0;
     Py_XSETREF(((PyFunctionObject *)op)->func_defaults, defaults);
     return 0;
 }
@@ -202,6 +203,7 @@ PyFunction_SetKwDefaults(PyObject *op, PyObject *defaults)
                         "non-dict keyword only default args");
         return -1;
     }
+    ((PyFunctionObject *)op)->func_version = 0;
     Py_XSETREF(((PyFunctionObject *)op)->func_kwdefaults, defaults);
     return 0;
 }
@@ -234,6 +236,7 @@ PyFunction_SetClosure(PyObject *op, PyObject *closure)
                      Py_TYPE(closure)->tp_name);
         return -1;
     }
+    ((PyFunctionObject *)op)->func_version = 0;
     Py_XSETREF(((PyFunctionObject *)op)->func_closure, closure);
     return 0;
 }
@@ -265,6 +268,7 @@ PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
                         "non-dict annotations");
         return -1;
     }
+    ((PyFunctionObject *)op)->func_version = 0;
     Py_XSETREF(((PyFunctionObject *)op)->func_annotations, annotations);
     return 0;
 }


### PR DESCRIPTION
Will be used in much the same way as the version numbers on classes and dictionary keys.
Provides us a fast way to check that the function object is in the same state as when we specialize code for it.

<!-- issue-number: [bpo-44207](https://bugs.python.org/issue44207) -->
https://bugs.python.org/issue44207
<!-- /issue-number -->
