### PR TITLE
bpo-45118: Fix regrtest second summary for re-run tests

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -66,6 +66,7 @@ class Regrtest:
         self.resource_denieds = []
         self.environment_changed = []
         self.run_no_tests = []
+        self.need_rerun = []
         self.rerun = []
         self.first_result = None
         self.interrupted = False
@@ -116,7 +117,7 @@ class Regrtest:
         elif isinstance(result, Failed):
             if not rerun:
                 self.bad.append(test_name)
-                self.rerun.append(result)
+                self.need_rerun.append(result)
         elif isinstance(result, DidNotRun):
             self.run_no_tests.append(test_name)
         elif isinstance(result, Interrupted):
@@ -312,10 +313,12 @@ class Regrtest:
 
         self.log()
         self.log("Re-running failed tests in verbose mode")
-        rerun_list = self.rerun[:]
-        self.rerun = []
+        rerun_list = list(self.need_rerun)
+        self.need_rerun.clear()
         for result in rerun_list:
             test_name = result.name
+            self.rerun.append(test_name)
+
             errors = result.errors or []
             failures = result.failures or []
             error_names = [test_full_name.split(" ")[0] for (test_full_name, *_) in errors]
@@ -397,7 +400,7 @@ class Regrtest:
         if self.rerun:
             print()
             print("%s:" % count(len(self.rerun), "re-run test"))
-            printlist(r.name for r in self.rerun)
+            printlist(self.rerun)
 
         if self.run_no_tests:
             print()


### PR DESCRIPTION
Fix regrtest second summary when using -w/--verbose2 command line
option: lists re-run tests in the second test summary.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45118](https://bugs.python.org/issue45118) -->
https://bugs.python.org/issue45118
<!-- /issue-number -->
