### PR TITLE
bpo-44651: delete entry of "coercion" in Doc/glossary.rst

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -216,16 +216,6 @@ Glossary
       A variable defined in a class and intended to be modified only at
       class level (i.e., not in an instance of the class).
 
-   coercion
-      The implicit conversion of an instance of one type to another during an
-      operation which involves two arguments of the same type.  For example,
-      ``int(3.15)`` converts the floating point number to the integer ``3``, but
-      in ``3+4.5``, each argument is of a different type (one int, one float),
-      and both must be converted to the same type before they can be added or it
-      will raise a :exc:`TypeError`.  Without coercion, all arguments of even
-      compatible types would have to be normalized to the same value by the
-      programmer, e.g., ``float(3)+4.5`` rather than just ``3+4.5``.
-
    complex number
       An extension of the familiar real number system in which all numbers are
       expressed as a sum of a real part and an imaginary part.  Imaginary

--- a/Misc/NEWS.d/next/Documentation/2021-07-18-22-26-02.bpo-44651.SjT9iY.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-18-22-26-02.bpo-44651.SjT9iY.rst
@@ -1,0 +1,1 @@
+Delete entry "coercion" in Doc/glossary.rst for its outdated definition.


### PR DESCRIPTION
The definition of "coercion" in Doc/glossary.rst was unclear in some aspects.
After discussion about the history and current status of this entry, deletion of it was suggested in conclusion.

Thanks for review.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44651](https://bugs.python.org/issue44651) -->
https://bugs.python.org/issue44651
<!-- /issue-number -->
