### PR TITLE
Fix reST markup in dataclasses.rst

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -205,7 +205,7 @@ Module contents
    follows a field with a default value.  This is true whether this
    occurs in a single class, or as a result of class inheritance.
 
-.. function:: field(*, default=MISSING, default_factory=MISSING, init=True, repr=True, hash=None, compare=True, metadata=None, kw_only=MISSING):
+.. function:: field(*, default=MISSING, default_factory=MISSING, init=True, repr=True, hash=None, compare=True, metadata=None, kw_only=MISSING)
 
    For common and simple use cases, no other functionality is
    required.  There are, however, some dataclass features that


### PR DESCRIPTION
The signature of field() had an extraneous colon at the end, causing it
to appear all bold and without the module name.

[The problematic signature can be seen by scrolling a bit at https://docs.python.org/3.10/library/dataclasses.html#dataclasses.dataclass.]