### PR TITLE
bpo-39039: tarfile raises descriptive exception from zlib.error

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -46,7 +46,6 @@ import time
 import struct
 import copy
 import re
-import zlib
 
 try:
     import pwd
@@ -2350,8 +2349,6 @@ class TarFile(object):
                     raise ReadError(str(e)) from None
             except SubsequentHeaderError as e:
                 raise ReadError(str(e)) from None
-            except zlib.error as e:
-                raise ExtractError('archive may be corrupted or invalid') from e
             break
 
         if tarinfo is not None:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2349,6 +2349,15 @@ class TarFile(object):
                     raise ReadError(str(e)) from None
             except SubsequentHeaderError as e:
                 raise ReadError(str(e)) from None
+            except Exception as e:
+                try:
+                    import zlib
+                    if isinstance(e, zlib.error):
+                        raise ReadError(f'zlib error: {e}')
+                    else:
+                        raise e
+                except ImportError:
+                    raise e
             break
 
         if tarinfo is not None:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2349,15 +2349,18 @@ class TarFile(object):
                     raise ReadError(str(e)) from None
             except SubsequentHeaderError as e:
                 raise ReadError(str(e)) from None
-            except Exception as e:
-                try:
-                    import zlib
-                    if isinstance(e, zlib.error):
-                        raise ReadError(f'zlib error: {e}')
-                    else:
-                        raise e
-                except ImportError:
-                    raise e
+
+            # I am commenting out the fix in this commit to demonstrate that
+            # the test fails without it
+            # except Exception as e:
+            #     try:
+            #         import zlib
+            #         if isinstance(e, zlib.error):
+            #             raise ReadError(f'zlib error: {e}')
+            #         else:
+            #             raise e
+            #     except ImportError:
+            #         raise e
             break
 
         if tarinfo is not None:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -46,6 +46,7 @@ import time
 import struct
 import copy
 import re
+import zlib
 
 try:
     import pwd
@@ -2349,6 +2350,8 @@ class TarFile(object):
                     raise ReadError(str(e)) from None
             except SubsequentHeaderError as e:
                 raise ReadError(str(e)) from None
+            except zlib.error as e:
+                raise ExtractError('archive may be corrupted or invalid') from e
             break
 
         if tarinfo is not None:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2353,7 +2353,7 @@ class TarFile(object):
                 try:
                     import zlib
                     if isinstance(e, zlib.error):
-                        raise ReadError(f'zlib error: {e}')
+                        raise ReadError(f'zlib error: {e}') from None
                     else:
                         raise e
                 except ImportError:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2349,18 +2349,15 @@ class TarFile(object):
                     raise ReadError(str(e)) from None
             except SubsequentHeaderError as e:
                 raise ReadError(str(e)) from None
-
-            # I am commenting out the fix in this commit to demonstrate that
-            # the test fails without it
-            # except Exception as e:
-            #     try:
-            #         import zlib
-            #         if isinstance(e, zlib.error):
-            #             raise ReadError(f'zlib error: {e}')
-            #         else:
-            #             raise e
-            #     except ImportError:
-            #         raise e
+            except Exception as e:
+                try:
+                    import zlib
+                    if isinstance(e, zlib.error):
+                        raise ReadError(f'zlib error: {e}')
+                    else:
+                        raise e
+                except ImportError:
+                    raise e
             break
 
         if tarinfo is not None:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -691,7 +691,7 @@ class MiscReadTestBase(CommonReadTest):
                 self.assertEqual(m1.offset, m2.offset)
                 self.assertEqual(m1.get_info(), m2.get_info())
 
-    @unittest.skipIf(not zlib, "requires zlib")
+    @unittest.skipIf(zlib is None, "requires zlib")
     def test_zlib_error_does_not_leak(self):
         # bpo-39039: tarfile.open allowed zlib exceptions to bubble up when
         # parsing certain types of invalid data

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -20,6 +20,10 @@ try:
 except ImportError:
     gzip = None
 try:
+    import zlib
+except ImportError:
+    zlib = None
+try:
     import bz2
 except ImportError:
     bz2 = None
@@ -686,6 +690,16 @@ class MiscReadTestBase(CommonReadTest):
             for m1, m2 in zip(tar, tar):
                 self.assertEqual(m1.offset, m2.offset)
                 self.assertEqual(m1.get_info(), m2.get_info())
+
+    @unittest.skipIf(not zlib, "requires zlib")
+    def test_zlib_error_does_not_leak(self):
+        # bpo-39039: tarfile.open allowed zlib exceptions to bubble up when
+        # parsing certain types of invalid data
+        with unittest.mock.patch("tarfile.TarInfo.fromtarfile") as mock:
+            mock.side_effect = zlib.error
+            with self.assertRaises(tarfile.ReadError):
+                tarfile.open(self.tarname)
+
 
 class MiscReadTest(MiscReadTestBase, unittest.TestCase):
     test_fail_comp = None

--- a/Misc/NEWS.d/next/Library/2021-08-13-22-56-21.bpo-39039.7eFlk0.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-13-22-56-21.bpo-39039.7eFlk0.rst
@@ -1,0 +1,3 @@
+tarfile.open raises :exc:`~tarfile.ExtractError` when a zlib error occurs
+during file extraction. The message provides a user-friendly notice that the
+tar file may be corrupt or invalid.

--- a/Misc/NEWS.d/next/Library/2021-08-13-22-56-21.bpo-39039.7eFlk0.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-13-22-56-21.bpo-39039.7eFlk0.rst
@@ -1,3 +1,0 @@
-tarfile.open raises :exc:`~tarfile.ExtractError` when a zlib error occurs
-during file extraction. The message provides a user-friendly notice that the
-tar file may be corrupt or invalid.

--- a/Misc/NEWS.d/next/Library/2021-08-18-10-36-14.bpo-39039.A63LYh.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-18-10-36-14.bpo-39039.A63LYh.rst
@@ -1,0 +1,2 @@
+tarfile.open raises :exc:`~tarfile.ReadError` when a zlib error occurs
+during file extraction.


### PR DESCRIPTION
- during tarfile parsing, a zlib error indicates invalid data
- tarfile.open now raises a descriptive exception from the zlib error
- this makes it clear to the user that they may be trying to open a
  corrupted tar file

I think that this small changes achieves a fix for the bpo. Tests still pass,
so that's a good sign that maybe this change does not introduce side-effects,
but I am hoping that someone with knowledge of this library help me think
of some edge cases to try out.

Please note that I am a relative novice developer, and while this patch is
good to the best of my understanding, my understanding is not the best!


<!-- issue-number: [bpo-39039](https://bugs.python.org/issue39039) -->
https://bugs.python.org/issue39039
<!-- /issue-number -->
