### PR TITLE
bpo-42560: tweaks to intro of Tkinter docs- add macOS, drop ActiveState

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -11,9 +11,8 @@
 --------------
 
 The :mod:`tkinter` package ("Tk interface") is the standard Python interface to
-the Tk GUI toolkit.  Both Tk and :mod:`tkinter` are available on most Unix
-platforms, as well as on Windows systems.  (Tk itself is not part of Python; it
-is maintained at ActiveState.)
+the Tcl/Tk GUI toolkit.  Both Tk and :mod:`tkinter` are available on most Unix
+platforms, including macOS, as well as on Windows systems.
 
 Running ``python -m tkinter`` from the command line should open a window
 demonstrating a simple Tk interface, letting you know that :mod:`tkinter` is


### PR DESCRIPTION
- explicitly add macOS to platforms
- drop reference to ActiveState, which is no longer core Tcl/Tk maintainer
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42560](https://bugs.python.org/issue42560) -->
https://bugs.python.org/issue42560
<!-- /issue-number -->
