### PR TITLE
Add missing sentinel obj reference to dataclasses documentation

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -221,7 +221,7 @@ Module contents
      c.mylist += [1, 2, 3]
 
    As shown above, the :const:`MISSING` value is a sentinel object used to
-   detect if the ``default`` and ``default_factory`` parameters are
+   detect if the ``default``, ``default_factory`` and `kw_only` parameters are
    provided.  This sentinel is used because ``None`` is a valid value
    for ``default``.  No code should directly use the :const:`MISSING`
    value.

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -221,10 +221,9 @@ Module contents
      c.mylist += [1, 2, 3]
 
    As shown above, the :const:`MISSING` value is a sentinel object used to
-   detect if the ``default``, ``default_factory`` and `kw_only` parameters are
-   provided.  This sentinel is used because ``None`` is a valid value
-   for ``default``.  No code should directly use the :const:`MISSING`
-   value.
+   detect if some parameters are provided by the user. This sentinel is
+   used because ``None`` is a valid value for some parameters with
+   a distinct meaning.  No code should directly use the :const:`MISSING` value.
 
    The parameters to :func:`field` are:
 


### PR DESCRIPTION
This sentinel value (`MISSING`) is also used as default value for
`kw_only` parameter introduced in Python 3.10.
