### PR TITLE
Change quotes in tarfile docstrings to backticks

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1015,7 +1015,7 @@ class TarInfo(object):
         for keyword, value in pax_headers.items():
             keyword = keyword.encode("utf-8")
             if binary:
-                # Try to restore the original byte representation of `value'.
+                # Try to restore the original byte representation of `value`.
                 # Needless to say, that the encoding must match the string.
                 value = value.encode(encoding, "surrogateescape")
             else:
@@ -1453,13 +1453,13 @@ class TarFile(object):
             tarinfo=None, dereference=None, ignore_zeros=None, encoding=None,
             errors="surrogateescape", pax_headers=None, debug=None,
             errorlevel=None, copybufsize=None):
-        """Open an (uncompressed) tar archive `name'. `mode' is either 'r' to
+        """Open an (uncompressed) tar archive `name`. `mode` is either 'r' to
            read from an existing archive, 'a' to append data to an existing
-           file or 'w' to create a new file overwriting an existing one. `mode'
+           file or 'w' to create a new file overwriting an existing one. `mode`
            defaults to 'r'.
-           If `fileobj' is given, it is used for reading or writing data. If it
-           can be determined, `mode' is overridden by `fileobj's mode.
-           `fileobj' is not closed, when TarFile is closed.
+           If `fileobj` is given, it is used for reading or writing data. If it
+           can be determined, `mode` is overridden by `fileobj`'s mode.
+           `fileobj` is not closed, when TarFile is closed.
         """
         modes = {"r": "rb", "a": "r+b", "w": "wb", "x": "xb"}
         if mode not in modes:
@@ -1784,7 +1784,7 @@ class TarFile(object):
                 self.fileobj.close()
 
     def getmember(self, name):
-        """Return a TarInfo object for member `name'. If `name' can not be
+        """Return a TarInfo object for member `name`. If `name` can not be
            found in the archive, KeyError is raised. If a member occurs more
            than once in the archive, its last occurrence is assumed to be the
            most up-to-date version.
@@ -1812,11 +1812,11 @@ class TarFile(object):
 
     def gettarinfo(self, name=None, arcname=None, fileobj=None):
         """Create a TarInfo object from the result of os.stat or equivalent
-           on an existing file. The file is either named by `name', or
-           specified as a file object `fileobj' with a file descriptor. If
-           given, `arcname' specifies an alternative name for the file in the
-           archive, otherwise, the name is taken from the 'name' attribute of
-           'fileobj', or the 'name' argument. The name should be a text
+           on an existing file. The file is either named by `name`, or
+           specified as a file object `fileobj` with a file descriptor. If
+           given, `arcname` specifies an alternative name for the file in the
+           archive, otherwise, the name is taken from the `name` attribute of
+           `fileobj`, or the `name` argument. The name should be a text
            string.
         """
         self._check("awx")
@@ -1910,9 +1910,9 @@ class TarFile(object):
         return tarinfo
 
     def list(self, verbose=True, *, members=None):
-        """Print a table of contents to sys.stdout. If `verbose' is False, only
-           the names of the members are printed. If it is True, an `ls -l'-like
-           output is produced. `members' is optional and must be a subset of the
+        """Print a table of contents to sys.stdout. If `verbose` is False, only
+           the names of the members are printed. If it is True, an `ls -l`-like
+           output is produced. `members` is optional and must be a subset of the
            list returned by getmembers().
         """
         self._check()
@@ -1942,11 +1942,11 @@ class TarFile(object):
             print()
 
     def add(self, name, arcname=None, recursive=True, *, filter=None):
-        """Add the file `name' to the archive. `name' may be any type of file
-           (directory, fifo, symbolic link, etc.). If given, `arcname'
+        """Add the file `name` to the archive. `name` may be any type of file
+           (directory, fifo, symbolic link, etc.). If given, `arcname`
            specifies an alternative name for the file in the archive.
            Directories are added recursively by default. This can be avoided by
-           setting `recursive' to False. `filter' is a function
+           setting `recursive` to False. `filter` is a function
            that expects a TarInfo object argument and returns the changed
            TarInfo object, if it returns None the TarInfo object will be
            excluded from the archive.
@@ -1993,7 +1993,7 @@ class TarFile(object):
             self.addfile(tarinfo)
 
     def addfile(self, tarinfo, fileobj=None):
-        """Add the TarInfo object `tarinfo' to the archive. If `fileobj' is
+        """Add the TarInfo object `tarinfo` to the archive. If `fileobj` is
            given, it should be a binary file, and tarinfo.size bytes are read
            from it and added to the archive. You can create TarInfo objects
            directly, or by using gettarinfo().
@@ -2020,8 +2020,8 @@ class TarFile(object):
     def extractall(self, path=".", members=None, *, numeric_owner=False):
         """Extract all members from the archive to the current working
            directory and set owner, modification time and permissions on
-           directories afterwards. `path' specifies a different directory
-           to extract to. `members' is optional and must be a subset of the
+           directories afterwards. `path` specifies a different directory
+           to extract to. `members` is optional and must be a subset of the
            list returned by getmembers(). If `numeric_owner` is True, only
            the numbers for user/group names are used and not the names.
         """
@@ -2060,9 +2060,9 @@ class TarFile(object):
     def extract(self, member, path="", set_attrs=True, *, numeric_owner=False):
         """Extract a member from the archive to the current working directory,
            using its full name. Its file information is extracted as accurately
-           as possible. `member' may be a filename or a TarInfo object. You can
-           specify a different directory using `path'. File attributes (owner,
-           mtime, mode) are set unless `set_attrs' is False. If `numeric_owner`
+           as possible. `member` may be a filename or a TarInfo object. You can
+           specify a different directory using `path`. File attributes (owner,
+           mtime, mode) are set unless `set_attrs` is False. If `numeric_owner`
            is True, only the numbers for user/group names are used and not
            the names.
         """
@@ -2096,10 +2096,10 @@ class TarFile(object):
                 self._dbg(1, "tarfile: %s" % e)
 
     def extractfile(self, member):
-        """Extract a member from the archive as a file object. `member' may be
-           a filename or a TarInfo object. If `member' is a regular file or
+        """Extract a member from the archive as a file object. `member` may be
+           a filename or a TarInfo object. If `member` is a regular file or
            a link, an io.BufferedReader object is returned. For all other
-           existing members, None is returned. If `member' does not appear
+           existing members, None is returned. If `member` does not appear
            in the archive, KeyError is raised.
         """
         self._check("r")
@@ -2480,7 +2480,7 @@ def is_tarfile(name):
     """Return True if name points to a tar archive that we
        are able to handle, else return False.
 
-       'name' should be a string, file, or file-like object.
+       `name` should be a string, file, or file-like object.
     """
     try:
         if hasattr(name, "read"):


### PR DESCRIPTION
In `tarfile.py`, some of the docstrings contain references to variables, which are wrapped in backticks to format them as code. However, some of these are written with an opening backtick and closing single quote, which breaks the formatting in my IDE. This PR fixes this by changing the relevant single quotes to backticks.