### PR TITLE
gh-52841: Update urllib, httplib, smtplib docs to warn about global timeout value

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -46,8 +46,8 @@ The module provides the following classes:
    The optional *blocksize* parameter sets the buffer size in bytes for
    sending a file-like message body.
 
-   Warning: the global default timeout value is to never time out, which is often
-   not the desired value for this function.
+   Warning: the global default timeout value is set with no timeout, which may
+   not be the desired value for this function.
 
    For example, the following calls all create instances that connect to the server
    at the same host and port::

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -46,7 +46,7 @@ The module provides the following classes:
    The optional *blocksize* parameter sets the buffer size in bytes for
    sending a file-like message body.
 
-   Warning: the global default timeout value is set with no timeout, which may
+   The global default timeout value is set with no timeout, which may
    not be the desired value for this function.
 
    For example, the following calls all create instances that connect to the server

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -46,6 +46,9 @@ The module provides the following classes:
    The optional *blocksize* parameter sets the buffer size in bytes for
    sending a file-like message body.
 
+   Warning: the global default timeout value is to never time out, which is often
+   not the desired value for this function.
+
    For example, the following calls all create instances that connect to the server
    at the same host and port::
 

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -32,7 +32,7 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    than a success code, an :exc:`SMTPConnectError` is raised. The optional
    *timeout* parameter specifies a timeout in seconds for blocking operations
    like the connection attempt (if not specified, the global default timeout
-   setting will be used, which is set never to time out).  If the timeout expires,
+   setting will be used, which is set with no timeout).  If the timeout expires,
    :exc:`TimeoutError` is raised.  The optional source_address parameter allows binding
    to some specific source address in a machine with multiple network
    interfaces, and/or to some specific source TCP port. It takes a 2-tuple

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -32,8 +32,8 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    than a success code, an :exc:`SMTPConnectError` is raised. The optional
    *timeout* parameter specifies a timeout in seconds for blocking operations
    like the connection attempt (if not specified, the global default timeout
-   setting will be used).  If the timeout expires, :exc:`TimeoutError` is
-   raised.  The optional source_address parameter allows binding
+   setting will be used, which is set never to time out).  If the timeout expires,
+   :exc:`TimeoutError` is raised.  The optional source_address parameter allows binding
    to some specific source address in a machine with multiple network
    interfaces, and/or to some specific source TCP port. It takes a 2-tuple
    (host, port), for the socket to bind to as its source address before

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -664,8 +664,8 @@ OpenerDirector Objects
 
    .. note::
 
-      The global default timeout value is to never time out, which is often
-      not the desired value for this function.
+      The global default timeout value is set with no timeout, which may
+      not be the desired value for this function.
 
 .. method:: OpenerDirector.error(proto, *args)
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -42,8 +42,8 @@ The :mod:`urllib.request` module defines the following functions:
    the global default timeout setting will be used).  This actually
    only works for HTTP, HTTPS and FTP connections.
 
-   Warning: the global default timeout value is to never time out, which is often
-   not the desired value for this function.
+   Warning: the global default timeout value is set with no timeout, which may
+   not be the desired value for this function.
 
    If *context* is specified, it must be a :class:`ssl.SSLContext` instance
    describing the various SSL options. See :class:`~http.client.HTTPSConnection`

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -662,8 +662,10 @@ OpenerDirector Objects
    timeout setting will be used). The timeout feature actually works only for
    HTTP, HTTPS and FTP connections).
 
-   Warning: the global default timeout value is to never time out, which is often
-   not the desired value for this function.
+   .. note::
+
+      The global default timeout value is to never time out, which is often
+      not the desired value for this function.
 
 .. method:: OpenerDirector.error(proto, *args)
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -42,9 +42,6 @@ The :mod:`urllib.request` module defines the following functions:
    the global default timeout setting will be used).  This actually
    only works for HTTP, HTTPS and FTP connections.
 
-   Warning: the global default timeout value is set with no timeout, which may
-   not be the desired value for this function.
-
    If *context* is specified, it must be a :class:`ssl.SSLContext` instance
    describing the various SSL options. See :class:`~http.client.HTTPSConnection`
    for more details.
@@ -89,6 +86,11 @@ The :mod:`urllib.request` module defines the following functions:
    ``urllib2.urlopen``.  Proxy handling, which was done by passing a dictionary
    parameter to ``urllib.urlopen``, can be obtained by using
    :class:`ProxyHandler` objects.
+
+   .. note::
+
+      The global default timeout value is set with no timeout, which may
+      not be the desired value for this function.
 
    .. audit-event:: urllib.Request fullurl,data,headers,method urllib.request.urlopen
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -42,6 +42,9 @@ The :mod:`urllib.request` module defines the following functions:
    the global default timeout setting will be used).  This actually
    only works for HTTP, HTTPS and FTP connections.
 
+   Warning: the global default timeout value is to never time out, which is often
+   not the desired value for this function.
+
    If *context* is specified, it must be a :class:`ssl.SSLContext` instance
    describing the various SSL options. See :class:`~http.client.HTTPSConnection`
    for more details.
@@ -657,6 +660,8 @@ OpenerDirector Objects
    timeout setting will be used). The timeout feature actually works only for
    HTTP, HTTPS and FTP connections).
 
+   Warning: the global default timeout value is to never time out, which is often
+   not the desired value for this function.
 
 .. method:: OpenerDirector.error(proto, *args)
 

--- a/Misc/NEWS.d/next/Library/2022-12-09-10-35-36.bpo-44592.z-P3oe.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-09-10-35-36.bpo-44592.z-P3oe.rst
@@ -1,2 +1,0 @@
-Fixes inconsistent handling of case sensitivity of *extrasaction* arg in
-:class:`csv.DictWriter`.

--- a/Misc/NEWS.d/next/Library/2022-12-09-10-35-36.bpo-44592.z-P3oe.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-09-10-35-36.bpo-44592.z-P3oe.rst
@@ -1,0 +1,2 @@
+Fixes inconsistent handling of case sensitivity of *extrasaction* arg in
+:class:`csv.DictWriter`.


### PR DESCRIPTION


<!-- issue-number: [bpo-8595](https://bugs.python.org/issue8595) -->
https://bugs.python.org/issue8595
<!-- /issue-number -->

<!-- gh-issue-number: gh-52841 -->
* Issue: gh-52841
<!-- /gh-issue-number -->
