### PR TITLE
Updating a code example in the docs - classes.rst

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -908,7 +908,7 @@ Examples::
    >>> sum(x*y for x,y in zip(xvec, yvec))         # dot product
    260
 
-   >>>  unique_words= set(word for line in page.splitlines()  for word in line.split())
+   >>> unique_words = set(word for line in page.splitlines()  for word in line.split())
 
    >>> valedictorian = max((student.gpa, student.name) for student in graduates)
 

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -908,7 +908,7 @@ Examples::
    >>> sum(x*y for x,y in zip(xvec, yvec))         # dot product
    260
 
-   >>> unique_words = set(word for line in page  for word in line.split())
+   >>>  unique_words= set(word for line in page.splitlines()  for word in line.split())
 
    >>> valedictorian = max((student.gpa, student.name) for student in graduates)
 


### PR DESCRIPTION
the giving example for the generator expressions that yield all words from a page will actually yield all the characters from that page instead, giving that the `page` holds a multiline string as the name implies.
```py
>>> page = """hello, world
... I love Python!"""
>>> set(word for line in page for word in line.split())
{'n', 'h', 'd', 'o', 'e', ',', 'r', 'I', 't', 'v', 'P', 'l', 'w', 'y', '!'}
```
the example could be correct only if the `page` variable contains a list for lines instead, but then the variable name would need to reconsider, for example, `lines`.

the correct code would be something like:
```py
>>> set(word for line in page.splitlines() for word in line.split())
{'love', 'world', 'I', 'hello,', 'Python!'}
```
the same generator expressions also could be simplified to just
```py
>>> set(word for word in page.split())
{'love', 'world', 'I', 'hello,', 'Python!'}
```