### PR TITLE
tty/fit setraw acording to a man page

### DIFF
--- a/Lib/tty.py
+++ b/Lib/tty.py
@@ -18,11 +18,11 @@ CC = 6
 def setraw(fd, when=TCSAFLUSH):
     """Put terminal into a raw mode."""
     mode = tcgetattr(fd)
-    mode[IFLAG] = mode[IFLAG] & ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON)
+    mode[IFLAG] = mode[IFLAG] & ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON)
     mode[OFLAG] = mode[OFLAG] & ~(OPOST)
     mode[CFLAG] = mode[CFLAG] & ~(CSIZE | PARENB)
     mode[CFLAG] = mode[CFLAG] | CS8
-    mode[LFLAG] = mode[LFLAG] & ~(ECHO | ICANON | IEXTEN | ISIG)
+    mode[LFLAG] = mode[LFLAG] & ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN)
     mode[CC][VMIN] = 1
     mode[CC][VTIME] = 0
     tcsetattr(fd, when, mode)


### PR DESCRIPTION
Hi there,
Coincidentally I noticed that `setraw` explanation on a man page and python implementation is different.
There's no comment why.
So I just decided to open an issue but there's no issues here :(

It would be nice to put a comment why some of the settings were omitted.

And yes I think it might be a breaking change so it may not worth to be merged.

But leave a comment would be welcomed :)

____
https://man7.org/linux/man-pages/man3/termios.3.html

```
   Raw mode
       cfmakeraw() sets the terminal to something like the "raw" mode of
       the old Version 7 terminal driver: input is available character
       by character, echoing is disabled, and all special processing of
       terminal input and output characters is disabled.  The terminal
       attributes are set as follows:

           termios_p->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP
                           | INLCR | IGNCR | ICRNL | IXON);
           termios_p->c_oflag &= ~OPOST;
           termios_p->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
           termios_p->c_cflag &= ~(CSIZE | PARENB);
           termios_p->c_cflag |= CS8;
```

Thank you.
And sorry for bothering.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
