### PR TITLE
bpo-44925: [docs] Confusing deprecation notice for typing.IO

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1507,8 +1507,7 @@ Other concrete types
    :func:`open`.
 
    .. deprecated-removed:: 3.8 3.12
-      These types are also in the ``typing.io`` namespace, which was
-      never supported by type checkers and will be removed.
+      ``typing.io`` namespace is deprecated and will be removed.
 
 .. class:: Pattern
            Match

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1507,7 +1507,8 @@ Other concrete types
    :func:`open`.
 
    .. deprecated-removed:: 3.8 3.12
-      ``typing.io`` namespace is deprecated and will be removed.
+      The ``typing.io`` and ``typing.re`` namespaces are deprecated and will be
+      removed.
 
 .. class:: Pattern
            Match

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1507,7 +1507,7 @@ Other concrete types
    :func:`open`.
 
    .. deprecated-removed:: 3.8 3.12
-      The ``typing.io`` namespaces is deprecated and will be removed.
+      The ``typing.io`` namespace is deprecated and will be removed.
       These types should be directly imported from ``typing`` instead.
 
 .. class:: Pattern

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1507,8 +1507,8 @@ Other concrete types
    :func:`open`.
 
    .. deprecated-removed:: 3.8 3.12
-      The ``typing.io`` and ``typing.re`` namespaces are deprecated and will be
-      removed.
+      The ``typing.io`` namespaces is deprecated and will be removed.
+      These types should be directly imported from ``typing`` instead.
 
 .. class:: Pattern
            Match
@@ -1521,8 +1521,8 @@ Other concrete types
    ``Match[bytes]``.
 
    .. deprecated-removed:: 3.8 3.12
-      These types are also in the ``typing.re`` namespace, which was
-      never supported by type checkers and will be removed.
+      The ``typing.re`` namespace is deprecated and will be removed.
+      These types should be directly imported from ``typing`` instead.
 
    .. deprecated:: 3.9
       Classes ``Pattern`` and ``Match`` from :mod:`re` now support ``[]``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44925](https://bugs.python.org/issue44925) -->
https://bugs.python.org/issue44925
<!-- /issue-number -->
