### PR TITLE
bpo-45081: Fix __init__ method generation when inheriting from Protocol

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1015,11 +1015,6 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
         # Does this class have a post-init function?
         has_post_init = hasattr(cls, _POST_INIT_NAME)
 
-        # typing.Protocol can override __init__ method to object.__init__
-        inherits_from_protocol = any(getattr(c, '_is_protocol', False) for c in cls.__bases__)
-        if inherits_from_protocol and cls.__dict__.get('__init__') is object.__init__:
-            del cls.__init__
-
         _set_new_attribute(cls, '__init__',
                            _init_fn(all_init_fields,
                                     std_init_fields,

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1015,6 +1015,11 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen,
         # Does this class have a post-init function?
         has_post_init = hasattr(cls, _POST_INIT_NAME)
 
+        # typing.Protocol can override __init__ method to object.__init__
+        inherits_from_protocol = any(getattr(c, '_is_protocol', False) for c in cls.__bases__)
+        if inherits_from_protocol and cls.__dict__.get('__init__') is object.__init__:
+            del cls.__init__
+
         _set_new_attribute(cls, '__init__',
                            _init_fn(all_init_fields,
                                     std_init_fields,

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2151,6 +2151,7 @@ class TestInit(unittest.TestCase):
         self.assertEqual(C(5).x, 10)
 
     def test_inherit_from_protocol(self):
+        # Dataclasses inheriting from protocol should preserve their own `__init__`.
         # See bpo-45081.
 
         class P(Protocol):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -10,7 +10,7 @@ import inspect
 import builtins
 import unittest
 from unittest.mock import Mock
-from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Optional
+from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Optional, Protocol
 from typing import get_type_hints
 from collections import deque, OrderedDict, namedtuple
 from functools import total_ordering
@@ -2149,6 +2149,23 @@ class TestInit(unittest.TestCase):
             def __init__(self, x):
                 self.x = 2 * x
         self.assertEqual(C(5).x, 10)
+
+    def test_inherit_from_protocol(self):
+        class P(Protocol):
+            a: int
+
+        @dataclass
+        class C(P):
+            a: int
+
+        self.assertEqual(C(5).a, 5)
+
+        @dataclass
+        class D(P):
+            def __init__(self, a):
+                self.a = a * 2
+
+        self.assertEqual(D(5).a, 10)
 
 
 class TestRepr(unittest.TestCase):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2151,6 +2151,8 @@ class TestInit(unittest.TestCase):
         self.assertEqual(C(5).x, 10)
 
     def test_inherit_from_protocol(self):
+        # See bpo-45081.
+
         class P(Protocol):
             a: int
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1406,12 +1406,12 @@ def _no_init_or_replace_init(self, *args, **kwargs):
     if cls._is_protocol:
         raise TypeError('Protocols cannot be instantiated')
 
-    # Initially, `__init__` of a protocol subclass is set to `_no_init`.
-    # The first instantiation of the subclass will call `_no_init` which
+    # Initially, `__init__` of a protocol subclass is set to `_no_init_or_replace_init`.
+    # The first instantiation of the subclass will call `_no_init_or_replace_init` which
     # searches for a proper new `__init__` in the MRO. The new `__init__`
-    # replaces the subclass' old `__init__` (ie `_no_init`). Subsequent
+    # replaces the subclass' old `__init__` (ie `_no_init_or_replace_init`). Subsequent
     # instantiation of the protocol subclass will thus use the new
-    # `__init__` and no longer call `_no_init`.
+    # `__init__` and no longer call `_no_init_or_replace_init`.
     for base in cls.__mro__:
         init = base.__dict__.get('__init__', _no_init_or_replace_init)
         if init is not _no_init_or_replace_init:

--- a/Misc/NEWS.d/next/Library/2021-09-02-12-42-25.bpo-45081.tOjJ1k.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-02-12-42-25.bpo-45081.tOjJ1k.rst
@@ -1,0 +1,2 @@
+Fix issue when dataclasses that inherit from ``typing.Protocol`` subclasses
+have wrong ``__init__``. Patch provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45081](https://bugs.python.org/issue45081) -->
https://bugs.python.org/issue45081
<!-- /issue-number -->
