### PR TITLE
Update errors.rst

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -291,7 +291,7 @@ This can be useful when you are transforming exceptions. For example::
     Traceback (most recent call last):
       File "<stdin>", line 2, in <module>
       File "<stdin>", line 2, in func
-    OSError
+    IOError
     <BLANKLINE>
     The above exception was the direct cause of the following exception:
     <BLANKLINE>


### PR DESCRIPTION
Just a typo since the code example above indicates that an IOError is thrown, and not an OSError.