### PR TITLE
Remove unused variable.

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -8610,11 +8610,9 @@ is_exit_without_lineno(basicblock *b) {
 static int
 duplicate_exits_without_lineno(struct compiler *c)
 {
-    basicblock *entry = NULL;
     /* Copy all exit blocks without line number that are targets of a jump.
      */
     for (basicblock *b = c->u->u_blocks; b != NULL; b = b->b_list) {
-        entry = b;
         if (b->b_iused > 0 && is_jump(&b->b_instr[b->b_iused-1])) {
             switch (b->b_instr[b->b_iused-1].i_opcode) {
                 /* Note: Only actual jumps, not exception handlers */
@@ -8638,7 +8636,6 @@ duplicate_exits_without_lineno(struct compiler *c)
             }
         }
     }
-    assert(entry != NULL);
     /* Eliminate empty blocks */
     for (basicblock *b = c->u->u_blocks; b != NULL; b = b->b_list) {
         while (b->b_next && b->b_next->b_iused == 0) {


### PR DESCRIPTION
A bit of tidy up that should have been in #27673.
`entry` is unused in the release build, and the assert isn't useful in a debug build.