### PR TITLE
bpo-40897:Give priority to using the current class constructor in `inspect.signature`

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2444,23 +2444,23 @@ def _signature_from_callable(obj, *,
         if call is not None:
             sig = _get_signature_of(call)
         else:
-            create_method = None
-            # Now we check if the 'obj' class has a '__new__' method
+            factory_method = None
             new = _signature_get_user_defined_method(obj, '__new__')
-            # Finally, we should have at least __init__ implemented
             init = _signature_get_user_defined_method(obj, '__init__')
-            # Give priority to using the current class constructor
+            # Now we check if the 'obj' class has an own '__new__' method
             if '__new__' in obj.__dict__:
-                create_method = new
+                factory_method = new
+            # or an own '__init__' method
             elif '__init__' in obj.__dict__:
-                create_method = init
+                factory_method = init
+            # If not, we take inherited '__new__' or '__init__', if present
             elif new is not None:
-                create_method = new
+                factory_method = new
             elif init is not None:
-                create_method = init
+                factory_method = init
 
-            if create_method is not None:
-                sig = _get_signature_of(create_method)
+            if factory_method is not None:
+                sig = _get_signature_of(factory_method)
 
         if sig is None:
             # At this point we know, that `obj` is a class, with no user-

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3063,6 +3063,34 @@ class TestSignatureObject(unittest.TestCase):
                            ('bar', 2, ..., "keyword_only")),
                           ...))
 
+    def test_signature_on_subclass(self):
+        class A:
+            def __new__(cls, a=1, *args, **kwargs):
+                return object.__new__(cls)
+        class B(A):
+            def __init__(self, b):
+                pass
+        class C(A):
+            def __new__(cls, a=1, b=2, *args, **kwargs):
+                return object.__new__(cls)
+        class D(A):
+            pass
+
+        self.assertEqual(self.signature(B),
+                         ((('b', ..., ..., "positional_or_keyword"),),
+                          ...))
+        self.assertEqual(self.signature(C),
+                         ((('a', 1, ..., 'positional_or_keyword'),
+                           ('b', 2, ..., 'positional_or_keyword'),
+                           ('args', ..., ..., 'var_positional'),
+                           ('kwargs', ..., ..., 'var_keyword')),
+                          ...))
+        self.assertEqual(self.signature(D),
+                         ((('a', 1, ..., 'positional_or_keyword'),
+                           ('args', ..., ..., 'var_positional'),
+                           ('kwargs', ..., ..., 'var_keyword')),
+                          ...))
+
     @unittest.skipIf(MISSING_C_DOCSTRINGS,
                      "Signature information for builtins requires docstrings")
     def test_signature_on_class_without_init(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3091,6 +3091,19 @@ class TestSignatureObject(unittest.TestCase):
                            ('kwargs', ..., ..., 'var_keyword')),
                           ...))
 
+    def test_signature_on_generic_subclass(self):
+        from typing import Generic, TypeVar
+
+        T = TypeVar('T')
+
+        class A(Generic[T]):
+            def __init__(self, *, a: int) -> None:
+                pass
+
+        self.assertEqual(self.signature(A),
+                         ((('a', ..., int, 'keyword_only'),),
+                          None))
+
     @unittest.skipIf(MISSING_C_DOCSTRINGS,
                      "Signature information for builtins requires docstrings")
     def test_signature_on_class_without_init(self):

--- a/Misc/NEWS.d/next/Library/2021-07-16-13-40-31.bpo-40897.aveAre.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-16-13-40-31.bpo-40897.aveAre.rst
@@ -1,0 +1,2 @@
+Give priority to using the current class constructor in
+:func:`inspect.signature`. Patch by Weipeng Hong.


### PR DESCRIPTION


<!-- issue-number: [bpo-40897](https://bugs.python.org/issue40897) -->
https://bugs.python.org/issue40897
<!-- /issue-number -->
