### PR TITLE
bpo-44636: Collapse union of equal types

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -623,7 +623,7 @@ class TypesTests(unittest.TestCase):
         self.assertEqual(None | typing.List[int], typing.Union[None, typing.List[int]])
         self.assertEqual(str | float | int | complex | int, (int | str) | (float | complex))
         self.assertEqual(typing.Union[str, int, typing.List[int]], str | int | typing.List[int])
-        self.assertEqual(int | int, int)
+        self.assertIs(int | int, int)
         self.assertEqual(
             BaseException |
             bool |
@@ -651,6 +651,8 @@ class TypesTests(unittest.TestCase):
             3 | int
         with self.assertRaises(TypeError):
             Example() | int
+        x = int | str
+        self.assertNotEqual(x, {})
         with self.assertRaises(TypeError):
             (int | str) < typing.Union[str, int]
         with self.assertRaises(TypeError):
@@ -700,6 +702,8 @@ class TypesTests(unittest.TestCase):
         TV = typing.TypeVar('T')
         assert TV | str == typing.Union[TV, str]
         assert str | TV == typing.Union[str, TV]
+        self.assertIs((int | TV)[int], int)
+        self.assertIs((TV | int)[int], int)
 
     def test_union_args(self):
         self.assertEqual((int | str).__args__, (int, str))
@@ -717,6 +721,7 @@ class TypesTests(unittest.TestCase):
         self.assertEqual(list[int | list[T]][str], list[int | list[str]])
         self.assertEqual((list[T] | list[S]).__parameters__, (T, S))
         self.assertEqual((list[T] | list[S])[int, T], list[int] | list[T])
+        self.assertEqual((list[T] | list[S])[int, int], list[int])
 
     def test_or_type_operator_with_forward(self):
         T = typing.TypeVar('T')

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-16-09-36-12.bpo-44636.ZWebi8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-16-09-36-12.bpo-44636.ZWebi8.rst
@@ -1,0 +1,1 @@
+Collapse union of equal types. E.g. the result of ``int | int`` is now ``int``. Fix comparison of the union type with non-hashable objects. E.g. ``int | str == {}`` no longer raises a TypeError.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -185,9 +185,9 @@ union_richcompare(PyObject *a, PyObject *b, int op)
             }
         }
     } else {
-        if (PySet_Add(b_set, b) == -1) {
-            goto exit;
-        }
+        Py_DECREF(a_set);
+        Py_DECREF(b_set);
+        Py_RETURN_NOTIMPLEMENTED;
     }
     result = PyObject_RichCompare(a_set, b_set, op);
 exit:
@@ -549,17 +549,25 @@ _Py_Union(PyObject *args)
         }
     }
 
+    args = dedup_and_flatten_args(args);
+    if (args == NULL) {
+        return NULL;
+    }
+    if (PyTuple_GET_SIZE(args) == 1) {
+        PyObject *result1 = PyTuple_GET_ITEM(args, 0);
+        Py_INCREF(result1);
+        Py_DECREF(args);
+        return result1;
+    }
+
     result = PyObject_GC_New(unionobject, &_Py_UnionType);
     if (result == NULL) {
+        Py_DECREF(args);
         return NULL;
     }
 
     result->parameters = NULL;
-    result->args = dedup_and_flatten_args(args);
+    result->args = args;
     _PyObject_GC_TRACK(result);
-    if (result->args == NULL) {
-        Py_DECREF(result);
-        return NULL;
-    }
     return (PyObject*)result;
 }


### PR DESCRIPTION
The result of `int | int` is now `int`.

Fix comparison of the union type with non-hashable objects.
`int | str == {}` no longer raises a TypeError.


<!-- issue-number: [bpo-44636](https://bugs.python.org/issue44636) -->
https://bugs.python.org/issue44636
<!-- /issue-number -->
