### PR TITLE
bpo-44852: Support filtering over warnings without a set message

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2070,13 +2070,13 @@ def clear_ignored_deprecations(*tokens: object) -> None:
         raise ValueError("Provide token or tokens returned by ignore_deprecations_from")
 
     new_filters = []
+    endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
     for action, message, category, module, lineno in warnings.filters:
         if action == "ignore" and category is DeprecationWarning:
             if isinstance(message, re.Pattern):
                 msg = message.pattern
             else:
                 msg = message or ""
-            endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
             if msg.endswith(endswith):
                 continue
         new_filters.append((action, message, category, module, lineno))

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2073,10 +2073,11 @@ def clear_ignored_deprecations(*tokens: object) -> None:
     for action, message, category, module, lineno in warnings.filters:
         if action == "ignore" and category is DeprecationWarning:
             if isinstance(message, re.Pattern):
-                message = message.pattern
-            if tokens:
-                endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
-            if message.endswith(endswith):
+                msg = message.pattern
+            else:
+                msg = message or ""
+            endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
+            if msg.endswith(endswith):
                 continue
         new_filters.append((action, message, category, module, lineno))
     if warnings.filters != new_filters:


### PR DESCRIPTION
Turns out that the asyncio test suite on Windows contains deprecation warnings with `None` in the message field. When working on GH-27569 those caused test crashes.

Additional improvements:

- messages which were compiled regular expressions aren't unpacked back into
  strings for unmatched warnings;

- removed unnecessary "if tokens:" check (there's one before the for loop).

<!-- issue-number: [bpo-44852](https://bugs.python.org/issue44852) -->
https://bugs.python.org/issue44852
<!-- /issue-number -->
