### PR TITLE
bpo-44019: Implement operator.call().

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -250,6 +250,17 @@ Operations which work with sequences (some of them with mappings too) include:
 
    .. versionadded:: 3.4
 
+
+The following operation works with callables:
+
+.. function:: call(obj, / *args, **kwargs)
+              __call__(obj, /, *args, **kwargs)
+
+   Return ``obj(*args, **kwargs)``.
+
+   .. versionadded:: 3.11
+
+
 The :mod:`operator` module also defines tools for generalized attribute and item
 lookups.  These are useful for making fast field extractors as arguments for
 :func:`map`, :func:`sorted`, :meth:`itertools.groupby`, or other functions that

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -202,7 +202,7 @@ operator
 --------
 
 * A new function ``operator.call`` has been added, such that
-``operator.call(obj, *args, **kwargs) == obj(*args, **kwargs)``.
+  ``operator.call(obj, *args, **kwargs) == obj(*args, **kwargs)``.
   (Contributed by Antony Lee in :issue:`44019`.)
 
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -198,6 +198,14 @@ math
   Dickinson in :issue:`44339`.)
 
 
+operator
+--------
+
+* A new function ``operator.call`` has been added, such that
+``operator.call(obj, *args, **kwargs) == obj(*args, **kwargs)``.
+  (Contributed by Antony Lee in :issue:`44019`.)
+
+
 os
 --
 

--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -221,6 +221,12 @@ def length_hint(obj, default=0):
         raise ValueError(msg)
     return val
 
+# Other Operations ************************************************************#
+
+def call(obj, /, *args, **kwargs):
+    """Same as obj(*args, **kwargs)."""
+    return obj(*args, **kwargs)
+
 # Generalized Lookup Objects **************************************************#
 
 class attrgetter:
@@ -423,6 +429,7 @@ __not__ = not_
 __abs__ = abs
 __add__ = add
 __and__ = and_
+__call__ = call
 __floordiv__ = floordiv
 __index__ = index
 __inv__ = inv

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -518,6 +518,18 @@ class OperatorTestCase:
         with self.assertRaises(LookupError):
             operator.length_hint(X(LookupError))
 
+    def test_call(self):
+        operator = self.module
+
+        def func(*args, **kwargs): return args, kwargs
+
+        self.assertEqual(operator.call(func), ((), {}))
+        self.assertEqual(operator.call(func, 0, 1), ((0, 1), {}))
+        self.assertEqual(operator.call(func, a=2, obj=3),
+                         ((), {"a": 2, "obj": 3}))
+        self.assertEqual(operator.call(func, 0, 1, a=2, obj=3),
+                         ((0, 1), {"a": 2, "obj": 3}))
+
     def test_dunder_is_original(self):
         operator = self.module
 

--- a/Misc/NEWS.d/next/Library/2021-08-22-13-25-17.bpo-44019.BN8HDy.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-22-13-25-17.bpo-44019.BN8HDy.rst
@@ -1,0 +1,2 @@
+A new function ``operator.call`` has been added, such that
+``operator.call(obj, *args, **kwargs) == obj(*args, **kwargs)``.

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -886,6 +886,27 @@ _operator__compare_digest_impl(PyObject *module, PyObject *a, PyObject *b)
     return PyBool_FromLong(rc);
 }
 
+PyDoc_STRVAR(_operator_call__doc__,
+"call($module, obj, /, *args, **kwargs)\n"
+"--\n"
+"\n"
+"Same as obj(*args, **kwargs).");
+
+#define _OPERATOR_CALL_METHODDEF    \
+    {"call", (PyCFunction)(void(*)(void))_operator_call, METH_FASTCALL | METH_KEYWORDS, _operator_call__doc__},
+
+static PyObject *
+_operator_call(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    if (!_PyArg_CheckPositional("call", nargs, 1, PY_SSIZE_T_MAX)) {
+        return NULL;
+    }
+    return PyObject_Vectorcall(
+            args[0],
+            &args[1], (PyVectorcall_NARGS(nargs) - 1) | PY_VECTORCALL_ARGUMENTS_OFFSET,
+            kwnames);
+}
+
 /* operator methods **********************************************************/
 
 static struct PyMethodDef operator_methods[] = {
@@ -942,6 +963,7 @@ static struct PyMethodDef operator_methods[] = {
     _OPERATOR_GE_METHODDEF
     _OPERATOR__COMPARE_DIGEST_METHODDEF
     _OPERATOR_LENGTH_HINT_METHODDEF
+    _OPERATOR_CALL_METHODDEF
     {NULL,              NULL}           /* sentinel */
 
 };


### PR DESCRIPTION
Having `operator.call(obj, arg)` mean `type(obj).__call__(obj, arg)` is
consistent with the other dunder operators.  The semantics with `*args,
**kwargs` then follow naturally from the single-arg semantics.

-----

I realize that I proposed different semantics in the original bug report, but that didn't even actually match to the proposed use case; the second proposal in the thread is the correct one.  The semantics here work for at least two different use cases that I have seen:

- Using concurrent.futures.Executor.map on a list of callables (`executor.map(operator.call, callables)`).  In that case the performance doesn't actually matter much and a Python helper would in fact be fine.

- Loading a "typed" csv file (cf. numpy.loadtxt), where each column has a separate type, e.g.
```python
converters = [int, float, int, float]
lines = [  # Assume that we already `str.split` them.
    ["1", "2.2", "3", "4.4"],
    ["5", "6.6", "7", "8.8"],
]
[[*map(operator.call, converters, words)] for words in lines]
# faster than the list comprehension
[[conv(word) for conv, word in zip(converters, words)] for words in lines]
```
Here the performance actually matters (with numpy, one may easily be loading millions of rows).  A simple benchmark gives
```
$ ./python -mtimeit -s 'from operator import call; funcs = [int, float, float, int]; inputs = ["1", "2", "3", "4"]' -- '[*map(call, funcs, inputs)]'
500000 loops, best of 5: 761 nsec per loop
$ ./python -mtimeit -s 'from operator import call; funcs = [int, float, float, int]; inputs = ["1", "2", "3", "4"]' -- '[func(inp) for func, inp in zip(funcs, inputs)]'
200000 loops, best of 5: 1.07 usec per loop
```
i.e. `map(operator.call, ...)` gives a significant speedup.

<!-- issue-number: [bpo-44019](https://bugs.python.org/issue44019) -->
https://bugs.python.org/issue44019
<!-- /issue-number -->
