### PR TITLE
[3.8] bpo-33930: Fix segfault with deep recursion when cleaning method objects (GH-27678)

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -982,6 +982,21 @@ class ExceptionTests(unittest.TestCase):
         self.assertIsInstance(v, RecursionError, type(v))
         self.assertIn("maximum recursion depth exceeded", str(v))
 
+
+    @cpython_only
+    def test_crashcan_recursion(self):
+        # See bpo-33930
+
+        def foo():
+            o = object()
+            for x in range(1_000_000):
+                # Create a big chain of method objects that will trigger
+                # a deep chain of calls when they need to be destructed.
+                o = o.__dir__
+
+        foo()
+        support.gc_collect()
+
     @cpython_only
     def test_recursion_normalizing_exception(self):
         # Issue #22898.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-09-14-29-52.bpo-33930.--5LQ-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-09-14-29-52.bpo-33930.--5LQ-.rst
@@ -1,0 +1,2 @@
+Fix segmentation fault with deep recursion when cleaning method objects.
+Patch by Augusto Goulart and Pablo Galindo.

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -125,7 +125,10 @@ PyCFunction_GetFlags(PyObject *op)
 static void
 meth_dealloc(PyCFunctionObject *m)
 {
-    _PyObject_GC_UNTRACK(m);
+    // The Py_TRASHCAN mechanism requires that we be able to
+    // call PyObject_GC_UnTrack twice on an object.
+    PyObject_GC_UnTrack(m);
+    Py_TRASHCAN_BEGIN(m, meth_dealloc);
     if (m->m_weakreflist != NULL) {
         PyObject_ClearWeakRefs((PyObject*) m);
     }
@@ -139,6 +142,7 @@ meth_dealloc(PyCFunctionObject *m)
     else {
         PyObject_GC_Del(m);
     }
+    Py_TRASHCAN_END;
 }
 
 static PyObject *


### PR DESCRIPTION
(cherry picked from commit bfc2d5a5c4550ab3a2fadeb9459b4bd948ff61a2)

Co-authored-by: Pablo Galindo Salgado <Pablogsal@gmail.com>

<!-- issue-number: [bpo-33930](https://bugs.python.org/issue33930) -->
https://bugs.python.org/issue33930
<!-- /issue-number -->
