### PR TITLE
remove unecessary import in difflib.py

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1411,7 +1411,6 @@ def _mdiff(fromlines, tolines, context=None, linejunk=None,
     side difference markup.  Optional ndiff arguments may be passed to this
     function and they in turn will be passed to ndiff.
     """
-    import re
 
     # regular expression for finding intraline change indices
     change_re = re.compile(r'(\++|\-+|\^+)')


### PR DESCRIPTION
`import re` is already present as global variable in line 1083
