### PR TITLE
Doc: Change errant 3.10.0 to 3.10, to match other mentions

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -150,7 +150,7 @@ See :pep:`484` for more details.
 
 .. versionadded:: 3.5.2
 
-.. versionchanged:: 3.10.0
+.. versionchanged:: 3.10
    ``NewType`` is now a class rather than a function.  There is some additional
    runtime cost when calling ``NewType`` over a regular function.  However, this
    cost will be reduced in 3.11.0.
@@ -1323,7 +1323,7 @@ These are not used in annotations. They are building blocks for declaring types.
 
    .. versionadded:: 3.5.2
 
-   .. versionchanged:: 3.10.0
+   .. versionchanged:: 3.10
       ``NewType`` is now a class rather than a function.
 
 .. class:: TypedDict(dict)


### PR DESCRIPTION
The `typing` docs include two instances of `versionchanged:: 3.10.0`, when all other mentions of that version in the docs use `versionchanged:: 3.10`.