### PR TITLE
bpo-44813: move NEED_OPCODE_JUMP_TABLES toggle to opcode.h

### DIFF
--- a/Include/opcode.h
+++ b/Include/opcode.h
@@ -149,6 +149,7 @@ extern "C" {
 #define LOAD_GLOBAL_ADAPTIVE     41
 #define LOAD_GLOBAL_MODULE       42
 #define LOAD_GLOBAL_BUILTIN      43
+#define NEED_OPCODE_JUMP_TABLES
 #ifdef NEED_OPCODE_JUMP_TABLES
 static uint32_t _PyOpcode_RelativeJump[8] = {
     0U,

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -31,7 +31,6 @@
 #include "pycore_long.h"          // _PyLong_GetZero()
 #include "pycore_symtable.h"      // PySTEntryObject
 
-#define NEED_OPCODE_JUMP_TABLES
 #include "opcode.h"               // EXTENDED_ARG
 #include "wordcode_helpers.h"     // instrsize()
 

--- a/Tools/scripts/generate_opcode_h.py
+++ b/Tools/scripts/generate_opcode_h.py
@@ -70,6 +70,7 @@ def main(opcode_py, outfile='Include/opcode.h'):
                 next_op += 1
             fobj.write("#define %-23s %3s\n" % (name, next_op))
             used[next_op] = True
+        fobj.write("#define NEED_OPCODE_JUMP_TABLES\n")
         fobj.write("#ifdef NEED_OPCODE_JUMP_TABLES\n")
         write_int_array_from_ops("_PyOpcode_RelativeJump", opcode['hasjrel'], fobj)
         write_int_array_from_ops("_PyOpcode_Jump", opcode['hasjrel'] + opcode['hasjabs'], fobj)


### PR DESCRIPTION

Mark - is this toggle still needed, and can it move into opcode.h?

My reason for doing this is because I want to import opcode.h from another place (without having to define this there as well).


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44813](https://bugs.python.org/issue44813) -->
https://bugs.python.org/issue44813
<!-- /issue-number -->
