### PR TITLE
bpo-44860: Make sysconfig posix_user not depend on platlibdir

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -101,7 +101,7 @@ if _HAS_USER_BASE:
             'stdlib': '{userbase}/{platlibdir}/python{py_version_short}',
             'platstdlib': '{userbase}/{platlibdir}/python{py_version_short}',
             'purelib': '{userbase}/lib/python{py_version_short}/site-packages',
-            'platlib': '{userbase}/{platlibdir}/python{py_version_short}/site-packages',
+            'platlib': '{userbase}/lib/python{py_version_short}/site-packages',
             'include': '{userbase}/include/python{py_version_short}',
             'scripts': '{userbase}/bin',
             'data': '{userbase}',

--- a/Misc/NEWS.d/next/Library/2021-08-07-22-51-32.bpo-44860.PTvRrU.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-07-22-51-32.bpo-44860.PTvRrU.rst
@@ -1,0 +1,2 @@
+Fix the ``posix_user`` scheme in :mod:`sysconfig` to not depend on
+:data:`sys.platlibdir`.


### PR DESCRIPTION


<!-- issue-number: [bpo-44860](https://bugs.python.org/issue44860) -->
https://bugs.python.org/issue44860
<!-- /issue-number -->
