### PR TITLE
[3.9] bpo-41082: Add note on errors that may be raised by home() and expanduser()

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -708,7 +708,7 @@ call fails (for example because the path doesn't exist).
       >>> Path.home()
       PosixPath('/home/antoine')
 
-   Note that unlike :func:`os.path.expanduser`, on Posix systems a
+   Note that unlike :func:`os.path.expanduser`, on POSIX systems a
    :exc:`KeyError` or :exc:`RuntimeError` will be raised, and on Windows systems a
    :exc:`RuntimeError` will be raised if home directory can't be resolved.
 
@@ -768,7 +768,7 @@ call fails (for example because the path doesn't exist).
       >>> p.expanduser()
       PosixPath('/home/eric/films/Monty Python')
 
-   Note that unlike :func:`os.path.expanduser`, on Posix systems a
+   Note that unlike :func:`os.path.expanduser`, on POSIX systems a
    :exc:`KeyError` or :exc:`RuntimeError` will be raised, and on Windows systems a
    :exc:`RuntimeError` will be raised if home directory can't be resolved.
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -709,8 +709,8 @@ call fails (for example because the path doesn't exist).
       PosixPath('/home/antoine')
 
    Note that unlike :func:`os.path.expanduser`, on Posix systems a
-   :exc:`KeyError` will be raised, and on Windows systems a :exc:`RuntimeError`
-   will be raised if home directory can't be resolved.
+   :exc:`KeyError` or :exc:`RuntimeError` will be raised, and on Windows systems a
+   :exc:`RuntimeError` will be raised if home directory can't be resolved.
 
    .. versionadded:: 3.5
 
@@ -769,8 +769,8 @@ call fails (for example because the path doesn't exist).
       PosixPath('/home/eric/films/Monty Python')
 
    Note that unlike :func:`os.path.expanduser`, on Posix systems a
-   :exc:`KeyError` will be raised, and on Windows systems a :exc:`RuntimeError`
-   will be raised if home directory can't be resolved.
+   :exc:`KeyError` or :exc:`RuntimeError` will be raised, and on Windows systems a
+   :exc:`RuntimeError` will be raised if home directory can't be resolved.
 
    .. versionadded:: 3.5
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -709,7 +709,7 @@ call fails (for example because the path doesn't exist).
       PosixPath('/home/antoine')
 
    Note that unlike :func:`os.path.expanduser`, on Posix systems a
-   :exc:`KeyError` may be raised, and on Windows systems a :exc:`RuntimeError`
+   :exc:`KeyError` will be raised, and on Windows systems a :exc:`RuntimeError`
    will be raised if home directory can't be resolved.
 
    .. versionadded:: 3.5
@@ -769,7 +769,7 @@ call fails (for example because the path doesn't exist).
       PosixPath('/home/eric/films/Monty Python')
 
    Note that unlike :func:`os.path.expanduser`, on Posix systems a
-   :exc:`KeyError` may be raised, and on Windows systems a :exc:`RuntimeError`
+   :exc:`KeyError` will be raised, and on Windows systems a :exc:`RuntimeError`
    will be raised if home directory can't be resolved.
 
    .. versionadded:: 3.5

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -708,6 +708,10 @@ call fails (for example because the path doesn't exist).
       >>> Path.home()
       PosixPath('/home/antoine')
 
+   Note that unlike :func:`os.path.expanduser`, on Posix systems a
+   :exc:`KeyError` may be raised, and on Windows systems a :exc:`RuntimeError`
+   will be raised if home directory can't be resolved.
+
    .. versionadded:: 3.5
 
 
@@ -763,6 +767,10 @@ call fails (for example because the path doesn't exist).
       >>> p = PosixPath('~/films/Monty Python')
       >>> p.expanduser()
       PosixPath('/home/eric/films/Monty Python')
+
+   Note that unlike :func:`os.path.expanduser`, on Posix systems a
+   :exc:`KeyError` may be raised, and on Windows systems a :exc:`RuntimeError`
+   will be raised if home directory can't be resolved.
 
    .. versionadded:: 3.5
 


### PR DESCRIPTION
This issue was fixed in 3.10 with a code + doc fix, but was not backported. This docfix can potentially be applied to take care of this if we decide not to backport https://github.com/python/cpython/pull/18841 .

<!-- issue-number: [bpo-41082](https://bugs.python.org/issue41082) -->
https://bugs.python.org/issue41082
<!-- /issue-number -->
