### PR TITLE
bpo-45012 Release GIL around stat in os.scandir

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1644,6 +1644,7 @@ J. Sipprell
 Ngalim Siregar
 Kragen Sitaker
 Kaartic Sivaraam
+Stanisław Skonieczny
 Roman Skurikhin
 Ville Skyttä
 Michael Sloan

--- a/Misc/NEWS.d/next/Core and Builtins/2021-08-31-11-09-52.bpo-45012.ueeOcx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-08-31-11-09-52.bpo-45012.ueeOcx.rst
@@ -1,0 +1,2 @@
+In :mod:`posix`, release GIL during ``stat()``, ``lstat()``, and
+``fstatat()`` syscalls made by :func:`os.DirEntry.stat`. Patch by Stanisław Skonieczny.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -13489,8 +13489,10 @@ _Py_COMP_DIAG_POP
     if (self->dir_fd != DEFAULT_DIR_FD) {
 #ifdef HAVE_FSTATAT
       if (HAVE_FSTATAT_RUNTIME) {
+        Py_BEGIN_ALLOW_THREADS
         result = fstatat(self->dir_fd, path, &st,
                          follow_symlinks ? 0 : AT_SYMLINK_NOFOLLOW);
+        Py_END_ALLOW_THREADS
       } else
 
 #endif /* HAVE_FSTATAT */
@@ -13503,10 +13505,14 @@ _Py_COMP_DIAG_POP
     else
 #endif
     {
-        if (follow_symlinks)
+        Py_BEGIN_ALLOW_THREADS
+        if (follow_symlinks) {
             result = STAT(path, &st);
-        else
+        }
+        else {
             result = LSTAT(path, &st);
+        }
+        Py_END_ALLOW_THREADS
     }
 #if defined(MS_WINDOWS) && !USE_UNICODE_WCHAR_CACHE
     PyMem_Free(path);


### PR DESCRIPTION
Releasing GIL allows other threads to continue
its work when os.scandir is fetching DirEntry.stat
info from file system.

It might be important in case of
slow or unresponsive file system.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45012](https://bugs.python.org/issue45012) -->
https://bugs.python.org/issue45012
<!-- /issue-number -->
