### PR TITLE
bpo-45035: Revert "Make sysconfig posix_home depend on platlibdir"

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -37,10 +37,10 @@ _INSTALL_SCHEMES = {
         'data': '{base}',
         },
     'posix_home': {
-        'stdlib': '{installed_base}/{platlibdir}/python',
-        'platstdlib': '{base}/{platlibdir}/python',
+        'stdlib': '{installed_base}/lib/python',
+        'platstdlib': '{base}/lib/python',
         'purelib': '{base}/lib/python',
-        'platlib': '{base}/{platlibdir}/python',
+        'platlib': '{base}/lib/python',
         'include': '{installed_base}/include/python',
         'platinclude': '{installed_base}/include/python',
         'scripts': '{base}/bin',

--- a/Misc/NEWS.d/next/Library/2021-08-28-14-52-27.bpo-45035.O9mNam.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-28-14-52-27.bpo-45035.O9mNam.rst
@@ -1,2 +1,0 @@
-Fix the ``posix_home`` scheme in :mod:`sysconfig` to depend on
-:data:`sys.platlibdir`.


### PR DESCRIPTION
Reverts python/cpython#28011

<!-- issue-number: [bpo-45035](https://bugs.python.org/issue45035) -->
https://bugs.python.org/issue45035
<!-- /issue-number -->
