### PR TITLE
bpo-44645: Check for interrupts on any potentially backwards edge.

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1604,6 +1604,20 @@ class InterruptMainTests(unittest.TestCase):
         self.assertRaises(ValueError, _thread.interrupt_main, signal.NSIG)
         self.assertRaises(ValueError, _thread.interrupt_main, 1000000)
 
+    def test_can_interrupt_tight_loops(self):
+        #Nothing to assert here. It just shouldn't hang.
+
+        cont = True
+        def worker():
+            while cont:
+                pass
+
+        t = threading.Thread(target=worker)
+        t.start()
+        time.sleep(0.1)
+        cont = False
+        t.join()
+
 
 class AtexitTests(unittest.TestCase):
 

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1604,17 +1604,22 @@ class InterruptMainTests(unittest.TestCase):
         self.assertRaises(ValueError, _thread.interrupt_main, signal.NSIG)
         self.assertRaises(ValueError, _thread.interrupt_main, 1000000)
 
+    @threading_helper.reap_threads
     def test_can_interrupt_tight_loops(self):
         #Nothing to assert here. It just shouldn't hang.
 
         cont = True
+        started = False
         def worker():
+            nonlocal started
+            started = True
             while cont:
                 pass
 
         t = threading.Thread(target=worker)
         t.start()
-        time.sleep(0.1)
+        while not started:
+            pass
         cont = False
         t.join()
 

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1606,14 +1606,19 @@ class InterruptMainTests(unittest.TestCase):
 
     @threading_helper.reap_threads
     def test_can_interrupt_tight_loops(self):
-        #Nothing to assert here. It just shouldn't hang.
-
         cont = True
         started = False
+        iterations = 100_000_000
+
         def worker():
+            nonlocal iterations
             nonlocal started
             started = True
             while cont:
+                if iterations:
+                    iterations -= 1
+                else:
+                    return
                 pass
 
         t = threading.Thread(target=worker)
@@ -1622,6 +1627,7 @@ class InterruptMainTests(unittest.TestCase):
             pass
         cont = False
         t.join()
+        self.assertNotEqual(iterations, 0)
 
 
 class AtexitTests(unittest.TestCase):

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3638,14 +3638,17 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
             if (Py_IsFalse(cond)) {
                 Py_DECREF(cond);
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
                 DISPATCH();
             }
             err = PyObject_IsTrue(cond);
             Py_DECREF(cond);
             if (err > 0)
                 ;
-            else if (err == 0)
+            else if (err == 0) {
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
+            }
             else
                 goto error;
             DISPATCH();
@@ -3662,12 +3665,14 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
             if (Py_IsTrue(cond)) {
                 Py_DECREF(cond);
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
                 DISPATCH();
             }
             err = PyObject_IsTrue(cond);
             Py_DECREF(cond);
             if (err > 0) {
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
             }
             else if (err == 0)
                 ;


### PR DESCRIPTION



<!-- issue-number: [bpo-44645](https://bugs.python.org/issue44645) -->
https://bugs.python.org/issue44645
<!-- /issue-number -->