### PR TITLE
bpo-45084: Remove deprecated urllib.parse functions

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -291,6 +291,23 @@ Removed
   generator-based coroutine objects in the debug mode.
   (Contributed by Illia Volochii in :issue:`43216`.)
 
+* Remove the following undocumented functions of the :mod:`urllib.parse`
+  module, deprecated in Python 3.8:
+
+  * ``splitattr()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splithost()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splitnport()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splitpasswd()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splitport()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splitquery()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splittag()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splittype()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splituser()``: use :func:`~urllib.parse.urlparse` instead;
+  * ``splitvalue()``: use :func:`~urllib.parse.parse_qsl` instead;
+  * ``to_bytes()``: use Unicode instead.
+
+  (Contributed by Victor Stinner in :issue:`45084`.)
+
 Porting to Python 3.11
 ======================
 

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1057,12 +1057,7 @@ class UrlParseTestCase(unittest.TestCase):
 
     def test_all(self):
         expected = []
-        undocumented = {
-            'splitattr', 'splithost', 'splitnport', 'splitpasswd',
-            'splitport', 'splitquery', 'splittag', 'splittype', 'splituser',
-            'splitvalue',
-            'ResultBase', 'clear_cache', 'to_bytes', 'unwrap',
-        }
+        undocumented = {'ResultBase', 'clear_cache', 'unwrap'}
         for name in dir(urllib.parse):
             if name.startswith('_') or name in undocumented:
                 continue
@@ -1103,7 +1098,6 @@ class UrlParseTestCase(unittest.TestCase):
 
 class Utility_Tests(unittest.TestCase):
     """Testcase to test the various utility functions in the urllib."""
-    # In Python 2 this test class was in test_urllib.
 
     def test_splittype(self):
         splittype = urllib.parse._splittype
@@ -1184,18 +1178,6 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitport('[::1]'), ('[::1]', None))
         self.assertEqual(splitport(':88'), ('', '88'))
 
-    def test_splitnport(self):
-        splitnport = urllib.parse._splitnport
-        self.assertEqual(splitnport('parrot:88'), ('parrot', 88))
-        self.assertEqual(splitnport('parrot'), ('parrot', -1))
-        self.assertEqual(splitnport('parrot', 55), ('parrot', 55))
-        self.assertEqual(splitnport('parrot:'), ('parrot', -1))
-        self.assertEqual(splitnport('parrot:', 55), ('parrot', 55))
-        self.assertEqual(splitnport('127.0.0.1'), ('127.0.0.1', -1))
-        self.assertEqual(splitnport('127.0.0.1', 55), ('127.0.0.1', 55))
-        self.assertEqual(splitnport('parrot:cheese'), ('parrot', None))
-        self.assertEqual(splitnport('parrot:cheese', 55), ('parrot', None))
-
     def test_splitquery(self):
         # Normal cases are exercised by other tests; ensure that we also
         # catch cases with no port specified (testcase ensuring coverage)
@@ -1259,82 +1241,6 @@ class DeprecationTest(unittest.TestCase):
             old_class = urllib.parse.Quoter
             self.assertIs(old_class, urllib.parse._Quoter)
         self.assertIn('Quoter will be removed', str(cm.warning))
-
-    def test_splittype_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splittype('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splittype() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splithost_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splithost('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splithost() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splituser_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splituser('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splituser() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splitpasswd_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitpasswd('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitpasswd() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splitport_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitport('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitport() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splitnport_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitnport('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitnport() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splitquery_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitquery('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitquery() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splittag_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splittag('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splittag() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splitattr_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitattr('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitattr() is deprecated as of 3.8, '
-                         'use urllib.parse.urlparse() instead')
-
-    def test_splitvalue_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitvalue('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitvalue() is deprecated as of 3.8, '
-                         'use urllib.parse.parse_qsl() instead')
-
-    def test_to_bytes_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.to_bytes('')
-        self.assertEqual(str(cm.warning),
-                         'urllib.parse.to_bytes() is deprecated as of 3.8')
 
 
 if __name__ == "__main__":

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -989,12 +989,6 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
     return '&'.join(l)
 
 
-def to_bytes(url):
-    warnings.warn("urllib.parse.to_bytes() is deprecated as of 3.8",
-                  DeprecationWarning, stacklevel=2)
-    return _to_bytes(url)
-
-
 def _to_bytes(url):
     """to_bytes(u"URL") --> 'URL'."""
     # Most URL schemes require ASCII. If that changes, the conversion
@@ -1022,13 +1016,6 @@ def unwrap(url):
     return url
 
 
-def splittype(url):
-    warnings.warn("urllib.parse.splittype() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splittype(url)
-
-
 _typeprog = None
 def _splittype(url):
     """splittype('type:opaquestring') --> 'type', 'opaquestring'."""
@@ -1041,13 +1028,6 @@ def _splittype(url):
         scheme, data = match.groups()
         return scheme.lower(), data
     return None, url
-
-
-def splithost(url):
-    warnings.warn("urllib.parse.splithost() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splithost(url)
 
 
 _hostprog = None
@@ -1066,37 +1046,16 @@ def _splithost(url):
     return None, url
 
 
-def splituser(host):
-    warnings.warn("urllib.parse.splituser() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splituser(host)
-
-
 def _splituser(host):
     """splituser('user[:passwd]@host[:port]') --> 'user[:passwd]', 'host[:port]'."""
     user, delim, host = host.rpartition('@')
     return (user if delim else None), host
 
 
-def splitpasswd(user):
-    warnings.warn("urllib.parse.splitpasswd() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splitpasswd(user)
-
-
 def _splitpasswd(user):
     """splitpasswd('user:passwd') -> 'user', 'passwd'."""
     user, delim, passwd = user.partition(':')
     return user, (passwd if delim else None)
-
-
-def splitport(host):
-    warnings.warn("urllib.parse.splitport() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splitport(host)
 
 
 # splittag('/path#tag') --> '/path', 'tag'
@@ -1115,50 +1074,12 @@ def _splitport(host):
     return host, None
 
 
-def splitnport(host, defport=-1):
-    warnings.warn("urllib.parse.splitnport() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splitnport(host, defport)
-
-
-def _splitnport(host, defport=-1):
-    """Split host and port, returning numeric port.
-    Return given default port if no ':' found; defaults to -1.
-    Return numerical port if a valid number are found after ':'.
-    Return None if ':' but not a valid number."""
-    host, delim, port = host.rpartition(':')
-    if not delim:
-        host = port
-    elif port:
-        try:
-            nport = int(port)
-        except ValueError:
-            nport = None
-        return host, nport
-    return host, defport
-
-
-def splitquery(url):
-    warnings.warn("urllib.parse.splitquery() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splitquery(url)
-
-
 def _splitquery(url):
     """splitquery('/path?query') --> '/path', 'query'."""
     path, delim, query = url.rpartition('?')
     if delim:
         return path, query
     return url, None
-
-
-def splittag(url):
-    warnings.warn("urllib.parse.splittag() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splittag(url)
 
 
 def _splittag(url):
@@ -1169,25 +1090,11 @@ def _splittag(url):
     return url, None
 
 
-def splitattr(url):
-    warnings.warn("urllib.parse.splitattr() is deprecated as of 3.8, "
-                  "use urllib.parse.urlparse() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splitattr(url)
-
-
 def _splitattr(url):
     """splitattr('/path;attr1=value1;attr2=value2;...') ->
         '/path', ['attr1=value1', 'attr2=value2', ...]."""
     words = url.split(';')
     return words[0], words[1:]
-
-
-def splitvalue(attr):
-    warnings.warn("urllib.parse.splitvalue() is deprecated as of 3.8, "
-                  "use urllib.parse.parse_qsl() instead",
-                  DeprecationWarning, stacklevel=2)
-    return _splitvalue(attr)
 
 
 def _splitvalue(attr):

--- a/Misc/NEWS.d/next/Library/2021-09-02-00-09-25.bpo-45084.SDh6rf.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-02-00-09-25.bpo-45084.SDh6rf.rst
@@ -1,0 +1,16 @@
+Remove the following undocumented functions of the :mod:`urllib.parse`
+module, deprecated in Python 3.8:
+
+* ``splitattr()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splithost()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splitnport()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splitpasswd()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splitport()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splitquery()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splittag()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splittype()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splituser()``: use :func:`~urllib.parse.urlparse` instead;
+* ``splitvalue()``: use :func:`~urllib.parse.parse_qsl` instead;
+* ``to_bytes()``: use Unicode instead.
+
+Patch by Victor Stinner.


### PR DESCRIPTION
Remove the following undocumented urllib.parse functions, deprecated
in Python 3.8:

* splitattr()
* splithost()
* splitnport()
* splitpasswd()
* splitport()
* splitquery()
* splittag()
* splittype()
* splituser()
* splitvalue()
* to_bytes()

Use urlparse() or parse_qsl() instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45084](https://bugs.python.org/issue45084) -->
https://bugs.python.org/issue45084
<!-- /issue-number -->
