### PR TITLE
bpo-45041: Simplify `sqlite3.Cursor.executescript()`

### DIFF
--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -794,6 +794,13 @@ class ExtensionTests(unittest.TestCase):
             with self.assertRaises(sqlite.DataError):
                 cur.executescript("create table a(s);".ljust(size))
 
+    def test_cursor_executescript_tx_control(self):
+        con = sqlite.connect(":memory:")
+        con.execute("begin")
+        self.assertTrue(con.in_transaction)
+        con.executescript("select 1")
+        self.assertFalse(con.in_transaction)
+
     def test_connection_execute(self):
         con = sqlite.connect(":memory:")
         result = con.execute("select 5").fetchone()[0]

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -794,13 +794,6 @@ class ExtensionTests(unittest.TestCase):
             with self.assertRaises(sqlite.DataError):
                 cur.executescript("create table a(s);".ljust(size))
 
-    def test_cursor_executescript_tx_control(self):
-        con = sqlite.connect(":memory:")
-        con.execute("begin")
-        self.assertTrue(con.in_transaction)
-        con.executescript("select 1")
-        self.assertFalse(con.in_transaction)
-
     def test_connection_execute(self):
         con = sqlite.connect(":memory:")
         result = con.execute("select 5").fetchone()[0]

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -729,19 +729,13 @@ pysqlite_cursor_executescript_impl(pysqlite_Cursor *self,
                                    const char *sql_script)
 /*[clinic end generated code: output=8fd726dde1c65164 input=1ac0693dc8db02a8]*/
 {
-    _Py_IDENTIFIER(commit);
-    sqlite3_stmt* statement;
-    int rc;
-    size_t sql_len;
-    PyObject* result;
-
     if (!check_cursor(self)) {
         return NULL;
     }
 
     self->reset = 0;
 
-    sql_len = strlen(sql_script);
+    size_t sql_len = strlen(sql_script);
     int max_length = sqlite3_limit(self->connection->db,
                                    SQLITE_LIMIT_LENGTH, -1);
     if (sql_len >= (unsigned)max_length) {
@@ -750,47 +744,37 @@ pysqlite_cursor_executescript_impl(pysqlite_Cursor *self,
         return NULL;
     }
 
-    /* commit first */
-    result = _PyObject_CallMethodIdNoArgs((PyObject *)self->connection, &PyId_commit);
-    if (!result) {
-        goto error;
-    }
-    Py_DECREF(result);
+    // Commit if needed
+    sqlite3 *db = self->connection->db;
+    if (!sqlite3_get_autocommit(db)) {
+        int rc = SQLITE_OK;
 
-    pysqlite_state *state = self->connection->state;
+        Py_BEGIN_ALLOW_THREADS
+        rc = sqlite3_exec(db, "COMMIT", NULL, NULL, NULL);
+        Py_END_ALLOW_THREADS
+
+        if (rc != SQLITE_OK) {
+            goto error;
+        }
+    }
+
     while (1) {
+        int rc;
         const char *tail;
 
         Py_BEGIN_ALLOW_THREADS
-        rc = sqlite3_prepare_v2(self->connection->db,
-                                sql_script,
-                                (int)sql_len + 1,
-                                &statement,
+        sqlite3_stmt *stmt;
+        rc = sqlite3_prepare_v2(db, sql_script, (int)sql_len + 1, &stmt,
                                 &tail);
+        if (rc == SQLITE_OK) {
+            do {
+                (void)sqlite3_step(stmt);
+            } while (rc == SQLITE_ROW);
+            rc = sqlite3_finalize(stmt);
+        }
         Py_END_ALLOW_THREADS
+
         if (rc != SQLITE_OK) {
-            _pysqlite_seterror(state, self->connection->db);
-            goto error;
-        }
-
-        /* execute statement, and ignore results of SELECT statements */
-        do {
-            rc = pysqlite_step(statement);
-            if (PyErr_Occurred()) {
-                (void)sqlite3_finalize(statement);
-                goto error;
-            }
-        } while (rc == SQLITE_ROW);
-
-        if (rc != SQLITE_DONE) {
-            (void)sqlite3_finalize(statement);
-            _pysqlite_seterror(state, self->connection->db);
-            goto error;
-        }
-
-        rc = sqlite3_finalize(statement);
-        if (rc != SQLITE_OK) {
-            _pysqlite_seterror(state, self->connection->db);
             goto error;
         }
 
@@ -801,12 +785,11 @@ pysqlite_cursor_executescript_impl(pysqlite_Cursor *self,
         sql_script = tail;
     }
 
+    return Py_NewRef((PyObject *)self);
+
 error:
-    if (PyErr_Occurred()) {
-        return NULL;
-    } else {
-        return Py_NewRef((PyObject *)self);
-    }
+    _pysqlite_seterror(self->connection->state, db);
+    return NULL;
 }
 
 static PyObject *


### PR DESCRIPTION
- increase test coverage for executescript
- minimise number of times we save/restore thread state
- optimise SQLite C API usage
- simplify error handling
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45041](https://bugs.python.org/issue45041) -->
https://bugs.python.org/issue45041
<!-- /issue-number -->
