### PR TITLE
bpo-45030: Fix integer overflow in __reduce__ of the range iterator

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -375,8 +375,14 @@ class RangeTest(unittest.TestCase):
 
     def test_iterator_pickling(self):
         testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1), (13, 21, 3),
-                     (-2, 2, 2), (2**31-3, 2**31-1), (2**33, 2**33+2),
-                     (2**63-3, 2**63-1), (2**65, 2**65+2)]
+                     (-2, 2, 2)]
+        for M in 2**31, 2**63:
+            testcases += [
+                (M-3, M-1), (4*M, 4*M+2),
+                (M-2, M-1, 2), (-M+1, -M, -2),
+                (1, 2, M-1), (-1, -2, -M),
+                (1, M-1, M-1), (-1, -M, -M),
+            ]
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             for t in testcases:
                 with self.subTest(proto=proto, t=t):

--- a/Misc/NEWS.d/next/Library/2021-08-27-19-01-23.bpo-45030.tAmBbY.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-27-19-01-23.bpo-45030.tAmBbY.rst
@@ -1,0 +1,1 @@
+Fix integer overflow in pickling and copying the range iterator.


### PR DESCRIPTION


<!-- issue-number: [bpo-45030](https://bugs.python.org/issue45030) -->
https://bugs.python.org/issue45030
<!-- /issue-number -->
