### PR TITLE
[3.9] bpo-44461: Check early that a pdb target is valid for execution. (GH-27227)

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1694,6 +1694,14 @@ def main():
         print('Error:', mainpyfile, 'does not exist')
         sys.exit(1)
 
+    if run_as_module:
+        import runpy
+        try:
+            runpy._get_module_details(mainpyfile)
+        except Exception:
+            traceback.print_exc()
+            sys.exit(1)
+
     sys.argv[:] = args      # Hide "pdb.py" and pdb options from argument list
 
     if not run_as_module:

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -14,7 +14,6 @@ import linecache
 from contextlib import ExitStack
 from io import StringIO
 from test import support
-from test.support import os_helper
 # This little helper class is essential for testing pdb under doctest.
 from test.test_doctest import _FakeInput
 from unittest.mock import patch
@@ -1636,12 +1635,12 @@ def bœr():
     def test_package_without_a_main(self):
         pkg_name = 't_pkg'
         module_name = 't_main'
-        os_helper.rmtree(pkg_name)
+        support.rmtree(pkg_name)
         modpath = pkg_name + '/' + module_name
         os.makedirs(modpath)
         with open(modpath + '/__init__.py', 'w') as f:
             pass
-        self.addCleanup(os_helper.rmtree, pkg_name)
+        self.addCleanup(support.rmtree, pkg_name)
         stdout, stderr = self._run_pdb(['-m', modpath.replace('/', '.')], "")
         self.assertIn(
             "'t_pkg.t_main' is a package and cannot be directly executed",

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -14,6 +14,7 @@ import linecache
 from contextlib import ExitStack
 from io import StringIO
 from test import support
+from test.support import os_helper
 # This little helper class is essential for testing pdb under doctest.
 from test.test_doctest import _FakeInput
 from unittest.mock import patch

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1632,6 +1632,20 @@ def bœr():
         self.assertIn("ImportError: No module named t_main.__main__",
                       stdout.splitlines())
 
+    def test_package_without_a_main(self):
+        pkg_name = 't_pkg'
+        module_name = 't_main'
+        os_helper.rmtree(pkg_name)
+        modpath = pkg_name + '/' + module_name
+        os.makedirs(modpath)
+        with open(modpath + '/__init__.py', 'w') as f:
+            pass
+        self.addCleanup(os_helper.rmtree, pkg_name)
+        stdout, stderr = self._run_pdb(['-m', modpath.replace('/', '.')], "")
+        self.assertIn(
+            "'t_pkg.t_main' is a package and cannot be directly executed",
+            stdout)
+
     def test_blocks_at_first_code_line(self):
         script = """
                 #This is a comment, on line 2

--- a/Misc/NEWS.d/next/Library/2021-06-29-21-17-17.bpo-44461.acqRnV.rst
+++ b/Misc/NEWS.d/next/Library/2021-06-29-21-17-17.bpo-44461.acqRnV.rst
@@ -1,0 +1,1 @@
+Fix bug with :mod:`pdb`'s handling of import error due to a package which does not have a ``__main__`` module


### PR DESCRIPTION


<!-- issue-number: [bpo-44461](https://bugs.python.org/issue44461) -->
https://bugs.python.org/issue44461
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco