### PR TITLE
Remove a redundant assignment

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -700,8 +700,6 @@ PyImport_ExecCodeModuleWithPathnames(const char *name, PyObject *co,
         if (cpathobj == NULL)
             goto error;
     }
-    else
-        cpathobj = NULL;
 
     if (pathname != NULL) {
         pathobj = PyUnicode_DecodeFSDefault(pathname);


### PR DESCRIPTION
A variable is redundantly set to NULL when its value is already NULL.