### PR TITLE
bpo-45059: Fix typo: using "==" instead of "="

### DIFF
--- a/Lib/idlelib/idle_test/test_macosx.py
+++ b/Lib/idlelib/idle_test/test_macosx.py
@@ -34,7 +34,7 @@ class InitTktypeTest(unittest.TestCase):
         for platform, types in ('darwin', alltypes), ('other', nontypes):
             with self.subTest(platform=platform):
                 macosx.platform = platform
-                macosx._tk_type == None
+                macosx._tk_type = None
                 macosx._init_tk_type()
                 self.assertIn(macosx._tk_type, types)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-45059](https://bugs.python.org/issue45059) -->
https://bugs.python.org/issue45059
<!-- /issue-number -->
