### PR TITLE
asyncio: don't do anything in _SelectorDatagramTransport if we're closed

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -1032,7 +1032,7 @@ class _SelectorDatagramTransport(_SelectorTransport):
         if not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError(f'data argument must be a bytes-like object, '
                             f'not {type(data).__name__!r}')
-        if not data:
+        if self._closing or not data:
             return
 
         if self._address:


### PR DESCRIPTION
It could happen that the transport's sendto() method is invoked after
the transport was closed. Closing the transport sets the _sock attribute
to None, which then causes the following exception:

    Traceback (most recent call last):
      File "/usr/lib/python3.9/asyncio/selector_events.py", line 1056, in sendto
	self._sock.sendto(data, addr)
    AttributeError: 'NoneType' object has no attribute 'sendto'

So just check if we're closed before doing anything, similarly to what we already
do in other methods.
