### PR TITLE
bpo-43950: support long lines in traceback.py

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -485,6 +485,28 @@ class TracebackErrorLocationCaretTests(unittest.TestCase):
         )
         self.assertEqual(result_lines, expected_error.splitlines())
 
+    def test_traceback_very_long_line(self):
+        source = "a" * 256
+        bytecode = compile(source, TESTFN, "exec")
+
+        with open(TESTFN, "w") as file:
+            file.write(source)
+        self.addCleanup(unlink, TESTFN)
+
+        func = partial(exec, bytecode)
+        result_lines = self.get_exception(func)
+
+        lineno_f = bytecode.co_firstlineno
+        expected_error = (
+            'Traceback (most recent call last):\n'
+            f'  File "{__file__}", line {self.callable_line}, in get_exception\n'
+            '    callable()\n'
+            '    ^^^^^^^^^^\n'
+            f'  File "{TESTFN}", line {lineno_f}, in <module>\n'
+            f'    {source}\n'
+        )
+        self.assertEqual(result_lines, expected_error.splitlines())
+
     def assertSpecialized(self, func, expected_specialization):
         result_lines = self.get_exception(func)
         specialization_line = result_lines[-1]

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -462,7 +462,11 @@ class StackSummary(list):
             row.append('    {}\n'.format(frame.line.strip()))
 
             stripped_characters = len(frame._original_line) - len(frame.line.lstrip())
-            if frame.end_lineno == frame.lineno and frame.end_colno != 0:
+            if (
+                frame.end_lineno == frame.lineno
+                and frame.colno is not None
+                and frame.end_colno is not None
+            ):
                 colno = _byte_offset_to_character_offset(frame._original_line, frame.colno)
                 end_colno = _byte_offset_to_character_offset(frame._original_line, frame.end_colno)
 


### PR DESCRIPTION
We use `None` for the Python API, so this condition used to fail (in the `_byte_offset_to_character_offset` function where it was raising can't compare `None` with `int`s). 

<!-- issue-number: [bpo-43950](https://bugs.python.org/issue43950) -->
https://bugs.python.org/issue43950
<!-- /issue-number -->
