### PR TITLE
bpo-4442:  Document use of __new__ for subclasses of immutable types

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1826,6 +1826,55 @@ For example, here is the implementation of
                 return True
         return False
 
+
+How can a subclass control what data is stored in an immutable instance?
+------------------------------------------------------------------------
+
+When subclassing an immutable type, override the :meth:`__new__` method
+instead of the :meth:`__init__` method.  The latter only runs *after*
+an instance is created when it is too late to store data in an
+immutable instance.
+
+For example, all of these classes modify the inherited contructor.
+
+.. testcode::
+
+    from datetime import date
+
+    class FirstOfMonthDate(date):
+        "Always choose the first day of the month"
+        def __new__(cls, year, month, day):
+            return super().__new__(cls, year, month, 1)
+
+
+    class NamedInt(int):
+        "Allow text names for some numbers"
+        xlat = {'zero': 0, 'one': 1, 'ten': 10}
+        def __new__(cls, value):
+            value = cls.xlat.get(value, value)
+            return super().__new__(cls, value)
+
+    class TitleStr(str):
+        "Convert str to name suitable for a URL path"
+        def __new__(cls, s):
+            s = s.lower().replace(' ', '-')
+            s = ''.join([c for c in s if c.isalnum() or c == '-'])
+            return super().__new__(cls, s)
+
+The classes can be used like this:
+
+.. doctest::
+
+    >>> FirstOfMonthDate(2012, 2, 14)
+    FirstOfMonthDate(2012, 2, 1)
+    >>> NamedInt('ten')
+    10
+    >>> NamedInt(20)
+    20
+    >>> TitleStr('Blog: Why Python Rocks')
+    'blog-why-python-rocks'
+
+
 How do I cache method calls?
 ----------------------------
 

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1831,11 +1831,12 @@ How can a subclass control what data is stored in an immutable instance?
 ------------------------------------------------------------------------
 
 When subclassing an immutable type, override the :meth:`__new__` method
-instead of the :meth:`__init__` method.  The latter only runs *after*
-an instance is created when it is too late to store data in an
-immutable instance.
+instead of the :meth:`__init__` method.  The latter only runs *after* an
+instance is created which is too late to store data in an immutable
+instance.
 
-For example, all of these classes modify the inherited contructor.
+For example, all of these immutable classes have a different signature
+than the type they inherited from:
 
 .. testcode::
 
@@ -1845,7 +1846,6 @@ For example, all of these classes modify the inherited contructor.
         "Always choose the first day of the month"
         def __new__(cls, year, month, day):
             return super().__new__(cls, year, month, 1)
-
 
     class NamedInt(int):
         "Allow text names for some numbers"

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1835,8 +1835,8 @@ instead of the :meth:`__init__` method.  The latter only runs *after* an
 instance is created which is too late to store data in an immutable
 instance.
 
-For example, all of these immutable classes have a different signature
-than the type they inherited from:
+All of these immutable classes have a different signature than their
+parent class:
 
 .. testcode::
 

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1832,7 +1832,7 @@ How can a subclass control what data is stored in an immutable instance?
 
 When subclassing an immutable type, override the :meth:`__new__` method
 instead of the :meth:`__init__` method.  The latter only runs *after* an
-instance is created which is too late to store data in an immutable
+instance is created, which is too late to alter data in an immutable
 instance.
 
 All of these immutable classes have a different signature than their


### PR DESCRIPTION


<!-- issue-number: [bpo-4442](https://bugs.python.org/issue4442) -->
https://bugs.python.org/issue4442
<!-- /issue-number -->
