### PR TITLE
bpo-44698: Restore complex pow behaviour for small integral exponents

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -269,21 +269,32 @@ class ComplexTest(unittest.TestCase):
                     except OverflowError:
                         pass
 
-        # Check that z**2.0 is handled identically to z**2.
+        # Check that small integer exponents are handled identically
+        # regardless of type.
         values = [
             complex(5.0, 12.0),
             complex(5.0e100, 12.0e100),
             complex(-4.0, INF),
             complex(INF, 0.0),
         ]
+        exponents = [-19, -5, -3, -2, -1, 0, 1, 2, 3, 5, 19]
         for value in values:
-            with self.subTest(value=value):
-                int_square = value**2
-                float_square = value**2.0
-                self.assertFloatsAreIdentical(
-                    int_square.real, float_square.real)
-                self.assertFloatsAreIdentical(
-                    int_square.imag, float_square.imag)
+            for exponent in exponents:
+                with self.subTest(value=value, exponent=exponent):
+                    try:
+                        int_pow = value**exponent
+                    except OverflowError:
+                        int_pow = "overflow"
+                    try:
+                        float_pow = value**float(exponent)
+                    except OverflowError:
+                        float_pow = "overflow"
+                    try:
+                        complex_pow = value**complex(exponent)
+                    except OverflowError:
+                        complex_pow = "overflow"
+                    self.assertEqual(str(float_pow), str(int_pow))
+                    self.assertEqual(str(complex_pow), str(int_pow))
 
     def test_boolcontext(self):
         for i in range(100):

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -269,8 +269,9 @@ class ComplexTest(unittest.TestCase):
                     except OverflowError:
                         pass
 
+    def test_pow_with_small_integer_exponents(self):
         # Check that small integer exponents are handled identically
-        # regardless of type.
+        # regardless of their type.
         values = [
             complex(5.0, 12.0),
             complex(5.0e100, 12.0e100),

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -269,6 +269,22 @@ class ComplexTest(unittest.TestCase):
                     except OverflowError:
                         pass
 
+        # Check that z**2.0 is handled identically to z**2.
+        values = [
+            complex(5.0, 12.0),
+            complex(5.0e100, 12.0e100),
+            complex(-4.0, INF),
+            complex(INF, 0.0),
+        ]
+        for value in values:
+            with self.subTest(value=value):
+                int_square = value**2
+                float_square = value**2.0
+                self.assertFloatsAreIdentical(
+                    int_square.real, float_square.real)
+                self.assertFloatsAreIdentical(
+                    int_square.imag, float_square.imag)
+
     def test_boolcontext(self):
         for i in range(100):
             self.assertTrue(complex(random() + 1e-6, random() + 1e-6))

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-15-10-39-06.bpo-44698.lITKNc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-15-10-39-06.bpo-44698.lITKNc.rst
@@ -1,0 +1,2 @@
+Restore behaviour of complex exponentiation with integer-valued exponent of
+type :class:`float` or :class:`complex`.

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -507,7 +507,6 @@ static PyObject *
 complex_pow(PyObject *v, PyObject *w, PyObject *z)
 {
     Py_complex p;
-    Py_complex exponent;
     Py_complex a, b;
     TO_COMPLEX(v, a);
     TO_COMPLEX(w, b);
@@ -517,13 +516,13 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
         return NULL;
     }
     errno = 0;
-    exponent = b;
-    if (exponent.imag == 0.0 && exponent.real == floor(exponent.real)
-                             && fabs(exponent.real) <= 100.0) {
-        p = c_powi(a, (long)exponent.real);
+    // Check whether the exponent has a small integer value, and if so use
+    // a faster and more accurate algorithm.
+    if (b.imag == 0.0 && b.real == floor(b.real) && fabs(b.real) <= 100.0) {
+        p = c_powi(a, (long)b.real);
     }
     else {
-        p = _Py_c_pow(a, exponent);
+        p = _Py_c_pow(a, b);
     }
 
     Py_ADJUST_ERANGE2(p.real, p.imag);

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -518,7 +518,7 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
     }
     errno = 0;
     exponent = b;
-    if (exponent.imag == 0.0 && exponent.real == rint(exponent.real)
+    if (exponent.imag == 0.0 && exponent.real == floor(exponent.real)
                              && fabs(exponent.real) <= 100.0) {
         p = c_powi(a, (long)exponent.real);
     }

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -172,8 +172,6 @@ c_powu(Py_complex x, long n)
 static Py_complex
 c_powi(Py_complex x, long n)
 {
-    Py_complex cn;
-
     if (n > 0)
         return c_powu(x,n);
     else


### PR DESCRIPTION
PR #27278 fixed undefined behaviour in complex exponentiation, but also changed the behaviour for exponentiations whose exponent was a small integer but not actually an `int`, for example as in `(3+4j)**2.0`. In particular, the overflow behaviour for these expressions changed:

Prior to #27278:

```python
>>> complex("infj")**2
(nan+nanj)
>>> complex("infj")**2.0
(nan+nanj)
```

After #27278 :

```python
>>> complex("infj")**2
(nan+nanj)
>>> complex("infj")**2.0
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: complex exponentiation
```

This PR restores the old behaviour, but does not re-introduce the undefined behaviour fixed by the original PR.



<!-- issue-number: [bpo-44698](https://bugs.python.org/issue44698) -->
https://bugs.python.org/issue44698
<!-- /issue-number -->
