### PR TITLE
bpo-44479: Do not regenerate files during a PGO build as it will invalidate the profile

### DIFF
--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -78,7 +78,9 @@
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 
-  <Target Name="Regen" DependsOnTargets="_TouchRegenSources;_RegenPegen;_RegenAST_H;_RegenOpcodes;_RegenTokens;_RegenKeywords">
+  <Target Name="Regen"
+          Condition="$(Configuration) != 'PGUpdate'"
+          DependsOnTargets="_TouchRegenSources;_RegenPegen;_RegenAST_H;_RegenOpcodes;_RegenTokens;_RegenKeywords">
     <Message Text="Generated sources are up to date" Importance="high" />
   </Target>
 
@@ -119,5 +121,7 @@
     <Message Text="Wrote $(OutDir)LICENSE.txt" Importance="high" />
   </Target>
 
-  <Target Name="PostBuildRegen" DependsOnTargets="_RegenTestFrozenmain;_RegenLicense" />
+  <Target Name="PostBuildRegen"
+          Condition="$(Configuration) != 'PGInstrument' and $(Configuration) != 'PGUpdate'"
+          DependsOnTargets="_RegenTestFrozenmain;_RegenLicense" />
 </Project>


### PR DESCRIPTION


<!-- issue-number: [bpo-44479](https://bugs.python.org/issue44479) -->
https://bugs.python.org/issue44479
<!-- /issue-number -->
