### PR TITLE
bpo-44301: Docs: Note that tp_clear and m_clear are not always called

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -221,6 +221,12 @@ or request "multi-phase initialization" by returning the definition struct itsel
       than 0 and the module state (as returned by :c:func:`PyModule_GetState`)
       is ``NULL``.
 
+      Like :c:member:`PyTypeObject.tp_clear`, this function is not *always*
+      called before a module is deallocated. For example, when reference
+      counting is enough to determine that an object is no longer used,
+      the cyclic garbage collector is not involved and
+      :c:member:`~PyModuleDef.m_free` is called directly.
+
       .. versionchanged:: 3.9
          No longer called before the module state is allocated.
 

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1381,6 +1381,12 @@ and :c:type:`PyType_Type` effectively act as defaults.)
    so that *self* knows the contained object can no longer be used.  The
    :c:func:`Py_CLEAR` macro performs the operations in a safe order.
 
+   Note that :c:member:`~PyTypeObject.tp_clear` is not *always* called
+   before an instance is deallocated. For example, when reference counting
+   is enough to determine that an object is no longer used, the cyclic garbage
+   collector is not involved and :c:member:`~PyTypeObject.tp_dealloc` is
+   called directly.
+
    Because the goal of :c:member:`~PyTypeObject.tp_clear` functions is to break reference cycles,
    it's not necessary to clear contained objects like Python strings or Python
    integers, which can't participate in reference cycles. On the other hand, it may


### PR DESCRIPTION
It was not clear from the documentation that `tp_clear` (or in this case, `m_clear` of modules) is only called by the cyclic GC; when the object reaches zero refcount, `tp_clear` isn't called.

<!-- issue-number: [bpo-44301](https://bugs.python.org/issue44301) -->
https://bugs.python.org/issue44301
<!-- /issue-number -->
