### PR TITLE
bpo-44559: [Enum] Correct `versionadded` to 3.11 for new features

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -131,7 +131,7 @@ Module Contents
 
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
-.. versionadded:: 3.10  ``StrEnum``, ``EnumCheck``, ``FlagBoundary``
+.. versionadded:: 3.11  ``StrEnum``, ``EnumCheck``, ``FlagBoundary``
 
 ---------------
 
@@ -584,7 +584,7 @@ Data Types
 
    CONTINUOUS and NAMED_FLAGS are designed to work with integer-valued members.
 
-.. versionadded:: 3.10
+.. versionadded:: 3.11
 
 .. class:: FlagBoundary
 
@@ -647,7 +647,7 @@ Data Types
          >>> KeepFlag(2**2 + 2**4)
          KeepFlag.BLUE|0x10
 
-.. versionadded:: 3.10
+.. versionadded:: 3.11
 
 ---------------
 
@@ -673,7 +673,7 @@ Utilites and Decorators
    also injects the members, and their aliases, into the global namespace they
    were defined in.
 
-.. versionadded:: 3.10
+.. versionadded:: 3.11
 
 .. decorator:: property
 
@@ -686,7 +686,7 @@ Utilites and Decorators
              *Enum* class, and *Enum* subclasses can define members with the
              names ``value`` and ``name``.
 
-.. versionadded:: 3.10
+.. versionadded:: 3.11
 
 .. decorator:: unique
 
@@ -712,7 +712,7 @@ Utilites and Decorators
    :class:`EnumCheck` are used to specify which constraints should be checked
    on the decorated enumeration.
 
-.. versionadded:: 3.10
+.. versionadded:: 3.11
 
 ---------------
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
I don't see those features in 3.10, so I assume they get introduced in 3.11.
I don't know where to check, if these features are really introduced in 3.11, so please double check.

<!-- issue-number: [bpo-44559](https://bugs.python.org/issue44559) -->
https://bugs.python.org/issue44559
<!-- /issue-number -->
