### PR TITLE
bpo-44722: Added a Multiline Formatter

### DIFF
--- a/Lib/string.py
+++ b/Lib/string.py
@@ -350,9 +350,7 @@ class MultilineFormatter(Formatter):
                 if recursion_depth == 2:
                   if isinstance(obj, str) and "\n" in obj:
                     
-                    pos = 0
-                    for item in result:
-                      pos += len(item)
+                    pos = sum(len(item) for item in result)
                     
                     lines = obj.split("\n")
                     obj = lines.pop(0)


### PR DESCRIPTION
### RFC: string Multiline Formatter

I'd like to contribute a multiline formatter to the string library.
This is a first draft, that I've so far done basic testing for.

_Please let me know your thoughts. I am sure it can be further improved._


**The idea:**

Format strings
- that are comprised of field values with newlines (Multiline)
- as Multiline strings in a quasi tabbed format.

This is in particular useful for logging of information, that occupies multiple lines.

**For example:**

Given the format string `'{levelname}:{name}:{message}:{api}'`,
where the message and the api field is a string with multiple lines (contains newlines) ...

**Result:**

... Is formatted as:
```
2021-07-23 09:50:28,981 module_name WARNING     Quota exceeded         Google-Cloud-API
                                                Backing off for 5s     version: v1
                                                after trying 2x
```

<!-- issue-number: [bpo-44722](https://bugs.python.org/issue44722) -->
https://bugs.python.org/issue44722
<!-- /issue-number -->
