### PR TITLE
bpo-44707: Fix an undefined behavior of the null pointer arithmetic

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -180,9 +180,10 @@ PyList_New(Py_ssize_t size)
 static PyObject *
 list_new_prealloc(Py_ssize_t size)
 {
+    assert(size > 0);
     PyListObject *op = (PyListObject *) PyList_New(0);
-    if (size == 0 || op == NULL) {
-        return (PyObject *) op;
+    if (op == NULL) {
+        return NULL;
     }
     assert(op->ob_item == NULL);
     op->ob_item = PyMem_New(PyObject *, size);
@@ -459,6 +460,9 @@ list_slice(PyListObject *a, Py_ssize_t ilow, Py_ssize_t ihigh)
     PyObject **src, **dest;
     Py_ssize_t i, len;
     len = ihigh - ilow;
+    if (len <= 0) {
+        return PyList_New(0);
+    }
     np = (PyListObject *) list_new_prealloc(len);
     if (np == NULL)
         return NULL;
@@ -512,6 +516,9 @@ list_concat(PyListObject *a, PyObject *bb)
 #define b ((PyListObject *)bb)
     assert((size_t)Py_SIZE(a) + (size_t)Py_SIZE(b) < PY_SSIZE_T_MAX);
     size = Py_SIZE(a) + Py_SIZE(b);
+    if (size == 0) {
+        return PyList_New(0);
+    }
     np = (PyListObject *) list_new_prealloc(size);
     if (np == NULL) {
         return NULL;


### PR DESCRIPTION


<!-- issue-number: [bpo-44707](https://bugs.python.org/issue44707) -->
https://bugs.python.org/issue44707
<!-- /issue-number -->
