### PR TITLE
bpo-41322: added deprecation warning for tests returning value!=None

### DIFF
--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import warnings
 
 from .case import TestCase
 
@@ -62,7 +63,9 @@ class IsolatedAsyncioTestCase(TestCase):
         self._callAsync(self.asyncSetUp)
 
     def _callTestMethod(self, method):
-        self._callMaybeAsync(method)
+        if self._callMaybeAsync(method) is not None:
+            warnings.warn(f'It is deprecated to return a value!=None from a '
+                          f'test case ({method})', DeprecationWarning)
 
     def _callTearDown(self):
         self._callAsync(self.asyncTearDown)

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -546,7 +546,9 @@ class TestCase(object):
         self.setUp()
 
     def _callTestMethod(self, method):
-        method()
+        if method() is not None:
+            warnings.warn(f'It is deprecated to return a value!=None from a '
+                          f'test case ({method})', DeprecationWarning)
 
     def _callTearDown(self):
         self.tearDown()

--- a/Misc/NEWS.d/next/Library/2021-08-12-16-22-16.bpo-41322.utscTd.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-12-16-22-16.bpo-41322.utscTd.rst
@@ -1,0 +1,3 @@
+Added ``DeprecationWarning`` for tests and async tests that return a
+value!=None (as this may indicate an improperly written test, for example a
+test written as a generator function).


### PR DESCRIPTION


<!-- issue-number: [bpo-41322](https://bugs.python.org/issue41322) -->
https://bugs.python.org/issue41322
<!-- /issue-number -->
