### PR TITLE
bpo-44878: Remove loop from interpreter. All dispatching is done by gotos.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-11-14-12-41.bpo-44878.pAbBfc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-11-14-12-41.bpo-44878.pAbBfc.rst
@@ -1,0 +1,2 @@
+Remove the loop from the bytecode interpreter. All instructions end with a
+DISPATCH macro, so the loop is now redundant.


### PR DESCRIPTION
This PR is mostly reformatting the body of the loop.

The real diff (without whitespace changes): https://github.com/python/cpython/pull/27727/files?w=1

<!-- issue-number: [bpo-44878](https://bugs.python.org/issue44878) -->
https://bugs.python.org/issue44878
<!-- /issue-number -->
