### PR TITLE
bpo-44622: Set line number of END_ASYNC_FOR to match that of iterator.

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -943,7 +943,7 @@ if 1:
         genexp_lines = [None, 1, 3, 1]
 
         genexp_code = return_genexp.__code__.co_consts[1]
-        code_lines = [None if line is None else line-return_genexp.__code__.co_firstlineno
+        code_lines = [ None if line is None else line-return_genexp.__code__.co_firstlineno
                       for (_, _, line) in genexp_code.co_lines() ]
         self.assertEqual(genexp_lines, code_lines)
 
@@ -954,10 +954,9 @@ if 1:
                body
 
         expected_lines = [None, 1, 2, 1]
-        code_lines = [None if line is None else line-test.__code__.co_firstlineno
+        code_lines = [ None if line is None else line-test.__code__.co_firstlineno
                       for (_, _, line) in test.__code__.co_lines() ]
         self.assertEqual(expected_lines, code_lines)
-
 
     def test_big_dict_literal(self):
         # The compiler has a flushing point in "compiler_dict" that calls compiles

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -947,6 +947,17 @@ if 1:
                       for (_, _, line) in genexp_code.co_lines() ]
         self.assertEqual(genexp_lines, code_lines)
 
+    def test_line_number_implicit_return_after_async_for(self):
+
+        async def test(aseq):
+            async for i in aseq:
+               body
+
+        expected_lines = [None, 1, 2, 1]
+        code_lines = [None if line is None else line-test.__code__.co_firstlineno
+                      for (_, _, line) in test.__code__.co_lines() ]
+        self.assertEqual(expected_lines, code_lines)
+
 
     def test_big_dict_literal(self):
         # The compiler has a flushing point in "compiler_dict" that calls compiles

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -951,7 +951,7 @@ if 1:
 
         async def test(aseq):
             async for i in aseq:
-               body
+                body
 
         expected_lines = [None, 1, 2, 1]
         code_lines = [ None if line is None else line-test.__code__.co_firstlineno

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3002,7 +3002,7 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     /* Except block for __anext__ */
     compiler_use_next_block(c, except);
 
-    UNSET_LOC(c);
+    SET_LOC(c, s->v.AsyncFor.iter);
     ADDOP(c, END_ASYNC_FOR);
 
     /* `else` block */

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3002,6 +3002,8 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     /* Except block for __anext__ */
     compiler_use_next_block(c, except);
 
+    /* Use same line number as the iterator,
+     * as the END_ASYNC_FOR succeeds the `for`, not the body. */
     SET_LOC(c, s->v.AsyncFor.iter);
     ADDOP(c, END_ASYNC_FOR);
 


### PR DESCRIPTION
`END_ASYNC_FOR` can only follow the iterator, so giving it the same line number as the iterator is correct even though `END_ASYNC_FOR` is artificial.

By giving `END_ASYNC_FOR` a real line number, any artificial code following it gets a meaningful line number.


<!-- issue-number: [bpo-44622](https://bugs.python.org/issue44622) -->
https://bugs.python.org/issue44622
<!-- /issue-number -->
