### PR TITLE
bpo-43950: ensure source_line is present when specializing the traceback

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -123,7 +123,10 @@ class TracebackCases(unittest.TestCase):
 
     def test_recursion_error_during_traceback(self):
         code = textwrap.dedent("""
+                import sys
                 from weakref import ref
+
+                sys.setrecursionlimit(15)
 
                 def f():
                     ref(lambda: 0, [])
@@ -133,7 +136,7 @@ class TracebackCases(unittest.TestCase):
                     f()
                 except RecursionError:
                     pass
-            """)
+        """)
         try:
             with open(TESTFN, 'w') as f:
                 f.write(code)

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -121,6 +121,28 @@ class TracebackCases(unittest.TestCase):
         finally:
             unlink(TESTFN)
 
+    def test_recursion_error_during_traceback(self):
+        code = textwrap.dedent("""
+                from weakref import ref
+
+                def f():
+                    ref(lambda: 0, [])
+                    f()
+
+                try:
+                    f()
+                except RecursionError:
+                    pass
+            """)
+        try:
+            with open(TESTFN, 'w') as f:
+                f.write(code)
+
+            rc, _, _ = assert_python_ok(TESTFN)
+            self.assertEqual(rc, 0)
+        finally:
+            unlink(TESTFN)
+
     def test_bad_indentation(self):
         err = self.get_exception_format(self.syntax_error_bad_indentation,
                                         IndentationError)

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -699,11 +699,11 @@ tb_displayline(PyTracebackObject* tb, PyObject *f, PyObject *filename, int linen
     Py_DECREF(line);
     if (err != 0)
         return err;
+
     int truncation = _TRACEBACK_SOURCE_LINE_INDENT;
     PyObject* source_line = NULL;
-
     if (_Py_DisplaySourceLine(f, filename, lineno, _TRACEBACK_SOURCE_LINE_INDENT,
-                               &truncation, &source_line) != 0) {
+                               &truncation, &source_line) != 0 || !source_line) {
         /* ignore errors since we can't report them, can we? */
         err = ignore_source_errors();
         goto done;


### PR DESCRIPTION
There seems to be different cases where the `_PyDisplay_Line()` function returns `0` without displaying the actual line but also without having any errors raised. 

https://github.com/python/cpython/blob/4512848ab92c8ed6aafb54d6e1908b1074558c43/Python/traceback.c#L414-L420
https://github.com/python/cpython/blob/4512848ab92c8ed6aafb54d6e1908b1074558c43/Python/traceback.c#L436-L446

This patch ensures that the line is retrieved and displayed. 

<!-- issue-number: [bpo-43950](https://bugs.python.org/issue43950) -->
https://bugs.python.org/issue43950
<!-- /issue-number -->
