### PR TITLE
bpo-45061: Detect Py_DECREF(Py_True) bug

### DIFF
--- a/Misc/NEWS.d/next/C API/2021-08-31-15-21-36.bpo-45061.ZH0HVe.rst
+++ b/Misc/NEWS.d/next/C API/2021-08-31-15-21-36.bpo-45061.ZH0HVe.rst
@@ -1,0 +1,3 @@
+Add a deallocator to the :class:`bool` type to detect refcount bugs in C
+extensions which call ``Py_DECREF(Py_True);`` or ``Py_DECREF(Py_False);`` by
+mistake. Patch by Victor Stinner.

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -156,8 +156,8 @@ static PyNumberMethods bool_as_number = {
 static void _Py_NO_RETURN
 bool_dealloc(PyObject* Py_UNUSED(ignore))
 {
-    Py_FatalError("deallocating True or False likely caused by refcount bug "
-                  "in a C extension");
+    Py_FatalError("deallocating True or False likely caused by "
+                  "a refcount bug in a C extension");
 }
 
 /* The type object for bool.  Note that this cannot be subclassed! */

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -153,6 +153,13 @@ static PyNumberMethods bool_as_number = {
     0,                          /* nb_index */
 };
 
+static void _Py_NO_RETURN
+bool_dealloc(PyObject* Py_UNUSED(ignore))
+{
+    Py_FatalError("deallocating True or False likely caused by refcount bug "
+                  "in a C extension");
+}
+
 /* The type object for bool.  Note that this cannot be subclassed! */
 
 PyTypeObject PyBool_Type = {
@@ -160,7 +167,7 @@ PyTypeObject PyBool_Type = {
     "bool",
     sizeof(struct _longobject),
     0,
-    0,                                          /* tp_dealloc */
+    bool_dealloc,                               /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1560,14 +1560,11 @@ none_repr(PyObject *op)
     return PyUnicode_FromString("None");
 }
 
-/* ARGUSED */
 static void _Py_NO_RETURN
-none_dealloc(PyObject* ignore)
+none_dealloc(PyObject* Py_UNUSED(ignore))
 {
-    /* This should never get called, but we also don't want to SEGV if
-     * we accidentally decref None out of existence.
-     */
-    Py_FatalError("deallocating None");
+    Py_FatalError("deallocating None likely caused by refcount bug "
+                  "in a C extension");
 }
 
 static PyObject *

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1563,7 +1563,7 @@ none_repr(PyObject *op)
 static void _Py_NO_RETURN
 none_dealloc(PyObject* Py_UNUSED(ignore))
 {
-    Py_FatalError("deallocating None likely caused by refcount bug "
+    Py_FatalError("deallocating None likely caused by a refcount bug "
                   "in a C extension");
 }
 


### PR DESCRIPTION
Add a deallocator to the bool type to detect refcount bugs in C
extensions which call Py_DECREF(Py_True) or Py_DECREF(Py_False) by
mistake.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45061](https://bugs.python.org/issue45061) -->
https://bugs.python.org/issue45061
<!-- /issue-number -->
