### PR TITLE
platform: Import subprocess in function.

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -116,7 +116,6 @@ import collections
 import os
 import re
 import sys
-import subprocess
 import functools
 import itertools
 
@@ -748,6 +747,7 @@ class _Processor:
         """
         Fall back to `uname -p`
         """
+        import subprocess
         try:
             return subprocess.check_output(
                 ['uname', '-p'],


### PR DESCRIPTION
#10892 made platform imports subprocess lazily.
But #12239 reverted the change accidentally.