### PR TITLE
[3.9] bpo-44135: Refine explanation of how passing tuples to issubclass() behaves (GH-26193)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -862,8 +862,8 @@ are always available.  They are listed here in alphabetical order.
    Return ``True`` if *class* is a subclass (direct, indirect or :term:`virtual
    <abstract base class>`) of *classinfo*.  A
    class is considered a subclass of itself. *classinfo* may be a tuple of class
-   objects, in which case every entry in *classinfo* will be checked. In any other
-   case, a :exc:`TypeError` exception is raised.
+   objects, in which case return ``True`` if *class* is a subclass of any entry
+   in *classinfo*.  In any other case, a :exc:`TypeError` exception is raised.
 
 
 .. function:: iter(object[, sentinel])


### PR DESCRIPTION
This is a quasi-backport to 3.9 since the wording in this branch is different.

Co-authored-by: Zachary Kneupper zachary.kneupper@gmail.com


<!-- issue-number: [bpo-44135](https://bugs.python.org/issue44135) -->
https://bugs.python.org/issue44135
<!-- /issue-number -->
