### PR TITLE
Remove unused UNKNOWN macros from `sqlite3` headers

### DIFF
--- a/Modules/_sqlite/cursor.h
+++ b/Modules/_sqlite/cursor.h
@@ -54,5 +54,4 @@ typedef struct
 
 int pysqlite_cursor_setup_types(PyObject *module);
 
-#define UNKNOWN (-1)
 #endif

--- a/Modules/_sqlite/prepare_protocol.h
+++ b/Modules/_sqlite/prepare_protocol.h
@@ -32,5 +32,4 @@ typedef struct
 
 int pysqlite_prepare_protocol_setup_types(PyObject *module);
 
-#define UNKNOWN (-1)
 #endif


### PR DESCRIPTION
The macros were made obsolete in pysqlite v2.0.2, May 21 2005.
See https://github.com/ghaering/pysqlite/commit/5114cfc287b4943e07812863ec2e3a7fe07724db

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
