### PR TITLE
[3.9] bpo-44947: Refine the syntax error for trailing commas in import statements (GH-27814)

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -692,5 +692,5 @@ invalid_group:
     | '(' a=starred_expression ')' {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "can't use starred expression here") }
 invalid_import_from_targets:
-    | import_from_as_names ',' {
+    | import_from_as_names ',' NEWLINE {
         RAISE_SYNTAX_ERROR("trailing comma not allowed without surrounding parentheses") }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -727,6 +727,13 @@ SyntaxError: trailing comma not allowed without surrounding parentheses
 Traceback (most recent call last):
 SyntaxError: trailing comma not allowed without surrounding parentheses
 
+# Check that we dont raise the "trailing comma" error if there is more
+# input to the left of the valid part that we parsed.
+
+>>> from t import x,y, and 3
+Traceback (most recent call last):
+SyntaxError: invalid syntax
+
 >>> (): int
 Traceback (most recent call last):
 SyntaxError: only single target (not tuple) can be annotated

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-18-19-09-28.bpo-44947.mcvGdS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-18-19-09-28.bpo-44947.mcvGdS.rst
@@ -1,0 +1,2 @@
+Refine the syntax error for trailing commas in import statements. Patch by
+Pablo Galindo.

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -15375,7 +15375,7 @@ invalid_group_rule(Parser *p)
     return _res;
 }
 
-// invalid_import_from_targets: import_from_as_names ','
+// invalid_import_from_targets: import_from_as_names ',' NEWLINE
 static void *
 invalid_import_from_targets_rule(Parser *p)
 {
@@ -15386,21 +15386,24 @@ invalid_import_from_targets_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // import_from_as_names ','
+    { // import_from_as_names ',' NEWLINE
         if (p->error_indicator) {
             D(p->level--);
             return NULL;
         }
-        D(fprintf(stderr, "%*c> invalid_import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from_as_names ','"));
+        D(fprintf(stderr, "%*c> invalid_import_from_targets[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "import_from_as_names ',' NEWLINE"));
         Token * _literal;
         asdl_seq* import_from_as_names_var;
+        Token * newline_var;
         if (
             (import_from_as_names_var = import_from_as_names_rule(p))  // import_from_as_names
             &&
             (_literal = _PyPegen_expect_token(p, 12))  // token=','
+            &&
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
         {
-            D(fprintf(stderr, "%*c+ invalid_import_from_targets[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "import_from_as_names ','"));
+            D(fprintf(stderr, "%*c+ invalid_import_from_targets[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "import_from_as_names ',' NEWLINE"));
             _res = RAISE_SYNTAX_ERROR ( "trailing comma not allowed without surrounding parentheses" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -15411,7 +15414,7 @@ invalid_import_from_targets_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s invalid_import_from_targets[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "import_from_as_names ','"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "import_from_as_names ',' NEWLINE"));
     }
     _res = NULL;
   done:


### PR DESCRIPTION
(cherry picked from commit b2f68b190035540872072ac1d2349e7745e85596)

Co-authored-by: Pablo Galindo Salgado <Pablogsal@gmail.com>

<!-- issue-number: [bpo-44947](https://bugs.python.org/issue44947) -->
https://bugs.python.org/issue44947
<!-- /issue-number -->
