### PR TITLE
Make asyncio main importable by fixing references to global vars

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -52,7 +52,7 @@ class AsyncIOInteractiveConsole(code.InteractiveConsole):
             except BaseException as exc:
                 future.set_exception(exc)
 
-        loop.call_soon_threadsafe(callback)
+        self.loop.call_soon_threadsafe(callback)
 
         try:
             return future.result()
@@ -77,7 +77,7 @@ class REPLThread(threading.Thread):
                 f'{getattr(sys, "ps1", ">>> ")}import asyncio'
             )
 
-            console.interact(
+            self.console.interact(
                 banner=banner,
                 exitmsg='exiting asyncio REPL...')
         finally:
@@ -86,7 +86,7 @@ class REPLThread(threading.Thread):
                 message=r'^coroutine .* was never awaited$',
                 category=RuntimeWarning)
 
-            loop.call_soon_threadsafe(loop.stop)
+            self.loop.call_soon_threadsafe(self.loop.stop)
 
 
 if __name__ == '__main__':
@@ -111,6 +111,8 @@ if __name__ == '__main__':
 
     repl_thread = REPLThread()
     repl_thread.daemon = True
+    repl_thread.loop = loop
+    repl_thread.console = console
     repl_thread.start()
 
     while True:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

RIght now, importing this module makes classes in it unusable as the `name == '__main__'` block isn't run. This is a small fix for that.

The change is small but please let me know if this is issue number worthy.