### PR TITLE
bpo-24234: fix bytes.__bytes__ to not truncate at a zero byte

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -982,14 +982,14 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
     type2test = bytes
 
     def test__bytes__(self):
-        foo = b'foo'
+        foo = b'foo\x00bar'
         self.assertEqual(foo.__bytes__(), foo)
         self.assertEqual(type(foo.__bytes__()), self.type2test)
 
         class bytes_subclass(bytes):
             pass
 
-        bar = bytes_subclass(b'bar')
+        bar = bytes_subclass(b'bar\x00foo')
         self.assertEqual(bar.__bytes__(), bar)
         self.assertEqual(type(bar.__bytes__()), self.type2test)
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1701,7 +1701,7 @@ bytes___bytes___impl(PyBytesObject *self)
         return (PyObject *)self;
     }
     else {
-        return PyBytes_FromString(self->ob_sval);
+        return PyBytes_FromStringAndSize(self->ob_sval, Py_SIZE(self));
     }
 }
 


### PR DESCRIPTION
Fixes buildbot failures introduced in GH-27901.


<!-- issue-number: [bpo-24234](https://bugs.python.org/issue24234) -->
https://bugs.python.org/issue24234
<!-- /issue-number -->
