### PR TITLE
[3.9] bpo-45057: Simplify RegressionTestResult (GH-28081)

### DIFF
--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -14,19 +14,16 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 
 class RegressionTestResult(unittest.TextTestResult):
-    separator1 = '=' * 70 + '\n'
-    separator2 = '-' * 70 + '\n'
 
     def __init__(self, stream, descriptions, verbosity):
-        super().__init__(stream=stream, descriptions=descriptions, verbosity=0)
+        super().__init__(stream=stream, descriptions=descriptions,
+                         verbosity=2 if verbosity else 0)
         self.buffer = True
         self.__suite = ET.Element('testsuite')
         self.__suite.set('start', datetime.utcnow().isoformat(' '))
 
         self.__e = None
         self.__start_time = None
-        self.__results = []
-        self.__verbose = bool(verbosity)
 
     @classmethod
     def __getId(cls, test):
@@ -44,9 +41,6 @@ class RegressionTestResult(unittest.TextTestResult):
         super().startTest(test)
         self.__e = e = ET.SubElement(self.__suite, 'testcase')
         self.__start_time = time.perf_counter()
-        if self.__verbose:
-            self.stream.write(f'{self.getDescription(test)} ... ')
-            self.stream.flush()
 
     def _add_result(self, test, capture=False, **args):
         e = self.__e
@@ -80,10 +74,6 @@ class RegressionTestResult(unittest.TextTestResult):
             else:
                 e2.text = str(v)
 
-    def __write(self, c, word):
-        if self.__verbose:
-            self.stream.write(f'{word}\n')
-
     @classmethod
     def __makeErrorDict(cls, err_type, err_value, err_tb):
         if isinstance(err_type, type):
@@ -106,45 +96,26 @@ class RegressionTestResult(unittest.TextTestResult):
     def addError(self, test, err):
         self._add_result(test, True, error=self.__makeErrorDict(*err))
         super().addError(test, err)
-        self.__write('E', 'ERROR')
 
     def addExpectedFailure(self, test, err):
         self._add_result(test, True, output=self.__makeErrorDict(*err))
         super().addExpectedFailure(test, err)
-        self.__write('x', 'expected failure')
 
     def addFailure(self, test, err):
         self._add_result(test, True, failure=self.__makeErrorDict(*err))
         super().addFailure(test, err)
-        self.__write('F', 'FAIL')
 
     def addSkip(self, test, reason):
         self._add_result(test, skipped=reason)
         super().addSkip(test, reason)
-        self.__write('S', f'skipped {reason!r}')
 
     def addSuccess(self, test):
         self._add_result(test)
         super().addSuccess(test)
-        self.__write('.', 'ok')
 
     def addUnexpectedSuccess(self, test):
         self._add_result(test, outcome='UNEXPECTED_SUCCESS')
         super().addUnexpectedSuccess(test)
-        self.__write('u', 'unexpected success')
-
-    def printErrors(self):
-        if self.__verbose:
-            self.stream.write('\n')
-        self.printErrorList('ERROR', self.errors)
-        self.printErrorList('FAIL', self.failures)
-
-    def printErrorList(self, flavor, errors):
-        for test, err in errors:
-            self.stream.write(self.separator1)
-            self.stream.write(f'{flavor}: {self.getDescription(test)}\n')
-            self.stream.write(self.separator2)
-            self.stream.write('%s\n' % err)
 
     def get_xml_element(self):
         e = self.__suite


### PR DESCRIPTION
Remove code which duplicates the functionality of TextTestResult.
(cherry picked from commit 2b76a5322fdf71d62b531fd765085f96f981c244)


<!-- issue-number: [bpo-45057](https://bugs.python.org/issue45057) -->
https://bugs.python.org/issue45057
<!-- /issue-number -->
