### PR TITLE
bpo-44678: Separate error message for discontinuous padding in binascii.a2b_base64 strict mode

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -133,6 +133,9 @@ class BinASCIITest(unittest.TestCase):
         def assertLeadingPadding(data, non_strict_mode_expected_result: bytes):
             _assertRegexTemplate(r'(?i)Leading padding', data, non_strict_mode_expected_result)
 
+        def assertDiscontinuousPadding(data, non_strict_mode_expected_result: bytes):
+            _assertRegexTemplate(r'(?i)Discontinuous padding', data, non_strict_mode_expected_result)
+
         # Test excess data exceptions
         assertExcessData(b'ab==a', b'i')
         assertExcessData(b'ab===', b'i')
@@ -151,8 +154,8 @@ class BinASCIITest(unittest.TestCase):
         assertLeadingPadding(b'=', b'')
         assertLeadingPadding(b'==', b'')
         assertLeadingPadding(b'===', b'')
-        assertLeadingPadding(b'ab=c=', b'i\xb7')
-        assertLeadingPadding(b'ab=ab==', b'i\xb6\x9b')
+        assertDiscontinuousPadding(b'ab=c=', b'i\xb7')
+        assertDiscontinuousPadding(b'ab=ab==', b'i\xb6\x9b')
 
 
     def test_base64errors(self):

--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -130,7 +130,7 @@ class BinASCIITest(unittest.TestCase):
         def assertNonBase64Data(data, non_strict_mode_expected_result: bytes):
             _assertRegexTemplate(r'(?i)Only base64 data', data, non_strict_mode_expected_result)
 
-        def assertMalformedPadding(data, non_strict_mode_expected_result: bytes):
+        def assertLeadingPadding(data, non_strict_mode_expected_result: bytes):
             _assertRegexTemplate(r'(?i)Leading padding', data, non_strict_mode_expected_result)
 
         # Test excess data exceptions
@@ -148,11 +148,11 @@ class BinASCIITest(unittest.TestCase):
         assertNonBase64Data(b'a\x00b==', b'i')
 
         # Test malformed padding
-        assertMalformedPadding(b'=', b'')
-        assertMalformedPadding(b'==', b'')
-        assertMalformedPadding(b'===', b'')
-        assertMalformedPadding(b'ab=c=', b'i\xb7')
-        assertMalformedPadding(b'ab=ab==', b'i\xb6\x9b')
+        assertLeadingPadding(b'=', b'')
+        assertLeadingPadding(b'==', b'')
+        assertLeadingPadding(b'===', b'')
+        assertLeadingPadding(b'ab=c=', b'i\xb7')
+        assertLeadingPadding(b'ab=ab==', b'i\xb6\x9b')
 
 
     def test_base64errors(self):

--- a/Misc/NEWS.d/next/Library/2021-07-19-18-45-00.bpo-44678.YMEAu0.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-19-18-45-00.bpo-44678.YMEAu0.rst
@@ -1,0 +1,1 @@
+Added a seperate error message for discontinuous padding in *binascii.a2b_base64* strict mode.

--- a/Misc/NEWS.d/next/Library/2021-07-19-18-45-00.bpo-44678.YMEAu0.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-19-18-45-00.bpo-44678.YMEAu0.rst
@@ -1,1 +1,1 @@
-Added a seperate error message for discontinuous padding in *binascii.a2b_base64* strict mode.
+Added a separate error message for discontinuous padding in *binascii.a2b_base64* strict mode.

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -464,7 +464,6 @@ binascii_a2b_base64_impl(PyObject *module, Py_buffer *data, int strict_mode)
     unsigned char *bin_data_start = bin_data;
 
     if (strict_mode && ascii_len > 0 && ascii_data[0] == '=') {
-        malformed_padding:
         state = get_binascii_state(module);
         if (state) {
             PyErr_SetString(state->Error, "Leading padding not allowed");
@@ -516,7 +515,11 @@ binascii_a2b_base64_impl(PyObject *module, Py_buffer *data, int strict_mode)
 
         // Characters that are not '=', in the middle of the padding, are not allowed
         if (strict_mode && padding_started) {
-            goto malformed_padding;
+            state = get_binascii_state(module);
+            if (state) {
+                PyErr_SetString(state->Error, "Discontinuous padding not allowed");
+            }
+            goto error_end;
         }
         pads = 0;
 


### PR DESCRIPTION
@gpshead follow up to #24402.

<!-- issue-number: [bpo-44678](https://bugs.python.org/issue44678) -->
https://bugs.python.org/issue44678
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead