### PR TITLE
bpo-44648: Fix error type in inspect.getsource() in interactive session

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -781,6 +781,8 @@ def getfile(object):
             module = sys.modules.get(object.__module__)
             if getattr(module, '__file__', None):
                 return module.__file__
+            if object.__module__ == '__main__':
+                raise OSError('source code not available')
         raise TypeError('{!r} is a built-in class'.format(object))
     if ismethod(object):
         object = object.__func__

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -585,6 +585,15 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getsource_on_code_object(self):
         self.assertSourceEqual(mod.eggs.__code__, 12, 18)
 
+class TestGetsourceInteractive(unittest.TestCase):
+    def tearDown(self):
+        mod.ParrotDroppings.__module__ = mod
+
+    def test_getclasses_interactive(self):
+        mod.ParrotDroppings.__module__ = '__main__'
+        with self.assertRaises(OSError) as e:
+            inspect.getsource(mod.ParrotDroppings)
+
 class TestGettingSourceOfToplevelFrames(GetSourceBase):
     fodderModule = mod
 
@@ -4301,7 +4310,8 @@ def test_main():
         TestBoundArguments, TestSignaturePrivateHelpers,
         TestSignatureDefinitions, TestIsDataDescriptor,
         TestGetClosureVars, TestUnwrap, TestMain, TestReload,
-        TestGetCoroutineState, TestGettingSourceOfToplevelFrames
+        TestGetCoroutineState, TestGettingSourceOfToplevelFrames,
+        TestGetsourceInteractive,
     )
 
 if __name__ == "__main__":

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -588,10 +588,15 @@ class TestRetrievingSourceCode(GetSourceBase):
 class TestGetsourceInteractive(unittest.TestCase):
     def tearDown(self):
         mod.ParrotDroppings.__module__ = mod
+        sys.modules['__main__'] = self.main
 
     def test_getclasses_interactive(self):
+        self.main = sys.modules['__main__']
+        class MockModule:
+            __file__ = None
+        sys.modules['__main__'] = MockModule
         mod.ParrotDroppings.__module__ = '__main__'
-        with self.assertRaises(OSError) as e:
+        with self.assertRaisesRegex(OSError, 'source code not available') as e:
             inspect.getsource(mod.ParrotDroppings)
 
 class TestGettingSourceOfToplevelFrames(GetSourceBase):

--- a/Misc/NEWS.d/next/Library/2021-07-15-16-51-32.bpo-44648.2o49TB.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-15-16-51-32.bpo-44648.2o49TB.rst
@@ -1,0 +1,3 @@
+Fixed wrong error being thrown by :func:`inspect.getsource` when examining a
+class in the interactive session. Instead of :exc:`TypeError`, it should be
+:exc:`OSError` with appropriate error message.


### PR DESCRIPTION
Fix error TypeError, 'built in class' => OSError, 'source code not available'

<!-- issue-number: [bpo-44648](https://bugs.python.org/issue44648) -->
https://bugs.python.org/issue44648
<!-- /issue-number -->
