### PR TITLE
bpo-45061: Enhance faulthandler traceback wit no Python frame

### DIFF
--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1071,7 +1071,7 @@ dump_traceback(int fd, PyThreadState *tstate, int write_header)
 
     frame = tstate->frame;
     if (frame == NULL) {
-        PUTS(fd, "<no Python frame>\n");
+        PUTS(fd, "  <no Python frame>\n");
         return;
     }
 


### PR DESCRIPTION
Fix indentation of <no Python frame> message in a faulthandler
traceback or a Fatal Python error traceback. Example:

Current thread 0x00007f03896fb740 (most recent call first):
  Garbage-collecting
  <no Python frame>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45061](https://bugs.python.org/issue45061) -->
https://bugs.python.org/issue45061
<!-- /issue-number -->
