### PR TITLE
bpo-44822: Don't truncate `str`s with embedded NULL chars returned by `sqlite3` UDF callbacks

### DIFF
--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -53,6 +53,8 @@ def with_tracebacks(strings):
 
 def func_returntext():
     return "foo"
+def func_returntextwithnull():
+    return "1\x002"
 def func_returnunicode():
     return "bar"
 def func_returnint():
@@ -168,6 +170,7 @@ class FunctionTests(unittest.TestCase):
         self.con = sqlite.connect(":memory:")
 
         self.con.create_function("returntext", 0, func_returntext)
+        self.con.create_function("returntextwithnull", 0, func_returntextwithnull)
         self.con.create_function("returnunicode", 0, func_returnunicode)
         self.con.create_function("returnint", 0, func_returnint)
         self.con.create_function("returnfloat", 0, func_returnfloat)
@@ -210,6 +213,12 @@ class FunctionTests(unittest.TestCase):
         val = cur.fetchone()[0]
         self.assertEqual(type(val), str)
         self.assertEqual(val, "foo")
+
+    def test_func_return_text_with_null_char(self):
+        cur = self.con.cursor()
+        res = cur.execute("select returntextwithnull()").fetchone()[0]
+        self.assertEqual(type(res), str)
+        self.assertEqual(res, "1\x002")
 
     def test_func_return_unicode(self):
         cur = self.con.cursor()

--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -165,6 +165,15 @@ class AggrSum:
     def finalize(self):
         return self.val
 
+class AggrText:
+    def __init__(self):
+        self.txt = ""
+    def step(self, txt):
+        self.txt = self.txt + txt
+    def finalize(self):
+        return self.txt
+
+
 class FunctionTests(unittest.TestCase):
     def setUp(self):
         self.con = sqlite.connect(":memory:")
@@ -399,6 +408,7 @@ class AggregateTests(unittest.TestCase):
         self.con.create_aggregate("checkType", 2, AggrCheckType)
         self.con.create_aggregate("checkTypes", -1, AggrCheckTypes)
         self.con.create_aggregate("mysum", 1, AggrSum)
+        self.con.create_aggregate("aggtxt", 1, AggrText)
 
     def tearDown(self):
         #self.cur.close()
@@ -494,6 +504,15 @@ class AggregateTests(unittest.TestCase):
         cur = self.con.execute("select mysum(i) from (select 1 as i) where i == 0")
         val = cur.fetchone()[0]
         self.assertIsNone(val)
+
+    def test_aggr_text(self):
+        cur = self.con.cursor()
+        for txt in ["foo", "1\x002"]:
+            with self.subTest(txt=txt):
+                cur.execute("select aggtxt(?) from test", (txt,))
+                val = cur.fetchone()[0]
+                self.assertEqual(val, txt)
+
 
 class AuthorizerTests(unittest.TestCase):
     @staticmethod

--- a/Misc/NEWS.d/next/Library/2021-08-04-12-29-00.bpo-44822.zePNXA.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-04-12-29-00.bpo-44822.zePNXA.rst
@@ -1,0 +1,3 @@
+:mod:`sqlite3` now raises :exc:`OverflowError` if an user-defined function
+returns a :class:`str` larger than ``INT_MAX`` bytes. Patch by Erlend E.
+Aasland.

--- a/Misc/NEWS.d/next/Library/2021-08-04-12-29-00.bpo-44822.zePNXA.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-04-12-29-00.bpo-44822.zePNXA.rst
@@ -1,3 +1,3 @@
-:mod:`sqlite3` now raises :exc:`OverflowError` if an user-defined function
-returns a :class:`str` larger than ``INT_MAX`` bytes. Patch by Erlend E.
+:mod:`sqlite3` user-defined functions returning :class:`strings <str>` with
+embedded ``NULL`` characters are no longer truncated. Patch by Erlend E.
 Aasland.

--- a/Misc/NEWS.d/next/Library/2021-08-04-12-29-00.bpo-44822.zePNXA.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-04-12-29-00.bpo-44822.zePNXA.rst
@@ -1,3 +1,3 @@
-:mod:`sqlite3` user-defined functions returning :class:`strings <str>` with
-embedded ``NULL`` characters are no longer truncated. Patch by Erlend E.
-Aasland.
+:mod:`sqlite3` user-defined functions and aggregators returning
+:class:`strings <str>` with embedded NUL characters are no longer
+truncated. Patch by Erlend E. Aasland.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -525,7 +525,9 @@ _pysqlite_set_result(sqlite3_context* context, PyObject* py_val)
             return -1;
         }
         if (sz > INT_MAX) {
-            sz = -1;  // Let SQLite compute string length
+            PyErr_SetString(PyExc_OverflowError,
+                            "String is longer than INT_MAX bytes");
+            return -1;
         }
         sqlite3_result_text(context, str, (int)sz, SQLITE_TRANSIENT);
     } else if (PyObject_CheckBuffer(py_val)) {

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -519,10 +519,15 @@ _pysqlite_set_result(sqlite3_context* context, PyObject* py_val)
     } else if (PyFloat_Check(py_val)) {
         sqlite3_result_double(context, PyFloat_AsDouble(py_val));
     } else if (PyUnicode_Check(py_val)) {
-        const char *str = PyUnicode_AsUTF8(py_val);
-        if (str == NULL)
+        Py_ssize_t sz;
+        const char *str = PyUnicode_AsUTF8AndSize(py_val, &sz);
+        if (str == NULL) {
             return -1;
-        sqlite3_result_text(context, str, -1, SQLITE_TRANSIENT);
+        }
+        if (sz > INT_MAX) {
+            sz = -1;  // Let SQLite compute string length
+        }
+        sqlite3_result_text(context, str, (int)sz, SQLITE_TRANSIENT);
     } else if (PyObject_CheckBuffer(py_val)) {
         Py_buffer view;
         if (PyObject_GetBuffer(py_val, &view, PyBUF_SIMPLE) != 0) {

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -526,7 +526,7 @@ _pysqlite_set_result(sqlite3_context* context, PyObject* py_val)
         }
         if (sz > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError,
-                            "String is longer than INT_MAX bytes");
+                            "string is longer than INT_MAX bytes");
             return -1;
         }
         sqlite3_result_text(context, str, (int)sz, SQLITE_TRANSIENT);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44822](https://bugs.python.org/issue44822) -->
https://bugs.python.org/issue44822
<!-- /issue-number -->
