### PR TITLE
bpo-45035: distutils install command doesn't use platlibdir

### DIFF
--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -60,8 +60,10 @@ for main_key in INSTALL_SCHEMES:
         value = value.replace("$py_version_nodot_plat", "$py_version_nodot")
         if key == "headers":
             value += "/$dist_name"
-        if sys.version_info >= (3, 9) and key == "platlib":
-            # platlibdir is available since 3.9: bpo-1294959
+        if (sys.version_info >= (3, 9) and key == "platlib"
+           and main_key != 'unix_home'):
+            # platlibdir is available since 3.9 (bpo-1294959).
+            # Don't use it for the unix_home scheme (bpo-45035)
             value = value.replace("/lib/", "/$platlibdir/")
         INSTALL_SCHEMES[main_key][key] = value
 

--- a/Lib/distutils/tests/test_install.py
+++ b/Lib/distutils/tests/test_install.py
@@ -67,7 +67,7 @@ class InstallTestCase(support.TempdirManager,
 
         libdir = os.path.join(destination, "lib", "python")
         check_path(cmd.install_lib, libdir)
-        platlibdir = os.path.join(destination, sys.platlibdir, "python")
+        platlibdir = os.path.join(destination, 'lib', "python")
         check_path(cmd.install_platlib, platlibdir)
         check_path(cmd.install_purelib, libdir)
         check_path(cmd.install_headers,

--- a/Misc/NEWS.d/next/Library/2021-09-07-15-15-14.bpo-45035.WQ4nqH.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-07-15-15-14.bpo-45035.WQ4nqH.rst
@@ -1,0 +1,3 @@
+The :mod:`distutils` install command no longer use :data:`sys.platlibdir` (ex:
+``lib64/`` on Fedora) for the ``unix_home`` scheme, but always use the ``lib/``
+subdirectory.  Patch by Victor Stinner.


### PR DESCRIPTION
The distutils install command no longer use sys.platlibdir (ex:
lib64/ on Fedora) for the "unix_home" scheme, but always use the lib/
subdirectory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45035](https://bugs.python.org/issue45035) -->
https://bugs.python.org/issue45035
<!-- /issue-number -->
