### PR TITLE
bpo-44698: Fix undefined behaviour in complex exponentiation.

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 from test import support
 from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
                                INVALID_UNDERSCORE_LITERALS)
@@ -247,6 +248,26 @@ class ComplexTest(unittest.TestCase):
 
         b = 5.1+2.3j
         self.assertRaises(ValueError, pow, a, b, 0)
+
+        # Check some boundary conditions; some of these used to invoke
+        # undefined behaviour (https://bugs.python.org/issue44698). We're
+        # not actually checking the results of these operations, just making
+        # sure they don't crash (for example when using clang's
+        # UndefinedBehaviourSanitizer).
+        values = (sys.maxsize, sys.maxsize+1, sys.maxsize-1,
+                  -sys.maxsize, -sys.maxsize+1, -sys.maxsize+1)
+        for real in values:
+            for imag in values:
+                with self.subTest(real=real, imag=imag):
+                    c = complex(real, imag)
+                    try:
+                        c ** real
+                    except OverflowError:
+                        pass
+                    try:
+                        c ** c
+                    except OverflowError:
+                        pass
 
     def test_boolcontext(self):
         for i in range(100):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-21-15-26-56.bpo-44698.DA4_0o.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-21-15-26-56.bpo-44698.DA4_0o.rst
@@ -1,0 +1,1 @@
+Fix undefined behaviour in complex object exponentiation.

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -526,7 +526,10 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
     }
     errno = 0;
     exponent = b;
-    int_exponent = (long)exponent.real;
+    if ((double)LONG_MIN <= exponent.real && exponent.real <= (double)LONG_MAX)
+        int_exponent = (long)exponent.real;
+    else
+        int_exponent = 0;
     if (exponent.imag == 0. && exponent.real == int_exponent)
         p = c_powi(a, int_exponent);
     else

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -526,7 +526,7 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
     }
     errno = 0;
     exponent = b;
-    if ((double)LONG_MIN <= exponent.real && exponent.real <= (double)LONG_MAX)
+    if ((double)LONG_MIN <= exponent.real && exponent.real < (double)LONG_MAX)
         int_exponent = (long)exponent.real;
     else
         int_exponent = 0;


### PR DESCRIPTION
The undefined behaviour is already triggered by an existing check in test_complex (test_truediv, later moved to test_pow), which was commented out until Python 3.8. Clang's UBSan, specifically -fsanitize=float-cast-overflow, caught the error. It's present in all Python versions that I have access to, but it's probably not worth fixing in 3.8 and earlier.

<!-- issue-number: [bpo-44698](https://bugs.python.org/issue44698) -->
https://bugs.python.org/issue44698
<!-- /issue-number -->
