### PR TITLE
bpo-44606: Fix __instancecheck__ and __subclasscheck__ for the union type.

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -674,6 +674,9 @@ class TypesTests(unittest.TestCase):
         x = int | None
         self.assertIsInstance(None, x)
         self.assertTrue(issubclass(type(None), x))
+        x = int | collections.abc.Mapping
+        self.assertIsInstance({}, x)
+        self.assertTrue(issubclass(dict, x))
 
     def test_bad_instancecheck(self):
         class BadMeta(type):

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -661,6 +661,36 @@ class TypesTests(unittest.TestCase):
             x.__args__ = [str, int]
             (int | str ) == x
 
+    def test_instancecheck(self):
+        x = int | str
+        self.assertIsInstance(1, x)
+        self.assertIsInstance(True, x)
+        self.assertIsInstance('a', x)
+        self.assertNotIsInstance(None, x)
+        self.assertTrue(issubclass(int, x))
+        self.assertTrue(issubclass(bool, x))
+        self.assertTrue(issubclass(str, x))
+        self.assertFalse(issubclass(type(None), x))
+        x = int | None
+        self.assertIsInstance(None, x)
+        self.assertTrue(issubclass(type(None), x))
+
+    def test_bad_instancecheck(self):
+        class BadMeta(type):
+            def __instancecheck__(cls, inst):
+                1/0
+        x = int | BadMeta('A', (), {})
+        self.assertTrue(isinstance(1, x))
+        self.assertRaises(ZeroDivisionError, isinstance, [], x)
+
+    def test_bad_subclasscheck(self):
+        class BadMeta(type):
+            def __subclasscheck__(cls, sub):
+                1/0
+        x = int | BadMeta('A', (), {})
+        self.assertTrue(issubclass(int, x))
+        self.assertRaises(ZeroDivisionError, issubclass, list, x)
+
     def test_or_type_operator_with_TypeVar(self):
         TV = typing.TypeVar('T')
         assert TV | str == typing.Union[TV, str]
@@ -754,9 +784,9 @@ class TypesTests(unittest.TestCase):
         for type_ in union_ga:
             with self.subTest(f"check isinstance/issubclass is invalid for {type_}"):
                 with self.assertRaises(TypeError):
-                    isinstance(list, type_)
+                    isinstance(1, type_)
                 with self.assertRaises(TypeError):
-                    issubclass(list, type_)
+                    issubclass(int, type_)
 
     def test_or_type_operator_with_bad_module(self):
         class TypeVar:

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-13-20-22-12.bpo-44606.S3Bv2w.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-13-20-22-12.bpo-44606.S3Bv2w.rst
@@ -1,0 +1,1 @@
+Fix ``__instancecheck__`` and ``__subclasscheck__`` for the union type.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -70,8 +70,14 @@ union_instancecheck(PyObject *self, PyObject *instance)
         if (arg == Py_None) {
             arg = (PyObject *)&_PyNone_Type;
         }
-        if (PyType_Check(arg) && PyObject_IsInstance(instance, arg) != 0) {
-            Py_RETURN_TRUE;
+        if (PyType_Check(arg)) {
+            int res = PyObject_IsInstance(instance, arg);
+            if (res < 0) {
+                return NULL;
+            }
+            if (res) {
+                Py_RETURN_TRUE;
+            }
         }
     }
     Py_RETURN_FALSE;
@@ -93,8 +99,17 @@ union_subclasscheck(PyObject *self, PyObject *instance)
     Py_ssize_t nargs = PyTuple_GET_SIZE(alias->args);
     for (Py_ssize_t iarg = 0; iarg < nargs; iarg++) {
         PyObject *arg = PyTuple_GET_ITEM(alias->args, iarg);
-        if (PyType_Check(arg) && (PyType_IsSubtype((PyTypeObject *)instance, (PyTypeObject *)arg) != 0)) {
-            Py_RETURN_TRUE;
+        if (arg == Py_None) {
+            arg = (PyObject *)&_PyNone_Type;
+        }
+        if (PyType_Check(arg)) {
+            int res = PyObject_IsSubclass(instance, arg);
+            if (res < 0) {
+                return NULL;
+            }
+            if (res) {
+                Py_RETURN_TRUE;
+            }
         }
     }
    Py_RETURN_FALSE;


### PR DESCRIPTION
* Fix issubclass() for None.
  E.g. issubclass(type(None), int | None) returns now True.
* Fix issubclass() for virtual subclasses.
  E.g. issubclass(dict, int | collections.abc.Mapping) returns now True.
* Fix crash in isinstance() if the check for one of items raises exception.


<!-- issue-number: [bpo-44606](https://bugs.python.org/issue44606) -->
https://bugs.python.org/issue44606
<!-- /issue-number -->
