### PR TITLE
bpo-45040: Simplify `sqlite3` transaction control functions

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -396,43 +396,29 @@ static PyObject *
 pysqlite_connection_commit_impl(pysqlite_Connection *self)
 /*[clinic end generated code: output=3da45579e89407f2 input=39c12c04dda276a8]*/
 {
-    int rc;
-    sqlite3_stmt* statement;
-
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
     }
 
     if (!sqlite3_get_autocommit(self->db)) {
+        int rc;
 
         Py_BEGIN_ALLOW_THREADS
+        sqlite3_stmt *statement;
         rc = sqlite3_prepare_v2(self->db, "COMMIT", 7, &statement, NULL);
+        if (rc == SQLITE_OK) {
+            (void)sqlite3_step(statement);
+            rc = sqlite3_finalize(statement);
+        }
         Py_END_ALLOW_THREADS
+
         if (rc != SQLITE_OK) {
-            _pysqlite_seterror(self->state, self->db);
-            goto error;
+            (void)_pysqlite_seterror(self->state, self->db);
+            return NULL;
         }
-
-        rc = pysqlite_step(statement);
-        if (rc != SQLITE_DONE) {
-            _pysqlite_seterror(self->state, self->db);
-        }
-
-        Py_BEGIN_ALLOW_THREADS
-        rc = sqlite3_finalize(statement);
-        Py_END_ALLOW_THREADS
-        if (rc != SQLITE_OK && !PyErr_Occurred()) {
-            _pysqlite_seterror(self->state, self->db);
-        }
-
     }
 
-error:
-    if (PyErr_Occurred()) {
-        return NULL;
-    } else {
-        Py_RETURN_NONE;
-    }
+    Py_RETURN_NONE;
 }
 
 /*[clinic input]
@@ -445,9 +431,6 @@ static PyObject *
 pysqlite_connection_rollback_impl(pysqlite_Connection *self)
 /*[clinic end generated code: output=b66fa0d43e7ef305 input=12d4e8d068942830]*/
 {
-    int rc;
-    sqlite3_stmt* statement;
-
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
     }
@@ -455,34 +438,25 @@ pysqlite_connection_rollback_impl(pysqlite_Connection *self)
     if (!sqlite3_get_autocommit(self->db)) {
         pysqlite_do_all_statements(self);
 
+        int rc;
+
         Py_BEGIN_ALLOW_THREADS
+        sqlite3_stmt *statement;
         rc = sqlite3_prepare_v2(self->db, "ROLLBACK", 9, &statement, NULL);
+        if (rc == SQLITE_OK) {
+            (void)sqlite3_step(statement);
+            rc = sqlite3_finalize(statement);
+        }
         Py_END_ALLOW_THREADS
+
         if (rc != SQLITE_OK) {
-            _pysqlite_seterror(self->state, self->db);
-            goto error;
-        }
-
-        rc = pysqlite_step(statement);
-        if (rc != SQLITE_DONE) {
-            _pysqlite_seterror(self->state, self->db);
-        }
-
-        Py_BEGIN_ALLOW_THREADS
-        rc = sqlite3_finalize(statement);
-        Py_END_ALLOW_THREADS
-        if (rc != SQLITE_OK && !PyErr_Occurred()) {
-            _pysqlite_seterror(self->state, self->db);
+            (void)_pysqlite_seterror(self->state, self->db);
+            return NULL;
         }
 
     }
 
-error:
-    if (PyErr_Occurred()) {
-        return NULL;
-    } else {
-        Py_RETURN_NONE;
-    }
+    Py_RETURN_NONE;
 }
 
 static int


### PR DESCRIPTION
- only save/restore thread state once pr. function
- optimise SQLite C API usage
- simplify error paths
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45040](https://bugs.python.org/issue45040) -->
https://bugs.python.org/issue45040
<!-- /issue-number -->
