### PR TITLE
bpo-44693: Update __future__ entry in Doc/glossary.rst

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -451,14 +451,13 @@ Glossary
       for best practices on working with annotations.
 
    __future__
-      A :ref:`future statement <future>`, "from __future__ import *feature*
-      ...", directs the compiler to compile the current module using syntax or
-      semantics that will become standard in a future release of Python. The
-      :mod:`__future__` module documents the possible values of *feature*.
-
-      By importing the :mod:`__future__` module and evaluating its variables,
-      you can see when a new feature was first added to the language and when it
-      becomes the default::
+      A :ref:`future statement <future>`, ``from __future__ import <feature>``,
+      directs the compiler to compile the current module using syntax or
+      semantics that will become standard in a future release of Python.
+      The :mod:`__future__` module documents the possible values of
+      *feature*.  By importing this module and evaluating its variables,
+      you can see when a new feature was first added to the language and
+      when it will (or did) become the default::
 
          >>> import __future__
          >>> __future__.division

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -451,9 +451,9 @@ Glossary
       for best practices on working with annotations.
 
    __future__
-      A :ref:`future statement <future>`, "from __future__ import *feature* 
-      ...", directs the compiler to compile the current module using syntax or 
-      semantics that will become standard in a future release of Python. The 
+      A :ref:`future statement <future>`, "from __future__ import *feature*
+      ...", directs the compiler to compile the current module using syntax or
+      semantics that will become standard in a future release of Python. The
       :mod:`__future__` module documents the possible values of *feature*.
 
       By importing the :mod:`__future__` module and evaluating its variables,

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -451,8 +451,10 @@ Glossary
       for best practices on working with annotations.
 
    __future__
-      A pseudo-module which programmers can use to enable new language features
-      which are not compatible with the current interpreter.
+      A :ref:`future statement <future>`, "from __future__ import *feature* 
+      ...", directs the compiler to compile the current module using syntax or 
+      semantics that will become standard in a future release of Python. The 
+      :mod:`__future__` module documents the possible values of *feature*.
 
       By importing the :mod:`__future__` module and evaluating its variables,
       you can see when a new feature was first added to the language and when it

--- a/Misc/NEWS.d/next/Documentation/2021-07-25-23-04-15.bpo-44693.JuCbNq.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-07-25-23-04-15.bpo-44693.JuCbNq.rst
@@ -1,0 +1,2 @@
+Update the definition of __future__ in the glossary by replacing the confusing
+word "pseudo-module" with a more accurate description.


### PR DESCRIPTION
Replace sentence with confusing "pseudo-module" with two sentences separating future statements and the __future__ module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44693](https://bugs.python.org/issue44693) -->
https://bugs.python.org/issue44693
<!-- /issue-number -->
