### PR TITLE
bpo-44756: in ./Doc, `make build` depends on `make html`

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -45,7 +45,7 @@ help:
 	@echo "  check      to run a check for frequent markup errors"
 	@echo "  serve      to serve the documentation on the localhost (8000)"
 
-build:
+build: venv
 	-mkdir -p build
 # Look first for a Misc/NEWS file (building from a source release tarball
 # or old repo) and use that, otherwise look for a Misc/NEWS.d directory
@@ -137,14 +137,21 @@ pydoc-topics: build
 htmlview: html
 	 $(PYTHON) -c "import webbrowser; webbrowser.open('build/html/index.html')"
 
-clean:
-	-rm -rf build/* $(VENVDIR)/*
+clean: clean-venv
+	-rm -rf build/*
+
+clean-venv:
+	rm -rf $(VENVDIR)
 
 venv:
-	$(PYTHON) -m venv $(VENVDIR)
-	$(VENVDIR)/bin/python3 -m pip install -U pip setuptools
-	$(VENVDIR)/bin/python3 -m pip install -r requirements.txt
-	@echo "The venv has been created in the $(VENVDIR) directory"
+	@if [ -d $(VENVDIR) ] ; then \
+		echo "venv already exists"; \
+	else \
+		$(PYTHON) -m venv $(VENVDIR); \
+		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools; \
+		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \
+		echo "The venv has been created in the $(VENVDIR) directory"; \
+	fi
 
 dist:
 	rm -rf dist

--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -28,28 +28,24 @@ install the tools into there.
 Using make
 ----------
 
-To get started on UNIX, you can create a virtual environment with the command ::
-
-  make venv
-
-That will install all the tools necessary to build the documentation. Assuming
-the virtual environment was created in the ``venv`` directory (the default;
-configurable with the VENVDIR variable), you can run the following command to
-build the HTML output files::
+To get started on UNIX, you can create a virtual environment and build
+documentation with the command::
 
   make html
 
-By default, if the virtual environment is not created, the Makefile will
-look for instances of sphinxbuild and blurb installed on your process PATH
-(configurable with the SPHINXBUILD and BLURB variables).
+The virtual environment in the ``venv`` directory will contain all the tools
+necessary to build the documentation.  You can also configure where the virtual
+environment directory will be with the ``VENVDIR`` variable.
 
 On Windows, we try to emulate the Makefile as closely as possible with a
 ``make.bat`` file. If you need to specify the Python interpreter to use,
-set the PYTHON environment variable instead.
+set the PYTHON environment variable.
 
 Available make targets are:
 
-* "clean", which removes all build files.
+* "clean", which removes all build files and the virtual environment.
+
+* "clean-venv", which removes the virtual environment directory.
 
 * "venv", which creates a virtual environment with all necessary tools
   installed.

--- a/Misc/NEWS.d/next/Tools-Demos/2021-07-28-00-51-55.bpo-44756.pvAajB.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2021-07-28-00-51-55.bpo-44756.pvAajB.rst
@@ -1,0 +1,6 @@
+In the Makefile for documentation (:file:`Doc/Makefile`), the ``build`` rule
+is dependent on the ``venv`` rule. Therefore, ``html``, ``latex``, and other
+build-dependent rules are also now dependent on ``venv``. The ``venv`` rule
+only performs an action if ``$(VENVDIR)`` does not exist.
+:file:`Doc/README.rst` was updated; most users now only need to type ``make
+html``.


### PR DESCRIPTION
- venv rule is now conditional, and only does anything if $VENVDIR does not
  exist
- add rule "clean-venv"
- as a result, rules dependent on build are now dependent on venv:
  - html
  - latex
  - etc.
- update Doc/README.rst appropriately. Now users usually only need to type
  "make html"

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44756](https://bugs.python.org/issue44756) -->
https://bugs.python.org/issue44756
<!-- /issue-number -->
