### PR TITLE
bpo-34013: Don't consider a grouped expression when reporting legacy print syntax errors

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1073,7 +1073,7 @@ expression_without_invalid[expr_ty]:
     | disjunction
     | lambdef
 invalid_legacy_expression:
-    | a=NAME b=star_expressions {
+    | a=NAME !'(' b=star_expressions {
         _PyPegen_check_legacy_stmt(p, a) ? RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b,
             "Missing parentheses in call to '%U'. Did you mean %U(...)?", a->v.Name.id, a->v.Name.id) : NULL}
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -182,6 +182,15 @@ class ExceptionTests(unittest.TestCase):
         s = 'exec f(a+b,c)'
         ckmsg(s, "Missing parentheses in call to 'exec'. Did you mean exec(...)?")
 
+        # Check that we don't incorrectly identify '(...)' as an expression to the right
+        # of 'print'
+
+        s = 'print (a+b,c) $ 42'
+        ckmsg(s, "invalid syntax")
+
+        s = 'exec (a+b,c) $ 42'
+        ckmsg(s, "invalid syntax")
+
         # should not apply to subclasses, see issue #31161
         s = '''if True:\nprint "No indent"'''
         ckmsg(s, "expected an indented block after 'if' statement on line 1", IndentationError)

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -18158,7 +18158,7 @@ expression_without_invalid_rule(Parser *p)
     return _res;
 }
 
-// invalid_legacy_expression: NAME star_expressions
+// invalid_legacy_expression: NAME !'(' star_expressions
 static void *
 invalid_legacy_expression_rule(Parser *p)
 {
@@ -18169,21 +18169,23 @@ invalid_legacy_expression_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // NAME star_expressions
+    { // NAME !'(' star_expressions
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> invalid_legacy_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME star_expressions"));
+        D(fprintf(stderr, "%*c> invalid_legacy_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME !'(' star_expressions"));
         expr_ty a;
         expr_ty b;
         if (
             (a = _PyPegen_name_token(p))  // NAME
             &&
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 7)  // token='('
+            &&
             (b = star_expressions_rule(p))  // star_expressions
         )
         {
-            D(fprintf(stderr, "%*c+ invalid_legacy_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME star_expressions"));
+            D(fprintf(stderr, "%*c+ invalid_legacy_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME !'(' star_expressions"));
             _res = _PyPegen_check_legacy_stmt ( p , a ) ? RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "Missing parentheses in call to '%U'. Did you mean %U(...)?" , a -> v . Name . id , a -> v . Name . id ) : NULL;
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -18194,7 +18196,7 @@ invalid_legacy_expression_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s invalid_legacy_expression[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME star_expressions"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME !'(' star_expressions"));
     }
     _res = NULL;
   done:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-34013](https://bugs.python.org/issue34013) -->
https://bugs.python.org/issue34013
<!-- /issue-number -->
