### PR TITLE
[3.10] bpo-44654: Do not export the union type related symbols (GH-27223).

### DIFF
--- a/Include/internal/pycore_unionobject.h
+++ b/Include/internal/pycore_unionobject.h
@@ -10,11 +10,11 @@ extern "C" {
 
 extern PyTypeObject _PyUnion_Type;
 #define _PyUnion_Check(op) Py_IS_TYPE(op, &_PyUnion_Type)
-PyAPI_FUNC(PyObject *) _Py_union_type_or(PyObject *, PyObject *);
+extern PyObject *_Py_union_type_or(PyObject *, PyObject *);
 
 #define _PyGenericAlias_Check(op) PyObject_TypeCheck(op, &Py_GenericAliasType)
-PyObject *_Py_subs_parameters(PyObject *, PyObject *, PyObject *, PyObject *);
-PyObject *_Py_make_parameters(PyObject *);
+extern PyObject *_Py_subs_parameters(PyObject *, PyObject *, PyObject *, PyObject *);
+extern PyObject *_Py_make_parameters(PyObject *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
(cherry picked from commit 8f50f44592190b5a8cb115f0d58d577036e68308)


<!-- issue-number: [bpo-44654](https://bugs.python.org/issue44654) -->
https://bugs.python.org/issue44654
<!-- /issue-number -->
