### PR TITLE
DOC: Fix typos in `Enum` example

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -273,7 +273,7 @@ Data Types
          ...     SUNDAY = 7
          ...     @classmethod
          ...     def today(cls):
-         ...         print('today is %s' % cls(date.today.isoweekday).naem)
+         ...         print('today is %s' % cls(date.today().isoweekday()).name)
          >>> dir(Weekday.SATURDAY)
          ['__class__', '__doc__', '__module__', 'name', 'today', 'value']
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Initially I wanted to fix the typo with "naem", when I realized that there are missing parentheses for the `today` and `isoweekday` function call.
In my opinion, readability could be improved by making it a f-string:
```python
print(f'today is {cls(date.today().isoweekday()).name}')
```