### PR TITLE
bpo-44564 Move formatted assertion under deprecation warning context.

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2321,7 +2321,7 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(str(OkayEnum.one), 'one')
         with self.assertWarns(DeprecationWarning):
             self.assertEqual('{}'.format(OkayEnum.one), '1')
-        self.assertEqual(OkayEnum.one, '{}'.format(OkayEnum.one))
+            self.assertEqual(OkayEnum.one, '{}'.format(OkayEnum.one))
         self.assertEqual(repr(OkayEnum.one), 'OkayEnum.one')
         #
         class DumbMixin:


### PR DESCRIPTION
[bpo-44564](https://bugs.python.org/issue44564)

One of the format calls in the `test_custom_strenum_with_warning` test wasn't under the DeprecationWarning context manager.

<!-- issue-number: [bpo-44564](https://bugs.python.org/issue44564) -->
https://bugs.python.org/issue44564
<!-- /issue-number -->
