### PR TITLE
bpo-31746: Revert "Prevent segfaults with uninitialised `sqlite3.Connection` objects"

### DIFF
--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -243,26 +243,6 @@ class ConnectionTests(unittest.TestCase):
             self.assertEqual(cu.fetchone()[0], n)
 
 
-class UninitialisedConnectionTests(unittest.TestCase):
-    def setUp(self):
-        self.cx = sqlite.Connection.__new__(sqlite.Connection)
-
-    def test_uninit_operations(self):
-        funcs = (
-            lambda: self.cx.isolation_level,
-            lambda: self.cx.total_changes,
-            lambda: self.cx.in_transaction,
-            lambda: self.cx.iterdump(),
-            lambda: self.cx.cursor(),
-            lambda: self.cx.close(),
-        )
-        for func in funcs:
-            with self.subTest(func=func):
-                self.assertRaisesRegex(sqlite.ProgrammingError,
-                                       "Base Connection.__init__ not called",
-                                       func)
-
-
 class OpenTests(unittest.TestCase):
     _sql = "create table test(id integer)"
 
@@ -971,7 +951,6 @@ def suite():
         ModuleTests,
         SqliteOnConflictTests,
         ThreadTests,
-        UninitialisedConnectionTests,
     ]
     return unittest.TestSuite(
         [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -111,6 +111,8 @@ pysqlite_connection_init_impl(pysqlite_Connection *self,
 
     const char *database = PyBytes_AsString(database_obj);
 
+    self->initialized = 1;
+
     self->begin_statement = NULL;
 
     Py_CLEAR(self->statement_cache);
@@ -145,7 +147,7 @@ pysqlite_connection_init_impl(pysqlite_Connection *self,
         Py_INCREF(isolation_level);
     }
     Py_CLEAR(self->isolation_level);
-    if (pysqlite_connection_set_isolation_level(self, isolation_level, NULL) != 0) {
+    if (pysqlite_connection_set_isolation_level(self, isolation_level, NULL) < 0) {
         Py_DECREF(isolation_level);
         return -1;
     }
@@ -192,8 +194,6 @@ pysqlite_connection_init_impl(pysqlite_Connection *self,
     if (PySys_Audit("sqlite3.connect/handle", "O", self) < 0) {
         return -1;
     }
-
-    self->initialized = 1;
 
     return 0;
 }
@@ -368,13 +368,6 @@ pysqlite_connection_close_impl(pysqlite_Connection *self)
 /*[clinic end generated code: output=a546a0da212c9b97 input=3d58064bbffaa3d3]*/
 {
     if (!pysqlite_check_thread(self)) {
-        return NULL;
-    }
-
-    if (!self->initialized) {
-        pysqlite_state *state = pysqlite_get_state(NULL);
-        PyErr_SetString(state->ProgrammingError,
-                        "Base Connection.__init__ not called.");
         return NULL;
     }
 
@@ -1265,9 +1258,6 @@ int pysqlite_check_thread(pysqlite_Connection* self)
 
 static PyObject* pysqlite_connection_get_isolation_level(pysqlite_Connection* self, void* unused)
 {
-    if (!pysqlite_check_connection(self)) {
-        return NULL;
-    }
     return Py_NewRef(self->isolation_level);
 }
 
@@ -1299,17 +1289,11 @@ pysqlite_connection_set_isolation_level(pysqlite_Connection* self, PyObject* iso
         return -1;
     }
     if (isolation_level == Py_None) {
-        /* We might get called during connection init, so we cannot use
-         * pysqlite_connection_commit() here. */
-        if (self->db && !sqlite3_get_autocommit(self->db)) {
-            int rc;
-            Py_BEGIN_ALLOW_THREADS
-            rc = sqlite3_exec(self->db, "COMMIT", NULL, NULL, NULL);
-            Py_END_ALLOW_THREADS
-            if (rc != SQLITE_OK) {
-                return _pysqlite_seterror(self->db);
-            }
+        PyObject *res = pysqlite_connection_commit(self, NULL);
+        if (!res) {
+            return -1;
         }
+        Py_DECREF(res);
 
         self->begin_statement = NULL;
     } else {


### PR DESCRIPTION
Reverts python/cpython#27431

<!-- issue-number: [bpo-31746](https://bugs.python.org/issue31746) -->
https://bugs.python.org/issue31746
<!-- /issue-number -->
