### PR TITLE
bpo-45021: Fix a hang in forked children

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -36,6 +36,12 @@ def _python_exit():
 # See bpo-39812 for context.
 threading._register_atexit(_python_exit)
 
+# Make sure `_global_shutdown_lock` is reinit in forked children
+if hasattr(os, 'register_at_fork'):
+    os.register_at_fork(before=_global_shutdown_lock.acquire,
+                        after_in_child=_global_shutdown_lock._at_fork_reinit,
+                        after_in_parent=_global_shutdown_lock.release)
+
 
 class _WorkItem(object):
     def __init__(self, future, fn, args, kwargs):

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -36,7 +36,7 @@ def _python_exit():
 # See bpo-39812 for context.
 threading._register_atexit(_python_exit)
 
-# Make sure `_global_shutdown_lock` is reinit in forked children
+# At fork, reinitialize the `_global_shutdown_lock` lock in the child process
 if hasattr(os, 'register_at_fork'):
     os.register_at_fork(before=_global_shutdown_lock.acquire,
                         after_in_child=_global_shutdown_lock._at_fork_reinit,

--- a/Misc/NEWS.d/next/Library/2021-08-28-13-00-12.bpo-45021.rReeaj.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-28-13-00-12.bpo-45021.rReeaj.rst
@@ -1,0 +1,1 @@
+Fix a potential deadlock at shutdown of forked children when using :mod:`concurrent.futures` module


### PR DESCRIPTION
_global_shutdown_lock should be reinitialized in forked children

<!-- issue-number: [bpo-45021](https://bugs.python.org/issue45021) -->
https://bugs.python.org/issue45021
<!-- /issue-number -->
