### PR TITLE
[3.8] bpo-36384: [doc] Correct typos in CVE-2021-29921 fix description

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2317,7 +2317,7 @@ Changes in the Python API
 Starting with Python 3.8.12 the :mod:`ipaddress` module no longer accepts
 any leading zeros in IPv4 address strings. Leading zeros are ambiguous and
 interpreted as octal notation by some libraries. For example the legacy
-function :func:`socket.inet_aton` treats leading zeros as octal notatation.
+function :func:`socket.inet_aton` treats leading zeros as octal notation.
 glibc implementation of modern :func:`~socket.inet_pton` does not accept
 any leading zeros.
 

--- a/Misc/NEWS.d/next/Security/2021-03-30-16-29-51.bpo-36384.sCAmLs.rst
+++ b/Misc/NEWS.d/next/Security/2021-03-30-16-29-51.bpo-36384.sCAmLs.rst
@@ -1,6 +1,6 @@
 :mod:`ipaddress` module no longer accepts any leading zeros in IPv4 address
 strings. Leading zeros are ambiguous and interpreted as octal notation by
 some libraries. For example the legacy function :func:`socket.inet_aton`
-treats leading zeros as octal notatation. glibc implementation of modern
+treats leading zeros as octal notation. glibc implementation of modern
 :func:`~socket.inet_pton` does not accept any leading zeros. For a while
 the :mod:`ipaddress` module used to accept ambiguous leading zeros.


### PR DESCRIPTION


<!-- issue-number: [bpo-36384](https://bugs.python.org/issue36384) -->
https://bugs.python.org/issue36384
<!-- /issue-number -->
