### PR TITLE
[3.10] Partially revert "bpo-44676: Add ability to serialize types.Union (GH-27244) (GH-27333)"

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -806,38 +806,6 @@ class UnionTests(unittest.TestCase):
         eq(x[NT], int | NT | bytes)
         eq(x[S], int | S | bytes)
 
-    def test_union_pickle(self):
-        alias = list[T] | int
-        s = pickle.dumps(alias)
-        loaded = pickle.loads(s)
-        self.assertEqual(alias, loaded)
-        self.assertEqual(alias.__args__, loaded.__args__)
-        self.assertEqual(alias.__parameters__, loaded.__parameters__)
-
-    def test_union_from_args(self):
-        with self.assertRaisesRegex(
-                TypeError,
-                r"^Each union argument must be a type, got 1$",
-        ):
-            types.Union._from_args((1,))
-
-        with self.assertRaisesRegex(
-                TypeError,
-                r"Union._from_args\(\) argument 'args' must be tuple, not int$",
-        ):
-            types.Union._from_args(1)
-
-        with self.assertRaisesRegex(ValueError, r"args must be not empty"):
-            types.Union._from_args(())
-
-        alias = types.Union._from_args((int, list[T], None))
-
-        self.assertEqual(alias.__args__, (int, list[T], type(None)))
-        self.assertEqual(alias.__parameters__, (T,))
-
-        result = types.Union._from_args((int,))
-        self.assertIs(int, result)
-
     def test_union_parameter_substitution_errors(self):
         T = typing.TypeVar("T")
         x = int | T

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -321,7 +321,7 @@ def _eval_type(t, globalns, localns, recursive_guard=frozenset()):
         if isinstance(t, GenericAlias):
             return GenericAlias(t.__origin__, ev_args)
         if isinstance(t, types.Union):
-            return types.Union._from_args(ev_args)
+            return functools.reduce(operator.or_, ev_args)
         else:
             return t.copy_with(ev_args)
     return t
@@ -1806,7 +1806,7 @@ def _strip_annotations(t):
         stripped_args = tuple(_strip_annotations(a) for a in t.__args__)
         if stripped_args == t.__args__:
             return t
-        return types.Union._from_args(stripped_args)
+        return functools.reduce(operator.or_, stripped_args)
 
     return t
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-07-19-19-53-46.bpo-44676.WgIMvh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-07-19-19-53-46.bpo-44676.WgIMvh.rst
@@ -1,2 +1,0 @@
-Add ability to serialise ``types.Union`` objects. Patch provided by Yurii
-Karabas.

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -362,18 +362,6 @@ error:
     return NULL;
 }
 
-static PyObject *
-union_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
-{
-    unionobject *alias = (unionobject *)self;
-    PyObject* from_args = PyObject_GetAttrString(self, "_from_args");
-    if (from_args == NULL) {
-        return NULL;
-    }
-
-    return Py_BuildValue("N(O)", from_args, alias->args);
-}
-
 static PyMemberDef union_members[] = {
         {"__args__", T_OBJECT, offsetof(unionobject, args), READONLY},
         {0}
@@ -399,10 +387,8 @@ union_from_args(PyObject *cls, PyObject *args)
 }
 
 static PyMethodDef union_methods[] = {
-        {"_from_args", union_from_args, METH_O | METH_CLASS},
         {"__instancecheck__", union_instancecheck, METH_O},
         {"__subclasscheck__", union_subclasscheck, METH_O},
-        {"__reduce__", union_reduce, METH_NOARGS},
         {0}};
 
 


### PR DESCRIPTION
We only need the refactoring parts for future backports. The added support for pickling is removed.


<!-- issue-number: [bpo-44676](https://bugs.python.org/issue44676) -->
https://bugs.python.org/issue44676
<!-- /issue-number -->
