### PR TITLE
Do not compute `size` of `args` passed to `SystemExit_init` when we can

### DIFF
--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -574,10 +574,10 @@ SimpleExtendsException(PyExc_BaseException, GeneratorExit,
 static int
 SystemExit_init(PySystemExitObject *self, PyObject *args, PyObject *kwds)
 {
-    Py_ssize_t size = PyTuple_GET_SIZE(args);
-
     if (BaseException_init((PyBaseExceptionObject *)self, args, kwds) == -1)
         return -1;
+
+    Py_ssize_t size = PyTuple_GET_SIZE(args);
 
     if (size == 0)
         return 0;


### PR DESCRIPTION
Just a micro optimization, I think that it does not need a BPO entry.