### PR TITLE
[skip issue] [skip news] Update libffi dll name to libffi-8

### DIFF
--- a/Tools/msi/lib/lib_files.wxs
+++ b/Tools/msi/lib/lib_files.wxs
@@ -23,7 +23,7 @@
                 <File Name="libssl$(var.ssltag).dll" KeyPath="yes" />
             </Component>
             <Component Id="libffi.dll" Directory="DLLs" Guid="*">
-                <File Name="libffi-7.dll" KeyPath="yes" />
+                <File Name="libffi-8.dll" KeyPath="yes" />
             </Component>
             <Component Id="venvlauncher.exe" Directory="Lib_venv_scripts_nt" Guid="*">
                 <File Name="python.exe" Source="venvlauncher.exe" KeyPath="yes" />


### PR DESCRIPTION
In Tools/msi/lib/lib_files.wxs, the libffi dll name was still kept as libffi-7.dll, corresponding to version 3.3.0. As GH-28146 updates libffi version to 3.4.2 (and the dll name to libffi-8.dll), this causes failure when building the Windows installer.