### PR TITLE
bpo-44895: Temporarily add an extra gc.collect() call

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1014,6 +1014,9 @@ class ExceptionTests(unittest.TestCase):
 
     def test_no_hang_on_context_chain_cycle2(self):
         # See issue 25782. Cycle at head of context chain.
+        while gc.collect():
+            # Remove this once issue 44895 is resolved
+            pass
 
         class A(Exception):
             pass


### PR DESCRIPTION
This is part of an investigation of a non-deterministic reference leak. While we're looking for the root cause, this is included temporarily so that CI doesn't fail on this particular issue. This enables it to find other regressions in the meantime, which would otherwise be shadowed by our known issue.

<!-- issue-number: [bpo-44895](https://bugs.python.org/issue44895) -->
https://bugs.python.org/issue44895
<!-- /issue-number -->
