### PR TITLE
bpo-41983: add availability info to socket docs

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -197,6 +197,8 @@ created.  Socket addresses are represented as follows:
   - *addr* - Optional bytes-like object specifying the hardware physical
     address, whose interpretation depends on the device.
 
+   .. availability:: Linux >= 2.2.
+
 - :const:`AF_QIPCRTR` is a Linux-only socket based interface for communicating
   with services running on co-processors in Qualcomm platforms. The address
   family is represented as a ``(node, port)`` tuple where the *node* and *port*

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -204,6 +204,8 @@ created.  Socket addresses are represented as follows:
   family is represented as a ``(node, port)`` tuple where the *node* and *port*
   are non-negative integers.
 
+   .. availability:: Linux >= 4.7.
+
   .. versionadded:: 3.8
 
 - :const:`IPPROTO_UDPLITE` is a variant of UDP which allows you to specify


### PR DESCRIPTION
AF_PACKET section is missing availability info (though it is available by clicking through to AF_PACKET constant doc), which is inconsistent with other sections and probably lead to misunderstanding in Issue 41983.

(same for AF_QIPCRTR)

<!-- issue-number: [bpo-41983](https://bugs.python.org/issue41983) -->
https://bugs.python.org/issue41983
<!-- /issue-number -->
