### PR TITLE
bpo-44353: Add test to cover __or__ of two typing.NewType

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3693,12 +3693,15 @@ class NewTypeTests(BaseTestCase):
 
     def test_or(self):
         UserId = NewType('UserId', int)
+        UserName = NewType('UserName', str)
 
-        self.assertEqual(UserId | int, Union[UserId, int])
-        self.assertEqual(int | UserId, Union[int, UserId])
+        for cls in (int, UserName):
+            with self.subTest(cls=cls):
+                self.assertEqual(UserId | cls, Union[UserId, cls])
+                self.assertEqual(cls | UserId, Union[cls, UserId])
 
-        self.assertEqual(get_args(UserId | int), (UserId, int))
-        self.assertEqual(get_args(int | UserId), (int, UserId))
+                self.assertEqual(get_args(UserId | cls), (UserId, cls))
+                self.assertEqual(get_args(cls | UserId), (cls, UserId))
 
     def test_special_attrs(self):
         UserId = NewType('UserId', int)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44353](https://bugs.python.org/issue44353) -->
https://bugs.python.org/issue44353
<!-- /issue-number -->
