### PR TITLE
[3.9] bpo-45060: Get rid of few uses of the equality operators with None (GH-28087).

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -216,7 +216,7 @@ supported.
       contains them all::
 
          k = db.firstkey()
-         while k != None:
+         while k is not None:
              print(k)
              k = db.nextkey(k)
 

--- a/Lib/ctypes/_aix.py
+++ b/Lib/ctypes/_aix.py
@@ -282,7 +282,7 @@ def find_shared(paths, name):
         if path.exists(archive):
             members = get_shared(get_ld_headers(archive))
             member = get_member(re.escape(name), members)
-            if member != None:
+            if member is not None:
                 return (base, member)
             else:
                 return (None, None)
@@ -307,7 +307,7 @@ def find_library(name):
 
     libpaths = get_libpaths()
     (base, member) = find_shared(libpaths, name)
-    if base != None:
+    if base is not None:
         return f"{base}({member})"
 
     # To get here, a member in an archive has not been found

--- a/Lib/email/contentmanager.py
+++ b/Lib/email/contentmanager.py
@@ -144,7 +144,7 @@ def _encode_text(string, charset, cte, policy):
     linesep = policy.linesep.encode('ascii')
     def embedded_body(lines): return linesep.join(lines) + linesep
     def normal_body(lines): return b'\n'.join(lines) + b'\n'
-    if cte==None:
+    if cte is None:
         # Use heuristics to decide on the "best" encoding.
         if max((len(x) for x in lines), default=0) <= policy.max_line_length:
             try:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -344,7 +344,7 @@ class TestTimeZone(unittest.TestCase):
         with self.assertRaises(TypeError): timezone(ZERO) < timezone(ZERO)
         self.assertIn(timezone(ZERO), {timezone(ZERO)})
         self.assertTrue(timezone(ZERO) != None)
-        self.assertFalse(timezone(ZERO) ==  None)
+        self.assertFalse(timezone(ZERO) == None)
 
         tz = timezone(ZERO)
         self.assertTrue(tz == ALWAYS_EQ)

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -433,7 +433,7 @@ The following code prints every key in the database db, without having
 to create a list in memory that contains them all:
 
       k = db.firstkey()
-      while k != None:
+      while k is not None:
           print(k)
           k = db.nextkey(k)
 [clinic start generated code]*/
@@ -441,7 +441,7 @@ to create a list in memory that contains them all:
 static PyObject *
 _gdbm_gdbm_nextkey_impl(dbmobject *self, const char *key,
                         Py_ssize_clean_t key_length)
-/*[clinic end generated code: output=192ab892de6eb2f6 input=1f1606943614e36f]*/
+/*[clinic end generated code: output=192ab892de6eb2f6 input=b7b0949c520d730c]*/
 {
     PyObject *v;
     datum dbm_key, nextkey;

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -139,7 +139,7 @@ PyDoc_STRVAR(_gdbm_gdbm_nextkey__doc__,
 "to create a list in memory that contains them all:\n"
 "\n"
 "      k = db.firstkey()\n"
-"      while k != None:\n"
+"      while k is not None:\n"
 "          print(k)\n"
 "          k = db.nextkey(k)");
 
@@ -298,4 +298,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2766471b2fa1a816 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f48d6e8d4c8a3465 input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -1632,7 +1632,7 @@ class BlockPrinter:
         dsl_name = block.dsl_name
         write = self.f.write
 
-        assert not ((dsl_name == None) ^ (output == None)), "you must specify dsl_name and output together, dsl_name " + repr(dsl_name)
+        assert not ((dsl_name is None) ^ (output is None)), "you must specify dsl_name and output together, dsl_name " + repr(dsl_name)
 
         if not dsl_name:
             write(input)
@@ -2957,7 +2957,7 @@ class int_converter(CConverter):
             self.format_unit = 'C'
         elif accept != {int}:
             fail("int_converter: illegal 'accept' argument " + repr(accept))
-        if type != None:
+        if type is not None:
             self.type = type
 
     def parse_arg(self, argname, displayname):


### PR DESCRIPTION
(cherry picked from commit 3c65457156d87e55010507d616b4eecb7a02883d)


<!-- issue-number: [bpo-45060](https://bugs.python.org/issue45060) -->
https://bugs.python.org/issue45060
<!-- /issue-number -->
