### PR TITLE
bpo-19113: remove unused test_errors

### DIFF
--- a/Lib/ctypes/test/test_functions.py
+++ b/Lib/ctypes/test/test_functions.py
@@ -209,15 +209,6 @@ class FunctionTestCase(unittest.TestCase):
         result = f(byref(c_int(99)))
         self.assertNotEqual(result.contents, 99)
 
-    def test_errors(self):
-        f = dll._testfunc_p_p
-        f.restype = c_int
-
-        class X(Structure):
-            _fields_ = [("y", c_int)]
-
-        self.assertRaises(TypeError, f, X()) #cannot convert parameter
-
     ################################################################
     def test_shorts(self):
         f = dll._testfunc_callback_i_if


### PR DESCRIPTION
This test was added as part of commit:
https://github.com/python/cpython/commit/babddfca758abe34ff12023f63b18d745fae7ca9

It was added alongside a test with the same name at line 300. Therefore, this test can be removed as it was never used because was always shadowed by the second test; and because it is failing now when enabled.

It should be removed to avoid confusion and test failures if second test is ever moved or renamed.



<!-- issue-number: [bpo-19113](https://bugs.python.org/issue19113) -->
https://bugs.python.org/issue19113
<!-- /issue-number -->
