### PR TITLE
Fix a SystemError in code.replace()

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -320,6 +320,15 @@ class CodeTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             co.replace(co_nlocals=co.co_nlocals + 1)
 
+    def test_shrinking_localsplus(self):
+        # Check that PyCode_NewWithPosOnlyArgs resizes both
+        # localsplusnames and localspluskinds, if an argument is a cell.
+        def func(arg):
+            return lambda: arg
+        code = func.__code__
+        newcode = code.replace(co_name="func")  # Should not raise SystemError
+        self.assertEqual(code, newcode)
+
     def test_empty_linetable(self):
         def func():
             pass

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -471,9 +471,11 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
                                localsplusnames, localspluskinds);
     }
     // If any cells were args then nlocalsplus will have shrunk.
-    if (_PyTuple_Resize(&localsplusnames, nlocalsplus) < 0
-            || _PyBytes_Resize(&localspluskinds, nlocalsplus) < 0) {
-        goto error;
+    if (nlocalsplus != PyTuple_GET_SIZE(localsplusnames)) {
+        if (_PyTuple_Resize(&localsplusnames, nlocalsplus) < 0
+                || _PyBytes_Resize(&localspluskinds, nlocalsplus) < 0) {
+            goto error;
+        }
     }
 
     struct _PyCodeConstructor con = {

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -471,8 +471,8 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
                                localsplusnames, localspluskinds);
     }
     // If any cells were args then nlocalsplus will have shrunk.
-    // We don't bother resizing localspluskinds.
-    if (_PyTuple_Resize(&localsplusnames, nlocalsplus) < 0) {
+    if (_PyTuple_Resize(&localsplusnames, nlocalsplus) < 0
+            || _PyBytes_Resize(&localspluskinds, nlocalsplus) < 0) {
         goto error;
     }
 


### PR DESCRIPTION
Noticed this when working on Experiment D.

While the comment said 'We don't bother resizing localspluskinds',
this would cause .replace() to crash when it happened.
(Also types.CodeType(), but testing that is tedious, and this tests all
code paths.)
