### PR TITLE
bpo-27175: Partially support cross-platform pathlib pickling/unpickling.

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2367,6 +2367,23 @@ class _BasePathTest(object):
             pp = pickle.loads(dumped)
             self.assertEqual(pp.stat(), p.stat())
 
+    def test_pickling_cross_platform(self):
+        if os.name == 'nt':
+            other_cls = pathlib.PosixPath
+            other_pure_cls = pathlib.PurePosixPath
+        else:
+            other_cls = pathlib.WindowsPath
+            other_pure_cls = pathlib.PureWindowsPath
+        try:
+            other_cls._flavour.is_supported = True
+            p = other_cls(BASE, 'fileA')
+            for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+                dumped = pickle.dumps(p, proto)
+                pp = pickle.loads(dumped)
+                self.assertEqual(pp, other_pure_cls(BASE, 'fileA'))
+        finally:
+            other_cls._flavour.is_supported = False
+
     def test_parts_interning(self):
         P = self.cls
         p = P('/usr/bin/foo')

--- a/Misc/NEWS.d/next/Library/2021-08-31-11-30-59.bpo-27175.asAlrG.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-31-11-30-59.bpo-27175.asAlrG.rst
@@ -1,0 +1,4 @@
+``pathlib.PosixPath`` is now unpickled as ``PurePosixPath`` on Windows, and
+conversely, ``WindowsPath`` is now unpickled as ``PureWindowsPath`` on
+POSIX. (Previously, concrete path classes were not unpicklable at all on the
+"opposite" OS.)


### PR DESCRIPTION
Unpickle concrete Paths as PurePaths on platforms where the
corresponding concrete Path class cannot be instantiated (i.e., a
pickled PosixPath gets unpickled as a PurePosixPath on Windows, and
vice-versa).

(See longer discussion, including possible alternatives, on the bpo issue.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-27175](https://bugs.python.org/issue27175) -->
https://bugs.python.org/issue27175
<!-- /issue-number -->
