### PR TITLE
bpo-42527: Use ignore mode instead strict for headers enconding in order to encode headers with special chars like emojis

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -506,7 +506,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                 self._headers_buffer = []
             self._headers_buffer.append(("%s %d %s\r\n" %
                     (self.protocol_version, code, message)).encode(
-                        'utf-8', 'strict'))
+                        'latin-1', 'ignore'))
 
     def send_header(self, keyword, value):
         """Send a MIME header to the headers buffer."""
@@ -514,7 +514,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
             if not hasattr(self, '_headers_buffer'):
                 self._headers_buffer = []
             self._headers_buffer.append(
-                ("%s: %s\r\n" % (keyword, value)).encode('utf-8', 'strict'))
+                ("%s: %s\r\n" % (keyword, value)).encode('latin-1', 'ignore'))
 
         if keyword.lower() == 'connection':
             if value.lower() == 'close':

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -506,7 +506,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
                 self._headers_buffer = []
             self._headers_buffer.append(("%s %d %s\r\n" %
                     (self.protocol_version, code, message)).encode(
-                        'latin-1', 'strict'))
+                        'utf-8', 'strict'))
 
     def send_header(self, keyword, value):
         """Send a MIME header to the headers buffer."""
@@ -514,7 +514,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
             if not hasattr(self, '_headers_buffer'):
                 self._headers_buffer = []
             self._headers_buffer.append(
-                ("%s: %s\r\n" % (keyword, value)).encode('latin-1', 'strict'))
+                ("%s: %s\r\n" % (keyword, value)).encode('utf-8', 'strict'))
 
         if keyword.lower() == 'connection':
             if value.lower() == 'close':

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -126,6 +126,14 @@ class BaseHTTPServerTestCase(BaseTestCase):
             body = self.headers['x-special-incoming'].encode('utf-8')
             self.wfile.write(body)
 
+        def do_LATINONEEMOJIHEADER(self):
+            self.send_response(999)
+            self.send_header('X-Special', 'Emoji Dängerous Mind🛒')
+            self.send_header('Connection', 'close')
+            self.end_headers()
+            body = self.headers['x-special-incoming'].encode('utf-8')
+            self.wfile.write(body)
+
         def do_SEND_ERROR(self):
             self.send_error(int(self.path[1:]))
 
@@ -242,6 +250,14 @@ class BaseHTTPServerTestCase(BaseTestCase):
         })
         res = self.con.getresponse()
         self.assertEqual(res.getheader('X-Special'), 'Dängerous Mind')
+        self.assertEqual(res.read(), 'Ärger mit Unicode'.encode('utf-8'))
+
+    def test_latin1_header_with_emoji(self):
+        self.con.request('LATINONEEMOJIHEADER', '/', headers={
+            'X-Special-Incoming':       'Ärger mit Unicode'
+        })
+        res = self.con.getresponse()
+        self.assertEqual(res.getheader('X-Special'), 'Emoji Dängerous Mind')
         self.assertEqual(res.read(), 'Ärger mit Unicode'.encode('utf-8'))
 
     def test_error_content_length(self):

--- a/Misc/NEWS.d/next/Library/2021-08-25-15-33-23.bpo-42527.M7RMp5.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-25-15-33-23.bpo-42527.M7RMp5.rst
@@ -1,0 +1,1 @@
+Use utf-8 instead of latin-1

--- a/Misc/NEWS.d/next/Library/2021-08-25-16-15-39.bpo-42527.M7RMp5.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-25-16-15-39.bpo-42527.M7RMp5.rst
@@ -1,0 +1,1 @@
+Use utf-8 instead of latin-1

--- a/Misc/NEWS.d/next/Library/2021-08-25-16-16-34.bpo-42527.DrXbr7.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-25-16-16-34.bpo-42527.DrXbr7.rst
@@ -1,0 +1,1 @@
+Use ignore mode instead strict for headers enconding in order to encode headers with special chars like emojis


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42527](https://bugs.python.org/issue42527) -->
https://bugs.python.org/issue42527
<!-- /issue-number -->
