### PR TITLE
bpo-45034: Fixes how upper limit is formatted for `struct.pack("H", ...)`

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -679,13 +679,22 @@ class StructTest(unittest.TestCase):
                 struct.calcsize(s)
 
     @support.cpython_only
-    def test_issue45034(self):
+    def test_issue45034_unsigned(self):
         from _testcapi import USHRT_MAX
         error_msg = f'ushort format requires 0 <= number <= {USHRT_MAX}'
         with self.assertRaisesRegex(struct.error, error_msg):
             struct.pack('H', 70000)  # too large
         with self.assertRaisesRegex(struct.error, error_msg):
             struct.pack('H', -1)  # too small
+
+    @support.cpython_only
+    def test_issue45034_signed(self):
+        from _testcapi import SHRT_MIN, SHRT_MAX
+        error_msg = f'short format requires {SHRT_MIN} <= number <= {SHRT_MAX}'
+        with self.assertRaisesRegex(struct.error, error_msg):
+            struct.pack('h', 70000)  # too large
+        with self.assertRaisesRegex(struct.error, error_msg):
+            struct.pack('h', -70000)  # too small
 
 
 class UnpackIteratorTest(unittest.TestCase):

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -678,6 +678,15 @@ class StructTest(unittest.TestCase):
                                         'embedded null character'):
                 struct.calcsize(s)
 
+    @support.cpython_only
+    def test_issue45034(self):
+        from _testcapi import USHRT_MAX
+        error_msg = f'ushort format requires 0 <= number <= {USHRT_MAX}'
+        with self.assertRaisesRegex(struct.error, error_msg):
+            struct.pack('H', 70000)  # too large
+        with self.assertRaisesRegex(struct.error, error_msg):
+            struct.pack('H', -1)  # too small
+
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1663,6 +1663,7 @@ Ryan Smith-Roberts
 Rafal Smotrzyk
 Josh Snider
 Eric Snow
+Nikita Sobolev
 Dirk Soede
 Nir Soffer
 Paul Sokolovsky

--- a/Misc/NEWS.d/next/Library/2021-09-05-20-33-25.bpo-45034.62NLD5.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-05-20-33-25.bpo-45034.62NLD5.rst
@@ -1,2 +1,2 @@
-Changes how max value is formatted for ``struct.pack`` with ``'H'`` mode and
-too large / small numbers.
+Changes how error is formatted for ``struct.pack`` with ``'H'`` and ``'h'`` modes and
+too large / small numbers. Now it shows the actual numeric limits, while previously it was showing arithmetic expressions.

--- a/Misc/NEWS.d/next/Library/2021-09-05-20-33-25.bpo-45034.62NLD5.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-05-20-33-25.bpo-45034.62NLD5.rst
@@ -1,0 +1,2 @@
+Changes how max value is formatted for ``struct.pack`` with ``'H'`` mode and
+too large / small numbers.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -609,7 +609,7 @@ np_ushort(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     if (x < 0 || x > USHRT_MAX) {
         PyErr_Format(state->StructError,
                      "ushort format requires 0 <= number <= %u",
-                     USHRT_MAX);
+                     (unsigned int)(USHRT_MAX));
         return -1;
     }
     y = (unsigned short)x;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -591,8 +591,7 @@ np_short(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     if (x < SHRT_MIN || x > SHRT_MAX) {
         PyErr_Format(state->StructError,
                      "short format requires %d <= number <= %d",
-                     SHRT_MIN,
-                     SHRT_MAX);
+                     (int)SHRT_MIN, (int)SHRT_MAX);
         return -1;
     }
     y = (short)x;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -607,9 +607,9 @@ np_ushort(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     if (get_long(state, v, &x) < 0)
         return -1;
     if (x < 0 || x > USHRT_MAX) {
-        PyErr_SetString(state->StructError,
-                        "ushort format requires 0 <= number <= "
-                        Py_STRINGIFY(USHRT_MAX));
+        PyErr_Format(state->StructError,
+                     "ushort format requires 0 <= number <= %zu",
+                     USHRT_MAX);
         return -1;
     }
     y = (unsigned short)x;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -589,9 +589,10 @@ np_short(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     if (get_long(state, v, &x) < 0)
         return -1;
     if (x < SHRT_MIN || x > SHRT_MAX) {
-        PyErr_SetString(state->StructError,
-                        "short format requires " Py_STRINGIFY(SHRT_MIN)
-                        " <= number <= " Py_STRINGIFY(SHRT_MAX));
+        PyErr_Format(state->StructError,
+                     "short format requires %d <= number <= %d",
+                     SHRT_MIN,
+                     SHRT_MAX);
         return -1;
     }
     y = (short)x;
@@ -609,7 +610,7 @@ np_ushort(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     if (x < 0 || x > USHRT_MAX) {
         PyErr_Format(state->StructError,
                      "ushort format requires 0 <= number <= %u",
-                     (unsigned int)(USHRT_MAX));
+                     (unsigned int)USHRT_MAX);
         return -1;
     }
     y = (unsigned short)x;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -608,7 +608,7 @@ np_ushort(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
         return -1;
     if (x < 0 || x > USHRT_MAX) {
         PyErr_Format(state->StructError,
-                     "ushort format requires 0 <= number <= %zu",
+                     "ushort format requires 0 <= number <= %u",
                      USHRT_MAX);
         return -1;
     }


### PR DESCRIPTION

<!-- issue-number: [bpo-45034](https://bugs.python.org/issue45034) -->
https://bugs.python.org/issue45034
<!-- /issue-number -->

It was:
> struct.error: ushort format requires 0 <= number <= (0x7fff * 2 + 1)

It is now:
> struct.error: ushort format requires 0 <= number <= 65535
