### PR TITLE
bpo-44810: raise error on several drive letters in url2pathname

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -31,6 +31,9 @@ def url2pathname(url):
     if len(comp) != 2 or comp[0][-1] not in string.ascii_letters:
         error = 'Bad URL: ' + url
         raise OSError(error)
+    if len(comp[0]) > 1 and comp[0][-2] not in {"/", "\\"}:
+        error = 'Bad URL (too many drive letters [before the first | ]): ' + url
+        raise OSError(error)
     drive = comp[0][-1].upper()
     components = comp[1].split('/')
     path = drive + ':'


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44810](https://bugs.python.org/issue44810) -->
https://bugs.python.org/issue44810
<!-- /issue-number -->
