### PR TITLE
[3.10] bpo-44353: Expand NewType tests for complex __qualname__ (GH-27311)

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2375,8 +2375,10 @@ class NewType:
     """
 
     def __init__(self, name, tp):
-        self.__name__ = name
         self.__qualname__ = name
+        if '.' in name:
+            name = name.rpartition('.')[-1]
+        self.__name__ = name
         self.__module__ = _callee(default='typing')
         self.__supertype__ = tp
 
@@ -2385,6 +2387,9 @@ class NewType:
 
     def __call__(self, x):
         return x
+
+    def __reduce__(self):
+        return self.__qualname__
 
     def __or__(self, other):
         return Union[self, other]


### PR DESCRIPTION
Make NewType pickleable by name.
(cherry picked from commit e89ef0ad2a299770a88ece8f7a316f7d3eb65c9f)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>


<!-- issue-number: [bpo-44353](https://bugs.python.org/issue44353) -->
https://bugs.python.org/issue44353
<!-- /issue-number -->
