### PR TITLE
bpo-44990: Change layout of evaluation frames. "Layout B"

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -30,7 +30,6 @@ typedef struct _interpreter_frame {
     struct _interpreter_frame *previous;
     int f_lasti;       /* Last instruction if called */
     int stacktop;     /* Offset of TOS from localsplus  */
-    int nlocalsplus;
     PyFrameState f_state;  /* What state the frame is in */
     PyObject *localsplus[1];
 } InterpreterFrame;
@@ -52,18 +51,18 @@ _PyFrameHasCompleted(InterpreterFrame *f) {
 
 static inline PyObject **
 _PyFrame_Stackbase(InterpreterFrame *f) {
-    return f->localsplus + f->nlocalsplus;
+    return f->localsplus + f->f_code->co_nlocalsplus;
 }
 
 static inline PyObject *
 _PyFrame_StackPeek(InterpreterFrame *f) {
-    assert(f->stacktop > f->nlocalsplus);
+    assert(f->stacktop > f->f_code->co_nlocalsplus);
     return f->localsplus[f->stacktop-1];
 }
 
 static inline PyObject *
 _PyFrame_StackPop(InterpreterFrame *f) {
-    assert(f->stacktop > f->nlocalsplus);
+    assert(f->stacktop > f->f_code->co_nlocalsplus);
     f->stacktop--;
     return f->localsplus[f->stacktop];
 }
@@ -88,7 +87,6 @@ _PyFrame_InitializeSpecials(
     frame->f_builtins = Py_NewRef(con->fc_builtins);
     frame->f_globals = Py_NewRef(con->fc_globals);
     frame->f_locals = Py_XNewRef(locals);
-    frame->nlocalsplus = nlocalsplus;
     frame->stacktop = nlocalsplus;
     frame->frame_obj = NULL;
     frame->generator = NULL;

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -35,16 +35,24 @@ typedef struct _interpreter_frame {
     PyObject *stack[1];
 } InterpreterFrame;
 
-static inline int _PyFrame_IsRunnable(InterpreterFrame *f) {
+static inline int
+_PyFrame_IsRunnable(InterpreterFrame *f) {
     return f->f_state < FRAME_EXECUTING;
 }
 
-static inline int _PyFrame_IsExecuting(InterpreterFrame *f) {
+static inline int
+_PyFrame_IsExecuting(InterpreterFrame *f) {
     return f->f_state == FRAME_EXECUTING;
 }
 
-static inline int _PyFrameHasCompleted(InterpreterFrame *f) {
+static inline int
+_PyFrameHasCompleted(InterpreterFrame *f) {
     return f->f_state > FRAME_EXECUTING;
+}
+
+static inline PyObject **
+_PyFrame_Stackbase(InterpreterFrame *f) {
+    return &f->stack[0];
 }
 
 #define FRAME_SPECIALS_SIZE ((sizeof(InterpreterFrame)-1)/sizeof(PyObject *))
@@ -76,6 +84,18 @@ static inline PyObject**
 _PyFrame_GetLocalsArray(InterpreterFrame *frame)
 {
     return ((PyObject **)frame) - frame->nlocalsplus;
+}
+
+static inline PyObject**
+_PyFrame_GetStackPointer(InterpreterFrame *frame)
+{
+    return frame->stack+frame->stackdepth;
+}
+
+static inline void
+_PyFrame_SetStackPointer(InterpreterFrame *frame, PyObject **stack_pointer)
+{
+    frame->stackdepth = (int)(stack_pointer - frame->stack);
 }
 
 /* For use by _PyFrame_GetFrameObject

--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -34,41 +34,34 @@ typedef struct _interpreter_frame {
     PyObject *localsplus[1];
 } InterpreterFrame;
 
-static inline int
-_PyFrame_IsRunnable(InterpreterFrame *f) {
+static inline int _PyFrame_IsRunnable(InterpreterFrame *f) {
     return f->f_state < FRAME_EXECUTING;
 }
 
-static inline int
-_PyFrame_IsExecuting(InterpreterFrame *f) {
+static inline int _PyFrame_IsExecuting(InterpreterFrame *f) {
     return f->f_state == FRAME_EXECUTING;
 }
 
-static inline int
-_PyFrameHasCompleted(InterpreterFrame *f) {
+static inline int _PyFrameHasCompleted(InterpreterFrame *f) {
     return f->f_state > FRAME_EXECUTING;
 }
 
-static inline PyObject **
-_PyFrame_Stackbase(InterpreterFrame *f) {
+static inline PyObject **_PyFrame_Stackbase(InterpreterFrame *f) {
     return f->localsplus + f->f_code->co_nlocalsplus;
 }
 
-static inline PyObject *
-_PyFrame_StackPeek(InterpreterFrame *f) {
+static inline PyObject *_PyFrame_StackPeek(InterpreterFrame *f) {
     assert(f->stacktop > f->f_code->co_nlocalsplus);
     return f->localsplus[f->stacktop-1];
 }
 
-static inline PyObject *
-_PyFrame_StackPop(InterpreterFrame *f) {
+static inline PyObject *_PyFrame_StackPop(InterpreterFrame *f) {
     assert(f->stacktop > f->f_code->co_nlocalsplus);
     f->stacktop--;
     return f->localsplus[f->stacktop];
 }
 
-static inline void
-_PyFrame_StackPush(InterpreterFrame *f, PyObject *value) {
+static inline void _PyFrame_StackPush(InterpreterFrame *f, PyObject *value) {
     f->localsplus[f->stacktop] = value;
     f->stacktop++;
 }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -190,8 +190,7 @@ gen_send_ex2(PyGenObject *gen, PyObject *arg, PyObject **presult,
     /* Push arg onto the frame's value stack */
     result = arg ? arg : Py_None;
     Py_INCREF(result);
-    frame->stack[frame->stackdepth] = result;
-    frame->stackdepth++;
+    _PyFrame_StackPush(frame, result);
 
     frame->previous = tstate->frame;
 
@@ -350,8 +349,7 @@ _PyGen_yf(PyGenObject *gen)
 
         if (code[(frame->f_lasti+1)*sizeof(_Py_CODEUNIT)] != YIELD_FROM)
             return NULL;
-        assert(frame->stackdepth > 0);
-        yf = frame->stack[frame->stackdepth-1];
+        yf = _PyFrame_StackPeek(frame);
         Py_INCREF(yf);
     }
 
@@ -469,9 +467,7 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
         if (!ret) {
             PyObject *val;
             /* Pop subiterator from stack */
-            assert(gen->gi_xframe->stackdepth > 0);
-            gen->gi_xframe->stackdepth--;
-            ret = gen->gi_xframe->stack[gen->gi_xframe->stackdepth];
+            ret = _PyFrame_StackPop(gen->gi_xframe);
             assert(ret == yf);
             Py_DECREF(ret);
             /* Termination repetition of YIELD_FROM */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8874,7 +8874,7 @@ super_init_without_args(PyFrameObject *f, PyCodeObject *co,
         return -1;
     }
 
-    assert(f->f_frame->nlocalsplus > 0);
+    assert(f->f_frame->f_code->co_nlocalsplus > 0);
     PyObject *firstarg = _PyFrame_GetLocalsArray(f->f_frame)[0];
     // The first argument might be a cell.
     if (firstarg != NULL && (_PyLocals_GetKind(co->co_localspluskinds, 0) & CO_FAST_CELL)) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4818,7 +4818,8 @@ exception_unwind:
             assert(_PyErr_Occurred(tstate));
 
             /* Pop remaining stack entries. */
-            while (!EMPTY()) {
+            PyObject **stackbase = _PyFrame_Stackbase(frame);
+            while (stack_pointer > stackbase) {
                 PyObject *o = POP();
                 Py_XDECREF(o);
             }

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -15,10 +15,7 @@ _PyFrame_Traverse(InterpreterFrame *frame, visitproc visit, void *arg)
    /* locals */
     PyObject **locals = _PyFrame_GetLocalsArray(frame);
     int i = 0;
-    for (; i < frame->nlocalsplus; i++) {
-        Py_VISIT(locals[i]);
-    }
-    /* stack */
+    /* locals and stack */
     for (; i <frame->stacktop; i++) {
         Py_VISIT(locals[i]);
     }
@@ -48,7 +45,7 @@ _PyFrame_MakeAndSetFrameObject(InterpreterFrame *frame)
 static InterpreterFrame *
 copy_frame_to_heap(InterpreterFrame *frame)
 {
-    assert(frame->stacktop >= frame->nlocalsplus);
+    assert(frame->stacktop >= frame->f_code->co_nlocalsplus);
     Py_ssize_t size = ((char*)&frame->localsplus[frame->stacktop]) - (char *)frame;
     InterpreterFrame *copy = PyMem_Malloc(size);
     if (copy == NULL) {

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -14,12 +14,13 @@ _PyFrame_Traverse(InterpreterFrame *frame, visitproc visit, void *arg)
     Py_VISIT(frame->f_code);
    /* locals */
     PyObject **locals = _PyFrame_GetLocalsArray(frame);
-    for (int i = 0; i < frame->nlocalsplus; i++) {
+    int i = 0;
+    for (; i < frame->nlocalsplus; i++) {
         Py_VISIT(locals[i]);
     }
     /* stack */
-    for (int i = 0; i <frame->stackdepth; i++) {
-        Py_VISIT(frame->stack[i]);
+    for (; i <frame->stacktop; i++) {
+        Py_VISIT(locals[i]);
     }
     return 0;
 }
@@ -47,17 +48,15 @@ _PyFrame_MakeAndSetFrameObject(InterpreterFrame *frame)
 static InterpreterFrame *
 copy_frame_to_heap(InterpreterFrame *frame)
 {
-
-    Py_ssize_t size = ((char*)&frame->stack[frame->stackdepth]) - (char *)_PyFrame_GetLocalsArray(frame);
-    PyObject **copy = PyMem_Malloc(size);
+    assert(frame->stacktop >= frame->nlocalsplus);
+    Py_ssize_t size = ((char*)&frame->localsplus[frame->stacktop]) - (char *)frame;
+    InterpreterFrame *copy = PyMem_Malloc(size);
     if (copy == NULL) {
         PyErr_NoMemory();
         return NULL;
     }
-    PyObject **locals = _PyFrame_GetLocalsArray(frame);
-    memcpy(copy, locals, size);
-    InterpreterFrame *res = (InterpreterFrame *)(copy + frame->nlocalsplus);
-    return res;
+    memcpy(copy, frame, size);
+    return copy;
 }
 
 static inline void
@@ -103,7 +102,6 @@ take_ownership(PyFrameObject *f, InterpreterFrame *frame)
 int
 _PyFrame_Clear(InterpreterFrame * frame, int take)
 {
-    PyObject **localsarray = ((PyObject **)frame)-frame->nlocalsplus;
     if (frame->frame_obj) {
         PyFrameObject *f = frame->frame_obj;
         frame->frame_obj = NULL;
@@ -120,16 +118,13 @@ _PyFrame_Clear(InterpreterFrame * frame, int take)
         }
         Py_DECREF(f);
     }
-    for (int i = 0; i < frame->nlocalsplus; i++) {
-        Py_XDECREF(localsarray[i]);
-    }
-    assert(frame->stackdepth >= 0);
-    for (int i = 0; i < frame->stackdepth; i++) {
-        Py_DECREF(frame->stack[i]);
+    assert(_PyFrame_GetStackPointer(frame) >= _PyFrame_Stackbase(frame));
+    for (int i = 0; i < frame->stacktop; i++) {
+        Py_XDECREF(frame->localsplus[i]);
     }
     clear_specials(frame);
     if (take) {
-        PyMem_Free(_PyFrame_GetLocalsArray(frame));
+        PyMem_Free(frame);
     }
     return 0;
 }

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -958,9 +958,11 @@ class PyFramePtr:
         if self.is_optimized_out():
             return
 
+
         obj_ptr_ptr = gdb.lookup_type("PyObject").pointer().pointer()
-        base = self._gdbval.cast(obj_ptr_ptr)
-        localsplus = base - self._f_nlocalsplus()
+
+        localsplus = self._gdbval["localsplus"].cast(obj_ptr_ptr)
+
         for i in safe_range(self.co_nlocals):
             pyop_value = PyObjectPtr.from_pyobject_ptr(localsplus[i])
             if pyop_value.is_null():


### PR DESCRIPTION
Changes the layout of evaluation frames from:

* stack
* specials & linkage
* locals

to:

* stack
* locals
* specials & linkage

(Higher addresses at top)

Which is how the old frame object was laid out (at least after the "block stack" was removed).

This simplifies the code and is generally less surprising to the reader (locals is now a constant positive offset from the frame pointer, not a computed negative offset).

It is no slower, in fact it is [about 1% faster](https://gist.github.com/markshannon/c92adc066049e3dd608d0bc18bbb4b16)


<!-- issue-number: [bpo-44990](https://bugs.python.org/issue44990) -->
https://bugs.python.org/issue44990
<!-- /issue-number -->
