### PR TITLE
bpo-44657: Fix instancemethod_call to use PyInstanceMethod_GET_FUNCTION

### DIFF
--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -462,7 +462,7 @@ instancemethod_traverse(PyObject *self, visitproc visit, void *arg) {
 static PyObject *
 instancemethod_call(PyObject *self, PyObject *arg, PyObject *kw)
 {
-    return PyObject_Call(PyMethod_GET_FUNCTION(self), arg, kw);
+    return PyObject_Call(PyInstanceMethod_GET_FUNCTION(self), arg, kw);
 }
 
 static PyObject *


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44657](https://bugs.python.org/issue44657) -->
https://bugs.python.org/issue44657
<!-- /issue-number -->
