### PR TITLE
bpo-45121: Fix issue when Protocol.__init__ raise RecursionError

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1610,6 +1610,16 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, "@runtime_checkable"):
             isinstance(1, P)
 
+    def test_super_call_init(self):
+        class P(Protocol):
+            x: int
+
+        class Foo(P):
+            def __init__(self):
+                super().__init__()
+
+        Foo()
+
 
 class GenericTests(BaseTestCase):
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1618,7 +1618,7 @@ class ProtocolTests(BaseTestCase):
             def __init__(self):
                 super().__init__()
 
-        Foo()
+        Foo()  # Previously triggered RecursionError
 
 
 class GenericTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1406,6 +1406,12 @@ def _no_init_or_replace_init(self, *args, **kwargs):
     if cls._is_protocol:
         raise TypeError('Protocols cannot be instantiated')
 
+    # When `_no_init_or_replace_init` called using super() there are no
+    # need to calculate correct `__init__` method to call.
+    # see bpo-45121
+    if cls.__init__ is not _no_init_or_replace_init:
+        return
+
     # Initially, `__init__` of a protocol subclass is set to `_no_init_or_replace_init`.
     # The first instantiation of the subclass will call `_no_init_or_replace_init` which
     # searches for a proper new `__init__` in the MRO. The new `__init__`

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1406,9 +1406,8 @@ def _no_init_or_replace_init(self, *args, **kwargs):
     if cls._is_protocol:
         raise TypeError('Protocols cannot be instantiated')
 
-    # When `_no_init_or_replace_init` called using super() there are no
-    # need to calculate correct `__init__` method to call.
-    # see bpo-45121
+    # Already using a custom `__init__`. No need to calculate correct
+    # `__init__` to call. This can lead to RecursionError. See bpo-45121.
     if cls.__init__ is not _no_init_or_replace_init:
         return
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
@@ -1,2 +1,2 @@
-Fix issue where ``Protocol.__init__`` raises ``RecursionError`` when called
-using ``super()``. Patch provided by Yurii Karabas.
+Fix issue when ``Protocol.__init__`` raises ``RecursionError`` when it
+called directly or via ``super()``. Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
@@ -1,0 +1,2 @@
+Fix issue when ``Protocol.__init__`` raise ``RecursionError`` when it called
+using ``super()``. Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
@@ -1,2 +1,2 @@
-Fix issue when ``Protocol.__init__`` raise ``RecursionError`` when it called
+Fix issue where ``Protocol.__init__`` raises ``RecursionError`` when called
 using ``super()``. Patch provided by Yurii Karabas.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
@@ -1,2 +1,2 @@
-Fix issue when ``Protocol.__init__`` raises ``RecursionError`` when it
+Fix issue where ``Protocol.__init__`` raises ``RecursionError`` when it's
 called directly or via ``super()``. Patch provided by Yurii Karabas.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45121](https://bugs.python.org/issue45121) -->
https://bugs.python.org/issue45121
<!-- /issue-number -->
