### PR TITLE
bpo-44756: Remove misleading NEWS entries of a change that was reverted before release

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2021-08-06-19-36-21.bpo-44756.1Ngzon.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-08-06-19-36-21.bpo-44756.1Ngzon.rst
@@ -1,3 +1,0 @@
-Reverted automated virtual environment creation on ``make html`` when
-building documentation. It turned out to be disruptive for downstream
-distributors.

--- a/Misc/NEWS.d/next/Tools-Demos/2021-07-28-00-51-55.bpo-44756.pvAajB.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2021-07-28-00-51-55.bpo-44756.pvAajB.rst
@@ -1,6 +1,0 @@
-In the Makefile for documentation (:file:`Doc/Makefile`), the ``build`` rule
-is dependent on the ``venv`` rule. Therefore, ``html``, ``latex``, and other
-build-dependent rules are also now dependent on ``venv``. The ``venv`` rule
-only performs an action if ``$(VENVDIR)`` does not exist.
-:file:`Doc/README.rst` was updated; most users now only need to type ``make
-html``.


### PR DESCRIPTION
They are misleading because the first one is in Tools/Demos and the other one is in Documentation so it's not easy to tell the revert happened.

<!-- issue-number: [bpo-44756](https://bugs.python.org/issue44756) -->
https://bugs.python.org/issue44756
<!-- /issue-number -->
