### PR TITLE
bpo-44978: allow Argument Clinic to handle __complex__ special methods

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2021-08-22-11-45-31.bpo-44978.QupKV3.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2021-08-22-11-45-31.bpo-44978.QupKV3.rst
@@ -1,0 +1,1 @@
+Allow the Argument Clinic tool to handle ``__complex__`` special methods.

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2181,7 +2181,6 @@ __add__
 __and__
 __bytes__
 __call__
-__complex__
 __delitem__
 __divmod__
 __eq__


### PR DESCRIPTION
As far as I can tell, `__complex__` should need no special handling by Argument Clinic, so it should be safe to remove it from the set of unsupported methods. (`__int__` and `__float__` are there because they make use of a special slot, but `__complex__` has no slot.)

<!-- issue-number: [bpo-44978](https://bugs.python.org/issue44978) -->
https://bugs.python.org/issue44978
<!-- /issue-number -->
