### PR TITLE
bpo-44967: pydoc: return non-zero exit code when query is not found

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1775,24 +1775,18 @@ def render_doc(thing, title='Python Library Documentation: %s', forceload=0,
 def doc(thing, title='Python Library Documentation: %s', forceload=0,
         output=None):
     """Display text documentation, given an object or a path to an object."""
-    try:
-        if output is None:
-            pager(render_doc(thing, title, forceload))
-        else:
-            output.write(render_doc(thing, title, forceload, plaintext))
-    except (ImportError, ErrorDuringImport) as value:
-        print(value)
+    if output is None:
+        pager(render_doc(thing, title, forceload))
+    else:
+        output.write(render_doc(thing, title, forceload, plaintext))
 
 def writedoc(thing, forceload=0):
     """Write HTML documentation to a file in the current directory."""
-    try:
-        object, name = resolve(thing, forceload)
-        page = html.page(describe(object), html.document(object, name))
-        with open(name + '.html', 'w', encoding='utf-8') as file:
-            file.write(page)
-        print('wrote', name + '.html')
-    except (ImportError, ErrorDuringImport) as value:
-        print(value)
+    object, name = resolve(thing, forceload)
+    page = html.page(describe(object), html.document(object, name))
+    with open(name + '.html', 'w', encoding='utf-8') as file:
+        file.write(page)
+    print('wrote', name + '.html')
 
 def writedocs(dir, pkgpath='', done=None):
     """Write out HTML documentation for all modules in a directory tree."""
@@ -2786,7 +2780,7 @@ def cli():
         for arg in args:
             if ispath(arg) and not os.path.exists(arg):
                 print('file %r does not exist' % arg)
-                break
+                sys.exit(1)
             try:
                 if ispath(arg) and os.path.isfile(arg):
                     arg = importfile(arg)
@@ -2797,8 +2791,9 @@ def cli():
                         writedoc(arg)
                 else:
                     help.help(arg)
-            except ErrorDuringImport as value:
+            except (ImportError, ErrorDuringImport) as value:
                 print(value)
+                sys.exit(1)
 
     except (getopt.error, BadUsage):
         cmd = os.path.splitext(os.path.basename(sys.argv[0]))[0]

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -24,7 +24,7 @@ import textwrap
 from io import StringIO
 from collections import namedtuple
 from test.support import os_helper
-from test.support.script_helper import assert_python_ok
+from test.support.script_helper import assert_python_ok, assert_python_failure
 from test.support import threading_helper
 from test.support import (reap_children, captured_output, captured_stdout,
                           captured_stderr, requires_docstrings)
@@ -345,6 +345,14 @@ def run_pydoc(module_name, *args, **env):
     rc, out, err = assert_python_ok('-B', pydoc.__file__, *args, **env)
     return out.strip()
 
+def run_pydoc_fail(module_name, *args, **env):
+    """
+    Runs pydoc on the specified module expecting a failure.
+    """
+    args = args + (module_name,)
+    rc, out, err = assert_python_failure('-B', pydoc.__file__, *args, **env)
+    return out.strip()
+
 def get_pydoc_html(module):
     "Returns pydoc generated output as html"
     doc = pydoc.HTMLDoc()
@@ -487,7 +495,7 @@ class PydocDocTest(unittest.TestCase):
 
     def test_not_here(self):
         missing_module = "test.i_am_not_here"
-        result = str(run_pydoc(missing_module), 'ascii')
+        result = str(run_pydoc_fail(missing_module), 'ascii')
         expected = missing_pattern % missing_module
         self.assertEqual(expected, result,
             "documentation for missing module found")
@@ -501,7 +509,7 @@ class PydocDocTest(unittest.TestCase):
 
     def test_input_strip(self):
         missing_module = " test.i_am_not_here "
-        result = str(run_pydoc(missing_module), 'ascii')
+        result = str(run_pydoc_fail(missing_module), 'ascii')
         expected = missing_pattern % missing_module.strip()
         self.assertEqual(expected, result)
 
@@ -902,7 +910,7 @@ class PydocImportTest(PydocBaseTest):
         for importstring, expectedinmsg in testpairs:
             with open(sourcefn, 'w') as f:
                 f.write("import {}\n".format(importstring))
-            result = run_pydoc(modname, PYTHONPATH=TESTFN).decode("ascii")
+            result = run_pydoc_fail(modname, PYTHONPATH=TESTFN).decode("ascii")
             expected = badimport_pattern % (modname, expectedinmsg)
             self.assertEqual(expected, result)
 

--- a/Misc/NEWS.d/next/Tools-Demos/2021-08-26-11-57-31.bpo-44967.UT1RMV.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2021-08-26-11-57-31.bpo-44967.UT1RMV.rst
@@ -1,0 +1,1 @@
+pydoc now returns a non-zero status code when a module cannot be found.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44967](https://bugs.python.org/issue44967) -->
https://bugs.python.org/issue44967
<!-- /issue-number -->
