### PR TITLE
bpo-36643: Unwrap ForwardRefs and string types in dataclasses.fields() result

### DIFF
--- a/Lib/test/dataclass_forward_ref.py
+++ b/Lib/test/dataclass_forward_ref.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class A:
+    a: Optional['A']

--- a/Lib/test/dataclass_forward_ref_child.py
+++ b/Lib/test/dataclass_forward_ref_child.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from test.dataclass_forward_ref import A
+
+
+@dataclass
+class B(A):
+    b: Optional['B']

--- a/Lib/test/dataclass_forward_ref_str.py
+++ b/Lib/test/dataclass_forward_ref_str.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class A:
+    a: Optional[A]

--- a/Misc/NEWS.d/next/Library/2021-07-24-14-32-24.bpo-36643.54-Wdj.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-24-14-32-24.bpo-36643.54-Wdj.rst
@@ -1,0 +1,2 @@
+Unwrap ``dataclasses.Field.type`` forward references returned by
+``dataclasses.fields()``.


### PR DESCRIPTION
[dataclasses.fields()][fields] returns [dataclasses.Field](https://docs.python.org/3/library/dataclasses.html#dataclasses.Field) instances which can have `Field.type` to be actual types, `ForwardRef` or `str` (in case of `__future__.annotations`). This behaviour is overall obscure leaking implementation details, and making every user of `fields()` reimplement the unwrapping of types, mixing between `dataclasses.fields()` and `typing.get_type_hints()` (which does perform unwrapping of types).

This PR fixes this behaviour by unwrapping the types during `fields()` execution.

Also, see https://bugs.python.org/issue36643

Please let me know if there are any documentation, code style, or implementation changes that need to be performed for this to be merged. 

(On a side note: it seems like `Field` is marked as an internal object in documentation — it is said not to be instantiated directly by users. Call to `fields()` returns `Field` objects, but it seems like no builtins use anything except for `Field.name` when calling `fields()`. Maybe it is better to separate internal/external APIs here in some way?)


[fields]: https://docs.python.org/3/library/dataclasses.html#dataclasses.fields
[Field]: https://docs.python.org/3/library/dataclasses.html#dataclasses.Field

<!-- issue-number: [bpo-36643](https://bugs.python.org/issue36643) -->
https://bugs.python.org/issue36643
<!-- /issue-number -->
