### PR TITLE
bpo-43950: make BinOp specializations more reliable

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -485,6 +485,44 @@ class TracebackErrorLocationCaretTests(unittest.TestCase):
         )
         self.assertEqual(result_lines, expected_error.splitlines())
 
+    def assertSpecialized(self, func, expected_specialization):
+        result_lines = self.get_exception(func)
+        specialization_line = result_lines[-1]
+        self.assertEqual(specialization_line.lstrip(), expected_specialization)
+
+    def test_specialization_variations(self):
+        self.assertSpecialized(lambda: 1/0,
+                                      "~^~")
+        self.assertSpecialized(lambda: 1/0/3,
+                                      "~^~")
+        self.assertSpecialized(lambda: 1 / 0,
+                                      "~~^~~")
+        self.assertSpecialized(lambda: 1 / 0 / 3,
+                                      "~~^~~")
+        self.assertSpecialized(lambda: 1/ 0,
+                                      "~^~~")
+        self.assertSpecialized(lambda: 1/ 0/3,
+                                      "~^~~")
+        self.assertSpecialized(lambda: 1    /  0,
+                                      "~~~~~^~~~")
+        self.assertSpecialized(lambda: 1    /  0   / 5,
+                                      "~~~~~^~~~")
+        self.assertSpecialized(lambda: 1 /0,
+                                      "~~^~")
+        self.assertSpecialized(lambda: 1//0,
+                                      "~^^~")
+        self.assertSpecialized(lambda: 1//0//4,
+                                      "~^^~")
+        self.assertSpecialized(lambda: 1 // 0,
+                                      "~~^^~~")
+        self.assertSpecialized(lambda: 1 // 0 // 4,
+                                      "~~^^~~")
+        self.assertSpecialized(lambda: 1 //0,
+                                      "~~^^~")
+        self.assertSpecialized(lambda: 1// 0,
+                                      "~^^~~")
+
+
 @cpython_only
 @requires_debug_ranges()
 class CPythonTracebackErrorCaretTests(TracebackErrorLocationCaretTests):

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -496,7 +496,7 @@ class StackSummary(list):
 
                     try:
                         anchors = _extract_caret_anchors_from_line_segment(
-                            frame._original_line[colno - 1:end_colno]
+                            frame._original_line[colno - 1:end_colno - 1]
                         )
                     except Exception:
                         anchors = None

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -543,7 +543,7 @@ extract_anchors_from_expr(const char *segment_str, expr_ty expr, Py_ssize_t *lef
         case BinOp_kind: {
             expr_ty left = expr->v.BinOp.left;
             expr_ty right = expr->v.BinOp.right;
-            for (int i = left->end_col_offset + 1; i < right->col_offset; i++) {
+            for (int i = left->end_col_offset; i < right->col_offset; i++) {
                 if (IS_WHITESPACE(segment_str[i])) {
                     continue;
                 }


### PR DESCRIPTION
Ensure that we are parsing the correct segment (`[right->end, left->start)`) for BinOps.

<!-- issue-number: [bpo-43950](https://bugs.python.org/issue43950) -->
https://bugs.python.org/issue43950
<!-- /issue-number -->
