### PR TITLE
[3.10] bpo-44479: Do not regenerate files during a PGO build as it will invalidate the profile. (GH-27460)

### DIFF
--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -78,16 +78,14 @@
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 
-  <Target Name="Regen" DependsOnTargets="_TouchRegenSources;_RegenPegen;_RegenAST_H;_RegenOpcodes;_RegenTokens;_RegenKeywords">
+  <Target Name="Regen"
+          Condition="$(Configuration) != 'PGUpdate'"
+          DependsOnTargets="_TouchRegenSources;_RegenPegen;_RegenAST_H;_RegenOpcodes;_RegenTokens;_RegenKeywords">
     <Message Text="Generated sources are up to date" Importance="high" />
   </Target>
 
 
   <ItemGroup>
-    <_TestFrozenSources Include="$(PySourcePath)Programs\freeze_test_frozenmain.py;
-                                 $(PySourcePath)Programs\test_frozenmain.py;
-                                 @(_OpcodeOutputs)" />
-    <_TestFrozenOutputs Include="$(PySourcePath)Programs\test_frozenmain.h" />
     <_LicenseSources Include="$(PySourcePath)LICENSE;
                               $(PySourcePath)PC\crtlicense.txt;
                               $(bz2Dir)LICENSE;
@@ -112,5 +110,7 @@
     <Message Text="Wrote $(OutDir)LICENSE.txt" Importance="high" />
   </Target>
 
-  <Target Name="PostBuildRegen" DependsOnTargets="_RegenLicense" />
+  <Target Name="PostBuildRegen"
+          Condition="$(Configuration) != 'PGInstrument' and $(Configuration) != 'PGUpdate'"
+          DependsOnTargets="_RegenLicense" />
 </Project>


### PR DESCRIPTION
Also remove some unused code that should not have been backported.

<!-- issue-number: [bpo-44479](https://bugs.python.org/issue44479) -->
https://bugs.python.org/issue44479
<!-- /issue-number -->
