### PR TITLE
bpo-44720: Don't crash when calling weakref.proxy(not_an_iterator).__next__

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -411,6 +411,36 @@ class ReferencesTestCase(TestBase):
             # can be killed in the middle of the call
             "blech" in p
 
+    def test_proxy_next(self):
+        arr = [4, 5, 6]
+        def iterator_func():
+            yield from arr
+        it = iterator_func()
+
+        class IteratesWeakly:
+            def __iter__(self):
+                return weakref.proxy(it)
+
+        weak_it = IteratesWeakly()
+
+        # Calls proxy.__next__
+        self.assertEqual(list(weak_it), [4, 5, 6])
+
+    def test_proxy_bad_next(self):
+        # bpo-44720: PyIter_Next() shouldn't be called if the reference
+        # isn't an iterator.
+
+        not_an_iterator = lambda: 0
+
+        class A:
+            def __iter__(self):
+                return weakref.proxy(not_an_iterator)
+        a = A()
+
+        msg = "Weakref referenced a non-iterator"
+        with self.assertRaisesRegex(TypeError, msg):
+            list(a)
+
     def test_proxy_reversed(self):
         class MyObj:
             def __len__(self):

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -437,7 +437,7 @@ class ReferencesTestCase(TestBase):
                 return weakref.proxy(not_an_iterator)
         a = A()
 
-        msg = "Weakref referenced a non-iterator"
+        msg = "Weakref proxy referenced a non-iterator"
         with self.assertRaisesRegex(TypeError, msg):
             list(a)
 

--- a/Misc/NEWS.d/next/Library/2021-07-24-02-17-59.bpo-44720.shU5Qm.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-24-02-17-59.bpo-44720.shU5Qm.rst
@@ -1,0 +1,1 @@
+``weakref.proxy`` objects referencing non-iterators now raise ``TypeError`` rather than dereferencing the null ``tp_iternext`` slot and crashing.

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -657,6 +657,12 @@ proxy_iternext(PyWeakReference *proxy)
         return NULL;
 
     PyObject *obj = PyWeakref_GET_OBJECT(proxy);
+    if (!PyIter_Check(obj)) {
+        PyErr_Format(PyExc_TypeError,
+                     "Weakref referenced a non-iterator '%.200s' object",
+                     Py_TYPE(obj)->tp_name);
+        return NULL;
+    }
     Py_INCREF(obj);
     PyObject* res = PyIter_Next(obj);
     Py_DECREF(obj);

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -659,8 +659,8 @@ proxy_iternext(PyWeakReference *proxy)
     PyObject *obj = PyWeakref_GET_OBJECT(proxy);
     if (!PyIter_Check(obj)) {
         PyErr_Format(PyExc_TypeError,
-                     "Weakref referenced a non-iterator '%.200s' object",
-                     Py_TYPE(obj)->tp_name);
+            "Weakref proxy referenced a non-iterator '%.200s' object",
+            Py_TYPE(obj)->tp_name);
         return NULL;
     }
     Py_INCREF(obj);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44720](https://bugs.python.org/issue44720) -->
https://bugs.python.org/issue44720
<!-- /issue-number -->
