### PR TITLE
[3.9] bpo-44621: Set line number of END_ASYNC_FOR so that it doesn't show in traces.

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2816,6 +2816,12 @@ compiler_async_for(struct compiler *c, stmt_ty s)
 
     /* Except block for __anext__ */
     compiler_use_next_block(c, except);
+
+    /* We don't want to trace the END_ASYNC_FOR, so make sure
+     * that it has the same lineno as the following instruction. */
+    if (asdl_seq_LEN(s->v.For.orelse)) {
+        SET_LOC(c, (stmt_ty)asdl_seq_GET(s->v.For.orelse, 0));
+    }
     ADDOP(c, END_ASYNC_FOR);
 
     /* `else` block */


### PR DESCRIPTION
Fix tracing of `END_ASYNC_FOR` at end of async for loop. 

@ambv Does this need a NEWS item?

<!-- issue-number: [bpo-44621](https://bugs.python.org/issue44621) -->
https://bugs.python.org/issue44621
<!-- /issue-number -->
