### PR TITLE
bpo-44962 fix a race in WeakKeyDict, WeakValueDict and WeakSet when two threads attempt to commit the last pending removal

### DIFF
--- a/Lib/_weakrefset.py
+++ b/Lib/_weakrefset.py
@@ -58,8 +58,7 @@ class WeakSet:
                 item = pop()
             except IndexError:
                 return
-            else:
-                discard(item)
+            discard(item)
 
     def __iter__(self):
         with _IterationGuard(self):

--- a/Lib/_weakrefset.py
+++ b/Lib/_weakrefset.py
@@ -51,10 +51,15 @@ class WeakSet:
             self.update(data)
 
     def _commit_removals(self):
-        l = self._pending_removals
+        pop = self._pending_removals.pop
         discard = self.data.discard
-        while l:
-            discard(l.pop())
+        while True:
+            try:
+                item = pop()
+            except IndexError:
+                return
+            else:
+                discard(item)
 
     def __iter__(self):
         with _IterationGuard(self):

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -129,8 +129,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
                 key = pop()
             except IndexError:
                 return
-            else:
-                _atomic_removal(d, key)
+            _atomic_removal(d, key)
 
     def __getitem__(self, key):
         if self._pending_removals:

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -119,7 +119,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
         self.data = {}
         self.update(other, **kw)
 
-    def _commit_removals(self):
+    def _commit_removals(self, _atomic_removal=_remove_dead_weakref):
         pop = self._pending_removals.pop
         d = self.data
         # We shouldn't encounter any KeyError, because this method should
@@ -130,7 +130,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
             except IndexError:
                 return
             else:
-                _remove_dead_weakref(d, key)
+                _atomic_removal(d, key)
 
     def __getitem__(self, key):
         if self._pending_removals:

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -398,11 +398,11 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
                 key = pop()
             except IndexError:
                 return
-            else:
-                try:
-                    del d[key]
-                except KeyError:
-                    pass
+
+            try:
+                del d[key]
+            except KeyError:
+                pass
 
     def _scrub_removals(self):
         d = self.data

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -374,7 +374,10 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
                 if self._iterating:
                     self._pending_removals.append(k)
                 else:
-                    del self.data[k]
+                    try:
+                        del self.data[k]
+                    except KeyError:
+                        pass
         self._remove = remove
         # A list of dead weakrefs (keys to be removed)
         self._pending_removals = []

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
@@ -1,1 +1,1 @@
-Fix a race in WeakSet when two threads attempt to commit the last pending removal. This fixes asyncio.create_task and fixes a data loss in asyncio.run where shutdown_asyncgens is not run
+Fix a race in WeakKeyDict, WeakValueDict and WeakSet when two threads attempt to commit the last pending removal. This fixes asyncio.create_task and fixes a data loss in asyncio.run where shutdown_asyncgens is not run

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
@@ -1,0 +1,1 @@
+fix a race in WeakSet

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
@@ -1,1 +1,1 @@
-fix a race in WeakSet
+Fix a race in WeakSet when two threads attempt to commit the last pending removal. This fixes asyncio.create_task and fixes a data loss in asyncio.run where shutdown_asyncgens is not run

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-23-19-55-08.bpo-44962.J00ftt.rst
@@ -1,1 +1,1 @@
-Fix a race in WeakKeyDict, WeakValueDict and WeakSet when two threads attempt to commit the last pending removal. This fixes asyncio.create_task and fixes a data loss in asyncio.run where shutdown_asyncgens is not run
+Fix a race in WeakKeyDictionary, WeakValueDictionary and WeakSet when two threads attempt to commit the last pending removal. This fixes asyncio.create_task and fixes a data loss in asyncio.run where shutdown_asyncgens is not run


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44962](https://bugs.python.org/issue44962) -->
https://bugs.python.org/issue44962
<!-- /issue-number -->
