### PR TITLE
Remove stray non-printable chars from email module

### DIFF
--- a/Lib/email/__init__.py
+++ b/Lib/email/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
     ]
 
 
-
+
 # Some convenience routines.  Don't import Parser and Message as side-effects
 # of importing email since those cascadingly import most of the rest of the
 # email package.

--- a/Lib/email/base64mime.py
+++ b/Lib/email/base64mime.py
@@ -45,7 +45,7 @@ EMPTYSTRING = ''
 MISC_LEN = 7
 
 
-
+
 # Helpers
 def header_length(bytearray):
     """Return the length of s when it is encoded with base64."""
@@ -57,7 +57,7 @@ def header_length(bytearray):
     return n
 
 
-
+
 def header_encode(header_bytes, charset='iso-8859-1'):
     """Encode a single header line with Base64 encoding in a given charset.
 
@@ -72,7 +72,7 @@ def header_encode(header_bytes, charset='iso-8859-1'):
     return '=?%s?b?%s?=' % (charset, encoded)
 
 
-
+
 def body_encode(s, maxlinelen=76, eol=NL):
     r"""Encode a string with base64.
 
@@ -98,7 +98,7 @@ def body_encode(s, maxlinelen=76, eol=NL):
     return EMPTYSTRING.join(encvec)
 
 
-
+
 def decode(string):
     """Decode a raw base64 string, returning a bytes object.
 

--- a/Lib/email/charset.py
+++ b/Lib/email/charset.py
@@ -18,7 +18,7 @@ from email import errors
 from email.encoders import encode_7or8bit
 
 
-
+
 # Flags for types of header encodings
 QP          = 1 # Quoted-Printable
 BASE64      = 2 # Base64
@@ -32,7 +32,7 @@ UNKNOWN8BIT = 'unknown-8bit'
 EMPTYSTRING = ''
 
 
-
+
 # Defaults
 CHARSETS = {
     # input        header enc  body enc output conv
@@ -104,7 +104,7 @@ CODEC_MAP = {
     }
 
 
-
+
 # Convenience functions for extending the above mappings
 def add_charset(charset, header_enc=None, body_enc=None, output_charset=None):
     """Add character set properties to the global registry.
@@ -153,7 +153,7 @@ def add_codec(charset, codecname):
     CODEC_MAP[charset] = codecname
 
 
-
+
 # Convenience function for encoding strings, taking into account
 # that they might be unknown-8bit (ie: have surrogate-escaped bytes)
 def _encode(string, codec):
@@ -163,7 +163,7 @@ def _encode(string, codec):
         return string.encode(codec)
 
 
-
+
 class Charset:
     """Map character sets to their email properties.
 

--- a/Lib/email/encoders.py
+++ b/Lib/email/encoders.py
@@ -16,7 +16,7 @@ from base64 import encodebytes as _bencode
 from quopri import encodestring as _encodestring
 
 
-
+
 def _qencode(s):
     enc = _encodestring(s, quotetabs=True)
     # Must encode spaces, which quopri.encodestring() doesn't do
@@ -34,7 +34,7 @@ def encode_base64(msg):
     msg['Content-Transfer-Encoding'] = 'base64'
 
 
-
+
 def encode_quopri(msg):
     """Encode the message's payload in quoted-printable.
 
@@ -46,7 +46,7 @@ def encode_quopri(msg):
     msg['Content-Transfer-Encoding'] = 'quoted-printable'
 
 
-
+
 def encode_7or8bit(msg):
     """Set the Content-Transfer-Encoding header to 7bit or 8bit."""
     orig = msg.get_payload(decode=True)
@@ -64,6 +64,6 @@ def encode_7or8bit(msg):
         msg['Content-Transfer-Encoding'] = '7bit'
 
 
-
+
 def encode_noop(msg):
     """Do nothing."""

--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -41,7 +41,7 @@ NL = '\n'
 NeedMoreData = object()
 
 
-
+
 class BufferedSubFile(object):
     """A file-ish object that can have new data loaded into it.
 
@@ -132,7 +132,7 @@ class BufferedSubFile(object):
         return line
 
 
-
+
 class FeedParser:
     """A feed-style parser of email."""
 

--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -22,7 +22,7 @@ NLCRE = re.compile(r'\r\n|\r|\n')
 fcre = re.compile(r'^From ', re.MULTILINE)
 
 
-
+
 class Generator:
     """Generates output from a Message object tree.
 
@@ -392,7 +392,7 @@ class Generator:
     def _compile_re(cls, s, flags):
         return re.compile(s, flags)
 
-
+
 class BytesGenerator(Generator):
     """Generates a bytes version of a Message object tree.
 
@@ -443,7 +443,7 @@ class BytesGenerator(Generator):
         return re.compile(s.encode('ascii'), flags)
 
 
-
+
 _FMT = '[Non-text (%(type)s) part of message omitted, filename %(filename)s]'
 
 class DecodedGenerator(Generator):
@@ -503,7 +503,7 @@ class DecodedGenerator(Generator):
                     }, file=self)
 
 
-
+
 # Helper used by Generator._make_boundary
 _width = len(repr(sys.maxsize-1))
 _fmt = '%%0%dd' % _width

--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -52,12 +52,12 @@ fcre = re.compile(r'[\041-\176]+:$')
 _embedded_header = re.compile(r'\n[^ \t]+:')
 
 
-
+
 # Helpers
 _max_append = email.quoprimime._max_append
 
 
-
+
 def decode_header(header):
     """Decode a message header value without converting charset.
 
@@ -152,7 +152,7 @@ def decode_header(header):
     return collapsed
 
 
-
+
 def make_header(decoded_seq, maxlinelen=None, header_name=None,
                 continuation_ws=' '):
     """Create a Header from a sequence of pairs as returned by decode_header()
@@ -175,7 +175,7 @@ def make_header(decoded_seq, maxlinelen=None, header_name=None,
     return h
 
 
-
+
 class Header:
     def __init__(self, s=None, charset=None,
                  maxlinelen=None, header_name=None,
@@ -409,7 +409,7 @@ class Header:
         self._chunks = chunks
 
 
-
+
 class _ValueFormatter:
     def __init__(self, headerlen, maxlen, continuation_ws, splitchars):
         self._maxlen = maxlen

--- a/Lib/email/iterators.py
+++ b/Lib/email/iterators.py
@@ -15,7 +15,7 @@ import sys
 from io import StringIO
 
 
-
+
 # This function will become a method of the Message class
 def walk(self):
     """Walk over the message tree, yielding each subpart.
@@ -29,7 +29,7 @@ def walk(self):
             yield from subpart.walk()
 
 
-
+
 # These two functions are imported into the Iterators.py interface module.
 def body_line_iterator(msg, decode=False):
     """Iterate over the parts, returning string payloads line-by-line.
@@ -55,7 +55,7 @@ def typed_subpart_iterator(msg, maintype='text', subtype=None):
                 yield subpart
 
 
-
+
 def _structure(msg, fp=None, level=0, include_default=False):
     """A handy debugging aid"""
     if fp is None:

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -35,7 +35,7 @@ def _splitparam(param):
     if not sep:
         return a.strip(), None
     return a.strip(), b.strip()
-
+
 def _formatparam(param, value=None, quote=True):
     """Convenience function to format and return a key=value pair.
 
@@ -101,7 +101,7 @@ def _unquotevalue(value):
         return utils.unquote(value)
 
 
-
+
 class Message:
     """Basic message object.
 

--- a/Lib/email/mime/audio.py
+++ b/Lib/email/mime/audio.py
@@ -13,7 +13,7 @@ from email import encoders
 from email.mime.nonmultipart import MIMENonMultipart
 
 
-
+
 _sndhdr_MIMEmap = {'au'  : 'basic',
                    'wav' :'x-wav',
                    'aiff':'x-aiff',
@@ -38,7 +38,7 @@ def _whatsnd(data):
     return None
 
 
-
+
 class MIMEAudio(MIMENonMultipart):
     """Class for generating audio/* MIME documents."""
 

--- a/Lib/email/mime/base.py
+++ b/Lib/email/mime/base.py
@@ -11,7 +11,7 @@ import email.policy
 from email import message
 
 
-
+
 class MIMEBase(message.Message):
     """Base class for MIME specializations."""
 

--- a/Lib/email/mime/image.py
+++ b/Lib/email/mime/image.py
@@ -12,7 +12,7 @@ from email import encoders
 from email.mime.nonmultipart import MIMENonMultipart
 
 
-
+
 class MIMEImage(MIMENonMultipart):
     """Class for generating image/* type MIME documents."""
 

--- a/Lib/email/mime/message.py
+++ b/Lib/email/mime/message.py
@@ -10,7 +10,7 @@ from email import message
 from email.mime.nonmultipart import MIMENonMultipart
 
 
-
+
 class MIMEMessage(MIMENonMultipart):
     """Class representing message/* MIME documents."""
 

--- a/Lib/email/mime/multipart.py
+++ b/Lib/email/mime/multipart.py
@@ -9,7 +9,7 @@ __all__ = ['MIMEMultipart']
 from email.mime.base import MIMEBase
 
 
-
+
 class MIMEMultipart(MIMEBase):
     """Base class for MIME multipart/* type messages."""
 

--- a/Lib/email/mime/nonmultipart.py
+++ b/Lib/email/mime/nonmultipart.py
@@ -10,7 +10,7 @@ from email import errors
 from email.mime.base import MIMEBase
 
 
-
+
 class MIMENonMultipart(MIMEBase):
     """Base class for MIME non-multipart type messages."""
 

--- a/Lib/email/mime/text.py
+++ b/Lib/email/mime/text.py
@@ -10,7 +10,7 @@ from email.charset import Charset
 from email.mime.nonmultipart import MIMENonMultipart
 
 
-
+
 class MIMEText(MIMENonMultipart):
     """Class for generating text/* type MIME documents."""
 

--- a/Lib/email/parser.py
+++ b/Lib/email/parser.py
@@ -67,7 +67,7 @@ class Parser:
         return self.parse(StringIO(text), headersonly=headersonly)
 
 
-
+
 class HeaderParser(Parser):
     def parse(self, fp, headersonly=True):
         return Parser.parse(self, fp, True)
@@ -75,7 +75,7 @@ class HeaderParser(Parser):
     def parsestr(self, text, headersonly=True):
         return Parser.parsestr(self, text, True)
 
-
+
 class BytesParser:
 
     def __init__(self, *args, **kw):


### PR DESCRIPTION
For some reason, there are 40 instances of the `` character being present in the email module, usually just before a function/class definition, i.e. places where there are three empty lines. This PR simply strips them off.

---
There's 45 more instances of these characters, namely in these files:
<details>
<summary>Click to show</summary>

```
Lib/test/test_isinstance.py
Modules/_io/_iomodule.c
Modules/_io/bufferedio.c
Tools/i18n/pygettext.py
Tools/pynche/README
Tools/pynche/Switchboard.py
Tools/pynche/PyncheWidget.py
Tools/pynche/Main.py
Tools/pynche/StripViewer.py
Tools/pynche/TypeinViewer.py
Tools/pynche/ChipViewer.py
Tools/pynche/DetailsViewer.py
Tools/pynche/ColorDB.py
Tools/pynche/pyColorChooser.py
Tools/pynche/TextViewer.py
```
</details>

I could add a commit removing it from all those files as well, if that is okay.