### PR TITLE
gh-88760: fix (Async)ExitStack handling of __context__

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -531,10 +531,10 @@ class ExitStack(_BaseExitStack, AbstractContextManager):
             # Context may not be correct, so find the end of the chain
             while 1:
                 exc_context = new_exc.__context__
-                if exc_context is old_exc:
+                if exc_context is None or exc_context is old_exc:
                     # Context is already set correctly (see issue 20317)
                     return
-                if exc_context is None or exc_context is frame_exc:
+                if exc_context is frame_exc:
                     break
                 new_exc = exc_context
             # Change the end of the chain to point to the exception
@@ -671,10 +671,10 @@ class AsyncExitStack(_BaseExitStack, AbstractAsyncContextManager):
             # Context may not be correct, so find the end of the chain
             while 1:
                 exc_context = new_exc.__context__
-                if exc_context is old_exc:
+                if exc_context is None or exc_context is old_exc:
                     # Context is already set correctly (see issue 20317)
                     return
-                if exc_context is None or exc_context is frame_exc:
+                if exc_context is frame_exc:
                     break
                 new_exc = exc_context
             # Change the end of the chain to point to the exception

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -794,6 +794,40 @@ class TestBaseExitStack:
         self.assertIsInstance(inner_exc, ValueError)
         self.assertIsInstance(inner_exc.__context__, ZeroDivisionError)
 
+    def test_exit_exception_explicit_none_context(self):
+        # Ensure ExitStack chaining matches actual nested `with` statements
+        # regarding explicit __context__ = None.
+
+        class MyException(Exception):
+            pass
+
+        @contextmanager
+        def my_cm():
+            try:
+                yield
+            except BaseException:
+                exc = MyException()
+                try:
+                    raise exc
+                finally:
+                    exc.__context__ = None
+
+        @contextmanager
+        def my_cm_with_exit_stack():
+            with self.exit_stack() as stack:
+                stack.enter_context(my_cm())
+                yield stack
+
+        for cm in (my_cm, my_cm_with_exit_stack):
+            with self.subTest():
+                try:
+                    with cm():
+                        raise IndexError()
+                except MyException as exc:
+                    self.assertIsNone(exc.__context__)
+                else:
+                    self.fail("Expected IndexError, but no exception was raised")
+
     def test_exit_exception_non_suppressing(self):
         # http://bugs.python.org/issue19092
         def raise_exc(exc):

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -557,6 +557,41 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         self.assertIsInstance(inner_exc.__context__, ZeroDivisionError)
 
     @_async_test
+    async def test_async_exit_exception_explicit_none_context(self):
+        # Ensure AsyncExitStack chaining matches actual nested `with` statements
+        # regarding explicit __context__ = None.
+
+        class MyException(Exception):
+            pass
+
+        @asynccontextmanager
+        async def my_cm():
+            try:
+                yield
+            except BaseException:
+                exc = MyException()
+                try:
+                    raise exc
+                finally:
+                    exc.__context__ = None
+
+        @asynccontextmanager
+        async def my_cm_with_exit_stack():
+            async with self.exit_stack() as stack:
+                await stack.enter_async_context(my_cm())
+                yield stack
+
+        for cm in (my_cm, my_cm_with_exit_stack):
+            with self.subTest():
+                try:
+                    async with cm():
+                        raise IndexError()
+                except MyException as exc:
+                    self.assertIsNone(exc.__context__)
+                else:
+                    self.fail("Expected IndexError, but no exception was raised")
+
+    @_async_test
     async def test_instance_bypass_async(self):
         class Example(object): pass
         cm = Example()

--- a/Misc/NEWS.d/next/Library/2021-07-12-10-32-48.bpo-44594.eEa5zi.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-12-10-32-48.bpo-44594.eEa5zi.rst
@@ -1,1 +1,3 @@
-Fix an edge case of :class:`ExitStack` and :class:`AsyncExitStack` exception chaining.  They will now match `with` block behavior when `__context__` is explicitly set to `None` when the exception is in flight.
+Fix an edge case of :class:`ExitStack` and :class:`AsyncExitStack` exception
+chaining.  They will now match ``with`` block behavior when ``__context__`` is
+explicitly set to ``None`` when the exception is in flight.

--- a/Misc/NEWS.d/next/Library/2021-07-12-10-32-48.bpo-44594.eEa5zi.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-12-10-32-48.bpo-44594.eEa5zi.rst
@@ -1,0 +1,1 @@
+Fix an edge case of :class:`ExitStack` and :class:`AsyncExitStack` exception chaining.  They will now match `with` block behavior when `__context__` is explicitly set to `None` when the exception is in flight.


### PR DESCRIPTION
Make `enter_[async_]context(foo())` equivalent to `[async] with foo()` regarding `__context__` when an exception is raised.

Previously, exceptions would be caught and re-raised with the wrong context when explicitly overriding `__context__` with `None`.  In other words, in usage like the following where we explicitly try to clear the context  to `None` on an exception in flight, (Async)ExitStack will overwrite that with the context of the old exception, while the real (async) `with` will not:

```python
exc = foo()
try:
    raise exc
finally:
    exc.__context__ = None  # ExitStack will stomp on this value
```

This bug seems to have existed from the first version of (Async)ExitStack.  Namely, the `_fix_exception_context()` code was trying to substitute a suitable value for `__context__` when the exception was *raised* with a context of `None`.  But this handling was not needed, since raising with `__context__` of `None` will be replaced with a suitable context by Python's machinery before (Async)ExitStack accesses the exception via `sys.exc_info()`.  Since this handling in (Async)ExitStack had no purpose and interferes with the valid use case of clearing `__context__` on an *in-flight* exception, this PR removes it.

Included are unit tests verifying that (Async)ExitStack now match the behavior of (async) `with` when clearing the context of an in-flight exception to `None`.

TODO:
  * [x] unit tests
  * [x] make sure this PR is backported to Python 3.10 and older

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44594](https://bugs.python.org/issue44594) -->
https://bugs.python.org/issue44594
<!-- /issue-number -->


<!-- gh-issue-number: gh-88760 -->
* Issue: gh-88760
<!-- /gh-issue-number -->
