### PR TITLE
gh-89114: Allow setting EPOLLEXCLUSIVE on selectors.EpollSelector

### DIFF
--- a/Doc/library/selectors.rst
+++ b/Doc/library/selectors.rst
@@ -212,10 +212,25 @@ constants below:
 
    :func:`select.epoll`-based selector.
 
+   .. attribute:: exclusive
+
+      Check if *EPOLLEXCLUSIVE* will be set on newly registered
+      files.
+
    .. method:: fileno()
 
       This returns the file descriptor used by the underlying
       :func:`select.epoll` object.
+
+   .. method:: set_exclusive(value)
+
+      Enable or disable setting *EPOLLEXCLUSIVE* on newly
+      registered files. A file descriptor with *EPOLLEXCLUSIVE* set on it
+      will raise :exc:`OSError` if you attempt to
+      :meth:`~BaseSelector.modify` it. You must unregister and
+      re-register a file descriptor to enable or disable *EPOLLEXCLUSIVE*.
+
+      *value* must be a boolean.
 
 .. class:: DevpollSelector()
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -617,6 +617,7 @@ Subhendu Ghosh
 Jonathan Giddy
 Johannes Gijsbers
 Michael Gilfix
+David Gilman
 Julian Gindi
 Yannick Gingras
 Neil Girdhar

--- a/Misc/NEWS.d/next/Library/2021-08-19-02-56-29.bpo-44951.zamheK.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-19-02-56-29.bpo-44951.zamheK.rst
@@ -1,0 +1,1 @@
+:func:`selectors.EpollSelector.set_exclusive` added to enable setting *EPOLLEXCLUSIVE* automatically on polled file descriptors.


### PR DESCRIPTION
See:

https://bugs.python.org/issue44951 (GH-89114)
https://bugs.python.org/issue35517 (GH-79698)
https://github.com/python/cpython/pull/11193

<!-- issue-number: [bpo-44951](https://bugs.python.org/issue44951) -->
https://bugs.python.org/issue44951
<!-- /issue-number -->

<!-- gh-issue-number: gh-89114 -->
* Issue: gh-89114
<!-- /gh-issue-number -->
