### PR TITLE
bpo-44929: Fix enum string representation in the REPL

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1390,17 +1390,28 @@ def _power_of_two(value):
     return value == 2 ** _high_bit(value)
 
 def global_enum_repr(self):
-    return '%s.%s' % (self.__class__.__module__, self._name_)
+    """
+    use module.enum_name instead of class.enum_name
+
+    the module is the last module in case of a multi-module name
+    """
+    module = self.__class__.__module__.split('.')[-1]
+    return '%s.%s' % (module, self._name_)
 
 def global_flag_repr(self):
-    module = self.__class__.__module__
+    """
+    use module.flag_name instead of class.flag_name
+
+    the module is the last module in case of a multi-module name
+    """
+    module = self.__class__.__module__.split('.')[-1]
     cls_name = self.__class__.__name__
     if self._name_ is None:
         return "%s.%s(%x)" % (module, cls_name, self._value_)
     if _is_single_bit(self):
         return '%s.%s' % (module, self._name_)
     if self._boundary_ is not FlagBoundary.KEEP:
-        return module + module.join(self.name.split('|'))
+        return '|'.join(['%s.%s' % (module, name) for name in self.name.split('|')])
     else:
         name = []
         for n in self._name_.split('|'):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1396,7 +1396,7 @@ def global_flag_repr(self):
     module = self.__class__.__module__
     cls_name = self.__class__.__name__
     if self._name_ is None:
-        return "%x" % (module, cls_name, self._value_)
+        return "%s.%s(%x)" % (module, cls_name, self._value_)
     if _is_single_bit(self):
         return '%s.%s' % (module, self._name_)
     if self._boundary_ is not FlagBoundary.KEEP:

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1407,7 +1407,7 @@ def global_flag_repr(self):
     module = self.__class__.__module__.split('.')[-1]
     cls_name = self.__class__.__name__
     if self._name_ is None:
-        return "%s.%s(%x)" % (module, cls_name, self._value_)
+        return "%s.%s(0x%x)" % (module, cls_name, self._value_)
     if _is_single_bit(self):
         return '%s.%s' % (module, self._name_)
     if self._boundary_ is not FlagBoundary.KEEP:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3255,6 +3255,10 @@ class TestIntFlag(unittest.TestCase):
                 repr(HeadlightsK(2**0 + 2**2 + 2**3)),
                 '%(m)s.LOW_BEAM_K|%(m)s.FOG_K|0x8' % {'m': SHORT_MODULE},
                 )
+        self.assertEqual(
+                repr(HeadlightsK(2**3)),
+                '%(m)s.HeadlightsK(0x8)' % {'m': SHORT_MODULE},
+                )
 
     def test_global_repr_conform1(self):
         self.assertEqual(
@@ -3264,6 +3268,10 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(
                 repr(HeadlightsC(2**0 + 2**2 + 2**3)),
                 '%(m)s.LOW_BEAM_C|%(m)s.FOG_C' % {'m': SHORT_MODULE},
+                )
+        self.assertEqual(
+                repr(HeadlightsC(2**3)),
+                '%(m)s.OFF_C' % {'m': SHORT_MODULE},
                 )
 
     def test_format(self):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3132,8 +3132,6 @@ class TestFlag(unittest.TestCase):
         self.assertFalse(NeverEnum.__dict__.get('_test2', False))
 
 
-
-
 class TestIntFlag(unittest.TestCase):
     """Tests of the IntFlags."""
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3112,6 +3112,22 @@ class TestFlag(unittest.TestCase):
         self.assertFalse(NeverEnum.__dict__.get('_test2', False))
 
 
+@enum.global_enum
+class HeadlightsK(IntFlag, boundary=enum.KEEP):
+    OFF = 0
+    LOW_BEAM = auto()
+    HIGH_BEAM = auto()
+    FOG = auto()
+
+
+@enum.global_enum
+class HeadlightsC(IntFlag, boundary=enum.CONFORM):
+    OFF = 0
+    LOW_BEAM = auto()
+    HIGH_BEAM = auto()
+    FOG = auto()
+
+
 class TestIntFlag(unittest.TestCase):
     """Tests of the IntFlags."""
 
@@ -3223,6 +3239,24 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(repr(~(Open.RO | Open.CE)), 'Open.AC')
         self.assertEqual(repr(~(Open.WO | Open.CE)), 'Open.RW')
         self.assertEqual(repr(Open(~4)), '-5')
+
+    def test_global_repr_keep1(self):
+        self.assertEqual(repr(HeadlightsK(0)), 'test.test_enum.HeadlightsK.OFF')
+
+    def test_global_repr_keep2(self):
+        self.assertEqual(
+            repr(HeadlightsK(2**0 + 2**2 + 2**3)),
+            'test.test_enum.HeadlightsK.LOW_BEAM|test.test_enum.HeadlightsK.FOG|0x8',
+        )
+
+    def test_global_repr_conform1(self):
+        self.assertEqual(repr(HeadlightsC(0)), 'test.test_enum.HeadlightsC.OFF')
+
+    def test_global_repr_conform2(self):
+        self.assertEqual(
+            repr(HeadlightsC(2**0 + 2**2 + 2**3)),
+            'test.test_enum.HeadlightsC.LOW_BEAM|test.test_enum.HeadlightsC.FOG|0x8',
+        )
 
     def test_format(self):
         Perm = self.Perm

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-16-23-16-17.bpo-44929.qpMEky.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-16-23-16-17.bpo-44929.qpMEky.rst
@@ -1,0 +1,2 @@
+Fix some edge cases of ``enum.Flag`` string representation in the REPL.
+Patch by Pablo Galindo.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44929](https://bugs.python.org/issue44929) -->
https://bugs.python.org/issue44929
<!-- /issue-number -->
