### PR TITLE
[3.10] bpo-44645: Check for interrupts on any potentially backwards edge.

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1604,6 +1604,31 @@ class InterruptMainTests(unittest.TestCase):
         self.assertRaises(ValueError, _thread.interrupt_main, signal.NSIG)
         self.assertRaises(ValueError, _thread.interrupt_main, 1000000)
 
+    @threading_helper.reap_threads
+    def test_can_interrupt_tight_loops(self):
+        cont = True
+        started = False
+        iterations = 100_000_000
+
+        def worker():
+            nonlocal iterations
+            nonlocal started
+            started = True
+            while cont:
+                if iterations:
+                    iterations -= 1
+                else:
+                    return
+                pass
+
+        t = threading.Thread(target=worker)
+        t.start()
+        while not started:
+            pass
+        cont = False
+        t.join()
+        self.assertNotEqual(iterations, 0)
+
 
 class AtexitTests(unittest.TestCase):
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3759,14 +3759,17 @@ main_loop:
             if (Py_IsFalse(cond)) {
                 Py_DECREF(cond);
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
                 DISPATCH();
             }
             err = PyObject_IsTrue(cond);
             Py_DECREF(cond);
             if (err > 0)
                 ;
-            else if (err == 0)
+            else if (err == 0) {
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
+            }
             else
                 goto error;
             DISPATCH();
@@ -3783,12 +3786,14 @@ main_loop:
             if (Py_IsTrue(cond)) {
                 Py_DECREF(cond);
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
                 DISPATCH();
             }
             err = PyObject_IsTrue(cond);
             Py_DECREF(cond);
             if (err > 0) {
                 JUMPTO(oparg);
+                CHECK_EVAL_BREAKER();
             }
             else if (err == 0)
                 ;


### PR DESCRIPTION
Backport of #27167

<!-- issue-number: [bpo-44645](https://bugs.python.org/issue44645) -->
https://bugs.python.org/issue44645
<!-- /issue-number -->
