### PR TITLE
bpo-44765: [doc] Fixes typo in `http.server.rst`

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -197,7 +197,7 @@ provides three different variants:
       request header it responds back with a ``100 Continue`` followed by ``200
       OK`` headers.
       This method can be overridden to raise an error if the server does not
-      want the client to continue.  For e.g. server can chose to send ``417
+      want the client to continue.  For e.g. server can choose to send ``417
       Expectation Failed`` as a response header and ``return False``.
 
       .. versionadded:: 3.2


### PR DESCRIPTION
<!-- issue-number: [bpo-44765](https://bugs.python.org/issue44765) -->
https://bugs.python.org/issue44765
<!-- /issue-number -->
