### PR TITLE
bpo-44524: Add missed __name__ and __qualname__ to typing module objects

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4554,9 +4554,10 @@ class SpecialAttrsTests(BaseTestCase):
         )
 
         for cls in cls_to_check:
-            self.assertEqual(cls.__name__, cls._name)
-            self.assertEqual(cls.__qualname__, cls._name)
-            self.assertEqual(cls.__module__, 'typing')
+            with self.subTest(cls=cls):
+                self.assertEqual(cls.__name__, cls._name)
+                self.assertEqual(cls.__qualname__, cls._name)
+                self.assertEqual(cls.__module__, 'typing')
 
 class AllTests(BaseTestCase):
     """Tests for __all__."""

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4498,6 +4498,54 @@ class TypeGuardTests(BaseTestCase):
             issubclass(int, TypeGuard)
 
 
+class SpecialAttrsTests(BaseTestCase):
+    def test_special_attrs(self):
+        cls_to_check = (
+            typing.AbstractSet,
+            typing.AsyncContextManager,
+            typing.AsyncGenerator,
+            typing.AsyncIterable,
+            typing.AsyncIterator,
+            typing.Awaitable,
+            typing.ByteString,
+            typing.Callable,
+            typing.ChainMap,
+            typing.Collection,
+            typing.Container,
+            typing.ContextManager,
+            typing.Coroutine,
+            typing.Counter,
+            typing.DefaultDict,
+            typing.Deque,
+            typing.Dict,
+            typing.FrozenSet,
+            typing.Generator,
+            typing.Hashable,
+            typing.ItemsView,
+            typing.Iterable,
+            typing.Iterator,
+            typing.KeysView,
+            typing.List,
+            typing.Mapping,
+            typing.MappingView,
+            typing.MutableMapping,
+            typing.MutableSequence,
+            typing.MutableSet,
+            typing.OrderedDict,
+            typing.Reversible,
+            typing.Sequence,
+            typing.Set,
+            typing.Sized,
+            typing.Tuple,
+            typing.Type,
+            typing.ValuesView,
+        )
+
+        for cls in cls_to_check:
+            self.assertEqual(cls.__name__, cls._name)
+            self.assertEqual(cls.__qualname__, cls._name)
+            self.assertEqual(cls.__module__, 'typing')
+
 class AllTests(BaseTestCase):
     """Tests for __all__."""
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4543,7 +4543,7 @@ class SpecialAttrsTests(BaseTestCase):
 
         for cls in cls_to_check:
             self.assertEqual(cls.__name__, cls._name)
-            self.assertEqual(cls.__qualname__, f'typing.{cls._name}')
+            self.assertEqual(cls.__qualname__, cls._name)
             self.assertEqual(cls.__module__, 'typing')
 
 class AllTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4543,7 +4543,7 @@ class SpecialAttrsTests(BaseTestCase):
 
         for cls in cls_to_check:
             self.assertEqual(cls.__name__, cls._name)
-            self.assertEqual(cls.__qualname__, cls._name)
+            self.assertEqual(cls.__qualname__, f'typing.{cls._name}')
             self.assertEqual(cls.__module__, 'typing')
 
 class AllTests(BaseTestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4501,6 +4501,7 @@ class TypeGuardTests(BaseTestCase):
 class SpecialAttrsTests(BaseTestCase):
     def test_special_attrs(self):
         cls_to_check = (
+            # ABC classes
             typing.AbstractSet,
             typing.AsyncContextManager,
             typing.AsyncGenerator,
@@ -4539,6 +4540,17 @@ class SpecialAttrsTests(BaseTestCase):
             typing.Tuple,
             typing.Type,
             typing.ValuesView,
+            # Special Forms
+            typing.Any,
+            typing.NoReturn,
+            typing.ClassVar,
+            typing.Final,
+            typing.Union,
+            typing.Optional,
+            typing.Literal,
+            typing.TypeAlias,
+            typing.Concatenate,
+            typing.TypeGuard,
         )
 
         for cls in cls_to_check:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -935,6 +935,9 @@ class _BaseGenericAlias(_Final, _root=True):
         return tuple(res)
 
     def __getattr__(self, attr):
+        if attr in {'__name__', '__qualname__'}:
+            return self._name
+
         # We are careful for copy and pickle.
         # Also for simplicity we just don't relay all dunder names
         if '__origin__' in self.__dict__ and not _is_dunder(attr):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -935,10 +935,8 @@ class _BaseGenericAlias(_Final, _root=True):
         return tuple(res)
 
     def __getattr__(self, attr):
-        if attr == '__name__':
+        if attr in {'__name__', '__qualname__'}:
             return self._name
-        if attr == '__qualname__':
-            return f'typing.{self._name}'
 
         # We are careful for copy and pickle.
         # Also for simplicity we just don't relay all dunder names

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -358,6 +358,12 @@ class _SpecialForm(_Final, _root=True):
         self._name = getitem.__name__
         self.__doc__ = getitem.__doc__
 
+    def __getattr__(self, item):
+        if item in {'__name__', '__qualname__'}:
+            return self._name
+
+        raise AttributeError(item)
+
     def __mro_entries__(self, bases):
         raise TypeError(f"Cannot subclass {self!r}")
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -935,8 +935,10 @@ class _BaseGenericAlias(_Final, _root=True):
         return tuple(res)
 
     def __getattr__(self, attr):
-        if attr in {'__name__', '__qualname__'}:
+        if attr == '__name__':
             return self._name
+        if attr == '__qualname__':
+            return f'typing.{self._name}'
 
         # We are careful for copy and pickle.
         # Also for simplicity we just don't relay all dunder names

--- a/Misc/NEWS.d/next/Library/2021-07-19-14-04-42.bpo-44524.Nbf2JC.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-19-14-04-42.bpo-44524.Nbf2JC.rst
@@ -1,2 +1,2 @@
-Add missed ``__name__`` and ``__qualname__`` attribute to ``typing`` module
-objects. Patch provided by Yurii Karabas.
+Add missing ``__name__`` and ``__qualname__`` attributes to ``typing`` module
+classes. Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Library/2021-07-19-14-04-42.bpo-44524.Nbf2JC.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-19-14-04-42.bpo-44524.Nbf2JC.rst
@@ -1,0 +1,2 @@
+Add missed ``__name__`` and ``__qualname__`` attribute to ``typing`` module
+objects. Patch provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44524](https://bugs.python.org/issue44524) -->
https://bugs.python.org/issue44524
<!-- /issue-number -->
