### PR TITLE
bpo-44613: Make importlib.metadata non-provisional

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -8,12 +8,10 @@
    :synopsis: The implementation of the importlib metadata.
 
 .. versionadded:: 3.8
+.. versionchanged:: 3.10
+   ``importlib.metadata`` is no longer provisional.
 
 **Source code:** :source:`Lib/importlib/metadata.py`
-
-.. note::
-   This functionality is provisional and may deviate from the usual
-   version semantics of the standard library.
 
 ``importlib.metadata`` is a library that provides for access to installed
 package metadata.  Built in part on Python's import system, this library

--- a/Misc/NEWS.d/next/Documentation/2021-07-12-11-39-20.bpo-44613.DIXNzc.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-12-11-39-20.bpo-44613.DIXNzc.rst
@@ -1,0 +1,1 @@
+importlib.metadata is no longer provisional.


### PR DESCRIPTION
As discussed with @jaraco, `importlib.metadata` will be non-provisional in Python 3.10.

<!-- issue-number: [bpo-44613](https://bugs.python.org/issue44613) -->
https://bugs.python.org/issue44613
<!-- /issue-number -->
