### PR TITLE
[3.9] bpo-44815: Always show deprecation in asyncio.gather/sleep()

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -635,16 +635,16 @@ def __sleep0():
 
 async def sleep(delay, result=None, *, loop=None):
     """Coroutine that completes after a given time (in seconds)."""
-    if delay <= 0:
-        await __sleep0()
-        return result
-
     if loop is None:
         loop = events.get_running_loop()
     else:
         warnings.warn("The loop argument is deprecated since Python 3.8, "
                       "and scheduled for removal in Python 3.10.",
                       DeprecationWarning, stacklevel=2)
+
+    if delay <= 0:
+        await __sleep0()
+        return result
 
     future = loop.create_future()
     h = loop.call_later(delay,
@@ -750,13 +750,14 @@ def gather(*coros_or_futures, loop=None, return_exceptions=False):
     after catching an exception (raised by one of the awaitables) from
     gather won't cancel any other awaitables.
     """
+    if loop is not None:
+        warnings.warn("The loop argument is deprecated since Python 3.8, "
+                      "and scheduled for removal in Python 3.10.",
+                      DeprecationWarning, stacklevel=2)
+
     if not coros_or_futures:
         if loop is None:
             loop = events.get_event_loop()
-        else:
-            warnings.warn("The loop argument is deprecated since Python 3.8, "
-                          "and scheduled for removal in Python 3.10.",
-                          DeprecationWarning, stacklevel=2)
         outer = loop.create_future()
         outer.set_result([])
         return outer

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -635,9 +635,7 @@ def __sleep0():
 
 async def sleep(delay, result=None, *, loop=None):
     """Coroutine that completes after a given time (in seconds)."""
-    if loop is None:
-        loop = events.get_running_loop()
-    else:
+    if loop is not None:
         warnings.warn("The loop argument is deprecated since Python 3.8, "
                       "and scheduled for removal in Python 3.10.",
                       DeprecationWarning, stacklevel=2)
@@ -645,6 +643,9 @@ async def sleep(delay, result=None, *, loop=None):
     if delay <= 0:
         await __sleep0()
         return result
+
+    if loop is None:
+        loop = events.get_running_loop()
 
     future = loop.create_future()
     h = loop.call_later(delay,

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3260,10 +3260,11 @@ def clear_ignored_deprecations(*tokens: object) -> None:
     for action, message, category, module, lineno in warnings.filters:
         if action == "ignore" and category is DeprecationWarning:
             if isinstance(message, re.Pattern):
-                message = message.pattern
-            if tokens:
-                endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
-            if message.endswith(endswith):
+                msg = message.pattern
+            else:
+                msg = message or ""
+            endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
+            if msg.endswith(endswith):
                 continue
         new_filters.append((action, message, category, module, lineno))
     if warnings.filters != new_filters:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3257,13 +3257,13 @@ def clear_ignored_deprecations(*tokens: object) -> None:
         raise ValueError("Provide token or tokens returned by ignore_deprecations_from")
 
     new_filters = []
+    endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
     for action, message, category, module, lineno in warnings.filters:
         if action == "ignore" and category is DeprecationWarning:
             if isinstance(message, re.Pattern):
                 msg = message.pattern
             else:
                 msg = message or ""
-            endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
             if msg.endswith(endswith):
                 continue
         new_filters.append((action, message, category, module, lineno))

--- a/Lib/test/test_asyncio/__init__.py
+++ b/Lib/test/test_asyncio/__init__.py
@@ -4,7 +4,6 @@ import unittest
 
 # Skip tests if we don't have concurrent.futures.
 support.import_module('concurrent.futures')
-module_deprecation_tokens = set()
 
 
 def load_tests(loader, _, pattern):
@@ -21,26 +20,18 @@ class AsyncioTestSuite(unittest.TestSuite):
     would be tedious, let's run this once and for all.
     """
     def run(self, result, debug=False):
+        ignore = support.ignore_deprecations_from
+        tokens = {
+            ignore("asyncio.base_events", like=r".*loop argument.*"),
+            ignore("asyncio.unix_events", like=r".*loop argument.*"),
+            ignore("asyncio.futures", like=r".*loop argument.*"),
+            ignore("asyncio.runners", like=r".*loop argument.*"),
+            ignore("asyncio.subprocess", like=r".*loop argument.*"),
+            ignore("asyncio.tasks", like=r".*loop argument.*"),
+            ignore("test.test_asyncio.test_queues", like=r".*loop argument.*"),
+            ignore("test.test_asyncio.test_tasks", like=r".*loop argument.*"),
+        }
         try:
-            setUpModule()
             super().run(result, debug=debug)
         finally:
-            tearDownModule()
-
-
-def setUpModule():
-    ignore = support.ignore_deprecations_from
-    module_deprecation_tokens.update((
-        ignore("asyncio.base_events", like=r".*loop argument.*"),
-        ignore("asyncio.unix_events", like=r".*loop argument.*"),
-        ignore("asyncio.futures", like=r".*loop argument.*"),
-        ignore("asyncio.runners", like=r".*loop argument.*"),
-        ignore("asyncio.subprocess", like=r".*loop argument.*"),
-        ignore("asyncio.tasks", like=r".*loop argument.*"),
-        ignore("test.test_asyncio.test_queues", like=r".*loop argument.*"),
-        ignore("test.test_asyncio.test_tasks", like=r".*loop argument.*"),
-    ))
-
-
-def tearDownModule():
-    support.clear_ignored_deprecations(*module_deprecation_tokens)
+            support.clear_ignored_deprecations(*tokens)

--- a/Lib/test/test_asyncio/__init__.py
+++ b/Lib/test/test_asyncio/__init__.py
@@ -1,8 +1,46 @@
 import os
-from test.support import load_package_tests, import_module
+from test import support
+import unittest
 
 # Skip tests if we don't have concurrent.futures.
-import_module('concurrent.futures')
+support.import_module('concurrent.futures')
+module_deprecation_tokens = set()
 
-def load_tests(*args):
-    return load_package_tests(os.path.dirname(__file__), *args)
+
+def load_tests(loader, _, pattern):
+    pkg_dir = os.path.dirname(__file__)
+    suite = AsyncioTestSuite()
+    return support.load_package_tests(pkg_dir, loader, suite, pattern)
+
+
+class AsyncioTestSuite(unittest.TestSuite):
+    """A custom test suite that also runs setup/teardown for the whole package.
+
+    Normally unittest only runs setUpModule() and tearDownModule() within each
+    test module part of the test suite. Copying those functions to each file
+    would be tedious, let's run this once and for all.
+    """
+    def run(self, result, debug=False):
+        try:
+            setUpModule()
+            super().run(result, debug=debug)
+        finally:
+            tearDownModule()
+
+
+def setUpModule():
+    ignore = support.ignore_deprecations_from
+    module_deprecation_tokens.update((
+        ignore("asyncio.base_events", like=r".*loop argument.*"),
+        ignore("asyncio.unix_events", like=r".*loop argument.*"),
+        ignore("asyncio.futures", like=r".*loop argument.*"),
+        ignore("asyncio.runners", like=r".*loop argument.*"),
+        ignore("asyncio.subprocess", like=r".*loop argument.*"),
+        ignore("asyncio.tasks", like=r".*loop argument.*"),
+        ignore("test.test_asyncio.test_queues", like=r".*loop argument.*"),
+        ignore("test.test_asyncio.test_tasks", like=r".*loop argument.*"),
+    ))
+
+
+def tearDownModule():
+    support.clear_ignored_deprecations(*module_deprecation_tokens)

--- a/Misc/NEWS.d/next/Library/2021-08-03-15-02-28.bpo-44815.9AmFfy.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-03-15-02-28.bpo-44815.9AmFfy.rst
@@ -1,0 +1,2 @@
+Always show ``loop=`` arg deprecations in :func:`asyncio.gather` and
+:func:`asyncio.sleep`


### PR DESCRIPTION


<!-- issue-number: [bpo-44815](https://bugs.python.org/issue44815) -->
https://bugs.python.org/issue44815
<!-- /issue-number -->
