### PR TITLE
bpo-44632: Fix support of TypeVar in the union type

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -756,6 +756,7 @@ class TypesTests(unittest.TestCase):
     def test_or_type_repr(self):
         assert repr(int | None) == "int | None"
         assert repr(int | typing.GenericAlias(list, int)) == "int | list[int]"
+        assert repr(int | typing.TypeVar('T')) == "int | ~T"
 
     def test_or_type_operator_with_genericalias(self):
         a = list[int]
@@ -792,13 +793,18 @@ class TypesTests(unittest.TestCase):
                     issubclass(int, type_)
 
     def test_or_type_operator_with_bad_module(self):
-        class TypeVar:
+        class BadMeta(type):
+            __qualname__ = 'TypeVar'
             @property
             def __module__(self):
                 1 / 0
+        TypeVar = BadMeta('TypeVar', (), {})
+        _SpecialForm = BadMeta('_SpecialForm', (), {})
         # Crashes in Issue44483
         with self.assertRaises(ZeroDivisionError):
             str | TypeVar()
+        with self.assertRaises(ZeroDivisionError):
+            str | _SpecialForm()
 
     @cpython_only
     def test_or_type_operator_reference_cycle(self):

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -133,7 +133,7 @@ is_typing_name(PyObject *obj, char *name)
     if (strcmp(type->tp_name, name) != 0) {
         return 0;
     }
-    return is_typing_module(obj);
+    return is_typing_module((PyObject *)type);
 }
 
 static PyObject *


### PR DESCRIPTION


<!-- issue-number: [bpo-44632](https://bugs.python.org/issue44632) -->
https://bugs.python.org/issue44632
<!-- /issue-number -->
