### PR TITLE
bpo-44944: Added _heappush_max implementation for max heap push in heapq

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -176,6 +176,11 @@ def heapify(x):
     for i in reversed(range(n//2)):
         _siftup(x, i)
 
+def _heappush_max(heap, item):
+    """Maxheap version of heappush."""
+    heap.append(item)
+    _siftdown_max(heap, 0, len(heap)-1)
+
 def _heappop_max(heap):
     """Maxheap version of a heappop."""
     lastelt = heap.pop()    # raises appropriate IndexError if heap is empty


### PR DESCRIPTION
Python heapq module doesn't have an implementation of Max Heap by default and the internal private methods implemented for the same don't have a push functionality. This might be useful for users in case they require a max heap functionality for non trivial comparable objects.

<!-- issue-number: [bpo-44944](https://bugs.python.org/issue44944) -->
https://bugs.python.org/issue44944
<!-- /issue-number -->
