### PR TITLE
bpo-33671 fix orphaned comment in shutil.copyfileobj

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -188,9 +188,9 @@ def _copyfileobj_readinto(fsrc, fdst, length=COPY_BUFSIZE):
 
 def copyfileobj(fsrc, fdst, length=0):
     """copy data from file-like object fsrc to file-like object fdst"""
-    # Localize variable access to minimize overhead.
     if not length:
         length = COPY_BUFSIZE
+    # Localize variable access to minimize overhead.
     fsrc_read = fsrc.read
     fdst_write = fdst.write
     while True:


### PR DESCRIPTION
looks like this was accidentally orphaned in #12016

(requesting skip-news skip-issue)

<!-- issue-number: [bpo-33671](https://bugs.python.org/issue33671) -->
https://bugs.python.org/issue33671
<!-- /issue-number -->
