### PR TITLE
bpo-43950: support positions for dis.Instructions created through dis.Bytecode

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -564,7 +564,8 @@ class Bytecode:
                                        co.co_names, co.co_consts,
                                        self._linestarts,
                                        line_offset=self._line_offset,
-                                       exception_entries=self.exception_entries)
+                                       exception_entries=self.exception_entries,
+                                       co_positions=co.co_positions())
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__,

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1302,6 +1302,11 @@ class BytecodeTests(InstructionTestCase):
         b = dis.Bytecode.from_traceback(tb)
         self.assertEqual(b.dis(), dis_traceback)
 
+    @requires_debug_ranges()
+    def test_bytecode_co_positions(self):
+        bytecode = dis.Bytecode("a=1")
+        for instr, positions in zip(bytecode, bytecode.codeobj.co_positions()):
+            assert instr.positions == positions
 
 class TestBytecodeTestCase(BytecodeTestCase):
     def test_assert_not_in_with_op_not_in_bytecode(self):


### PR DESCRIPTION


<!-- issue-number: [bpo-43950](https://bugs.python.org/issue43950) -->
https://bugs.python.org/issue43950
<!-- /issue-number -->
