### PR TITLE
bpo-44653: Support typing.Union in parameter substitution of the union type

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -772,6 +772,21 @@ class UnionTests(unittest.TestCase):
         self.assertEqual((list[T] | list[S])[int, T], list[int] | list[T])
         self.assertEqual((list[T] | list[S])[int, int], list[int])
 
+    def test_union_parameter_substitution_union(self):
+        T = typing.TypeVar("T")
+        res = (int | T)[str | list]
+        self.assertEqual(res, int | str | list)
+        self.assertIsInstance(res, types.Union)
+        res = (int | T)[str | int]
+        self.assertEqual(res, int | str)
+        self.assertIsInstance(res, types.Union)
+        res = (int | T)[typing.Union[str, list]]
+        self.assertEqual(res, int | str | list)
+        self.assertIsInstance(res, types.Union)
+        res = (int | T)[typing.Union[str, int]]
+        self.assertEqual(res, int | str)
+        self.assertIsInstance(res, types.Union)
+
     def test_union_parameter_substitution_errors(self):
         T = typing.TypeVar("T")
         x = int | T

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-18-19-32-38.bpo-44653.lu99mE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-18-19-32-38.bpo-44653.lu99mE.rst
@@ -1,0 +1,1 @@
+Support ``typing.Union`` in parameter substitution of the union type.


### PR DESCRIPTION


<!-- issue-number: [bpo-44653](https://bugs.python.org/issue44653) -->
https://bugs.python.org/issue44653
<!-- /issue-number -->
