### PR TITLE
Update test__opcode and _Py_GetSpecializationStats with recent specialization stat changes

### DIFF
--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -85,7 +85,9 @@ class SpecializationStatsTests(unittest.TestCase):
                 stat_names + ['specialization_failure_kinds'])
             for sn in stat_names:
                 self.assertIsInstance(stats['load_attr'][sn], int)
-            self.assertIsInstance(stats['load_attr']['specialization_failure_kinds'], tuple)
+            self.assertIsInstance(
+                stats['load_attr']['specialization_failure_kinds'],
+                tuple)
             for v in stats['load_attr']['specialization_failure_kinds']:
                 self.assertIsInstance(v, int)
         else:

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -90,8 +90,6 @@ class SpecializationStatsTests(unittest.TestCase):
                 tuple)
             for v in stats['load_attr']['specialization_failure_kinds']:
                 self.assertIsInstance(v, int)
-        else:
-            print('No specialization stats to check')
 
 
 if __name__ == "__main__":

--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -82,12 +82,14 @@ class SpecializationStatsTests(unittest.TestCase):
             self.assertCountEqual(stats.keys(), specialized_opcodes)
             self.assertCountEqual(
                 stats['load_attr'].keys(),
-                stat_names + ['fails'])
+                stat_names + ['specialization_failure_kinds'])
             for sn in stat_names:
                 self.assertIsInstance(stats['load_attr'][sn], int)
             self.assertIsInstance(stats['load_attr']['specialization_failure_kinds'], tuple)
             for v in stats['load_attr']['specialization_failure_kinds']:
                 self.assertIsInstance(v, int)
+        else:
+            print('No specialization stats to check')
 
 
 if __name__ == "__main__":

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -122,6 +122,7 @@ _Py_GetSpecializationStats(void) {
     err += add_stat_dict(stats, LOAD_ATTR, "load_attr");
     err += add_stat_dict(stats, LOAD_GLOBAL, "load_global");
     err += add_stat_dict(stats, BINARY_SUBSCR, "binary_subscr");
+    err += add_stat_dict(stats, STORE_ATTR, "store_attr");
     if (err < 0) {
         Py_DECREF(stats);
         return NULL;


### PR DESCRIPTION
This fixes a couple of recent breaks in the test__opcode.SpecializationStatsTests, which is not enabled on CI yet.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
