### PR TITLE
bpo-44849: Fix os.set_inheritable() on FreeBSD 14 with O_PATH

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-08-06-13-00-28.bpo-44849.O78F_f.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-06-13-00-28.bpo-44849.O78F_f.rst
@@ -1,0 +1,4 @@
+Fix the :func:`os.set_inheritable` function on FreeBSD 14 for file descriptor
+opened with the :data:`~os.O_PATH` flag: ignore the :data:`~errno.EBADF`
+error on ``ioctl()``, fallback on the ``fcntl()`` implementation. Patch by
+Victor Stinner.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1374,10 +1374,11 @@ set_inheritable(int fd, int inheritable, int raise, int *atomic_flag_works)
             return 0;
         }
 
-#ifdef __linux__
+#ifdef O_PATH
         if (errno == EBADF) {
-            // On Linux, ioctl(FIOCLEX) will fail with EBADF for O_PATH file descriptors
-            // Fall through to the fcntl() path
+            // bpo-44849: On Linux and FreeBSD, ioctl(FIOCLEX) fails with EBADF
+            // on O_PATH file descriptors. Fall through to the fcntl()
+            // implementation.
         }
         else
 #endif


### PR DESCRIPTION
Fix the os.set_inheritable() functon on FreeBSD 14 for file
descriptor opened with the O_PATH flag: ignore the EBADF error on
ioctl(), fallback on the fcntl() implementation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44849](https://bugs.python.org/issue44849) -->
https://bugs.python.org/issue44849
<!-- /issue-number -->
