### PR TITLE
bpo-44926: `get_type_hints`: Add note about type aliases with forward refs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2013,6 +2013,14 @@ Introspection helpers
            'name': Annotated[str, 'some marker']
        }
 
+   .. note::
+
+      :func:`get_type_hints` does not work reliably with :ref:`type aliases <type-aliases>` that include
+      forward references.
+      When type aliases are imported into other modules, their forward references are
+      not evaluated in the namespace they were originally declared in.
+      Consider avoiding forward references by enabling postponed evaluation of annotations (:pep:`563`) instead.
+
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2015,9 +2015,10 @@ Introspection helpers
 
    .. note::
 
-      :func:`get_type_hints` does not work with imported :ref:`type aliases <type-aliases>` that include
-      forward references.
-      Enabling postponed evaluation of annotations (:pep:`563`) may remove the need for most forward references.
+      :func:`get_type_hints` does not work with imported
+      :ref:`type aliases <type-aliases>` that include forward references.
+      Enabling postponed evaluation of annotations (:pep:`563`) may remove
+      the need for most forward references.
 
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2015,10 +2015,8 @@ Introspection helpers
 
    .. note::
 
-      :func:`get_type_hints` does not work reliably with :ref:`type aliases <type-aliases>` that include
+      :func:`get_type_hints` does not work with imported :ref:`type aliases <type-aliases>` that include
       forward references.
-      When type aliases are imported into other modules, their forward references are
-      not evaluated in the namespace they were originally declared in.
       Consider avoiding forward references by enabling postponed evaluation of annotations (:pep:`563`) instead.
 
    .. versionchanged:: 3.9

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2017,7 +2017,7 @@ Introspection helpers
 
       :func:`get_type_hints` does not work with imported :ref:`type aliases <type-aliases>` that include
       forward references.
-      Consider avoiding forward references by enabling postponed evaluation of annotations (:pep:`563`) instead.
+      Enabling postponed evaluation of annotations (:pep:`563`) may remove the need for most forward references.
 
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.


### PR DESCRIPTION
As agreed on in [bpo-44926](https://bugs.python.org/issue44926), this PR adds a small note to `typing.get_type_hints` explaining that it fails on type aliases with forward references imported from other modules. 

I've tried to keep the text short. The first commit has a slightly longer version if we want more details/explanation here, but I think this should be enough. :)

<!-- issue-number: [bpo-44926](https://bugs.python.org/issue44926) -->
https://bugs.python.org/issue44926
<!-- /issue-number -->
