### PR TITLE
bpo-44954: Fix wrong result in float.fromhex corner case

### DIFF
--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -1468,6 +1468,16 @@ class HexFloatTestCase(unittest.TestCase):
         self.identical(fromHex('0X1.0000000000001fp0'), 1.0+2*EPS)
         self.identical(fromHex('0x1.00000000000020p0'), 1.0+2*EPS)
 
+        # Regression test for a corner-case bug reported in b.p.o. 44954
+        self.identical(fromHex('0x.8p-1074'), 0.0)
+        self.identical(fromHex('0x.80p-1074'), 0.0)
+        self.identical(fromHex('0x.81p-1074'), TINY)
+        self.identical(fromHex('0x8p-1078'), 0.0)
+        self.identical(fromHex('0x8.0p-1078'), 0.0)
+        self.identical(fromHex('0x8.1p-1078'), TINY)
+        self.identical(fromHex('0x80p-1082'), 0.0)
+        self.identical(fromHex('0x81p-1082'), TINY)
+
     def test_roundtrip(self):
         def roundtrip(x):
             return fromHex(toHex(x))

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -1479,7 +1479,7 @@ class HexFloatTestCase(unittest.TestCase):
         self.identical(fromHex('0x81p-1082'), TINY)
         self.identical(fromHex('.8p-1074'), 0.0)
         self.identical(fromHex('8p-1078'), 0.0)
-        self.identical(fromHex('-.8p-1074'), 0.0)
+        self.identical(fromHex('-.8p-1074'), -0.0)
         self.identical(fromHex('+8p-1078'), 0.0)
 
     def test_roundtrip(self):

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -1477,6 +1477,10 @@ class HexFloatTestCase(unittest.TestCase):
         self.identical(fromHex('0x8.1p-1078'), TINY)
         self.identical(fromHex('0x80p-1082'), 0.0)
         self.identical(fromHex('0x81p-1082'), TINY)
+        self.identical(fromHex('.8p-1074'), 0.0)
+        self.identical(fromHex('8p-1078'), 0.0)
+        self.identical(fromHex('-.8p-1074'), 0.0)
+        self.identical(fromHex('+8p-1078'), 0.0)
 
     def test_roundtrip(self):
         def roundtrip(x):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-19-14-43-24.bpo-44954.dLn3lg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-19-14-43-24.bpo-44954.dLn3lg.rst
@@ -1,0 +1,2 @@
+Fixed a corner case bug where the result of ``float.fromhex('0x.8p-1074')``
+was rounded the wrong way.

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1464,7 +1464,7 @@ float_fromhex(PyTypeObject *type, PyObject *string)
     if ((digit & half_eps) != 0) {
         round_up = 0;
         if ((digit & (3*half_eps-1)) != 0 || (half_eps == 8 &&
-                key_digit + 1 < ndigits && (HEX_DIGIT(key_digit+1) & 1) != 0))
+                key_digit+1 < ndigits && (HEX_DIGIT(key_digit+1) & 1) != 0))
             round_up = 1;
         else
             for (i = key_digit-1; i >= 0; i--)

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1463,8 +1463,8 @@ float_fromhex(PyTypeObject *type, PyObject *string)
        bits lsb, lsb-2, lsb-3, lsb-4, ... is 1. */
     if ((digit & half_eps) != 0) {
         round_up = 0;
-        if ((digit & (3*half_eps-1)) != 0 ||
-            (half_eps == 8 && (HEX_DIGIT(key_digit+1) & 1) != 0))
+        if ((digit & (3*half_eps-1)) != 0 || (half_eps == 8 &&
+                key_digit + 1 < ndigits && (HEX_DIGIT(key_digit+1) & 1) != 0))
             round_up = 1;
         else
             for (i = key_digit-1; i >= 0; i--)


### PR DESCRIPTION
This PR fixes a corner-case bug where the rounding logic in `float.fromhex` resulted in a value that was rounded the wrong way. Assuming IEEE 754 binary64 floating-point, the bug can only occur in the case where:

- the exact value of the input is `2**-1075`
- the binary exponent is two more than an integer multiple of 4, so that the only nonzero hex digit in the significand is an `8`
- the `8` is not preceded by any zeros

Example bad inputs  are `'0x.8p-1074'`, `'0x.80p-1074'`and `0x8p-1078`. In these cases, the rounding logic tries to interpret the `x` character as a hex digit, decides that as a hex digit `x` is odd, and so ends up rounding the value up to `2**-1074`, when it should have been rounded down to `0`.

The case of a string that doesn't start with `0x` is worse: for an input like `.8p-1074` or `.80p-1074` or `8p-1078`, the rounding logic examines the character *before* the beginning of the string to decide how to round.

This bug affects all Python versions back to 2.7; the fix should be backported to 3.9 and 3.10, but I don't think it's critical enough to go into 3.10.0.rc2 - it can wait for 3.10.1.




<!-- issue-number: [bpo-44954](https://bugs.python.org/issue44954) -->
https://bugs.python.org/issue44954
<!-- /issue-number -->
