### PR TITLE
bpo-44891: Tests `id` preserving on `* 1` for `str` and `bytes`

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1185,7 +1185,6 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
 
         s = SubBytes(b'qwerty()')
         self.assertEqual(id(s), id(s))
-        self.assertNotEqual(id(s), id(s))
         self.assertNotEqual(id(s), id(s * -4))
         self.assertNotEqual(id(s), id(s * 0))
         self.assertNotEqual(id(s), id(s * 1))

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1169,6 +1169,29 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
         self.assertEqual(bytes(ba), b'ab')
         self.assertRaises(TypeError, bytes, bb)
 
+    def test_repeat_id_preserving(self):
+        a = b'123abc1@'
+        b = b'456zyx-+'
+        self.assertEqual(id(a), id(a))
+        self.assertNotEqual(id(a), id(b))
+        self.assertNotEqual(id(a), id(a * -4))
+        self.assertNotEqual(id(a), id(a * 0))
+        self.assertEqual(id(a), id(a * 1))
+        self.assertEqual(id(a), id(1 * a))
+        self.assertNotEqual(id(a), id(a * 2))
+
+        class SubBytes(bytes):
+            pass
+
+        s = SubBytes(b'qwerty()')
+        self.assertEqual(id(s), id(s))
+        self.assertNotEqual(id(s), id(s))
+        self.assertNotEqual(id(s), id(s * -4))
+        self.assertNotEqual(id(s), id(s * 0))
+        self.assertNotEqual(id(s), id(s * 1))
+        self.assertNotEqual(id(s), id(1 * s))
+        self.assertNotEqual(id(s), id(s * 2))
+
 
 class ByteArrayTest(BaseBytesTest, unittest.TestCase):
     type2test = bytearray

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -508,6 +508,29 @@ class UnicodeTest(string_tests.CommonTest,
         text = 'abc def'
         self.assertIs(text.replace(pattern, pattern), text)
 
+    def test_repeat_id_preserving(self):
+        a = '123abc1@'
+        b = '456zyx-+'
+        self.assertEqual(id(a), id(a))
+        self.assertNotEqual(id(a), id(b))
+        self.assertNotEqual(id(a), id(a * -4))
+        self.assertNotEqual(id(a), id(a * 0))
+        self.assertEqual(id(a), id(a * 1))
+        self.assertEqual(id(a), id(1 * a))
+        self.assertNotEqual(id(a), id(a * 2))
+
+        class SubStr(str):
+            pass
+
+        s = SubStr('qwerty()')
+        self.assertEqual(id(s), id(s))
+        self.assertNotEqual(id(s), id(s))
+        self.assertNotEqual(id(s), id(s * -4))
+        self.assertNotEqual(id(s), id(s * 0))
+        self.assertNotEqual(id(s), id(s * 1))
+        self.assertNotEqual(id(s), id(1 * s))
+        self.assertNotEqual(id(s), id(s * 2))
+
     def test_bytes_comparison(self):
         with warnings_helper.check_warnings():
             warnings.simplefilter('ignore', BytesWarning)

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -524,7 +524,6 @@ class UnicodeTest(string_tests.CommonTest,
 
         s = SubStr('qwerty()')
         self.assertEqual(id(s), id(s))
-        self.assertNotEqual(id(s), id(s))
         self.assertNotEqual(id(s), id(s * -4))
         self.assertNotEqual(id(s), id(s * 0))
         self.assertNotEqual(id(s), id(s * 1))

--- a/Misc/NEWS.d/next/Tests/2021-08-13-12-11-06.bpo-44891.T9_mBT.rst
+++ b/Misc/NEWS.d/next/Tests/2021-08-13-12-11-06.bpo-44891.T9_mBT.rst
@@ -1,0 +1,2 @@
+Tests were added to clarify :func:`id` is preserved when ``obj * 1`` is used
+on :class:`str` and :class:`bytes` objects. Patch by Nikita Sobolev.


### PR DESCRIPTION


<!-- issue-number: [bpo-44891](https://bugs.python.org/issue44891) -->
https://bugs.python.org/issue44891
<!-- /issue-number -->
