### PR TITLE
bpo-43219: handle Solaris as well

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -37,6 +37,7 @@ TESTFN2 = TESTFN + "2"
 TESTFN_SRC = TESTFN + "_SRC"
 TESTFN_DST = TESTFN + "_DST"
 MACOS = sys.platform.startswith("darwin")
+SOLARIS = sys.platform.startswith("sunos")
 AIX = sys.platform[:3] == 'aix'
 try:
     import grp
@@ -1249,7 +1250,7 @@ class TestCopy(BaseTest, unittest.TestCase):
         # Make sure file is not corrupted.
         self.assertEqual(read_file(src_file), 'foo')
 
-    @unittest.skipIf(MACOS or _winapi, 'On MACOS and Windows the errors are not confusing (though different)')
+    @unittest.skipIf(MACOS or SOLARIS or _winapi, 'On MACOS, Solaris and Windows the errors are not confusing (though different)')
     def test_copyfile_nonexistent_dir(self):
         # Issue 43219
         src_dir = self.mkdtemp()


### PR DESCRIPTION
On Solaris (I checked this on Oracle and SmartOS), the error is:

    NotADirectoryError: [Errno 20] Not a directory: 'not_a_dir/'

which I think belongs to the 'errors are not confusing' category with Windows and macOS.

<!-- issue-number: [bpo-43219](https://bugs.python.org/issue43219) -->
https://bugs.python.org/issue43219
<!-- /issue-number -->
