### PR TITLE
bpo-43950: check against the raw string, not the pyobject

### DIFF
--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -605,7 +605,7 @@ extract_anchors_from_line(PyObject *filename, PyObject *line,
     }
 
     const char *segment_str = PyUnicode_AsUTF8(segment);
-    if (!segment) {
+    if (!segment_str) {
         goto done;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-43950](https://bugs.python.org/issue43950) -->
https://bugs.python.org/issue43950
<!-- /issue-number -->
