### PR TITLE
bpo-44806: Fix issue with typing.Protocol __init__ method generation

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1558,6 +1558,24 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, "@runtime_checkable"):
             isinstance(1, P)
 
+    def test_protocol_init_method(self):  # see bpo-44806
+        class P(Protocol):
+            x: int
+
+        class D1(P):
+            pass
+
+        class D2(P):
+            def __init__(self, x):
+                self.x = x
+
+        with self.assertRaisesRegex(TypeError, r"D1\(\) takes no arguments"):
+            D1(x=1)
+
+        d2 = D2(x=1)
+
+        self.assertIsInstance(d2, D2)
+        self.assertEqual(d2.x, 1)
 
 class GenericTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1569,13 +1569,23 @@ class ProtocolTests(BaseTestCase):
             def __init__(self, x):
                 self.x = x
 
-        with self.assertRaisesRegex(TypeError, r"D1\(\) takes no arguments"):
-            D1(x=1)
+        class B:
+            def __init__(self, x):
+                self.x = x
 
-        d2 = D2(x=1)
+        class D3(P, B):
+            pass
 
-        self.assertIsInstance(d2, D2)
-        self.assertEqual(d2.x, 1)
+        with self.subTest(cls=D1):
+            with self.assertRaisesRegex(TypeError, r"D1\(\) takes no arguments"):
+                D1(x=1)
+
+        for cls in (D2, D3):
+            with self.subTest(cls=cls):
+                d = cls(x=1)
+
+                self.assertIsInstance(d, cls)
+                self.assertEqual(d.x, 1)
 
 class GenericTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1522,6 +1522,9 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
 
         # We have nothing more to do for non-protocols...
         if not cls._is_protocol:
+            if '__init__' not in cls.__dict__:
+                # bpo-44806: reset __init__ method to default one
+                cls.__init__ = object.__init__
             return
 
         # ... otherwise check consistency of bases, and prohibit instantiation.

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1523,8 +1523,11 @@ class Protocol(Generic, metaclass=_ProtocolMeta):
         # We have nothing more to do for non-protocols...
         if not cls._is_protocol:
             if '__init__' not in cls.__dict__:
-                # bpo-44806: reset __init__ method to default one
-                cls.__init__ = object.__init__
+                # bpo-44806: reset __init__ method to correct one
+                cls.__init__ = next(
+                    (b.__init__ for b in cls.__bases__ if b.__init__ is not _no_init),
+                    object.__init__,
+                )
             return
 
         # ... otherwise check consistency of bases, and prohibit instantiation.

--- a/Misc/NEWS.d/next/Library/2021-08-02-12-30-39.bpo-44806.q1ah2P.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-02-12-30-39.bpo-44806.q1ah2P.rst
@@ -1,3 +1,3 @@
 Fix issue when ``typing.Protocol`` delivered class get ``__init__`` method
-that can accepts unlimited *args and **kwargs. Patch provided by Yurii
+that can accepts unlimited `*args` and `**kwargs`. Patch provided by Yurii
 Karabas.

--- a/Misc/NEWS.d/next/Library/2021-08-02-12-30-39.bpo-44806.q1ah2P.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-02-12-30-39.bpo-44806.q1ah2P.rst
@@ -1,0 +1,3 @@
+Fix issue when ``typing.Protocol`` delivered class get ``__init__`` method
+that can accepts unlimited *args and **kwargs. Patch provided by Yurii
+Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44806](https://bugs.python.org/issue44806) -->
https://bugs.python.org/issue44806
<!-- /issue-number -->

https://github.com/python/typing/issues/644