### PR TITLE
attrs be dictionary??

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -306,7 +306,7 @@ class HTMLParser(_markupbase.ParserBase):
         self.__starttag_text = rawdata[i:endpos]
 
         # Now parse the data between i+1 and j into a tag and attrs
-        attrs = []
+        attrs = dict()
         match = tagfind_tolerant.match(rawdata, i+1)
         assert match, 'unexpected call to parse_starttag()'
         k = match.end()
@@ -323,7 +323,7 @@ class HTMLParser(_markupbase.ParserBase):
                 attrvalue = attrvalue[1:-1]
             if attrvalue:
                 attrvalue = unescape(attrvalue)
-            attrs.append((attrname.lower(), attrvalue))
+            attrs[attrname.lower()] = attrvalue
             k = m.end()
 
         end = rawdata[k:endpos].strip()


### PR DESCRIPTION
Just a suggestion but every time I use this Parser I'm always making the tupled list into the dictionary.  Dictionary makes more sense for attribute property nature of html(/xml) nature of tags

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
