### PR TITLE
[3.9] bpo-25130: Make SQLite tests more compatible with PyPy (GH-28021)

### DIFF
--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -150,7 +150,8 @@ class BackupTests(unittest.TestCase):
                 self.cx.backup(bck, name='non-existing')
         self.assertIn(
             str(cm.exception),
-            ['SQL logic error', 'SQL logic error or missing database']
+            ['SQL logic error', 'SQL logic error or missing database',
+             'unknown database non-existing']
         )
 
         self.cx.execute("ATTACH DATABASE ':memory:' AS attached_db")

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -395,6 +395,9 @@ class CursorTests(unittest.TestCase):
             def __init__(self):
                 self.value = 5
 
+            def __iter__(self):
+                return self
+
             def __next__(self):
                 if self.value == 10:
                     raise StopIteration

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -127,11 +127,11 @@ class RegressionTests(unittest.TestCase):
         con = sqlite.connect(":memory:",detect_types=sqlite.PARSE_DECLTYPES)
         con.execute("create table foo(bar timestamp)")
         con.execute("insert into foo(bar) values (?)", (datetime.datetime.now(),))
-        con.execute(SELECT)
+        con.execute(SELECT).close()
         con.execute("drop table foo")
         con.execute("create table foo(bar integer)")
         con.execute("insert into foo(bar) values (5)")
-        con.execute(SELECT)
+        con.execute(SELECT).close()
 
     def CheckBindMutatingList(self):
         # Issue41662: Crash when mutate a list of parameters during iteration.


### PR DESCRIPTION
(cherry picked from commit 07d3d54)


<!-- issue-number: [bpo-25130](https://bugs.python.org/issue25130) -->
https://bugs.python.org/issue25130
<!-- /issue-number -->
