### PR TITLE
bpo-44995: Remove some incorrect REPL prompt markers

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -478,9 +478,9 @@ Random Remarks
 If the same attribute name occurs in both an instance and in a class,
 then attribute lookup prioritizes the instance::
 
-    >>> class Warehouse:
-            purpose = 'storage'
-            region = 'west'
+    class Warehouse:
+        purpose = 'storage'
+        region = 'west'
 
     >>> w1 = Warehouse()
     >>> print(w1.purpose, w1.region)


### PR DESCRIPTION
These cause the class to be partially hidden when clicking the >>> three angled button in the rendered Sphinx documentation.

Closes: https://bugs.python.org/issue44995

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44995](https://bugs.python.org/issue44995) -->
https://bugs.python.org/issue44995
<!-- /issue-number -->
