### PR TITLE
bpo-43913: Fix bugs in cleaning up classes and modules in unittest.

### DIFF
--- a/Lib/unittest/suite.py
+++ b/Lib/unittest/suite.py
@@ -149,8 +149,9 @@ class TestSuite(BaseTestSuite):
         if getattr(currentClass, "__unittest_skip__", False):
             return
 
+        failed = False
         try:
-            failed = currentClass._classSetupFailed = False
+            currentClass._classSetupFailed = False
         except TypeError:
             # test may actually be a function
             # so its class will be a builtin-type
@@ -166,8 +167,9 @@ class TestSuite(BaseTestSuite):
                 except Exception as e:
                     if isinstance(result, _DebugResult):
                         raise
+                    failed = True
                     try:
-                        failed = currentClass._classSetupFailed = True
+                        currentClass._classSetupFailed = True
                     except TypeError:
                         pass
                     className = util.strclass(currentClass)

--- a/Misc/NEWS.d/next/Library/2021-08-27-23-40-51.bpo-43913.Uo1Gt5.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-27-23-40-51.bpo-43913.Uo1Gt5.rst
@@ -1,0 +1,8 @@
+Fix bugs in cleaning up classes and modules in :mod:`unittest`:
+
+* Functions registered with :func:`~unittest.addModuleCleanup` were not called unless the user defines ``tearDownModule()`` in their test module.
+* Functions registered with :meth:`~unittest.TestCase.addClassCleanup` were not called if ``tearDownClass`` is set to ``None``.
+* Buffering in :class:`~unittest.TestResult` did not work with functions registered with ``addClassCleanup()`` and ``addModuleCleanup()``.
+* Errors in functions registered with ``addClassCleanup()`` and ``addModuleCleanup()`` were not handled correctly in buffered and debug modes.
+* Errors in ``setUpModule()`` and functions registered with ``addModuleCleanup()`` were reported in wrong order.
+* And several lesser bugs.


### PR DESCRIPTION
* Functions registered with addModuleCleanup() were not called unless
  the user defines tearDownModule() in their test module.
* Functions registered with addClassCleanup() were not called if
  tearDownClass is set to None.
* Buffering in TestResult did not work with functions registered
  with addClassCleanup() and addModuleCleanup().
* Errors in functions registered with addClassCleanup() and
  addModuleCleanup() were not handled correctly in buffered and
  debug modes.
* Errors in setUpModule() and functions registered with
  addModuleCleanup() were reported in wrong order.
* And several lesser bugs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43913](https://bugs.python.org/issue43913) -->
https://bugs.python.org/issue43913
<!-- /issue-number -->
