### PR TITLE
bpo-45115: Enable optimiaztions on Windows debug build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,11 +95,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -p Win32
+      run: .\PCbuild\build.bat -e -p Win32 -d
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
-      run: .\PCbuild\rt.bat -p Win32 -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
+      run: .\PCbuild\rt.bat -p Win32 -d -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
 
   build_win_amd64:
     name: 'Windows (x64)'
@@ -111,11 +111,11 @@ jobs:
     - name: Register MSVC problem matcher
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -p x64
+      run: .\PCbuild\build.bat -e -p x64 -d
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
-      run: .\PCbuild\rt.bat -p x64 -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
+      run: .\PCbuild\rt.bat -p x64 -d -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0
 
   build_macos:
     name: 'macOS'

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -284,6 +284,11 @@ CPython bytecode changes
 Build Changes
 =============
 
+* On Windows, enable compiler optimizations on the debug build to make tests
+  run faster and to reduce the stack memory usage, especially with static
+  inline functions used in Python public header files.
+  (Contributed by Victor Stinner in :issue:`45115`.)
+
 
 Deprecated
 ==========

--- a/Misc/NEWS.d/next/Build/2021-09-06-17-22-14.bpo-45115.4n0_eo.rst
+++ b/Misc/NEWS.d/next/Build/2021-09-06-17-22-14.bpo-45115.4n0_eo.rst
@@ -1,0 +1,3 @@
+On Windows, enable compiler optimizations on the debug build to make tests
+run faster and to reduce the stack memory usage, especially with static
+inline functions used in Python public header files.

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -104,6 +104,8 @@
       <AdditionalIncludeDirectories Condition="$(IncludeExternals)">$(zlibDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_BUILD_CORE_BUILTIN;Py_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(IncludeExternals)">_Py_HAVE_ZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MaxSpeed</Optimization>
+      <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Default</InlineFunctionExpansion>
     </ClCompile>
     <Link>
       <AdditionalDependencies>version.lib;shlwapi.lib;ws2_32.lib;pathcch.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
On Windows, enable compiler optimizations on the debug build to make
tests run faster and to reduce the stack memory usage, especially
with static inline functions used in Python public header files.

The Windows GitHub Actions now build Python in debug mode to catch
more bugs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45115](https://bugs.python.org/issue45115) -->
https://bugs.python.org/issue45115
<!-- /issue-number -->
