### PR TITLE
bpo-44821: Eagerly assign __dict__ for new objects.

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -180,8 +180,7 @@ extern int _Py_CheckSlotResult(
 
 extern PyObject* _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems);
 
-int
-_PyObject_InitializeDict(PyObject *obj);
+extern int _PyObject_InitializeDict(PyObject *obj);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -180,6 +180,9 @@ extern int _Py_CheckSlotResult(
 
 extern PyObject* _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems);
 
+int
+_PyObject_InitializeDict(PyObject *obj);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -323,9 +323,13 @@ class CAPITest(unittest.TestCase):
                         break
         """
         rc, out, err = assert_python_ok('-c', code)
-        self.assertIn(b'MemoryError 1', out)
-        self.assertIn(b'MemoryError 2 20', out)
-        self.assertIn(b'MemoryError 3 30', out)
+        lines = out.splitlines()
+        for i, line in enumerate(lines, 1):
+            self.assertIn(b'MemoryError', out)
+            *_, count = line.split(b' ')
+            count = int(count)
+            self.assertLessEqual(count, i*5)
+            self.assertGreaterEqual(count, i*5-1)
 
     def test_mapping_keys_values_items(self):
         class Mapping1(dict):

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -566,7 +566,7 @@ id(foo)''')
         #  http://bugs.python.org/issue8032#msg100537 )
         gdb_repr, gdb_output = self.get_gdb_repr('id(__builtins__.help)', import_site=True)
 
-        m = re.match(r'<_Helper at remote 0x-?[0-9a-f]+>', gdb_repr)
+        m = re.match(r'<_Helper\(\) at remote 0x-?[0-9a-f]+>', gdb_repr)
         self.assertTrue(m,
                         msg='Unexpected rendering %r' % gdb_repr)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-04-11-37-38.bpo-44821.67YHGI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-04-11-37-38.bpo-44821.67YHGI.rst
@@ -1,0 +1,2 @@
+Create instance dictionaries (__dict__) eagerly, to improve regularity of
+object layout and assist specialization.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4505,7 +4505,15 @@ object_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_DECREF(joined);
         return NULL;
     }
-    return type->tp_alloc(type, 0);
+    PyObject *obj = type->tp_alloc(type, 0);
+    if (obj == NULL) {
+        return NULL;
+    }
+    if (_PyObject_InitializeDict(obj)) {
+        Py_DECREF(obj);
+        return NULL;
+    }
+    return obj;
 }
 
 static void


### PR DESCRIPTION
This is part of our drive to make layout of objects more regular and efficient.
This has little or no overall [impact on performance](https://gist.github.com/markshannon/8350aad501778d3a64d8ac4891ad5a4d)

The main reason for this PR is make specialization of `STORE_ATTR` work well.

<!-- issue-number: [bpo-44821](https://bugs.python.org/issue44821) -->
https://bugs.python.org/issue44821
<!-- /issue-number -->
