### PR TITLE
bpo-44655: Include the name of the type in unset __slots__ attribute errors

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1303,6 +1303,11 @@ order (MRO) for bases """
         with self.assertRaises(AttributeError):
             del X().a
 
+        class X(object):
+            __slots__ = "a"
+        with self.assertRaisesRegex(AttributeError, "'X' object has no attribute 'a'"):
+            X().a
+
     def test_slots_special(self):
         # Testing __dict__ and __weakref__ in __slots__...
         class D(object):

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1303,6 +1303,7 @@ order (MRO) for bases """
         with self.assertRaises(AttributeError):
             del X().a
 
+        # Inherit from object on purpose to check some backwards compatibility paths
         class X(object):
             __slots__ = "a"
         with self.assertRaisesRegex(AttributeError, "'X' object has no attribute 'a'"):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-16-21-35-14.bpo-44655.95I7M6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-16-21-35-14.bpo-44655.95I7M6.rst
@@ -1,0 +1,2 @@
+Include the name of the type in unset __slots__ attribute errors. Patch by
+Pablo Galindo

--- a/Python/structmember.c
+++ b/Python/structmember.c
@@ -5,11 +5,11 @@
 #include "structmember.h"         // PyMemberDef
 
 PyObject *
-PyMember_GetOne(const char *addr, PyMemberDef *l)
+PyMember_GetOne(const char *obj_addr, PyMemberDef *l)
 {
     PyObject *v;
 
-    addr += l->offset;
+    const char* addr = obj_addr + l->offset;
     switch (l->type) {
     case T_BOOL:
         v = PyBool_FromLong(*(char*)addr);
@@ -69,8 +69,13 @@ PyMember_GetOne(const char *addr, PyMemberDef *l)
         break;
     case T_OBJECT_EX:
         v = *(PyObject **)addr;
-        if (v == NULL)
-            PyErr_SetString(PyExc_AttributeError, l->name);
+        if (v == NULL) {
+            PyObject *obj = (PyObject *)obj_addr;
+            PyTypeObject *tp = Py_TYPE(obj);
+            PyErr_Format(PyExc_AttributeError,
+                         "'%.50s' object has no attribute '%s'",
+                         tp->tp_name, l->name);
+       }
         Py_XINCREF(v);
         break;
     case T_LONGLONG:

--- a/Python/structmember.c
+++ b/Python/structmember.c
@@ -73,7 +73,7 @@ PyMember_GetOne(const char *obj_addr, PyMemberDef *l)
             PyObject *obj = (PyObject *)obj_addr;
             PyTypeObject *tp = Py_TYPE(obj);
             PyErr_Format(PyExc_AttributeError,
-                         "'%.50s' object has no attribute '%s'",
+                         "'%.200s' object has no attribute '%s'",
                          tp->tp_name, l->name);
        }
         Py_XINCREF(v);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44655](https://bugs.python.org/issue44655) -->
https://bugs.python.org/issue44655
<!-- /issue-number -->
