### PR TITLE
[3.10] bpo-33930: Fix typo in the test name.

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1171,7 +1171,7 @@ class ExceptionTests(unittest.TestCase):
 
 
     @cpython_only
-    def test_crashcan_recursion(self):
+    def test_trashcan_recursion(self):
         # See bpo-33930
 
         def foo():


### PR DESCRIPTION
[bpo-33930](https://bugs.python.org/issue33930): Fix typo in the test name. (GH-27733)
(cherry picked from commit f08e6d1bb3c5655f184af88c6793e90908bb6338)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Automerge-Triggered-By: GH:benjaminp