### PR TITLE
bpo-44771: Sync with importlib_resources 5.2.2, fixing refleak.

### DIFF
--- a/Lib/importlib/_common.py
+++ b/Lib/importlib/_common.py
@@ -87,14 +87,16 @@ def _tempfile(reader, suffix=''):
     # properly.
     fd, raw_path = tempfile.mkstemp(suffix=suffix)
     try:
-        os.write(fd, reader())
-        os.close(fd)
+        try:
+            os.write(fd, reader())
+        finally:
+            os.close(fd)
         del reader
         yield pathlib.Path(raw_path)
     finally:
         try:
             os.remove(raw_path)
-        except (FileNotFoundError, PermissionError):
+        except FileNotFoundError:
             pass
 
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1516,6 +1516,7 @@ TESTSUBDIRS=	ctypes/test \
 		test/test_importlib/namespace_pkgs/project3/parent/child \
 		test/test_importlib/namespacedata01 \
 		test/test_importlib/partial \
+		test/test_importlib/resources \
 		test/test_importlib/source \
 		test/test_importlib/zipdata01 \
 		test/test_importlib/zipdata02 \


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44771](https://bugs.python.org/issue44771) -->
https://bugs.python.org/issue44771
<!-- /issue-number -->
