### PR TITLE
bpo-44524: Do not set _name of _SpecialForm without need

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4929,7 +4929,6 @@ class SpecialAttrsTests(BaseTestCase):
                 self.assertEqual(cls.__name__, name, str(cls))
                 self.assertEqual(cls.__qualname__, name, str(cls))
                 self.assertEqual(cls.__module__, 'typing', str(cls))
-                self.assertEqual(getattr(cls, '_name', name), name, str(cls))
                 for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                     s = pickle.dumps(cls, proto)
                     loaded = pickle.loads(s)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -461,7 +461,7 @@ def ClassVar(self, parameters):
     be used with isinstance() or issubclass().
     """
     item = _type_check(parameters, f'{self} accepts only single type.')
-    return _GenericAlias(self, (item,), name="ClassVar")
+    return _GenericAlias(self, (item,))
 
 @_SpecialForm
 def Final(self, parameters):
@@ -482,7 +482,7 @@ def Final(self, parameters):
     There is no runtime checking of these properties.
     """
     item = _type_check(parameters, f'{self} accepts only single type.')
-    return _GenericAlias(self, (item,), name="Final")
+    return _GenericAlias(self, (item,))
 
 @_SpecialForm
 def Union(self, parameters):
@@ -520,12 +520,9 @@ def Union(self, parameters):
     parameters = _remove_dups_flatten(parameters)
     if len(parameters) == 1:
         return parameters[0]
-
     if len(parameters) == 2 and type(None) in parameters:
-        name = "Optional"
-    else:
-        name = "Union"
-    return _UnionGenericAlias(self, parameters, name=name)
+        return _UnionGenericAlias(self, parameters, name="Optional")
+    return _UnionGenericAlias(self, parameters)
 
 @_SpecialForm
 def Optional(self, parameters):
@@ -570,7 +567,7 @@ def Literal(self, parameters):
     except TypeError:  # unhashable parameters
         pass
 
-    return _LiteralGenericAlias(self, parameters, name="Literal")
+    return _LiteralGenericAlias(self, parameters)
 
 
 @_SpecialForm
@@ -609,7 +606,7 @@ def Concatenate(self, parameters):
                         "ParamSpec variable.")
     msg = "Concatenate[arg, ...]: each arg must be a type."
     parameters = tuple(_type_check(p, msg) for p in parameters)
-    return _ConcatenateGenericAlias(self, parameters, name="Concatenate")
+    return _ConcatenateGenericAlias(self, parameters)
 
 
 @_SpecialForm
@@ -657,7 +654,7 @@ def TypeGuard(self, parameters):
     PEP 647 (User-Defined Type Guards).
     """
     item = _type_check(parameters, f'{self} accepts only single type.')
-    return _GenericAlias(self, (item,), name="TypeGuard")
+    return _GenericAlias(self, (item,))
 
 
 class ForwardRef(_Final, _root=True):
@@ -962,7 +959,7 @@ class _BaseGenericAlias(_Final, _root=True):
 
     def __getattr__(self, attr):
         if attr in {'__name__', '__qualname__'}:
-            return self._name
+            return self._name or self.__origin__.__name__
 
         # We are careful for copy and pickle.
         # Also for simplicity we just don't relay all dunder names


### PR DESCRIPTION
Because setting non-empty `_name` affects other behavior.

In most cases `__name__` can be derived from `__origin__.__name__`.


<!-- issue-number: [bpo-44524](https://bugs.python.org/issue44524) -->
https://bugs.python.org/issue44524
<!-- /issue-number -->
