### PR TITLE
bpo-44666: Use default encoding as fallback for compile_file

### DIFF
--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -254,9 +254,8 @@ def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
                 else:
                     print('*** ', end='')
                 # escape non-printable characters in msg
-                msg = err.msg.encode(sys.stdout.encoding,
-                                     errors='backslashreplace')
-                msg = msg.decode(sys.stdout.encoding)
+                encoding = sys.stdout.encoding or sys.getdefaultencoding()
+                msg = err.msg.encode(encoding, errors='backslashreplace').decode(encoding)
                 print(msg)
             except (SyntaxError, UnicodeError, OSError) as e:
                 success = False

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -169,6 +169,14 @@ class CompileallTestsBase:
         compileall.compile_file(data_file)
         self.assertFalse(os.path.exists(os.path.join(data_dir, '__pycache__')))
 
+
+    def test_compile_file_encoding_fallback(self):
+        # Bug 44666 reported that compile_file failed when sys.stdout.encoding is None
+        self.add_bad_source_file()
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertFalse(compileall.compile_file(self.bad_source_path))
+
+
     def test_optimize(self):
         # make sure compiling with different optimization settings than the
         # interpreter's creates the correct file names

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -794,6 +794,7 @@ Fredrik Håård
 Florian Höch
 Oleg Höfling
 Robert Hölzl
+Stefan Hölzl
 Catalin Iacob
 Mihai Ibanescu
 Ali Ikinci

--- a/Misc/NEWS.d/next/Library/2021-07-21-10-43-22.bpo-44666.CEThkv.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-21-10-43-22.bpo-44666.CEThkv.rst
@@ -1,0 +1,1 @@
+fixed issue in :func:`compileall.compile_file` when ``sys.stdout`` is redirected

--- a/Misc/NEWS.d/next/Library/2021-07-21-10-43-22.bpo-44666.CEThkv.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-21-10-43-22.bpo-44666.CEThkv.rst
@@ -1,1 +1,2 @@
-fixed issue in :func:`compileall.compile_file` when ``sys.stdout`` is redirected
+Fixed issue in :func:`compileall.compile_file` when ``sys.stdout`` is redirected.
+Patch by Stefan Hölzl.


### PR DESCRIPTION
When sys.stdout.encoding is None compile_file will fall back to
sys.getdefaultencoding to encode/decode error messages.

<!-- issue-number: [bpo-44666](https://bugs.python.org/issue44666) -->
https://bugs.python.org/issue44666
<!-- /issue-number -->
