### PR TITLE
[3.9] Fail the CI if an optional module fails to compile (GH-27466).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,8 @@ jobs:
     runs-on: macos-latest
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    env:
+      PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v2
     - name: Configure CPython
@@ -151,6 +153,7 @@ jobs:
     if: needs.check_source.outputs.run_tests == 'true'
     env:
       OPENSSL_VER: 1.1.1k
+      PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     # Set rpath with env var instead of -Wl,-rpath linker flag
     # OpenSSL ignores LDFLAGS when linking bin/openssl
     - LD_RUN_PATH="${OPENSSL_DIR}/lib"
+    - PYTHONSTRICTEXTENSIONBUILD=1
 
 branches:
   only:

--- a/setup.py
+++ b/setup.py
@@ -540,6 +540,9 @@ class PyBuildExt(build_ext):
                   "APIs, https://github.com/libressl-portable/portable/issues/381")
             print()
 
+        if os.environ.get("PYTHONSTRICTEXTENSIONBUILD") and (self.failed or self.failed_on_import):
+            raise RuntimeError("Failed to build some stdlib modules")
+
     def build_extension(self, ext):
 
         if ext.name == '_ctypes':


### PR DESCRIPTION
(cherry picked from commit 7cad0bee80a536c7e47f54cf43174175834f30a0)

Co-authored-by: Pablo Galindo Salgado <Pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
