### PR TITLE
bpo-43613: Faster implementation of gzip.compress and gzip.decompress

### DIFF
--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -174,19 +174,30 @@ The module defines the following items:
 
    Compress the *data*, returning a :class:`bytes` object containing
    the compressed data.  *compresslevel* and *mtime* have the same meaning as in
-   the :class:`GzipFile` constructor above.
+   the :class:`GzipFile` constructor above. When *mtime* is set to ``0``, this
+   function is equivalent to :func:`zlib.compress` with *wbits* set to ``31``.
+   The zlib function is faster.
 
    .. versionadded:: 3.2
    .. versionchanged:: 3.8
       Added the *mtime* parameter for reproducible output.
+   .. versionchanged:: 3.11
+      Speed is improved by compressing all data at once instead of in a
+      streamed fashion. Calls with *mtime* set to ``0`` are delegated to
+      :func:`zlib.compress` for better speed.
 
 .. function:: decompress(data)
 
    Decompress the *data*, returning a :class:`bytes` object containing the
-   uncompressed data.
+   uncompressed data. This function is capable of decompressing multi-member
+   gzip data (multiple gzip blocks concatenated together). When the data is
+   certain to contain only one member the :func:`zlib.decompress` function with
+   *wbits* set to 31 is faster.
 
    .. versionadded:: 3.2
-
+   .. versionchanged:: 3.11
+      Speed is improved by decompressing members at once in memory instead of in
+      a streamed fashion.
 
 .. _gzip-usage-examples:
 

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -47,34 +47,17 @@ The available exception and functions in this module are:
       platforms, use ``adler32(data) & 0xffffffff``.
 
 
-.. function:: compress(data, /, level=-1)
+.. function:: compress(data, /, level=-1, wbits=MAX_WBITS)
 
    Compresses the bytes in *data*, returning a bytes object containing compressed data.
-   *level* is an integer from ``0`` to ``9`` or ``-1`` controlling the level of compression;
+
+    *level* is an integer from ``0`` to ``9`` or ``-1`` controlling the level of compression;
    ``1`` (Z_BEST_SPEED) is fastest and produces the least compression, ``9`` (Z_BEST_COMPRESSION)
    is slowest and produces the most.  ``0`` (Z_NO_COMPRESSION) is no compression.
    The default value is ``-1`` (Z_DEFAULT_COMPRESSION).  Z_DEFAULT_COMPRESSION represents a default
    compromise between speed and compression (currently equivalent to level 6).
-   Raises the :exc:`error` exception if any error occurs.
 
-   .. versionchanged:: 3.6
-      *level* can now be used as a keyword parameter.
-
-
-.. function:: compressobj(level=-1, method=DEFLATED, wbits=MAX_WBITS, memLevel=DEF_MEM_LEVEL, strategy=Z_DEFAULT_STRATEGY[, zdict])
-
-   Returns a compression object, to be used for compressing data streams that won't
-   fit into memory at once.
-
-   *level* is the compression level -- an integer from ``0`` to ``9`` or ``-1``.
-   A value of ``1`` (Z_BEST_SPEED) is fastest and produces the least compression,
-   while a value of ``9`` (Z_BEST_COMPRESSION) is slowest and produces the most.
-   ``0`` (Z_NO_COMPRESSION) is no compression.  The default value is ``-1`` (Z_DEFAULT_COMPRESSION).
-   Z_DEFAULT_COMPRESSION represents a default compromise between speed and compression
-   (currently equivalent to level 6).
-
-   *method* is the compression algorithm. Currently, the only supported value is
-   :const:`DEFLATED`.
+   .. _compress-wbits:
 
    The *wbits* argument controls the size of the history buffer (or the
    "window size") used when compressing data, and whether a header and
@@ -93,6 +76,33 @@ The available exception and functions in this module are:
    * +25 to +31 = 16 + (9 to 15): Uses the low 4 bits of the value as the
      window size logarithm, while including a basic :program:`gzip` header
      and trailing checksum in the output.
+
+   Raises the :exc:`error` exception if any error occurs.
+
+   .. versionchanged:: 3.6
+      *level* can now be used as a keyword parameter.
+
+   .. versionchanged:: 3.10
+      *wbits* parameter added.
+
+.. function:: compressobj(level=-1, method=DEFLATED, wbits=MAX_WBITS, memLevel=DEF_MEM_LEVEL, strategy=Z_DEFAULT_STRATEGY[, zdict])
+
+   Returns a compression object, to be used for compressing data streams that won't
+   fit into memory at once.
+
+   *level* is the compression level -- an integer from ``0`` to ``9`` or ``-1``.
+   A value of ``1`` (Z_BEST_SPEED) is fastest and produces the least compression,
+   while a value of ``9`` (Z_BEST_COMPRESSION) is slowest and produces the most.
+   ``0`` (Z_NO_COMPRESSION) is no compression.  The default value is ``-1`` (Z_DEFAULT_COMPRESSION).
+   Z_DEFAULT_COMPRESSION represents a default compromise between speed and compression
+   (currently equivalent to level 6).
+
+   *method* is the compression algorithm. Currently, the only supported value is
+   :const:`DEFLATED`.
+
+   The *wbits* parameter controls the size of the history buffer (or the
+   "window size"), and what header and trailer format will be used  It has
+   the same meaning as `described for compress() <#compress-wbits>`__.
 
    The *memLevel* argument controls the amount of memory used for the
    internal compression state. Valid values range from ``1`` to ``9``.

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -51,7 +51,7 @@ The available exception and functions in this module are:
 
    Compresses the bytes in *data*, returning a bytes object containing compressed data.
 
-    *level* is an integer from ``0`` to ``9`` or ``-1`` controlling the level of compression;
+   *level* is an integer from ``0`` to ``9`` or ``-1`` controlling the level of compression;
    ``1`` (Z_BEST_SPEED) is fastest and produces the least compression, ``9`` (Z_BEST_COMPRESSION)
    is slowest and produces the most.  ``0`` (Z_NO_COMPRESSION) is no compression.
    The default value is ``-1`` (Z_DEFAULT_COMPRESSION).  Z_DEFAULT_COMPRESSION represents a default

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -50,7 +50,6 @@ The available exception and functions in this module are:
 .. function:: compress(data, /, level=-1, wbits=MAX_WBITS)
 
    Compresses the bytes in *data*, returning a bytes object containing compressed data.
-
    *level* is an integer from ``0`` to ``9`` or ``-1`` controlling the level of compression;
    ``1`` (Z_BEST_SPEED) is fastest and produces the least compression, ``9`` (Z_BEST_COMPRESSION)
    is slowest and produces the most.  ``0`` (Z_NO_COMPRESSION) is no compression.
@@ -82,8 +81,9 @@ The available exception and functions in this module are:
    .. versionchanged:: 3.6
       *level* can now be used as a keyword parameter.
 
-   .. versionchanged:: 3.10
-      *wbits* parameter added.
+   .. versionchanged:: 3.11
+      The *wbits* parameter is now available to set window bits and
+      compression type.
 
 .. function:: compressobj(level=-1, method=DEFLATED, wbits=MAX_WBITS, memLevel=DEF_MEM_LEVEL, strategy=Z_DEFAULT_STRATEGY[, zdict])
 
@@ -101,7 +101,7 @@ The available exception and functions in this module are:
    :const:`DEFLATED`.
 
    The *wbits* parameter controls the size of the history buffer (or the
-   "window size"), and what header and trailer format will be used  It has
+   "window size"), and what header and trailer format will be used. It has
    the same meaning as `described for compress() <#compress-wbits>`__.
 
    The *memLevel* argument controls the amount of memory used for the

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -544,14 +544,43 @@ class _GzipReader(_compression.DecompressReader):
         super()._rewind()
         self._new_member = True
 
-def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
+
+def _create_simple_gzip_header(compresslevel: int,
+                               mtime = None) -> bytes:
+    """
+    Write a simple gzip header with no extra fields.
+    :param compresslevel: Compresslevel used to determine the xfl bytes.
+    :param mtime: The mtime (must support conversion to a 32-bit integer).
+    :return: A bytes object representing the gzip header.
+    """
+    if mtime is None:
+        mtime = time.time()
+    if compresslevel == _COMPRESS_LEVEL_BEST:
+        xfl = 2
+    elif compresslevel == _COMPRESS_LEVEL_FAST:
+        xfl = 4
+    else:
+        xfl = 0
+    # Pack ID1 and ID2 magic bytes, method (8=deflate), header flags (no extra
+    # fields added to header), mtime, xfl and os (255 for unknown OS).
+    return struct.pack("<BBBBLBB", 0x1f, 0x8b, 8, 0, int(mtime), xfl, 255)
+
+
+def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=0):
     """Compress data in one shot and return the compressed string.
     Optional argument is the compression level, in range of 0-9.
+    mtime can be used to set the modification time. 0 is default,
+    use 'None' for current time.
     """
-    buf = io.BytesIO()
-    with GzipFile(fileobj=buf, mode='wb', compresslevel=compresslevel, mtime=mtime) as f:
-        f.write(data)
-    return buf.getvalue()
+    if mtime == 0:
+        # Use zlib as it creates the header with 0 mtime by default.
+        # This is faster and with less overhead.
+        return zlib.compress(data, level=compresslevel, wbits=31)
+    header = _create_simple_gzip_header(compresslevel, mtime)
+    trailer = struct.pack("LL", zlib.crc32(data), (len(data) & 0xffffffff))
+    # Wbits=-15 creates a raw deflate block.
+    return b"".join([header, zlib.compress(data, wbits=-15), trailer])
+
 
 def decompress(data):
     """Decompress a gzip compressed string in one shot.

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -421,7 +421,7 @@ def _read_exact(fp, n):
 
 def _read_gzip_header(fp):
     '''Read a gzip header from `fp` and progress to the end of the header.
-    
+
     Returns last mtime if header was present or None otherwise.
     '''
     magic = fp.read(2)
@@ -579,9 +579,10 @@ def _create_simple_gzip_header(compresslevel: int,
 
 def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
     """Compress data in one shot and return the compressed string.
-    Optional argument is the compression level, in range of 0-9.
-    mtime can be used to set the modification time. 0 is default,
-    use 'None' for current time.
+
+    compresslevel sets the compression level in range of 0-9.
+    mtime can be used to set the modification time. The modification time is
+    set to the current time by default.
     """
     if mtime == 0:
         # Use zlib as it creates the header with 0 mtime by default.

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -587,7 +587,7 @@ def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=0):
         # This is faster and with less overhead.
         return zlib.compress(data, level=compresslevel, wbits=31)
     header = _create_simple_gzip_header(compresslevel, mtime)
-    trailer = struct.pack("LL", zlib.crc32(data), (len(data) & 0xffffffff))
+    trailer = struct.pack("<LL", zlib.crc32(data), (len(data) & 0xffffffff))
     # Wbits=-15 creates a raw deflate block.
     return b"".join([header, zlib.compress(data, wbits=-15), trailer])
 

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -589,7 +589,7 @@ def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
     header = _create_simple_gzip_header(compresslevel, mtime)
     trailer = struct.pack("<LL", zlib.crc32(data), (len(data) & 0xffffffff))
     # Wbits=-15 creates a raw deflate block.
-    return b"".join([header, zlib.compress(data, wbits=-15), trailer])
+    return header + zlib.compress(data, wbits=-15) + trailer
 
 
 def decompress(data):

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -605,9 +605,8 @@ def decompress(data):
         do = zlib.decompressobj(wbits=-zlib.MAX_WBITS)
         # Read all the data except the header
         decompressed = do.decompress(data[fp.tell():])
-        checksum, length = struct.unpack("<II", do.unused_data[:8])
-        crc = zlib.crc32(decompressed)
-        if crc != checksum:
+        crc, length = struct.unpack("<II", do.unused_data[:8])
+        if crc != zlib.crc32(decompressed):
             raise BadGzipFile("CRC check failed")
         if length != (len(block) & 0xffffffff):
             raise BadGzipFile("Incorrect length of data produced")

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -420,9 +420,10 @@ def _read_exact(fp, n):
 
 
 def _read_gzip_header(fp):
-    '''Read a gzip header from a filestream and progresses the stream to
-    the end of the header. Returns last mtime if header was present or None
-    if no header was present'''
+    '''Read a gzip header from `fp` and progress to the end of the header.
+    
+    Returns last mtime if header was present or None otherwise.
+    '''
     magic = fp.read(2)
     if magic == b'':
         return None

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -576,7 +576,7 @@ def _create_simple_gzip_header(compresslevel: int,
     return struct.pack("<BBBBLBB", 0x1f, 0x8b, 8, 0, int(mtime), xfl, 255)
 
 
-def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=0):
+def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
     """Compress data in one shot and return the compressed string.
     Optional argument is the compression level, in range of 0-9.
     mtime can be used to set the modification time. 0 is default,

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -831,6 +831,12 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         dco = zlib.decompressobj(32 + 15)
         self.assertEqual(dco.decompress(gzip), HAMLET_SCENE)
 
+        for wbits in (-15, 15, 31):
+            self.assertEqual(
+                zlib.decompress(
+                    zlib.compress(HAMLET_SCENE, wbits=wbits), wbits=wbits
+                ), HAMLET_SCENE)
+
 
 def choose_lines(source, number, seed=None, generator=random):
     """Return a list of number lines randomly chosen from the source"""

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -832,11 +832,12 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         self.assertEqual(dco.decompress(gzip), HAMLET_SCENE)
 
         for wbits in (-15, 15, 31):
-            self.assertEqual(
-                zlib.decompress(
+            with self.subTest(wbits=wbits):
+                expected = HAMLET_SCENE
+                actual = zlib.decompress(
                     zlib.compress(HAMLET_SCENE, wbits=wbits), wbits=wbits
-                ), HAMLET_SCENE)
-
+                )
+                self.assertEqual(expected, actual)
 
 def choose_lines(source, number, seed=None, generator=random):
     """Return a list of number lines randomly chosen from the source"""

--- a/Misc/NEWS.d/next/Library/2021-03-24-09-40-02.bpo-43612.vMGZ4y.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-24-09-40-02.bpo-43612.vMGZ4y.rst
@@ -1,0 +1,5 @@
+``zlib.compress`` now accepts a wbits parameter which allows users to
+compress data as a raw deflate block without zlib headers and trailers in
+one go. Previously this required instantiating a ``zlib.compressobj``. It
+also provides a faster alternative to ``gzip.compress`` when wbits=31 is
+used.

--- a/Misc/NEWS.d/next/Library/2021-03-24-09-40-02.bpo-43612.vMGZ4y.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-24-09-40-02.bpo-43612.vMGZ4y.rst
@@ -1,4 +1,4 @@
-``zlib.compress`` now accepts a wbits parameter which allows users to
+:func:``zlib.compress`` now accepts a wbits parameter which allows users to
 compress data as a raw deflate block without zlib headers and trailers in
 one go. Previously this required instantiating a ``zlib.compressobj``. It
 also provides a faster alternative to ``gzip.compress`` when wbits=31 is

--- a/Misc/NEWS.d/next/Library/2021-03-24-09-40-02.bpo-43612.vMGZ4y.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-24-09-40-02.bpo-43612.vMGZ4y.rst
@@ -1,4 +1,4 @@
-:func:``zlib.compress`` now accepts a wbits parameter which allows users to
+:func:`zlib.compress` now accepts a wbits parameter which allows users to
 compress data as a raw deflate block without zlib headers and trailers in
 one go. Previously this required instantiating a ``zlib.compressobj``. It
 also provides a faster alternative to ``gzip.compress`` when wbits=31 is

--- a/Misc/NEWS.d/next/Library/2021-08-25-10-28-49.bpo-43613.WkYmI0.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-25-10-28-49.bpo-43613.WkYmI0.rst
@@ -1,0 +1,3 @@
+Improve the speed of :func:`gzip.compress` and :func:`gzip.decompress` by
+compressing and decompressing at once in memory instead of in a streamed
+fashion.

--- a/Modules/clinic/zlibmodule.c.h
+++ b/Modules/clinic/zlibmodule.c.h
@@ -3,7 +3,7 @@ preserve
 [clinic start generated code]*/
 
 PyDoc_STRVAR(zlib_compress__doc__,
-"compress($module, data, /, level=Z_DEFAULT_COMPRESSION)\n"
+"compress($module, data, /, level=Z_DEFAULT_COMPRESSION, wbits=MAX_WBITS)\n"
 "--\n"
 "\n"
 "Returns a bytes object containing compressed data.\n"
@@ -11,7 +11,9 @@ PyDoc_STRVAR(zlib_compress__doc__,
 "  data\n"
 "    Binary data to be compressed.\n"
 "  level\n"
-"    Compression level, in 0-9 or -1.");
+"    Compression level, in 0-9 or -1.\n"
+"  wbits\n"
+"    The window buffer size and container format.");
 
 #define ZLIB_COMPRESS_METHODDEF    \
     {"compress", (PyCFunction)(void(*)(void))zlib_compress, METH_FASTCALL|METH_KEYWORDS, zlib_compress__doc__},
@@ -25,13 +27,13 @@ zlib_compress(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"", "level", "wbits", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "compress", 0};
-    PyObject *argsbuf[2];
+    PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     Py_buffer data = {NULL, NULL};
     int level = Z_DEFAULT_COMPRESSION;
     int wbits = MAX_WBITS;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 3, 0, argsbuf);
     if (!args) {
         goto exit;
     }
@@ -54,17 +56,9 @@ zlib_compress(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
             goto skip_optional_pos;
         }
     }
-    {
-        int ival = -1;
-        PyObject *iobj = _PyNumber_Index(args[2]);
-        if (iobj != NULL) {
-            ival = _PyLong_AsInt(iobj);
-            Py_DECREF(iobj);
-        }
-        if (ival == -1 && PyErr_Occurred()) {
-            goto exit;
-        }
-        wbits = ival;
+    wbits = _PyLong_AsInt(args[2]);
+    if (wbits == -1 && PyErr_Occurred()) {
+        goto exit;
     }
 skip_optional_pos:
     return_value = zlib_compress_impl(module, &data, level, wbits);
@@ -821,4 +815,4 @@ exit:
 #ifndef ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF
     #define ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF
 #endif /* !defined(ZLIB_DECOMPRESS___DEEPCOPY___METHODDEF) */
-/*[clinic end generated code: output=6736bae59fab268b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e3e8a6142ea045a7 input=a9049054013a1b77]*/

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -310,12 +310,14 @@ zlib.compress
     /
     level: int(c_default="Z_DEFAULT_COMPRESSION") = Z_DEFAULT_COMPRESSION
         Compression level, in 0-9 or -1.
+    wbits: int(c_default="MAX_WBITS") = MAX_WBITS
+        The window buffer size and container format.
 
 Returns a bytes object containing compressed data.
 [clinic start generated code]*/
 
 static PyObject *
-zlib_compress_impl(PyObject *module, Py_buffer *data, int level)
+zlib_compress_impl(PyObject *module, Py_buffer *data, int level, int wbits)
 /*[clinic end generated code: output=d80906d73f6294c8 input=638d54b6315dbed3]*/
 {
     PyObject *RetVal;
@@ -336,7 +338,7 @@ zlib_compress_impl(PyObject *module, Py_buffer *data, int level)
     zst.zalloc = PyZlib_Malloc;
     zst.zfree = PyZlib_Free;
     zst.next_in = ibuf;
-    int err = deflateInit(&zst, level);
+    int err =  deflateInit2(&zst, level, DEFLATED, wbits, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
 
     switch (err) {
     case Z_OK:

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -318,7 +318,7 @@ Returns a bytes object containing compressed data.
 
 static PyObject *
 zlib_compress_impl(PyObject *module, Py_buffer *data, int level, int wbits)
-/*[clinic end generated code: output=d80906d73f6294c8 input=638d54b6315dbed3]*/
+/*[clinic end generated code: output=46bd152fadd66df2 input=c4d06ee5782a7e3f]*/
 {
     PyObject *RetVal;
     int flush;

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -338,7 +338,8 @@ zlib_compress_impl(PyObject *module, Py_buffer *data, int level, int wbits)
     zst.zalloc = PyZlib_Malloc;
     zst.zfree = PyZlib_Free;
     zst.next_in = ibuf;
-    int err =  deflateInit2(&zst, level, DEFLATED, wbits, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+    int err = deflateInit2(&zst, level, DEFLATED, wbits, DEF_MEM_LEVEL,
+                           Z_DEFAULT_STRATEGY);
 
     switch (err) {
     case Z_OK:


### PR DESCRIPTION
This also includes the changes from https://github.com/python/cpython/pull/25011 for [bpo-43612](https://bugs.python.org/issue43612). These make more sense in the context of these changes.

Currently gzip.compress and gzip.decompress are implemented with GzipFile. This is a lot of overhead when a simple in memory compression is needed. As shown in the benchmarks below, the overhead is considerable for datasizes below 4096 bytes (which are probably very common targets for in memory compression and decompression).

This PR changes the implementations to compress and decompress in memory.

I compiled python before and after this change with `--enable-optimizations` to ensure a fair comparison.
I used this script to benchmark:

```python
import gzip
import pathlib
import statistics
import sys
import timeit

DATA=pathlib.Path(sys.argv[1]).read_bytes()

SIZES = [0, 128, 512, 1024, 4096, 8192, 16384]

def benchmark(bench_string, number=1000, repetitions=10):
    for size in SIZES:
        data = DATA[:size]
        compressed_data = gzip.compress(data)
        timeit_kwargs=dict(globals=dict(**locals(), **globals()),
                           number=number)
        results = [timeit.timeit(bench_string, **timeit_kwargs) for _ in range(repetitions)]
        average = statistics.mean(results)
        print(f"Data size {size}: {round(average * (1_000_000 / number),2)} microseconds average")

if __name__ == "__main__":
    print("gzip compression")
    benchmark("gzip.compress(compressed_data)")
    print()
    print("gzip decompression")
    benchmark("gzip.decompress(compressed_data)")
```

Before:
```
gzip compression
Data size 0: 7.92 microseconds average
Data size 128: 12.1 microseconds average
Data size 512: 18.45 microseconds average
Data size 1024: 22.41 microseconds average
Data size 4096: 32.51 microseconds average
Data size 8192: 41.03 microseconds average
Data size 16384: 57.99 microseconds average

gzip decompression
Data size 0: 8.99 microseconds average
Data size 128: 10.26 microseconds average
Data size 512: 12.62 microseconds average
Data size 1024: 13.55 microseconds average
Data size 4096: 21.12 microseconds average
Data size 8192: 30.59 microseconds average
Data size 16384: 61.24 microseconds average

```

After:
```
gzip compression
Data size 0: 3.68 microseconds average
Data size 128: 7.64 microseconds average
Data size 512: 14.06 microseconds average
Data size 1024: 17.42 microseconds average
Data size 4096: 27.25 microseconds average
Data size 8192: 37.09 microseconds average
Data size 16384: 53.48 microseconds average

gzip decompression
Data size 0: 1.98 microseconds average
Data size 128: 3.74 microseconds average
Data size 512: 5.36 microseconds average
Data size 1024: 6.72 microseconds average
Data size 4096: 14.1 microseconds average
Data size 8192: 23.57 microseconds average
Data size 16384: 52.72 microseconds average
```



<!-- issue-number: [bpo-43613](https://bugs.python.org/issue43613) -->
https://bugs.python.org/issue43613
<!-- /issue-number -->
