### PR TITLE
bpo-33930: Fix segfault with deep recursion when cleaning method objects

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1027,6 +1027,16 @@ class ExceptionTests(unittest.TestCase):
         self.assertIsInstance(v, RecursionError, type(v))
         self.assertIn("maximum recursion depth exceeded", str(v))
 
+
+    @cpython_only
+    def test_crashcan_recursion(self):
+        def foo():
+            o = object()
+            for x in range(1000000):
+                o = o.__dir__
+
+        foo()
+
     @cpython_only
     def test_recursion_normalizing_exception(self):
         # Issue #22898.

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1030,9 +1030,13 @@ class ExceptionTests(unittest.TestCase):
 
     @cpython_only
     def test_crashcan_recursion(self):
+        # See bpo-33930
+
         def foo():
             o = object()
-            for x in range(1000000):
+            for x in range(1_000_000):
+                # Create a big chain of method objects that will trigger
+                # a deep chain of calls when they need to be destructed.
                 o = o.__dir__
 
         foo()

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1036,6 +1036,7 @@ class ExceptionTests(unittest.TestCase):
                 o = o.__dir__
 
         foo()
+        support.gc_collect()
 
     @cpython_only
     def test_recursion_normalizing_exception(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-09-14-29-52.bpo-33930.--5LQ-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-09-14-29-52.bpo-33930.--5LQ-.rst
@@ -1,0 +1,2 @@
+Fix segmentation failt with deep recursion when cleaning method objects.
+Patch by Augusto Goulart and Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-09-14-29-52.bpo-33930.--5LQ-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-09-14-29-52.bpo-33930.--5LQ-.rst
@@ -1,2 +1,2 @@
-Fix segmentation failt with deep recursion when cleaning method objects.
+Fix segmentation fault with deep recursion when cleaning method objects.
 Patch by Augusto Goulart and Pablo Galindo.

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -160,7 +160,8 @@ PyCMethod_GetClass(PyObject *op)
 static void
 meth_dealloc(PyCFunctionObject *m)
 {
-    _PyObject_GC_UNTRACK(m);
+    PyObject_GC_UnTrack(m);
+    Py_TRASHCAN_SAFE_BEGIN(m);
     if (m->m_weakreflist != NULL) {
         PyObject_ClearWeakRefs((PyObject*) m);
     }
@@ -170,6 +171,7 @@ meth_dealloc(PyCFunctionObject *m)
     Py_XDECREF(m->m_self);
     Py_XDECREF(m->m_module);
     PyObject_GC_Del(m);
+    Py_TRASHCAN_SAFE_END(m);
 }
 
 static PyObject *

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -160,6 +160,8 @@ PyCMethod_GetClass(PyObject *op)
 static void
 meth_dealloc(PyCFunctionObject *m)
 {
+    // The Py_TRASHCAN mechanism requires that we be able to
+    // call PyObject_GC_UnTrack twice on an object.
     PyObject_GC_UnTrack(m);
     Py_TRASHCAN_BEGIN(m, meth_dealloc);
     if (m->m_weakreflist != NULL) {

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -161,7 +161,7 @@ static void
 meth_dealloc(PyCFunctionObject *m)
 {
     PyObject_GC_UnTrack(m);
-    Py_TRASHCAN_SAFE_BEGIN(m);
+    Py_TRASHCAN_BEGIN(m, meth_dealloc);
     if (m->m_weakreflist != NULL) {
         PyObject_ClearWeakRefs((PyObject*) m);
     }
@@ -171,7 +171,7 @@ meth_dealloc(PyCFunctionObject *m)
     Py_XDECREF(m->m_self);
     Py_XDECREF(m->m_module);
     PyObject_GC_Del(m);
-    Py_TRASHCAN_SAFE_END(m);
+    Py_TRASHCAN_END;
 }
 
 static PyObject *


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-33930](https://bugs.python.org/issue33930) -->
https://bugs.python.org/issue33930
<!-- /issue-number -->

Co-authored by Augusto Goulart