### PR TITLE
bpo-44717: refactor _PyModuleSpec helpers

### DIFF
--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -724,43 +724,51 @@ module_repr(PyModuleObject *m)
 int
 _PyModuleSpec_IsInitializing(PyObject *spec)
 {
-    if (spec != NULL) {
-        _Py_IDENTIFIER(_initializing);
-        PyObject *value = _PyObject_GetAttrId(spec, &PyId__initializing);
-        if (value != NULL) {
-            int initializing = PyObject_IsTrue(value);
-            Py_DECREF(value);
-            if (initializing >= 0) {
-                return initializing;
-            }
-        }
+    if (spec == NULL) {
+         goto exit;
     }
+
+    _Py_IDENTIFIER(_initializing);
+    PyObject *value = _PyObject_GetAttrId(spec, &PyId__initializing);
+    if (value == NULL) {
+        goto exit;
+    }
+
+    int initializing = PyObject_IsTrue(value);
+    Py_DECREF(value);
+    if (initializing >= 0) {
+        return initializing;
+    }
+exit:
     PyErr_Clear();
     return 0;
 }
 
 /* Check if the submodule name is in the "_uninitialized_submodules" attribute
    of the module spec.
+   Clear the exception and return 0 if spec is NULL.
  */
 int
 _PyModuleSpec_IsUninitializedSubmodule(PyObject *spec, PyObject *name)
 {
     if (spec == NULL) {
-         return 0;
+         goto exit;
     }
 
     _Py_IDENTIFIER(_uninitialized_submodules);
     PyObject *value = _PyObject_GetAttrId(spec, &PyId__uninitialized_submodules);
     if (value == NULL) {
-        return 0;
+        goto exit;
     }
 
     int is_uninitialized = PySequence_Contains(value, name);
     Py_DECREF(value);
-    if (is_uninitialized == -1) {
-        return 0;
+    if (is_uninitialized >= 0) {
+        return is_uninitialized;
     }
-    return is_uninitialized;
+exit:
+    PyErr_Clear();
+    return 0;
 }
 
 static PyObject*


### PR DESCRIPTION
This PR refactors `_PyModuleSpec_IsInitializing`, as suggested in #26822, and adds the exception cleaning side effect to `_PyModuleSpec_IsUninitializedSubmodule`. The exception cleaning is not really needed in `_PyModuleSpec_IsUninitializedSubmodule` as we are using it, but it makes the code too fragile, so I think it would be best to align it with `_PyModuleSpec_IsInitializing`, this was an oversight of the initial implementation. Btw, sorry for all of the back and forward on this bpo :confused: 

<!-- issue-number: [bpo-44717](https://bugs.python.org/issue44717) -->
https://bugs.python.org/issue44717
<!-- /issue-number -->
