### PR TITLE
gh-86690: pdb: additional documentation on retval

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1238,6 +1238,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_retval(self, arg):
         """retval
         Print the return value for the last return of a function.
+        Alternatively, the return value can be accessed with the local
+        variable ``__return__``
         """
         if '__return__' in self.curframe_locals:
             self.message(repr(self.curframe_locals['__return__']))

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -107,6 +107,7 @@ def test_pdb_basic_commands():
     ...     'jump 8',     # jump over second for loop
     ...     'return',     # return out of function
     ...     'retval',     # display return value
+    ...     '__return__', # access the return value
     ...     'next',       # step to test_function3()
     ...     'step',       # stepping into test_function3()
     ...     'args',       # display function args
@@ -140,7 +141,7 @@ def test_pdb_basic_commands():
     [EOF]
     (Pdb) bt
     ...
-      <doctest test.test_pdb.test_pdb_basic_commands[4]>(25)<module>()
+      <doctest test.test_pdb.test_pdb_basic_commands[4]>(26)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_basic_commands[3]>(3)test_function()
     -> ret = test_function_2('baz')
@@ -184,6 +185,8 @@ def test_pdb_basic_commands():
     > <doctest test.test_pdb.test_pdb_basic_commands[0]>(10)test_function_2()->'BAZ'
     -> return foo.upper()
     (Pdb) retval
+    'BAZ'
+    (Pdb) __return__
     'BAZ'
     (Pdb) next
     > <doctest test.test_pdb.test_pdb_basic_commands[3]>(4)test_function()


### PR DESCRIPTION
Add documentation on `retval`stating that the return value itself can be
accessed via the `__return__` local variable.

This is intended to let people know that they can access complex objects
using this variable (for example access `__return__.thingy()`)


<!-- issue-number: [bpo-42524](https://bugs.python.org/issue42524) -->
https://bugs.python.org/issue42524
<!-- /issue-number -->

<!-- gh-issue-number: gh-86690 -->
* Issue: gh-86690
<!-- /gh-issue-number -->
