### PR TITLE
Add return values for logging methods

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -385,6 +385,7 @@ def setLogRecordFactory(factory):
     """
     global _logRecordFactory
     _logRecordFactory = factory
+    return factory
 
 def getLogRecordFactory():
     """
@@ -1276,6 +1277,7 @@ def setLoggerClass(klass):
                             + klass.__name__)
     global _loggerClass
     _loggerClass = klass
+    return klass
 
 def getLoggerClass():
     """


### PR DESCRIPTION
It's super common I guess to use `setLoggerClass` and `setLogRecordFactory`  to properly override the `Logger` and `LogRecord` implementations to add new behavior. Defining the class then calling the method is a bit clunky though.

E.g.,
```python
TRACE = logging.DEBUG - 5
logging.addLevelName(TRACE, 'TRACE')


class Logger(logging.Logger):
    """Extend Logger class to include new level methods."""

    def trace(self, msg, *args, **kwargs):
        """Log 'msg % args' with severity 'TRACE'."""
        if self.isEnabledFor(TRACE):
            self._log(TRACE, msg, args, **kwargs)


logging.setLoggerClass(Logger)
```

Given that the current implementation is called in this way, adding a return value will have no effect on legacy code, but will enable the _decorator_ syntax to clean this up a bit.

I.e.,
```python
TRACE = logging.DEBUG - 5
logging.addLevelName(TRACE, 'TRACE')


@logging.setLoggerClass
class Logger(logging.Logger):
    """Extend Logger class to include new level methods."""

    def trace(self, msg, *args, **kwargs):
        """Log 'msg % args' with severity 'TRACE'."""
        if self.isEnabledFor(TRACE):
            self._log(TRACE, msg, args, **kwargs)
```

Similarly for `setLogRecordFactory`,

```python

HOSTNAME = sockets.gethostname()


@logging.setLogRecordFactory
class LogRecord(logging.LogRecord):
    """Extends LogRecord to allow '%(hostname)s' attribute."""

    def __init__(self, *args, **kwargs) -> None:
        super().__init__(*args, **kwargs)
        self.hostname = HOSTNAME
```

I understand that `logging` is a very long lived part of the standard library, but I think this small change would clean up a lot of new code that uses these methods.