### PR TITLE
bpo-44661: Update property_descr_set to use vectorcall if possible.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-17-14-20-59.bpo-44661.BQbXiH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-17-14-20-59.bpo-44661.BQbXiH.rst
@@ -1,2 +1,2 @@
-Update property_descr_set to use vectorcall if possible. Patch by Dong-hee
+Update ``property_descr_set`` to use vectorcall if possible. Patch by Dong-hee
 Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-17-14-20-59.bpo-44661.BQbXiH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-17-14-20-59.bpo-44661.BQbXiH.rst
@@ -1,0 +1,2 @@
+Update property_descr_set to use vectorcall if possible. Patch by Dong-hee
+Na.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1614,10 +1614,13 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
     propertyobject *gs = (propertyobject *)self;
     PyObject *func, *res;
 
-    if (value == NULL)
+    if (value == NULL) {
         func = gs->prop_del;
-    else
+    }
+    else {
         func = gs->prop_set;
+    }
+
     if (func == NULL) {
         if (gs->prop_name != NULL) {
             PyErr_Format(PyExc_AttributeError,
@@ -1625,7 +1628,8 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
                         "can't delete attribute %R" :
                         "can't set attribute %R",
                         gs->prop_name);
-        } else {
+        }
+        else {
             PyErr_SetString(PyExc_AttributeError,
                             value == NULL ?
                             "can't delete attribute" :
@@ -1633,14 +1637,19 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
         }
         return -1;
     }
+
     if (value == NULL) {
         res = PyObject_CallOneArg(func, obj);
-    } else {
+    }
+    else {
         PyObject *args[] = { obj, value };
         res = PyObject_Vectorcall(func, args, 2, NULL);
     }
-    if (res == NULL)
+
+    if (res == NULL) {
         return -1;
+    }
+
     Py_DECREF(res);
     return 0;
 }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1633,10 +1633,12 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
         }
         return -1;
     }
-    if (value == NULL)
+    if (value == NULL) {
         res = PyObject_CallOneArg(func, obj);
-    else
-        res = PyObject_CallFunctionObjArgs(func, obj, value, NULL);
+    } else {
+        PyObject *args[] = { obj, value };
+        res = PyObject_Vectorcall(func, args, 2, NULL);
+    }
     if (res == NULL)
         return -1;
     Py_DECREF(res);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44661](https://bugs.python.org/issue44661) -->
https://bugs.python.org/issue44661
<!-- /issue-number -->

````
Mean +- std dev: [property_base] 140 ns +- 5 ns -> [property_vectorcall] 125 ns +- 2 ns: 1.12x faster
````