### PR TITLE
[3.10] bpo-45000: Raise SyntaxError when try to delete __debug__ (GH-27947)

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -59,6 +59,10 @@ SyntaxError: cannot assign to __debug__
 Traceback (most recent call last):
 SyntaxError: cannot assign to __debug__
 
+>>> del __debug__
+Traceback (most recent call last):
+SyntaxError: cannot delete __debug__
+
 >>> f() = 1
 Traceback (most recent call last):
 SyntaxError: cannot assign to function call here. Maybe you meant '==' instead of '='?

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-25-23-17-32.bpo-45000.XjmyLl.rst
@@ -1,0 +1,2 @@
+A :exc:`SyntaxError` is now raised when trying to delete :const:`__debug__`.
+Patch by Dong-hee Na.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2264,6 +2264,10 @@ forbidden_name(struct compiler *c, identifier name, expr_context_ty ctx)
         compiler_error(c, "cannot assign to __debug__");
         return 1;
     }
+    if (ctx == Del && _PyUnicode_EqualToASCIIString(name, "__debug__")) {
+        compiler_error(c, "cannot delete __debug__");
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
(cherry picked from commit 551da597a0996b0fb3af425f48aa5bc63ea6b963)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45000](https://bugs.python.org/issue45000) -->
https://bugs.python.org/issue45000
<!-- /issue-number -->
