### PR TITLE
bpo-24444: fix an error in argparse help when help for an option is blank

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -526,12 +526,13 @@ class HelpFormatter(object):
         parts = [action_header]
 
         # if there was help for the action, add lines of help text
-        if action.help:
+        if action.help and action.help.strip():
             help_text = self._expand_help(action)
-            help_lines = self._split_lines(help_text, help_width)
-            parts.append('%*s%s\n' % (indent_first, '', help_lines[0]))
-            for line in help_lines[1:]:
-                parts.append('%*s%s\n' % (help_position, '', line))
+            if help_text:
+                help_lines = self._split_lines(help_text, help_width)
+                parts.append('%*s%s\n' % (indent_first, '', help_lines[0]))
+                for line in help_lines[1:]:
+                    parts.append('%*s%s\n' % (help_position, '', line))
 
         # or add a newline if the description doesn't end with one
         elif not action_header.endswith('\n'):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2165,6 +2165,42 @@ class TestAddSubparsers(TestCase):
                               wrap\N{NO-BREAK SPACE}at non-breaking spaces
         '''))
 
+    def test_help_blank(self):
+        # Issue 24444
+        parser = ErrorRaisingArgumentParser(
+            prog='PROG', description='main description')
+        parser.add_argument(
+            'foo',
+            help='    ')
+        self.assertEqual(parser.format_help(), textwrap.dedent('''\
+            usage: PROG [-h] foo
+
+            main description
+
+            positional arguments:
+              foo         
+
+            options:
+              -h, --help  show this help message and exit
+        '''))
+
+        parser = ErrorRaisingArgumentParser(
+            prog='PROG', description='main description')
+        parser.add_argument(
+            'foo', choices=[],
+            help='%(choices)s')
+        self.assertEqual(parser.format_help(), textwrap.dedent('''\
+            usage: PROG [-h] {}
+
+            main description
+
+            positional arguments:
+              {}          
+
+            options:
+              -h, --help  show this help message and exit
+        '''))
+
     def test_help_alternate_prefix_chars(self):
         parser = self._get_parser(prefix_chars='+:/')
         self.assertEqual(parser.format_usage(),

--- a/Misc/NEWS.d/next/Library/2021-08-30-00-19-23.bpo-24444.Ki4bgz.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-30-00-19-23.bpo-24444.Ki4bgz.rst
@@ -1,0 +1,3 @@
+Fixed an error raised in :mod:`argparse` help display when help for an
+option is set to 1+ blank spaces or when *choices* arg is an empty list or
+tuple.

--- a/Misc/NEWS.d/next/Library/2021-08-30-00-19-23.bpo-24444.Ki4bgz.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-30-00-19-23.bpo-24444.Ki4bgz.rst
@@ -1,3 +1,2 @@
 Fixed an error raised in :mod:`argparse` help display when help for an
-option is set to 1+ blank spaces or when *choices* arg is an empty list or
-tuple.
+option is set to 1+ blank spaces or when *choices* arg is an empty container.


### PR DESCRIPTION
I think it may be good to fix this because cmd-line help is more likely to be forgotten in testing and so a program may be distributed to users with one of these two bugs that break cmd line help and so make it unusable.

<!-- issue-number: [bpo-24444](https://bugs.python.org/issue24444) -->
https://bugs.python.org/issue24444
<!-- /issue-number -->
