### PR TITLE
Fix 404 link to the pyporting mailing list

### DIFF
--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -20,8 +20,8 @@ Porting Python 2 Code to Python 3
    came into existence, you can read Nick Coghlan's `Python 3 Q & A`_ or
    Brett Cannon's `Why Python 3 exists`_.
 
-   For help with porting, you can email the python-porting_ mailing list with
-   questions.
+   
+   For help with porting, you can use this python-converter-tool_.
 
 The Short Explanation
 =====================
@@ -446,7 +446,7 @@ to make sure everything functions as expected in both versions of Python.
 
 .. _pytype: https://github.com/google/pytype
 .. _python-future: http://python-future.org/
-.. _python-porting: https://mail.python.org/mailman/listinfo/python-porting
+.. _python-converter-tool: https://360techexplorer.com/tools/python-2-to-3-converter/
 .. _six: https://pypi.org/project/six
 .. _tox: https://pypi.org/project/tox
 .. _trove classifier: https://pypi.org/classifiers

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -20,7 +20,7 @@ Porting Python 2 Code to Python 3
    came into existence, you can read Nick Coghlan's `Python 3 Q & A`_ or
    Brett Cannon's `Why Python 3 exists`_.
 
-   
+
    For help with porting, you can view the archived python-porting_ mailing list.
 
 The Short Explanation

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -21,7 +21,7 @@ Porting Python 2 Code to Python 3
    Brett Cannon's `Why Python 3 exists`_.
 
    
-   For help with porting, you can use this python-converter-tool_.
+   For help with porting, you can view the archived python-porting_ mailing list.
 
 The Short Explanation
 =====================

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -446,7 +446,7 @@ to make sure everything functions as expected in both versions of Python.
 
 .. _pytype: https://github.com/google/pytype
 .. _python-future: http://python-future.org/
-.. _python-converter-tool: https://360techexplorer.com/tools/python-2-to-3-converter/
+.. _python-porting: https://mail.python.org/pipermail/python-porting/
 .. _six: https://pypi.org/project/six
 .. _tox: https://pypi.org/project/tox
 .. _trove classifier: https://pypi.org/classifiers


### PR DESCRIPTION
https://mail.python.org/mailman/listinfo/python-porting this link is broken and return 404 error. So i just removed it.
Also, this page is about proting code so i linked out to my own python converter tool. (Its not a paid tool)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
