### PR TITLE
[3.9] bpo-42167: Remove doc reference to obsolete opcode

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -741,7 +741,7 @@ iterations of the loop.
 
    This opcode performs several operations before a with block starts.  First,
    it loads :meth:`~object.__exit__` from the context manager and pushes it onto
-   the stack for later use by :opcode:`WITH_CLEANUP_START`.  Then,
+   the stack for later use by :opcode:`WITH_EXCEPT_START`.  Then,
    :meth:`~object.__enter__` is called, and a finally block pointing to *delta*
    is pushed.  Finally, the result of calling the ``__enter__()`` method is pushed onto
    the stack.  The next opcode will either ignore it (:opcode:`POP_TOP`), or


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

`WITH_CLEANUP_START` was removed in GH-6641. This is now consistent with the `WITH_EXCEPT_START` documentation entry 3 entries above, and with the implementation [here](https://github.com/python/cpython/blob/a13edfb857793f0f92a4fef3919f215e008df5c5/Python/ceval.c#L3400).

<!-- issue-number: [bpo-42167](https://bugs.python.org/issue42167) -->
https://bugs.python.org/issue42167
<!-- /issue-number -->
