### PR TITLE
Remove default return value of compileall.main

### DIFF
--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -456,8 +456,6 @@ def main():
         if args.quiet < 2:
             print("\n[interrupted]")
         return False
-    return True
-
 
 if __name__ == '__main__':
     exit_status = int(not main())


### PR DESCRIPTION
The function will return either way in one of those lines: `458`, `452`, `450` in the try-except block