### PR TITLE
bpo-25782: avoid hang in PyErr_SetObject when current exception has a…

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -972,7 +972,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertIsInstance(exc.__context__, ValueError)
         self.assertIs(exc.__context__.__context__, exc.__context__)
 
-    def test_no_hang_on_context_chain_cycle1(self):
+    def test_no_hang_on_context_chain_cycle2(self):
         # See issue 25782. Cycle at head of context chain.
 
         class A(Exception):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -953,6 +953,24 @@ class ExceptionTests(unittest.TestCase):
             pass
         self.assertEqual(e, (None, None, None))
 
+    def test_no_hang_on_context_chain_cycle(self):
+        # See issue 25782.
+
+        def cycle():
+            try:
+                raise ValueError(1)
+            except ValueError as ex:
+                ex.__context__ = ex
+                raise TypeError(2)
+
+        try:
+            cycle()
+        except Exception as e:
+            exc = e
+
+        self.assertIsInstance(exc, TypeError)
+        self.assertIsInstance(exc.__context__, ValueError)
+
     def test_unicode_change_attributes(self):
         # See issue 7309. This was a crasher.
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-07-21-39-19.bpo-25782.B22lMx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-07-21-39-19.bpo-25782.B22lMx.rst
@@ -1,0 +1,1 @@
+Fix bug where ``PyErr_SetObject`` hangs when the current exception has a cycle in its context chain.

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -148,12 +148,16 @@ _PyErr_SetObject(PyThreadState *tstate, PyObject *exception, PyObject *value)
             value = fixed_value;
         }
 
-        /* Avoid reference cycles through the context chain.
+        /* Avoid creating new reference cycles through the
+           context chain, while taking care not to hang on
+           pre-existing ones.
            This is O(chain length) but context chains are
            usually very short. Sensitive readers may try
            to inline the call to PyException_GetContext. */
         if (exc_value != value) {
             PyObject *o = exc_value, *context;
+            PyObject *slow_o = o;  /* Floyd's cycle detection algo */
+            int slow_update_toggle = 0;
             while ((context = PyException_GetContext(o))) {
                 Py_DECREF(context);
                 if (context == value) {
@@ -161,6 +165,15 @@ _PyErr_SetObject(PyThreadState *tstate, PyObject *exception, PyObject *value)
                     break;
                 }
                 o = context;
+                if (o == slow_o) {
+                    /* pre-existing cycle - leave it */
+                    break;
+                }
+                if (slow_update_toggle) {
+                    slow_o = PyException_GetContext(slow_o);
+                    Py_DECREF(slow_o);
+                }
+                slow_update_toggle = !slow_update_toggle;
             }
             PyException_SetContext(value, exc_value);
         }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -166,7 +166,8 @@ _PyErr_SetObject(PyThreadState *tstate, PyObject *exception, PyObject *value)
                 }
                 o = context;
                 if (o == slow_o) {
-                    /* pre-existing cycle - leave it */
+                    /* pre-existing cycle - all exceptions on the
+                       path were visited and checked.  */
                     break;
                 }
                 if (slow_update_toggle) {


### PR DESCRIPTION
… cycle in its __context__ chain

Co-authored-by: Dennis Sweeney 36520290+sweeneyde@users.noreply.github.com

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-25782](https://bugs.python.org/issue25782) -->
https://bugs.python.org/issue25782
<!-- /issue-number -->
