### PR TITLE
bpo-44896: drop lineno requirement on nodes for ast.unparse

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -788,7 +788,12 @@ class _Unparser(NodeVisitor):
             return node
 
     def get_type_comment(self, node):
-        comment = self._type_ignores.get(node.lineno) or node.type_comment
+        comment = None
+        if node.type_comment is not None:
+            comment = node.type_comment
+        elif (lineno := getattr(node, 'lineno', None)) is not None:
+            comment = self._type_ignores.get(lineno)
+
         if comment is not None:
             return f" # type: {comment}"
 

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -425,6 +425,30 @@ class UnparseTestCase(ASTTestCase):
         ):
             self.check_ast_roundtrip(statement, type_comments=True)
 
+    def test_ast_without_attributes(self):
+        node = ast.Module(
+            body = [
+                ast.Assign(
+                    targets=[ast.Name(id="hello", ctx=ast.Store())],
+                    value=ast.Constant(value="world")
+                )
+            ],
+            type_ignores = []
+        )
+        self.check_ast_roundtrip(node, type_comments=True)
+
+    def test_type_comment_without_line_numbers(self):
+        node = ast.Module(
+            body = [
+                ast.Assign(
+                    targets=[ast.Name(id="hello", ctx=ast.Store())],
+                    value=ast.Constant(value="world"),
+                    type_comment="bla bla"
+                )
+            ],
+            type_ignores = []
+        )
+        self.check_ast_roundtrip(node, type_comments=True)
 
 class CosmeticTestCase(ASTTestCase):
     """Test if there are cosmetic issues caused by unnecesary additions"""


### PR DESCRIPTION


<!-- issue-number: [bpo-44896](https://bugs.python.org/issue44896) -->
https://bugs.python.org/issue44896
<!-- /issue-number -->
