### PR TITLE
bpo-44964: Add a note explaining the new semantics of f_last_i in frame objects

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1069,8 +1069,9 @@ Internal types
       :attr:`f_code` is the code object being executed in this frame; :attr:`f_locals`
       is the dictionary used to look up local variables; :attr:`f_globals` is used for
       global variables; :attr:`f_builtins` is used for built-in (intrinsic) names;
-      :attr:`f_lasti` gives the precise instruction (this is an index into the
-      bytecode string of the code object).
+      :attr:`f_lasti` gives the precise instruction (it represents a wordcode index, which
+      means that to get an index into the bytecode string of the code object it needs to be
+      multiplied by 2).
 
       Accessing ``f_code`` raises an :ref:`auditing event <auditing>`
       ``object.__getattr__`` with arguments ``obj`` and ``"f_code"``.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -1948,6 +1948,12 @@ Changes in the C API
        source_buf = PyBytes_AsString(source_bytes_object);
        code = Py_CompileString(source_buf, filename, Py_file_input);
 
+  * For ``FrameObject`` objects, the ``f_lasti`` member now represents a wordcode
+    offset instead of a simple offset into the bytecode string. This means that this
+    number needs to be multiplied by 2 to be used with APIs that expect a byte offset
+    instead (like :c:func:`PyCode_Addr2Line` for example). Notice as well that the
+    ``f_lasti`` member of ``FrameObject`` objects is not considered stable.
+
 CPython bytecode changes
 ========================
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44964](https://bugs.python.org/issue44964) -->
https://bugs.python.org/issue44964
<!-- /issue-number -->
