### PR TITLE
bpo-44919: Fix issue when TypedDict subtypes ignore any other metaclass

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4294,6 +4294,18 @@ class TypedDictTests(BaseTestCase):
             {'a': typing.Optional[int], 'b': int}
         )
 
+    def test_custom_metaclass(self):
+        class _Foo(TypedDict):
+            pass
+
+        class _CustomTypedDictMeta(type(_Foo)):
+            pass
+
+        class _NewTypedDict(_Foo, metaclass=_CustomTypedDictMeta):
+            pass
+
+        self.assertIsInstance(_NewTypedDict, _CustomTypedDictMeta)
+
 
 class IOTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2287,10 +2287,10 @@ class _TypedDictMeta(type):
         Subclasses and instances of TypedDict return actual dictionaries.
         """
         for base in bases:
-            if type(base) is not _TypedDictMeta:
+            if not issubclass(type(base), _TypedDictMeta):
                 raise TypeError('cannot inherit from both a TypedDict type '
                                 'and a non-TypedDict base class')
-        tp_dict = type.__new__(_TypedDictMeta, name, (dict,), ns)
+        tp_dict = type.__new__(cls, name, (dict,), ns)
 
         annotations = {}
         own_annotations = ns.get('__annotations__', {})

--- a/Misc/NEWS.d/next/Library/2021-08-30-11-45-51.bpo-44919.oxoji7.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-30-11-45-51.bpo-44919.oxoji7.rst
@@ -1,0 +1,2 @@
+Fix issue when ``TypedDict`` subtypes ignore any other metaclasses. Patch
+provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44919](https://bugs.python.org/issue44919) -->
https://bugs.python.org/issue44919
<!-- /issue-number -->
