### PR TITLE
bpo-34451: Document prompt and output toggle feature in html tutorial

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -11,6 +11,13 @@ with a prompt are output from the interpreter. Note that a secondary prompt on a
 line by itself in an example means you must type a blank line; this is used to
 end a multi-line command.
 
+.. only:: html
+
+   You can toggle the display of prompts and output by clicking the ``>>>``
+   link in the upper-right corner of an example box.  If you hide the prompts
+   and output for an example, then you can easily copy and paste the input
+   lines into your interpreter.
+
 .. index:: single: # (hash); comment
 
 Many of the examples in this manual, even those entered at the interactive

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -13,8 +13,8 @@ end a multi-line command.
 
 .. only:: html
 
-   You can toggle the display of prompts and output by clicking the ``>>>``
-   link in the upper-right corner of an example box.  If you hide the prompts
+   You can toggle the display of prompts and output by clicking on ``>>>``
+   in the upper-right corner of an example box.  If you hide the prompts
    and output for an example, then you can easily copy and paste the input
    lines into your interpreter.
 


### PR DESCRIPTION
This PR addresses https://bugs.python.org/issue34451. I followed Raymond's comment to display the note only in the HTML version of the documentation using the Sphinx [`.. only::`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?#directive-only) directive. I confirmed the new text appears in the `make html` output but is absent from the output of `make text`.

The first place that the `>>>` feature appears in the Tutorial is in example two of [Section 2.1.2 Interactive Mode](https://docs.python.org/3/tutorial/interpreter.html#interactive-mode). However, discussion of the examples in the manual is deferred to the following page https://docs.python.org/3/tutorial/introduction.html, and this was the location referenced in the bpo. There may be a better location to document this feature.

Thank you for taking the time to review this PR.

<!-- issue-number: [bpo-34451](https://bugs.python.org/issue34451) -->
https://bugs.python.org/issue34451
<!-- /issue-number -->
