### PR TITLE
Minor fixes to specialization stats.

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -320,9 +320,11 @@ typedef struct _stats {
 
 extern SpecializationStats _specialization_stats[256];
 #define STAT_INC(opname, name) _specialization_stats[opname].name++
+#define STAT_DEC(opname, name) _specialization_stats[opname].name--
 void _Py_PrintSpecializationStats(void);
 #else
 #define STAT_INC(opname, name) ((void)0)
+#define STAT_DEC(opname, name) ((void)0)
 #endif
 
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1931,6 +1931,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, InterpreterFrame *frame, int thr
                 UPDATE_PREV_INSTR_OPARG(next_instr, oparg - 1);
                 assert(_Py_OPCODE(next_instr[-1]) == BINARY_SUBSCR_ADAPTIVE);
                 assert(_Py_OPARG(next_instr[-1]) == oparg - 1);
+                STAT_DEC(BINARY_SUBSCR, unquickened);
                 JUMP_TO_INSTRUCTION(BINARY_SUBSCR);
             }
         }
@@ -3380,6 +3381,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, InterpreterFrame *frame, int thr
                 STAT_INC(LOAD_ATTR, deferred);
                 cache->adaptive.counter--;
                 oparg = cache->adaptive.original_oparg;
+                STAT_DEC(LOAD_ATTR, unquickened);
                 JUMP_TO_INSTRUCTION(LOAD_ATTR);
             }
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2944,6 +2944,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, InterpreterFrame *frame, int thr
                 STAT_INC(LOAD_GLOBAL, deferred);
                 cache->adaptive.counter--;
                 oparg = cache->adaptive.original_oparg;
+                STAT_DEC(LOAD_GLOBAL, unquickened);
                 JUMP_TO_INSTRUCTION(LOAD_GLOBAL);
             }
         }

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -125,7 +125,8 @@ done:
     Py_XDECREF(key);
 }
 
-#define SPECIALIZATION_FAIL(opcode, type, attribute, kind) _Py_IncrementTypeCounter(opcode, (PyObject *)(type), attribute, kind)
+#define SPECIALIZATION_FAIL(opcode, type, attribute, kind) _Py_IncrementTypeCounter(opcode, (PyObject *)(type), (PyObject *)(attribute), kind)
+
 
 #endif
 #endif
@@ -644,6 +645,7 @@ success:
     return 0;
 }
 
+
 int
 _Py_Specialize_BinarySubscr(
      PyObject *container, PyObject *sub, _Py_CODEUNIT *instr)
@@ -654,7 +656,8 @@ _Py_Specialize_BinarySubscr(
             *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_LIST_INT, saturating_start());
             goto success;
         } else {
-            SPECIALIZATION_FAIL(BINARY_SUBSCR, Py_TYPE(container), sub, "list; non-integer subscr");
+            SPECIALIZATION_FAIL(BINARY_SUBSCR, Py_TYPE(container), Py_TYPE(sub), "list; non-integer subscr");
+            goto fail;
         }
     }
     if (container_type == &PyTuple_Type) {
@@ -662,15 +665,15 @@ _Py_Specialize_BinarySubscr(
             *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_TUPLE_INT, saturating_start());
             goto success;
         } else {
-            SPECIALIZATION_FAIL(BINARY_SUBSCR, Py_TYPE(container), sub, "tuple; non-integer subscr");
+            SPECIALIZATION_FAIL(BINARY_SUBSCR, Py_TYPE(container), Py_TYPE(sub), "tuple; non-integer subscr");
+            goto fail;
         }
     }
     if (container_type == &PyDict_Type) {
         *instr = _Py_MAKECODEUNIT(BINARY_SUBSCR_DICT, saturating_start());
         goto success;
     }
-
-    SPECIALIZATION_FAIL(BINARY_SUBSCR, Py_TYPE(container), sub, "not list|tuple|dict");
+    SPECIALIZATION_FAIL(BINARY_SUBSCR, Py_TYPE(container), Py_TYPE(sub), "not list|tuple|dict");
     goto fail;
 fail:
     STAT_INC(BINARY_SUBSCR, specialization_failure);


### PR DESCRIPTION
* Use class, not value in fail stats for BINARY_SUBSCR.  We don't care whether the subscript is 7 or 13, we care that it is an int.
* Fix counts for unquickened instructions. We were counting `ADAPTIVE` instructions as unquickened as well. 
