### PR TITLE
bpo-44600: Refactor new tracing tests

### DIFF
--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -3059,78 +3059,85 @@ class TestValueErrors(unittest.TestCase):
 
 class TestTracing(unittest.TestCase):
 
-    def _test_trace(self, func, expected_linenos, *f_args):
-        actual_linenos = set()
+    @staticmethod
+    def _trace(func, *args, **kwargs):
+        actual_linenos = []
+
         def trace(frame, event, arg):
-            if frame.f_code.co_name == func.__name__:
+            if event == "line" and frame.f_code.co_name == func.__name__:
+                assert arg is None
                 relative_lineno = frame.f_lineno - func.__code__.co_firstlineno
-                actual_linenos.add(relative_lineno)
+                actual_linenos.append(relative_lineno)
             return trace
 
+        old_trace = sys.gettrace()
         sys.settrace(trace)
-        func(*f_args)
-        sys.settrace(None)
-        self.assertSetEqual(actual_linenos, expected_linenos)
+        try:
+            func(*args, **kwargs)
+        finally:
+            sys.settrace(old_trace)
+        return actual_linenos
 
-    def test_default_case_traces_correctly_a(self):
-        def default_no_assign(command):                        # 0
-            match command.split():                             # 1
-                case ["go", direction] if direction in "nesw": # 2
-                    return f"go {direction}"                   # 3
-                case ["go", _]:                                # 4
-                    return "no go"                             # 5
-                case _:                                        # 6
-                    return "default"                           # 7
+    def test_default_wildcard(self):
+        def f(command):                                         # 0
+            match command.split():                              # 1
+                case ["go", direction] if direction in "nesw":  # 2
+                    return f"go {direction}"                    # 3
+                case ["go", _]:                                 # 4
+                    return "no go"                              # 5
+                case _:                                         # 6
+                    return "default"                            # 7
 
-        self._test_trace(default_no_assign, {0, 1, 2, 3}, "go n")
-        self._test_trace(default_no_assign, {0, 1, 2, 4, 5}, "go x")
-        self._test_trace(default_no_assign, {0, 1, 2, 4, 6, 7}, "spam")
+        self.assertListEqual(self._trace(f, "go n"), [1, 2, 3])
+        self.assertListEqual(self._trace(f, "go x"), [1, 2, 4, 5])
+        self.assertListEqual(self._trace(f, "spam"), [1, 2, 4, 6, 7])
 
-    def test_default_case_traces_correctly_b(self):
-        def default_wildcard_assign(command):                  # 0
-            match command.split():                             # 1
-                case ["go", direction] if direction in "nesw": # 2
-                    return f"go {direction}"                   # 3
-                case ["go", _]:                                # 4
-                    return "no go"                             # 5
-                case x:                                        # 6
-                    return x                                   # 7
+    def test_default_capture(self):
+        def f(command):                                         # 0
+            match command.split():                              # 1
+                case ["go", direction] if direction in "nesw":  # 2
+                    return f"go {direction}"                    # 3
+                case ["go", _]:                                 # 4
+                    return "no go"                              # 5
+                case x:                                         # 6
+                    return x                                    # 7
 
-        self._test_trace(default_wildcard_assign, {0, 1, 2, 3}, "go n")
-        self._test_trace(default_wildcard_assign, {0, 1, 2, 4, 5}, "go x")
-        self._test_trace(default_wildcard_assign, {0, 1, 2, 4, 6, 7}, "spam")
+        self.assertListEqual(self._trace(f, "go n"), [1, 2, 3])
+        self.assertListEqual(self._trace(f, "go x"), [1, 2, 4, 5])
+        self.assertListEqual(self._trace(f, "spam"), [1, 2, 4, 6, 7])
 
-    def test_default_case_traces_correctly_c(self):
-        def no_default(command):                               # 0
-            match command.split():                             # 1
-                case ["go", direction] if direction in "nesw": # 2
-                    return f"go {direction}"                   # 3
-                case ["go", _]:                                # 4
-                    return "no go"                             # 5
+    def test_no_default(self):
+        def f(command):                                         # 0
+            match command.split():                              # 1
+                case ["go", direction] if direction in "nesw":  # 2
+                    return f"go {direction}"                    # 3
+                case ["go", _]:                                 # 4
+                    return "no go"                              # 5
 
-        self._test_trace(no_default, {0, 1, 2, 3}, "go n")
-        self._test_trace(no_default, {0, 1, 2, 4, 5}, "go x")
-        self._test_trace(no_default, {0, 1, 2, 4}, "spam")
+        self.assertListEqual(self._trace(f, "go n"), [1, 2, 3])
+        self.assertListEqual(self._trace(f, "go x"), [1, 2, 4, 5])
+        self.assertListEqual(self._trace(f, "spam"), [1, 2, 4])
 
-    def test_default_case_traces_correctly_d(self):
-        def only_default_no_assign(command):  # 0
-            match command.split():            # 1
-                case _:                       # 2
-                    return "default"          # 3
+    def test_only_default_wildcard(self):
+        def f(command):               # 0
+            match command.split():    # 1
+                case _:               # 2
+                    return "default"  # 3
 
-        self._test_trace(only_default_no_assign, {0, 1, 2, 3}, "go n")
-        self._test_trace(only_default_no_assign, {0, 1, 2, 3} , "go x")
-        self._test_trace(only_default_no_assign, {0, 1, 2, 3}, "spam")
+        self.assertListEqual(self._trace(f, "go n"), [1, 2, 3])
+        self.assertListEqual(self._trace(f, "go x"), [1, 2, 3])
+        self.assertListEqual(self._trace(f, "spam"), [1, 2, 3])
 
-    def test_default_case_traces_correctly_e(self):
-        def only_default_wildcard_assign(command):  # 0
-            match command.split():                  # 1
-                case x:                             # 2
-                    return x                        # 3
+    def test_only_default_capture(self):
+        def f(command):             # 0
+            match command.split():  # 1
+                case x:             # 2
+                    return x        # 3
 
-        self._test_trace(only_default_wildcard_assign, {0, 1, 2, 3}, "go n")
-        self._test_trace(only_default_wildcard_assign, {0, 1, 2, 3} , "go x")
-        self._test_trace(only_default_wildcard_assign, {0, 1, 2, 3}, "spam")
+        self.assertListEqual(self._trace(f, "go n"), [1, 2, 3])
+        self.assertListEqual(self._trace(f, "go x"), [1, 2, 3])
+        self.assertListEqual(self._trace(f, "spam"), [1, 2, 3])
+
 
 if __name__ == "__main__":
     """


### PR DESCRIPTION
This is just a minor update to assert not only that the expected lines are covered, but that they are also covered in the correct order. It also cleans things up a tiny bit, and makes it possible to step through these tests with a debugger.

<!-- issue-number: [bpo-44600](https://bugs.python.org/issue44600) -->
https://bugs.python.org/issue44600
<!-- /issue-number -->
