### PR TITLE
bpo-44968: Fix test_subprocess_wait_no_same_group in test_asyncio

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1971,10 +1971,11 @@ class SubprocessTestsMixin:
                         functools.partial(MySubprocessProtocol, self.loop),
                         'exit 7', stdin=None, stdout=None, stderr=None,
                         start_new_session=True)
-        _, proto = yield self.loop.run_until_complete(connect)
+        transp, proto = self.loop.run_until_complete(connect)
         self.assertIsInstance(proto, MySubprocessProtocol)
         self.loop.run_until_complete(proto.completed)
         self.assertEqual(7, proto.returncode)
+        transp.close()
 
     def test_subprocess_exec_invalid_args(self):
         async def connect(**kwds):


### PR DESCRIPTION
The code of the test was never executed because the test function
was unintentionally converted to a generator function.


<!-- issue-number: [bpo-44968](https://bugs.python.org/issue44968) -->
https://bugs.python.org/issue44968
<!-- /issue-number -->
