### PR TITLE
bpo-44979: add pathlib.Path.relative (GH-27890)

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1440,6 +1440,14 @@ class Path(PurePath):
 
         return self
 
+    @classmethod
+    def relative(cls, path, depth=1):
+        """
+        Return path that is constructed relatively to caller file.
+        """
+        base = Path(sys._getframe(depth).f_code.co_filename).parent
+        return (base / path).resolve()
+
 
 class PosixPath(Path, PurePosixPath):
     """Path subclass for non-Windows systems.

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2429,6 +2429,10 @@ class _BasePathTest(object):
     def test_complex_symlinks_relative_dot_dot(self):
         self._check_complex_symlinks(os.path.join('dirA', '..'))
 
+    def test_relative(self):
+        p = self.cls.relative('..')
+        assert p.name == 'Lib', p.name
+
 
 class PathTest(_BasePathTest, unittest.TestCase):
     cls = pathlib.Path


### PR DESCRIPTION
Enhancement to pathlib.Path that allows construction of path relative to caller's file


<!-- issue-number: [bpo-44979](https://bugs.python.org/issue44979) -->
https://bugs.python.org/issue44979
<!-- /issue-number -->
