### PR TITLE
 bpo-44647: Add a permanent Unicode-valued env var to regrtest 

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -14,6 +14,9 @@ from test.libregrtest.utils import (setup_unraisable_hook,
                                     setup_threading_excepthook)
 
 
+UNICODE_GUARD_ENV = "PYTHONREGRTEST_UNICODE_GUARD"
+
+
 def setup_tests(ns):
     try:
         stderr_fd = sys.__stderr__.fileno()
@@ -97,6 +100,13 @@ def setup_tests(ns):
     if ns.xmlpath:
         from test.support.testresult import RegressionTestResult
         RegressionTestResult.USE_XML = True
+
+    # Ensure there's a non-ASCII character in env vars at all times to force
+    # tests consider this case. See BPO-44647 for details.
+    os.environ.setdefault(
+        UNICODE_GUARD_ENV,
+        "\N{SMILING FACE WITH SUNGLASSES}",
+    )
 
 
 def replace_stdout():

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -19,7 +19,7 @@ import unittest
 from test import libregrtest
 from test import support
 from test.support import os_helper
-from test.libregrtest import utils
+from test.libregrtest import utils, setup
 
 
 Py_DEBUG = hasattr(sys, 'gettotalrefcount')
@@ -1297,6 +1297,14 @@ class ArgsTestCase(BaseTestCase):
                                   fail_env_changed=True)
         self.assertIn("Warning -- Uncaught thread exception", output)
         self.assertIn("Exception: bug in thread", output)
+
+    def test_unicode_guard_env(self):
+        guard = os.environ.get(setup.UNICODE_GUARD_ENV)
+        self.assertIsNotNone(guard, f"{setup.UNICODE_GUARD_ENV} not set")
+        if guard != "\N{SMILING FACE WITH SUNGLASSES}":
+            # Skip to signify that the env var value was changed by the user;
+            # possibly to something ASCII to work around Unicode issues.
+            self.skipTest("Modified guard")
 
     def test_cleanup(self):
         dirname = os.path.join(self.tmptestdir, "test_python_123")

--- a/Misc/NEWS.d/next/Tests/2021-07-16-14-02-33.bpo-44647.5LzqIy.rst
+++ b/Misc/NEWS.d/next/Tests/2021-07-16-14-02-33.bpo-44647.5LzqIy.rst
@@ -1,0 +1,4 @@
+Added a permanent Unicode-valued environment variable to regression tests to
+ensure they handle this use case in the future. If your test environment
+breaks because of that, report a bug to us, and temporarily set
+PYTHONREGRTEST_UNICODE_GUARD=0 in your test environment.


### PR DESCRIPTION
Added a permanent Unicode-valued environment variable to regression tests to
ensure they handle this use case in the future. If your test environment
breaks because of that, report a bug to us, and temporarily set
PYTHONREGRTEST_UNICODE_GUARD=0 in your test environment.

<!-- issue-number: [bpo-44647](https://bugs.python.org/issue44647) -->
https://bugs.python.org/issue44647
<!-- /issue-number -->
