### PR TITLE
bpo-44799: Fix InitVar resolving using get_type_hints

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -228,6 +228,9 @@ class InitVar:
     def __init__(self, type):
         self.type = type
 
+    def __call__(self, *args, **kwargs):  # required by typing.get_type_hints, see bpo-44799
+        raise TypeError("InitVar object is not callable")
+
     def __repr__(self):
         if isinstance(self.type, type):
             type_name = self.type.__name__

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3831,5 +3831,19 @@ class TestKeywordArgs(unittest.TestCase):
                 c: int = 1
                 d: int
 
+    def test_lazy_init_var_get_type_hints(self):
+        @dataclass
+        class Foo:
+            a: "InitVar[int]"
+
+        hints = get_type_hints(Foo)
+
+        self.assertIsInstance(hints.get("a"), InitVar)
+        self.assertEqual(hints.get("a").type, int)
+
+    def test_init_var_is_not_callable(self):
+        with self.assertRaisesRegex(TypeError, r"InitVar object is not callable"):
+            InitVar[int]()
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2021-08-02-16-21-59.bpo-44799.hXfxPO.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-02-16-21-59.bpo-44799.hXfxPO.rst
@@ -1,0 +1,2 @@
+Fix issue when ``dataclass.InitVar`` can not be evaluated using
+``typing.get_type_hints``. Patch provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44799](https://bugs.python.org/issue44799) -->
https://bugs.python.org/issue44799
<!-- /issue-number -->
