### PR TITLE
Classify specialization failures. Provides more useful stats, with lower overhead.

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -305,6 +305,8 @@ int _Py_Specialize_BinarySubscr(PyObject *sub, PyObject *container, _Py_CODEUNIT
 #define SPECIALIZATION_STATS_DETAILED 0
 #define SPECIALIZATION_STATS_TO_FILE 0
 
+#define SPECIALIZATION_FAILURE_KINDS 20
+
 #if SPECIALIZATION_STATS
 
 typedef struct _stats {
@@ -316,7 +318,7 @@ typedef struct _stats {
     uint64_t deopt;
     uint64_t unquickened;
 #if SPECIALIZATION_STATS_DETAILED
-    PyObject *miss_types;
+    uint64_t specialization_failure_kinds[SPECIALIZATION_FAILURE_KINDS];
 #endif
 } SpecializationStats;
 

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -85,9 +85,8 @@ class SpecializationStatsTests(unittest.TestCase):
                 stat_names + ['fails'])
             for sn in stat_names:
                 self.assertIsInstance(stats['load_attr'][sn], int)
-            self.assertIsInstance(stats['load_attr']['fails'], dict)
-            for k,v in stats['load_attr']['fails'].items():
-                self.assertIsInstance(k, tuple)
+            self.assertIsInstance(stats['load_attr']['specialization_failure_kinds'], tuple)
+            for v in stats['load_attr']['specialization_failure_kinds']:
                 self.assertIsInstance(v, int)
 
 

--- a/Tools/scripts/summarize_specialization_stats.py
+++ b/Tools/scripts/summarize_specialization_stats.py
@@ -23,6 +23,18 @@ def print_stats(name, family_stats):
             print(f"{key:>12}:{family_stats[key]:>12} {100*family_stats[key]/total:0.1f}%")
     for key in ("specialization_success",  "specialization_failure"):
         print(f"  {key}:{family_stats[key]:>12}")
+    total_failures = family_stats["specialization_failure"]
+    failure_kinds = [ 0 ] * 20
+    for key in family_stats:
+        if not key.startswith("specialization_failure_kind"):
+            continue
+        _, index = key[:-1].split("[")
+        index =  int(index)
+        failure_kinds[index] = family_stats[key]
+    for index, value in enumerate(failure_kinds):
+        if not value:
+            continue
+        print(f"    kind {index:>2}: {value:>8} {100*value/total_failures:0.1f}%")
 
 def main():
     stats = collections.defaultdict(collections.Counter)


### PR DESCRIPTION
This PR classifies specializes failures, so that we can get numbers on specialization failures.
This replaces the previous dictionary of unstructured data with an array of numbers, which can be collated using the 
`summarize_specialization_stats.py` script.

The downside is that interpretation of the data now needs cross referencing with the list of `SPEC_FAIL` #defines.
IMO, being able to gather precise numerical values is easily worth that minor inconvenience.
