### PR TITLE
bpo-16580: [doc] Add examples to int.to_bytes and int.from_bytes

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -529,6 +529,18 @@ class`. In addition, it provides a few more methods:
     given, an :exc:`OverflowError` is raised. The default value for *signed*
     is ``False``.
 
+    Equivalent to::
+
+        def to_bytes(n, length, byteorder, signed=False):
+            if byteorder == 'little':
+                order = range(length)
+            elif byteorder == 'big':
+                order = reversed(range(length))
+            else:
+                raise ValueError("byteorder must be either 'little' or 'big'")
+
+            return bytes((n >> i*8) & 0xff for i in order)
+
     .. versionadded:: 3.2
 
 .. classmethod:: int.from_bytes(bytes, byteorder, *, signed=False)
@@ -558,6 +570,23 @@ class`. In addition, it provides a few more methods:
 
     The *signed* argument indicates whether two's complement is used to
     represent the integer.
+
+    Equivalent to::
+
+        def from_bytes(bytes, byteorder, signed=False):
+            if byteorder == 'little':
+                little_ordered = list(bytes)
+            elif byteorder == 'big':
+                little_ordered = list(reversed(bytes))
+            else:
+                raise ValueError("byteorder must be either 'little' or 'big'")
+
+            n = sum(b << i*8 for i, b in enumerate(little_ordered))
+            if signed and little_ordered and (little_ordered[-1] & 0x80):
+                n -= 1 << 8*len(little_ordered)
+
+            return n
+
 
     .. versionadded:: 3.2
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -587,7 +587,6 @@ class`. In addition, it provides a few more methods:
 
             return n
 
-
     .. versionadded:: 3.2
 
 .. method:: int.as_integer_ratio()

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1122,13 +1122,15 @@ class LongTest(unittest.TestCase):
 
                 try:
                     self.assertEqual(
-                        equivalent_python(test, len(expected), byteorder, signed=signed),
+                        equivalent_python(
+                            test, len(expected), byteorder, signed=signed),
                         expected
                     )
                 except Exception as err:
                     raise AssertionError(
-                        "Code equivalent from docs is not equivalent for conversion of {0} with byteorder byteorder={1} and signed={2}"
-                        .format(test, byteorder, signed)) from err
+                        "Code equivalent from docs is not equivalent for "
+                        "conversion of {0} with byteorder byteorder={1} and "
+                        "signed={2}".format(test, byteorder, signed)) from err
 
         # Convert integers to signed big-endian byte arrays.
         tests1 = {
@@ -1248,7 +1250,8 @@ class LongTest(unittest.TestCase):
                     )
                 except Exception as err:
                     raise AssertionError(
-                        "Code equivalent from docs is not equivalent for conversion of {0} with byteorder={1!r} and signed={2}"
+                        "Code equivalent from docs is not equivalent for "
+                        "conversion of {0} with byteorder={1!r} and signed={2}"
                         .format(test, byteorder, signed)) from err
 
         # Convert signed big-endian byte arrays to integers.

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1103,6 +1103,13 @@ class LongTest(unittest.TestCase):
 
     def test_to_bytes(self):
         def check(tests, byteorder, signed=False):
+            def equivalent_python(n, length, byteorder, signed=False):
+                if byteorder == 'little':
+                    order = range(length)
+                elif byteorder == 'big':
+                    order = reversed(range(length))
+                return bytes((n >> i*8) & 0xff for i in order)
+
             for test, expected in tests.items():
                 try:
                     self.assertEqual(
@@ -1111,6 +1118,16 @@ class LongTest(unittest.TestCase):
                 except Exception as err:
                     raise AssertionError(
                         "failed to convert {0} with byteorder={1} and signed={2}"
+                        .format(test, byteorder, signed)) from err
+
+                try:
+                    self.assertEqual(
+                        equivalent_python(test, len(expected), byteorder, signed=signed),
+                        expected
+                    )
+                except Exception as err:
+                    raise AssertionError(
+                        "Code equivalent from docs is not equivalent for conversion of {0} with byteorder byteorder={1} and signed={2}"
                         .format(test, byteorder, signed)) from err
 
         # Convert integers to signed big-endian byte arrays.
@@ -1202,6 +1219,18 @@ class LongTest(unittest.TestCase):
 
     def test_from_bytes(self):
         def check(tests, byteorder, signed=False):
+            def equivalent_python(byte_array, byteorder, signed=False):
+                if byteorder == 'little':
+                    little_ordered = list(byte_array)
+                elif byteorder == 'big':
+                    little_ordered = list(reversed(byte_array))
+
+                n = sum(b << i*8 for i, b in enumerate(little_ordered))
+                if signed and little_ordered and (little_ordered[-1] & 0x80):
+                    n -= 1 << 8*len(little_ordered)
+
+                return n
+
             for test, expected in tests.items():
                 try:
                     self.assertEqual(
@@ -1210,6 +1239,16 @@ class LongTest(unittest.TestCase):
                 except Exception as err:
                     raise AssertionError(
                         "failed to convert {0} with byteorder={1!r} and signed={2}"
+                        .format(test, byteorder, signed)) from err
+
+                try:
+                    self.assertEqual(
+                        equivalent_python(test, byteorder, signed=signed),
+                        expected
+                    )
+                except Exception as err:
+                    raise AssertionError(
+                        "Code equivalent from docs is not equivalent for conversion of {0} with byteorder={1!r} and signed={2}"
                         .format(test, byteorder, signed)) from err
 
         # Convert signed big-endian byte arrays to integers.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -306,6 +306,7 @@ Mitch Chapman
 Matt Chaput
 William Chargin
 Yogesh Chaudhari
+Gautam Chaudhuri
 David Chaum
 Nicolas Chauvat
 Jerry Chen

--- a/Misc/NEWS.d/next/Documentation/2021-08-13-20-17-59.bpo-16580.MZ_iK9.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-08-13-20-17-59.bpo-16580.MZ_iK9.rst
@@ -1,0 +1,2 @@
+Added code equivalents for the ``int.to_bytes`` and ``int.from_bytes``
+functions, as well as tests ensuring that these code equivalents are valid.

--- a/Misc/NEWS.d/next/Documentation/2021-08-13-20-17-59.bpo-16580.MZ_iK9.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-08-13-20-17-59.bpo-16580.MZ_iK9.rst
@@ -1,2 +1,2 @@
-Added code equivalents for the ``int.to_bytes`` and ``int.from_bytes``
-functions, as well as tests ensuring that these code equivalents are valid.
+Added code equivalents for the :meth:`int.to_bytes` and :meth:`int.from_bytes`
+methods, as well as tests ensuring that these code equivalents are valid.


### PR DESCRIPTION
I've also added tests for the code equivalents.

<!-- issue-number: [bpo-16580](https://bugs.python.org/issue16580) -->
https://bugs.python.org/issue16580
<!-- /issue-number -->
