### PR TITLE
bpo-42053: Remove misleading check in os.fwalk()

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -461,8 +461,7 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
                 dirs.remove('CVS')  # don't visit CVS directories
         """
         sys.audit("os.fwalk", top, topdown, onerror, follow_symlinks, dir_fd)
-        if not isinstance(top, int) or not hasattr(top, '__index__'):
-            top = fspath(top)
+        top = fspath(top)
         # Note: To guard against symlink races, we use the standard
         # lstat()/open()/fstat() trick.
         if not follow_symlinks:


### PR DESCRIPTION
os.fwalk() does not support integer as the first argument,
and never supported.


<!-- issue-number: [bpo-42053](https://bugs.python.org/issue42053) -->
https://bugs.python.org/issue42053
<!-- /issue-number -->
