### PR TITLE
bpo-44752: Make rlcompleter not call `@property` methods

### DIFF
--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -176,6 +176,16 @@ class Completer:
                 if (word[:n] == attr and
                     not (noprefix and word[:n+1] == noprefix)):
                     match = "%s.%s" % (expr, word)
+                    if isinstance(getattr(type(thisobject), word, None),
+                                  property):
+                        # bpo-44752: thisobject.word is a method decorated by
+                        # `@property`. What follows applies a postfix if
+                        # thisobject.word is callable, but know we know that
+                        # this is not callable (because it is a property).
+                        # Also, getattr(thisobject, word) will evaluate the
+                        # property method, which is not desirable.
+                        matches.append(match)
+                        continue
                     try:
                         val = getattr(thisobject, word)
                     except Exception:

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -80,20 +80,21 @@ class TestRlcompleter(unittest.TestCase):
                              ['egg.{}('.format(x) for x in dir(str)
                               if x.startswith('s')])
 
-    def test_getattr_called(self):
-        # Ensure getattr() is invoked no more than once per attribute
-        # note the special case for @properties methods below; that is why
-        # we use __dir__ and __getattr__ in class Foo.
+    def test_excessive_getattr(self):
+        """Ensure getattr() is invoked no more than once per attribute"""
+
+        # note the special case for @property methods below; that is why
+        # we use __dir__ and __getattr__ in class Foo to create a "magic"
+        # class attribute 'bar'. This forces `getattr` to call __getattr__
+        # (which is doesn't necessarily do).
         class Foo:
             calls = 0
-            def __getattr__(self, name):
+            bar = ''
+            def __getattribute__(self, name):
                 if name == 'bar':
                     self.calls += 1
                     return None
-                return super().__getattr__(name)
-
-            def __dir__(self):
-                return list(super().__dir__()) + ['bar']
+                return super().__getattribute__(name)
 
         f = Foo()
         completer = rlcompleter.Completer(dict(f=f))

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -80,18 +80,41 @@ class TestRlcompleter(unittest.TestCase):
                              ['egg.{}('.format(x) for x in dir(str)
                               if x.startswith('s')])
 
-    def test_excessive_getattr(self):
+    def test_getattr_called(self):
         # Ensure getattr() is invoked no more than once per attribute
+        # note the special case for @properties methods below; that is why
+        # we use __dir__ and __getattr__ in class Foo.
         class Foo:
             calls = 0
-            @property
-            def bar(self):
-                self.calls += 1
-                return None
+            def __getattr__(self, name):
+                if name == 'bar':
+                    self.calls += 1
+                    return None
+                return super().__getattr__(name)
+
+            def __dir__(self):
+                return list(super().__dir__()) + ['bar']
+
         f = Foo()
         completer = rlcompleter.Completer(dict(f=f))
         self.assertEqual(completer.complete('f.b', 0), 'f.bar')
-        self.assertLessEqual(f.calls, 1)
+        self.assertEqual(f.calls, 1)
+
+    def test_property_method_not_called(self):
+        class Foo:
+            _bar = 0
+            property_called = False
+
+            @property
+            def bar(self):
+                self.property_called = True
+                return self._bar
+
+        f = Foo()
+        completer = rlcompleter.Completer(dict(f=f))
+        self.assertEqual(completer.complete('f.b', 0), 'f.bar')
+        self.assertFalse(f.property_called)
+
 
     def test_uncreated_attr(self):
         # Attributes like properties and slots should be completed even when

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -91,7 +91,7 @@ class TestRlcompleter(unittest.TestCase):
         f = Foo()
         completer = rlcompleter.Completer(dict(f=f))
         self.assertEqual(completer.complete('f.b', 0), 'f.bar')
-        self.assertEqual(f.calls, 1)
+        self.assertLessEqual(f.calls, 1)
 
     def test_uncreated_attr(self):
         # Attributes like properties and slots should be completed even when

--- a/Misc/NEWS.d/next/Library/2021-07-27-22-11-29.bpo-44752._bvbrZ.rst
+++ b/Misc/NEWS.d/next/Library/2021-07-27-22-11-29.bpo-44752._bvbrZ.rst
@@ -1,0 +1,2 @@
+:mod:`rcompleter` does not call :func:`getattr` on :class:`property` objects
+to avoid the side-effect of  evaluating the corresponding method.


### PR DESCRIPTION
- rlcompleter was calling these methods to identify whether to add
  parenthesis to the completion, based on if the attribute is callable.
- for property objects, completion with parenthesis are never desirable.
- property methods with print statements behaved very strangely, which
  was especially unfriendly to language newcomers. <tab> could suddenly
  produce output unexpectedly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44752](https://bugs.python.org/issue44752) -->
https://bugs.python.org/issue44752
<!-- /issue-number -->
