### PR TITLE
docs: Remove duplicate callback word

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -196,7 +196,7 @@ Scheduling callbacks
 
 .. method:: loop.call_soon(callback, *args, context=None)
 
-   Schedule the *callback* :term:`callback` to be called with
+   Schedule the :term:`callback` to be called with
    *args* arguments at the next iteration of the event loop.
 
    Callbacks are called in the order in which they are registered.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

First callback word refers to the method parameter, while
the second is a link to the glossary. No other place in this
doc uses that format. Makes the doc a bit redundant, as 
seen on the image below:

![Screenshot from 2021-08-07 14-48-00](https://user-images.githubusercontent.com/1156874/128609473-988ed2cd-3fdb-4a40-80ad-93330046c8ff.png)
