### PR TITLE
Fix typo in help.html

### DIFF
--- a/Lib/idlelib/help.html
+++ b/Lib/idlelib/help.html
@@ -504,7 +504,7 @@ available module-level names by running your code
 and not restarting the Shell thereafter.  This is especially useful
 after adding imports at the top of a file.  This also increases
 possible attribute completions.</p>
-<p>Completion boxes intially exclude names beginning with ‘_’ or, for
+<p>Completion boxes initially exclude names beginning with ‘_’ or, for
 modules, not included in ‘__all__’.  The hidden names can be accessed
 by typing ‘_’ after ‘.’, either before or after the box is opened.</p>
 </div>


### PR DESCRIPTION
Fix typo:

intially -> initially
