### PR TITLE
bpo-42560: add warning to Tkinter docs about outdated pre-8.5 documentation online

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -34,8 +34,8 @@ details that are unchanged.
 
    Tcl/Tk 8.5 (2007) introduced a modern set of themed user interface components
    along with a new API to use them. Both old and new APIs are still available.
-   Unfortunately, most documentation you will find online uses the old API and
-   is woefully outdated.
+   Most documentation you will find online still uses the old API and
+   can be woefully outdated.
 
 .. seealso::
 

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -30,6 +30,13 @@ make the experience more pythonic. This documentation will concentrate on these
 additions and changes, and refer to the official Tcl/Tk documentation for
 details that are unchanged.
 
+.. warning::
+
+   Tcl/Tk 8.5 (2007) introduced a modern set of themed user interface components
+   along with a new API to use them. Both old and new API's are still available.
+   Unfortunately, most documentation you will find online uses the old API and
+   is woefully outdated.
+
 .. seealso::
 
    Tkinter documentation:

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -30,7 +30,7 @@ make the experience more pythonic. This documentation will concentrate on these
 additions and changes, and refer to the official Tcl/Tk documentation for
 details that are unchanged.
 
-.. warning::
+.. note::
 
    Tcl/Tk 8.5 (2007) introduced a modern set of themed user interface components
    along with a new API to use them. Both old and new APIs are still available.

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -33,7 +33,7 @@ details that are unchanged.
 .. warning::
 
    Tcl/Tk 8.5 (2007) introduced a modern set of themed user interface components
-   along with a new API to use them. Both old and new API's are still available.
+   along with a new API to use them. Both old and new APIs are still available.
    Unfortunately, most documentation you will find online uses the old API and
    is woefully outdated.
 


### PR DESCRIPTION
As this is just before the section talking about external resources (which we effectively depend on at present, as our own documentation is limited), I feel it's very much worth mentioning that so much of what is available is out of date.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42560](https://bugs.python.org/issue42560) -->
https://bugs.python.org/issue42560
<!-- /issue-number -->
