### PR TITLE
bpo-44946: Streamline operators and creation of ints for common case of single 'digit'.

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -124,18 +124,21 @@ PyLongObject *
 _PyLong_New(Py_ssize_t size)
 {
     PyLongObject *result;
-    /* Number of bytes needed is: offsetof(PyLongObject, ob_digit) +
-       sizeof(digit)*size.  Previous incarnations of this code used
-       sizeof(PyVarObject) instead of the offsetof, but this risks being
-       incorrect in the presence of padding between the PyVarObject header
-       and the digits. */
     if (size > (Py_ssize_t)MAX_LONG_DIGITS) {
         PyErr_SetString(PyExc_OverflowError,
                         "too many digits in integer");
         return NULL;
     }
+    /* Fast operations for single digit integers (including zero)
+     * assume that there is always at least one digit present. */
+    Py_ssize_t ndigits = size ? size : 1;
+    /* Number of bytes needed is: offsetof(PyLongObject, ob_digit) +
+       sizeof(digit)*size.  Previous incarnations of this code used
+       sizeof(PyVarObject) instead of the offsetof, but this risks being
+       incorrect in the presence of padding between the PyVarObject header
+       and the digits. */
     result = PyObject_Malloc(offsetof(PyLongObject, ob_digit) +
-                             size*sizeof(digit));
+                             ndigits*sizeof(digit));
     if (!result) {
         PyErr_NoMemory();
         return NULL;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -273,8 +273,9 @@ PyLong_FromLong(long ival)
     if (!(abs_ival >> PyLong_SHIFT)) {
         return _PyLong_FromMedium((sdigit)ival);
     }
-    /* Must be at least two digits */
-    unsigned long t = abs_ival >> (PyLong_SHIFT *2);
+    /* Must be at least two digits.
+     * Do shift in two steps to avoid undefined behavior. */
+    unsigned long t = (abs_ival >> PyLong_SHIFT) >> PyLong_SHIFT;
     Py_ssize_t ndigits = 2;
     while (t) {
         ++ndigits;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -40,7 +40,7 @@ medium_value(PyLongObject *x)
 #define IS_SMALL_INT(ival) (-NSMALLNEGINTS <= (ival) && (ival) < NSMALLPOSINTS)
 #define IS_SMALL_UINT(ival) ((ival) < NSMALLPOSINTS)
 
-#define IS_MEDIUM_INT(x) (((unsigned long)x)+PyLong_MASK <= 2*PyLong_MASK)
+#define IS_MEDIUM_INT(x) (((twodigits)x)+PyLong_MASK <= 2*PyLong_MASK)
 
 static PyObject *
 get_small_int(sdigit ival)
@@ -239,7 +239,7 @@ _PyLong_FromLarge(long ival)
  * to a PyLong.
  */
 static inline PyObject *
-_PyLong_FromSDigit(sdigit x)
+_PyLong_FromSDigit(stwodigits x)
 {
     if (IS_SMALL_INT(x)) {
         return get_small_int(x);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -179,39 +179,37 @@ _PyLong_FromMedium(sdigit x)
 }
 
 static PyObject *
-_PyLong_FromLarge(long ival)
+_PyLong_FromLarge(stwodigits ival)
 {
-    PyLongObject *v;
-    unsigned long abs_ival;
-    unsigned long t;  /* unsigned so >> doesn't propagate sign bit */
-    int ndigits = 0;
+    twodigits abs_ival;
     int sign;
     assert(!IS_MEDIUM_INT(ival));
 
     if (ival < 0) {
         /* negate: can't write this as abs_ival = -ival since that
            invokes undefined behaviour when ival is LONG_MIN */
-        abs_ival = 0U-(unsigned long)ival;
+        abs_ival = 0U-(twodigits)ival;
         sign = -1;
     }
     else {
-        abs_ival = (unsigned long)ival;
+        abs_ival = (twodigits)ival;
         sign = 1;
     }
     /* Loop to determine number of digits */
-    t = abs_ival;
+    twodigits t = abs_ival;
+    Py_ssize_t ndigits = 0;
     while (t) {
         ++ndigits;
         t >>= PyLong_SHIFT;
     }
-    v = _PyLong_New(ndigits);
+    PyLongObject *v = _PyLong_New(ndigits);
     if (v != NULL) {
         digit *p = v->ob_digit;
         Py_SET_SIZE(v, ndigits * sign);
         t = abs_ival;
         while (t) {
             *p++ = Py_SAFE_DOWNCAST(
-                t & PyLong_MASK, unsigned long, digit);
+                t & PyLong_MASK, twodigits, digit);
             t >>= PyLong_SHIFT;
         }
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3084,7 +3084,7 @@ long_add(PyLongObject *a, PyLongObject *b)
     CHECK_BINOP(a, b);
 
     if (IS_MEDIUM_VALUE(a) && IS_MEDIUM_VALUE(b)) {
-        return PyLong_FromLong(medium_value(a) + medium_value(b));
+        return _PyLong_FromSTwoDigits(medium_value(a) + medium_value(b));
     }
     if (Py_SIZE(a) < 0) {
         if (Py_SIZE(b) < 0) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4372,7 +4372,7 @@ long_invert(PyLongObject *v)
     /* Implement ~x as -(x+1) */
     PyLongObject *x;
     if (IS_MEDIUM_VALUE(v))
-        return PyLong_FromLong(-(medium_value(v)+1));
+        return _PyLong_FromSDigit(~medium_value(v));
     x = (PyLongObject *) long_add(v, (PyLongObject *)_PyLong_GetOne());
     if (x == NULL)
         return NULL;
@@ -4387,7 +4387,7 @@ long_neg(PyLongObject *v)
 {
     PyLongObject *z;
     if (IS_MEDIUM_VALUE(v))
-        return PyLong_FromLong(-medium_value(v));
+        return _PyLong_FromSDigit(-medium_value(v));
     z = (PyLongObject *)_PyLong_Copy(v);
     if (z != NULL)
         Py_SET_SIZE(z, -(Py_SIZE(v)));

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -43,7 +43,7 @@ medium_value(PyLongObject *x)
 #define IS_MEDIUM_INT(x) (((twodigits)x)+PyLong_MASK <= 2*PyLong_MASK)
 
 static PyObject *
-get_small_int(stwodigits ival)
+get_small_int(sdigit ival)
 {
     assert(IS_SMALL_INT(ival));
     PyObject *v = __PyLong_GetSmallInt_internal(ival);
@@ -58,7 +58,7 @@ maybe_small_long(PyLongObject *v)
         stwodigits ival = medium_value(v);
         if (IS_SMALL_INT(ival)) {
             Py_DECREF(v);
-            return (PyLongObject *)get_small_int(ival);
+            return (PyLongObject *)get_small_int((sdigit)ival);
         }
     }
     return v;
@@ -147,7 +147,7 @@ _PyLong_Copy(PyLongObject *src)
     if (i < 2) {
         stwodigits ival = medium_value(src);
         if (IS_SMALL_INT(ival)) {
-            return get_small_int(ival);
+            return get_small_int((sdigit)ival);
         }
     }
     result = _PyLong_New(i);
@@ -221,11 +221,11 @@ static inline PyObject *
 _PyLong_FromSTwoDigits(stwodigits x)
 {
     if (IS_SMALL_INT(x)) {
-        return get_small_int(x);
+        return get_small_int((sdigit)x);
     }
     assert(x != 0);
     if (IS_MEDIUM_INT(x)) {
-        return _PyLong_FromMedium(x);
+        return _PyLong_FromMedium((sdigit)x);
     }
     return _PyLong_FromLarge(x);
 }
@@ -258,7 +258,7 @@ PyLong_FromLong(long ival)
 #define PYLONG_FROM_UINT(INT_TYPE, ival) \
     do { \
         if (IS_SMALL_UINT(ival)) { \
-            return get_small_int((stwodigits)(ival)); \
+            return get_small_int((sdigit)(ival)); \
         } \
         /* Count the number of Python digits. */ \
         Py_ssize_t ndigits = 0; \
@@ -1050,7 +1050,7 @@ PyLong_FromLongLong(long long ival)
     int negative = 0;
 
     if (IS_SMALL_INT(ival)) {
-        return get_small_int((stwodigits)ival);
+        return get_small_int((sdigit)ival);
     }
 
     if (ival < 0) {
@@ -1097,7 +1097,7 @@ PyLong_FromSsize_t(Py_ssize_t ival)
     int negative = 0;
 
     if (IS_SMALL_INT(ival)) {
-        return get_small_int((stwodigits)ival);
+        return get_small_int((sdigit)ival);
     }
 
     if (ival < 0) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -42,8 +42,7 @@ medium_value(PyLongObject *x)
 
 static inline int is_medium_int(stwodigits x)
 {
-    /* We have to take care here to make sure that we are
-     * comparing unsigned values. */
+    /* Take care that we are comparing unsigned values. */
     twodigits x_plus_mask = ((twodigits)x) + PyLong_MASK;
     return x_plus_mask < ((twodigits)PyLong_MASK) + PyLong_BASE;
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -178,7 +178,7 @@ _PyLong_Copy(PyLongObject *src)
 }
 
 static PyObject *
-PyLong_FromMedium(sdigit x)
+_PyLong_FromMedium(sdigit x)
 {
     assert(!IS_SMALL_INT(x));
     assert(IS_MEDIUM_INT(x));
@@ -246,7 +246,7 @@ _PyLong_FromSDigit(sdigit x)
     }
     assert(x != 0);
     if (IS_MEDIUM_INT(x)) {
-        return PyLong_FromMedium(x);
+        return _PyLong_FromMedium(x);
     }
     return _PyLong_FromLarge(x);
 }
@@ -262,7 +262,7 @@ PyLong_FromLong(long ival)
 
     assert(ival != 0);
     if (IS_MEDIUM_INT(ival)) {
-        return PyLong_FromMedium(ival);
+        return _PyLong_FromMedium(ival);
     }
     return _PyLong_FromLarge(ival);
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -43,7 +43,7 @@ medium_value(PyLongObject *x)
 #define IS_MEDIUM_INT(x) (((twodigits)x)+PyLong_MASK <= 2*PyLong_MASK)
 
 static PyObject *
-get_small_int(sdigit ival)
+get_small_int(stwodigits ival)
 {
     assert(IS_SMALL_INT(ival));
     PyObject *v = __PyLong_GetSmallInt_internal(ival);
@@ -145,7 +145,7 @@ _PyLong_Copy(PyLongObject *src)
     if (i < 0)
         i = -(i);
     if (i < 2) {
-        sdigit ival = medium_value(src);
+        stwodigits ival = medium_value(src);
         if (IS_SMALL_INT(ival)) {
             return get_small_int(ival);
         }
@@ -258,7 +258,7 @@ PyLong_FromLong(long ival)
 #define PYLONG_FROM_UINT(INT_TYPE, ival) \
     do { \
         if (IS_SMALL_UINT(ival)) { \
-            return get_small_int((sdigit)(ival)); \
+            return get_small_int((stwodigits)(ival)); \
         } \
         /* Count the number of Python digits. */ \
         Py_ssize_t ndigits = 0; \
@@ -1050,7 +1050,7 @@ PyLong_FromLongLong(long long ival)
     int negative = 0;
 
     if (IS_SMALL_INT(ival)) {
-        return get_small_int((sdigit)ival);
+        return get_small_int((stwodigits)ival);
     }
 
     if (ival < 0) {
@@ -1097,7 +1097,7 @@ PyLong_FromSsize_t(Py_ssize_t ival)
     int negative = 0;
 
     if (IS_SMALL_INT(ival)) {
-        return get_small_int((sdigit)ival);
+        return get_small_int((stwodigits)ival);
     }
 
     if (ival < 0) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -27,14 +27,14 @@ _Py_IDENTIFIER(little);
 _Py_IDENTIFIER(big);
 
 /* Is this PyLong of size 1, 0 or -1? */
-#define IS_MEDIUM_VALUE(x) (((size_t)Py_SIZE(x)) + 1 < 3)
+#define IS_MEDIUM_VALUE(x) (((size_t)Py_SIZE(x)) + 1U < 3U)
 
 /* convert a PyLong of size 1, 0 or -1 to a C integer */
-static inline sdigit
+static inline stwodigits
 medium_value(PyLongObject *x)
 {
     assert(IS_MEDIUM_VALUE(x));
-    return Py_SIZE(x) * x->ob_digit[0];
+    return ((stwodigits)Py_SIZE(x)) * x->ob_digit[0];
 }
 
 #define IS_SMALL_INT(ival) (-NSMALLNEGINTS <= (ival) && (ival) < NSMALLPOSINTS)
@@ -55,7 +55,7 @@ static PyLongObject *
 maybe_small_long(PyLongObject *v)
 {
     if (v && IS_MEDIUM_VALUE(v)) {
-        long ival = medium_value(v);
+        sdigit ival = medium_value(v);
         if (IS_SMALL_INT(ival)) {
             Py_DECREF(v);
             return (PyLongObject *)get_small_int(ival);
@@ -3565,7 +3565,7 @@ long_mul(PyLongObject *a, PyLongObject *b)
 
     /* fast path for single-digit multiplication */
     if (IS_MEDIUM_VALUE(a) && IS_MEDIUM_VALUE(b)) {
-        stwodigits v = (stwodigits)(medium_value(a)) * medium_value(b);
+        stwodigits v = medium_value(a) * medium_value(b);
         return PyLong_FromLongLong((long long)v);
     }
 


### PR DESCRIPTION
Modest speedup of [1%](https://gist.github.com/markshannon/972e1dd85895452b002c150d75b32785)

The speedup is unexciting, although every little helps.
However, this will help with specialization of integer operations, as that will remove additional overhead.

The obvious other speedup of using a freelist is left for another PR, as we need to rationalize our use of freelists before adding more.

Skipping NEWS as there is no change to any APIs and the performance increase is marginal.

<!-- issue-number: [bpo-44946](https://bugs.python.org/issue44946) -->
https://bugs.python.org/issue44946
<!-- /issue-number -->
