### PR TITLE
bpo-44942: Add numberpad enter bind to TK's simpleDialog

### DIFF
--- a/Lib/tkinter/simpledialog.py
+++ b/Lib/tkinter/simpledialog.py
@@ -176,6 +176,7 @@ class Dialog(Toplevel):
         w.pack(side=LEFT, padx=5, pady=5)
 
         self.bind("<Return>", self.ok)
+        self.bind("<KP_Enter>", self.ok)
         self.bind("<Escape>", self.cancel)
 
         box.pack()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This is a trivial PR that binds the numberpad enter button to `self.ok` in simpleDialog's `Dialog` class, as Tk treats that the number-pad enter and the main-enter buttons separately.

<!-- issue-number: [bpo-44942](https://bugs.python.org/issue44942) -->
https://bugs.python.org/issue44942
<!-- /issue-number -->
