### PR TITLE
bpo-45000: Raise SyntaxError when try to delete __debug__

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -176,9 +176,7 @@ Other CPython Implementation Changes
   support :class:`typing.SupportsComplex` and :class:`typing.SupportsBytes` protocols.
   (Contributed by Mark Dickinson and Dong-hee Na in :issue:`24234`.)
 
-* if user try to delete :const:`__debug__`, CPython now raises :exc:`SyntaxError` instead of
-  :exc:`NameError`.
-  (Contributed by Dong-hee Na in :issue:`45000`.)
+*  A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting the :const:`__debug__` constant. (Contributed by Dong-hee Na in :issue:`45000`.)
 
 
 New Modules

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -176,6 +176,10 @@ Other CPython Implementation Changes
   support :class:`typing.SupportsComplex` and :class:`typing.SupportsBytes` protocols.
   (Contributed by Mark Dickinson and Dong-hee Na in :issue:`24234`.)
 
+* if user try to delete :const:`__debug__`, CPython now raises :exc:`SyntaxError` instead of
+  :exc:`NameError`.
+  (Contributed by Dong-hee Na in :issue:`45000`.)
+
 
 New Modules
 ===========

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -59,6 +59,10 @@ SyntaxError: cannot assign to __debug__
 Traceback (most recent call last):
 SyntaxError: cannot assign to __debug__
 
+>>> del __debug__
+Traceback (most recent call last):
+SyntaxError: cannot delete __debug__
+
 >>> f() = 1
 Traceback (most recent call last):
 SyntaxError: cannot assign to function call here. Maybe you meant '==' instead of '='?

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
@@ -1,2 +1,2 @@
-Raise a :exc:`SyntaxError` when try to deleting `__debug__`. Patch by
+Raise a :exc:`SyntaxError` when try to delete `__debug__`. Patch by
 Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
@@ -1,0 +1,2 @@
+Raise a :exc:`SyntaxError` when try to deleting `__debug__`. Patch by
+Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
@@ -1,2 +1,2 @@
-Raise a :exc:`SyntaxError` when try to delete :const:`__debug__`.
+A :exc:`SyntaxError` is now raised when trying to delete :const:`__debug__`.
 Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
@@ -1,2 +1,2 @@
-Raise a :exc:`SyntaxError` when try to delete `__debug__`. Patch by
-Dong-hee Na.
+Raise a :exc:`SyntaxError` when try to delete :const:`__debug__`.
+Patch by Dong-hee Na.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2343,6 +2343,10 @@ forbidden_name(struct compiler *c, identifier name, expr_context_ty ctx)
         compiler_error(c, "cannot assign to __debug__");
         return 1;
     }
+    if (ctx == Del && _PyUnicode_EqualToASCIIString(name, "__debug__")) {
+        compiler_error(c, "cannot delete __debug__");
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45000](https://bugs.python.org/issue45000) -->
https://bugs.python.org/issue45000
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal