### PR TITLE
bpo-31299: make it possible to filter out frames from tracebacks

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -357,7 +357,8 @@ capture data for later printing in a lightweight fashion.
 
       Returns a string for printing one of the frames involved in the stack.
       This method gets called for each frame object to be printed in the
-      :class:`StackSummary`.
+      :class:`StackSummary`. If it returns ``None``, the frame is omitted
+       from the output.
 
       .. versionadded:: 3.11
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -358,7 +358,7 @@ capture data for later printing in a lightweight fashion.
       Returns a string for printing one of the frames involved in the stack.
       This method gets called for each frame object to be printed in the
       :class:`StackSummary`. If it returns ``None``, the frame is omitted
-       from the output.
+      from the output.
 
       .. versionadded:: 3.11
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -515,6 +515,9 @@ class StackSummary(list):
         last_name = None
         count = 0
         for frame in self:
+            formatted_frame = self.format_frame(frame)
+            if formatted_frame is None:
+                continue
             if (last_file is None or last_file != frame.filename or
                 last_line is None or last_line != frame.lineno or
                 last_name is None or last_name != frame.name):

--- a/Misc/NEWS.d/next/Library/2021-08-30-13-55-09.bpo-31299.9QzjZs.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-30-13-55-09.bpo-31299.9QzjZs.rst
@@ -1,0 +1,1 @@
+Add option to completely drop frames from a traceback by returning ``None`` from a :meth:`~traceback.StackSummary.format_frame` override.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-31299](https://bugs.python.org/issue31299) -->
https://bugs.python.org/issue31299
<!-- /issue-number -->
