### PR TITLE
closes bpo-44751: Move crypt.h include from public header to _cryptmodule

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -35,19 +35,6 @@
 #ifndef MS_WINDOWS
 #include <unistd.h>
 #endif
-#ifdef HAVE_CRYPT_H
-#if defined(HAVE_CRYPT_R) && !defined(_GNU_SOURCE)
-/* Required for glibc to expose the crypt_r() function prototype. */
-#  define _GNU_SOURCE
-#  define _Py_GNU_SOURCE_FOR_CRYPT
-#endif
-#include <crypt.h>
-#ifdef _Py_GNU_SOURCE_FOR_CRYPT
-/* Don't leak the _GNU_SOURCE define to other headers. */
-#  undef _GNU_SOURCE
-#  undef _Py_GNU_SOURCE_FOR_CRYPT
-#endif
-#endif
 
 /* For size_t? */
 #ifdef HAVE_STDDEF_H

--- a/Misc/NEWS.d/next/C API/2021-07-27-17-29-12.bpo-44751.4qmbDG.rst
+++ b/Misc/NEWS.d/next/C API/2021-07-27-17-29-12.bpo-44751.4qmbDG.rst
@@ -1,0 +1,2 @@
+Remove crypt.h include from the public Python.h header and move it to
+_cryptmodule.c, which is the only file that needs it.

--- a/Misc/NEWS.d/next/C API/2021-07-27-17-29-12.bpo-44751.4qmbDG.rst
+++ b/Misc/NEWS.d/next/C API/2021-07-27-17-29-12.bpo-44751.4qmbDG.rst
@@ -1,2 +1,1 @@
-Remove crypt.h include from the public Python.h header and move it to
-_cryptmodule.c, which is the only file that needs it.
+Remove ``crypt.h`` include from the public ``Python.h`` header.

--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -4,6 +4,9 @@
 #include "Python.h"
 
 #include <sys/types.h>
+#ifdef HAVE_CRYPT_H
+#include <crypt.h>
+#endif
 
 /* Module crypt */
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44751](https://bugs.python.org/issue44751) -->
https://bugs.python.org/issue44751
<!-- /issue-number -->

Automerge-Triggered-By: GH:benjaminp