### PR TITLE
gh-88974: Set Signature Algorithms for a given SSL Context

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-02-13-20-52.bpo-44811.KEAxGE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-02-13-20-52.bpo-44811.KEAxGE.rst
@@ -1,0 +1,1 @@
+Expose the OpenSSL function SSL_CTX_set1_sigalgs_list to allow the user to modify the supported signature algorithms for a given SSL Context.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3276,6 +3276,31 @@ _ssl__SSLContext_get_ciphers_impl(PySSLContext *self)
 
 }
 
+/*[clinic input]
+_ssl._SSLContext.set_sigalgs
+    sigalgslist: str
+    /
+[clinic start generated code]*/
+
+static PyObject *
+_ssl__SSLContext_set_sigalgs_impl(PySSLContext *self,
+                                  const char *sigalgslist)
+/*[clinic end generated code: output=e2fedc85569fbee5 input=55d55d1ad9de10cc]*/
+{
+    int ret = SSL_CTX_set1_sigalgs_list(self->ctx, sigalgslist);
+    if (ret == 0) {
+        /* Clearing the error queue is necessary on some OpenSSL versions,
+           otherwise the error will be reported again when another SSL call
+           is done. */
+        ERR_clear_error();
+        PyErr_SetString(get_state_ctx(self)->PySSLErrorObject,
+                        "No Signature algorithms can be selected.");
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+
 
 static int
 do_protocol_selection(int alpn, unsigned char **out, unsigned char *outlen,
@@ -4637,6 +4662,7 @@ static struct PyMethodDef context_methods[] = {
     _SSL__SSLCONTEXT__WRAP_SOCKET_METHODDEF
     _SSL__SSLCONTEXT__WRAP_BIO_METHODDEF
     _SSL__SSLCONTEXT_SET_CIPHERS_METHODDEF
+    _SSL__SSLCONTEXT_SET_SIGALGS_METHODDEF
     _SSL__SSLCONTEXT__SET_ALPN_PROTOCOLS_METHODDEF
     _SSL__SSLCONTEXT_LOAD_CERT_CHAIN_METHODDEF
     _SSL__SSLCONTEXT_LOAD_DH_PARAMS_METHODDEF

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -478,6 +478,43 @@ _ssl__SSLContext_get_ciphers(PySSLContext *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLContext_get_ciphers_impl(self);
 }
 
+PyDoc_STRVAR(_ssl__SSLContext_set_sigalgs__doc__,
+"set_sigalgs($self, sigalgslist, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLCONTEXT_SET_SIGALGS_METHODDEF    \
+    {"set_sigalgs", (PyCFunction)_ssl__SSLContext_set_sigalgs, METH_O, _ssl__SSLContext_set_sigalgs__doc__},
+
+static PyObject *
+_ssl__SSLContext_set_sigalgs_impl(PySSLContext *self,
+                                  const char *sigalgslist);
+
+static PyObject *
+_ssl__SSLContext_set_sigalgs(PySSLContext *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    const char *sigalgslist;
+
+    if (!PyUnicode_Check(arg)) {
+        _PyArg_BadArgument("set_sigalgs", "argument", "str", arg);
+        goto exit;
+    }
+    Py_ssize_t sigalgslist_length;
+    sigalgslist = PyUnicode_AsUTF8AndSize(arg, &sigalgslist_length);
+    if (sigalgslist == NULL) {
+        goto exit;
+    }
+    if (strlen(sigalgslist) != (size_t)sigalgslist_length) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        goto exit;
+    }
+    return_value = _ssl__SSLContext_set_sigalgs_impl(self, sigalgslist);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLContext__set_alpn_protocols__doc__,
 "_set_alpn_protocols($self, protos, /)\n"
 "--\n"
@@ -1358,4 +1395,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=5a7d7bf5cf8ee092 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dc8dd31a56fe1181 input=a9049054013a1b77]*/


### PR DESCRIPTION
Expose the OpenSSL function SSL_CTX_set1_sigalgs_list to allow the user to modify the supported signature algorithms for a given SSL Context.

OpenSSL documentation: https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set1_sigalgs_list.html
Issue: https://bugs.python.org/issue44811


<!-- issue-number: [bpo-44811](https://bugs.python.org/issue44811) -->
https://bugs.python.org/issue44811
<!-- /issue-number -->

<!-- gh-issue-number: gh-88974 -->
* Issue: gh-88974
<!-- /gh-issue-number -->
