### PR TITLE
bpo-44544: add textwrap placeholder arg

### DIFF
--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -17,11 +17,11 @@ If you're just wrapping or filling one or two text strings, the convenience
 functions should be good enough; otherwise, you should use an instance of
 :class:`TextWrapper` for efficiency.
 
-.. function:: wrap(text, width=70, initial_indent="", \
+.. function:: wrap(text, width=70, *, initial_indent="", \
                    subsequent_indent="", expand_tabs=True, \
                    replace_whitespace=True, fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
-                   break_on_hyphens=True, tabsize=8, *, max_lines=None, \
+                   break_on_hyphens=True, tabsize=8, max_lines=None, \
                    placeholder=' [...]')
 
    Wraps the single paragraph in *text* (a string) so every line is at most
@@ -35,12 +35,12 @@ functions should be good enough; otherwise, you should use an instance of
    :func:`wrap` behaves.
 
 
-.. function:: fill(text, width=70, initial_indent="", \
+.. function:: fill(text, width=70, *, initial_indent="", \
                    subsequent_indent="", expand_tabs=True, \
                    replace_whitespace=True, fix_sentence_endings=False, \
                    break_long_words=True, drop_whitespace=True, \
                    break_on_hyphens=True, tabsize=8, \
-                   *, max_lines=None, placeholder=' [...]')
+                   max_lines=None, placeholder=' [...]')
 
    Wraps the single paragraph in *text*, and returns a single string containing the
    wrapped paragraph.  :func:`fill` is shorthand for  ::
@@ -51,9 +51,9 @@ functions should be good enough; otherwise, you should use an instance of
    :func:`wrap`.
 
 
-.. function:: shorten(text, width, fix_sentence_endings=False, \
+.. function:: shorten(text, width, *, fix_sentence_endings=False, \
                       break_long_words=True, break_on_hyphens=True, \
-                      *, placeholder=' [...]')
+                      placeholder=' [...]')
 
    Collapse and truncate the given *text* to fit in the given *width*.
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -17,11 +17,11 @@ If you're just wrapping or filling one or two text strings, the convenience
 functions should be good enough; otherwise, you should use an instance of
 :class:`TextWrapper` for efficiency.
 
-.. function:: wrap(text, width=70, *, initial_indent="", \
-                   subsequent_indent="", expand_tabs=True, \
-                   replace_whitespace=True, fix_sentence_endings=False, \
-                   break_long_words=True, drop_whitespace=True, \
-                   break_on_hyphens=True, tabsize=8, max_lines=None)
+.. function:: wrap(text, width=70, initial_indent="", subsequent_indent="", \
+                   expand_tabs=True, replace_whitespace=True, \
+                   fix_sentence_endings=False, break_long_words=True, \
+                   drop_whitespace=True, break_on_hyphens=True, tabsize=8, *, \
+                   max_lines=None, placeholder=' [...]')
 
    Wraps the single paragraph in *text* (a string) so every line is at most
    *width* characters long.  Returns a list of output lines, without final
@@ -34,12 +34,11 @@ functions should be good enough; otherwise, you should use an instance of
    :func:`wrap` behaves.
 
 
-.. function:: fill(text, width=70, *, initial_indent="", \
-                   subsequent_indent="", expand_tabs=True, \
-                   replace_whitespace=True, fix_sentence_endings=False, \
-                   break_long_words=True, drop_whitespace=True, \
-                   break_on_hyphens=True, tabsize=8, \
-                   max_lines=None)
+.. function:: fill(text, width=70, initial_indent="", subsequent_indent="", \
+                   expand_tabs=True, replace_whitespace=True, \
+                   fix_sentence_endings=False, break_long_words=True, \
+                   drop_whitespace=True, break_on_hyphens=True, tabsize=8, *, \
+                   max_lines=None, placeholder=' [...]')
 
    Wraps the single paragraph in *text*, and returns a single string containing the
    wrapped paragraph.  :func:`fill` is shorthand for  ::
@@ -50,8 +49,8 @@ functions should be good enough; otherwise, you should use an instance of
    :func:`wrap`.
 
 
-.. function:: shorten(text, width, *, fix_sentence_endings=False, \
-                      break_long_words=True, break_on_hyphens=True, \
+.. function:: shorten(text, width, fix_sentence_endings=False, \
+                      break_long_words=True, break_on_hyphens=True, *, \
                       placeholder=' [...]')
 
    Collapse and truncate the given *text* to fit in the given *width*.

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -17,11 +17,12 @@ If you're just wrapping or filling one or two text strings, the convenience
 functions should be good enough; otherwise, you should use an instance of
 :class:`TextWrapper` for efficiency.
 
-.. function:: wrap(text, width=70, initial_indent="", subsequent_indent="", \
-                   expand_tabs=True, replace_whitespace=True, \
-                   fix_sentence_endings=False, break_long_words=True, \
-                   drop_whitespace=True, break_on_hyphens=True, tabsize=8, *, \
-                   max_lines=None, placeholder=' [...]')
+.. function:: wrap(text, width=70, initial_indent="", \
+                   subsequent_indent="", expand_tabs=True, \
+                   replace_whitespace=True, fix_sentence_endings=False, \
+                   break_long_words=True, drop_whitespace=True, \
+                   break_on_hyphens=True, tabsize=8, *, max_lines=None, \
+                   placeholder=' [...]')
 
    Wraps the single paragraph in *text* (a string) so every line is at most
    *width* characters long.  Returns a list of output lines, without final
@@ -34,11 +35,12 @@ functions should be good enough; otherwise, you should use an instance of
    :func:`wrap` behaves.
 
 
-.. function:: fill(text, width=70, initial_indent="", subsequent_indent="", \
-                   expand_tabs=True, replace_whitespace=True, \
-                   fix_sentence_endings=False, break_long_words=True, \
-                   drop_whitespace=True, break_on_hyphens=True, tabsize=8, *, \
-                   max_lines=None, placeholder=' [...]')
+.. function:: fill(text, width=70, initial_indent="", \
+                   subsequent_indent="", expand_tabs=True, \
+                   replace_whitespace=True, fix_sentence_endings=False, \
+                   break_long_words=True, drop_whitespace=True, \
+                   break_on_hyphens=True, tabsize=8, \
+                   *, max_lines=None, placeholder=' [...]')
 
    Wraps the single paragraph in *text*, and returns a single string containing the
    wrapped paragraph.  :func:`fill` is shorthand for  ::
@@ -50,8 +52,8 @@ functions should be good enough; otherwise, you should use an instance of
 
 
 .. function:: shorten(text, width, fix_sentence_endings=False, \
-                      break_long_words=True, break_on_hyphens=True, *, \
-                      placeholder=' [...]')
+                      break_long_words=True, break_on_hyphens=True, \
+                      *, placeholder=' [...]')
 
    Collapse and truncate the given *text* to fit in the given *width*.
 


### PR DESCRIPTION
A small follow up fix to the linked issue -- add placeholder arg which does have effect in these 2 functions.

<!-- issue-number: [bpo-44544](https://bugs.python.org/issue44544) -->
https://bugs.python.org/issue44544
<!-- /issue-number -->
