### PR TITLE
bpo-44206: Make sure that dict-keys's version is set to zero when value is popped.

### DIFF
--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -332,6 +332,18 @@ a = A(destroyed)"""
         self.assertFalse("__annotations__" in ann_module4.__dict__)
 
 
+    def test_repeated_attribute_pops(self):
+        # Repeated accesses to module attribute will be specialized
+        # Check that popping the attribute doesn't break it
+        m = ModuleType("test")
+        d = m.__dict__
+        count = 0
+        for _ in range(100):
+            m.attr = 1
+            count += m.attr # Might be specialized
+            d.pop("attr")
+        self.assertEqual(count, 100)
+
     # frozen and namespace module reprs are tested in importlib.
 
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1798,6 +1798,7 @@ _PyDict_Pop_KnownHash(PyObject *dict, PyObject *key, Py_hash_t hash, PyObject *d
     assert(old_value != NULL);
     mp->ma_used--;
     mp->ma_version_tag = DICT_NEXT_VERSION();
+    mp->ma_keys->dk_version = 0;
     dictkeys_set_index(mp->ma_keys, hashpos, DKIX_DUMMY);
     ep = &DK_ENTRIES(mp->ma_keys)[ix];
     mp->ma_keys->dk_version = 0;


### PR DESCRIPTION


<!-- issue-number: [bpo-44206](https://bugs.python.org/issue44206) -->
https://bugs.python.org/issue44206
<!-- /issue-number -->
