### PR TITLE
bpo-37596: Make `set` and `frozenset` marshalling deterministic

### DIFF
--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -351,7 +351,7 @@ class BugsTestCase(unittest.TestCase):
         for kind in ("set", "frozenset"):
             script = f"import marshal; print(marshal.dumps({kind}({elements})))"
             with self.subTest(kind):
-                # {nan, b"b", "x", b'a', b'c', 'y', 'z'}
+                # {nan, b'b', 'x', b'a', b'c', 'y', 'z'}
                 _, a, _ = assert_python_ok("-c", script, PYTHONHASHSEED="0")
                 # {nan, 'x', b'a', 'z', b'b', 'y', b'c'}
                 _, b, _ = assert_python_ok("-c", script, PYTHONHASHSEED="1")

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -345,18 +345,29 @@ class BugsTestCase(unittest.TestCase):
             self.assertRaises(EOFError, marshal.loads, data[0: i])
 
     def test_deterministic_sets(self):
-        # bpo-37596: sets and frozensets must always marshal deterministically!
-        # Test this by seeding string hashes:
-        elements = "(float('nan'), b'a', b'b', b'c', 'x', 'y', 'z')"
+        # bpo-37596: To support reproducible builds, sets and frozensets need to
+        # have their elements serialized in a consistent order (even when they
+        # have been scrambled by hash randomization):
         for kind in ("set", "frozenset"):
-            script = f"import marshal; print(marshal.dumps({kind}({elements})))"
-            with self.subTest(kind):
-                # {nan, b'b', 'x', b'a', b'c', 'y', 'z'}
-                _, a, _ = assert_python_ok("-c", script, PYTHONHASHSEED="0")
-                # {nan, 'x', b'a', 'z', b'b', 'y', b'c'}
-                _, b, _ = assert_python_ok("-c", script, PYTHONHASHSEED="1")
-                self.assertEqual(a, b)
-
+            for elements in (
+                "float('nan'), b'a', b'b', b'c', 'x', 'y', 'z'",
+                # Also test for bad interactions with backreferencing:
+                "('string', 1), ('string', 2), ('string', 3)",
+            ):
+                s = f"{kind}([{elements}])"
+                with self.subTest(s):
+                    # First, make sure that our test case still has different
+                    # orders under hash seeds 0 and 1. If this check fails, we
+                    # need to update this test with different elements:
+                    args = ["-c", f"print({s})"]
+                    _, repr_0, _ = assert_python_ok(*args, PYTHONHASHSEED="0")
+                    _, repr_1, _ = assert_python_ok(*args, PYTHONHASHSEED="1")
+                    self.assertNotEqual(repr_0, repr_1)
+                    # Then, perform the actual test:
+                    args = ["-c", f"import marshal; print(marshal.dumps({s}))"]
+                    _, dump_0, _ = assert_python_ok(*args, PYTHONHASHSEED="0")
+                    _, dump_1, _ = assert_python_ok(*args, PYTHONHASHSEED="1")
+                    self.assertEqual(dump_0, dump_1)
 
 LARGE_SIZE = 2**31
 pointer_size = 8 if sys.maxsize > 0xFFFFFFFF else 4

--- a/Misc/NEWS.d/next/Library/2021-08-23-21-39-59.bpo-37596.ojRcwB.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-23-21-39-59.bpo-37596.ojRcwB.rst
@@ -1,2 +1,2 @@
 Ensure that :class:`set` and :class:`frozenset` objects are always
-:mod:`marshalled <marshal>` deterministically.
+:mod:`marshalled <marshal>` reproducibly.

--- a/Misc/NEWS.d/next/Library/2021-08-23-21-39-59.bpo-37596.ojRcwB.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-23-21-39-59.bpo-37596.ojRcwB.rst
@@ -1,0 +1,2 @@
+Ensure that :class:`set` and :class:`frozenset` objects are always
+:mod:`marshalled <marshal>` deterministically.

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -532,9 +532,10 @@ w_complex_object(PyObject *v, char flag, WFILE *p)
             goto anyset_done;
         }
         for (Py_ssize_t i = 0; i < n; i++) {
-            PyObject *pair = PyList_GET_ITEM(pairs, i);
-            PyObject *value = PyTuple_GET_ITEM(pair, 1);
+            pair = PyList_GET_ITEM(pairs, i);
+            value = PyTuple_GET_ITEM(pair, 1);
             w_object(value, p);
+            pair = NULL;
         }
     anyset_done:
         Py_XDECREF(pairs);

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -503,10 +503,10 @@ w_complex_object(PyObject *v, char flag, WFILE *p)
             W_TYPE(TYPE_SET, p);
         n = PySet_GET_SIZE(v);
         W_SIZE(n, p);
-        // bpo-37596: We need to write the elements in a deterministic order!
-        // Since we know that they all need marshal support anyways, this can
-        // be conveniently accomplished by using their marshal serializations
-        // as sort keys:
+        // bpo-37596: To support reproducible builds, sets and frozensets need
+        // to have their elements serialized in a consistent order (even when
+        // they have been scrambled by hash randomization). To ensure this, we
+        // use an order equivalent to sorted(v, key=marshal.dumps):
         PyObject *pairs = PyList_New(0);
         if (pairs == NULL) {
             p->error = WFERR_NOMEMORY;
@@ -520,15 +520,15 @@ w_complex_object(PyObject *v, char flag, WFILE *p)
             }
             PyObject *pair = PyTuple_Pack(2, dump, value);
             Py_DECREF(dump);
-            int error = pair == NULL || PyList_Append(pairs, pair);
-            Py_XDECREF(pair);
-            if (error) {
+            if (pair == NULL || PyList_Append(pairs, pair)) {
                 p->error = WFERR_NOMEMORY;
+                Py_XDECREF(pair);
                 goto anyset_done;
             }
+            Py_DECREF(pair);
         }
         if (PyList_Sort(pairs)) {
-            p->error = WFERR_UNMARSHALLABLE;
+            p->error = WFERR_NOMEMORY;
             goto anyset_done;
         }
         for (Py_ssize_t i = 0; i < n; i++) {

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -503,9 +503,42 @@ w_complex_object(PyObject *v, char flag, WFILE *p)
             W_TYPE(TYPE_SET, p);
         n = PySet_GET_SIZE(v);
         W_SIZE(n, p);
+        // bpo-37596: We need to write the elements in a deterministic order!
+        // Since we know that they all need marshal support anyways, this can
+        // be conveniently accomplished by using their marshal serializations
+        // as sort keys:
+        PyObject *pairs = PyList_New(0);
+        if (pairs == NULL) {
+            p->error = WFERR_NOMEMORY;
+            return;
+        }
+        PyObject *pair = NULL;
         while (_PySet_NextEntry(v, &pos, &value, &hash)) {
+            PyObject *dump = PyMarshal_WriteObjectToString(value, p->version);
+            if (dump == NULL) {
+                p->error = WFERR_UNMARSHALLABLE;
+                goto anyset_done;
+            }
+            pair = PyTuple_Pack(2, dump, value);
+            Py_DECREF(dump);
+            if (pair == NULL || PyList_Append(pairs, pair)) {
+                p->error = WFERR_NOMEMORY;
+                goto anyset_done;
+            }
+            Py_CLEAR(pair);
+        }
+        if (PyList_Sort(pairs)) {
+            p->error = WFERR_UNMARSHALLABLE;
+            goto anyset_done;
+        }
+        for (Py_ssize_t i = 0; i < n; i++) {
+            PyObject *pair = PyList_GET_ITEM(pairs, i);
+            PyObject *value = PyTuple_GET_ITEM(pair, 1);
             w_object(value, p);
         }
+    anyset_done:
+        Py_XDECREF(pairs);
+        Py_XDECREF(pair);
     }
     else if (PyCode_Check(v)) {
         PyCodeObject *co = (PyCodeObject *)v;


### PR DESCRIPTION
This PR is intended as an alternative to #27769.


<!-- issue-number: [bpo-37596](https://bugs.python.org/issue37596) -->
https://bugs.python.org/issue37596
<!-- /issue-number -->
