### PR TITLE
bpo-44630: Fix assertion errors in csv module

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -459,7 +459,7 @@ class TestDialectRegistry(unittest.TestCase):
             delimiter = "\u039B"
 
         class unspecified():
-            # A class to pass as dialect but with no attributes attributes.
+            # A class to pass as dialect but with no dialect attributes.
             pass
 
         csv.register_dialect('testC', testC)

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -458,9 +458,15 @@ class TestDialectRegistry(unittest.TestCase):
         class testUni(csv.excel):
             delimiter = "\u039B"
 
+        class unspecified():
+            # A class to pass as dialect but with no attributes attributes.
+            pass
+
         csv.register_dialect('testC', testC)
         try:
             self.compare_dialect_123("1,2,3\r\n")
+            self.compare_dialect_123("1,2,3\r\n", dialect=None)
+            self.compare_dialect_123("1,2,3\r\n", dialect=unspecified)
             self.compare_dialect_123("1\t2\t3\r\n", testA)
             self.compare_dialect_123("1:2:3\r\n", dialect=testB())
             self.compare_dialect_123("1|2|3\r\n", dialect='testC')

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -421,9 +421,14 @@ dialect_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     Py_XINCREF(skipinitialspace);
     Py_XINCREF(strict);
     if (dialect != NULL) {
-#define DIALECT_GETATTR(v, n) \
-        if (v == NULL) \
-            v = PyObject_GetAttrString(dialect, n)
+#define DIALECT_GETATTR(v, n)                            \
+        do {                                             \
+            if (v == NULL) {                             \
+                v = PyObject_GetAttrString(dialect, n);  \
+                if (v == NULL)                           \
+                    PyErr_Clear();                       \
+            }                                            \
+        } while (0)
         DIALECT_GETATTR(delimiter, "delimiter");
         DIALECT_GETATTR(doublequote, "doublequote");
         DIALECT_GETATTR(escapechar, "escapechar");
@@ -432,7 +437,6 @@ dialect_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         DIALECT_GETATTR(quoting, "quoting");
         DIALECT_GETATTR(skipinitialspace, "skipinitialspace");
         DIALECT_GETATTR(strict, "strict");
-        PyErr_Clear();
     }
 
     /* check types and convert to C values */


### PR DESCRIPTION
Fix assertion errors in the csv module, when passing None as the 'dialect' argument. The csv module not clearing exceptions between calls to PyObject_GetAttrString() causes assertion failures in pydebug mode (or with assertions enabled).

Add a minimal test that would've caught this (passing None as dialect, or any object that isn't a csv.Dialect subclass, which the csv module allows and caters to, even though it is not documented.) In pydebug mode, the test triggers the assertion failure in the old code.


<!-- issue-number: [bpo-44630](https://bugs.python.org/issue44630) -->
https://bugs.python.org/issue44630
<!-- /issue-number -->
