### PR TITLE
bpo-38291: Fix a deprecation warning in typing tests

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4653,9 +4653,6 @@ class AllTests(BaseTestCase):
             if k in actual_all or (
                 # avoid private names
                 not k.startswith('_') and
-                # avoid things in the io / re typing submodules
-                k not in typing.io.__all__ and
-                k not in typing.re.__all__ and
                 k not in {'io', 're'} and
                 # there's a few types and metaclasses that aren't exported
                 not k.endswith(('Meta', '_contra', '_co')) and


### PR DESCRIPTION
The test was accessing typing.{io,re}.__all__, which triggered the
warning. This check isn't necessary anymore, since the objects from
typing.{io,re}.__all__ are in typing.__all__ as well, since Python 3.10.

A NEWS should not be required, since this affects the tests only.

Cc @serhiy-storchaka 

<!-- issue-number: [bpo-38291](https://bugs.python.org/issue38291) -->
https://bugs.python.org/issue38291
<!-- /issue-number -->
