### PR TITLE
[3.9] bpo-45042: Now test classes decorated with `requires_hashdigest…

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3769,6 +3769,7 @@ class _TestSharedMemory(BaseTestCase):
         local_sms.buf[:len(binary_data)] = binary_data
         local_sms.close()
 
+    @unittest.skipIf(sys.platform == "win32", "test is broken on Windows")
     def test_shared_memory_basics(self):
         sms = shared_memory.SharedMemory('test01_tsmb', create=True, size=512)
         self.addCleanup(sms.unlink)

--- a/Lib/test/support/hashlib_helper.py
+++ b/Lib/test/support/hashlib_helper.py
@@ -21,8 +21,21 @@ def requires_hashdigest(digestname, openssl=None, usedforsecurity=True):
     ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS
     ValueError: unsupported hash type md4
     """
-    def decorator(func):
-        @functools.wraps(func)
+    def decorator(func_or_class):
+        if isinstance(func_or_class, type):
+            setUpClass = func_or_class.__dict__.get('setUpClass')
+            if setUpClass is None:
+                def setUpClass(cls):
+                    super(func_or_class, cls).setUpClass()
+                setUpClass.__qualname__ = func_or_class.__qualname__ + '.setUpClass'
+                setUpClass.__module__ = func_or_class.__module__
+            else:
+                setUpClass = setUpClass.__func__
+            setUpClass = classmethod(decorator(setUpClass))
+            func_or_class.setUpClass = setUpClass
+            return func_or_class
+
+        @functools.wraps(func_or_class)
         def wrapper(*args, **kwargs):
             try:
                 if openssl and _hashlib is not None:
@@ -33,6 +46,6 @@ def requires_hashdigest(digestname, openssl=None, usedforsecurity=True):
                 raise unittest.SkipTest(
                     f"hash digest '{digestname}' is not available."
                 )
-            return func(*args, **kwargs)
+            return func_or_class(*args, **kwargs)
         return wrapper
     return decorator

--- a/Lib/test/test_tools/test_md5sum.py
+++ b/Lib/test/test_tools/test_md5sum.py
@@ -1,5 +1,6 @@
 """Tests for the md5sum script in the Tools directory."""
 
+import sys
 import os
 import unittest
 from test import support
@@ -15,8 +16,8 @@ class MD5SumTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.script = os.path.join(scriptsdir, 'md5sum.py')
-        os.mkdir(support.TESTFN)
-        cls.fodder = os.path.join(support.TESTFN, 'md5sum.fodder')
+        os.mkdir(support.TESTFN_ASCII)
+        cls.fodder = os.path.join(support.TESTFN_ASCII, 'md5sum.fodder')
         with open(cls.fodder, 'wb') as f:
             f.write(b'md5sum\r\ntest file\r\n')
         cls.fodder_md5 = b'd38dae2eb1ab346a292ef6850f9e1a0d'
@@ -24,7 +25,7 @@ class MD5SumTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        support.rmtree(support.TESTFN)
+        support.rmtree(support.TESTFN_ASCII)
 
     def test_noargs(self):
         rc, out, err = assert_python_ok(self.script)

--- a/Misc/NEWS.d/next/Tests/2021-08-30-11-54-14.bpo-45042.QMz3X8.rst
+++ b/Misc/NEWS.d/next/Tests/2021-08-30-11-54-14.bpo-45042.QMz3X8.rst
@@ -1,0 +1,1 @@
+Fixes that test classes decorated with ``@hashlib_helper.requires_hashdigest`` were skipped all the time.


### PR DESCRIPTION
…` are not skipped (GH-28060)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>.
(cherry picked from commit dd7b816ac87e468e2fa65ce83c2a03fe1da8503e)

Co-authored-by: Nikita Sobolev <mail@sobolevn.me>


<!-- issue-number: [bpo-45042](https://bugs.python.org/issue45042) -->
https://bugs.python.org/issue45042
<!-- /issue-number -->
