### PR TITLE
bpo-43948: Change osx_framework_user include to match distutils’s header value

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -111,7 +111,7 @@ if _HAS_USER_BASE:
             'platstdlib': '{userbase}/lib/python',
             'purelib': '{userbase}/lib/python/site-packages',
             'platlib': '{userbase}/lib/python/site-packages',
-            'include': '{userbase}/include',
+            'include': '{userbase}/include/python{py_version_short}',
             'scripts': '{userbase}/bin',
             'data': '{userbase}',
             },

--- a/Misc/NEWS.d/next/macOS/2021-07-12-15-42-02.bpo-41972.yUjE8j.rst
+++ b/Misc/NEWS.d/next/macOS/2021-07-12-15-42-02.bpo-41972.yUjE8j.rst
@@ -1,0 +1,2 @@
+The framework build's user header path in sysconfig is changed to add a
+'pythonX.Y' component to match distutils's behavior.


### PR DESCRIPTION


<!-- issue-number: [bpo-43948](https://bugs.python.org/issue43948) -->
https://bugs.python.org/issue43948
<!-- /issue-number -->
