### PR TITLE
bpo-44689: ctypes.util.find_library() now finds macOS 11+ system libraries when built on older macOS systems

### DIFF
--- a/Lib/ctypes/macholib/dyld.py
+++ b/Lib/ctypes/macholib/dyld.py
@@ -6,11 +6,10 @@ import os
 from ctypes.macholib.framework import framework_info
 from ctypes.macholib.dylib import dylib_info
 from itertools import *
-
 try:
-    from _ctypes import shared_library_is_loadable
+    from _ctypes import _dyld_shared_cache_contains_path
 except ImportError:
-    def shared_library_is_loadable(path):
+    def _dyld_shared_cache_contains_path(*args):
         raise NotImplementedError
 
 __all__ = [
@@ -123,18 +122,15 @@ def dyld_find(name, executable_path=None, env=None):
     """
     Find a library or framework using dyld semantics
     """
-    paths = list(dyld_image_suffix_search(chain(
-                 dyld_override_search(name, env),
-                 dyld_executable_path_search(name, executable_path),
-                 dyld_default_search(name, env),
-                 ), env))
+    for path in dyld_image_suffix_search(chain(
+                dyld_override_search(name, env),
+                dyld_executable_path_search(name, executable_path),
+                dyld_default_search(name, env),
+            ), env):
 
-    for path in paths:
         if os.path.isfile(path):
             return path
-
-    for path in reversed(paths):
-        if shared_library_is_loadable(path):
+        if _dyld_shared_cache_contains_path(path):
             return path
 
     raise ValueError("dylib %s could not be found" % (name,))

--- a/Lib/ctypes/macholib/dyld.py
+++ b/Lib/ctypes/macholib/dyld.py
@@ -130,8 +130,11 @@ def dyld_find(name, executable_path=None, env=None):
 
         if os.path.isfile(path):
             return path
-        if _dyld_shared_cache_contains_path(path):
-            return path
+        try:
+            if _dyld_shared_cache_contains_path(path):
+                return path
+        except NotImplementedError:
+            pass
 
     raise ValueError("dylib %s could not be found" % (name,))
 

--- a/Lib/ctypes/macholib/dyld.py
+++ b/Lib/ctypes/macholib/dyld.py
@@ -6,7 +6,12 @@ import os
 from ctypes.macholib.framework import framework_info
 from ctypes.macholib.dylib import dylib_info
 from itertools import *
-from _ctypes import shared_library_is_loadable
+
+try:
+    from _ctypes import shared_library_is_loadable
+except ImportError:
+    def shared_library_is_loadable(path):
+        raise NotImplementedError
 
 __all__ = [
     'dyld_find', 'framework_find',

--- a/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
+++ b/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
@@ -1,2 +1,5 @@
-You can now compile Python on MacOS < 11.0 and
-:meth:`ctypes.util.find_library` will still work on MacOS >= 11.0.
+ :meth:`ctypes.util.find_library` now works correctly on macOS 11 Big Sur
+ even if Python is built on an older version of macOS.  Previously, when
+ built on older macOS systems, ``find_library`` was not able to find
+ macOS system libraries when running on Big Sur due to changes in
+ how system libraries are stored.

--- a/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
+++ b/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
@@ -1,3 +1,2 @@
-You no longer need to compile Python on the same version of macOS that you
-will be running it on (Catalina vs Big Sur) in order for
-:meth:`ctypes.util.find_library` to work.
+You can now compile Python on MacOS < 11.0 and
+:meth:`ctypes.util.find_library` will still work on MacOS >= 11.0.

--- a/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
+++ b/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
@@ -1,1 +1,3 @@
-You no longer need to compile Python on the same version of MacOS that you will be running it on (Catalina vs Big Sur) in order for ctypes.util.find_library to work.
+You no longer need to compile Python on the same version of macOS that you
+will be running it on (Catalina vs Big Sur) in order for
+:meth:`ctypes.util.find_library` to work.

--- a/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
+++ b/Misc/NEWS.d/next/macOS/2021-07-20-22-27-01.bpo-44689.mmT_xH.rst
@@ -1,0 +1,1 @@
+You no longer need to compile Python on the same version of MacOS that you will be running it on (Catalina vs Big Sur) in order for ctypes.util.find_library to work.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1447,7 +1447,7 @@ copy_com_pointer(PyObject *self, PyObject *args)
 #define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH_RUNTIME \
     __builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 #else
-// Support the deprecated case of compiling on an older MacOS version
+// Support the deprecated case of compiling on an older macOS version
 static void *libsystem_b_handle;
 static bool (*_dyld_shared_cache_contains_path)(const char *path);
 


### PR DESCRIPTION
# Improve binary portability between MacOS versions

https://bugs.python.org/issue44689

When compiling CPython using a MacOS Catalina build server, it won't work as expected when trying to run it on MacOS Big Sur. In particular, `ctypes.util.find_library(name)` will always return None. This PR adds support for compiling on an older MacOS version.


## Background

Checking if a shared library exists on MacOS Big Sur is no longer possible by looking at the file system. Instead, Apple recommends the use of dlopen to check if a shared library exists ([MacOS Big Sur 11.0.1 changenotes](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes)). Note that using dlopen to check for library existence is not ideal, since this might cause arbitrary side effects.


### _dyld_shared_cache_contains_path and build time requirements
The current solution (introduced in https://github.com/python/cpython/pull/22855) to make find_library work on MacOS Big Sur does not use dlopen, but rather _dyld_shared_cache_contains_path from `#include <mach-io/dyld>`. This function/symbol is only available on MacOS Big Sur, meaning it will only be included if you compile CPython on MacOS Big Sur.

In other words, if we compile CPython on MacOS Catalina, and move the binary to MacOS Big Sur, `from _ctypes import _dyld_shared_cache_contains_path` will raise an ImportError - and find_library will not work, always returning None.
```diff
# ctypes/macholib/dyld.py
# ...

+try:
+    from _ctypes import _dyld_shared_cache_contains_path
+except ImportError:
+    def _dyld_shared_cache_contains_path(*args):
+        raise NotImplementedError

# ...

def dyld_find(name, executable_path=None, env=None):
    """
    Find a library or framework using dyld semantics
    """
    for path in dyld_image_suffix_search(chain(
                dyld_override_search(name, env),
                dyld_executable_path_search(name, executable_path),
                dyld_default_search(name, env),
            ), env):

        if os.path.isfile(path):
            return path
+        try:
+            if _dyld_shared_cache_contains_path(path):
+                return path
+        except NotImplementedError:
+            pass
# ...
```

## Method/Verification
In order to support building for MacOS >= 11.0 (Big Sur or later) with a build server running MacOS < 11.0 (Catalina or earlier), we use [dynamic loading](https://en.wikipedia.org/wiki/Dynamic_loading) to avoid errors when compiling. _dyld_shared_cache_contains_path will be resolved at runtime instead of compile-time, since it is not available at compile-time in this case.

The downside to doing this at runtime instead of compile-time is that the compiler won't give us useful error messages. This is why we want to keep using the [weak linking](https://github.com/python/cpython/tree/main/Mac#weak-linking-support) approach when compiling on MacOS >= 11.0 (Big Sur or later) - and only use dynamic loading to support the [deprecated use case](https://bugs.python.org/msg398959) of compiling on an older MacOS version.

To test that this works, I've set up 2 virtual machines using [OSX-KVM](https://github.com/kholia/OSX-KVM) on a Manjaro Linux host:
- Catalina (*OS: macOS Catalina 10.15.7 19H15 x86_64, Kernel 19.6.0*)
- Big Sur (*OS: macOS 11.4 20F71 x86_64, Kernel: 20.5.0*)

Files are copied between the 2 virtual machines using rsync:
```sh
#!/usr/bin/env bash
rm -rf "./local"
echo "Pulling from Catalina... (/usr/local/ -> ./local)"
rsync -a -e "ssh -p 2222" tobias@localhost:/usr/local .
echo "Pushing to BigSur... (./local/ -> /usr/local)"
rsync -a -e "ssh -p 3222" ./local/* tobias@localhost:/usr/local/
echo "Done!"
```

### Checks
- Compile on **Catalina** and install, copy `/usr/local/*` over to **BigSur**, and call `find_library('c')`

## Results
### Before this change:
:x: Compile on **Catalina** and install, copy `/usr/local/*` over to **BigSur**, and call `find_library('c')`
```
Python 3.11.0a0 (heads/main:635bfe8162, Jul 19 2021, 08:09:05) [Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ctypes.util import find_library; print(find_library('c'))
None
```

### After this change:
:heavy_check_mark: Compile on **Catalina** and install, copy `/usr/local/*` over to **BigSur**, and call `find_library('c')`
```
Python 3.11.0a0 (heads/macos-ctypes-find-library:0858c0c9ff, Jul 19 2021, 17:52:24) [Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ctypes.util import find_library; print(find_library('c'))
/usr/lib/libc.dylib
```

## Related issues/Symptoms of the issue
Note that some of these are closed due to the symptom having been treated - rather than the underlying cause.

- https://github.com/NixOS/nixpkgs/issues/105038
- https://github.com/jupyterlab/jupyterlab/issues/9863
- https://github.com/arsenetar/send2trash/issues/51
- https://github.com/minrk/appnope/issues/12
- https://github.com/jupyterlab/jupyterlab/issues/9410
- https://github.com/hbldh/bleak/issues/372
- https://bugs.python.org/issue43052
- https://stackoverflow.com/questions/65065482/error-when-importing-pyautogui-on-macos-10-13-and-python-3-8

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44689](https://bugs.python.org/issue44689) -->
https://bugs.python.org/issue44689
<!-- /issue-number -->
