### PR TITLE
bpo-44647: Fix test_httpservers failing on Unicode characters in os.environ on Windows

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -367,7 +367,7 @@ def init(files=None):
     if files is None or _db is None:
         db = MimeTypes()
         # Quick return if not supported
-        db.read_windows_registry()
+        # db.read_windows_registry()
 
         if files is None:
             files = knownfiles

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -367,7 +367,7 @@ def init(files=None):
     if files is None or _db is None:
         db = MimeTypes()
         # Quick return if not supported
-        # db.read_windows_registry()
+        db.read_windows_registry()
 
         if files is None:
             files = knownfiles

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -855,7 +855,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
             with self.subTest(headers):
                 res = self.request('/cgi-bin/file6.py', 'GET', headers=headers)
                 self.assertEqual(http.HTTPStatus.OK, res.status)
-                print(count, self.HOST, self.PORT, res.length, res.status, repr(res.headers), repr(os.environ))
+                print(count, self.HOST, self.PORT, res.length, res.status, repr(str(res.headers)), str(os.environ))
                 expected = f"'HTTP_ACCEPT': {expected!r}"
                 self.assertIn(expected.encode('ascii'), res.read())
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -855,7 +855,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
             with self.subTest(headers):
                 res = self.request('/cgi-bin/file6.py', 'GET', headers=headers)
                 self.assertEqual(http.HTTPStatus.OK, res.status)
-                print(count, self.HOST, self.PORT, res.length, res.status, repr(str(res.headers)), str(os.environ))
+                print(count, self.HOST, self.PORT, res.length, res.status, repr(str(res.headers)), dict(os.environ))
                 expected = f"'HTTP_ACCEPT': {expected!r}"
                 self.assertIn(expected.encode('ascii'), res.read())
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -845,11 +845,14 @@ class CGIHTTPServerTestCase(BaseTestCase):
             ((('Accept', 'text/html'), ('ACCEPT', 'text/plain')),
                'text/html,text/plain'),
         )
+        count = 0
         for headers, expected in tests:
+            count += 1
             headers = OrderedDict(headers)
             with self.subTest(headers):
                 res = self.request('/cgi-bin/file6.py', 'GET', headers=headers)
                 self.assertEqual(http.HTTPStatus.OK, res.status)
+                print(count, res.length, res.status, res.headers)
                 expected = f"'HTTP_ACCEPT': {expected!r}"
                 self.assertIn(expected.encode('ascii'), res.read())
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -593,9 +593,12 @@ cgi_file6 = """\
 #!%s
 import os
 
-print("Content-type: text/plain")
+print("X-ambv: was here")
+print("Content-type: text/html")
 print()
+print("<pre>")
 print(repr(os.environ))
+print("</pre>")
 """
 
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -855,7 +855,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
             with self.subTest(headers):
                 res = self.request('/cgi-bin/file6.py', 'GET', headers=headers)
                 self.assertEqual(http.HTTPStatus.OK, res.status)
-                print(count, self.HOST, self.PORT, res.length, res.status, res.headers)
+                print(count, self.HOST, self.PORT, res.length, res.status, repr(res.headers), repr(os.environ))
                 expected = f"'HTTP_ACCEPT': {expected!r}"
                 self.assertIn(expected.encode('ascii'), res.read())
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -852,7 +852,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
             with self.subTest(headers):
                 res = self.request('/cgi-bin/file6.py', 'GET', headers=headers)
                 self.assertEqual(http.HTTPStatus.OK, res.status)
-                print(count, res.length, res.status, res.headers)
+                print(count, self.HOST, self.PORT, res.length, res.status, res.headers)
                 expected = f"'HTTP_ACCEPT': {expected!r}"
                 self.assertIn(expected.encode('ascii'), res.read())
 


### PR DESCRIPTION
GH-23638 introduced a new test for Accept: headers in CGI HTTP servers. This test serializes all of `os.environ` on the server side.  For non-UTF8 locales this can fail for some Unicode characters found in environment variables. This change fixes the HTTP_ACCEPT test.

Check the issue for more details, and the comments in this PR for hunting the root cause down. This was first encountered when working on GH-27115.

<!-- issue-number: [bpo-44647](https://bugs.python.org/issue44647) -->
https://bugs.python.org/issue44647
<!-- /issue-number -->
