### PR TITLE
bpo-44878: Add missing DISPATCH()

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1583,6 +1583,8 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, InterpreterFrame *frame, int thr
              }
         }
 
+    DISPATCH();
+
     tracing_dispatch:
     {
         int instr_prev = frame->f_lasti;


### PR DESCRIPTION
Prevents using the (slow) tracing dispatch on every entry to the interpreter.



<!-- issue-number: [bpo-44878](https://bugs.python.org/issue44878) -->
https://bugs.python.org/issue44878
<!-- /issue-number -->
