### PR TITLE
bpo-20803: doc: clarify that struct.pack_into writes 0x00 for pad bytes

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -60,7 +60,8 @@ The module defines the following exception and functions:
    Pack the values *v1*, *v2*, ... according to the format string *format* and
    write the packed bytes into the writable buffer *buffer* starting at
    position *offset*.  Note that *offset* is a required argument.
-
+.. note::
+   'x' padding inserts null bytes to pad bytes.
 
 .. function:: unpack(format, buffer)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-20803](https://bugs.python.org/issue20803) -->
https://bugs.python.org/issue20803
<!-- /issue-number -->
