### PR TITLE
bpo-44935: enable posix_spawn() on Solaris

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -660,8 +660,9 @@ def _use_posix_spawn():
         # os.posix_spawn() is not available
         return False
 
-    if sys.platform == 'darwin':
-        # posix_spawn() is a syscall on macOS and properly reports errors
+    if sys.platform in ('darwin', 'sunos5'):
+        # posix_spawn() is a syscall on both macOS and Solaris,
+        # and properly reports errors
         return True
 
     # Check libc name and runtime libc version

--- a/Misc/NEWS.d/next/Library/2021-08-17-16-01-44.bpo-44935.roUl0G.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-17-16-01-44.bpo-44935.roUl0G.rst
@@ -1,0 +1,2 @@
+:mod:`subprocess` on Solaris now also uses :func:`os.posix_spawn()` for
+better performance.


### PR DESCRIPTION
Solaris also provides `posix_spawn()` syscall that can/should be used in the subprocess module to spawn new processes.

<!-- issue-number: [bpo-44935](https://bugs.python.org/issue44935) -->
https://bugs.python.org/issue44935
<!-- /issue-number -->
