### PR TITLE
bpo-44690: Adopt binacii.a2b_base64's strict mode in base64.b64decode

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -78,6 +78,8 @@ The modern interface provides:
    these non-alphabet characters in the input result in a
    :exc:`binascii.Error`.
 
+   For more information about the strict base64 check, see :func:`binascii.a2b_base64`
+
 
 .. function:: standard_b64encode(s)
 

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -76,6 +76,9 @@ def b64decode(s, altchars=None, validate=False):
     normal base-64 alphabet nor the alternative alphabet are discarded prior
     to the padding check.  If validate is True, these non-alphabet characters
     in the input result in a binascii.Error.
+    For more information about the strict base64 check, see:
+
+    https://docs.python.org/3.11/library/binascii.html#binascii.a2b_base64
     """
     s = _bytes_from_decode_data(s)
     if altchars is not None:

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -82,9 +82,7 @@ def b64decode(s, altchars=None, validate=False):
         altchars = _bytes_from_decode_data(altchars)
         assert len(altchars) == 2, repr(altchars)
         s = s.translate(bytes.maketrans(altchars, b'+/'))
-    if validate and not re.fullmatch(b'[A-Za-z0-9+/]*={0,2}', s):
-        raise binascii.Error('Non-base64 digit found')
-    return binascii.a2b_base64(s)
+    return binascii.a2b_base64(s, strict_mode=validate)
 
 
 def standard_b64encode(s):

--- a/Misc/NEWS.d/next/Library/2021-07-20-22-03-24.bpo-44690.tV7Zjg.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-20-22-03-24.bpo-44690.tV7Zjg.rst
@@ -1,0 +1,1 @@
+Adopt *binacii.a2b_base64*'s strict mode in *base64.b64decode*.


### PR DESCRIPTION


<!-- issue-number: [bpo-44690](https://bugs.python.org/issue44690) -->
https://bugs.python.org/issue44690
<!-- /issue-number -->
