### PR TITLE
bpo-44348: BaseException deallocator uses trashcan

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-07-00-21-04.bpo-44348.f8w_Td.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-07-00-21-04.bpo-44348.f8w_Td.rst
@@ -1,0 +1,8 @@
+The deallocator function of the :exc:`BaseException` type now uses the
+trashcan mecanism to prevent stack overflow. For example, when a
+:exc:`RecursionError` instance is raised, it can be linked to another
+RecursionError through the ``__context__`` attribute or the
+``__traceback__`` attribute, and then a chain of exceptions is created. When
+the chain is destroyed, nested deallocator function calls can crash with a
+stack overflow if the chain is too long compared to the available stack
+memory. Patch by Victor Stinner.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -89,9 +89,11 @@ BaseException_clear(PyBaseExceptionObject *self)
 static void
 BaseException_dealloc(PyBaseExceptionObject *self)
 {
-    _PyObject_GC_UNTRACK(self);
+    PyObject_GC_UnTrack(self);
+    Py_TRASHCAN_BEGIN(self, BaseException_dealloc)
     BaseException_clear(self);
     Py_TYPE(self)->tp_free((PyObject *)self);
+    Py_TRASHCAN_END
 }
 
 static int

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -90,6 +90,9 @@ static void
 BaseException_dealloc(PyBaseExceptionObject *self)
 {
     PyObject_GC_UnTrack(self);
+    // bpo-44348: The trashcan mecanism prevents stack overflow when deleting
+    // long chains of exceptions. For example, exceptions can be chained
+    // through the __context__ attributes or the __traceback__ attribute.
     Py_TRASHCAN_BEGIN(self, BaseException_dealloc)
     BaseException_clear(self);
     Py_TYPE(self)->tp_free((PyObject *)self);


### PR DESCRIPTION
The deallocator function of the BaseException type now uses the
trashcan mecanism to prevent stack overflow. For example, when a
RecursionError instance is raised, it can be linked to another
RecursionError through the __context__ attribute or the __traceback__
attribute, and then a chain of exceptions is created. When the chain
is destroyed, nested deallocator function calls can crash with a
stack overflow if the chain is too long compared to the available
stack memory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44348](https://bugs.python.org/issue44348) -->
https://bugs.python.org/issue44348
<!-- /issue-number -->
