### PR TITLE
DOC: remove documentation for non-existing socket class attributes

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -151,9 +151,6 @@ getblocking() -- return True if socket is blocking, False if non-blocking\n\
 setsockopt(level, optname, value[, optlen]) -- set socket options\n\
 settimeout(None | float) -- set or clear the timeout\n\
 shutdown(how) -- shut down traffic in one or both directions\n\
-if_nameindex() -- return all network interface indices and names\n\
-if_nametoindex(name) -- return the corresponding interface index\n\
-if_indextoname(index) -- return the corresponding interface name\n\
 \n\
  [*] not available on all platforms!");
 


### PR DESCRIPTION
The module-level functions `if_nameindex`, `if_nametoindex` and `if_indextoname` were documented as existing on the class.

```
import socket
s = socket.socket()
s.if_nameindex()  # AttributeError
socket.if_nameindex()
# Prints the expected result
```

Does this qualify as a "small documentation fix" that needs no issue, or should I open a corresponding issue.

Note the [documentation](https://docs.python.org/3/library/socket.html#socket.if_nametoindex) is a bit confusing since it is not clear that the `socket` prefix here refers to the module, not the object. The object docs start a few lines down. So the `rst` docs need no fixes.