### PR TITLE
bpo-44676: Fix reference leaks in union_reduce

### DIFF
--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -445,7 +445,7 @@ union_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
         return NULL;
     }
 
-    return Py_BuildValue("O(O)", from_args, alias->args);
+    return Py_BuildValue("N(O)", from_args, alias->args);
 }
 
 static PyMemberDef union_members[] = {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44676](https://bugs.python.org/issue44676) -->
https://bugs.python.org/issue44676
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal