### PR TITLE
bpo-45007: Update multissl to openssl 1.1.1l as well

### DIFF
--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -47,7 +47,7 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1k",
+    "1.1.1l",
     "3.0.0-beta1"
 ]
 


### PR DESCRIPTION
This was missed while upgrading CI.

<!-- issue-number: [bpo-45007](https://bugs.python.org/issue45007) -->
https://bugs.python.org/issue45007
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran