### PR TITLE
bpo-45120: Updated windows 'cp' encodings to match 'bestfit' specification.

### DIFF
--- a/Lib/encodings/cp1250.py
+++ b/Lib/encodings/cp1250.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1250 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1250.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1250 generated from 'WindowsBestFit/cp1250.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\ufffe'   #  0x83 -> UNDEFINED
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\ufffe'   #  0x88 -> UNDEFINED
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\u0160'   #  0x8A -> LATIN CAPITAL LETTER S WITH CARON
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\u015a'   #  0x8C -> LATIN CAPITAL LETTER S WITH ACUTE
-    '\u0164'   #  0x8D -> LATIN CAPITAL LETTER T WITH CARON
-    '\u017d'   #  0x8E -> LATIN CAPITAL LETTER Z WITH CARON
-    '\u0179'   #  0x8F -> LATIN CAPITAL LETTER Z WITH ACUTE
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\ufffe'   #  0x98 -> UNDEFINED
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\u0161'   #  0x9A -> LATIN SMALL LETTER S WITH CARON
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\u015b'   #  0x9C -> LATIN SMALL LETTER S WITH ACUTE
-    '\u0165'   #  0x9D -> LATIN SMALL LETTER T WITH CARON
-    '\u017e'   #  0x9E -> LATIN SMALL LETTER Z WITH CARON
-    '\u017a'   #  0x9F -> LATIN SMALL LETTER Z WITH ACUTE
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\u02c7'   #  0xA1 -> CARON
-    '\u02d8'   #  0xA2 -> BREVE
-    '\u0141'   #  0xA3 -> LATIN CAPITAL LETTER L WITH STROKE
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\u0104'   #  0xA5 -> LATIN CAPITAL LETTER A WITH OGONEK
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xa8'     #  0xA8 -> DIAERESIS
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\u015e'   #  0xAA -> LATIN CAPITAL LETTER S WITH CEDILLA
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\u017b'   #  0xAF -> LATIN CAPITAL LETTER Z WITH DOT ABOVE
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\u02db'   #  0xB2 -> OGONEK
-    '\u0142'   #  0xB3 -> LATIN SMALL LETTER L WITH STROKE
-    '\xb4'     #  0xB4 -> ACUTE ACCENT
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\xb8'     #  0xB8 -> CEDILLA
-    '\u0105'   #  0xB9 -> LATIN SMALL LETTER A WITH OGONEK
-    '\u015f'   #  0xBA -> LATIN SMALL LETTER S WITH CEDILLA
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\u013d'   #  0xBC -> LATIN CAPITAL LETTER L WITH CARON
-    '\u02dd'   #  0xBD -> DOUBLE ACUTE ACCENT
-    '\u013e'   #  0xBE -> LATIN SMALL LETTER L WITH CARON
-    '\u017c'   #  0xBF -> LATIN SMALL LETTER Z WITH DOT ABOVE
-    '\u0154'   #  0xC0 -> LATIN CAPITAL LETTER R WITH ACUTE
-    '\xc1'     #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
-    '\xc2'     #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
-    '\u0102'   #  0xC3 -> LATIN CAPITAL LETTER A WITH BREVE
-    '\xc4'     #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
-    '\u0139'   #  0xC5 -> LATIN CAPITAL LETTER L WITH ACUTE
-    '\u0106'   #  0xC6 -> LATIN CAPITAL LETTER C WITH ACUTE
-    '\xc7'     #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
-    '\u010c'   #  0xC8 -> LATIN CAPITAL LETTER C WITH CARON
-    '\xc9'     #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
-    '\u0118'   #  0xCA -> LATIN CAPITAL LETTER E WITH OGONEK
-    '\xcb'     #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
-    '\u011a'   #  0xCC -> LATIN CAPITAL LETTER E WITH CARON
-    '\xcd'     #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
-    '\xce'     #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
-    '\u010e'   #  0xCF -> LATIN CAPITAL LETTER D WITH CARON
-    '\u0110'   #  0xD0 -> LATIN CAPITAL LETTER D WITH STROKE
-    '\u0143'   #  0xD1 -> LATIN CAPITAL LETTER N WITH ACUTE
-    '\u0147'   #  0xD2 -> LATIN CAPITAL LETTER N WITH CARON
-    '\xd3'     #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
-    '\xd4'     #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
-    '\u0150'   #  0xD5 -> LATIN CAPITAL LETTER O WITH DOUBLE ACUTE
-    '\xd6'     #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
-    '\xd7'     #  0xD7 -> MULTIPLICATION SIGN
-    '\u0158'   #  0xD8 -> LATIN CAPITAL LETTER R WITH CARON
-    '\u016e'   #  0xD9 -> LATIN CAPITAL LETTER U WITH RING ABOVE
-    '\xda'     #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
-    '\u0170'   #  0xDB -> LATIN CAPITAL LETTER U WITH DOUBLE ACUTE
-    '\xdc'     #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
-    '\xdd'     #  0xDD -> LATIN CAPITAL LETTER Y WITH ACUTE
-    '\u0162'   #  0xDE -> LATIN CAPITAL LETTER T WITH CEDILLA
-    '\xdf'     #  0xDF -> LATIN SMALL LETTER SHARP S
-    '\u0155'   #  0xE0 -> LATIN SMALL LETTER R WITH ACUTE
-    '\xe1'     #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
-    '\xe2'     #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
-    '\u0103'   #  0xE3 -> LATIN SMALL LETTER A WITH BREVE
-    '\xe4'     #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
-    '\u013a'   #  0xE5 -> LATIN SMALL LETTER L WITH ACUTE
-    '\u0107'   #  0xE6 -> LATIN SMALL LETTER C WITH ACUTE
-    '\xe7'     #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
-    '\u010d'   #  0xE8 -> LATIN SMALL LETTER C WITH CARON
-    '\xe9'     #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
-    '\u0119'   #  0xEA -> LATIN SMALL LETTER E WITH OGONEK
-    '\xeb'     #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
-    '\u011b'   #  0xEC -> LATIN SMALL LETTER E WITH CARON
-    '\xed'     #  0xED -> LATIN SMALL LETTER I WITH ACUTE
-    '\xee'     #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
-    '\u010f'   #  0xEF -> LATIN SMALL LETTER D WITH CARON
-    '\u0111'   #  0xF0 -> LATIN SMALL LETTER D WITH STROKE
-    '\u0144'   #  0xF1 -> LATIN SMALL LETTER N WITH ACUTE
-    '\u0148'   #  0xF2 -> LATIN SMALL LETTER N WITH CARON
-    '\xf3'     #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
-    '\xf4'     #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
-    '\u0151'   #  0xF5 -> LATIN SMALL LETTER O WITH DOUBLE ACUTE
-    '\xf6'     #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
-    '\xf7'     #  0xF7 -> DIVISION SIGN
-    '\u0159'   #  0xF8 -> LATIN SMALL LETTER R WITH CARON
-    '\u016f'   #  0xF9 -> LATIN SMALL LETTER U WITH RING ABOVE
-    '\xfa'     #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
-    '\u0171'   #  0xFB -> LATIN SMALL LETTER U WITH DOUBLE ACUTE
-    '\xfc'     #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
-    '\xfd'     #  0xFD -> LATIN SMALL LETTER Y WITH ACUTE
-    '\u0163'   #  0xFE -> LATIN SMALL LETTER T WITH CEDILLA
-    '\u02d9'   #  0xFF -> DOT ABOVE
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> REVERSE SOLIDUS
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX ACCENT
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE ACCENT
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\x81'
+    '\u201a'    #  0x82 -> SINGLE LOW-9 QUOTATION MARK
+    '\x83'
+    '\u201e'    #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\x88'
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\u0160'    #  0x8A -> LATIN CAPITAL LETTER S WITH CARON
+    '\u2039'    #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    '\u015a'    #  0x8C -> LATIN CAPITAL LETTER S WITH ACUTE
+    '\u0164'    #  0x8D -> LATIN CAPITAL LETTER T WITH CARON
+    '\u017d'    #  0x8E -> LATIN CAPITAL LETTER Z WITH CARON
+    '\u0179'    #  0x8F -> LATIN CAPITAL LETTER Z WITH ACUTE
+    '\x90'
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\x98'
+    '\u2122'    #  0x99 -> TRADE MARK SIGN
+    '\u0161'    #  0x9A -> LATIN SMALL LETTER S WITH CARON
+    '\u203a'    #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    '\u015b'    #  0x9C -> LATIN SMALL LETTER S WITH ACUTE
+    '\u0165'    #  0x9D -> LATIN SMALL LETTER T WITH CARON
+    '\u017e'    #  0x9E -> LATIN SMALL LETTER Z WITH CARON
+    '\u017a'    #  0x9F -> LATIN SMALL LETTER Z WITH ACUTE
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\u02c7'    #  0xA1 -> CARON
+    '\u02d8'    #  0xA2 -> BREVE
+    '\u0141'    #  0xA3 -> LATIN CAPITAL LETTER L WITH STROKE
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\u0104'    #  0xA5 -> LATIN CAPITAL LETTER A WITH OGONEK
+    '\xa6'      #  0xA6 -> BROKEN BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xa8'      #  0xA8 -> DIAERESIS
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\u015e'    #  0xAA -> LATIN CAPITAL LETTER S WITH CEDILLA
+    '\xab'      #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED SIGN
+    '\u017b'    #  0xAF -> LATIN CAPITAL LETTER Z WITH DOT ABOVE
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-MINUS SIGN
+    '\u02db'    #  0xB2 -> OGONEK
+    '\u0142'    #  0xB3 -> LATIN SMALL LETTER L WITH STROKE
+    '\xb4'      #  0xB4 -> ACUTE ACCENT
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PILCROW SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\xb8'      #  0xB8 -> CEDILLA
+    '\u0105'    #  0xB9 -> LATIN SMALL LETTER A WITH OGONEK
+    '\u015f'    #  0xBA -> LATIN SMALL LETTER S WITH CEDILLA
+    '\xbb'      #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\u013d'    #  0xBC -> LATIN CAPITAL LETTER L WITH CARON
+    '\u02dd'    #  0xBD -> DOUBLE ACUTE ACCENT
+    '\u013e'    #  0xBE -> LATIN SMALL LETTER L WITH CARON
+    '\u017c'    #  0xBF -> LATIN SMALL LETTER Z WITH DOT ABOVE
+    '\u0154'    #  0xC0 -> LATIN CAPITAL LETTER R WITH ACUTE
+    '\xc1'      #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
+    '\xc2'      #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+    '\u0102'    #  0xC3 -> LATIN CAPITAL LETTER A WITH BREVE
+    '\xc4'      #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
+    '\u0139'    #  0xC5 -> LATIN CAPITAL LETTER L WITH ACUTE
+    '\u0106'    #  0xC6 -> LATIN CAPITAL LETTER C WITH ACUTE
+    '\xc7'      #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
+    '\u010c'    #  0xC8 -> LATIN CAPITAL LETTER C WITH CARON
+    '\xc9'      #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
+    '\u0118'    #  0xCA -> LATIN CAPITAL LETTER E WITH OGONEK
+    '\xcb'      #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
+    '\u011a'    #  0xCC -> LATIN CAPITAL LETTER E WITH CARON
+    '\xcd'      #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
+    '\xce'      #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+    '\u010e'    #  0xCF -> LATIN CAPITAL LETTER D WITH CARON
+    '\u0110'    #  0xD0 -> LATIN CAPITAL LETTER D WITH STROKE
+    '\u0143'    #  0xD1 -> LATIN CAPITAL LETTER N WITH ACUTE
+    '\u0147'    #  0xD2 -> LATIN CAPITAL LETTER N WITH CARON
+    '\xd3'      #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
+    '\xd4'      #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+    '\u0150'    #  0xD5 -> LATIN CAPITAL LETTER O WITH DOUBLE ACUTE
+    '\xd6'      #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
+    '\xd7'      #  0xD7 -> MULTIPLICATION SIGN
+    '\u0158'    #  0xD8 -> LATIN CAPITAL LETTER R WITH CARON
+    '\u016e'    #  0xD9 -> LATIN CAPITAL LETTER U WITH RING ABOVE
+    '\xda'      #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
+    '\u0170'    #  0xDB -> LATIN CAPITAL LETTER U WITH DOUBLE ACUTE
+    '\xdc'      #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
+    '\xdd'      #  0xDD -> LATIN CAPITAL LETTER Y WITH ACUTE
+    '\u0162'    #  0xDE -> LATIN CAPITAL LETTER T WITH CEDILLA
+    '\xdf'      #  0xDF -> LATIN SMALL LETTER SHARP S
+    '\u0155'    #  0xE0 -> LATIN SMALL LETTER R WITH ACUTE
+    '\xe1'      #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
+    '\xe2'      #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
+    '\u0103'    #  0xE3 -> LATIN SMALL LETTER A WITH BREVE
+    '\xe4'      #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
+    '\u013a'    #  0xE5 -> LATIN SMALL LETTER L WITH ACUTE
+    '\u0107'    #  0xE6 -> LATIN SMALL LETTER C WITH ACUTE
+    '\xe7'      #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
+    '\u010d'    #  0xE8 -> LATIN SMALL LETTER C WITH CARON
+    '\xe9'      #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
+    '\u0119'    #  0xEA -> LATIN SMALL LETTER E WITH OGONEK
+    '\xeb'      #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
+    '\u011b'    #  0xEC -> LATIN SMALL LETTER E WITH CARON
+    '\xed'      #  0xED -> LATIN SMALL LETTER I WITH ACUTE
+    '\xee'      #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
+    '\u010f'    #  0xEF -> LATIN SMALL LETTER D WITH CARON
+    '\u0111'    #  0xF0 -> LATIN SMALL LETTER D WITH STROKE
+    '\u0144'    #  0xF1 -> LATIN SMALL LETTER N WITH ACUTE
+    '\u0148'    #  0xF2 -> LATIN SMALL LETTER N WITH CARON
+    '\xf3'      #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
+    '\xf4'      #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
+    '\u0151'    #  0xF5 -> LATIN SMALL LETTER O WITH DOUBLE ACUTE
+    '\xf6'      #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
+    '\xf7'      #  0xF7 -> DIVISION SIGN
+    '\u0159'    #  0xF8 -> LATIN SMALL LETTER R WITH CARON
+    '\u016f'    #  0xF9 -> LATIN SMALL LETTER U WITH RING ABOVE
+    '\xfa'      #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
+    '\u0171'    #  0xFB -> LATIN SMALL LETTER U WITH DOUBLE ACUTE
+    '\xfc'      #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
+    '\xfd'      #  0xFD -> LATIN SMALL LETTER Y WITH ACUTE
+    '\u0163'    #  0xFE -> LATIN SMALL LETTER T WITH CEDILLA
+    '\u02d9'    #  0xFF -> DOT ABOVE
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1251.py
+++ b/Lib/encodings/cp1251.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1251 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1251.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1251 generated from 'WindowsBestFit/cp1251.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u0402'   #  0x80 -> CYRILLIC CAPITAL LETTER DJE
-    '\u0403'   #  0x81 -> CYRILLIC CAPITAL LETTER GJE
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\u0453'   #  0x83 -> CYRILLIC SMALL LETTER GJE
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\u20ac'   #  0x88 -> EURO SIGN
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\u0409'   #  0x8A -> CYRILLIC CAPITAL LETTER LJE
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\u040a'   #  0x8C -> CYRILLIC CAPITAL LETTER NJE
-    '\u040c'   #  0x8D -> CYRILLIC CAPITAL LETTER KJE
-    '\u040b'   #  0x8E -> CYRILLIC CAPITAL LETTER TSHE
-    '\u040f'   #  0x8F -> CYRILLIC CAPITAL LETTER DZHE
-    '\u0452'   #  0x90 -> CYRILLIC SMALL LETTER DJE
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\ufffe'   #  0x98 -> UNDEFINED
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\u0459'   #  0x9A -> CYRILLIC SMALL LETTER LJE
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\u045a'   #  0x9C -> CYRILLIC SMALL LETTER NJE
-    '\u045c'   #  0x9D -> CYRILLIC SMALL LETTER KJE
-    '\u045b'   #  0x9E -> CYRILLIC SMALL LETTER TSHE
-    '\u045f'   #  0x9F -> CYRILLIC SMALL LETTER DZHE
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\u040e'   #  0xA1 -> CYRILLIC CAPITAL LETTER SHORT U
-    '\u045e'   #  0xA2 -> CYRILLIC SMALL LETTER SHORT U
-    '\u0408'   #  0xA3 -> CYRILLIC CAPITAL LETTER JE
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\u0490'   #  0xA5 -> CYRILLIC CAPITAL LETTER GHE WITH UPTURN
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\u0401'   #  0xA8 -> CYRILLIC CAPITAL LETTER IO
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\u0404'   #  0xAA -> CYRILLIC CAPITAL LETTER UKRAINIAN IE
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\u0407'   #  0xAF -> CYRILLIC CAPITAL LETTER YI
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\u0406'   #  0xB2 -> CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I
-    '\u0456'   #  0xB3 -> CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-    '\u0491'   #  0xB4 -> CYRILLIC SMALL LETTER GHE WITH UPTURN
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\u0451'   #  0xB8 -> CYRILLIC SMALL LETTER IO
-    '\u2116'   #  0xB9 -> NUMERO SIGN
-    '\u0454'   #  0xBA -> CYRILLIC SMALL LETTER UKRAINIAN IE
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\u0458'   #  0xBC -> CYRILLIC SMALL LETTER JE
-    '\u0405'   #  0xBD -> CYRILLIC CAPITAL LETTER DZE
-    '\u0455'   #  0xBE -> CYRILLIC SMALL LETTER DZE
-    '\u0457'   #  0xBF -> CYRILLIC SMALL LETTER YI
-    '\u0410'   #  0xC0 -> CYRILLIC CAPITAL LETTER A
-    '\u0411'   #  0xC1 -> CYRILLIC CAPITAL LETTER BE
-    '\u0412'   #  0xC2 -> CYRILLIC CAPITAL LETTER VE
-    '\u0413'   #  0xC3 -> CYRILLIC CAPITAL LETTER GHE
-    '\u0414'   #  0xC4 -> CYRILLIC CAPITAL LETTER DE
-    '\u0415'   #  0xC5 -> CYRILLIC CAPITAL LETTER IE
-    '\u0416'   #  0xC6 -> CYRILLIC CAPITAL LETTER ZHE
-    '\u0417'   #  0xC7 -> CYRILLIC CAPITAL LETTER ZE
-    '\u0418'   #  0xC8 -> CYRILLIC CAPITAL LETTER I
-    '\u0419'   #  0xC9 -> CYRILLIC CAPITAL LETTER SHORT I
-    '\u041a'   #  0xCA -> CYRILLIC CAPITAL LETTER KA
-    '\u041b'   #  0xCB -> CYRILLIC CAPITAL LETTER EL
-    '\u041c'   #  0xCC -> CYRILLIC CAPITAL LETTER EM
-    '\u041d'   #  0xCD -> CYRILLIC CAPITAL LETTER EN
-    '\u041e'   #  0xCE -> CYRILLIC CAPITAL LETTER O
-    '\u041f'   #  0xCF -> CYRILLIC CAPITAL LETTER PE
-    '\u0420'   #  0xD0 -> CYRILLIC CAPITAL LETTER ER
-    '\u0421'   #  0xD1 -> CYRILLIC CAPITAL LETTER ES
-    '\u0422'   #  0xD2 -> CYRILLIC CAPITAL LETTER TE
-    '\u0423'   #  0xD3 -> CYRILLIC CAPITAL LETTER U
-    '\u0424'   #  0xD4 -> CYRILLIC CAPITAL LETTER EF
-    '\u0425'   #  0xD5 -> CYRILLIC CAPITAL LETTER HA
-    '\u0426'   #  0xD6 -> CYRILLIC CAPITAL LETTER TSE
-    '\u0427'   #  0xD7 -> CYRILLIC CAPITAL LETTER CHE
-    '\u0428'   #  0xD8 -> CYRILLIC CAPITAL LETTER SHA
-    '\u0429'   #  0xD9 -> CYRILLIC CAPITAL LETTER SHCHA
-    '\u042a'   #  0xDA -> CYRILLIC CAPITAL LETTER HARD SIGN
-    '\u042b'   #  0xDB -> CYRILLIC CAPITAL LETTER YERU
-    '\u042c'   #  0xDC -> CYRILLIC CAPITAL LETTER SOFT SIGN
-    '\u042d'   #  0xDD -> CYRILLIC CAPITAL LETTER E
-    '\u042e'   #  0xDE -> CYRILLIC CAPITAL LETTER YU
-    '\u042f'   #  0xDF -> CYRILLIC CAPITAL LETTER YA
-    '\u0430'   #  0xE0 -> CYRILLIC SMALL LETTER A
-    '\u0431'   #  0xE1 -> CYRILLIC SMALL LETTER BE
-    '\u0432'   #  0xE2 -> CYRILLIC SMALL LETTER VE
-    '\u0433'   #  0xE3 -> CYRILLIC SMALL LETTER GHE
-    '\u0434'   #  0xE4 -> CYRILLIC SMALL LETTER DE
-    '\u0435'   #  0xE5 -> CYRILLIC SMALL LETTER IE
-    '\u0436'   #  0xE6 -> CYRILLIC SMALL LETTER ZHE
-    '\u0437'   #  0xE7 -> CYRILLIC SMALL LETTER ZE
-    '\u0438'   #  0xE8 -> CYRILLIC SMALL LETTER I
-    '\u0439'   #  0xE9 -> CYRILLIC SMALL LETTER SHORT I
-    '\u043a'   #  0xEA -> CYRILLIC SMALL LETTER KA
-    '\u043b'   #  0xEB -> CYRILLIC SMALL LETTER EL
-    '\u043c'   #  0xEC -> CYRILLIC SMALL LETTER EM
-    '\u043d'   #  0xED -> CYRILLIC SMALL LETTER EN
-    '\u043e'   #  0xEE -> CYRILLIC SMALL LETTER O
-    '\u043f'   #  0xEF -> CYRILLIC SMALL LETTER PE
-    '\u0440'   #  0xF0 -> CYRILLIC SMALL LETTER ER
-    '\u0441'   #  0xF1 -> CYRILLIC SMALL LETTER ES
-    '\u0442'   #  0xF2 -> CYRILLIC SMALL LETTER TE
-    '\u0443'   #  0xF3 -> CYRILLIC SMALL LETTER U
-    '\u0444'   #  0xF4 -> CYRILLIC SMALL LETTER EF
-    '\u0445'   #  0xF5 -> CYRILLIC SMALL LETTER HA
-    '\u0446'   #  0xF6 -> CYRILLIC SMALL LETTER TSE
-    '\u0447'   #  0xF7 -> CYRILLIC SMALL LETTER CHE
-    '\u0448'   #  0xF8 -> CYRILLIC SMALL LETTER SHA
-    '\u0449'   #  0xF9 -> CYRILLIC SMALL LETTER SHCHA
-    '\u044a'   #  0xFA -> CYRILLIC SMALL LETTER HARD SIGN
-    '\u044b'   #  0xFB -> CYRILLIC SMALL LETTER YERU
-    '\u044c'   #  0xFC -> CYRILLIC SMALL LETTER SOFT SIGN
-    '\u044d'   #  0xFD -> CYRILLIC SMALL LETTER E
-    '\u044e'   #  0xFE -> CYRILLIC SMALL LETTER YU
-    '\u044f'   #  0xFF -> CYRILLIC SMALL LETTER YA
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> REVERSE SOLIDUS
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX ACCENT
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE ACCENT
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u0402'    #  0x80 -> CYRILLIC CAPITAL LETTER DJE
+    '\u0403'    #  0x81 -> CYRILLIC CAPITAL LETTER GJE
+    '\u201a'    #  0x82 -> SINGLE LOW-9 QUOTATION MARK
+    '\u0453'    #  0x83 -> CYRILLIC SMALL LETTER GJE
+    '\u201e'    #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\u20ac'    #  0x88 -> EURO SIGN
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\u0409'    #  0x8A -> CYRILLIC CAPITAL LETTER LJE
+    '\u2039'    #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    '\u040a'    #  0x8C -> CYRILLIC CAPITAL LETTER NJE
+    '\u040c'    #  0x8D -> CYRILLIC CAPITAL LETTER KJE
+    '\u040b'    #  0x8E -> CYRILLIC CAPITAL LETTER TSHE
+    '\u040f'    #  0x8F -> CYRILLIC CAPITAL LETTER DZHE
+    '\u0452'    #  0x90 -> CYRILLIC SMALL LETTER DJE
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\x98'
+    '\u2122'    #  0x99 -> TRADE MARK SIGN
+    '\u0459'    #  0x9A -> CYRILLIC SMALL LETTER LJE
+    '\u203a'    #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    '\u045a'    #  0x9C -> CYRILLIC SMALL LETTER NJE
+    '\u045c'    #  0x9D -> CYRILLIC SMALL LETTER KJE
+    '\u045b'    #  0x9E -> CYRILLIC SMALL LETTER TSHE
+    '\u045f'    #  0x9F -> CYRILLIC SMALL LETTER DZHE
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\u040e'    #  0xA1 -> CYRILLIC CAPITAL LETTER SHORT U
+    '\u045e'    #  0xA2 -> CYRILLIC SMALL LETTER SHORT U
+    '\u0408'    #  0xA3 -> CYRILLIC CAPITAL LETTER JE
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\u0490'    #  0xA5 -> CYRILLIC CAPITAL LETTER GHE WITH UPTURN
+    '\xa6'      #  0xA6 -> BROKEN BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\u0401'    #  0xA8 -> CYRILLIC CAPITAL LETTER IO
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\u0404'    #  0xAA -> CYRILLIC CAPITAL LETTER UKRAINIAN IE
+    '\xab'      #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED SIGN
+    '\u0407'    #  0xAF -> CYRILLIC CAPITAL LETTER YI
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-MINUS SIGN
+    '\u0406'    #  0xB2 -> CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I
+    '\u0456'    #  0xB3 -> CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+    '\u0491'    #  0xB4 -> CYRILLIC SMALL LETTER GHE WITH UPTURN
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PILCROW SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\u0451'    #  0xB8 -> CYRILLIC SMALL LETTER IO
+    '\u2116'    #  0xB9 -> NUMERO SIGN
+    '\u0454'    #  0xBA -> CYRILLIC SMALL LETTER UKRAINIAN IE
+    '\xbb'      #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\u0458'    #  0xBC -> CYRILLIC SMALL LETTER JE
+    '\u0405'    #  0xBD -> CYRILLIC CAPITAL LETTER DZE
+    '\u0455'    #  0xBE -> CYRILLIC SMALL LETTER DZE
+    '\u0457'    #  0xBF -> CYRILLIC SMALL LETTER YI
+    '\u0410'    #  0xC0 -> CYRILLIC CAPITAL LETTER A
+    '\u0411'    #  0xC1 -> CYRILLIC CAPITAL LETTER BE
+    '\u0412'    #  0xC2 -> CYRILLIC CAPITAL LETTER VE
+    '\u0413'    #  0xC3 -> CYRILLIC CAPITAL LETTER GHE
+    '\u0414'    #  0xC4 -> CYRILLIC CAPITAL LETTER DE
+    '\u0415'    #  0xC5 -> CYRILLIC CAPITAL LETTER IE
+    '\u0416'    #  0xC6 -> CYRILLIC CAPITAL LETTER ZHE
+    '\u0417'    #  0xC7 -> CYRILLIC CAPITAL LETTER ZE
+    '\u0418'    #  0xC8 -> CYRILLIC CAPITAL LETTER I
+    '\u0419'    #  0xC9 -> CYRILLIC CAPITAL LETTER SHORT I
+    '\u041a'    #  0xCA -> CYRILLIC CAPITAL LETTER KA
+    '\u041b'    #  0xCB -> CYRILLIC CAPITAL LETTER EL
+    '\u041c'    #  0xCC -> CYRILLIC CAPITAL LETTER EM
+    '\u041d'    #  0xCD -> CYRILLIC CAPITAL LETTER EN
+    '\u041e'    #  0xCE -> CYRILLIC CAPITAL LETTER O
+    '\u041f'    #  0xCF -> CYRILLIC CAPITAL LETTER PE
+    '\u0420'    #  0xD0 -> CYRILLIC CAPITAL LETTER ER
+    '\u0421'    #  0xD1 -> CYRILLIC CAPITAL LETTER ES
+    '\u0422'    #  0xD2 -> CYRILLIC CAPITAL LETTER TE
+    '\u0423'    #  0xD3 -> CYRILLIC CAPITAL LETTER U
+    '\u0424'    #  0xD4 -> CYRILLIC CAPITAL LETTER EF
+    '\u0425'    #  0xD5 -> CYRILLIC CAPITAL LETTER HA
+    '\u0426'    #  0xD6 -> CYRILLIC CAPITAL LETTER TSE
+    '\u0427'    #  0xD7 -> CYRILLIC CAPITAL LETTER CHE
+    '\u0428'    #  0xD8 -> CYRILLIC CAPITAL LETTER SHA
+    '\u0429'    #  0xD9 -> CYRILLIC CAPITAL LETTER SHCHA
+    '\u042a'    #  0xDA -> CYRILLIC CAPITAL LETTER HARD SIGN
+    '\u042b'    #  0xDB -> CYRILLIC CAPITAL LETTER YERU
+    '\u042c'    #  0xDC -> CYRILLIC CAPITAL LETTER SOFT SIGN
+    '\u042d'    #  0xDD -> CYRILLIC CAPITAL LETTER E
+    '\u042e'    #  0xDE -> CYRILLIC CAPITAL LETTER YU
+    '\u042f'    #  0xDF -> CYRILLIC CAPITAL LETTER YA
+    '\u0430'    #  0xE0 -> CYRILLIC SMALL LETTER A
+    '\u0431'    #  0xE1 -> CYRILLIC SMALL LETTER BE
+    '\u0432'    #  0xE2 -> CYRILLIC SMALL LETTER VE
+    '\u0433'    #  0xE3 -> CYRILLIC SMALL LETTER GHE
+    '\u0434'    #  0xE4 -> CYRILLIC SMALL LETTER DE
+    '\u0435'    #  0xE5 -> CYRILLIC SMALL LETTER IE
+    '\u0436'    #  0xE6 -> CYRILLIC SMALL LETTER ZHE
+    '\u0437'    #  0xE7 -> CYRILLIC SMALL LETTER ZE
+    '\u0438'    #  0xE8 -> CYRILLIC SMALL LETTER I
+    '\u0439'    #  0xE9 -> CYRILLIC SMALL LETTER SHORT I
+    '\u043a'    #  0xEA -> CYRILLIC SMALL LETTER KA
+    '\u043b'    #  0xEB -> CYRILLIC SMALL LETTER EL
+    '\u043c'    #  0xEC -> CYRILLIC SMALL LETTER EM
+    '\u043d'    #  0xED -> CYRILLIC SMALL LETTER EN
+    '\u043e'    #  0xEE -> CYRILLIC SMALL LETTER O
+    '\u043f'    #  0xEF -> CYRILLIC SMALL LETTER PE
+    '\u0440'    #  0xF0 -> CYRILLIC SMALL LETTER ER
+    '\u0441'    #  0xF1 -> CYRILLIC SMALL LETTER ES
+    '\u0442'    #  0xF2 -> CYRILLIC SMALL LETTER TE
+    '\u0443'    #  0xF3 -> CYRILLIC SMALL LETTER U
+    '\u0444'    #  0xF4 -> CYRILLIC SMALL LETTER EF
+    '\u0445'    #  0xF5 -> CYRILLIC SMALL LETTER HA
+    '\u0446'    #  0xF6 -> CYRILLIC SMALL LETTER TSE
+    '\u0447'    #  0xF7 -> CYRILLIC SMALL LETTER CHE
+    '\u0448'    #  0xF8 -> CYRILLIC SMALL LETTER SHA
+    '\u0449'    #  0xF9 -> CYRILLIC SMALL LETTER SHCHA
+    '\u044a'    #  0xFA -> CYRILLIC SMALL LETTER HARD SIGN
+    '\u044b'    #  0xFB -> CYRILLIC SMALL LETTER YERU
+    '\u044c'    #  0xFC -> CYRILLIC SMALL LETTER SOFT SIGN
+    '\u044d'    #  0xFD -> CYRILLIC SMALL LETTER E
+    '\u044e'    #  0xFE -> CYRILLIC SMALL LETTER YU
+    '\u044f'    #  0xFF -> CYRILLIC SMALL LETTER YA
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1252.py
+++ b/Lib/encodings/cp1252.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1252 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1252 generated from 'WindowsBestFit/cp1252.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\u0192'   #  0x83 -> LATIN SMALL LETTER F WITH HOOK
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\u02c6'   #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\u0160'   #  0x8A -> LATIN CAPITAL LETTER S WITH CARON
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\u0152'   #  0x8C -> LATIN CAPITAL LIGATURE OE
-    '\ufffe'   #  0x8D -> UNDEFINED
-    '\u017d'   #  0x8E -> LATIN CAPITAL LETTER Z WITH CARON
-    '\ufffe'   #  0x8F -> UNDEFINED
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\u02dc'   #  0x98 -> SMALL TILDE
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\u0161'   #  0x9A -> LATIN SMALL LETTER S WITH CARON
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\u0153'   #  0x9C -> LATIN SMALL LIGATURE OE
-    '\ufffe'   #  0x9D -> UNDEFINED
-    '\u017e'   #  0x9E -> LATIN SMALL LETTER Z WITH CARON
-    '\u0178'   #  0x9F -> LATIN CAPITAL LETTER Y WITH DIAERESIS
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\xa1'     #  0xA1 -> INVERTED EXCLAMATION MARK
-    '\xa2'     #  0xA2 -> CENT SIGN
-    '\xa3'     #  0xA3 -> POUND SIGN
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\xa5'     #  0xA5 -> YEN SIGN
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xa8'     #  0xA8 -> DIAERESIS
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\xaa'     #  0xAA -> FEMININE ORDINAL INDICATOR
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\xaf'     #  0xAF -> MACRON
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\xb2'     #  0xB2 -> SUPERSCRIPT TWO
-    '\xb3'     #  0xB3 -> SUPERSCRIPT THREE
-    '\xb4'     #  0xB4 -> ACUTE ACCENT
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\xb8'     #  0xB8 -> CEDILLA
-    '\xb9'     #  0xB9 -> SUPERSCRIPT ONE
-    '\xba'     #  0xBA -> MASCULINE ORDINAL INDICATOR
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xbc'     #  0xBC -> VULGAR FRACTION ONE QUARTER
-    '\xbd'     #  0xBD -> VULGAR FRACTION ONE HALF
-    '\xbe'     #  0xBE -> VULGAR FRACTION THREE QUARTERS
-    '\xbf'     #  0xBF -> INVERTED QUESTION MARK
-    '\xc0'     #  0xC0 -> LATIN CAPITAL LETTER A WITH GRAVE
-    '\xc1'     #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
-    '\xc2'     #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
-    '\xc3'     #  0xC3 -> LATIN CAPITAL LETTER A WITH TILDE
-    '\xc4'     #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
-    '\xc5'     #  0xC5 -> LATIN CAPITAL LETTER A WITH RING ABOVE
-    '\xc6'     #  0xC6 -> LATIN CAPITAL LETTER AE
-    '\xc7'     #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
-    '\xc8'     #  0xC8 -> LATIN CAPITAL LETTER E WITH GRAVE
-    '\xc9'     #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
-    '\xca'     #  0xCA -> LATIN CAPITAL LETTER E WITH CIRCUMFLEX
-    '\xcb'     #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
-    '\xcc'     #  0xCC -> LATIN CAPITAL LETTER I WITH GRAVE
-    '\xcd'     #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
-    '\xce'     #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
-    '\xcf'     #  0xCF -> LATIN CAPITAL LETTER I WITH DIAERESIS
-    '\xd0'     #  0xD0 -> LATIN CAPITAL LETTER ETH
-    '\xd1'     #  0xD1 -> LATIN CAPITAL LETTER N WITH TILDE
-    '\xd2'     #  0xD2 -> LATIN CAPITAL LETTER O WITH GRAVE
-    '\xd3'     #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
-    '\xd4'     #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
-    '\xd5'     #  0xD5 -> LATIN CAPITAL LETTER O WITH TILDE
-    '\xd6'     #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
-    '\xd7'     #  0xD7 -> MULTIPLICATION SIGN
-    '\xd8'     #  0xD8 -> LATIN CAPITAL LETTER O WITH STROKE
-    '\xd9'     #  0xD9 -> LATIN CAPITAL LETTER U WITH GRAVE
-    '\xda'     #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
-    '\xdb'     #  0xDB -> LATIN CAPITAL LETTER U WITH CIRCUMFLEX
-    '\xdc'     #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
-    '\xdd'     #  0xDD -> LATIN CAPITAL LETTER Y WITH ACUTE
-    '\xde'     #  0xDE -> LATIN CAPITAL LETTER THORN
-    '\xdf'     #  0xDF -> LATIN SMALL LETTER SHARP S
-    '\xe0'     #  0xE0 -> LATIN SMALL LETTER A WITH GRAVE
-    '\xe1'     #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
-    '\xe2'     #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
-    '\xe3'     #  0xE3 -> LATIN SMALL LETTER A WITH TILDE
-    '\xe4'     #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
-    '\xe5'     #  0xE5 -> LATIN SMALL LETTER A WITH RING ABOVE
-    '\xe6'     #  0xE6 -> LATIN SMALL LETTER AE
-    '\xe7'     #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
-    '\xe8'     #  0xE8 -> LATIN SMALL LETTER E WITH GRAVE
-    '\xe9'     #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
-    '\xea'     #  0xEA -> LATIN SMALL LETTER E WITH CIRCUMFLEX
-    '\xeb'     #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
-    '\xec'     #  0xEC -> LATIN SMALL LETTER I WITH GRAVE
-    '\xed'     #  0xED -> LATIN SMALL LETTER I WITH ACUTE
-    '\xee'     #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
-    '\xef'     #  0xEF -> LATIN SMALL LETTER I WITH DIAERESIS
-    '\xf0'     #  0xF0 -> LATIN SMALL LETTER ETH
-    '\xf1'     #  0xF1 -> LATIN SMALL LETTER N WITH TILDE
-    '\xf2'     #  0xF2 -> LATIN SMALL LETTER O WITH GRAVE
-    '\xf3'     #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
-    '\xf4'     #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
-    '\xf5'     #  0xF5 -> LATIN SMALL LETTER O WITH TILDE
-    '\xf6'     #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
-    '\xf7'     #  0xF7 -> DIVISION SIGN
-    '\xf8'     #  0xF8 -> LATIN SMALL LETTER O WITH STROKE
-    '\xf9'     #  0xF9 -> LATIN SMALL LETTER U WITH GRAVE
-    '\xfa'     #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
-    '\xfb'     #  0xFB -> LATIN SMALL LETTER U WITH CIRCUMFLEX
-    '\xfc'     #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
-    '\xfd'     #  0xFD -> LATIN SMALL LETTER Y WITH ACUTE
-    '\xfe'     #  0xFE -> LATIN SMALL LETTER THORN
-    '\xff'     #  0xFF -> LATIN SMALL LETTER Y WITH DIAERESIS
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> REVERSE SOLIDUS
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX ACCENT
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE ACCENT
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\x81'
+    '\u201a'    #  0x82 -> SINGLE LOW-9 QUOTATION MARK
+    '\u0192'    #  0x83 -> LATIN SMALL LETTER F WITH HOOK
+    '\u201e'    #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\u02c6'    #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\u0160'    #  0x8A -> LATIN CAPITAL LETTER S WITH CARON
+    '\u2039'    #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    '\u0152'    #  0x8C -> LATIN CAPITAL LIGATURE OE
+    '\x8d'
+    '\u017d'    #  0x8E -> LATIN CAPITAL LETTER Z WITH CARON
+    '\x8f'
+    '\x90'
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\u02dc'    #  0x98 -> SMALL TILDE
+    '\u2122'    #  0x99 -> TRADE MARK SIGN
+    '\u0161'    #  0x9A -> LATIN SMALL LETTER S WITH CARON
+    '\u203a'    #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    '\u0153'    #  0x9C -> LATIN SMALL LIGATURE OE
+    '\x9d'
+    '\u017e'    #  0x9E -> LATIN SMALL LETTER Z WITH CARON
+    '\u0178'    #  0x9F -> LATIN CAPITAL LETTER Y WITH DIAERESIS
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\xa1'      #  0xA1 -> INVERTED EXCLAMATION MARK
+    '\xa2'      #  0xA2 -> CENT SIGN
+    '\xa3'      #  0xA3 -> POUND SIGN
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\xa5'      #  0xA5 -> YEN SIGN
+    '\xa6'      #  0xA6 -> BROKEN BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xa8'      #  0xA8 -> DIAERESIS
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\xaa'      #  0xAA -> FEMININE ORDINAL INDICATOR
+    '\xab'      #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED SIGN
+    '\xaf'      #  0xAF -> MACRON
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-MINUS SIGN
+    '\xb2'      #  0xB2 -> SUPERSCRIPT TWO
+    '\xb3'      #  0xB3 -> SUPERSCRIPT THREE
+    '\xb4'      #  0xB4 -> ACUTE ACCENT
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PILCROW SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\xb8'      #  0xB8 -> CEDILLA
+    '\xb9'      #  0xB9 -> SUPERSCRIPT ONE
+    '\xba'      #  0xBA -> MASCULINE ORDINAL INDICATOR
+    '\xbb'      #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xbc'      #  0xBC -> VULGAR FRACTION ONE QUARTER
+    '\xbd'      #  0xBD -> VULGAR FRACTION ONE HALF
+    '\xbe'      #  0xBE -> VULGAR FRACTION THREE QUARTERS
+    '\xbf'      #  0xBF -> INVERTED QUESTION MARK
+    '\xc0'      #  0xC0 -> LATIN CAPITAL LETTER A WITH GRAVE
+    '\xc1'      #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
+    '\xc2'      #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+    '\xc3'      #  0xC3 -> LATIN CAPITAL LETTER A WITH TILDE
+    '\xc4'      #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
+    '\xc5'      #  0xC5 -> LATIN CAPITAL LETTER A WITH RING ABOVE
+    '\xc6'      #  0xC6 -> LATIN CAPITAL LIGATURE AE
+    '\xc7'      #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
+    '\xc8'      #  0xC8 -> LATIN CAPITAL LETTER E WITH GRAVE
+    '\xc9'      #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
+    '\xca'      #  0xCA -> LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+    '\xcb'      #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
+    '\xcc'      #  0xCC -> LATIN CAPITAL LETTER I WITH GRAVE
+    '\xcd'      #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
+    '\xce'      #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+    '\xcf'      #  0xCF -> LATIN CAPITAL LETTER I WITH DIAERESIS
+    '\xd0'      #  0xD0 -> LATIN CAPITAL LETTER ETH
+    '\xd1'      #  0xD1 -> LATIN CAPITAL LETTER N WITH TILDE
+    '\xd2'      #  0xD2 -> LATIN CAPITAL LETTER O WITH GRAVE
+    '\xd3'      #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
+    '\xd4'      #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+    '\xd5'      #  0xD5 -> LATIN CAPITAL LETTER O WITH TILDE
+    '\xd6'      #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
+    '\xd7'      #  0xD7 -> MULTIPLICATION SIGN
+    '\xd8'      #  0xD8 -> LATIN CAPITAL LETTER O WITH STROKE
+    '\xd9'      #  0xD9 -> LATIN CAPITAL LETTER U WITH GRAVE
+    '\xda'      #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
+    '\xdb'      #  0xDB -> LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+    '\xdc'      #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
+    '\xdd'      #  0xDD -> LATIN CAPITAL LETTER Y WITH ACUTE
+    '\xde'      #  0xDE -> LATIN CAPITAL LETTER THORN
+    '\xdf'      #  0xDF -> LATIN SMALL LETTER SHARP S
+    '\xe0'      #  0xE0 -> LATIN SMALL LETTER A WITH GRAVE
+    '\xe1'      #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
+    '\xe2'      #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
+    '\xe3'      #  0xE3 -> LATIN SMALL LETTER A WITH TILDE
+    '\xe4'      #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
+    '\xe5'      #  0xE5 -> LATIN SMALL LETTER A WITH RING ABOVE
+    '\xe6'      #  0xE6 -> LATIN SMALL LIGATURE AE
+    '\xe7'      #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
+    '\xe8'      #  0xE8 -> LATIN SMALL LETTER E WITH GRAVE
+    '\xe9'      #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
+    '\xea'      #  0xEA -> LATIN SMALL LETTER E WITH CIRCUMFLEX
+    '\xeb'      #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
+    '\xec'      #  0xEC -> LATIN SMALL LETTER I WITH GRAVE
+    '\xed'      #  0xED -> LATIN SMALL LETTER I WITH ACUTE
+    '\xee'      #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
+    '\xef'      #  0xEF -> LATIN SMALL LETTER I WITH DIAERESIS
+    '\xf0'      #  0xF0 -> LATIN SMALL LETTER ETH
+    '\xf1'      #  0xF1 -> LATIN SMALL LETTER N WITH TILDE
+    '\xf2'      #  0xF2 -> LATIN SMALL LETTER O WITH GRAVE
+    '\xf3'      #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
+    '\xf4'      #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
+    '\xf5'      #  0xF5 -> LATIN SMALL LETTER O WITH TILDE
+    '\xf6'      #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
+    '\xf7'      #  0xF7 -> DIVISION SIGN
+    '\xf8'      #  0xF8 -> LATIN SMALL LETTER O WITH STROKE
+    '\xf9'      #  0xF9 -> LATIN SMALL LETTER U WITH GRAVE
+    '\xfa'      #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
+    '\xfb'      #  0xFB -> LATIN SMALL LETTER U WITH CIRCUMFLEX
+    '\xfc'      #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
+    '\xfd'      #  0xFD -> LATIN SMALL LETTER Y WITH ACUTE
+    '\xfe'      #  0xFE -> LATIN SMALL LETTER THORN
+    '\xff'      #  0xFF -> LATIN SMALL LETTER Y WITH DIAERESIS
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1253.py
+++ b/Lib/encodings/cp1253.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1253 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1253.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1253 generated from 'WindowsBestFit/cp1253.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\u0192'   #  0x83 -> LATIN SMALL LETTER F WITH HOOK
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\ufffe'   #  0x88 -> UNDEFINED
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\ufffe'   #  0x8A -> UNDEFINED
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\ufffe'   #  0x8C -> UNDEFINED
-    '\ufffe'   #  0x8D -> UNDEFINED
-    '\ufffe'   #  0x8E -> UNDEFINED
-    '\ufffe'   #  0x8F -> UNDEFINED
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\ufffe'   #  0x98 -> UNDEFINED
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\ufffe'   #  0x9A -> UNDEFINED
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\ufffe'   #  0x9C -> UNDEFINED
-    '\ufffe'   #  0x9D -> UNDEFINED
-    '\ufffe'   #  0x9E -> UNDEFINED
-    '\ufffe'   #  0x9F -> UNDEFINED
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\u0385'   #  0xA1 -> GREEK DIALYTIKA TONOS
-    '\u0386'   #  0xA2 -> GREEK CAPITAL LETTER ALPHA WITH TONOS
-    '\xa3'     #  0xA3 -> POUND SIGN
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\xa5'     #  0xA5 -> YEN SIGN
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xa8'     #  0xA8 -> DIAERESIS
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\ufffe'   #  0xAA -> UNDEFINED
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\u2015'   #  0xAF -> HORIZONTAL BAR
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\xb2'     #  0xB2 -> SUPERSCRIPT TWO
-    '\xb3'     #  0xB3 -> SUPERSCRIPT THREE
-    '\u0384'   #  0xB4 -> GREEK TONOS
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\u0388'   #  0xB8 -> GREEK CAPITAL LETTER EPSILON WITH TONOS
-    '\u0389'   #  0xB9 -> GREEK CAPITAL LETTER ETA WITH TONOS
-    '\u038a'   #  0xBA -> GREEK CAPITAL LETTER IOTA WITH TONOS
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\u038c'   #  0xBC -> GREEK CAPITAL LETTER OMICRON WITH TONOS
-    '\xbd'     #  0xBD -> VULGAR FRACTION ONE HALF
-    '\u038e'   #  0xBE -> GREEK CAPITAL LETTER UPSILON WITH TONOS
-    '\u038f'   #  0xBF -> GREEK CAPITAL LETTER OMEGA WITH TONOS
-    '\u0390'   #  0xC0 -> GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
-    '\u0391'   #  0xC1 -> GREEK CAPITAL LETTER ALPHA
-    '\u0392'   #  0xC2 -> GREEK CAPITAL LETTER BETA
-    '\u0393'   #  0xC3 -> GREEK CAPITAL LETTER GAMMA
-    '\u0394'   #  0xC4 -> GREEK CAPITAL LETTER DELTA
-    '\u0395'   #  0xC5 -> GREEK CAPITAL LETTER EPSILON
-    '\u0396'   #  0xC6 -> GREEK CAPITAL LETTER ZETA
-    '\u0397'   #  0xC7 -> GREEK CAPITAL LETTER ETA
-    '\u0398'   #  0xC8 -> GREEK CAPITAL LETTER THETA
-    '\u0399'   #  0xC9 -> GREEK CAPITAL LETTER IOTA
-    '\u039a'   #  0xCA -> GREEK CAPITAL LETTER KAPPA
-    '\u039b'   #  0xCB -> GREEK CAPITAL LETTER LAMDA
-    '\u039c'   #  0xCC -> GREEK CAPITAL LETTER MU
-    '\u039d'   #  0xCD -> GREEK CAPITAL LETTER NU
-    '\u039e'   #  0xCE -> GREEK CAPITAL LETTER XI
-    '\u039f'   #  0xCF -> GREEK CAPITAL LETTER OMICRON
-    '\u03a0'   #  0xD0 -> GREEK CAPITAL LETTER PI
-    '\u03a1'   #  0xD1 -> GREEK CAPITAL LETTER RHO
-    '\ufffe'   #  0xD2 -> UNDEFINED
-    '\u03a3'   #  0xD3 -> GREEK CAPITAL LETTER SIGMA
-    '\u03a4'   #  0xD4 -> GREEK CAPITAL LETTER TAU
-    '\u03a5'   #  0xD5 -> GREEK CAPITAL LETTER UPSILON
-    '\u03a6'   #  0xD6 -> GREEK CAPITAL LETTER PHI
-    '\u03a7'   #  0xD7 -> GREEK CAPITAL LETTER CHI
-    '\u03a8'   #  0xD8 -> GREEK CAPITAL LETTER PSI
-    '\u03a9'   #  0xD9 -> GREEK CAPITAL LETTER OMEGA
-    '\u03aa'   #  0xDA -> GREEK CAPITAL LETTER IOTA WITH DIALYTIKA
-    '\u03ab'   #  0xDB -> GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA
-    '\u03ac'   #  0xDC -> GREEK SMALL LETTER ALPHA WITH TONOS
-    '\u03ad'   #  0xDD -> GREEK SMALL LETTER EPSILON WITH TONOS
-    '\u03ae'   #  0xDE -> GREEK SMALL LETTER ETA WITH TONOS
-    '\u03af'   #  0xDF -> GREEK SMALL LETTER IOTA WITH TONOS
-    '\u03b0'   #  0xE0 -> GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS
-    '\u03b1'   #  0xE1 -> GREEK SMALL LETTER ALPHA
-    '\u03b2'   #  0xE2 -> GREEK SMALL LETTER BETA
-    '\u03b3'   #  0xE3 -> GREEK SMALL LETTER GAMMA
-    '\u03b4'   #  0xE4 -> GREEK SMALL LETTER DELTA
-    '\u03b5'   #  0xE5 -> GREEK SMALL LETTER EPSILON
-    '\u03b6'   #  0xE6 -> GREEK SMALL LETTER ZETA
-    '\u03b7'   #  0xE7 -> GREEK SMALL LETTER ETA
-    '\u03b8'   #  0xE8 -> GREEK SMALL LETTER THETA
-    '\u03b9'   #  0xE9 -> GREEK SMALL LETTER IOTA
-    '\u03ba'   #  0xEA -> GREEK SMALL LETTER KAPPA
-    '\u03bb'   #  0xEB -> GREEK SMALL LETTER LAMDA
-    '\u03bc'   #  0xEC -> GREEK SMALL LETTER MU
-    '\u03bd'   #  0xED -> GREEK SMALL LETTER NU
-    '\u03be'   #  0xEE -> GREEK SMALL LETTER XI
-    '\u03bf'   #  0xEF -> GREEK SMALL LETTER OMICRON
-    '\u03c0'   #  0xF0 -> GREEK SMALL LETTER PI
-    '\u03c1'   #  0xF1 -> GREEK SMALL LETTER RHO
-    '\u03c2'   #  0xF2 -> GREEK SMALL LETTER FINAL SIGMA
-    '\u03c3'   #  0xF3 -> GREEK SMALL LETTER SIGMA
-    '\u03c4'   #  0xF4 -> GREEK SMALL LETTER TAU
-    '\u03c5'   #  0xF5 -> GREEK SMALL LETTER UPSILON
-    '\u03c6'   #  0xF6 -> GREEK SMALL LETTER PHI
-    '\u03c7'   #  0xF7 -> GREEK SMALL LETTER CHI
-    '\u03c8'   #  0xF8 -> GREEK SMALL LETTER PSI
-    '\u03c9'   #  0xF9 -> GREEK SMALL LETTER OMEGA
-    '\u03ca'   #  0xFA -> GREEK SMALL LETTER IOTA WITH DIALYTIKA
-    '\u03cb'   #  0xFB -> GREEK SMALL LETTER UPSILON WITH DIALYTIKA
-    '\u03cc'   #  0xFC -> GREEK SMALL LETTER OMICRON WITH TONOS
-    '\u03cd'   #  0xFD -> GREEK SMALL LETTER UPSILON WITH TONOS
-    '\u03ce'   #  0xFE -> GREEK SMALL LETTER OMEGA WITH TONOS
-    '\ufffe'   #  0xFF -> UNDEFINED
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> REVERSE SOLIDUS
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX ACCENT
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE ACCENT
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\x81'
+    '\u201a'    #  0x82 -> SINGLE LOW-9 QUOTATION MARK
+    '\u0192'    #  0x83 -> LATIN SMALL LETTER F WITH HOOK
+    '\u201e'    #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\x88'
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\x8a'
+    '\u2039'    #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    '\x8c'
+    '\x8d'
+    '\x8e'
+    '\x8f'
+    '\x90'
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\x98'
+    '\u2122'    #  0x99 -> TRADE MARK SIGN
+    '\x9a'
+    '\u203a'    #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    '\x9c'
+    '\x9d'
+    '\x9e'
+    '\x9f'
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\u0385'    #  0xA1 -> GREEK DIALYTIKA TONOS
+    '\u0386'    #  0xA2 -> GREEK CAPITAL LETTER ALPHA WITH TONOS
+    '\xa3'      #  0xA3 -> POUND SIGN
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\xa5'      #  0xA5 -> YEN SIGN
+    '\xa6'      #  0xA6 -> BROKEN BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xa8'      #  0xA8 -> DIAERESIS
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\uf8f9'    #  0xAA -> UNDEFINED -> EUDC
+    '\xab'      #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED SIGN
+    '\u2015'    #  0xAF -> HORIZONTAL BAR
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-MINUS SIGN
+    '\xb2'      #  0xB2 -> SUPERSCRIPT TWO
+    '\xb3'      #  0xB3 -> SUPERSCRIPT THREE
+    '\u0384'    #  0xB4 -> GREEK TONOS
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PILCROW SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\u0388'    #  0xB8 -> GREEK CAPITAL LETTER EPSILON WITH TONOS
+    '\u0389'    #  0xB9 -> GREEK CAPITAL LETTER ETA WITH TONOS
+    '\u038a'    #  0xBA -> GREEK CAPITAL LETTER IOTA WITH TONOS
+    '\xbb'      #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\u038c'    #  0xBC -> GREEK CAPITAL LETTER OMICRON WITH TONOS
+    '\xbd'      #  0xBD -> VULGAR FRACTION ONE HALF
+    '\u038e'    #  0xBE -> GREEK CAPITAL LETTER UPSILON WITH TONOS
+    '\u038f'    #  0xBF -> GREEK CAPITAL LETTER OMEGA WITH TONOS
+    '\u0390'    #  0xC0 -> GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
+    '\u0391'    #  0xC1 -> GREEK CAPITAL LETTER ALPHA
+    '\u0392'    #  0xC2 -> GREEK CAPITAL LETTER BETA
+    '\u0393'    #  0xC3 -> GREEK CAPITAL LETTER GAMMA
+    '\u0394'    #  0xC4 -> GREEK CAPITAL LETTER DELTA
+    '\u0395'    #  0xC5 -> GREEK CAPITAL LETTER EPSILON
+    '\u0396'    #  0xC6 -> GREEK CAPITAL LETTER ZETA
+    '\u0397'    #  0xC7 -> GREEK CAPITAL LETTER ETA
+    '\u0398'    #  0xC8 -> GREEK CAPITAL LETTER THETA
+    '\u0399'    #  0xC9 -> GREEK CAPITAL LETTER IOTA
+    '\u039a'    #  0xCA -> GREEK CAPITAL LETTER KAPPA
+    '\u039b'    #  0xCB -> GREEK CAPITAL LETTER LAMDA
+    '\u039c'    #  0xCC -> GREEK CAPITAL LETTER MU
+    '\u039d'    #  0xCD -> GREEK CAPITAL LETTER NU
+    '\u039e'    #  0xCE -> GREEK CAPITAL LETTER XI
+    '\u039f'    #  0xCF -> GREEK CAPITAL LETTER OMICRON
+    '\u03a0'    #  0xD0 -> GREEK CAPITAL LETTER PI
+    '\u03a1'    #  0xD1 -> GREEK CAPITAL LETTER RHO
+    '\uf8fa'    #  0xD2 -> UNDEFINED -> EUDC
+    '\u03a3'    #  0xD3 -> GREEK CAPITAL LETTER SIGMA
+    '\u03a4'    #  0xD4 -> GREEK CAPITAL LETTER TAU
+    '\u03a5'    #  0xD5 -> GREEK CAPITAL LETTER UPSILON
+    '\u03a6'    #  0xD6 -> GREEK CAPITAL LETTER PHI
+    '\u03a7'    #  0xD7 -> GREEK CAPITAL LETTER CHI
+    '\u03a8'    #  0xD8 -> GREEK CAPITAL LETTER PSI
+    '\u03a9'    #  0xD9 -> GREEK CAPITAL LETTER OMEGA
+    '\u03aa'    #  0xDA -> GREEK CAPITAL LETTER IOTA WITH DIALYTIKA
+    '\u03ab'    #  0xDB -> GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA
+    '\u03ac'    #  0xDC -> GREEK SMALL LETTER ALPHA WITH TONOS
+    '\u03ad'    #  0xDD -> GREEK SMALL LETTER EPSILON WITH TONOS
+    '\u03ae'    #  0xDE -> GREEK SMALL LETTER ETA WITH TONOS
+    '\u03af'    #  0xDF -> GREEK SMALL LETTER IOTA WITH TONOS
+    '\u03b0'    #  0xE0 -> GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS
+    '\u03b1'    #  0xE1 -> GREEK SMALL LETTER ALPHA
+    '\u03b2'    #  0xE2 -> GREEK SMALL LETTER BETA
+    '\u03b3'    #  0xE3 -> GREEK SMALL LETTER GAMMA
+    '\u03b4'    #  0xE4 -> GREEK SMALL LETTER DELTA
+    '\u03b5'    #  0xE5 -> GREEK SMALL LETTER EPSILON
+    '\u03b6'    #  0xE6 -> GREEK SMALL LETTER ZETA
+    '\u03b7'    #  0xE7 -> GREEK SMALL LETTER ETA
+    '\u03b8'    #  0xE8 -> GREEK SMALL LETTER THETA
+    '\u03b9'    #  0xE9 -> GREEK SMALL LETTER IOTA
+    '\u03ba'    #  0xEA -> GREEK SMALL LETTER KAPPA
+    '\u03bb'    #  0xEB -> GREEK SMALL LETTER LAMDA
+    '\u03bc'    #  0xEC -> GREEK SMALL LETTER MU
+    '\u03bd'    #  0xED -> GREEK SMALL LETTER NU
+    '\u03be'    #  0xEE -> GREEK SMALL LETTER XI
+    '\u03bf'    #  0xEF -> GREEK SMALL LETTER OMICRON
+    '\u03c0'    #  0xF0 -> GREEK SMALL LETTER PI
+    '\u03c1'    #  0xF1 -> GREEK SMALL LETTER RHO
+    '\u03c2'    #  0xF2 -> GREEK SMALL LETTER FINAL SIGMA
+    '\u03c3'    #  0xF3 -> GREEK SMALL LETTER SIGMA
+    '\u03c4'    #  0xF4 -> GREEK SMALL LETTER TAU
+    '\u03c5'    #  0xF5 -> GREEK SMALL LETTER UPSILON
+    '\u03c6'    #  0xF6 -> GREEK SMALL LETTER PHI
+    '\u03c7'    #  0xF7 -> GREEK SMALL LETTER CHI
+    '\u03c8'    #  0xF8 -> GREEK SMALL LETTER PSI
+    '\u03c9'    #  0xF9 -> GREEK SMALL LETTER OMEGA
+    '\u03ca'    #  0xFA -> GREEK SMALL LETTER IOTA WITH DIALYTIKA
+    '\u03cb'    #  0xFB -> GREEK SMALL LETTER UPSILON WITH DIALYTIKA
+    '\u03cc'    #  0xFC -> GREEK SMALL LETTER OMICRON WITH TONOS
+    '\u03cd'    #  0xFD -> GREEK SMALL LETTER UPSILON WITH TONOS
+    '\u03ce'    #  0xFE -> GREEK SMALL LETTER OMEGA WITH TONOS
+    '\uf8fb'    #  0xFF -> UNDEFINED -> EUDC
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1254.py
+++ b/Lib/encodings/cp1254.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1254 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1254.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1254 generated from 'WindowsBestFit/cp1254.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\u0192'   #  0x83 -> LATIN SMALL LETTER F WITH HOOK
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\u02c6'   #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\u0160'   #  0x8A -> LATIN CAPITAL LETTER S WITH CARON
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\u0152'   #  0x8C -> LATIN CAPITAL LIGATURE OE
-    '\ufffe'   #  0x8D -> UNDEFINED
-    '\ufffe'   #  0x8E -> UNDEFINED
-    '\ufffe'   #  0x8F -> UNDEFINED
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\u02dc'   #  0x98 -> SMALL TILDE
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\u0161'   #  0x9A -> LATIN SMALL LETTER S WITH CARON
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\u0153'   #  0x9C -> LATIN SMALL LIGATURE OE
-    '\ufffe'   #  0x9D -> UNDEFINED
-    '\ufffe'   #  0x9E -> UNDEFINED
-    '\u0178'   #  0x9F -> LATIN CAPITAL LETTER Y WITH DIAERESIS
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\xa1'     #  0xA1 -> INVERTED EXCLAMATION MARK
-    '\xa2'     #  0xA2 -> CENT SIGN
-    '\xa3'     #  0xA3 -> POUND SIGN
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\xa5'     #  0xA5 -> YEN SIGN
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xa8'     #  0xA8 -> DIAERESIS
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\xaa'     #  0xAA -> FEMININE ORDINAL INDICATOR
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\xaf'     #  0xAF -> MACRON
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\xb2'     #  0xB2 -> SUPERSCRIPT TWO
-    '\xb3'     #  0xB3 -> SUPERSCRIPT THREE
-    '\xb4'     #  0xB4 -> ACUTE ACCENT
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\xb8'     #  0xB8 -> CEDILLA
-    '\xb9'     #  0xB9 -> SUPERSCRIPT ONE
-    '\xba'     #  0xBA -> MASCULINE ORDINAL INDICATOR
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xbc'     #  0xBC -> VULGAR FRACTION ONE QUARTER
-    '\xbd'     #  0xBD -> VULGAR FRACTION ONE HALF
-    '\xbe'     #  0xBE -> VULGAR FRACTION THREE QUARTERS
-    '\xbf'     #  0xBF -> INVERTED QUESTION MARK
-    '\xc0'     #  0xC0 -> LATIN CAPITAL LETTER A WITH GRAVE
-    '\xc1'     #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
-    '\xc2'     #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
-    '\xc3'     #  0xC3 -> LATIN CAPITAL LETTER A WITH TILDE
-    '\xc4'     #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
-    '\xc5'     #  0xC5 -> LATIN CAPITAL LETTER A WITH RING ABOVE
-    '\xc6'     #  0xC6 -> LATIN CAPITAL LETTER AE
-    '\xc7'     #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
-    '\xc8'     #  0xC8 -> LATIN CAPITAL LETTER E WITH GRAVE
-    '\xc9'     #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
-    '\xca'     #  0xCA -> LATIN CAPITAL LETTER E WITH CIRCUMFLEX
-    '\xcb'     #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
-    '\xcc'     #  0xCC -> LATIN CAPITAL LETTER I WITH GRAVE
-    '\xcd'     #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
-    '\xce'     #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
-    '\xcf'     #  0xCF -> LATIN CAPITAL LETTER I WITH DIAERESIS
-    '\u011e'   #  0xD0 -> LATIN CAPITAL LETTER G WITH BREVE
-    '\xd1'     #  0xD1 -> LATIN CAPITAL LETTER N WITH TILDE
-    '\xd2'     #  0xD2 -> LATIN CAPITAL LETTER O WITH GRAVE
-    '\xd3'     #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
-    '\xd4'     #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
-    '\xd5'     #  0xD5 -> LATIN CAPITAL LETTER O WITH TILDE
-    '\xd6'     #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
-    '\xd7'     #  0xD7 -> MULTIPLICATION SIGN
-    '\xd8'     #  0xD8 -> LATIN CAPITAL LETTER O WITH STROKE
-    '\xd9'     #  0xD9 -> LATIN CAPITAL LETTER U WITH GRAVE
-    '\xda'     #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
-    '\xdb'     #  0xDB -> LATIN CAPITAL LETTER U WITH CIRCUMFLEX
-    '\xdc'     #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
-    '\u0130'   #  0xDD -> LATIN CAPITAL LETTER I WITH DOT ABOVE
-    '\u015e'   #  0xDE -> LATIN CAPITAL LETTER S WITH CEDILLA
-    '\xdf'     #  0xDF -> LATIN SMALL LETTER SHARP S
-    '\xe0'     #  0xE0 -> LATIN SMALL LETTER A WITH GRAVE
-    '\xe1'     #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
-    '\xe2'     #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
-    '\xe3'     #  0xE3 -> LATIN SMALL LETTER A WITH TILDE
-    '\xe4'     #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
-    '\xe5'     #  0xE5 -> LATIN SMALL LETTER A WITH RING ABOVE
-    '\xe6'     #  0xE6 -> LATIN SMALL LETTER AE
-    '\xe7'     #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
-    '\xe8'     #  0xE8 -> LATIN SMALL LETTER E WITH GRAVE
-    '\xe9'     #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
-    '\xea'     #  0xEA -> LATIN SMALL LETTER E WITH CIRCUMFLEX
-    '\xeb'     #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
-    '\xec'     #  0xEC -> LATIN SMALL LETTER I WITH GRAVE
-    '\xed'     #  0xED -> LATIN SMALL LETTER I WITH ACUTE
-    '\xee'     #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
-    '\xef'     #  0xEF -> LATIN SMALL LETTER I WITH DIAERESIS
-    '\u011f'   #  0xF0 -> LATIN SMALL LETTER G WITH BREVE
-    '\xf1'     #  0xF1 -> LATIN SMALL LETTER N WITH TILDE
-    '\xf2'     #  0xF2 -> LATIN SMALL LETTER O WITH GRAVE
-    '\xf3'     #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
-    '\xf4'     #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
-    '\xf5'     #  0xF5 -> LATIN SMALL LETTER O WITH TILDE
-    '\xf6'     #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
-    '\xf7'     #  0xF7 -> DIVISION SIGN
-    '\xf8'     #  0xF8 -> LATIN SMALL LETTER O WITH STROKE
-    '\xf9'     #  0xF9 -> LATIN SMALL LETTER U WITH GRAVE
-    '\xfa'     #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
-    '\xfb'     #  0xFB -> LATIN SMALL LETTER U WITH CIRCUMFLEX
-    '\xfc'     #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
-    '\u0131'   #  0xFD -> LATIN SMALL LETTER DOTLESS I
-    '\u015f'   #  0xFE -> LATIN SMALL LETTER S WITH CEDILLA
-    '\xff'     #  0xFF -> LATIN SMALL LETTER Y WITH DIAERESIS
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> REVERSE SOLIDUS
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX ACCENT
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE ACCENT
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\x81'
+    '\u201a'    #  0x82 -> SINGLE LOW-9 QUOTATION MARK
+    '\u0192'    #  0x83 -> LATIN SMALL LETTER F WITH HOOK
+    '\u201e'    #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\u02c6'    #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\u0160'    #  0x8A -> LATIN CAPITAL LETTER S WITH CARON
+    '\u2039'    #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    '\u0152'    #  0x8C -> LATIN CAPITAL LIGATURE OE
+    '\x8d'
+    '\x8e'
+    '\x8f'
+    '\x90'
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\u02dc'    #  0x98 -> SMALL TILDE
+    '\u2122'    #  0x99 -> TRADE MARK SIGN
+    '\u0161'    #  0x9A -> LATIN SMALL LETTER S WITH CARON
+    '\u203a'    #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    '\u0153'    #  0x9C -> LATIN SMALL LIGATURE OE
+    '\x9d'
+    '\x9e'
+    '\u0178'    #  0x9F -> LATIN CAPITAL LETTER Y WITH DIAERESIS
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\xa1'      #  0xA1 -> INVERTED EXCLAMATION MARK
+    '\xa2'      #  0xA2 -> CENT SIGN
+    '\xa3'      #  0xA3 -> POUND SIGN
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\xa5'      #  0xA5 -> YEN SIGN
+    '\xa6'      #  0xA6 -> BROKEN BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xa8'      #  0xA8 -> DIAERESIS
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\xaa'      #  0xAA -> FEMININE ORDINAL INDICATOR
+    '\xab'      #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED SIGN
+    '\xaf'      #  0xAF -> MACRON
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-MINUS SIGN
+    '\xb2'      #  0xB2 -> SUPERSCRIPT TWO
+    '\xb3'      #  0xB3 -> SUPERSCRIPT THREE
+    '\xb4'      #  0xB4 -> ACUTE ACCENT
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PILCROW SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\xb8'      #  0xB8 -> CEDILLA
+    '\xb9'      #  0xB9 -> SUPERSCRIPT ONE
+    '\xba'      #  0xBA -> MASCULINE ORDINAL INDICATOR
+    '\xbb'      #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xbc'      #  0xBC -> VULGAR FRACTION ONE QUARTER
+    '\xbd'      #  0xBD -> VULGAR FRACTION ONE HALF
+    '\xbe'      #  0xBE -> VULGAR FRACTION THREE QUARTERS
+    '\xbf'      #  0xBF -> INVERTED QUESTION MARK
+    '\xc0'      #  0xC0 -> LATIN CAPITAL LETTER A WITH GRAVE
+    '\xc1'      #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
+    '\xc2'      #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+    '\xc3'      #  0xC3 -> LATIN CAPITAL LETTER A WITH TILDE
+    '\xc4'      #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
+    '\xc5'      #  0xC5 -> LATIN CAPITAL LETTER A WITH RING ABOVE
+    '\xc6'      #  0xC6 -> LATIN CAPITAL LIGATURE AE
+    '\xc7'      #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
+    '\xc8'      #  0xC8 -> LATIN CAPITAL LETTER E WITH GRAVE
+    '\xc9'      #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
+    '\xca'      #  0xCA -> LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+    '\xcb'      #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
+    '\xcc'      #  0xCC -> LATIN CAPITAL LETTER I WITH GRAVE
+    '\xcd'      #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
+    '\xce'      #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+    '\xcf'      #  0xCF -> LATIN CAPITAL LETTER I WITH DIAERESIS
+    '\u011e'    #  0xD0 -> LATIN CAPITAL LETTER G WITH BREVE
+    '\xd1'      #  0xD1 -> LATIN CAPITAL LETTER N WITH TILDE
+    '\xd2'      #  0xD2 -> LATIN CAPITAL LETTER O WITH GRAVE
+    '\xd3'      #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
+    '\xd4'      #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+    '\xd5'      #  0xD5 -> LATIN CAPITAL LETTER O WITH TILDE
+    '\xd6'      #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
+    '\xd7'      #  0xD7 -> MULTIPLICATION SIGN
+    '\xd8'      #  0xD8 -> LATIN CAPITAL LETTER O WITH STROKE
+    '\xd9'      #  0xD9 -> LATIN CAPITAL LETTER U WITH GRAVE
+    '\xda'      #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
+    '\xdb'      #  0xDB -> LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+    '\xdc'      #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
+    '\u0130'    #  0xDD -> LATIN CAPITAL LETTER I WITH DOT ABOVE
+    '\u015e'    #  0xDE -> LATIN CAPITAL LETTER S WITH CEDILLA
+    '\xdf'      #  0xDF -> LATIN SMALL LETTER SHARP S
+    '\xe0'      #  0xE0 -> LATIN SMALL LETTER A WITH GRAVE
+    '\xe1'      #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
+    '\xe2'      #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
+    '\xe3'      #  0xE3 -> LATIN SMALL LETTER A WITH TILDE
+    '\xe4'      #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
+    '\xe5'      #  0xE5 -> LATIN SMALL LETTER A WITH RING ABOVE
+    '\xe6'      #  0xE6 -> LATIN SMALL LIGATURE AE
+    '\xe7'      #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
+    '\xe8'      #  0xE8 -> LATIN SMALL LETTER E WITH GRAVE
+    '\xe9'      #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
+    '\xea'      #  0xEA -> LATIN SMALL LETTER E WITH CIRCUMFLEX
+    '\xeb'      #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
+    '\xec'      #  0xEC -> LATIN SMALL LETTER I WITH GRAVE
+    '\xed'      #  0xED -> LATIN SMALL LETTER I WITH ACUTE
+    '\xee'      #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
+    '\xef'      #  0xEF -> LATIN SMALL LETTER I WITH DIAERESIS
+    '\u011f'    #  0xF0 -> LATIN SMALL LETTER G WITH BREVE
+    '\xf1'      #  0xF1 -> LATIN SMALL LETTER N WITH TILDE
+    '\xf2'      #  0xF2 -> LATIN SMALL LETTER O WITH GRAVE
+    '\xf3'      #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
+    '\xf4'      #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
+    '\xf5'      #  0xF5 -> LATIN SMALL LETTER O WITH TILDE
+    '\xf6'      #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
+    '\xf7'      #  0xF7 -> DIVISION SIGN
+    '\xf8'      #  0xF8 -> LATIN SMALL LETTER O WITH STROKE
+    '\xf9'      #  0xF9 -> LATIN SMALL LETTER U WITH GRAVE
+    '\xfa'      #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
+    '\xfb'      #  0xFB -> LATIN SMALL LETTER U WITH CIRCUMFLEX
+    '\xfc'      #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
+    '\u0131'    #  0xFD -> LATIN SMALL LETTER DOTLESS I
+    '\u015f'    #  0xFE -> LATIN SMALL LETTER S WITH CEDILLA
+    '\xff'      #  0xFF -> LATIN SMALL LETTER Y WITH DIAERESIS
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1255.py
+++ b/Lib/encodings/cp1255.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1255 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1255.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1255 generated from 'WindowsBestFit/cp1255.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\u0192'   #  0x83 -> LATIN SMALL LETTER F WITH HOOK
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\u02c6'   #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\ufffe'   #  0x8A -> UNDEFINED
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\ufffe'   #  0x8C -> UNDEFINED
-    '\ufffe'   #  0x8D -> UNDEFINED
-    '\ufffe'   #  0x8E -> UNDEFINED
-    '\ufffe'   #  0x8F -> UNDEFINED
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\u02dc'   #  0x98 -> SMALL TILDE
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\ufffe'   #  0x9A -> UNDEFINED
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\ufffe'   #  0x9C -> UNDEFINED
-    '\ufffe'   #  0x9D -> UNDEFINED
-    '\ufffe'   #  0x9E -> UNDEFINED
-    '\ufffe'   #  0x9F -> UNDEFINED
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\xa1'     #  0xA1 -> INVERTED EXCLAMATION MARK
-    '\xa2'     #  0xA2 -> CENT SIGN
-    '\xa3'     #  0xA3 -> POUND SIGN
-    '\u20aa'   #  0xA4 -> NEW SHEQEL SIGN
-    '\xa5'     #  0xA5 -> YEN SIGN
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xa8'     #  0xA8 -> DIAERESIS
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\xd7'     #  0xAA -> MULTIPLICATION SIGN
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\xaf'     #  0xAF -> MACRON
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\xb2'     #  0xB2 -> SUPERSCRIPT TWO
-    '\xb3'     #  0xB3 -> SUPERSCRIPT THREE
-    '\xb4'     #  0xB4 -> ACUTE ACCENT
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\xb8'     #  0xB8 -> CEDILLA
-    '\xb9'     #  0xB9 -> SUPERSCRIPT ONE
-    '\xf7'     #  0xBA -> DIVISION SIGN
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xbc'     #  0xBC -> VULGAR FRACTION ONE QUARTER
-    '\xbd'     #  0xBD -> VULGAR FRACTION ONE HALF
-    '\xbe'     #  0xBE -> VULGAR FRACTION THREE QUARTERS
-    '\xbf'     #  0xBF -> INVERTED QUESTION MARK
-    '\u05b0'   #  0xC0 -> HEBREW POINT SHEVA
-    '\u05b1'   #  0xC1 -> HEBREW POINT HATAF SEGOL
-    '\u05b2'   #  0xC2 -> HEBREW POINT HATAF PATAH
-    '\u05b3'   #  0xC3 -> HEBREW POINT HATAF QAMATS
-    '\u05b4'   #  0xC4 -> HEBREW POINT HIRIQ
-    '\u05b5'   #  0xC5 -> HEBREW POINT TSERE
-    '\u05b6'   #  0xC6 -> HEBREW POINT SEGOL
-    '\u05b7'   #  0xC7 -> HEBREW POINT PATAH
-    '\u05b8'   #  0xC8 -> HEBREW POINT QAMATS
-    '\u05b9'   #  0xC9 -> HEBREW POINT HOLAM
-    '\ufffe'   #  0xCA -> UNDEFINED
-    '\u05bb'   #  0xCB -> HEBREW POINT QUBUTS
-    '\u05bc'   #  0xCC -> HEBREW POINT DAGESH OR MAPIQ
-    '\u05bd'   #  0xCD -> HEBREW POINT METEG
-    '\u05be'   #  0xCE -> HEBREW PUNCTUATION MAQAF
-    '\u05bf'   #  0xCF -> HEBREW POINT RAFE
-    '\u05c0'   #  0xD0 -> HEBREW PUNCTUATION PASEQ
-    '\u05c1'   #  0xD1 -> HEBREW POINT SHIN DOT
-    '\u05c2'   #  0xD2 -> HEBREW POINT SIN DOT
-    '\u05c3'   #  0xD3 -> HEBREW PUNCTUATION SOF PASUQ
-    '\u05f0'   #  0xD4 -> HEBREW LIGATURE YIDDISH DOUBLE VAV
-    '\u05f1'   #  0xD5 -> HEBREW LIGATURE YIDDISH VAV YOD
-    '\u05f2'   #  0xD6 -> HEBREW LIGATURE YIDDISH DOUBLE YOD
-    '\u05f3'   #  0xD7 -> HEBREW PUNCTUATION GERESH
-    '\u05f4'   #  0xD8 -> HEBREW PUNCTUATION GERSHAYIM
-    '\ufffe'   #  0xD9 -> UNDEFINED
-    '\ufffe'   #  0xDA -> UNDEFINED
-    '\ufffe'   #  0xDB -> UNDEFINED
-    '\ufffe'   #  0xDC -> UNDEFINED
-    '\ufffe'   #  0xDD -> UNDEFINED
-    '\ufffe'   #  0xDE -> UNDEFINED
-    '\ufffe'   #  0xDF -> UNDEFINED
-    '\u05d0'   #  0xE0 -> HEBREW LETTER ALEF
-    '\u05d1'   #  0xE1 -> HEBREW LETTER BET
-    '\u05d2'   #  0xE2 -> HEBREW LETTER GIMEL
-    '\u05d3'   #  0xE3 -> HEBREW LETTER DALET
-    '\u05d4'   #  0xE4 -> HEBREW LETTER HE
-    '\u05d5'   #  0xE5 -> HEBREW LETTER VAV
-    '\u05d6'   #  0xE6 -> HEBREW LETTER ZAYIN
-    '\u05d7'   #  0xE7 -> HEBREW LETTER HET
-    '\u05d8'   #  0xE8 -> HEBREW LETTER TET
-    '\u05d9'   #  0xE9 -> HEBREW LETTER YOD
-    '\u05da'   #  0xEA -> HEBREW LETTER FINAL KAF
-    '\u05db'   #  0xEB -> HEBREW LETTER KAF
-    '\u05dc'   #  0xEC -> HEBREW LETTER LAMED
-    '\u05dd'   #  0xED -> HEBREW LETTER FINAL MEM
-    '\u05de'   #  0xEE -> HEBREW LETTER MEM
-    '\u05df'   #  0xEF -> HEBREW LETTER FINAL NUN
-    '\u05e0'   #  0xF0 -> HEBREW LETTER NUN
-    '\u05e1'   #  0xF1 -> HEBREW LETTER SAMEKH
-    '\u05e2'   #  0xF2 -> HEBREW LETTER AYIN
-    '\u05e3'   #  0xF3 -> HEBREW LETTER FINAL PE
-    '\u05e4'   #  0xF4 -> HEBREW LETTER PE
-    '\u05e5'   #  0xF5 -> HEBREW LETTER FINAL TSADI
-    '\u05e6'   #  0xF6 -> HEBREW LETTER TSADI
-    '\u05e7'   #  0xF7 -> HEBREW LETTER QOF
-    '\u05e8'   #  0xF8 -> HEBREW LETTER RESH
-    '\u05e9'   #  0xF9 -> HEBREW LETTER SHIN
-    '\u05ea'   #  0xFA -> HEBREW LETTER TAV
-    '\ufffe'   #  0xFB -> UNDEFINED
-    '\ufffe'   #  0xFC -> UNDEFINED
-    '\u200e'   #  0xFD -> LEFT-TO-RIGHT MARK
-    '\u200f'   #  0xFE -> RIGHT-TO-LEFT MARK
-    '\ufffe'   #  0xFF -> UNDEFINED
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE-QUOTE
+    '('         #  0x28 -> OPENING PARENTHESIS
+    ')'         #  0x29 -> CLOSING PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> PERIOD
+    '/'         #  0x2F -> SLASH
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> OPENING SQUARE BRACKET
+    '\\'        #  0x5C -> BACKSLASH
+    ']'         #  0x5D -> CLOSING SQUARE BRACKET
+    '^'         #  0x5E -> SPACING CIRCUMFLEX
+    '_'         #  0x5F -> SPACING UNDERSCORE
+    '`'         #  0x60 -> SPACING GRAVE
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> OPENING CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL BAR
+    '}'         #  0x7D -> CLOSING CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\x81'      #  0x81 -> UNDEFINED -> CONTROL
+    '\u201a'    #  0x82 -> LOW SINGLE COMMA QUOTATION MARK
+    '\u0192'    #  0x83 -> LATIN SMALL LETTER SCRIPT F
+    '\u201e'    #  0x84 -> LOW DOUBLE COMMA QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\u02c6'    #  0x88 -> MODIFIER LETTER CIRCUMFLEX
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\x8a'      #  0x8A -> UNDEFINED -> CONTROL
+    '\u2039'    #  0x8B -> LEFT POINTING SINGLE GUILLEMET
+    '\x8c'      #  0x8C -> UNDEFINED -> CONTROL
+    '\x8d'      #  0x8D -> UNDEFINED -> CONTROL
+    '\x8e'      #  0x8E -> UNDEFINED -> CONTROL
+    '\x8f'      #  0x8F -> UNDEFINED -> CONTROL
+    '\x90'      #  0x90 -> UNDEFINED -> CONTROL
+    '\u2018'    #  0x91 -> SINGLE TURNED COMMA QUOTATION MARK
+    '\u2019'    #  0x92 -> SINGLE COMMA QUOTATION MARK
+    '\u201c'    #  0x93 -> DOUBLE TURNED COMMA QUOTATION MARK
+    '\u201d'    #  0x94 -> DOUBLE COMMA QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\u02dc'    #  0x98 -> SPACING TILDE
+    '\u2122'    #  0x99 -> TRADEMARK
+    '\x9a'      #  0x9A -> UNDEFINED -> CONTROL
+    '\u203a'    #  0x9B -> RIGHT POINTING SINGLE GUILLEMET
+    '\x9c'      #  0x9C -> UNDEFINED -> CONTROL
+    '\x9d'      #  0x9D -> UNDEFINED -> CONTROL
+    '\x9e'      #  0x9E -> UNDEFINED -> CONTROL
+    '\x9f'      #  0x9F -> UNDEFINED -> CONTROL
+    '\xa0'      #  0xA0 -> NON-BREAKING SPACE
+    '\xa1'      #  0xA1 -> INVERTED EXCLAMATION MARK
+    '\xa2'      #  0xA2 -> CENT SIGN
+    '\xa3'      #  0xA3 -> POUND SIGN
+    '\u20aa'    #  0xA4 -> NEW SHEQEL SIGN
+    '\xa5'      #  0xA5 -> YEN SIGN
+    '\xa6'      #  0xA6 -> BROKEN VERTICAL BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xa8'      #  0xA8 -> SPACING DIAERESIS
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\xd7'      #  0xAA -> MULTIPLICATION SIGN
+    '\xab'      #  0xAB -> LEFT POINTING GUILLEMET
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED TRADE MARK SIGN
+    '\xaf'      #  0xAF -> SPACING MACRON
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-OR-MINUS SIGN
+    '\xb2'      #  0xB2 -> SUPERSCRIPT DIGIT TWO
+    '\xb3'      #  0xB3 -> SUPERSCRIPT DIGIT THREE
+    '\xb4'      #  0xB4 -> SPACING ACUTE
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PARAGRAPH SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\xb8'      #  0xB8 -> SPACING CEDILLA
+    '\xb9'      #  0xB9 -> SUPERSCRIPT DIGIT ONE
+    '\xf7'      #  0xBA -> DIVISION SIGN
+    '\xbb'      #  0xBB -> RIGHT POINTING GUILLEMET
+    '\xbc'      #  0xBC -> FRACTION ONE QUARTER
+    '\xbd'      #  0xBD -> FRACTION ONE HALF
+    '\xbe'      #  0xBE -> FRACTION THREE QUARTERS
+    '\xbf'      #  0xBF -> INVERTED QUESTION MARK
+    '\u05b0'    #  0xC0 -> HEBREW POINT SHEVA
+    '\u05b1'    #  0xC1 -> HEBREW POINT HATAF SEGOL
+    '\u05b2'    #  0xC2 -> HEBREW POINT HATAF PATAH
+    '\u05b3'    #  0xC3 -> HEBREW POINT HATAF QAMATS
+    '\u05b4'    #  0xC4 -> HEBREW POINT HIRIQ
+    '\u05b5'    #  0xC5 -> HEBREW POINT TSERE
+    '\u05b6'    #  0xC6 -> HEBREW POINT SEGOL
+    '\u05b7'    #  0xC7 -> HEBREW POINT PATAH
+    '\u05b8'    #  0xC8 -> HEBREW POINT QAMATS
+    '\u05b9'    #  0xC9 -> HEBREW POINT HOLAM
+    '\u05ba'    #  0xCA -> HEBREW POINT ????
+    '\u05bb'    #  0xCB -> HEBREW POINT QUBUTS
+    '\u05bc'    #  0xCC -> HEBREW POINT DAGESH
+    '\u05bd'    #  0xCD -> HEBREW POINT METEG
+    '\u05be'    #  0xCE -> HEBREW PUNCTUATION MAQAF
+    '\u05bf'    #  0xCF -> HEBREW POINT RAFE
+    '\u05c0'    #  0xD0 -> HEBREW POINT PASEQ
+    '\u05c1'    #  0xD1 -> HEBREW POINT SHIN DOT
+    '\u05c2'    #  0xD2 -> HEBREW POINT SIN DOT
+    '\u05c3'    #  0xD3 -> HEBREW PUNCTUATION SOF PASUQ
+    '\u05f0'    #  0xD4 -> HEBREW LIGATURE YIDDISH DOUBLE VAV
+    '\u05f1'    #  0xD5 -> HEBREW LIGATURE YIDDISH VAV YOD
+    '\u05f2'    #  0xD6 -> HEBREW LIGATURE YIDDISH DOUBLE YOD
+    '\u05f3'    #  0xD7 -> HEBREW PUNCTUATION GERESH
+    '\u05f4'    #  0xD8 -> HEBREW PUNCTUATION GERSHAYIM
+    '\uf88d'    #  0xD9 -> UNDEFINED -> EUDC
+    '\uf88e'    #  0xDA -> UNDEFINED -> EUDC
+    '\uf88f'    #  0xDB -> UNDEFINED -> EUDC
+    '\uf890'    #  0xDC -> UNDEFINED -> EUDC
+    '\uf891'    #  0xDD -> UNDEFINED -> EUDC
+    '\uf892'    #  0xDE -> UNDEFINED -> EUDC
+    '\uf893'    #  0xDF -> UNDEFINED -> EUDC
+    '\u05d0'    #  0xE0 -> HEBREW LETTER ALEF
+    '\u05d1'    #  0xE1 -> HEBREW LETTER BET
+    '\u05d2'    #  0xE2 -> HEBREW LETTER GIMEL
+    '\u05d3'    #  0xE3 -> HEBREW LETTER DALET
+    '\u05d4'    #  0xE4 -> HEBREW LETTER HE
+    '\u05d5'    #  0xE5 -> HEBREW LETTER VAV
+    '\u05d6'    #  0xE6 -> HEBREW LETTER ZAYIN
+    '\u05d7'    #  0xE7 -> HEBREW LETTER HET
+    '\u05d8'    #  0xE8 -> HEBREW LETTER TET
+    '\u05d9'    #  0xE9 -> HEBREW LETTER YOD
+    '\u05da'    #  0xEA -> HEBREW LETTER FINAL KAF
+    '\u05db'    #  0xEB -> HEBREW LETTER KAF
+    '\u05dc'    #  0xEC -> HEBREW LETTER LAMED
+    '\u05dd'    #  0xED -> HEBREW LETTER FINAL MEM
+    '\u05de'    #  0xEE -> HEBREW LETTER MEM
+    '\u05df'    #  0xEF -> HEBREW LETTER FINAL NUN
+    '\u05e0'    #  0xF0 -> HEBREW LETTER NUN
+    '\u05e1'    #  0xF1 -> HEBREW LETTER SAMEKH
+    '\u05e2'    #  0xF2 -> HEBREW LETTER AYIN
+    '\u05e3'    #  0xF3 -> HEBREW LETTER FINAL PE
+    '\u05e4'    #  0xF4 -> HEBREW LETTER PE
+    '\u05e5'    #  0xF5 -> HEBREW LETTER FINAL TSADI
+    '\u05e6'    #  0xF6 -> HEBREW LETTER TSADI
+    '\u05e7'    #  0xF7 -> HEBREW LETTER QOF
+    '\u05e8'    #  0xF8 -> HEBREW LETTER RESH
+    '\u05e9'    #  0xF9 -> HEBREW LETTER SHIN
+    '\u05ea'    #  0xFA -> HEBREW LETTER TAV
+    '\uf894'    #  0xFB -> UNDEFINED -> EUDC
+    '\uf895'    #  0xFC -> UNDEFINED -> EUDC
+    '\u200e'    #  0xFD -> LEFT-TO-RIGHT MARK
+    '\u200f'    #  0xFE -> RIGHT-TO-LEFT MARK
+    '\uf896'    #  0xFF -> UNDEFINED -> EUDC
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1256.py
+++ b/Lib/encodings/cp1256.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1256 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1256.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1256 generated from 'WindowsBestFit/cp1256.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\u067e'   #  0x81 -> ARABIC LETTER PEH
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\u0192'   #  0x83 -> LATIN SMALL LETTER F WITH HOOK
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\u02c6'   #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\u0679'   #  0x8A -> ARABIC LETTER TTEH
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\u0152'   #  0x8C -> LATIN CAPITAL LIGATURE OE
-    '\u0686'   #  0x8D -> ARABIC LETTER TCHEH
-    '\u0698'   #  0x8E -> ARABIC LETTER JEH
-    '\u0688'   #  0x8F -> ARABIC LETTER DDAL
-    '\u06af'   #  0x90 -> ARABIC LETTER GAF
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\u06a9'   #  0x98 -> ARABIC LETTER KEHEH
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\u0691'   #  0x9A -> ARABIC LETTER RREH
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\u0153'   #  0x9C -> LATIN SMALL LIGATURE OE
-    '\u200c'   #  0x9D -> ZERO WIDTH NON-JOINER
-    '\u200d'   #  0x9E -> ZERO WIDTH JOINER
-    '\u06ba'   #  0x9F -> ARABIC LETTER NOON GHUNNA
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\u060c'   #  0xA1 -> ARABIC COMMA
-    '\xa2'     #  0xA2 -> CENT SIGN
-    '\xa3'     #  0xA3 -> POUND SIGN
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\xa5'     #  0xA5 -> YEN SIGN
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xa8'     #  0xA8 -> DIAERESIS
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\u06be'   #  0xAA -> ARABIC LETTER HEH DOACHASHMEE
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\xaf'     #  0xAF -> MACRON
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\xb2'     #  0xB2 -> SUPERSCRIPT TWO
-    '\xb3'     #  0xB3 -> SUPERSCRIPT THREE
-    '\xb4'     #  0xB4 -> ACUTE ACCENT
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\xb8'     #  0xB8 -> CEDILLA
-    '\xb9'     #  0xB9 -> SUPERSCRIPT ONE
-    '\u061b'   #  0xBA -> ARABIC SEMICOLON
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xbc'     #  0xBC -> VULGAR FRACTION ONE QUARTER
-    '\xbd'     #  0xBD -> VULGAR FRACTION ONE HALF
-    '\xbe'     #  0xBE -> VULGAR FRACTION THREE QUARTERS
-    '\u061f'   #  0xBF -> ARABIC QUESTION MARK
-    '\u06c1'   #  0xC0 -> ARABIC LETTER HEH GOAL
-    '\u0621'   #  0xC1 -> ARABIC LETTER HAMZA
-    '\u0622'   #  0xC2 -> ARABIC LETTER ALEF WITH MADDA ABOVE
-    '\u0623'   #  0xC3 -> ARABIC LETTER ALEF WITH HAMZA ABOVE
-    '\u0624'   #  0xC4 -> ARABIC LETTER WAW WITH HAMZA ABOVE
-    '\u0625'   #  0xC5 -> ARABIC LETTER ALEF WITH HAMZA BELOW
-    '\u0626'   #  0xC6 -> ARABIC LETTER YEH WITH HAMZA ABOVE
-    '\u0627'   #  0xC7 -> ARABIC LETTER ALEF
-    '\u0628'   #  0xC8 -> ARABIC LETTER BEH
-    '\u0629'   #  0xC9 -> ARABIC LETTER TEH MARBUTA
-    '\u062a'   #  0xCA -> ARABIC LETTER TEH
-    '\u062b'   #  0xCB -> ARABIC LETTER THEH
-    '\u062c'   #  0xCC -> ARABIC LETTER JEEM
-    '\u062d'   #  0xCD -> ARABIC LETTER HAH
-    '\u062e'   #  0xCE -> ARABIC LETTER KHAH
-    '\u062f'   #  0xCF -> ARABIC LETTER DAL
-    '\u0630'   #  0xD0 -> ARABIC LETTER THAL
-    '\u0631'   #  0xD1 -> ARABIC LETTER REH
-    '\u0632'   #  0xD2 -> ARABIC LETTER ZAIN
-    '\u0633'   #  0xD3 -> ARABIC LETTER SEEN
-    '\u0634'   #  0xD4 -> ARABIC LETTER SHEEN
-    '\u0635'   #  0xD5 -> ARABIC LETTER SAD
-    '\u0636'   #  0xD6 -> ARABIC LETTER DAD
-    '\xd7'     #  0xD7 -> MULTIPLICATION SIGN
-    '\u0637'   #  0xD8 -> ARABIC LETTER TAH
-    '\u0638'   #  0xD9 -> ARABIC LETTER ZAH
-    '\u0639'   #  0xDA -> ARABIC LETTER AIN
-    '\u063a'   #  0xDB -> ARABIC LETTER GHAIN
-    '\u0640'   #  0xDC -> ARABIC TATWEEL
-    '\u0641'   #  0xDD -> ARABIC LETTER FEH
-    '\u0642'   #  0xDE -> ARABIC LETTER QAF
-    '\u0643'   #  0xDF -> ARABIC LETTER KAF
-    '\xe0'     #  0xE0 -> LATIN SMALL LETTER A WITH GRAVE
-    '\u0644'   #  0xE1 -> ARABIC LETTER LAM
-    '\xe2'     #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
-    '\u0645'   #  0xE3 -> ARABIC LETTER MEEM
-    '\u0646'   #  0xE4 -> ARABIC LETTER NOON
-    '\u0647'   #  0xE5 -> ARABIC LETTER HEH
-    '\u0648'   #  0xE6 -> ARABIC LETTER WAW
-    '\xe7'     #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
-    '\xe8'     #  0xE8 -> LATIN SMALL LETTER E WITH GRAVE
-    '\xe9'     #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
-    '\xea'     #  0xEA -> LATIN SMALL LETTER E WITH CIRCUMFLEX
-    '\xeb'     #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
-    '\u0649'   #  0xEC -> ARABIC LETTER ALEF MAKSURA
-    '\u064a'   #  0xED -> ARABIC LETTER YEH
-    '\xee'     #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
-    '\xef'     #  0xEF -> LATIN SMALL LETTER I WITH DIAERESIS
-    '\u064b'   #  0xF0 -> ARABIC FATHATAN
-    '\u064c'   #  0xF1 -> ARABIC DAMMATAN
-    '\u064d'   #  0xF2 -> ARABIC KASRATAN
-    '\u064e'   #  0xF3 -> ARABIC FATHA
-    '\xf4'     #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
-    '\u064f'   #  0xF5 -> ARABIC DAMMA
-    '\u0650'   #  0xF6 -> ARABIC KASRA
-    '\xf7'     #  0xF7 -> DIVISION SIGN
-    '\u0651'   #  0xF8 -> ARABIC SHADDA
-    '\xf9'     #  0xF9 -> LATIN SMALL LETTER U WITH GRAVE
-    '\u0652'   #  0xFA -> ARABIC SUKUN
-    '\xfb'     #  0xFB -> LATIN SMALL LETTER U WITH CIRCUMFLEX
-    '\xfc'     #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
-    '\u200e'   #  0xFD -> LEFT-TO-RIGHT MARK
-    '\u200f'   #  0xFE -> RIGHT-TO-LEFT MARK
-    '\u06d2'   #  0xFF -> ARABIC LETTER YEH BARREE
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE-QUOTE
+    '('         #  0x28 -> OPENING PARENTHESIS
+    ')'         #  0x29 -> CLOSING PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> PERIOD
+    '/'         #  0x2F -> SLASH
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> OPENING SQUARE BRACKET
+    '\\'        #  0x5C -> BACKSLASH
+    ']'         #  0x5D -> CLOSING SQUARE BRACKET
+    '^'         #  0x5E -> SPACING CIRCUMFLEX
+    '_'         #  0x5F -> SPACING UNDERSCORE
+    '`'         #  0x60 -> SPACING GRAVE
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> OPENING CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL BAR
+    '}'         #  0x7D -> CLOSING CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\u067e'    #  0x81 -> ARABIC TAA WITH THREE DOTS BELOW
+    '\u201a'    #  0x82 -> LOW SINGLE COMMA QUOTATION MARK
+    '\u0192'    #  0x83 -> LATIN SMALL LETTER SCRIPT F
+    '\u201e'    #  0x84 -> LOW DOUBLE COMMA QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\u02c6'    #  0x88 -> MODIFIER LETTER CIRCUMFLEX
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\u0679'    #  0x8A -> ARABIC LETTER TTEH
+    '\u2039'    #  0x8B -> LEFT POINTING SINGLE GUILLEMET
+    '\u0152'    #  0x8C -> LATIN CAPITAL LETTER O E
+    '\u0686'    #  0x8D -> ARABIC HAA WITH MIDDLE THREE DOTS DOWNWARD
+    '\u0698'    #  0x8E -> ARABIC RA WITH THREE DOTS ABOVE
+    '\u0688'    #  0x8F -> ARABIC LETTER DDAL
+    '\u06af'    #  0x90 -> ARABIC GAF
+    '\u2018'    #  0x91 -> SINGLE TURNED COMMA QUOTATION MARK
+    '\u2019'    #  0x92 -> SINGLE COMMA QUOTATION MARK
+    '\u201c'    #  0x93 -> DOUBLE TURNED COMMA QUOTATION MARK
+    '\u201d'    #  0x94 -> DOUBLE COMMA QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\u06a9'    #  0x98 -> ARABIC LETTER KEHEH
+    '\u2122'    #  0x99 -> TRADEMARK
+    '\u0691'    #  0x9A -> ARABIC LETTER RREH
+    '\u203a'    #  0x9B -> RIGHT POINTING SINGLE GUILLEMET
+    '\u0153'    #  0x9C -> LATIN SMALL LETTER O E
+    '\u200c'    #  0x9D -> ZERO WIDTH NON-JOINER
+    '\u200d'    #  0x9E -> ZERO WIDTH JOINER
+    '\u06ba'    #  0x9F -> ARABIC LETTER NOON GHUNNA
+    '\xa0'      #  0xA0 -> NON-BREAKING SPACE
+    '\u060c'    #  0xA1 -> ARABIC COMMA
+    '\xa2'      #  0xA2 -> CENT SIGN
+    '\xa3'      #  0xA3 -> POUND SIGN
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\xa5'      #  0xA5 -> YEN SIGN
+    '\xa6'      #  0xA6 -> BROKEN VERTICAL BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xa8'      #  0xA8 -> SPACING DIAERESIS
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\u06be'    #  0xAA -> ARABIC LETTER HEH DOACHASHMEE
+    '\xab'      #  0xAB -> LEFT POINTING GUILLEMET
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED TRADE MARK SIGN
+    '\xaf'      #  0xAF -> SPACING MACRON
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-OR-MINUS SIGN
+    '\xb2'      #  0xB2 -> SUPERSCRIPT DIGIT TWO
+    '\xb3'      #  0xB3 -> SUPERSCRIPT DIGIT THREE
+    '\xb4'      #  0xB4 -> SPACING ACUTE
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PARAGRAPH SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\xb8'      #  0xB8 -> SPACING CEDILLA
+    '\xb9'      #  0xB9 -> SUPERSCRIPT DIGIT ONE
+    '\u061b'    #  0xBA -> ARABIC SEMICOLON
+    '\xbb'      #  0xBB -> RIGHT POINTING GUILLEMET
+    '\xbc'      #  0xBC -> FRACTION ONE QUARTER
+    '\xbd'      #  0xBD -> FRACTION ONE HALF
+    '\xbe'      #  0xBE -> FRACTION THREE QUARTERS
+    '\u061f'    #  0xBF -> ARABIC QUESTION MARK
+    '\u06c1'    #  0xC0 -> ARABIC LETTER HEH GOAL
+    '\u0621'    #  0xC1 -> ARABIC LETTER HAMZAH
+    '\u0622'    #  0xC2 -> ARABIC LETTER MADDAH ON ALEF
+    '\u0623'    #  0xC3 -> ARABIC LETTER HAMZAH ON ALEF
+    '\u0624'    #  0xC4 -> ARABIC LETTER HAMZAH ON WAW
+    '\u0625'    #  0xC5 -> ARABIC LETTER HAMZAH UNDER ALEF
+    '\u0626'    #  0xC6 -> ARABIC LETTER HAMZAH ON YA
+    '\u0627'    #  0xC7 -> ARABIC LETTER ALEF
+    '\u0628'    #  0xC8 -> ARABIC LETTER BAA
+    '\u0629'    #  0xC9 -> ARABIC LETTER TAA MARBUTAH
+    '\u062a'    #  0xCA -> ARABIC LETTER TAA
+    '\u062b'    #  0xCB -> ARABIC LETTER THAA
+    '\u062c'    #  0xCC -> ARABIC LETTER JEEM
+    '\u062d'    #  0xCD -> ARABIC LETTER HAA
+    '\u062e'    #  0xCE -> ARABIC LETTER KHAA
+    '\u062f'    #  0xCF -> ARABIC LETTER DAL
+    '\u0630'    #  0xD0 -> ARABIC LETTER THAL
+    '\u0631'    #  0xD1 -> ARABIC LETTER RA
+    '\u0632'    #  0xD2 -> ARABIC LETTER ZAIN
+    '\u0633'    #  0xD3 -> ARABIC LETTER SEEN
+    '\u0634'    #  0xD4 -> ARABIC LETTER SHEEN
+    '\u0635'    #  0xD5 -> ARABIC LETTER SAD
+    '\u0636'    #  0xD6 -> ARABIC LETTER DAD
+    '\xd7'      #  0xD7 -> MULTIPLICATION SIGN
+    '\u0637'    #  0xD8 -> ARABIC LETTER TAH
+    '\u0638'    #  0xD9 -> ARABIC LETTER DHAH
+    '\u0639'    #  0xDA -> ARABIC LETTER AIN
+    '\u063a'    #  0xDB -> ARABIC LETTER GHAIN
+    '\u0640'    #  0xDC -> ARABIC TATWEEL
+    '\u0641'    #  0xDD -> ARABIC LETTER FA
+    '\u0642'    #  0xDE -> ARABIC LETTER QAF
+    '\u0643'    #  0xDF -> ARABIC LETTER CAF
+    '\xe0'      #  0xE0 -> LATIN SMALL LETTER A GRAVE
+    '\u0644'    #  0xE1 -> ARABIC LETTER LAM
+    '\xe2'      #  0xE2 -> LATIN SMALL LETTER A CIRCUMFLEX
+    '\u0645'    #  0xE3 -> ARABIC LETTER MEEM
+    '\u0646'    #  0xE4 -> ARABIC LETTER NOON
+    '\u0647'    #  0xE5 -> ARABIC LETTER HA
+    '\u0648'    #  0xE6 -> ARABIC LETTER WAW
+    '\xe7'      #  0xE7 -> LATIN SMALL LETTER C CEDILLA
+    '\xe8'      #  0xE8 -> LATIN SMALL LETTER E GRAVE
+    '\xe9'      #  0xE9 -> LATIN SMALL LETTER E ACUTE
+    '\xea'      #  0xEA -> LATIN SMALL LETTER E CIRCUMFLEX
+    '\xeb'      #  0xEB -> LATIN SMALL LETTER E DIAERESIS
+    '\u0649'    #  0xEC -> ARABIC LETTER ALEF MAQSURAH
+    '\u064a'    #  0xED -> ARABIC LETTER YA
+    '\xee'      #  0xEE -> LATIN SMALL LETTER I CIRCUMFLEX
+    '\xef'      #  0xEF -> LATIN SMALL LETTER I DIAERESIS
+    '\u064b'    #  0xF0 -> ARABIC FATHATAN
+    '\u064c'    #  0xF1 -> ARABIC DAMMATAN
+    '\u064d'    #  0xF2 -> ARABIC KASRATAN
+    '\u064e'    #  0xF3 -> ARABIC FATHAH
+    '\xf4'      #  0xF4 -> LATIN SMALL LETTER O CIRCUMFLEX
+    '\u064f'    #  0xF5 -> ARABIC DAMMAH
+    '\u0650'    #  0xF6 -> ARABIC KASRAH
+    '\xf7'      #  0xF7 -> DIVISION SIGN
+    '\u0651'    #  0xF8 -> ARABIC SHADDAH
+    '\xf9'      #  0xF9 -> LATIN SMALL LETTER U GRAVE
+    '\u0652'    #  0xFA -> ARABIC SUKUN
+    '\xfb'      #  0xFB -> LATIN SMALL LETTER U CIRCUMFLEX
+    '\xfc'      #  0xFC -> LATIN SMALL LETTER U DIAERESIS
+    '\u200e'    #  0xFD -> LEFT-TO-RIGHT MARK
+    '\u200f'    #  0xFE -> RIGHT-TO-LEFT MARK
+    '\u06d2'    #  0xFF -> ARABIC LETTER YEH BARREE
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1257.py
+++ b/Lib/encodings/cp1257.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1257 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1257.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1257 generated from 'WindowsBestFit/cp1257.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\ufffe'   #  0x83 -> UNDEFINED
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\ufffe'   #  0x88 -> UNDEFINED
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\ufffe'   #  0x8A -> UNDEFINED
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\ufffe'   #  0x8C -> UNDEFINED
-    '\xa8'     #  0x8D -> DIAERESIS
-    '\u02c7'   #  0x8E -> CARON
-    '\xb8'     #  0x8F -> CEDILLA
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\ufffe'   #  0x98 -> UNDEFINED
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\ufffe'   #  0x9A -> UNDEFINED
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\ufffe'   #  0x9C -> UNDEFINED
-    '\xaf'     #  0x9D -> MACRON
-    '\u02db'   #  0x9E -> OGONEK
-    '\ufffe'   #  0x9F -> UNDEFINED
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\ufffe'   #  0xA1 -> UNDEFINED
-    '\xa2'     #  0xA2 -> CENT SIGN
-    '\xa3'     #  0xA3 -> POUND SIGN
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\ufffe'   #  0xA5 -> UNDEFINED
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xd8'     #  0xA8 -> LATIN CAPITAL LETTER O WITH STROKE
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\u0156'   #  0xAA -> LATIN CAPITAL LETTER R WITH CEDILLA
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\xc6'     #  0xAF -> LATIN CAPITAL LETTER AE
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\xb2'     #  0xB2 -> SUPERSCRIPT TWO
-    '\xb3'     #  0xB3 -> SUPERSCRIPT THREE
-    '\xb4'     #  0xB4 -> ACUTE ACCENT
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\xf8'     #  0xB8 -> LATIN SMALL LETTER O WITH STROKE
-    '\xb9'     #  0xB9 -> SUPERSCRIPT ONE
-    '\u0157'   #  0xBA -> LATIN SMALL LETTER R WITH CEDILLA
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xbc'     #  0xBC -> VULGAR FRACTION ONE QUARTER
-    '\xbd'     #  0xBD -> VULGAR FRACTION ONE HALF
-    '\xbe'     #  0xBE -> VULGAR FRACTION THREE QUARTERS
-    '\xe6'     #  0xBF -> LATIN SMALL LETTER AE
-    '\u0104'   #  0xC0 -> LATIN CAPITAL LETTER A WITH OGONEK
-    '\u012e'   #  0xC1 -> LATIN CAPITAL LETTER I WITH OGONEK
-    '\u0100'   #  0xC2 -> LATIN CAPITAL LETTER A WITH MACRON
-    '\u0106'   #  0xC3 -> LATIN CAPITAL LETTER C WITH ACUTE
-    '\xc4'     #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
-    '\xc5'     #  0xC5 -> LATIN CAPITAL LETTER A WITH RING ABOVE
-    '\u0118'   #  0xC6 -> LATIN CAPITAL LETTER E WITH OGONEK
-    '\u0112'   #  0xC7 -> LATIN CAPITAL LETTER E WITH MACRON
-    '\u010c'   #  0xC8 -> LATIN CAPITAL LETTER C WITH CARON
-    '\xc9'     #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
-    '\u0179'   #  0xCA -> LATIN CAPITAL LETTER Z WITH ACUTE
-    '\u0116'   #  0xCB -> LATIN CAPITAL LETTER E WITH DOT ABOVE
-    '\u0122'   #  0xCC -> LATIN CAPITAL LETTER G WITH CEDILLA
-    '\u0136'   #  0xCD -> LATIN CAPITAL LETTER K WITH CEDILLA
-    '\u012a'   #  0xCE -> LATIN CAPITAL LETTER I WITH MACRON
-    '\u013b'   #  0xCF -> LATIN CAPITAL LETTER L WITH CEDILLA
-    '\u0160'   #  0xD0 -> LATIN CAPITAL LETTER S WITH CARON
-    '\u0143'   #  0xD1 -> LATIN CAPITAL LETTER N WITH ACUTE
-    '\u0145'   #  0xD2 -> LATIN CAPITAL LETTER N WITH CEDILLA
-    '\xd3'     #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
-    '\u014c'   #  0xD4 -> LATIN CAPITAL LETTER O WITH MACRON
-    '\xd5'     #  0xD5 -> LATIN CAPITAL LETTER O WITH TILDE
-    '\xd6'     #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
-    '\xd7'     #  0xD7 -> MULTIPLICATION SIGN
-    '\u0172'   #  0xD8 -> LATIN CAPITAL LETTER U WITH OGONEK
-    '\u0141'   #  0xD9 -> LATIN CAPITAL LETTER L WITH STROKE
-    '\u015a'   #  0xDA -> LATIN CAPITAL LETTER S WITH ACUTE
-    '\u016a'   #  0xDB -> LATIN CAPITAL LETTER U WITH MACRON
-    '\xdc'     #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
-    '\u017b'   #  0xDD -> LATIN CAPITAL LETTER Z WITH DOT ABOVE
-    '\u017d'   #  0xDE -> LATIN CAPITAL LETTER Z WITH CARON
-    '\xdf'     #  0xDF -> LATIN SMALL LETTER SHARP S
-    '\u0105'   #  0xE0 -> LATIN SMALL LETTER A WITH OGONEK
-    '\u012f'   #  0xE1 -> LATIN SMALL LETTER I WITH OGONEK
-    '\u0101'   #  0xE2 -> LATIN SMALL LETTER A WITH MACRON
-    '\u0107'   #  0xE3 -> LATIN SMALL LETTER C WITH ACUTE
-    '\xe4'     #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
-    '\xe5'     #  0xE5 -> LATIN SMALL LETTER A WITH RING ABOVE
-    '\u0119'   #  0xE6 -> LATIN SMALL LETTER E WITH OGONEK
-    '\u0113'   #  0xE7 -> LATIN SMALL LETTER E WITH MACRON
-    '\u010d'   #  0xE8 -> LATIN SMALL LETTER C WITH CARON
-    '\xe9'     #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
-    '\u017a'   #  0xEA -> LATIN SMALL LETTER Z WITH ACUTE
-    '\u0117'   #  0xEB -> LATIN SMALL LETTER E WITH DOT ABOVE
-    '\u0123'   #  0xEC -> LATIN SMALL LETTER G WITH CEDILLA
-    '\u0137'   #  0xED -> LATIN SMALL LETTER K WITH CEDILLA
-    '\u012b'   #  0xEE -> LATIN SMALL LETTER I WITH MACRON
-    '\u013c'   #  0xEF -> LATIN SMALL LETTER L WITH CEDILLA
-    '\u0161'   #  0xF0 -> LATIN SMALL LETTER S WITH CARON
-    '\u0144'   #  0xF1 -> LATIN SMALL LETTER N WITH ACUTE
-    '\u0146'   #  0xF2 -> LATIN SMALL LETTER N WITH CEDILLA
-    '\xf3'     #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
-    '\u014d'   #  0xF4 -> LATIN SMALL LETTER O WITH MACRON
-    '\xf5'     #  0xF5 -> LATIN SMALL LETTER O WITH TILDE
-    '\xf6'     #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
-    '\xf7'     #  0xF7 -> DIVISION SIGN
-    '\u0173'   #  0xF8 -> LATIN SMALL LETTER U WITH OGONEK
-    '\u0142'   #  0xF9 -> LATIN SMALL LETTER L WITH STROKE
-    '\u015b'   #  0xFA -> LATIN SMALL LETTER S WITH ACUTE
-    '\u016b'   #  0xFB -> LATIN SMALL LETTER U WITH MACRON
-    '\xfc'     #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
-    '\u017c'   #  0xFD -> LATIN SMALL LETTER Z WITH DOT ABOVE
-    '\u017e'   #  0xFE -> LATIN SMALL LETTER Z WITH CARON
-    '\u02d9'   #  0xFF -> DOT ABOVE
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT 0
+    '1'         #  0x31 -> DIGIT 1
+    '2'         #  0x32 -> DIGIT 2
+    '3'         #  0x33 -> DIGIT 3
+    '4'         #  0x34 -> DIGIT 4
+    '5'         #  0x35 -> DIGIT 5
+    '6'         #  0x36 -> DIGIT 6
+    '7'         #  0x37 -> DIGIT 7
+    '8'         #  0x38 -> DIGIT 8
+    '9'         #  0x39 -> DIGIT 9
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> A
+    'B'         #  0x42 -> B
+    'C'         #  0x43 -> C
+    'D'         #  0x44 -> D
+    'E'         #  0x45 -> E
+    'F'         #  0x46 -> F
+    'G'         #  0x47 -> G
+    'H'         #  0x48 -> H
+    'I'         #  0x49 -> I
+    'J'         #  0x4A -> J
+    'K'         #  0x4B -> K
+    'L'         #  0x4C -> L
+    'M'         #  0x4D -> M
+    'N'         #  0x4E -> N
+    'O'         #  0x4F -> O
+    'P'         #  0x50 -> P
+    'Q'         #  0x51 -> Q
+    'R'         #  0x52 -> R
+    'S'         #  0x53 -> S
+    'T'         #  0x54 -> T
+    'U'         #  0x55 -> U
+    'V'         #  0x56 -> V
+    'W'         #  0x57 -> W
+    'X'         #  0x58 -> X
+    'Y'         #  0x59 -> Y
+    'Z'         #  0x5A -> Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> BACKSLASH
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE
+    'a'         #  0x61 -> #A
+    'b'         #  0x62 -> #B
+    'c'         #  0x63 -> #C
+    'd'         #  0x64 -> #D
+    'e'         #  0x65 -> #E
+    'f'         #  0x66 -> #F
+    'g'         #  0x67 -> #G
+    'h'         #  0x68 -> #H
+    'i'         #  0x69 -> #I
+    'j'         #  0x6A -> #J
+    'k'         #  0x6B -> #K
+    'l'         #  0x6C -> #L
+    'm'         #  0x6D -> #M
+    'n'         #  0x6E -> #N
+    'o'         #  0x6F -> #O
+    'p'         #  0x70 -> #P
+    'q'         #  0x71 -> #Q
+    'r'         #  0x72 -> #R
+    's'         #  0x73 -> #S
+    't'         #  0x74 -> #T
+    'u'         #  0x75 -> #U
+    'v'         #  0x76 -> #V
+    'w'         #  0x77 -> #W
+    'x'         #  0x78 -> #X
+    'y'         #  0x79 -> #Y
+    'z'         #  0x7A -> #Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\x81'
+    '\u201a'    #  0x82 -> LOW SINGLE COMMA QUOTATION MARK
+    '\x83'      #  0x83 -> NOT USED
+    '\u201e'    #  0x84 -> LOW DOUBLE COMMA QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\x88'
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\x8a'
+    '\u2039'    #  0x8B -> LEFT POINTING SINGLE GUILLEMENT
+    '\x8c'
+    '\xa8'      #  0x8D -> DIAERESIS
+    '\u02c7'    #  0x8E -> HACEK
+    '\xb8'      #  0x8F -> CEDILLA
+    '\x90'
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\x98'      #  0x98 -> NOT USED
+    '\u2122'    #  0x99 -> TRADE MARK SIGN
+    '\x9a'
+    '\u203a'    #  0x9B -> RIGHT POINTING SINGLE GUILLEMENT
+    '\x9c'
+    '\xaf'      #  0x9D -> MACRON
+    '\u02db'    #  0x9E -> OGONEK
+    '\x9f'
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\uf8fc'    #  0xA1 -> UNDEFINED -> EUDC
+    '\xa2'      #  0xA2 -> CENT SIGN
+    '\xa3'      #  0xA3 -> POUND SIGN
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\uf8fd'    #  0xA5 -> UNDEFINED -> EUDC
+    '\xa6'      #  0xA6 -> BROKEN BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xd8'      #  0xA8 -> O STROKE
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\u0156'    #  0xAA -> R CEDILLA
+    '\xab'      #  0xAB -> LEFT POINTING GUILLEMENT
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED SIGN
+    '\xc6'      #  0xAF -> AE
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-MINUS SIGN
+    '\xb2'      #  0xB2 -> SUPERSCRIPT 2
+    '\xb3'      #  0xB3 -> SUPERSCRIPT 3
+    '\xb4'      #  0xB4 -> ACUTE
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PILCROW SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\xf8'      #  0xB8 -> #O STROKE
+    '\xb9'      #  0xB9 -> SUPERSCRIPT 1
+    '\u0157'    #  0xBA -> #R CEDILLA
+    '\xbb'      #  0xBB -> RIGHT POINTING GUILLEMENT
+    '\xbc'      #  0xBC -> FRACTION 1/4
+    '\xbd'      #  0xBD -> FRACTION 1/2
+    '\xbe'      #  0xBE -> FRACTION 3/4
+    '\xe6'      #  0xBF -> #AE
+    '\u0104'    #  0xC0 -> A OGONEK
+    '\u012e'    #  0xC1 -> I OGONEK
+    '\u0100'    #  0xC2 -> A MACRON
+    '\u0106'    #  0xC3 -> C ACUTE
+    '\xc4'      #  0xC4 -> A DIAERESIS
+    '\xc5'      #  0xC5 -> A RING ABOVE
+    '\u0118'    #  0xC6 -> E OGONEK
+    '\u0112'    #  0xC7 -> E MACRON
+    '\u010c'    #  0xC8 -> C HACEK
+    '\xc9'      #  0xC9 -> E ACUTE
+    '\u0179'    #  0xCA -> Z ACUTE
+    '\u0116'    #  0xCB -> E DOT ABOVE
+    '\u0122'    #  0xCC -> G CEDILLA
+    '\u0136'    #  0xCD -> K CEDILLA
+    '\u012a'    #  0xCE -> I MACRON
+    '\u013b'    #  0xCF -> L CEDILLA
+    '\u0160'    #  0xD0 -> S HACEK
+    '\u0143'    #  0xD1 -> N ACUTE
+    '\u0145'    #  0xD2 -> N CEDILLA
+    '\xd3'      #  0xD3 -> O ACUTE
+    '\u014c'    #  0xD4 -> O MACRON
+    '\xd5'      #  0xD5 -> O TILDE
+    '\xd6'      #  0xD6 -> O DIAERESIS
+    '\xd7'      #  0xD7 -> MULTIPLICATION SIGN
+    '\u0172'    #  0xD8 -> U OGONEK
+    '\u0141'    #  0xD9 -> L STROKE
+    '\u015a'    #  0xDA -> S ACUTE
+    '\u016a'    #  0xDB -> U MACRON
+    '\xdc'      #  0xDC -> U DIAERESIS
+    '\u017b'    #  0xDD -> Z DOT ABOVE
+    '\u017d'    #  0xDE -> Z HACEK
+    '\xdf'      #  0xDF -> SHARP SS
+    '\u0105'    #  0xE0 -> #A OGONEK
+    '\u012f'    #  0xE1 -> #I OGONEK
+    '\u0101'    #  0xE2 -> #A MACRON
+    '\u0107'    #  0xE3 -> #C ACUTE
+    '\xe4'      #  0xE4 -> #A DIAERESIS
+    '\xe5'      #  0xE5 -> #A RING ABOVE
+    '\u0119'    #  0xE6 -> #E OGONEK
+    '\u0113'    #  0xE7 -> #E MACRON
+    '\u010d'    #  0xE8 -> #C HACEK
+    '\xe9'      #  0xE9 -> #E ACUTE
+    '\u017a'    #  0xEA -> #Z ACUTE
+    '\u0117'    #  0xEB -> #E DOT ABOVE
+    '\u0123'    #  0xEC -> #G CEDILLA
+    '\u0137'    #  0xED -> #K CEDILLA
+    '\u012b'    #  0xEE -> #I MACRON
+    '\u013c'    #  0xEF -> #L CEDILLA
+    '\u0161'    #  0xF0 -> #S HACEK
+    '\u0144'    #  0xF1 -> #N ACUTE
+    '\u0146'    #  0xF2 -> #N CEDILLA
+    '\xf3'      #  0xF3 -> #O ACUTE
+    '\u014d'    #  0xF4 -> #O MACRON
+    '\xf5'      #  0xF5 -> #O TILDE
+    '\xf6'      #  0xF6 -> #O DIAERESIS
+    '\xf7'      #  0xF7 -> DIVISION SIGN
+    '\u0173'    #  0xF8 -> #U OGONEK
+    '\u0142'    #  0xF9 -> #L STROKE
+    '\u015b'    #  0xFA -> #S ACUTE
+    '\u016b'    #  0xFB -> #U MACRON
+    '\xfc'      #  0xFC -> #U DIAERESIS
+    '\u017c'    #  0xFD -> #Z DOT ABOVE
+    '\u017e'    #  0xFE -> #Z HACEK
+    '\u02d9'    #  0xFF -> DOT ABOVE
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp1258.py
+++ b/Lib/encodings/cp1258.py
@@ -1,4 +1,4 @@
-""" Python Character Mapping Codec cp1258 generated from 'MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1258.TXT' with gencodec.py.
+""" Python Character Mapping Codec cp1258 generated from 'WindowsBestFit/cp1258.txt' with gencodec.py.
 
 """#"
 
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\u201a'   #  0x82 -> SINGLE LOW-9 QUOTATION MARK
-    '\u0192'   #  0x83 -> LATIN SMALL LETTER F WITH HOOK
-    '\u201e'   #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\u2020'   #  0x86 -> DAGGER
-    '\u2021'   #  0x87 -> DOUBLE DAGGER
-    '\u02c6'   #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
-    '\u2030'   #  0x89 -> PER MILLE SIGN
-    '\ufffe'   #  0x8A -> UNDEFINED
-    '\u2039'   #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    '\u0152'   #  0x8C -> LATIN CAPITAL LIGATURE OE
-    '\ufffe'   #  0x8D -> UNDEFINED
-    '\ufffe'   #  0x8E -> UNDEFINED
-    '\ufffe'   #  0x8F -> UNDEFINED
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\u02dc'   #  0x98 -> SMALL TILDE
-    '\u2122'   #  0x99 -> TRADE MARK SIGN
-    '\ufffe'   #  0x9A -> UNDEFINED
-    '\u203a'   #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    '\u0153'   #  0x9C -> LATIN SMALL LIGATURE OE
-    '\ufffe'   #  0x9D -> UNDEFINED
-    '\ufffe'   #  0x9E -> UNDEFINED
-    '\u0178'   #  0x9F -> LATIN CAPITAL LETTER Y WITH DIAERESIS
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\xa1'     #  0xA1 -> INVERTED EXCLAMATION MARK
-    '\xa2'     #  0xA2 -> CENT SIGN
-    '\xa3'     #  0xA3 -> POUND SIGN
-    '\xa4'     #  0xA4 -> CURRENCY SIGN
-    '\xa5'     #  0xA5 -> YEN SIGN
-    '\xa6'     #  0xA6 -> BROKEN BAR
-    '\xa7'     #  0xA7 -> SECTION SIGN
-    '\xa8'     #  0xA8 -> DIAERESIS
-    '\xa9'     #  0xA9 -> COPYRIGHT SIGN
-    '\xaa'     #  0xAA -> FEMININE ORDINAL INDICATOR
-    '\xab'     #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xac'     #  0xAC -> NOT SIGN
-    '\xad'     #  0xAD -> SOFT HYPHEN
-    '\xae'     #  0xAE -> REGISTERED SIGN
-    '\xaf'     #  0xAF -> MACRON
-    '\xb0'     #  0xB0 -> DEGREE SIGN
-    '\xb1'     #  0xB1 -> PLUS-MINUS SIGN
-    '\xb2'     #  0xB2 -> SUPERSCRIPT TWO
-    '\xb3'     #  0xB3 -> SUPERSCRIPT THREE
-    '\xb4'     #  0xB4 -> ACUTE ACCENT
-    '\xb5'     #  0xB5 -> MICRO SIGN
-    '\xb6'     #  0xB6 -> PILCROW SIGN
-    '\xb7'     #  0xB7 -> MIDDLE DOT
-    '\xb8'     #  0xB8 -> CEDILLA
-    '\xb9'     #  0xB9 -> SUPERSCRIPT ONE
-    '\xba'     #  0xBA -> MASCULINE ORDINAL INDICATOR
-    '\xbb'     #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-    '\xbc'     #  0xBC -> VULGAR FRACTION ONE QUARTER
-    '\xbd'     #  0xBD -> VULGAR FRACTION ONE HALF
-    '\xbe'     #  0xBE -> VULGAR FRACTION THREE QUARTERS
-    '\xbf'     #  0xBF -> INVERTED QUESTION MARK
-    '\xc0'     #  0xC0 -> LATIN CAPITAL LETTER A WITH GRAVE
-    '\xc1'     #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
-    '\xc2'     #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
-    '\u0102'   #  0xC3 -> LATIN CAPITAL LETTER A WITH BREVE
-    '\xc4'     #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
-    '\xc5'     #  0xC5 -> LATIN CAPITAL LETTER A WITH RING ABOVE
-    '\xc6'     #  0xC6 -> LATIN CAPITAL LETTER AE
-    '\xc7'     #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
-    '\xc8'     #  0xC8 -> LATIN CAPITAL LETTER E WITH GRAVE
-    '\xc9'     #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
-    '\xca'     #  0xCA -> LATIN CAPITAL LETTER E WITH CIRCUMFLEX
-    '\xcb'     #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
-    '\u0300'   #  0xCC -> COMBINING GRAVE ACCENT
-    '\xcd'     #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
-    '\xce'     #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
-    '\xcf'     #  0xCF -> LATIN CAPITAL LETTER I WITH DIAERESIS
-    '\u0110'   #  0xD0 -> LATIN CAPITAL LETTER D WITH STROKE
-    '\xd1'     #  0xD1 -> LATIN CAPITAL LETTER N WITH TILDE
-    '\u0309'   #  0xD2 -> COMBINING HOOK ABOVE
-    '\xd3'     #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
-    '\xd4'     #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
-    '\u01a0'   #  0xD5 -> LATIN CAPITAL LETTER O WITH HORN
-    '\xd6'     #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
-    '\xd7'     #  0xD7 -> MULTIPLICATION SIGN
-    '\xd8'     #  0xD8 -> LATIN CAPITAL LETTER O WITH STROKE
-    '\xd9'     #  0xD9 -> LATIN CAPITAL LETTER U WITH GRAVE
-    '\xda'     #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
-    '\xdb'     #  0xDB -> LATIN CAPITAL LETTER U WITH CIRCUMFLEX
-    '\xdc'     #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
-    '\u01af'   #  0xDD -> LATIN CAPITAL LETTER U WITH HORN
-    '\u0303'   #  0xDE -> COMBINING TILDE
-    '\xdf'     #  0xDF -> LATIN SMALL LETTER SHARP S
-    '\xe0'     #  0xE0 -> LATIN SMALL LETTER A WITH GRAVE
-    '\xe1'     #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
-    '\xe2'     #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
-    '\u0103'   #  0xE3 -> LATIN SMALL LETTER A WITH BREVE
-    '\xe4'     #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
-    '\xe5'     #  0xE5 -> LATIN SMALL LETTER A WITH RING ABOVE
-    '\xe6'     #  0xE6 -> LATIN SMALL LETTER AE
-    '\xe7'     #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
-    '\xe8'     #  0xE8 -> LATIN SMALL LETTER E WITH GRAVE
-    '\xe9'     #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
-    '\xea'     #  0xEA -> LATIN SMALL LETTER E WITH CIRCUMFLEX
-    '\xeb'     #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
-    '\u0301'   #  0xEC -> COMBINING ACUTE ACCENT
-    '\xed'     #  0xED -> LATIN SMALL LETTER I WITH ACUTE
-    '\xee'     #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
-    '\xef'     #  0xEF -> LATIN SMALL LETTER I WITH DIAERESIS
-    '\u0111'   #  0xF0 -> LATIN SMALL LETTER D WITH STROKE
-    '\xf1'     #  0xF1 -> LATIN SMALL LETTER N WITH TILDE
-    '\u0323'   #  0xF2 -> COMBINING DOT BELOW
-    '\xf3'     #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
-    '\xf4'     #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
-    '\u01a1'   #  0xF5 -> LATIN SMALL LETTER O WITH HORN
-    '\xf6'     #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
-    '\xf7'     #  0xF7 -> DIVISION SIGN
-    '\xf8'     #  0xF8 -> LATIN SMALL LETTER O WITH STROKE
-    '\xf9'     #  0xF9 -> LATIN SMALL LETTER U WITH GRAVE
-    '\xfa'     #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
-    '\xfb'     #  0xFB -> LATIN SMALL LETTER U WITH CIRCUMFLEX
-    '\xfc'     #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
-    '\u01b0'   #  0xFD -> LATIN SMALL LETTER U WITH HORN
-    '\u20ab'   #  0xFE -> DONG SIGN
-    '\xff'     #  0xFF -> LATIN SMALL LETTER Y WITH DIAERESIS
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> REVERSE SOLIDUS
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX ACCENT
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE ACCENT
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\x81'      #  0x81 -> UNDEFINED -> CONTROL
+    '\u201a'    #  0x82 -> SINGLE LOW-9 QUOTATION MARK
+    '\u0192'    #  0x83 -> LATIN SMALL LETTER F WITH HOOK
+    '\u201e'    #  0x84 -> DOUBLE LOW-9 QUOTATION MARK
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\u2020'    #  0x86 -> DAGGER
+    '\u2021'    #  0x87 -> DOUBLE DAGGER
+    '\u02c6'    #  0x88 -> MODIFIER LETTER CIRCUMFLEX ACCENT
+    '\u2030'    #  0x89 -> PER MILLE SIGN
+    '\x8a'      #  0x8A -> UNDEFINED -> CONTROL
+    '\u2039'    #  0x8B -> SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    '\u0152'    #  0x8C -> LATIN CAPITAL LIGATURE OE
+    '\x8d'      #  0x8D -> UNDEFINED -> CONTROL
+    '\x8e'      #  0x8E -> UNDEFINED -> CONTROL
+    '\x8f'      #  0x8F -> UNDEFINED -> CONTROL
+    '\x90'      #  0x90 -> UNDEFINED -> CONTROL
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\u02dc'    #  0x98 -> SMALL TILDE
+    '\u2122'    #  0x99 -> TRADE MARK SIGN
+    '\x9a'      #  0x9A -> UNDEFINED -> CONTROL
+    '\u203a'    #  0x9B -> SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    '\u0153'    #  0x9C -> LATIN SMALL LIGATURE OE
+    '\x9d'      #  0x9D -> UNDEFINED -> CONTROL
+    '\x9e'      #  0x9E -> UNDEFINED -> CONTROL
+    '\u0178'    #  0x9F -> LATIN CAPITAL LETTER Y WITH DIAERESIS
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\xa1'      #  0xA1 -> INVERTED EXCLAMATION MARK
+    '\xa2'      #  0xA2 -> CENT SIGN
+    '\xa3'      #  0xA3 -> POUND SIGN
+    '\xa4'      #  0xA4 -> CURRENCY SIGN
+    '\xa5'      #  0xA5 -> YEN SIGN
+    '\xa6'      #  0xA6 -> BROKEN BAR
+    '\xa7'      #  0xA7 -> SECTION SIGN
+    '\xa8'      #  0xA8 -> DIAERESIS
+    '\xa9'      #  0xA9 -> COPYRIGHT SIGN
+    '\xaa'      #  0xAA -> FEMININE ORDINAL INDICATOR
+    '\xab'      #  0xAB -> LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xac'      #  0xAC -> NOT SIGN
+    '\xad'      #  0xAD -> SOFT HYPHEN
+    '\xae'      #  0xAE -> REGISTERED SIGN
+    '\xaf'      #  0xAF -> MACRON
+    '\xb0'      #  0xB0 -> DEGREE SIGN
+    '\xb1'      #  0xB1 -> PLUS-MINUS SIGN
+    '\xb2'      #  0xB2 -> SUPERSCRIPT TWO
+    '\xb3'      #  0xB3 -> SUPERSCRIPT THREE
+    '\xb4'      #  0xB4 -> ACUTE ACCENT
+    '\xb5'      #  0xB5 -> MICRO SIGN
+    '\xb6'      #  0xB6 -> PILCROW SIGN
+    '\xb7'      #  0xB7 -> MIDDLE DOT
+    '\xb8'      #  0xB8 -> CEDILLA
+    '\xb9'      #  0xB9 -> SUPERSCRIPT ONE
+    '\xba'      #  0xBA -> MASCULINE ORDINAL INDICATOR
+    '\xbb'      #  0xBB -> RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+    '\xbc'      #  0xBC -> VULGAR FRACTION ONE QUARTER
+    '\xbd'      #  0xBD -> VULGAR FRACTION ONE HALF
+    '\xbe'      #  0xBE -> VULGAR FRACTION THREE QUARTERS
+    '\xbf'      #  0xBF -> INVERTED QUESTION MARK
+    '\xc0'      #  0xC0 -> LATIN CAPITAL LETTER A WITH GRAVE
+    '\xc1'      #  0xC1 -> LATIN CAPITAL LETTER A WITH ACUTE
+    '\xc2'      #  0xC2 -> LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+    '\u0102'    #  0xC3 -> LATIN CAPITAL LETTER A WITH BREVE
+    '\xc4'      #  0xC4 -> LATIN CAPITAL LETTER A WITH DIAERESIS
+    '\xc5'      #  0xC5 -> LATIN CAPITAL LETTER A WITH RING ABOVE
+    '\xc6'      #  0xC6 -> LATIN CAPITAL LIGATURE AE
+    '\xc7'      #  0xC7 -> LATIN CAPITAL LETTER C WITH CEDILLA
+    '\xc8'      #  0xC8 -> LATIN CAPITAL LETTER E WITH GRAVE
+    '\xc9'      #  0xC9 -> LATIN CAPITAL LETTER E WITH ACUTE
+    '\xca'      #  0xCA -> LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+    '\xcb'      #  0xCB -> LATIN CAPITAL LETTER E WITH DIAERESIS
+    '\u0300'    #  0xCC -> COMBINING GRAVE ACCENT
+    '\xcd'      #  0xCD -> LATIN CAPITAL LETTER I WITH ACUTE
+    '\xce'      #  0xCE -> LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+    '\xcf'      #  0xCF -> LATIN CAPITAL LETTER I WITH DIAERESIS
+    '\u0110'    #  0xD0 -> LATIN CAPITAL LETTER D BAR
+    '\xd1'      #  0xD1 -> LATIN CAPITAL LETTER N WITH TILDE
+    '\u0309'    #  0xD2 -> COMBINING HOOK ABOVE
+    '\xd3'      #  0xD3 -> LATIN CAPITAL LETTER O WITH ACUTE
+    '\xd4'      #  0xD4 -> LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+    '\u01a0'    #  0xD5 -> LATIN CAPITAL LETTER O WITH HORN
+    '\xd6'      #  0xD6 -> LATIN CAPITAL LETTER O WITH DIAERESIS
+    '\xd7'      #  0xD7 -> MULTIPLICATION SIGN
+    '\xd8'      #  0xD8 -> LATIN CAPITAL LETTER O WITH STROKE
+    '\xd9'      #  0xD9 -> LATIN CAPITAL LETTER U WITH GRAVE
+    '\xda'      #  0xDA -> LATIN CAPITAL LETTER U WITH ACUTE
+    '\xdb'      #  0xDB -> LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+    '\xdc'      #  0xDC -> LATIN CAPITAL LETTER U WITH DIAERESIS
+    '\u01af'    #  0xDD -> LATIN CAPITAL LETTER U WITH HORN
+    '\u0303'    #  0xDE -> COMBINING TILDE
+    '\xdf'      #  0xDF -> LATIN SMALL LETTER SHARP S
+    '\xe0'      #  0xE0 -> LATIN SMALL LETTER A WITH GRAVE
+    '\xe1'      #  0xE1 -> LATIN SMALL LETTER A WITH ACUTE
+    '\xe2'      #  0xE2 -> LATIN SMALL LETTER A WITH CIRCUMFLEX
+    '\u0103'    #  0xE3 -> LATIN SMALL LETTER A WITH BREVE
+    '\xe4'      #  0xE4 -> LATIN SMALL LETTER A WITH DIAERESIS
+    '\xe5'      #  0xE5 -> LATIN SMALL LETTER A WITH RING ABOVE
+    '\xe6'      #  0xE6 -> LATIN SMALL LIGATURE AE
+    '\xe7'      #  0xE7 -> LATIN SMALL LETTER C WITH CEDILLA
+    '\xe8'      #  0xE8 -> LATIN SMALL LETTER E WITH GRAVE
+    '\xe9'      #  0xE9 -> LATIN SMALL LETTER E WITH ACUTE
+    '\xea'      #  0xEA -> LATIN SMALL LETTER E WITH CIRCUMFLEX
+    '\xeb'      #  0xEB -> LATIN SMALL LETTER E WITH DIAERESIS
+    '\u0301'    #  0xEC -> COMBINING ACUTE ACCENT
+    '\xed'      #  0xED -> LATIN SMALL LETTER I WITH ACUTE
+    '\xee'      #  0xEE -> LATIN SMALL LETTER I WITH CIRCUMFLEX
+    '\xef'      #  0xEF -> LATIN SMALL LETTER I WITH DIAERESIS
+    '\u0111'    #  0xF0 -> LATIN SMALL LETTER D BAR
+    '\xf1'      #  0xF1 -> LATIN SMALL LETTER N WITH TILDE
+    '\u0323'    #  0xF2 -> COMBINING DOT BELOW
+    '\xf3'      #  0xF3 -> LATIN SMALL LETTER O WITH ACUTE
+    '\xf4'      #  0xF4 -> LATIN SMALL LETTER O WITH CIRCUMFLEX
+    '\u01a1'    #  0xF5 -> LATIN SMALL LETTER O WITH HORN
+    '\xf6'      #  0xF6 -> LATIN SMALL LETTER O WITH DIAERESIS
+    '\xf7'      #  0xF7 -> DIVISION SIGN
+    '\xf8'      #  0xF8 -> LATIN SMALL LETTER O WITH STROKE
+    '\xf9'      #  0xF9 -> LATIN SMALL LETTER U WITH GRAVE
+    '\xfa'      #  0xFA -> LATIN SMALL LETTER U WITH ACUTE
+    '\xfb'      #  0xFB -> LATIN SMALL LETTER U WITH CIRCUMFLEX
+    '\xfc'      #  0xFC -> LATIN SMALL LETTER U WITH DIAERESIS
+    '\u01b0'    #  0xFD -> LATIN SMALL LETTER U WITH HORN
+    '\u20ab'    #  0xFE -> DONG SIGN
+    '\xff'      #  0xFF -> LATIN SMALL LETTER Y WITH DIAERESIS
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Lib/encodings/cp874.py
+++ b/Lib/encodings/cp874.py
@@ -8,24 +8,24 @@ import codecs
 
 class Codec(codecs.Codec):
 
-    def encode(self,input,errors='strict'):
-        return codecs.charmap_encode(input,errors,encoding_table)
+    def encode(self, input, errors='strict'):
+        return codecs.charmap_encode(input, errors, encoding_table)
 
-    def decode(self,input,errors='strict'):
-        return codecs.charmap_decode(input,errors,decoding_table)
+    def decode(self, input, errors='strict'):
+        return codecs.charmap_decode(input, errors, decoding_table)
 
 class IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
-        return codecs.charmap_encode(input,self.errors,encoding_table)[0]
+        return codecs.charmap_encode(input, self.errors, encoding_table)[0]
 
 class IncrementalDecoder(codecs.IncrementalDecoder):
     def decode(self, input, final=False):
-        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
+        return codecs.charmap_decode(input, self.errors, decoding_table)[0]
 
-class StreamWriter(Codec,codecs.StreamWriter):
+class StreamWriter(Codec, codecs.StreamWriter):
     pass
 
-class StreamReader(Codec,codecs.StreamReader):
+class StreamReader(Codec, codecs.StreamReader):
     pass
 
 ### encodings module API
@@ -45,263 +45,264 @@ def getregentry():
 ### Decoding Table
 
 decoding_table = (
-    '\x00'     #  0x00 -> NULL
-    '\x01'     #  0x01 -> START OF HEADING
-    '\x02'     #  0x02 -> START OF TEXT
-    '\x03'     #  0x03 -> END OF TEXT
-    '\x04'     #  0x04 -> END OF TRANSMISSION
-    '\x05'     #  0x05 -> ENQUIRY
-    '\x06'     #  0x06 -> ACKNOWLEDGE
-    '\x07'     #  0x07 -> BELL
-    '\x08'     #  0x08 -> BACKSPACE
-    '\t'       #  0x09 -> HORIZONTAL TABULATION
-    '\n'       #  0x0A -> LINE FEED
-    '\x0b'     #  0x0B -> VERTICAL TABULATION
-    '\x0c'     #  0x0C -> FORM FEED
-    '\r'       #  0x0D -> CARRIAGE RETURN
-    '\x0e'     #  0x0E -> SHIFT OUT
-    '\x0f'     #  0x0F -> SHIFT IN
-    '\x10'     #  0x10 -> DATA LINK ESCAPE
-    '\x11'     #  0x11 -> DEVICE CONTROL ONE
-    '\x12'     #  0x12 -> DEVICE CONTROL TWO
-    '\x13'     #  0x13 -> DEVICE CONTROL THREE
-    '\x14'     #  0x14 -> DEVICE CONTROL FOUR
-    '\x15'     #  0x15 -> NEGATIVE ACKNOWLEDGE
-    '\x16'     #  0x16 -> SYNCHRONOUS IDLE
-    '\x17'     #  0x17 -> END OF TRANSMISSION BLOCK
-    '\x18'     #  0x18 -> CANCEL
-    '\x19'     #  0x19 -> END OF MEDIUM
-    '\x1a'     #  0x1A -> SUBSTITUTE
-    '\x1b'     #  0x1B -> ESCAPE
-    '\x1c'     #  0x1C -> FILE SEPARATOR
-    '\x1d'     #  0x1D -> GROUP SEPARATOR
-    '\x1e'     #  0x1E -> RECORD SEPARATOR
-    '\x1f'     #  0x1F -> UNIT SEPARATOR
-    ' '        #  0x20 -> SPACE
-    '!'        #  0x21 -> EXCLAMATION MARK
-    '"'        #  0x22 -> QUOTATION MARK
-    '#'        #  0x23 -> NUMBER SIGN
-    '$'        #  0x24 -> DOLLAR SIGN
-    '%'        #  0x25 -> PERCENT SIGN
-    '&'        #  0x26 -> AMPERSAND
-    "'"        #  0x27 -> APOSTROPHE
-    '('        #  0x28 -> LEFT PARENTHESIS
-    ')'        #  0x29 -> RIGHT PARENTHESIS
-    '*'        #  0x2A -> ASTERISK
-    '+'        #  0x2B -> PLUS SIGN
-    ','        #  0x2C -> COMMA
-    '-'        #  0x2D -> HYPHEN-MINUS
-    '.'        #  0x2E -> FULL STOP
-    '/'        #  0x2F -> SOLIDUS
-    '0'        #  0x30 -> DIGIT ZERO
-    '1'        #  0x31 -> DIGIT ONE
-    '2'        #  0x32 -> DIGIT TWO
-    '3'        #  0x33 -> DIGIT THREE
-    '4'        #  0x34 -> DIGIT FOUR
-    '5'        #  0x35 -> DIGIT FIVE
-    '6'        #  0x36 -> DIGIT SIX
-    '7'        #  0x37 -> DIGIT SEVEN
-    '8'        #  0x38 -> DIGIT EIGHT
-    '9'        #  0x39 -> DIGIT NINE
-    ':'        #  0x3A -> COLON
-    ';'        #  0x3B -> SEMICOLON
-    '<'        #  0x3C -> LESS-THAN SIGN
-    '='        #  0x3D -> EQUALS SIGN
-    '>'        #  0x3E -> GREATER-THAN SIGN
-    '?'        #  0x3F -> QUESTION MARK
-    '@'        #  0x40 -> COMMERCIAL AT
-    'A'        #  0x41 -> LATIN CAPITAL LETTER A
-    'B'        #  0x42 -> LATIN CAPITAL LETTER B
-    'C'        #  0x43 -> LATIN CAPITAL LETTER C
-    'D'        #  0x44 -> LATIN CAPITAL LETTER D
-    'E'        #  0x45 -> LATIN CAPITAL LETTER E
-    'F'        #  0x46 -> LATIN CAPITAL LETTER F
-    'G'        #  0x47 -> LATIN CAPITAL LETTER G
-    'H'        #  0x48 -> LATIN CAPITAL LETTER H
-    'I'        #  0x49 -> LATIN CAPITAL LETTER I
-    'J'        #  0x4A -> LATIN CAPITAL LETTER J
-    'K'        #  0x4B -> LATIN CAPITAL LETTER K
-    'L'        #  0x4C -> LATIN CAPITAL LETTER L
-    'M'        #  0x4D -> LATIN CAPITAL LETTER M
-    'N'        #  0x4E -> LATIN CAPITAL LETTER N
-    'O'        #  0x4F -> LATIN CAPITAL LETTER O
-    'P'        #  0x50 -> LATIN CAPITAL LETTER P
-    'Q'        #  0x51 -> LATIN CAPITAL LETTER Q
-    'R'        #  0x52 -> LATIN CAPITAL LETTER R
-    'S'        #  0x53 -> LATIN CAPITAL LETTER S
-    'T'        #  0x54 -> LATIN CAPITAL LETTER T
-    'U'        #  0x55 -> LATIN CAPITAL LETTER U
-    'V'        #  0x56 -> LATIN CAPITAL LETTER V
-    'W'        #  0x57 -> LATIN CAPITAL LETTER W
-    'X'        #  0x58 -> LATIN CAPITAL LETTER X
-    'Y'        #  0x59 -> LATIN CAPITAL LETTER Y
-    'Z'        #  0x5A -> LATIN CAPITAL LETTER Z
-    '['        #  0x5B -> LEFT SQUARE BRACKET
-    '\\'       #  0x5C -> REVERSE SOLIDUS
-    ']'        #  0x5D -> RIGHT SQUARE BRACKET
-    '^'        #  0x5E -> CIRCUMFLEX ACCENT
-    '_'        #  0x5F -> LOW LINE
-    '`'        #  0x60 -> GRAVE ACCENT
-    'a'        #  0x61 -> LATIN SMALL LETTER A
-    'b'        #  0x62 -> LATIN SMALL LETTER B
-    'c'        #  0x63 -> LATIN SMALL LETTER C
-    'd'        #  0x64 -> LATIN SMALL LETTER D
-    'e'        #  0x65 -> LATIN SMALL LETTER E
-    'f'        #  0x66 -> LATIN SMALL LETTER F
-    'g'        #  0x67 -> LATIN SMALL LETTER G
-    'h'        #  0x68 -> LATIN SMALL LETTER H
-    'i'        #  0x69 -> LATIN SMALL LETTER I
-    'j'        #  0x6A -> LATIN SMALL LETTER J
-    'k'        #  0x6B -> LATIN SMALL LETTER K
-    'l'        #  0x6C -> LATIN SMALL LETTER L
-    'm'        #  0x6D -> LATIN SMALL LETTER M
-    'n'        #  0x6E -> LATIN SMALL LETTER N
-    'o'        #  0x6F -> LATIN SMALL LETTER O
-    'p'        #  0x70 -> LATIN SMALL LETTER P
-    'q'        #  0x71 -> LATIN SMALL LETTER Q
-    'r'        #  0x72 -> LATIN SMALL LETTER R
-    's'        #  0x73 -> LATIN SMALL LETTER S
-    't'        #  0x74 -> LATIN SMALL LETTER T
-    'u'        #  0x75 -> LATIN SMALL LETTER U
-    'v'        #  0x76 -> LATIN SMALL LETTER V
-    'w'        #  0x77 -> LATIN SMALL LETTER W
-    'x'        #  0x78 -> LATIN SMALL LETTER X
-    'y'        #  0x79 -> LATIN SMALL LETTER Y
-    'z'        #  0x7A -> LATIN SMALL LETTER Z
-    '{'        #  0x7B -> LEFT CURLY BRACKET
-    '|'        #  0x7C -> VERTICAL LINE
-    '}'        #  0x7D -> RIGHT CURLY BRACKET
-    '~'        #  0x7E -> TILDE
-    '\x7f'     #  0x7F -> DELETE
-    '\u20ac'   #  0x80 -> EURO SIGN
-    '\ufffe'   #  0x81 -> UNDEFINED
-    '\ufffe'   #  0x82 -> UNDEFINED
-    '\ufffe'   #  0x83 -> UNDEFINED
-    '\ufffe'   #  0x84 -> UNDEFINED
-    '\u2026'   #  0x85 -> HORIZONTAL ELLIPSIS
-    '\ufffe'   #  0x86 -> UNDEFINED
-    '\ufffe'   #  0x87 -> UNDEFINED
-    '\ufffe'   #  0x88 -> UNDEFINED
-    '\ufffe'   #  0x89 -> UNDEFINED
-    '\ufffe'   #  0x8A -> UNDEFINED
-    '\ufffe'   #  0x8B -> UNDEFINED
-    '\ufffe'   #  0x8C -> UNDEFINED
-    '\ufffe'   #  0x8D -> UNDEFINED
-    '\ufffe'   #  0x8E -> UNDEFINED
-    '\ufffe'   #  0x8F -> UNDEFINED
-    '\ufffe'   #  0x90 -> UNDEFINED
-    '\u2018'   #  0x91 -> LEFT SINGLE QUOTATION MARK
-    '\u2019'   #  0x92 -> RIGHT SINGLE QUOTATION MARK
-    '\u201c'   #  0x93 -> LEFT DOUBLE QUOTATION MARK
-    '\u201d'   #  0x94 -> RIGHT DOUBLE QUOTATION MARK
-    '\u2022'   #  0x95 -> BULLET
-    '\u2013'   #  0x96 -> EN DASH
-    '\u2014'   #  0x97 -> EM DASH
-    '\ufffe'   #  0x98 -> UNDEFINED
-    '\ufffe'   #  0x99 -> UNDEFINED
-    '\ufffe'   #  0x9A -> UNDEFINED
-    '\ufffe'   #  0x9B -> UNDEFINED
-    '\ufffe'   #  0x9C -> UNDEFINED
-    '\ufffe'   #  0x9D -> UNDEFINED
-    '\ufffe'   #  0x9E -> UNDEFINED
-    '\ufffe'   #  0x9F -> UNDEFINED
-    '\xa0'     #  0xA0 -> NO-BREAK SPACE
-    '\u0e01'   #  0xA1 -> THAI CHARACTER KO KAI
-    '\u0e02'   #  0xA2 -> THAI CHARACTER KHO KHAI
-    '\u0e03'   #  0xA3 -> THAI CHARACTER KHO KHUAT
-    '\u0e04'   #  0xA4 -> THAI CHARACTER KHO KHWAI
-    '\u0e05'   #  0xA5 -> THAI CHARACTER KHO KHON
-    '\u0e06'   #  0xA6 -> THAI CHARACTER KHO RAKHANG
-    '\u0e07'   #  0xA7 -> THAI CHARACTER NGO NGU
-    '\u0e08'   #  0xA8 -> THAI CHARACTER CHO CHAN
-    '\u0e09'   #  0xA9 -> THAI CHARACTER CHO CHING
-    '\u0e0a'   #  0xAA -> THAI CHARACTER CHO CHANG
-    '\u0e0b'   #  0xAB -> THAI CHARACTER SO SO
-    '\u0e0c'   #  0xAC -> THAI CHARACTER CHO CHOE
-    '\u0e0d'   #  0xAD -> THAI CHARACTER YO YING
-    '\u0e0e'   #  0xAE -> THAI CHARACTER DO CHADA
-    '\u0e0f'   #  0xAF -> THAI CHARACTER TO PATAK
-    '\u0e10'   #  0xB0 -> THAI CHARACTER THO THAN
-    '\u0e11'   #  0xB1 -> THAI CHARACTER THO NANGMONTHO
-    '\u0e12'   #  0xB2 -> THAI CHARACTER THO PHUTHAO
-    '\u0e13'   #  0xB3 -> THAI CHARACTER NO NEN
-    '\u0e14'   #  0xB4 -> THAI CHARACTER DO DEK
-    '\u0e15'   #  0xB5 -> THAI CHARACTER TO TAO
-    '\u0e16'   #  0xB6 -> THAI CHARACTER THO THUNG
-    '\u0e17'   #  0xB7 -> THAI CHARACTER THO THAHAN
-    '\u0e18'   #  0xB8 -> THAI CHARACTER THO THONG
-    '\u0e19'   #  0xB9 -> THAI CHARACTER NO NU
-    '\u0e1a'   #  0xBA -> THAI CHARACTER BO BAIMAI
-    '\u0e1b'   #  0xBB -> THAI CHARACTER PO PLA
-    '\u0e1c'   #  0xBC -> THAI CHARACTER PHO PHUNG
-    '\u0e1d'   #  0xBD -> THAI CHARACTER FO FA
-    '\u0e1e'   #  0xBE -> THAI CHARACTER PHO PHAN
-    '\u0e1f'   #  0xBF -> THAI CHARACTER FO FAN
-    '\u0e20'   #  0xC0 -> THAI CHARACTER PHO SAMPHAO
-    '\u0e21'   #  0xC1 -> THAI CHARACTER MO MA
-    '\u0e22'   #  0xC2 -> THAI CHARACTER YO YAK
-    '\u0e23'   #  0xC3 -> THAI CHARACTER RO RUA
-    '\u0e24'   #  0xC4 -> THAI CHARACTER RU
-    '\u0e25'   #  0xC5 -> THAI CHARACTER LO LING
-    '\u0e26'   #  0xC6 -> THAI CHARACTER LU
-    '\u0e27'   #  0xC7 -> THAI CHARACTER WO WAEN
-    '\u0e28'   #  0xC8 -> THAI CHARACTER SO SALA
-    '\u0e29'   #  0xC9 -> THAI CHARACTER SO RUSI
-    '\u0e2a'   #  0xCA -> THAI CHARACTER SO SUA
-    '\u0e2b'   #  0xCB -> THAI CHARACTER HO HIP
-    '\u0e2c'   #  0xCC -> THAI CHARACTER LO CHULA
-    '\u0e2d'   #  0xCD -> THAI CHARACTER O ANG
-    '\u0e2e'   #  0xCE -> THAI CHARACTER HO NOKHUK
-    '\u0e2f'   #  0xCF -> THAI CHARACTER PAIYANNOI
-    '\u0e30'   #  0xD0 -> THAI CHARACTER SARA A
-    '\u0e31'   #  0xD1 -> THAI CHARACTER MAI HAN-AKAT
-    '\u0e32'   #  0xD2 -> THAI CHARACTER SARA AA
-    '\u0e33'   #  0xD3 -> THAI CHARACTER SARA AM
-    '\u0e34'   #  0xD4 -> THAI CHARACTER SARA I
-    '\u0e35'   #  0xD5 -> THAI CHARACTER SARA II
-    '\u0e36'   #  0xD6 -> THAI CHARACTER SARA UE
-    '\u0e37'   #  0xD7 -> THAI CHARACTER SARA UEE
-    '\u0e38'   #  0xD8 -> THAI CHARACTER SARA U
-    '\u0e39'   #  0xD9 -> THAI CHARACTER SARA UU
-    '\u0e3a'   #  0xDA -> THAI CHARACTER PHINTHU
-    '\ufffe'   #  0xDB -> UNDEFINED
-    '\ufffe'   #  0xDC -> UNDEFINED
-    '\ufffe'   #  0xDD -> UNDEFINED
-    '\ufffe'   #  0xDE -> UNDEFINED
-    '\u0e3f'   #  0xDF -> THAI CURRENCY SYMBOL BAHT
-    '\u0e40'   #  0xE0 -> THAI CHARACTER SARA E
-    '\u0e41'   #  0xE1 -> THAI CHARACTER SARA AE
-    '\u0e42'   #  0xE2 -> THAI CHARACTER SARA O
-    '\u0e43'   #  0xE3 -> THAI CHARACTER SARA AI MAIMUAN
-    '\u0e44'   #  0xE4 -> THAI CHARACTER SARA AI MAIMALAI
-    '\u0e45'   #  0xE5 -> THAI CHARACTER LAKKHANGYAO
-    '\u0e46'   #  0xE6 -> THAI CHARACTER MAIYAMOK
-    '\u0e47'   #  0xE7 -> THAI CHARACTER MAITAIKHU
-    '\u0e48'   #  0xE8 -> THAI CHARACTER MAI EK
-    '\u0e49'   #  0xE9 -> THAI CHARACTER MAI THO
-    '\u0e4a'   #  0xEA -> THAI CHARACTER MAI TRI
-    '\u0e4b'   #  0xEB -> THAI CHARACTER MAI CHATTAWA
-    '\u0e4c'   #  0xEC -> THAI CHARACTER THANTHAKHAT
-    '\u0e4d'   #  0xED -> THAI CHARACTER NIKHAHIT
-    '\u0e4e'   #  0xEE -> THAI CHARACTER YAMAKKAN
-    '\u0e4f'   #  0xEF -> THAI CHARACTER FONGMAN
-    '\u0e50'   #  0xF0 -> THAI DIGIT ZERO
-    '\u0e51'   #  0xF1 -> THAI DIGIT ONE
-    '\u0e52'   #  0xF2 -> THAI DIGIT TWO
-    '\u0e53'   #  0xF3 -> THAI DIGIT THREE
-    '\u0e54'   #  0xF4 -> THAI DIGIT FOUR
-    '\u0e55'   #  0xF5 -> THAI DIGIT FIVE
-    '\u0e56'   #  0xF6 -> THAI DIGIT SIX
-    '\u0e57'   #  0xF7 -> THAI DIGIT SEVEN
-    '\u0e58'   #  0xF8 -> THAI DIGIT EIGHT
-    '\u0e59'   #  0xF9 -> THAI DIGIT NINE
-    '\u0e5a'   #  0xFA -> THAI CHARACTER ANGKHANKHU
-    '\u0e5b'   #  0xFB -> THAI CHARACTER KHOMUT
-    '\ufffe'   #  0xFC -> UNDEFINED
-    '\ufffe'   #  0xFD -> UNDEFINED
-    '\ufffe'   #  0xFE -> UNDEFINED
-    '\ufffe'   #  0xFF -> UNDEFINED
+    '\x00'      #  0x00 -> NULL
+    '\x01'      #  0x01 -> START OF HEADING
+    '\x02'      #  0x02 -> START OF TEXT
+    '\x03'      #  0x03 -> END OF TEXT
+    '\x04'      #  0x04 -> END OF TRANSMISSION
+    '\x05'      #  0x05 -> ENQUIRY
+    '\x06'      #  0x06 -> ACKNOWLEDGE
+    '\x07'      #  0x07 -> BELL
+    '\x08'      #  0x08 -> BACKSPACE
+    '\t'        #  0x09 -> HORIZONTAL TABULATION
+    '\n'        #  0x0A -> LINE FEED
+    '\x0b'      #  0x0B -> VERTICAL TABULATION
+    '\x0c'      #  0x0C -> FORM FEED
+    '\r'        #  0x0D -> CARRIAGE RETURN
+    '\x0e'      #  0x0E -> SHIFT OUT
+    '\x0f'      #  0x0F -> SHIFT IN
+    '\x10'      #  0x10 -> DATA LINK ESCAPE
+    '\x11'      #  0x11 -> DEVICE CONTROL ONE
+    '\x12'      #  0x12 -> DEVICE CONTROL TWO
+    '\x13'      #  0x13 -> DEVICE CONTROL THREE
+    '\x14'      #  0x14 -> DEVICE CONTROL FOUR
+    '\x15'      #  0x15 -> NEGATIVE ACKNOWLEDGE
+    '\x16'      #  0x16 -> SYNCHRONOUS IDLE
+    '\x17'      #  0x17 -> END OF TRANSMISSION BLOCK
+    '\x18'      #  0x18 -> CANCEL
+    '\x19'      #  0x19 -> END OF MEDIUM
+    '\x1a'      #  0x1A -> SUBSTITUTE
+    '\x1b'      #  0x1B -> ESCAPE
+    '\x1c'      #  0x1C -> FILE SEPARATOR
+    '\x1d'      #  0x1D -> GROUP SEPARATOR
+    '\x1e'      #  0x1E -> RECORD SEPARATOR
+    '\x1f'      #  0x1F -> UNIT SEPARATOR
+    ' '         #  0x20 -> SPACE
+    '!'         #  0x21 -> EXCLAMATION MARK
+    '"'         #  0x22 -> QUOTATION MARK
+    '#'         #  0x23 -> NUMBER SIGN
+    '$'         #  0x24 -> DOLLAR SIGN
+    '%'         #  0x25 -> PERCENT SIGN
+    '&'         #  0x26 -> AMPERSAND
+    "'"         #  0x27 -> APOSTROPHE
+    '('         #  0x28 -> LEFT PARENTHESIS
+    ')'         #  0x29 -> RIGHT PARENTHESIS
+    '*'         #  0x2A -> ASTERISK
+    '+'         #  0x2B -> PLUS SIGN
+    ','         #  0x2C -> COMMA
+    '-'         #  0x2D -> HYPHEN-MINUS
+    '.'         #  0x2E -> FULL STOP
+    '/'         #  0x2F -> SOLIDUS
+    '0'         #  0x30 -> DIGIT ZERO
+    '1'         #  0x31 -> DIGIT ONE
+    '2'         #  0x32 -> DIGIT TWO
+    '3'         #  0x33 -> DIGIT THREE
+    '4'         #  0x34 -> DIGIT FOUR
+    '5'         #  0x35 -> DIGIT FIVE
+    '6'         #  0x36 -> DIGIT SIX
+    '7'         #  0x37 -> DIGIT SEVEN
+    '8'         #  0x38 -> DIGIT EIGHT
+    '9'         #  0x39 -> DIGIT NINE
+    ':'         #  0x3A -> COLON
+    ';'         #  0x3B -> SEMICOLON
+    '<'         #  0x3C -> LESS-THAN SIGN
+    '='         #  0x3D -> EQUALS SIGN
+    '>'         #  0x3E -> GREATER-THAN SIGN
+    '?'         #  0x3F -> QUESTION MARK
+    '@'         #  0x40 -> COMMERCIAL AT
+    'A'         #  0x41 -> LATIN CAPITAL LETTER A
+    'B'         #  0x42 -> LATIN CAPITAL LETTER B
+    'C'         #  0x43 -> LATIN CAPITAL LETTER C
+    'D'         #  0x44 -> LATIN CAPITAL LETTER D
+    'E'         #  0x45 -> LATIN CAPITAL LETTER E
+    'F'         #  0x46 -> LATIN CAPITAL LETTER F
+    'G'         #  0x47 -> LATIN CAPITAL LETTER G
+    'H'         #  0x48 -> LATIN CAPITAL LETTER H
+    'I'         #  0x49 -> LATIN CAPITAL LETTER I
+    'J'         #  0x4A -> LATIN CAPITAL LETTER J
+    'K'         #  0x4B -> LATIN CAPITAL LETTER K
+    'L'         #  0x4C -> LATIN CAPITAL LETTER L
+    'M'         #  0x4D -> LATIN CAPITAL LETTER M
+    'N'         #  0x4E -> LATIN CAPITAL LETTER N
+    'O'         #  0x4F -> LATIN CAPITAL LETTER O
+    'P'         #  0x50 -> LATIN CAPITAL LETTER P
+    'Q'         #  0x51 -> LATIN CAPITAL LETTER Q
+    'R'         #  0x52 -> LATIN CAPITAL LETTER R
+    'S'         #  0x53 -> LATIN CAPITAL LETTER S
+    'T'         #  0x54 -> LATIN CAPITAL LETTER T
+    'U'         #  0x55 -> LATIN CAPITAL LETTER U
+    'V'         #  0x56 -> LATIN CAPITAL LETTER V
+    'W'         #  0x57 -> LATIN CAPITAL LETTER W
+    'X'         #  0x58 -> LATIN CAPITAL LETTER X
+    'Y'         #  0x59 -> LATIN CAPITAL LETTER Y
+    'Z'         #  0x5A -> LATIN CAPITAL LETTER Z
+    '['         #  0x5B -> LEFT SQUARE BRACKET
+    '\\'        #  0x5C -> REVERSE SOLIDUS
+    ']'         #  0x5D -> RIGHT SQUARE BRACKET
+    '^'         #  0x5E -> CIRCUMFLEX ACCENT
+    '_'         #  0x5F -> LOW LINE
+    '`'         #  0x60 -> GRAVE ACCENT
+    'a'         #  0x61 -> LATIN SMALL LETTER A
+    'b'         #  0x62 -> LATIN SMALL LETTER B
+    'c'         #  0x63 -> LATIN SMALL LETTER C
+    'd'         #  0x64 -> LATIN SMALL LETTER D
+    'e'         #  0x65 -> LATIN SMALL LETTER E
+    'f'         #  0x66 -> LATIN SMALL LETTER F
+    'g'         #  0x67 -> LATIN SMALL LETTER G
+    'h'         #  0x68 -> LATIN SMALL LETTER H
+    'i'         #  0x69 -> LATIN SMALL LETTER I
+    'j'         #  0x6A -> LATIN SMALL LETTER J
+    'k'         #  0x6B -> LATIN SMALL LETTER K
+    'l'         #  0x6C -> LATIN SMALL LETTER L
+    'm'         #  0x6D -> LATIN SMALL LETTER M
+    'n'         #  0x6E -> LATIN SMALL LETTER N
+    'o'         #  0x6F -> LATIN SMALL LETTER O
+    'p'         #  0x70 -> LATIN SMALL LETTER P
+    'q'         #  0x71 -> LATIN SMALL LETTER Q
+    'r'         #  0x72 -> LATIN SMALL LETTER R
+    's'         #  0x73 -> LATIN SMALL LETTER S
+    't'         #  0x74 -> LATIN SMALL LETTER T
+    'u'         #  0x75 -> LATIN SMALL LETTER U
+    'v'         #  0x76 -> LATIN SMALL LETTER V
+    'w'         #  0x77 -> LATIN SMALL LETTER W
+    'x'         #  0x78 -> LATIN SMALL LETTER X
+    'y'         #  0x79 -> LATIN SMALL LETTER Y
+    'z'         #  0x7A -> LATIN SMALL LETTER Z
+    '{'         #  0x7B -> LEFT CURLY BRACKET
+    '|'         #  0x7C -> VERTICAL LINE
+    '}'         #  0x7D -> RIGHT CURLY BRACKET
+    '~'         #  0x7E -> TILDE
+    '\x7f'      #  0x7F -> DELETE
+    '\u20ac'    #  0x80 -> EURO SIGN
+    '\ufffe'    #  0x81 -> UNDEFINED
+    '\ufffe'    #  0x82 -> UNDEFINED
+    '\ufffe'    #  0x83 -> UNDEFINED
+    '\ufffe'    #  0x84 -> UNDEFINED
+    '\u2026'    #  0x85 -> HORIZONTAL ELLIPSIS
+    '\ufffe'    #  0x86 -> UNDEFINED
+    '\ufffe'    #  0x87 -> UNDEFINED
+    '\ufffe'    #  0x88 -> UNDEFINED
+    '\ufffe'    #  0x89 -> UNDEFINED
+    '\ufffe'    #  0x8A -> UNDEFINED
+    '\ufffe'    #  0x8B -> UNDEFINED
+    '\ufffe'    #  0x8C -> UNDEFINED
+    '\ufffe'    #  0x8D -> UNDEFINED
+    '\ufffe'    #  0x8E -> UNDEFINED
+    '\ufffe'    #  0x8F -> UNDEFINED
+    '\ufffe'    #  0x90 -> UNDEFINED
+    '\u2018'    #  0x91 -> LEFT SINGLE QUOTATION MARK
+    '\u2019'    #  0x92 -> RIGHT SINGLE QUOTATION MARK
+    '\u201c'    #  0x93 -> LEFT DOUBLE QUOTATION MARK
+    '\u201d'    #  0x94 -> RIGHT DOUBLE QUOTATION MARK
+    '\u2022'    #  0x95 -> BULLET
+    '\u2013'    #  0x96 -> EN DASH
+    '\u2014'    #  0x97 -> EM DASH
+    '\ufffe'    #  0x98 -> UNDEFINED
+    '\ufffe'    #  0x99 -> UNDEFINED
+    '\ufffe'    #  0x9A -> UNDEFINED
+    '\ufffe'    #  0x9B -> UNDEFINED
+    '\ufffe'    #  0x9C -> UNDEFINED
+    '\ufffe'    #  0x9D -> UNDEFINED
+    '\ufffe'    #  0x9E -> UNDEFINED
+    '\ufffe'    #  0x9F -> UNDEFINED
+    '\xa0'      #  0xA0 -> NO-BREAK SPACE
+    '\u0e01'    #  0xA1 -> THAI CHARACTER KO KAI
+    '\u0e02'    #  0xA2 -> THAI CHARACTER KHO KHAI
+    '\u0e03'    #  0xA3 -> THAI CHARACTER KHO KHUAT
+    '\u0e04'    #  0xA4 -> THAI CHARACTER KHO KHWAI
+    '\u0e05'    #  0xA5 -> THAI CHARACTER KHO KHON
+    '\u0e06'    #  0xA6 -> THAI CHARACTER KHO RAKHANG
+    '\u0e07'    #  0xA7 -> THAI CHARACTER NGO NGU
+    '\u0e08'    #  0xA8 -> THAI CHARACTER CHO CHAN
+    '\u0e09'    #  0xA9 -> THAI CHARACTER CHO CHING
+    '\u0e0a'    #  0xAA -> THAI CHARACTER CHO CHANG
+    '\u0e0b'    #  0xAB -> THAI CHARACTER SO SO
+    '\u0e0c'    #  0xAC -> THAI CHARACTER CHO CHOE
+    '\u0e0d'    #  0xAD -> THAI CHARACTER YO YING
+    '\u0e0e'    #  0xAE -> THAI CHARACTER DO CHADA
+    '\u0e0f'    #  0xAF -> THAI CHARACTER TO PATAK
+    '\u0e10'    #  0xB0 -> THAI CHARACTER THO THAN
+    '\u0e11'    #  0xB1 -> THAI CHARACTER THO NANGMONTHO
+    '\u0e12'    #  0xB2 -> THAI CHARACTER THO PHUTHAO
+    '\u0e13'    #  0xB3 -> THAI CHARACTER NO NEN
+    '\u0e14'    #  0xB4 -> THAI CHARACTER DO DEK
+    '\u0e15'    #  0xB5 -> THAI CHARACTER TO TAO
+    '\u0e16'    #  0xB6 -> THAI CHARACTER THO THUNG
+    '\u0e17'    #  0xB7 -> THAI CHARACTER THO THAHAN
+    '\u0e18'    #  0xB8 -> THAI CHARACTER THO THONG
+    '\u0e19'    #  0xB9 -> THAI CHARACTER NO NU
+    '\u0e1a'    #  0xBA -> THAI CHARACTER BO BAIMAI
+    '\u0e1b'    #  0xBB -> THAI CHARACTER PO PLA
+    '\u0e1c'    #  0xBC -> THAI CHARACTER PHO PHUNG
+    '\u0e1d'    #  0xBD -> THAI CHARACTER FO FA
+    '\u0e1e'    #  0xBE -> THAI CHARACTER PHO PHAN
+    '\u0e1f'    #  0xBF -> THAI CHARACTER FO FAN
+    '\u0e20'    #  0xC0 -> THAI CHARACTER PHO SAMPHAO
+    '\u0e21'    #  0xC1 -> THAI CHARACTER MO MA
+    '\u0e22'    #  0xC2 -> THAI CHARACTER YO YAK
+    '\u0e23'    #  0xC3 -> THAI CHARACTER RO RUA
+    '\u0e24'    #  0xC4 -> THAI CHARACTER RU
+    '\u0e25'    #  0xC5 -> THAI CHARACTER LO LING
+    '\u0e26'    #  0xC6 -> THAI CHARACTER LU
+    '\u0e27'    #  0xC7 -> THAI CHARACTER WO WAEN
+    '\u0e28'    #  0xC8 -> THAI CHARACTER SO SALA
+    '\u0e29'    #  0xC9 -> THAI CHARACTER SO RUSI
+    '\u0e2a'    #  0xCA -> THAI CHARACTER SO SUA
+    '\u0e2b'    #  0xCB -> THAI CHARACTER HO HIP
+    '\u0e2c'    #  0xCC -> THAI CHARACTER LO CHULA
+    '\u0e2d'    #  0xCD -> THAI CHARACTER O ANG
+    '\u0e2e'    #  0xCE -> THAI CHARACTER HO NOKHUK
+    '\u0e2f'    #  0xCF -> THAI CHARACTER PAIYANNOI
+    '\u0e30'    #  0xD0 -> THAI CHARACTER SARA A
+    '\u0e31'    #  0xD1 -> THAI CHARACTER MAI HAN-AKAT
+    '\u0e32'    #  0xD2 -> THAI CHARACTER SARA AA
+    '\u0e33'    #  0xD3 -> THAI CHARACTER SARA AM
+    '\u0e34'    #  0xD4 -> THAI CHARACTER SARA I
+    '\u0e35'    #  0xD5 -> THAI CHARACTER SARA II
+    '\u0e36'    #  0xD6 -> THAI CHARACTER SARA UE
+    '\u0e37'    #  0xD7 -> THAI CHARACTER SARA UEE
+    '\u0e38'    #  0xD8 -> THAI CHARACTER SARA U
+    '\u0e39'    #  0xD9 -> THAI CHARACTER SARA UU
+    '\u0e3a'    #  0xDA -> THAI CHARACTER PHINTHU
+    '\ufffe'    #  0xDB -> UNDEFINED
+    '\ufffe'    #  0xDC -> UNDEFINED
+    '\ufffe'    #  0xDD -> UNDEFINED
+    '\ufffe'    #  0xDE -> UNDEFINED
+    '\u0e3f'    #  0xDF -> THAI CURRENCY SYMBOL BAHT
+    '\u0e40'    #  0xE0 -> THAI CHARACTER SARA E
+    '\u0e41'    #  0xE1 -> THAI CHARACTER SARA AE
+    '\u0e42'    #  0xE2 -> THAI CHARACTER SARA O
+    '\u0e43'    #  0xE3 -> THAI CHARACTER SARA AI MAIMUAN
+    '\u0e44'    #  0xE4 -> THAI CHARACTER SARA AI MAIMALAI
+    '\u0e45'    #  0xE5 -> THAI CHARACTER LAKKHANGYAO
+    '\u0e46'    #  0xE6 -> THAI CHARACTER MAIYAMOK
+    '\u0e47'    #  0xE7 -> THAI CHARACTER MAITAIKHU
+    '\u0e48'    #  0xE8 -> THAI CHARACTER MAI EK
+    '\u0e49'    #  0xE9 -> THAI CHARACTER MAI THO
+    '\u0e4a'    #  0xEA -> THAI CHARACTER MAI TRI
+    '\u0e4b'    #  0xEB -> THAI CHARACTER MAI CHATTAWA
+    '\u0e4c'    #  0xEC -> THAI CHARACTER THANTHAKHAT
+    '\u0e4d'    #  0xED -> THAI CHARACTER NIKHAHIT
+    '\u0e4e'    #  0xEE -> THAI CHARACTER YAMAKKAN
+    '\u0e4f'    #  0xEF -> THAI CHARACTER FONGMAN
+    '\u0e50'    #  0xF0 -> THAI DIGIT ZERO
+    '\u0e51'    #  0xF1 -> THAI DIGIT ONE
+    '\u0e52'    #  0xF2 -> THAI DIGIT TWO
+    '\u0e53'    #  0xF3 -> THAI DIGIT THREE
+    '\u0e54'    #  0xF4 -> THAI DIGIT FOUR
+    '\u0e55'    #  0xF5 -> THAI DIGIT FIVE
+    '\u0e56'    #  0xF6 -> THAI DIGIT SIX
+    '\u0e57'    #  0xF7 -> THAI DIGIT SEVEN
+    '\u0e58'    #  0xF8 -> THAI DIGIT EIGHT
+    '\u0e59'    #  0xF9 -> THAI DIGIT NINE
+    '\u0e5a'    #  0xFA -> THAI CHARACTER ANGKHANKHU
+    '\u0e5b'    #  0xFB -> THAI CHARACTER KHOMUT
+    '\ufffe'    #  0xFC -> UNDEFINED
+    '\ufffe'    #  0xFD -> UNDEFINED
+    '\ufffe'    #  0xFE -> UNDEFINED
+    '\ufffe'    #  0xFF -> UNDEFINED
 )
 
 ### Encoding table
-encoding_table=codecs.charmap_build(decoding_table)
+encoding_table = codecs.charmap_build(decoding_table)
+

--- a/Misc/NEWS.d/next/Library/2021-09-06-18-16-54.bpo-45120.3glJJ4.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-06-18-16-54.bpo-45120.3glJJ4.rst
@@ -1,0 +1,1 @@
+Updated windows "cp" encodings in accordance to the "bestfit" specification

--- a/Tools/unicode/Makefile
+++ b/Tools/unicode/Makefile
@@ -6,7 +6,7 @@
 #    Licensed to PSF under a Contributor Agreement.
 
 # Python binary to use
-PYTHON = python3
+PYTHON = python
 
 # Remove tool to use
 RM = /bin/rm

--- a/Tools/unicode/Makefile
+++ b/Tools/unicode/Makefile
@@ -6,7 +6,7 @@
 #    Licensed to PSF under a Contributor Agreement.
 
 # Python binary to use
-PYTHON = python
+PYTHON = python3
 
 # Remove tool to use
 RM = /bin/rm
@@ -15,7 +15,7 @@ RM = /bin/rm
 
 all:	distclean mappings codecs
 
-codecs:	misc windows iso apple ebcdic custom-mappings cjk
+codecs:	misc windows-bestfit iso apple ebcdic custom-mappings cjk
 
 ### Mappings
 
@@ -42,6 +42,17 @@ windows:	build/
 	$(PYTHON) gencodec.py MAPPINGS/VENDORS/MICSFT/WINDOWS/ build/
 	$(RM) build/cp9*
 	$(RM) -f build/readme.*
+
+windows-bestfit:	build/ 	windows
+	mkdir -p WindowsBestFit
+	cp MAPPINGS/VENDORS/MICSFT/WindowsBestFit/bestfit12* WindowsBestFit/
+	rename -f 's/bestfit/cp/' WindowsBestFit/*
+	sed -si '/^0x..\t/!d' WindowsBestFit/*
+	sed -si 's/;/#/' WindowsBestFit/*
+	sed -si 's/#[a-z]/#\U&/g' WindowsBestFit/*
+	sed -si 's/#.*[a-z]/\U&/g' WindowsBestFit/*
+	$(PYTHON) gencodec.py WindowsBestFit build/
+	rm -rf WindowsBestFit
 
 iso:	build/
 	$(PYTHON) gencodec.py MAPPINGS/ISO8859/ build/ iso


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

### [bpo-45120](https://bugs.python.org/issue45120): Updated windows 'cp' encodings to match 'bestfit' specification.

There is a mismatch in specification and behavior in some windows encodings.

Some older windows codepages specifications present "UNDEFINED" mapping, whereas in reality, they present another behavior which is updated in a section named "bestfit".

For example CP1252 has a corresponding bestfit1525: 

- CP1252: https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT

- bestfit1525: https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WindowsBestFit/bestfit1252.txt

They have the following differences: 

- In CP1252, bytes \x81 \x8d \x8f \x90 \x9d maps to "UNDEFINED". 

- In bestfit1252, they map to \u0081 \u008d \u008f \u0090 \u009d respectively. 

In the Windows API, the function 'MultiByteToWideChar' in "cp1252 mode" exhibits the bestfit1252 behavior.

This issue and PR proposes a correction for this behavior, updating the windows codepages where some code points where defined as "UNDEFINED" to the corresponding bestfit mapping. 

For example: "b'\x81'.decode('cp1252')" produces:
```
>>> b'\x81'.decode('cp1252')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/encodings/cp1252.py", line 15, in decode
    return codecs.charmap_decode(input,errors,decoding_table)
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 0: character maps to <undefined>
```

Where, i think, the intended behavior would be: 
```
>>> b'\x81'.decode('cp1252')
'\x81'
```

## This PR: 

- updates the Makefile in Tools/unicode/ adding 'windows-bestfit'. Adding some pre-processing to the files bestfit mapping files downloaded from ftp.unicode.org.

- Adds the direct output from the gencodec.py corresponding to the cp encodings in Lib/encodings/ 



<!-- issue-number: [bpo-45120](https://bugs.python.org/issue45120) -->
https://bugs.python.org/issue45120
<!-- /issue-number -->
