### PR TITLE
bpo-43950: support some multi-line expressions for PEP 657

### DIFF
--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -2835,6 +2835,7 @@ Check doctest with a non-ascii filename:
         Traceback (most recent call last):
           File ...
             exec(compile(example.source, filename, "single",
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           File "<doctest foo-bär@baz[0]>", line 1, in <module>
             raise Exception('clé')
             ^^^^^^^^^^^^^^^^^^^^^^

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -429,6 +429,7 @@ class TracebackErrorLocationCaretTests(unittest.TestCase):
             '    ^^^^^^^^^^\n'
             f'  File "{__file__}", line {lineno_f+1}, in f_with_multiline\n'
             '    raise ValueError(\n'
+            '    ^^^^^^^^^^^^^^^^^'
         )
         result_lines = self.get_exception(f_with_multiline)
         self.assertEqual(result_lines, expected_f.splitlines())

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -434,6 +434,29 @@ class TracebackErrorLocationCaretTests(unittest.TestCase):
         result_lines = self.get_exception(f_with_multiline)
         self.assertEqual(result_lines, expected_f.splitlines())
 
+    def test_caret_multiline_expression_bin_op(self):
+        # Make sure no carets are printed for expressions spanning multiple
+        # lines.
+        def f_with_multiline():
+            return (
+                1 /
+                0 +
+                2
+            )
+
+        lineno_f = f_with_multiline.__code__.co_firstlineno
+        expected_f = (
+            'Traceback (most recent call last):\n'
+            f'  File "{__file__}", line {self.callable_line}, in get_exception\n'
+            '    callable()\n'
+            '    ^^^^^^^^^^\n'
+            f'  File "{__file__}", line {lineno_f+2}, in f_with_multiline\n'
+            '    1 /\n'
+            '    ^^^'
+        )
+        result_lines = self.get_exception(f_with_multiline)
+        self.assertEqual(result_lines, expected_f.splitlines())
+
     def test_caret_for_binary_operators(self):
         def f_with_binary_operator():
             divisor = 20


### PR DESCRIPTION
This is basically something that I noticed up while fixing test runs for another issue. It is really common to have multiline calls, and when they fail the display is kind of weird since we omit the annotations. E.g;

```
 $ ./python t.py
Traceback (most recent call last):
  File "/home/isidentical/cpython/cpython/t.py", line 11, in <module>
    frame_1()
    ^^^^^^^^^
  File "/home/isidentical/cpython/cpython/t.py", line 5, in frame_1
    frame_2(              
  File "/home/isidentical/cpython/cpython/t.py", line 2, in frame_2
    return a / 0 / b / c
           ~~^~~
ZeroDivisionError: division by zero
```

This patch basically adds support for annotating the rest of the line, if the instruction covers multiple lines (start_line != end_line). 

<!-- issue-number: [bpo-43950](https://bugs.python.org/issue43950) -->
https://bugs.python.org/issue43950
<!-- /issue-number -->

Automerge-Triggered-By: GH:isidentical