### PR TITLE
[3.8] bpo-45007: Update to OpenSSL 1.1.1l in Windows build and CI (GH-28009)

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -1,14 +1,14 @@
 variables:
   coverage: false
 
-trigger: ['master', '3.9', '3.8', '3.7']
+trigger: ['main', '3.10', '3.9', '3.8', '3.7']
 
 jobs:
 - job: Prebuild
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -20,7 +20,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./docs-steps.yml
@@ -40,7 +40,7 @@ jobs:
     testRunPlatform: macos
 
   pool:
-    vmImage: macos-10.14
+    vmImage: macos-10.15
 
   steps:
   - template: ./macos-steps.yml
@@ -52,12 +52,12 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1k
+    openssl_version: 1.1.1l
 
   steps:
   - template: ./posix-steps.yml
@@ -78,12 +78,12 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1k
+    openssl_version: 1.1.1l
 
   steps:
   - template: ./posix-steps.yml

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -1,14 +1,14 @@
 variables:
   coverage: false
 
-pr: ['master', '3.9', '3.8', '3.7']
+pr: ['main', '3.10', '3.9', '3.8', '3.7']
 
 jobs:
 - job: Prebuild
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -20,7 +20,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   steps:
   - template: ./docs-steps.yml
@@ -38,7 +38,7 @@ jobs:
     testRunPlatform: macos
 
   pool:
-    vmImage: macos-10.14
+    vmImage: macos-10.15
 
   steps:
   - template: ./macos-steps.yml
@@ -52,12 +52,12 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.1k
+    openssl_version: 1.1.1l
 
   steps:
   - template: ./posix-steps.yml
@@ -78,12 +78,12 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.1k
+    openssl_version: 1.1.1l
 
   steps:
   - template: ./posix-steps.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,12 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
+<<<<<<< HEAD
       OPENSSL_VER: 1.1.1k
+=======
+      OPENSSL_VER: 1.1.1l
+      PYTHONSTRICTEXTENSIONBUILD: 1
+>>>>>>> d3bdbbf9a4 (bpo-45007: Update to OpenSSL 1.1.1l in Windows build and CI (GH-28009))
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
@@ -184,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openssl_ver: [1.0.2u, 1.1.0l, 1.1.1k, 3.0.0-alpha14]
+        openssl_ver: [1.0.2u, 1.1.0l, 1.1.1l, 3.0.0-beta1]
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,12 +143,7 @@ jobs:
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     env:
-<<<<<<< HEAD
-      OPENSSL_VER: 1.1.1k
-=======
       OPENSSL_VER: 1.1.1l
-      PYTHONSTRICTEXTENSIONBUILD: 1
->>>>>>> d3bdbbf9a4 (bpo-45007: Update to OpenSSL 1.1.1l in Windows build and CI (GH-28009))
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies

--- a/Misc/NEWS.d/next/Windows/2021-08-27-23-50-02.bpo-45007.NIBlVG.rst
+++ b/Misc/NEWS.d/next/Windows/2021-08-27-23-50-02.bpo-45007.NIBlVG.rst
@@ -1,0 +1,1 @@
+Update to OpenSSL 1.1.1l in Windows build

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0-rc0-r1
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1k
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1l
 set libraries=%libraries%                                       sqlite-3.35.5.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1k-1
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1l
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -62,8 +62,8 @@
     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
     <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
     <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1k\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1k-1\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.1l\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1l\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>


### PR DESCRIPTION
(cherry picked from commit d3bdbbf9a4352a24fc2bfc7a63a024b244b61aba)

Co-authored-by: Steve Dower <steve.dower@python.org>


<!-- issue-number: [bpo-45007](https://bugs.python.org/issue45007) -->
https://bugs.python.org/issue45007
<!-- /issue-number -->
