### PR TITLE
bpo-44713: [doc fix]: typo in subprocess.rst

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -689,7 +689,7 @@ execute, will be re-raised in the parent.
 
 The most common exception raised is :exc:`OSError`.  This occurs, for example,
 when trying to execute a non-existent file.  Applications should prepare for
-:exc:`OSError` exceptions. Note that, when ``"shell=True"``, :exc:`OSError`
+:exc:`OSError` exceptions. Note that, when ``shell=True``, :exc:`OSError`
 will be raised by the child only if the selected shell itself was not found.
 To determine if the shell failed to find the requested application, it is
 necessary to check the return code or output from the subprocess.


### PR DESCRIPTION
This fixes a small typo. The code fragment should not be quoted. Thank you
@merwok for the feedback.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44713](https://bugs.python.org/issue44713) -->
https://bugs.python.org/issue44713
<!-- /issue-number -->

Automerge-Triggered-By: GH:Mariatta