### PR TITLE
bpo-45003: Change __div__ to __truediv__ in py3 language reference.

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1256,7 +1256,7 @@ integer; the result is that of mathematical division with the 'floor' function
 applied to the result.  Division by zero raises the :exc:`ZeroDivisionError`
 exception.
 
-This operation can be customized using the special :meth:`__div__` and
+This operation can be customized using the special :meth:`__truediv__` and
 :meth:`__floordiv__` methods.
 
 .. index::


### PR DESCRIPTION
Change `__div__` to `__truediv__` in Python 3's Language Reference, Chapter 6, Section 7.


<!-- issue-number: [bpo-45003](https://bugs.python.org/issue45003) -->
https://bugs.python.org/issue45003
<!-- /issue-number -->
