### PR TITLE
bpo-42799: fnmatch module: bump up size of lru_cache for patterns

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -46,7 +46,7 @@ module.  See module :mod:`glob` for pathname expansion (:mod:`glob` uses
 a period are not special for this module, and are matched by the ``*`` and ``?``
 patterns.
 
-Also note that :func:`functools.lru_cache` with the size of 32768 will be used to
+Also note that :func:`functools.lru_cache` with the *maxsize* of 32768 is used to
 cache the compiled regex patterns in the following functions: :func:`fnmatch`,
 :func:`fnmatchcase`, :func:`filter`.
 

--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -46,6 +46,9 @@ module.  See module :mod:`glob` for pathname expansion (:mod:`glob` uses
 a period are not special for this module, and are matched by the ``*`` and ``?``
 patterns.
 
+Also note that :func:`functools.lru_cache` with the size of 32768 will be used to
+cache the compiled regex patterns in the following functions: :func:`fnmatch`,
+:func:`fnmatchcase`, :func:`filter`.
 
 .. function:: fnmatch(filename, pattern)
 

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -41,7 +41,7 @@ def fnmatch(name, pat):
     pat = os.path.normcase(pat)
     return fnmatchcase(name, pat)
 
-@functools.lru_cache(maxsize=256, typed=True)
+@functools.lru_cache(maxsize=32768, typed=True)
 def _compile_pattern(pat):
     if isinstance(pat, bytes):
         pat_str = str(pat, 'ISO-8859-1')

--- a/Misc/NEWS.d/next/Library/2021-07-10-19-55-13.bpo-42799.ad4tq8.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-10-19-55-13.bpo-42799.ad4tq8.rst
@@ -1,0 +1,4 @@
+In :mod:`fnmatch`, the cache size for compiled regex patterns
+(:func:`functools.lru_cache`) was bumped up from 256 to 32768, affecting
+functions: :func:`fnmatch.fnmatch`, :func:`fnmatch.fnmatchcase`,
+:func:`fnmatch.filter`.


### PR DESCRIPTION


<!-- issue-number: [bpo-42799](https://bugs.python.org/issue42799) -->
https://bugs.python.org/issue42799
<!-- /issue-number -->
