### PR TITLE
bpo-44572: On Windows platform disconnect STDIN in platform._syscmd_ver() to prevent erroneous STDIN consumption

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -280,6 +280,7 @@ def _syscmd_ver(system='', release='', version='',
     for cmd in ('ver', 'command /c ver', 'cmd /c ver'):
         try:
             info = subprocess.check_output(cmd,
+                                           stdin=subprocess.DEVNULL,
                                            stderr=subprocess.DEVNULL,
                                            text=True,
                                            shell=True)

--- a/Misc/NEWS.d/next/Windows/2021-07-13-15-32-49.bpo-44572.gXvhDc.rst
+++ b/Misc/NEWS.d/next/Windows/2021-07-13-15-32-49.bpo-44572.gXvhDc.rst
@@ -1,0 +1,1 @@
+Avoid consuming standard input in the :mod:`platform` module


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
If script.py contains a call to platform.win32* functions the following invocation
inadvertently consumes STDIN redirected from file:

python.exe script.py < file

To address the issue, stdin=subprocess.DEVNULL argument needs to be added to subprocess.check_output() call in platform._syscmd_ver().

<!-- issue-number: [bpo-44572](https://bugs.python.org/issue44572) -->
https://bugs.python.org/issue44572
<!-- /issue-number -->
