### PR TITLE
bpo-38956: don't print BooleanOptionalAction's default twice

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -876,7 +876,7 @@ class BooleanOptionalAction(Action):
                 _option_strings.append(option_string)
 
         if help is not None and default is not None:
-            help += f" (default: {default})"
+            help += " (default: %(default)s)"
 
         super().__init__(
             option_strings=_option_strings,

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4281,6 +4281,9 @@ class TestHelpArgumentDefaults(HelpTestCase):
     argument_signatures = [
         Sig('--foo', help='foo help - oh and by the way, %(default)s'),
         Sig('--bar', action='store_true', help='bar help'),
+        Sig('--taz', action=argparse.BooleanOptionalAction,
+            help='Whether to taz it', default=True),
+        Sig('--quux', help="Set the quux", default=42),
         Sig('spam', help='spam help'),
         Sig('badger', nargs='?', default='wooden', help='badger help'),
     ]
@@ -4289,25 +4292,29 @@ class TestHelpArgumentDefaults(HelpTestCase):
          [Sig('--baz', type=int, default=42, help='baz help')]),
     ]
     usage = '''\
-        usage: PROG [-h] [--foo FOO] [--bar] [--baz BAZ] spam [badger]
+        usage: PROG [-h] [--foo FOO] [--bar] [--taz | --no-taz] [--quux QUUX]
+                    [--baz BAZ]
+                    spam [badger]
         '''
     help = usage + '''\
 
         description
 
         positional arguments:
-          spam        spam help
-          badger      badger help (default: wooden)
+          spam             spam help
+          badger           badger help (default: wooden)
 
         options:
-          -h, --help  show this help message and exit
-          --foo FOO   foo help - oh and by the way, None
-          --bar       bar help (default: False)
+          -h, --help       show this help message and exit
+          --foo FOO        foo help - oh and by the way, None
+          --bar            bar help (default: False)
+          --taz, --no-taz  Whether to taz it (default: True)
+          --quux QUUX      Set the quux (default: 42)
 
         title:
           description
 
-          --baz BAZ   baz help (default: 42)
+          --baz BAZ        baz help (default: 42)
         '''
     version = ''
 

--- a/Misc/NEWS.d/next/Library/2021-08-09-13-17-10.bpo-38956.owWLNv.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-09-13-17-10.bpo-38956.owWLNv.rst
@@ -1,0 +1,1 @@
+:class:`argparse.BooleanOptionalAction`'s default value is now longer printed twice when used with :class:`argparse.ArgumentDefaultsHelpFormatter`.

--- a/Misc/NEWS.d/next/Library/2021-08-09-13-17-10.bpo-38956.owWLNv.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-09-13-17-10.bpo-38956.owWLNv.rst
@@ -1,1 +1,1 @@
-:class:`argparse.BooleanOptionalAction`'s default value is now longer printed twice when used with :class:`argparse.ArgumentDefaultsHelpFormatter`.
+:class:`argparse.BooleanOptionalAction`'s default value is no longer printed twice when used with :class:`argparse.ArgumentDefaultsHelpFormatter`.


### PR DESCRIPTION
This PR is a less intrusive fix to not double-print the default value when using `argparse.BooleanOptionalAction` with  `ArgumentDefaultsHelpFormatter`. The original bug report ([bpo-38956](https://bugs.python.org/issue38956)) was about removing the default entirely, but @rhettinger made a sensible point in https://github.com/python/cpython/pull/17447#discussion_r429630944 that a default should always been shown here. While #17447 seems to work as intended, progress stalled a bit presumably because it's not entirely trivial to review. This PR proposes a more straightforward attempt to solve the problem, which can hopefully be reviewed more easily. If the maintainers ultimately prefers #17447 that is perfectly fine with me of course. 😃 

In short, in this PR we make use of the fact that `ArgumentDefaultsHelpFormatter` already checks if the default is already included:

https://github.com/python/cpython/blob/2b496e79293a8b80e8ba0e514e186b3b1467b64b/Lib/argparse.py#L693

This condition previously did not trigger because `BooleanOptionalAction` already did the string interpolation directly.

<!-- issue-number: [bpo-38956](https://bugs.python.org/issue38956) -->
https://bugs.python.org/issue38956
<!-- /issue-number -->
