### PR TITLE
bpo-45052: Unskips a failing `test_shared_memory_basics` test

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3773,7 +3773,6 @@ class _TestSharedMemory(BaseTestCase):
         local_sms.buf[:len(binary_data)] = binary_data
         local_sms.close()
 
-    @unittest.skipIf(sys.platform == "win32", "test is broken on Windows")
     def test_shared_memory_basics(self):
         sms = shared_memory.SharedMemory('test01_tsmb', create=True, size=512)
         self.addCleanup(sms.unlink)
@@ -3792,7 +3791,6 @@ class _TestSharedMemory(BaseTestCase):
         pickled_sms = pickle.dumps(sms)
         sms2 = pickle.loads(pickled_sms)
         self.assertEqual(sms.name, sms2.name)
-        self.assertEqual(sms.size, sms2.size)
         self.assertEqual(bytes(sms.buf[0:6]), bytes(sms2.buf[0:6]), b'pickle')
 
         # Modify contents of shared memory segment through memoryview.

--- a/Misc/NEWS.d/next/Tests/2021-09-06-19-00-29.bpo-45052.yrOK3J.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-06-19-00-29.bpo-45052.yrOK3J.rst
@@ -1,0 +1,7 @@
+``WithProcessesTestSharedMemory.test_shared_memory_basics`` test was
+ignored, because ``self.assertEqual(sms.size, sms2.size)`` line was failing.
+It is now removed and test is unskipped.
+
+The main motivation for this line to be removed from the test is that the
+``size`` of ``SharedMemory`` is not ever guaranteed to be the same. It is
+decided by the platform.


### PR DESCRIPTION


<!-- issue-number: [bpo-45052](https://bugs.python.org/issue45052) -->
https://bugs.python.org/issue45052
<!-- /issue-number -->
