### PR TITLE
[3.9] bpo-45007: Update multissl to openssl 1.1.1l as well (GH-28044)

### DIFF
--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -49,8 +49,8 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1k",
-    "3.0.0-alpha16"
+    "1.1.1l",
+    "3.0.0-beta1"
 ]
 
 LIBRESSL_OLD_VERSIONS = [


### PR DESCRIPTION
This was missed while upgrading CI..
(cherry picked from commit d6cb5dd9e19210f5963ff8beadde7ca2fda71574)

Co-authored-by: Łukasz Langa <lukasz@langa.pl>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45007](https://bugs.python.org/issue45007) -->
https://bugs.python.org/issue45007
<!-- /issue-number -->
