### PR TITLE
bpo-42038: fix description of returned list of lines

### DIFF
--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -740,7 +740,7 @@ Traceback
 
    .. method:: format(limit=None, most_recent_first=False)
 
-      Format the traceback as a list of lines with newlines. Use the
+      Format the traceback as a list of lines. Use the
       :mod:`linecache` module to retrieve lines from the source code.
       If *limit* is set, format the *limit* most recent frames if *limit*
       is positive. Otherwise, format the ``abs(limit)`` oldest frames.

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -740,12 +740,12 @@ Traceback
 
    .. method:: format(limit=None, most_recent_first=False)
 
-      Format the traceback as a list of lines. Use the
-      :mod:`linecache` module to retrieve lines from the source code.
-      If *limit* is set, format the *limit* most recent frames if *limit*
-      is positive. Otherwise, format the ``abs(limit)`` oldest frames.
-      If *most_recent_first* is ``True``, the order of the formatted frames
-      is reversed, returning the most recent frame first instead of last.
+      Format the traceback as a list of lines. Use the :mod:`linecache` module to
+      retrieve lines from the source code.  If *limit* is set, format the *limit*
+      most recent frames if *limit* is positive. Otherwise, format the
+      ``abs(limit)`` oldest frames.  If *most_recent_first* is ``True``, the order
+      of the formatted frames is reversed, returning the most recent frame first
+      instead of last.
 
       Similar to the :func:`traceback.format_tb` function, except that
       :meth:`.format` does not include newlines.

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -740,12 +740,12 @@ Traceback
 
    .. method:: format(limit=None, most_recent_first=False)
 
-      Format the traceback as a list of lines. Use the :mod:`linecache` module to
-      retrieve lines from the source code.  If *limit* is set, format the *limit*
-      most recent frames if *limit* is positive. Otherwise, format the
-      ``abs(limit)`` oldest frames.  If *most_recent_first* is ``True``, the order
-      of the formatted frames is reversed, returning the most recent frame first
-      instead of last.
+      Format the traceback as a list of lines. Use the
+      :mod:`linecache` module to retrieve lines from the source code.
+      If *limit* is set, format the *limit* most recent frames if *limit*
+      is positive. Otherwise, format the ``abs(limit)`` oldest frames.
+      If *most_recent_first* is ``True``, the order of the formatted frames
+      is reversed, returning the most recent frame first instead of last.
 
       Similar to the :func:`traceback.format_tb` function, except that
       :meth:`.format` does not include newlines.

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -743,7 +743,7 @@ Traceback
       Format the traceback as a list of lines. Use the :mod:`linecache` module to
       retrieve lines from the source code. If *limit* is set, format the *limit*
       most recent frames if *limit* is positive. Otherwise, format the
-      ``abs(limit)`` oldest frames.  If *most_recent_first* is ``True``, the order
+      ``abs(limit)`` oldest frames. If *most_recent_first* is ``True``, the order
       of the formatted frames is reversed, returning the most recent frame first
       instead of last.
 

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -740,12 +740,12 @@ Traceback
 
    .. method:: format(limit=None, most_recent_first=False)
 
-      Format the traceback as a list of lines. Use the
-      :mod:`linecache` module to retrieve lines from the source code.
-      If *limit* is set, format the *limit* most recent frames if *limit*
-      is positive. Otherwise, format the ``abs(limit)`` oldest frames.
-      If *most_recent_first* is ``True``, the order of the formatted frames
-      is reversed, returning the most recent frame first instead of last.
+      Format the traceback as a list of lines. Use the :mod:`linecache` module to
+      retrieve lines from the source code. If *limit* is set, format the *limit*
+      most recent frames if *limit* is positive. Otherwise, format the
+      ``abs(limit)`` oldest frames.  If *most_recent_first* is ``True``, the order
+      of the formatted frames is reversed, returning the most recent frame first
+      instead of last.
 
       Similar to the :func:`traceback.format_tb` function, except that
       :meth:`.format` does not include newlines.


### PR DESCRIPTION
Using proposed fix by Lisa Roach.

I've left the paragraph un-reformatted to make it easier to review.

<!-- issue-number: [bpo-42038](https://bugs.python.org/issue42038) -->
https://bugs.python.org/issue42038
<!-- /issue-number -->
