### PR TITLE
bpo-44608: Fix memory leak in _tkinter._flatten()

### DIFF
--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -43,8 +43,14 @@ def get_tk_patchlevel():
 class TkinterTest(unittest.TestCase):
 
     def testFlattenLen(self):
-        # flatten(<object with no length>)
+        # Object without length.
         self.assertRaises(TypeError, _tkinter._flatten, True)
+        # Object with length, but not sequence.
+        self.assertRaises(TypeError, _tkinter._flatten, {})
+        # Sequence or set, but not tuple or list.
+        # (issue44608: there were leaks in the following cases)
+        self.assertRaises(TypeError, _tkinter._flatten, 'string')
+        self.assertRaises(TypeError, _tkinter._flatten, {'set'})
 
 
 class TclTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2021-07-13-09-01-33.bpo-44608.R3IcM1.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-13-09-01-33.bpo-44608.R3IcM1.rst
@@ -1,0 +1,2 @@
+Fix memory leak in :func:`_tkinter._flatten` if it is called with a sequence
+or set, but not list or tuple.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3197,8 +3197,10 @@ _tkinter__flatten(PyObject *module, PyObject *item)
 
     context.size = 0;
 
-    if (!_flatten1(&context, item,0))
+    if (!_flatten1(&context, item, 0)) {
+        Py_XDECREF(context.tuple);
         return NULL;
+    }
 
     if (_PyTuple_Resize(&context.tuple, context.size))
         return NULL;


### PR DESCRIPTION
if it is called with a sequence or set, but not list or tuple.


<!-- issue-number: [bpo-44608](https://bugs.python.org/issue44608) -->
https://bugs.python.org/issue44608
<!-- /issue-number -->
