### PR TITLE
Fix grammar in sys.setrecursionlimit error message

### DIFF
--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -344,8 +344,7 @@ def install_recursionlimit_wrappers():
             raise TypeError(f"setrecursionlimit() takes exactly one "
                             f"argument ({len(args)} given)")
         if not limit > 0:
-            raise ValueError(
-                "recursion limit must be greater or equal than 1")
+            raise ValueError("recursion limit must be positive")
 
         return setrecursionlimit.__wrapped__(limit + RECURSIONLIMIT_DELTA)
 

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -354,11 +354,11 @@ PyDoc_STRVAR(sys_setrecursionlimit__doc__,
 "setrecursionlimit($module, limit, /)\n"
 "--\n"
 "\n"
-"Set the maximum depth of the Python interpreter stack to n.\n"
+"Set the maximum depth of the Python interpreter stack to limit.\n"
 "\n"
 "This limit prevents infinite recursion from causing an overflow of the C\n"
 "stack and crashing Python.  The highest possible limit is platform-\n"
-"dependent.");
+"dependent. limit must be positive.");
 
 #define SYS_SETRECURSIONLIMIT_METHODDEF    \
     {"setrecursionlimit", (PyCFunction)sys_setrecursionlimit, METH_O, sys_setrecursionlimit__doc__},
@@ -992,4 +992,4 @@ sys_getandroidapilevel(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=855fc93b2347710b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=19f52bd1e4d7a963 input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1170,22 +1170,22 @@ sys.setrecursionlimit
     limit as new_limit: int
     /
 
-Set the maximum depth of the Python interpreter stack to n.
+Set the maximum depth of the Python interpreter stack to limit.
 
 This limit prevents infinite recursion from causing an overflow of the C
 stack and crashing Python.  The highest possible limit is platform-
-dependent.
+dependent. limit must be positive.
 [clinic start generated code]*/
 
 static PyObject *
 sys_setrecursionlimit_impl(PyObject *module, int new_limit)
-/*[clinic end generated code: output=35e1c64754800ace input=b0f7a23393924af3]*/
+/*[clinic end generated code: output=35e1c64754800ace input=52cd3fdb5b8f4fc8]*/
 {
     PyThreadState *tstate = _PyThreadState_GET();
 
     if (new_limit < 1) {
         _PyErr_SetString(tstate, PyExc_ValueError,
-                         "recursion limit must be greater or equal than 1");
+                         "recursion limit must be positive");
         return NULL;
     }
 


### PR DESCRIPTION
Currently, if `sys.setrecursionlimit` is called with a value that is <= 0 then it raises a ValueError:
```
>>> import sys
>>> sys.setrecursionlimit(-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: recursion limit must be greater or equal than 1
```
however the message of this ValueError is grammatically incorrect. This PR replaces this ValueError's message with
```
ValueError: recursion limit must be positive
```
which matches the style used throughout `Objects/longobject.c`, for example.

The fact that the limit must be positive has also been added to the functions docstring.

Since this is just fixing the grammar in an error message this PR does not have a corresponding bpo / issue. Please could a maintainer add the "skip issue" and "skip news" labels or let me know if this is a change that still needs to be documented.