### PR TITLE
bpo-45018: Fix rangeiter_reduce in rangeobject.c

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -374,26 +374,28 @@ class RangeTest(unittest.TestCase):
                                      list(r))
 
     def test_iterator_pickling(self):
-        testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1),
-                     (13, 21, 3), (-2, 2, 2), (2**65, 2**65+2)]
+        testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1), (13, 21, 3),
+                     (-2, 2, 2), (2**31-3, 2**31-1), (2**33, 2**33+2),
+                     (2**63-3, 2**63-1), (2**65, 2**65+2)]
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             for t in testcases:
-                it = itorg = iter(range(*t))
-                data = list(range(*t))
+                with self.subTest(proto=proto, t=t):
+                    it = itorg = iter(range(*t))
+                    data = list(range(*t))
 
-                d = pickle.dumps(it, proto)
-                it = pickle.loads(d)
-                self.assertEqual(type(itorg), type(it))
-                self.assertEqual(list(it), data)
+                    d = pickle.dumps(it, proto)
+                    it = pickle.loads(d)
+                    self.assertEqual(type(itorg), type(it))
+                    self.assertEqual(list(it), data)
 
-                it = pickle.loads(d)
-                try:
-                    next(it)
-                except StopIteration:
-                    continue
-                d = pickle.dumps(it, proto)
-                it = pickle.loads(d)
-                self.assertEqual(list(it), data[1:])
+                    it = pickle.loads(d)
+                    try:
+                        next(it)
+                    except StopIteration:
+                        continue
+                    d = pickle.dumps(it, proto)
+                    it = pickle.loads(d)
+                    self.assertEqual(list(it), data[1:])
 
     def test_exhausted_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -401,7 +401,11 @@ class RangeTest(unittest.TestCase):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.subTest(proto=proto):
                 it = iter(range(2**32 + 2))
+                _, _, idx = it.__reduce__()
+                self.assertEqual(idx, 0)
                 it.__setstate__(2**32 + 1)  # undocumented way to set r->index
+                _, _, idx = it.__reduce__()
+                self.assertEqual(idx, 2**32)
                 d = pickle.dumps(it, proto)
                 it = pickle.loads(d)
                 self.assertEqual(next(it), 2**32 + 1)

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -397,6 +397,23 @@ class RangeTest(unittest.TestCase):
                     it = pickle.loads(d)
                     self.assertEqual(list(it), data[1:])
 
+    def test_iterator_pickling_overflowing_index(self):
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                it = itorg = iter(range(2**32 + 2))
+                data = list(range(2**32 + 2)[2**32:])
+
+                d = pickle.dumps(it, proto)
+                it = pickle.loads(d)
+                self.assertEqual(type(itorg), type(it))
+
+                it = pickle.loads(d)
+                it.__setstate__(2**32 + 1)  # undocumented way to set r->index
+                d = pickle.dumps(it, proto)
+                it = pickle.loads(d)
+                self.assertEqual(list(it), data[1:])
+
+
     def test_exhausted_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             r = range(2**65, 2**65+2)

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -405,7 +405,7 @@ class RangeTest(unittest.TestCase):
                 self.assertEqual(idx, 0)
                 it.__setstate__(2**32 + 1)  # undocumented way to set r->index
                 _, _, idx = it.__reduce__()
-                self.assertEqual(idx, 2**32)
+                self.assertEqual(idx, 2**32 + 1)
                 d = pickle.dumps(it, proto)
                 it = pickle.loads(d)
                 self.assertEqual(next(it), 2**32 + 1)

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -400,19 +400,11 @@ class RangeTest(unittest.TestCase):
     def test_iterator_pickling_overflowing_index(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.subTest(proto=proto):
-                it = itorg = iter(range(2**32 + 2))
-                data = list(range(2**32 + 2)[2**32:])
-
-                d = pickle.dumps(it, proto)
-                it = pickle.loads(d)
-                self.assertEqual(type(itorg), type(it))
-
-                it = pickle.loads(d)
+                it = iter(range(2**32 + 2))
                 it.__setstate__(2**32 + 1)  # undocumented way to set r->index
                 d = pickle.dumps(it, proto)
                 it = pickle.loads(d)
-                self.assertEqual(list(it), data[1:])
-
+                self.assertEqual(next(it), 2**32 + 1)
 
     def test_exhausted_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-26-18-44-03.bpo-45018.pu8H9L.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-26-18-44-03.bpo-45018.pu8H9L.rst
@@ -1,0 +1,1 @@
+Fixed pickling of range iterators that iterated for over 2**32 times.

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -813,7 +813,7 @@ rangeiter_reduce(rangeiterobject *r, PyObject *Py_UNUSED(ignored))
     if (range == NULL)
         goto err;
     /* return the result */
-    return Py_BuildValue("N(N)i", _PyEval_GetBuiltinId(&PyId_iter),
+    return Py_BuildValue("N(N)l", _PyEval_GetBuiltinId(&PyId_iter),
                          range, r->index);
 err:
     Py_XDECREF(start);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This commit changes an `i` to an `l` as `r->index` is a long not an int

<!-- issue-number: [bpo-45018](https://bugs.python.org/issue45018) -->
https://bugs.python.org/issue45018
<!-- /issue-number -->
