### PR TITLE
bpo-42053: fixed fwalk incorrect boolean test for non-fd arguments

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -461,7 +461,7 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
                 dirs.remove('CVS')  # don't visit CVS directories
         """
         sys.audit("os.fwalk", top, topdown, onerror, follow_symlinks, dir_fd)
-        if not isinstance(top, int) or not hasattr(top, '__index__'):
+        if not isinstance(top, int) and not hasattr(top, '__index__'):
             top = fspath(top)
         # Note: To guard against symlink races, we use the standard
         # lstat()/open()/fstat() trick.

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1537,8 +1537,6 @@ class FwalkTests(WalkTests):
             def __fspath__(self):
                 return str(self.val)
 
-        # Not isinstance of int and not has __index__ method
-        # Without __fspath__ method it must raise TypeError.
         top = CustomBaseClass('.')
         with self.assertRaisesRegex(TypeError, f'open: path should be string, bytes or os.PathLike'):
             next(os.fwalk(top=top, follow_symlinks=True))

--- a/Misc/NEWS.d/next/Library/2021-08-04-16-45-58.bpo-42053.WzOl39.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-04-16-45-58.bpo-42053.WzOl39.rst
@@ -1,0 +1,2 @@
+fixed incorrect boolean test for non-fd arguments in os.fwalk.
+Added test with custom class and __index__ method


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42053](https://bugs.python.org/issue42053) -->
https://bugs.python.org/issue42053
<!-- /issue-number -->
