### PR TITLE
Add missing end of sentence in docs

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -350,7 +350,7 @@ The :class:`Future` class encapsulates the asynchronous execution of a callable.
        If the future is cancelled before completing then :exc:`.CancelledError`
        will be raised.
 
-       If the call raised, this method will raise the same exception.
+       If the call raised an exception, this method will raise the same exception.
 
     .. method:: exception(timeout=None)
 

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -20,6 +20,7 @@ The asynchronous execution can be performed with threads, using
 defined by the abstract :class:`Executor` class.
 
 
+
 Executor Objects
 ----------------
 

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -20,7 +20,6 @@ The asynchronous execution can be performed with threads, using
 defined by the abstract :class:`Executor` class.
 
 
-
 Executor Objects
 ----------------
 


### PR DESCRIPTION
Fixing a minor typo, I think the end of this sentence is missing