### PR TITLE
bpo-44839: Raise more specific errors in sqlite3

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-08-05-14-59-39.bpo-44839.MURNL9.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-05-14-59-39.bpo-44839.MURNL9.rst
@@ -1,0 +1,4 @@
+:class:`MemoryError` raised in user-defined function will now produce a
+MemoryError in :mod:`sqlite3`. :class:`OverflowError` will now be converted
+to :class:`~sqlite3.DataError`. Previously
+:class:`~sqlite3.OperationalError` was produced in these cases.

--- a/Misc/NEWS.d/next/Library/2021-08-05-14-59-39.bpo-44839.MURNL9.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-05-14-59-39.bpo-44839.MURNL9.rst
@@ -1,4 +1,4 @@
-:class:`MemoryError` raised in user-defined function will now produce a
-MemoryError in :mod:`sqlite3`. :class:`OverflowError` will now be converted
+:class:`MemoryError` raised in user-defined functions will now produce a
+``MemoryError`` in :mod:`sqlite3`. :class:`OverflowError` will now be converted
 to :class:`~sqlite3.DataError`. Previously
 :class:`~sqlite3.OperationalError` was produced in these cases.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -668,8 +668,7 @@ _pysqlite_func_callback(sqlite3_context *context, int argc, sqlite3_value **argv
         Py_DECREF(py_retval);
     }
     if (!ok) {
-        set_sqlite_error(context,
-                "user-defined function raised exception");
+        set_sqlite_error(context, "user-defined function raised exception");
     }
 
     PyGILState_Release(threadstate);


### PR DESCRIPTION
MemoryError raised in user-defined function will now preserve
its type. OverflowError will now be converted to DataError.
Previously both were converted to OperationalError.


<!-- issue-number: [bpo-44839](https://bugs.python.org/issue44839) -->
https://bugs.python.org/issue44839
<!-- /issue-number -->
