### PR TITLE
bpo-44646: Fix the hash of the union type.

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -663,6 +663,10 @@ class TypesTests(unittest.TestCase):
             x.__args__ = [str, int]
             (int | str ) == x
 
+    def test_hash(self):
+        self.assertEqual(hash(int | str), hash(str | int))
+        self.assertEqual(hash(int | str), hash(typing.Union[int, str]))
+
     def test_instancecheck(self):
         x = int | str
         self.assertIsInstance(1, x)

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-16-09-59-13.bpo-44646.Yb6s05.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-16-09-59-13.bpo-44646.Yb6s05.rst
@@ -1,0 +1,2 @@
+Fix the hash of the union type: it no longer depends on the order of
+arguments.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -36,11 +36,13 @@ static Py_hash_t
 union_hash(PyObject *self)
 {
     unionobject *alias = (unionobject *)self;
-    Py_hash_t h1 = PyObject_Hash(alias->args);
-    if (h1 == -1) {
-        return -1;
+    PyObject *args = PyFrozenSet_New(alias->args);
+    if (args == NULL) {
+        return (Py_hash_t)-1;
     }
-    return h1;
+    Py_hash_t hash = PyObject_Hash(args);
+    Py_DECREF(args);
+    return hash;
 }
 
 static int


### PR DESCRIPTION
It no longer depends on the order of arguments.
`hash(int | str) == hash(str | int)`


<!-- issue-number: [bpo-44646](https://bugs.python.org/issue44646) -->
https://bugs.python.org/issue44646
<!-- /issue-number -->
