### PR TITLE
bpo-44911: Fixed IsolatedAsyncioTestCase from throwing an exception on leaked tasks

### DIFF
--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -135,7 +135,7 @@ class IsolatedAsyncioTestCase(TestCase):
                 task.cancel()
 
             loop.run_until_complete(
-                asyncio.gather(*to_cancel, loop=loop, return_exceptions=True))
+                asyncio.gather(*to_cancel, return_exceptions=True))
 
             for task in to_cancel:
                 if task.cancelled():

--- a/Lib/unittest/test/test_async_case.py
+++ b/Lib/unittest/test/test_async_case.py
@@ -215,6 +215,26 @@ class TestAsyncCase(unittest.TestCase):
         test = Test("test_cancel")
         output = test.run()
         self.assertFalse(output.wasSuccessful())
+    
+    def test_cancellation_hanging_tasks(self):
+        cancelled = False
+        class Test(unittest.IsolatedAsyncioTestCase):
+            async def test_leaking_task(self):
+                async def coro():
+                    nonlocal cancelled
+                    try:
+                        await asyncio.sleep(1)
+                    except asyncio.CancelledError:
+                        cancelled = True
+                        raise
+                
+                # Leave this running in the background
+                asyncio.create_task(coro())
+        
+        test = Test("test_leaking_task")
+        output = test.run()
+        self.assertTrue(cancelled)
+
 
 
 

--- a/Lib/unittest/test/test_async_case.py
+++ b/Lib/unittest/test/test_async_case.py
@@ -215,7 +215,7 @@ class TestAsyncCase(unittest.TestCase):
         test = Test("test_cancel")
         output = test.run()
         self.assertFalse(output.wasSuccessful())
-    
+
     def test_cancellation_hanging_tasks(self):
         cancelled = False
         class Test(unittest.IsolatedAsyncioTestCase):
@@ -227,10 +227,10 @@ class TestAsyncCase(unittest.TestCase):
                     except asyncio.CancelledError:
                         cancelled = True
                         raise
-                
+
                 # Leave this running in the background
                 asyncio.create_task(coro())
-        
+
         test = Test("test_leaking_task")
         output = test.run()
         self.assertTrue(cancelled)

--- a/Misc/NEWS.d/next/Library/2021-08-14-00-55-16.bpo-44911.uk3hYk.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-14-00-55-16.bpo-44911.uk3hYk.rst
@@ -1,1 +1,1 @@
-:class:`~unittest.IsolatedAsyncioTestCase` will no longer throw an exception while cancelling leaked tasks.
+:class:`~unittest.IsolatedAsyncioTestCase` will no longer throw an exception while cancelling leaked tasks. Patch by Bar Harel.

--- a/Misc/NEWS.d/next/Library/2021-08-14-00-55-16.bpo-44911.uk3hYk.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-14-00-55-16.bpo-44911.uk3hYk.rst
@@ -1,0 +1,1 @@
+:class:`~unittest.IsolatedAsyncioTestCase` will no longer throw an exception while cancelling leaked tasks.


### PR DESCRIPTION
Made a search - No more `gather()`s left with the `loop` argument in the stdlib.

<!-- issue-number: [bpo-44911](https://bugs.python.org/issue44911) -->
https://bugs.python.org/issue44911
<!-- /issue-number -->
