### PR TITLE
bpo-42064: Offset arguments for PyObject_Vectorcall in the _sqlite module

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -59,19 +59,21 @@ static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self);
 static PyObject *
 new_statement_cache(pysqlite_Connection *self, int maxsize)
 {
-    PyObject *args[] = { PyLong_FromLong(maxsize), };
-    if (args[0] == NULL) {
+    PyObject *args[] = { NULL, PyLong_FromLong(maxsize), };
+    if (args[1] == NULL) {
         return NULL;
     }
     PyObject *lru_cache = self->state->lru_cache;
-    PyObject *inner = PyObject_Vectorcall(lru_cache, args, 1, NULL);
-    Py_DECREF(args[0]);
+    PyObject *inner = PyObject_Vectorcall(
+        lru_cache, args + 1, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+    Py_DECREF(args[1]);
     if (inner == NULL) {
         return NULL;
     }
 
-    args[0] = (PyObject *)self;  // Borrowed ref.
-    PyObject *res = PyObject_Vectorcall(inner, args, 1, NULL);
+    args[1] = (PyObject *)self;  // Borrowed ref.
+    PyObject *res = PyObject_Vectorcall(
+        inner, args + 1, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
     Py_DECREF(inner);
     return res;
 }
@@ -1482,8 +1484,9 @@ pysqlite_collation_callback(
 
     callback_context *ctx = (callback_context *)context;
     assert(ctx != NULL);
-    PyObject *args[] = { string1, string2 };  // Borrowed refs.
-    retval = PyObject_Vectorcall(ctx->callable, args, 2, NULL);
+    PyObject *args[] = { NULL, string1, string2 };  // Borrowed refs.
+    retval = PyObject_Vectorcall(
+        ctx->callable, args + 1, 2 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
     if (retval == NULL) {
         /* execution failed */
         goto finally;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -64,16 +64,16 @@ new_statement_cache(pysqlite_Connection *self, int maxsize)
         return NULL;
     }
     PyObject *lru_cache = self->state->lru_cache;
-    PyObject *inner = PyObject_Vectorcall(
-        lru_cache, args + 1, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+    size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+    PyObject *inner = PyObject_Vectorcall(lru_cache, args + 1, nargsf, NULL);
     Py_DECREF(args[1]);
     if (inner == NULL) {
         return NULL;
     }
 
     args[1] = (PyObject *)self;  // Borrowed ref.
-    PyObject *res = PyObject_Vectorcall(
-        inner, args + 1, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+    nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+    PyObject *res = PyObject_Vectorcall(inner, args + 1, nargsf, NULL);
     Py_DECREF(inner);
     return res;
 }
@@ -1485,8 +1485,8 @@ pysqlite_collation_callback(
     callback_context *ctx = (callback_context *)context;
     assert(ctx != NULL);
     PyObject *args[] = { NULL, string1, string2 };  // Borrowed refs.
-    retval = PyObject_Vectorcall(
-        ctx->callable, args + 1, 2 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+    size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+    retval = PyObject_Vectorcall(ctx->callable, args + 1, nargsf, NULL);
     if (retval == NULL) {
         /* execution failed */
         goto finally;

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -467,8 +467,8 @@ get_statement_from_cache(pysqlite_Cursor *self, PyObject *operation)
 {
     PyObject *args[] = { NULL, operation, };  // Borrowed ref.
     PyObject *cache = self->connection->statement_cache;
-    return PyObject_Vectorcall(
-        cache, args + 1, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+    size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+    return PyObject_Vectorcall(cache, args + 1, nargsf, NULL);
 }
 
 static PyObject *

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -465,7 +465,7 @@ error:
 static PyObject *
 get_statement_from_cache(pysqlite_Cursor *self, PyObject *operation)
 {
-    PyObject *args[] = { NULL, operation, };
+    PyObject *args[] = { NULL, operation, };  // Borrowed ref.
     PyObject *cache = self->connection->statement_cache;
     return PyObject_Vectorcall(
         cache, args + 1, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -465,9 +465,10 @@ error:
 static PyObject *
 get_statement_from_cache(pysqlite_Cursor *self, PyObject *operation)
 {
-    PyObject *args[] = { operation, };
+    PyObject *args[] = { NULL, operation, };
     PyObject *cache = self->connection->statement_cache;
-    return PyObject_Vectorcall(cache, args, 1, NULL);
+    return PyObject_Vectorcall(
+        cache, args + 1, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
 }
 
 static PyObject *


### PR DESCRIPTION
This weird mechanism allows e.g. methods to be called efficiently by providing space for a "self" argument; see [PY_VECTORCALL_ARGUMENTS_OFFSET docs](https://docs.python.org/3/c-api/call.html#c.PY_VECTORCALL_ARGUMENTS_OFFSET).


<!-- issue-number: [bpo-42064](https://bugs.python.org/issue42064) -->
https://bugs.python.org/issue42064
<!-- /issue-number -->
