### PR TITLE
bpo-44878: Remove the switch from the main interpreter loop when using computed gotos.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-11-12-03-52.bpo-44878.nEhjLi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-11-12-03-52.bpo-44878.nEhjLi.rst
@@ -1,0 +1,2 @@
+Remove switch statement for interpreter loop when using computed gotos. This
+makes sure that we only have one dispatch table in the interpreter.


### PR DESCRIPTION
There is no point in having two dispatch tables. Either we use the switch dispatch *or* use computed gotos. Not both.

Also moves lltrace and dxprofile code into the DISPATCH macro and friends to clarify the dispatch logic.

This also allows us to remove the loop, as all dispatching is done by some sort of goto.
But that is for another PR, as it requires reformatting over 3000 lines of code.

<!-- issue-number: [bpo-44878](https://bugs.python.org/issue44878) -->
https://bugs.python.org/issue44878
<!-- /issue-number -->
