### PR TITLE
bpo-44753: Don't use logfile extension when determining old files to …

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -360,7 +360,7 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
         fileNames = os.listdir(dirName)
         result = []
         # See bpo-44753: Don't use the extension when computing the prefix.
-        prefix = os.path.split(baseName)[0] + "."
+        prefix = os.path.splitext(baseName)[0] + "."
         plen = len(prefix)
         for fileName in fileNames:
             if fileName[:plen] == prefix:

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -359,7 +359,8 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
         dirName, baseName = os.path.split(self.baseFilename)
         fileNames = os.listdir(dirName)
         result = []
-        prefix = baseName + "."
+        # See bpo-44753: Don't use the extension when computing the prefix.
+        prefix = os.path.split(baseName)[0] + "."
         plen = len(prefix)
         for fileName in fileNames:
             if fileName[:plen] == prefix:


### PR DESCRIPTION
…be deleted.

<!-- issue-number: [bpo-44753](https://bugs.python.org/issue44753) -->
https://bugs.python.org/issue44753
<!-- /issue-number -->
