### PR TITLE
bpo-44980: fix test_constructor to return None value

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -212,7 +212,7 @@ class CodeTest(unittest.TestCase):
         CodeType = type(co)
 
         # test code constructor
-        return CodeType(co.co_argcount,
+        CodeType(co.co_argcount,
                         co.co_posonlyargcount,
                         co.co_kwonlyargcount,
                         co.co_nlocals,


### PR DESCRIPTION
Update test_constructor() to conform to deprecation in #27748

<!-- issue-number: [bpo-44980](https://bugs.python.org/issue44980) -->
https://bugs.python.org/issue44980
<!-- /issue-number -->
