### PR TITLE
Add missing gdbm dependencies to the UNIX CI

### DIFF
--- a/.github/workflows/posix-deps-apt.sh
+++ b/.github/workflows/posix-deps-apt.sh
@@ -9,6 +9,7 @@ apt-get -yq install \
     libbz2-dev \
     libffi-dev \
     libgdbm-dev \
+    libgdbm-compat-dev \
     liblzma-dev \
     libncurses5-dev \
     libreadline6-dev \


### PR DESCRIPTION
The `_gdbm` extension was not getting tested as the dependencies where not there. It looks like the older "dbm" files are moved to "gbdm-compat" package.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
