### PR TITLE
bpo-44815: Always show deprecation in asyncio.gather/sleep()

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -755,13 +755,14 @@ def gather(*coros_or_futures, loop=None, return_exceptions=False):
     after catching an exception (raised by one of the awaitables) from
     gather won't cancel any other awaitables.
     """
+    if loop is not None:
+        warnings.warn("The loop argument is deprecated since Python 3.8, "
+                      "and scheduled for removal in Python 3.10.",
+                      DeprecationWarning, stacklevel=2)
+
     if not coros_or_futures:
         if loop is None:
             loop = events.get_event_loop()
-        else:
-            warnings.warn("The loop argument is deprecated since Python 3.8, "
-                          "and scheduled for removal in Python 3.10.",
-                          DeprecationWarning, stacklevel=2)
         outer = loop.create_future()
         outer.set_result([])
         return outer

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -640,16 +640,16 @@ def __sleep0():
 
 async def sleep(delay, result=None, *, loop=None):
     """Coroutine that completes after a given time (in seconds)."""
-    if delay <= 0:
-        await __sleep0()
-        return result
-
     if loop is None:
         loop = events.get_running_loop()
     else:
         warnings.warn("The loop argument is deprecated since Python 3.8, "
                       "and scheduled for removal in Python 3.10.",
                       DeprecationWarning, stacklevel=2)
+
+    if delay <= 0:
+        await __sleep0()
+        return result
 
     future = loop.create_future()
     h = loop.call_later(delay,


### PR DESCRIPTION
Should also go into 3.9 branch.

<!-- issue-number: [bpo-44815](https://bugs.python.org/issue44815) -->
https://bugs.python.org/issue44815
<!-- /issue-number -->
