### PR TITLE
bpo-45010: Remove support of special method __div__ in unittest.mock

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2020,7 +2020,7 @@ The full list of supported magic methods is:
 * Context manager: ``__enter__``, ``__exit__``, ``__aenter__`` and ``__aexit__``
 * Unary numeric methods: ``__neg__``, ``__pos__`` and ``__invert__``
 * The numeric methods (including right hand and in-place variants):
-  ``__add__``, ``__sub__``, ``__mul__``, ``__matmul__``, ``__div__``, ``__truediv__``,
+  ``__add__``, ``__sub__``, ``__mul__``, ``__matmul__``, ``__truediv__``,
   ``__floordiv__``, ``__mod__``, ``__divmod__``, ``__lshift__``,
   ``__rshift__``, ``__and__``, ``__xor__``, ``__or__``, and ``__pow__``
 * Numeric conversion methods: ``__complex__``, ``__int__``, ``__float__``

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1929,7 +1929,7 @@ magic_methods = (
 )
 
 numerics = (
-    "add sub mul matmul div floordiv mod lshift rshift and xor or pow truediv"
+    "add sub mul matmul truediv floordiv mod lshift rshift and xor or pow"
 )
 inplace = ' '.join('i%s' % n for n in numerics.split())
 right = ' '.join('r%s' % n for n in numerics.split())

--- a/Misc/NEWS.d/next/Library/2021-08-26-09-54-14.bpo-45010.Cn23bQ.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-26-09-54-14.bpo-45010.Cn23bQ.rst
@@ -1,0 +1,2 @@
+Remove support of special method ``__div__`` in :mod:`unittest.mock`. It is
+not used in Python 3.


### PR DESCRIPTION


<!-- issue-number: [bpo-45010](https://bugs.python.org/issue45010) -->
https://bugs.python.org/issue45010
<!-- /issue-number -->
