### PR TITLE
bpo-44940: Clarify the documentation of re.findall()

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -824,10 +824,20 @@ form.
 .. function:: findall(pattern, string, flags=0)
 
    Return all non-overlapping matches of *pattern* in *string*, as a list of
-   strings.  The *string* is scanned left-to-right, and matches are returned in
-   the order found.  If one or more groups are present in the pattern, return a
-   list of groups; this will be a list of tuples if the pattern has more than
-   one group.  Empty matches are included in the result.
+   strings or tuples.  The *string* is scanned left-to-right, and matches
+   are returned in the order found.  Empty matches are included in the result.
+
+   The result depends on the number of capturing groups in the pattern.
+   If there are no groups, return a list of strings matching the whole
+   pattern.  If there is exactly one group, return a list of strings
+   matching the group.  If more than one groups are present, return a list
+   of tuples of strings matching the groups.  Non-capturing groups do not
+   affect the result.
+
+      >>> re.findall(r'\bf[a-z]*', 'which foot or hand fell fastest')
+      ['foot', 'fell', 'fastest']
+      >>> re.findall(r'(\w+)=(\d+)', 'set width=20 and height=10')
+      [('width', '20'), ('height', '10')]
 
    .. versionchanged:: 3.7
       Non-empty matches can now start just after a previous empty match.

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -830,9 +830,9 @@ form.
    The result depends on the number of capturing groups in the pattern.
    If there are no groups, return a list of strings matching the whole
    pattern.  If there is exactly one group, return a list of strings
-   matching the group.  If more than one groups are present, return a list
+   matching that group.  If multiple groups are present, return a list
    of tuples of strings matching the groups.  Non-capturing groups do not
-   affect the result.
+   affect the form of the result.
 
       >>> re.findall(r'\bf[a-z]*', 'which foot or hand fell fastest')
       ['foot', 'fell', 'fastest']


### PR DESCRIPTION


<!-- issue-number: [bpo-44940](https://bugs.python.org/issue44940) -->
https://bugs.python.org/issue44940
<!-- /issue-number -->
