### PR TITLE
Fix comment for typing._ProtocolMeta

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1417,7 +1417,7 @@ _PROTO_ALLOWLIST = {
 
 class _ProtocolMeta(ABCMeta):
     # This metaclass is really unfortunate and exists only because of
-    # the lack of __instancehook__.
+    # the lack of __subclasshook__.
     def __instancecheck__(cls, instance):
         # We need this method for situations where attributes are
         # assigned in __init__.


### PR DESCRIPTION
While I was working with `typing` I have notice reference on a `__instancehook__`  method. After short investigation I figured out that there is not such method and looks like it's a typo at comment.

I think it should point at a `__subclasshook__` as far as it override for every `Protocol` at `Protocol.__init_subclass__` method. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
