### PR TITLE
bpo-44914: Maintain invariants of type version tags.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-16-11-36-02.bpo-44914.6Lgrx3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-16-11-36-02.bpo-44914.6Lgrx3.rst
@@ -1,0 +1,5 @@
+Class version tags are no longer recycled.
+
+This means that a version tag serves as a unique identifier for the state of
+a class. We rely on this for effective specialization of the LOAD_ATTR and
+other instructions.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -296,7 +296,10 @@ PyType_ClearCache(void)
 void
 _PyType_Fini(PyInterpreterState *interp)
 {
-    _PyType_ClearCache(interp);
+    struct type_cache *cache = &interp->type_cache;
+    for (Py_ssize_t i = 0; i < (1 << MCACHE_SIZE_EXP); i++) {
+        Py_DECREF(cache->hashtable[i].name);
+    }
     if (_Py_IsMainInterpreter(interp)) {
         clear_slotdefs();
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -233,19 +233,14 @@ get_type_cache(void)
 
 
 static void
-type_cache_clear(struct type_cache *cache, int use_none)
+type_cache_clear(struct type_cache *cache)
 {
     for (Py_ssize_t i = 0; i < (1 << MCACHE_SIZE_EXP); i++) {
         struct type_cache_entry *entry = &cache->hashtable[i];
         entry->version = 0;
-        if (use_none) {
-            // Set to None so _PyType_Lookup() can use Py_SETREF(),
-            // rather than using slower Py_XSETREF().
-            Py_XSETREF(entry->name, Py_NewRef(Py_None));
-        }
-        else {
-            Py_CLEAR(entry->name);
-        }
+        // Set to None, rather than NULL, so _PyType_Lookup() can
+        // use Py_SETREF() rather than using slower Py_XSETREF().
+        Py_XSETREF(entry->name, Py_NewRef(Py_None));
         entry->value = NULL;
     }
 }
@@ -284,7 +279,7 @@ _PyType_ClearCache(PyInterpreterState *interp)
             sizeof(cache->hashtable) / 1024);
 #endif
 
-    type_cache_clear(cache, 1);
+    type_cache_clear(cache);
 
     return next_version_tag - 1;
 }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -298,7 +298,10 @@ _PyType_Fini(PyInterpreterState *interp)
 {
     struct type_cache *cache = &interp->type_cache;
     for (Py_ssize_t i = 0; i < (1 << MCACHE_SIZE_EXP); i++) {
-        Py_DECREF(cache->hashtable[i].name);
+        struct type_cache_entry *entry = &cache->hashtable[i];
+        entry->version = 0;
+        Py_CLEAR(entry->name);
+        entry->value = NULL;
     }
     if (_Py_IsMainInterpreter(interp)) {
         clear_slotdefs();


### PR DESCRIPTION
* Do not reset global version number counter: makes sure that version numbers are unique.
* Do not invalidate type versions unnecessarily.


<!-- issue-number: [bpo-44914](https://bugs.python.org/issue44914) -->
https://bugs.python.org/issue44914
<!-- /issue-number -->
