### PR TITLE
bpo-44725 : expose specialization stats in python

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -322,9 +322,7 @@ extern SpecializationStats _specialization_stats[256];
 #define STAT_INC(opname, name) _specialization_stats[opname].name++
 void _Py_PrintSpecializationStats(void);
 
-#if SPECIALIZATION_STATS
 PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
-#endif
 
 #else
 #define STAT_INC(opname, name) ((void)0)

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -321,6 +321,11 @@ typedef struct _stats {
 extern SpecializationStats _specialization_stats[256];
 #define STAT_INC(opname, name) _specialization_stats[opname].name++
 void _Py_PrintSpecializationStats(void);
+
+#if SPECIALIZATION_STATS
+PyAPI_FUNC(PyObject*) _Py_GetSpecializationStats(void);
+#endif
+
 #else
 #define STAT_INC(opname, name) ((void)0)
 #endif

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -234,3 +234,13 @@ _specialized_instructions = [
     "LOAD_GLOBAL_MODULE",
     "LOAD_GLOBAL_BUILTIN",
 ]
+
+_specialization_stats = [
+    "specialization_success",
+    "specialization_failure",
+    "hit",
+    "deferred",
+    "miss",
+    "deopt",
+    "unquickened",
+]

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -82,11 +82,11 @@ class SpecializationStatsTests(unittest.TestCase):
             self.assertCountEqual(stats.keys(), specialized_opcodes)
             self.assertCountEqual(
                 stats['load_attr'].keys(),
-                stat_names + ['detailed'])
+                stat_names + ['fails'])
             for sn in stat_names:
                 self.assertIsInstance(stats['load_attr'][sn], int)
-            self.assertIsInstance(stats['load_attr']['detailed'], dict)
-            for k,v in stats['load_attr']['detailed'].items():
+            self.assertIsInstance(stats['load_attr']['fails'], dict)
+            for k,v in stats['load_attr']['fails'].items():
                 self.assertIsInstance(k, tuple)
                 self.assertIsInstance(v, int)
 

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -67,8 +67,7 @@ class OpcodeTests(unittest.TestCase):
 
 class SpecializationStatsTests(unittest.TestCase):
     def test_specialization_stats(self):
-        STAT_NAMES = ['specialization_success', 'specialization_failure',
-                      'hit', 'deferred', 'miss', 'deopt', 'unquickened']
+        stat_names = opcode._specialization_stats
 
         specialized_opcodes = [
             op[:-len("_ADAPTIVE")].lower() for
@@ -83,8 +82,8 @@ class SpecializationStatsTests(unittest.TestCase):
             self.assertCountEqual(stats.keys(), specialized_opcodes)
             self.assertCountEqual(
                 stats['load_attr'].keys(),
-                STAT_NAMES + ['detailed'])
-            for sn in STAT_NAMES:
+                stat_names + ['detailed'])
+            for sn in stat_names:
                 self.assertIsInstance(stats['load_attr'][sn], int)
             self.assertIsInstance(stats['load_attr']['detailed'], dict)
             for k,v in stats['load_attr']['detailed'].items():

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -64,5 +64,27 @@ class OpcodeTests(unittest.TestCase):
                     self.assertEqual(nojump, common)
 
 
+class SpecializationStatsTests(unittest.TestCase):
+    def test_specialization_stats(self):
+        STAT_NAMES = ['specialization_success', 'specialization_failure',
+                      'hit', 'deferred', 'miss', 'deopt', 'unquickened']
+
+        stats = _opcode.get_specialization_stats()
+        if stats is not None:
+            self.assertIsInstance(stats, dict)
+            self.assertCountEqual(
+                stats.keys(),
+                ['load_attr', 'load_global', 'binary_subscr'])
+            self.assertCountEqual(
+                stats['load_attr'].keys(),
+                STAT_NAMES + ['detailed'])
+            for sn in STAT_NAMES:
+                self.assertIsInstance(stats['load_attr'][sn], int)
+            self.assertIsInstance(stats['load_attr']['detailed'], dict)
+            for k,v in stats['load_attr']['detailed'].items():
+                self.assertIsInstance(k, tuple)
+                self.assertIsInstance(v, int)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -1,6 +1,7 @@
 import dis
 from test.support.import_helper import import_module
 import unittest
+import opcode
 
 _opcode = import_module("_opcode")
 from _opcode import stack_effect
@@ -69,12 +70,17 @@ class SpecializationStatsTests(unittest.TestCase):
         STAT_NAMES = ['specialization_success', 'specialization_failure',
                       'hit', 'deferred', 'miss', 'deopt', 'unquickened']
 
+        specialized_opcodes = [
+            op[:-len("_ADAPTIVE")].lower() for
+            op in opcode._specialized_instructions
+            if op.endswith("_ADAPTIVE")]
+        self.assertIn('load_attr', specialized_opcodes)
+        self.assertIn('binary_subscr', specialized_opcodes)
+
         stats = _opcode.get_specialization_stats()
         if stats is not None:
             self.assertIsInstance(stats, dict)
-            self.assertCountEqual(
-                stats.keys(),
-                ['load_attr', 'load_global', 'binary_subscr'])
+            self.assertCountEqual(stats.keys(), specialized_opcodes)
             self.assertCountEqual(
                 stats['load_attr'].keys(),
                 STAT_NAMES + ['detailed'])

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-23-15-17-01.bpo-44725.qcuKaa.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-23-15-17-01.bpo-44725.qcuKaa.rst
@@ -1,0 +1,1 @@
+Expose specialization stats in python via :func:`_opcode.get_specialization_stats`.

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -88,7 +88,7 @@ _opcode_get_specialization_stats_impl(PyObject *module)
 #if SPECIALIZATION_STATS
     return _Py_GetSpecializationStats();
 #else
-    return Py_NewRef(Py_None);
+    Py_RETURN_NONE;
 #endif
 }
 

--- a/Modules/_opcode.c
+++ b/Modules/_opcode.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "opcode.h"
+#include "internal/pycore_code.h"
 
 /*[clinic input]
 module _opcode
@@ -73,9 +74,28 @@ _opcode_stack_effect_impl(PyObject *module, int opcode, PyObject *oparg,
     return effect;
 }
 
+/*[clinic input]
+
+_opcode.get_specialization_stats
+
+Return the specialization stats
+[clinic start generated code]*/
+
+static PyObject *
+_opcode_get_specialization_stats_impl(PyObject *module)
+/*[clinic end generated code: output=fcbc32fdfbec5c17 input=e1f60db68d8ce5f6]*/
+{
+#if SPECIALIZATION_STATS
+    return _Py_GetSpecializationStats();
+#else
+    return Py_NewRef(Py_None);
+#endif
+}
+
 static PyMethodDef
 opcode_functions[] =  {
     _OPCODE_STACK_EFFECT_METHODDEF
+    _OPCODE_GET_SPECIALIZATION_STATS_METHODDEF
     {NULL, NULL, 0, NULL}
 };
 

--- a/Modules/clinic/_opcode.c.h
+++ b/Modules/clinic/_opcode.c.h
@@ -56,4 +56,22 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=bcf66d25c2624197 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_opcode_get_specialization_stats__doc__,
+"get_specialization_stats($module, /)\n"
+"--\n"
+"\n"
+"Return the specialization stats");
+
+#define _OPCODE_GET_SPECIALIZATION_STATS_METHODDEF    \
+    {"get_specialization_stats", (PyCFunction)_opcode_get_specialization_stats, METH_NOARGS, _opcode_get_specialization_stats__doc__},
+
+static PyObject *
+_opcode_get_specialization_stats_impl(PyObject *module);
+
+static PyObject *
+_opcode_get_specialization_stats(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _opcode_get_specialization_stats_impl(module);
+}
+/*[clinic end generated code: output=1699b4b1488b49c1 input=a9049054013a1b77]*/

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -71,7 +71,7 @@ stats_to_dict(SpecializationStats *stats)
     ADD_STAT_TO_DICT(res, unquickened);
 #if SPECIALIZATION_STATS_DETAILED
     if (stats->miss_types != NULL) {
-        if (PyDict_SetItemString(res, "detailed", stats->miss_types) == -1) {
+        if (PyDict_SetItemString(res, "fails", stats->miss_types) == -1) {
             Py_DECREF(res);
             return NULL;
         }

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -49,6 +49,7 @@ SpecializationStats _specialization_stats[256] = { 0 };
         } \
         if (PyDict_SetItemString(res, #field, val) == -1) { \
             Py_DECREF(res); \
+            Py_DECREF(val); \
             return NULL; \
         } \
         Py_DECREF(val); \


### PR DESCRIPTION
This PR exposes the specialisation stats as a python dictionary. It makes them easier to work with (including delta for a code snippet and unit tests for the specialisation).

I suggest that we also:
1. Remove the print function. 
2. Define SPECIALIZATION_STATS and SPECIALIZATION_STATS_DETAILED to 1 if Py_DEBUG
3. Actually, remove SPECIALIZATION_STATS_DETAILED and make the detailed stats either always be in the output, or controlled by a parameter to get_specialization_stats.

Let me know if that sounds reasonable.

https://bugs.python.org/issue44725

```
>>> import _opcode, print
>>> pprint.pprint(_opcode.get_specialization_stats())
{'binary_subscr': {'deferred': 1545,
                   'deopt': 4,
                   'detailed': {(<class 'mappingproxy'>, 'asend', 'not list|tuple|dict'): 1,
                                (<class 'str'>, -3, 'not list|tuple|dict'): 1,
                                (<class 'str'>, -1, 'not list|tuple|dict'): 2,
                                (<class 'str'>, 0, 'not list|tuple|dict'): 8,
                                (<class 'str'>, 2, 'not list|tuple|dict'): 1,
                                (<class 'enum._EnumDict'>, '_ignore_', 'not list|tuple|dict'): 1,
                                (<class 'sre_parse.SubPattern'>, 0, 'not list|tuple|dict'): 8,
                                (<class 'str'>, 7, 'not list|tuple|dict'): 1,
                                (<class 'str'>, 19, 'not list|tuple|dict'): 1,
                                (<class 'str'>, 26, 'not list|tuple|dict'): 1,
                                (<class 'mappingproxy'>, 'from_bytes', 'not list|tuple|dict'): 1},
                   'hit': 870,
                   'miss': 12,
                   'specialization_failure': 49,
                   'specialization_success': 49,
                   'unquickened': 1879},
 'load_attr': {'deferred': 3206,
               'deopt': 24,
               'detailed': {(<class '_frozen_importlib.ModuleSpec'>, 'cached', 'property'): 2,
                            (<class '_frozen_importlib.ModuleSpec'>, 'has_location', 'property'): 2,
                            (<class '_frozen_importlib.ModuleSpec'>, 'parent', 'property'): 2,
                            (<class 'function'>, '__dict__', 'overriding descriptor'): 4,
                            (<class 'sys.flags'>, 'optimize', 'non-object slot'): 2,
                            (<class 'type'>, '_ORIGIN', '__getattribute__ overridden'): 1,
                            (<class 'type'>, 'find_spec', '__getattribute__ overridden'): 3,
                            (<class 'sys.flags'>, 'verbose', 'non-object slot'): 10,
                            (<class 'os.stat_result'>, 'st_mode', 'non-object slot'): 2,
                            (<class 'os.stat_result'>, 'st_mtime', 'non-object slot'): 3,
                            (<class 'os.stat_result'>, 'st_size', 'non-object slot'): 1,
                            (<class 'sys.flags'>, 'ignore_environment', 'non-object slot'): 2,
                            (<class 'module'>, '__dict__', 'index out of range'): 1,
                            (<class 'type'>, '__dict__', '__getattribute__ overridden'): 8,
                            (<class 'super'>, '__new__', '__getattribute__ overridden'): 3,
                            (<class 'type'>, '__mro__', '__getattribute__ overridden'): 3,
                            (<class 'type'>, '__new__', '__getattribute__ overridden'): 5,
                            (<class 'classmethod'>, '__func__', 'non-object slot'): 2,
                            (<class 'function'>, '__name__', 'overriding descriptor'): 2,
                            (<class 'frame'>, 'f_globals', 'overriding descriptor'): 1,
                            (<class 'enum.EnumType'>, 'VAR_KEYWORD', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, 'VAR_POSITIONAL', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, '__new__', '__getattribute__ overridden'): 4,
                            (<class 'enum.EnumType'>, '_member_map_', '__getattribute__ overridden'): 7,
                            (<class 'enum.EnumType'>, '_member_names_', '__getattribute__ overridden'): 4,
                            (<class 'enum.auto'>, 'value', 'no dict or not a dict'): 2,
                            (<class 'enum.EnumType'>, '_member_type_', '__getattribute__ overridden'): 7,
                            (<class 'NoneType'>, '__doc__', 'non descriptor'): 1,
                            (<class 'NoneType'>, '__new__', 'non descriptor'): 1,
                            (<class 'enum.EnumType'>, '__dict__', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, '__mro__', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, '__name__', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, '_generate_next_value_', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, '_new_member_', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, '_use_args_', '__getattribute__ overridden'): 2,
                            (<class 'enum.EnumType'>, '_value2member_map_', '__getattribute__ overridden'): 1,
                            (<enum 'FlagBoundary'>, '__init__', 'method'): 1,
                            (<class 'type'>, '__name__', '__getattribute__ overridden'): 1,
                            (<flag 'RegexFlag'>, '_value_', 'negative offset'): 1,
                            (<class 'enum.EnumType'>, '_iter_member_by_def_', '__getattribute__ overridden'): 1,
                            (<class 'sre_constants._NamedIntConstant'>, 'name', 'negative offset'): 2,
                            (<class 'list'>, 'append', 'method'): 10,
                            (<class 'sre_parse.SubPattern'>, 'append', 'method'): 1,
                            (<class 'sre_parse.Tokenizer'>, 'get', 'method'): 1,
                            (<class 'sre_parse.Tokenizer'>, 'match', 'method'): 2,
                            (<class 'type'>, '__call__', '__getattribute__ overridden'): 1,
                            (<class 'type'>, '__repr__', '__getattribute__ overridden'): 11,
                            (<class 'type'>, '_fields', '__getattribute__ overridden'): 1,
                            (<class 'builtin_function_or_method'>, '__call__', 'method'): 1,
                            (<class 'enum.EnumType'>, 'KEYWORD_ONLY', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, 'POSITIONAL_ONLY', '__getattribute__ overridden'): 1,
                            (<class 'enum.EnumType'>, 'POSITIONAL_OR_KEYWORD', '__getattribute__ overridden'): 1,
                            (<class 'pprint.PrettyPrinter'>, '_dispatch', 'attribute not in dict'): 1,
                            (<class '_io.TextIOWrapper'>, 'write', 'method'): 1,
                            (<class 'type'>, 'copy', '__getattribute__ overridden'): 4},
               'hit': 5628,
               'miss': 178,
               'specialization_failure': 120,
               'specialization_success': 157,
               'unquickened': 4886},
 'load_global': {'deferred': 3370,
                 'deopt': 199,
                 'hit': 7880,
                 'miss': 1538,
                 'specialization_failure': 0,
                 'specialization_success': 471,
                 'unquickened': 11157}}

```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44725](https://bugs.python.org/issue44725) -->
https://bugs.python.org/issue44725
<!-- /issue-number -->
