### PR TITLE
gh-88325: Change mimetype db to read windows registry values as non-strict

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -234,7 +234,7 @@ class MimeTypes:
             for suff in suffixes:
                 self.add_type(type, '.' + suff, strict)
 
-    def read_windows_registry(self, strict=True):
+    def read_windows_registry(self, strict=False):
         """
         Load the MIME types database from Windows registry.
 
@@ -246,9 +246,7 @@ class MimeTypes:
         if not _mimetypes_read_windows_registry and not _winreg:
             return
 
-        add_type = self.add_type
-        if strict:
-            add_type = lambda type, ext: self.add_type(type, ext, True)
+        add_type = lambda type, ext: self.add_type(type, ext, strict)
 
         # Accelerated function if it is available
         if _mimetypes_read_windows_registry:


### PR DESCRIPTION
[bpo-44159](https://bugs.python.org/issue44159) - Windows registry values are being used to set strict mimetypes.

This change changes the default behavior of the `read_windows_registry` function to add mimetypes in the registry as non-strict values. Prior to this change, `test_guess_type` in `test_mimetypes.py` would fail on Windows machines with a default mimetype for a .pic file set.



<!-- issue-number: [bpo-44159](https://bugs.python.org/issue44159) -->
https://bugs.python.org/issue44159
<!-- /issue-number -->

<!-- gh-issue-number: gh-88325 -->
* Issue: gh-88325
<!-- /gh-issue-number -->
