### PR TITLE
bpo-45082: Cleanup ctypes.c_buffer alias

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -330,10 +330,9 @@ property::
    10 b'Hi\x00lo\x00\x00\x00\x00\x00'
    >>>
 
-The :func:`create_string_buffer` function replaces the :func:`c_buffer` function
-(which is still available as an alias), as well as the :func:`c_string` function
-from earlier ctypes releases.  To create a mutable memory block containing
-unicode characters of the C type :c:type:`wchar_t` use the
+The :func:`create_string_buffer` function replaces the old :func:`c_buffer`
+function (which is still available as an alias).  To create a mutable memory
+block containing unicode characters of the C type :c:type:`wchar_t`, use the
 :func:`create_unicode_buffer` function.
 
 

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -65,12 +65,8 @@ def create_string_buffer(init, size=None):
         return buf
     raise TypeError(init)
 
-def c_buffer(init, size=None):
-##    "deprecated, use create_string_buffer instead"
-##    import warnings
-##    warnings.warn("c_buffer is deprecated, use create_string_buffer instead",
-##                  DeprecationWarning, stacklevel=2)
-    return create_string_buffer(init, size)
+# Alias to create_string_buffer() for backward compatibility
+c_buffer = create_string_buffer
 
 _c_functype_cache = {}
 def CFUNCTYPE(restype, *argtypes, **kw):

--- a/Lib/ctypes/test/test_strings.py
+++ b/Lib/ctypes/test/test_strings.py
@@ -85,74 +85,6 @@ class WStringArrayTestCase(unittest.TestCase):
         w = c_wchar(u)
         self.assertEqual(w.value, u)
 
-class StringTestCase(unittest.TestCase):
-    @unittest.skip('test disabled')
-    def test_basic_strings(self):
-        cs = c_string("abcdef")
-
-        # Cannot call len on a c_string any longer
-        self.assertRaises(TypeError, len, cs)
-        self.assertEqual(sizeof(cs), 7)
-
-        # The value property is the string up to the first terminating NUL.
-        self.assertEqual(cs.value, "abcdef")
-        self.assertEqual(c_string("abc\000def").value, "abc")
-
-        # The raw property is the total buffer contents:
-        self.assertEqual(cs.raw, "abcdef\000")
-        self.assertEqual(c_string("abc\000def").raw, "abc\000def\000")
-
-        # We can change the value:
-        cs.value = "ab"
-        self.assertEqual(cs.value, "ab")
-        self.assertEqual(cs.raw, "ab\000\000\000\000\000")
-
-        cs.raw = "XY"
-        self.assertEqual(cs.value, "XY")
-        self.assertEqual(cs.raw, "XY\000\000\000\000\000")
-
-        self.assertRaises(TypeError, c_string, "123")
-
-    @unittest.skip('test disabled')
-    def test_sized_strings(self):
-
-        # New in releases later than 0.4.0:
-        self.assertRaises(TypeError, c_string, None)
-
-        # New in releases later than 0.4.0:
-        # c_string(number) returns an empty string of size number
-        self.assertEqual(len(c_string(32).raw), 32)
-        self.assertRaises(ValueError, c_string, -1)
-        self.assertRaises(ValueError, c_string, 0)
-
-        # These tests fail, because it is no longer initialized
-##        self.assertEqual(c_string(2).value, "")
-##        self.assertEqual(c_string(2).raw, "\000\000")
-        self.assertEqual(c_string(2).raw[-1], "\000")
-        self.assertEqual(len(c_string(2).raw), 2)
-
-    @unittest.skip('test disabled')
-    def test_initialized_strings(self):
-
-        self.assertEqual(c_string("ab", 4).raw[:2], "ab")
-        self.assertEqual(c_string("ab", 4).raw[:2:], "ab")
-        self.assertEqual(c_string("ab", 4).raw[:2:-1], "ba")
-        self.assertEqual(c_string("ab", 4).raw[:2:2], "a")
-        self.assertEqual(c_string("ab", 4).raw[-1], "\000")
-        self.assertEqual(c_string("ab", 2).raw, "a\000")
-
-    @unittest.skip('test disabled')
-    def test_toolong(self):
-        cs = c_string("abcdef")
-        # Much too long string:
-        self.assertRaises(ValueError, setattr, cs, "value", "123456789012345")
-
-        # One char too long values:
-        self.assertRaises(ValueError, setattr, cs, "value", "1234567")
-
-    @unittest.skip('test disabled')
-    def test_perf(self):
-        check_perf()
 
 @need_symbol('c_wchar')
 class WStringTestCase(unittest.TestCase):
@@ -208,25 +140,6 @@ def run_test(rep, msg, func, arg):
     stop = clock()
     print("%20s: %.2f us" % (msg, ((stop-start)*1e6/5/rep)))
 
-def check_perf():
-    # Construct 5 objects
-
-    REP = 200000
-
-    run_test(REP, "c_string(None)", c_string, None)
-    run_test(REP, "c_string('abc')", c_string, 'abc')
-
-# Python 2.3 -OO, win2k, P4 700 MHz:
-#
-#      c_string(None): 1.75 us
-#     c_string('abc'): 2.74 us
-
-# Python 2.2 -OO, win2k, P4 700 MHz:
-#
-#      c_string(None): 2.95 us
-#     c_string('abc'): 3.67 us
-
 
 if __name__ == '__main__':
-##    check_perf()
     unittest.main()

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -530,8 +530,8 @@ PyCArg_repr(PyCArgObject *self)
         }
 
 /* Hm, are these 'z' and 'Z' codes useful at all?
-   Shouldn't they be replaced by the functionality of c_string
-   and c_wstring ?
+   Shouldn't they be replaced by the functionality of create_string_buffer()
+   and c_wstring() ?
 */
     case 'z':
     case 'Z':


### PR DESCRIPTION
* Remove commented deprecation of ctypes.c_buffer.
* Remove references to ctypes.c_string which doesn't exist.
* Remove StringTestCase: it only had skipped test methods.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45082](https://bugs.python.org/issue45082) -->
https://bugs.python.org/issue45082
<!-- /issue-number -->
