### PR TITLE
bpo-43838: Use a copy to delegate `types.MappingProxyType` operators

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -369,6 +369,12 @@ Standard names are defined for the following types:
       Updated to support the new union (``|``) operator from :pep:`584`, which
       simply delegates to the underlying mapping.
 
+   .. versionchanged:: 3.10
+
+      To avoid exposing the actual proxied object to arbitrary code, union and
+      rich comparison operations now delegate to a copy of the underlying
+      mapping instead.
+
    .. describe:: key in proxy
 
       Return ``True`` if the underlying mapping has a key *key*, else

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-22-16-10-14.bpo-43838.a5j8Q3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-22-16-10-14.bpo-43838.a5j8Q3.rst
@@ -1,0 +1,3 @@
+To avoid exposing the actual proxied object to arbitrary code, union and
+rich comparison operations on :class:`types.MappingProxyType` now delegate
+to a copy of the underlying mapping instead.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1044,14 +1044,24 @@ mappingproxy_or(PyObject *left, PyObject *right)
             return NULL;
         }
     }
+    else {
+        Py_INCREF(left);
+    }
     if (PyObject_TypeCheck(right, &PyDictProxy_Type)) {
         right = ((mappingproxyobject*)right)->mapping;
         right = _PyObject_CallMethodIdNoArgs(right, &PyId_copy);
         if (right == NULL) {
+            Py_DECREF(left);
             return NULL;
         }
     }
-    return PyNumber_Or(left, right);
+    else {
+        Py_INCREF(right);
+    }
+    PyObject *result = PyNumber_Or(left, right);
+    Py_DECREF(left);
+    Py_DECREF(right);
+    return result;
 }
 
 static PyObject *
@@ -1209,7 +1219,9 @@ mappingproxy_richcompare(mappingproxyobject *v, PyObject *w, int op)
     if (copy == NULL) {
         return NULL;
     }
-    return PyObject_RichCompare(copy, w, op);
+    PyObject *result = PyObject_RichCompare(copy, w, op);
+    Py_DECREF(copy);
+    return result;
 }
 
 static int


### PR DESCRIPTION
This keeps us from breaking encapsulation and (in 3.11) possibly segfaulting.

Should this be backported to 3.9 as a bugfix? If so, the docs should be updated to read `.. versionchanged:: 3.9.7`.


<!-- issue-number: [bpo-43838](https://bugs.python.org/issue43838) -->
https://bugs.python.org/issue43838
<!-- /issue-number -->
