### PR TITLE
bpo-44639: fix typo in sqlite.rst (transation => transaction)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -654,7 +654,7 @@ Cursor Objects
       This is a nonstandard convenience method for executing multiple SQL statements
       at once. It issues a ``COMMIT`` statement first, then executes the SQL script it
       gets as a parameter.  This method disregards :attr:`isolation_level`; any
-      transation control must be added to *sql_script*.
+      transaction control must be added to *sql_script*.
 
       *sql_script* can be an instance of :class:`str`.
 


### PR DESCRIPTION
To my understanding, this is supposed to say "transaction".

See the relevant source:

https://github.com/python/cpython/blob/a158b20019b50e3ece6e4743ec4e6ae8d818b690/Modules/_sqlite/connection.c#L1434-L1467

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44639](https://bugs.python.org/issue44639) -->
https://bugs.python.org/issue44639
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal