### PR TITLE
bpo-44895: libregrtest: refleak check clears types later

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -85,13 +85,15 @@ def dash_R(ns, test_name, test_func):
               flush=True)
 
     dash_R_cleanup(fs, ps, pic, zdc, abcs)
+    support.gc_collect()
 
     for i in rep_range:
         test_func()
-        dash_R_cleanup(fs, ps, pic, zdc, abcs)
 
-        # dash_R_cleanup() ends with collecting cyclic trash:
-        # read memory statistics immediately after.
+        dash_R_cleanup(fs, ps, pic, zdc, abcs)
+        support.gc_collect()
+
+        # Read memory statistics immediately after the garbage collection
         alloc_after = getallocatedblocks() - _getquickenedcount()
         rc_after = gettotalrefcount()
         fd_after = fd_count()
@@ -166,9 +168,6 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs):
         zipimport._zip_directory_cache.clear()
         zipimport._zip_directory_cache.update(zdc)
 
-    # clear type cache
-    sys._clear_type_cache()
-
     # Clear ABC registries, restoring previously saved ABC registries.
     abs_classes = [getattr(collections.abc, a) for a in collections.abc.__all__]
     abs_classes = filter(isabstract, abs_classes)
@@ -179,7 +178,11 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs):
                     obj.register(ref())
             obj._abc_caches_clear()
 
+    # Clear caches
     clear_caches()
+
+    # Clear type cache at the end: previous function calls can modify types
+    sys._clear_type_cache()
 
 
 def warm_caches():

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -217,5 +217,3 @@ def clear_caches():
     else:
         for f in typing._cleanups:
             f()
-
-    support.gc_collect()

--- a/Misc/NEWS.d/next/Tests/2021-09-01-17-17-44.bpo-44895.kV7H77.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-01-17-17-44.bpo-44895.kV7H77.rst
@@ -1,0 +1,5 @@
+libregrtest now clears the type cache later to reduce the risk of false alarm
+when checking for reference leaks. Previously, the type cache was cleared too
+early and libregrtest raised a false alarm about reference leaks under very
+specific conditions.
+Patch by Irit Katriel and Victor Stinner.


### PR DESCRIPTION
libregrtest now clears the type cache later to reduce the risk of
false alarm when checking for reference leaks. Previously, the type
cache was cleared too early and libregrtest raised a false alarm
about reference leaks under very specific conditions.

Move also support.gc_collect() outside clear/cleanup functions to
make the garbage collection more explicit.

Co-Authored-By: Irit Katriel <1055913+iritkatriel@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44895](https://bugs.python.org/issue44895) -->
https://bugs.python.org/issue44895
<!-- /issue-number -->
