### PR TITLE
bpo-44589: raise SyntaxError when mapping pattern has duplicate key

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -968,9 +968,9 @@ Syntax:
 At most one double star pattern may be in a mapping pattern.  The double star
 pattern must be the last subpattern in the mapping pattern.
 
-Duplicate key values in mapping patterns are disallowed. (If all key patterns
-are literal patterns this is considered a syntax error; otherwise this is a
-runtime error and will raise :exc:`ValueError`.)
+Duplicate keys in mapping patterns are disallowed. Duplicate literal keys will
+raise a :exc:`SyntaxError`. Two keys that otherwise have the same value will
+raise a :exc:`ValueError` at runtime.
 
 The following is the logical flow for matching a mapping pattern against a
 subject value:
@@ -982,7 +982,8 @@ subject value:
    mapping, the mapping pattern succeeds.
 
 #. If duplicate keys are detected in the mapping pattern, the pattern is
-   considered invalid and :exc:`ValueError` is raised.
+   considered invalid. A :exc:`SyntaxError` is raised for duplicate literal
+   values; or a :exc:`ValueError` for named keys of the same value.
 
 .. note:: Key-value pairs are matched using the two-argument form of the mapping
    subject's ``get()`` method.  Matched key-value pairs must already be present

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2901,6 +2901,13 @@ class TestSyntaxErrors(unittest.TestCase):
                 pass
         """)
 
+    def test_mapping_pattern_duplicate_key(self):
+        self.assert_syntax_error("""
+        match ...:
+            case {"a": y, "a": z}:
+                pass
+        """)
+
 
 class TestTypeErrors(unittest.TestCase):
 
@@ -3007,17 +3014,6 @@ class TestTypeErrors(unittest.TestCase):
 
 
 class TestValueErrors(unittest.TestCase):
-
-    def test_mapping_pattern_checks_duplicate_key_0(self):
-        x = {"a": 0, "b": 1}
-        w = y = z = None
-        with self.assertRaises(ValueError):
-            match x:
-                case {"a": y, "a": z}:
-                    w = 0
-        self.assertIs(w, None)
-        self.assertIs(y, None)
-        self.assertIs(z, None)
 
     def test_mapping_pattern_checks_duplicate_key_1(self):
         class Keys:

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2904,10 +2904,37 @@ class TestSyntaxErrors(unittest.TestCase):
     def test_mapping_pattern_duplicate_key(self):
         self.assert_syntax_error("""
         match ...:
-            case {"a": y, "a": z}:
+            case {"a": _, "a": _}:
                 pass
         """)
 
+    def test_mapping_pattern_duplicate_key_edge_case0(self):
+        self.assert_syntax_error("""
+        match ...:
+            case {0: _, False: _}:
+                pass
+        """)
+
+    def test_mapping_pattern_duplicate_key_edge_case1(self):
+        self.assert_syntax_error("""
+        match ...:
+            case {0: _, 0.0: _}:
+                pass
+        """)
+
+    def test_mapping_pattern_duplicate_key_edge_case2(self):
+        self.assert_syntax_error("""
+        match ...:
+            case {0: _, -0: _}:
+                pass
+        """)
+
+    def test_mapping_pattern_duplicate_key_edge_case3(self):
+        self.assert_syntax_error("""
+        match ...:
+            case {0: _, 0j: _}:
+                pass
+        """)
 
 class TestTypeErrors(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-13-23-19-41.bpo-44589.59OH8T.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-13-23-19-41.bpo-44589.59OH8T.rst
@@ -1,2 +1,2 @@
-Mapping patterns in match/case statements with two or more identical literal
-keys causes a syntax error.
+Mapping patterns in ``match`` statements with two or more equal literal
+keys will now raise a :exc:`SyntaxError` at compile-time.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-13-23-19-41.bpo-44589.59OH8T.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-13-23-19-41.bpo-44589.59OH8T.rst
@@ -1,0 +1,2 @@
+Mapping patterns in match/case statements with two or more identical literal
+keys causes a syntax error.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6199,8 +6199,7 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
                 return 0;
             }
             if (in_seen) {
-                const char *e =  "Duplicate literal keys in match pattern are "
-                                 "not allowed";
+                const char *e =  "mapping pattern checks duplicate key (%R)";
                 Py_DECREF(seen);
                 return compiler_error(c, e);
             }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6199,7 +6199,10 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
                 Py_DECREF(seen);
                 return compiler_error(c, e);
             }
-            PySet_Add(seen, key->v.Constant.value);
+            if (PySet_Add(seen, key->v.Constant.value)) {
+                Py_DECREF(seen);
+                return 0;
+            }
         }
 
         if (!MATCH_VALUE_EXPR(key)) {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6214,7 +6214,9 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
             compiler_error(c, e);
             goto error;
         }
-        VISIT(c, expr, key);
+        if (!compiler_visit_expr(c, key)) {
+            goto error;
+        }
     }
 
     // all keys have been checked; there are no duplicates

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6179,7 +6179,7 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
     // will hold only Constant_kind keys
     PyObject *seen = PySet_New(NULL);
     if (seen == NULL) {
-        return -1;
+        return 0;
     }
 
     for (Py_ssize_t i = 0; i < size; i++) {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6185,8 +6185,8 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
     for (Py_ssize_t i = 0; i < size; i++) {
         expr_ty key = asdl_seq_GET(keys, i);
         if (key == NULL) {
-            const char *e = "can't use NULL keys in MatchMapping (set 'rest' "
-                            "parameter instead)";
+            const char *e = "can't use NULL keys in MatchMapping "
+                            "(set 'rest' parameter instead)";
             SET_LOC(c, ((pattern_ty) asdl_seq_GET(patterns, i)));
             Py_DECREF(seen);
             return compiler_error(c, e);

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6185,9 +6185,10 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
     for (Py_ssize_t i = 0; i < size; i++) {
         expr_ty key = asdl_seq_GET(keys, i);
         if (key == NULL) {
-            const char *e = "can't use NULL keys in MatchMapping "
-                            "(set 'rest' parameter instead)";
+            const char *e = "can't use NULL keys in MatchMapping (set 'rest' "
+                            "parameter instead)";
             SET_LOC(c, ((pattern_ty) asdl_seq_GET(patterns, i)));
+            Py_DECREF(seen);
             return compiler_error(c, e);
         }
 
@@ -6195,6 +6196,7 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
             if (PySet_Contains(seen, key->v.Constant.value)) {
                 const char *e =  "Duplicate literal keys in match pattern are "
                                  "not allowed";
+                Py_DECREF(seen);
                 return compiler_error(c, e);
             }
             PySet_Add(seen, key->v.Constant.value);
@@ -6202,6 +6204,7 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
 
         if (!MATCH_VALUE_EXPR(key)) {
             const char *e = "mapping pattern keys may only match literals and attribute lookups";
+            Py_DECREF(seen);
             return compiler_error(c, e);
         }
         VISIT(c, expr, key);

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6193,7 +6193,12 @@ compiler_pattern_mapping(struct compiler *c, pattern_ty p, pattern_context *pc)
         }
 
         if (key->kind == Constant_kind) {
-            if (PySet_Contains(seen, key->v.Constant.value)) {
+            int in_seen = PySet_Contains(seen, key->v.Constant.value);
+            if (in_seen < 0) {
+                Py_DECREF(seen);
+                return 0;
+            }
+            if (in_seen) {
                 const char *e =  "Duplicate literal keys in match pattern are "
                                  "not allowed";
                 Py_DECREF(seen);


### PR DESCRIPTION
* match case pattern cannot have duplicate keys per PEP 634.
* when duplicate literal values are present, a syntax error should be
  raised; not a runtime ValueError, which was the prior behavior.

Tests have been updated to test the new behavior. Docs were not changed, because the behavior is now more closely aligned with the documentation and the PEP.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44589](https://bugs.python.org/issue44589) -->
https://bugs.python.org/issue44589
<!-- /issue-number -->
