### PR TITLE
bpo-44654: Do not export the union type related symbols

### DIFF
--- a/Include/internal/pycore_unionobject.h
+++ b/Include/internal/pycore_unionobject.h
@@ -8,13 +8,13 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-PyAPI_DATA(PyTypeObject) _PyUnion_Type;
+extern PyTypeObject _PyUnion_Type;
 #define _PyUnion_Check(op) Py_IS_TYPE(op, &_PyUnion_Type)
-PyAPI_FUNC(PyObject *) _Py_union_type_or(PyObject *, PyObject *);
+extern PyObject *_Py_union_type_or(PyObject *, PyObject *);
 
 #define _PyGenericAlias_Check(op) PyObject_TypeCheck(op, &Py_GenericAliasType)
-PyAPI_FUNC(PyObject *) _Py_subs_parameters(PyObject *, PyObject *, PyObject *, PyObject *);
-PyAPI_FUNC(PyObject *) _Py_make_parameters(PyObject *);
+extern PyObject *_Py_subs_parameters(PyObject *, PyObject *, PyObject *, PyObject *);
+extern PyObject *_Py_make_parameters(PyObject *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-44654](https://bugs.python.org/issue44654) -->
https://bugs.python.org/issue44654
<!-- /issue-number -->
