### PR TITLE
bpo-45132 Remove deprecated __getitem__ methods

### DIFF
--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -170,7 +170,7 @@ available for subclassing as well:
    .. versionchanged:: 3.2
       Can be used as a context manager.
 
-   .. deprecated-removed:: 3.8 3.11
+   .. versionchanged:: 3.11
       Support for :meth:`__getitem__` method has been removed.
 
    .. versionchanged:: 3.8

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -147,8 +147,7 @@ available for subclassing as well:
    :meth:`fileno`, :meth:`lineno`, :meth:`filelineno`, :meth:`isfirstline`,
    :meth:`isstdin`, :meth:`nextfile` and :meth:`close` correspond to the
    functions of the same name in the module. In addition it has a
-   :meth:`~io.TextIOBase.readline` method which returns the next input line,
-   and a :meth:`__getitem__` method which implements the sequence behavior.
+   :meth:`~io.TextIOBase.readline` method which returns the next input line.
    The sequence must be accessed in strictly sequential order; random access
    and :meth:`~io.TextIOBase.readline` cannot be mixed.
 
@@ -171,8 +170,8 @@ available for subclassing as well:
    .. versionchanged:: 3.2
       Can be used as a context manager.
 
-   .. deprecated:: 3.8
-      Support for :meth:`__getitem__` method is deprecated.
+   .. deprecated-removed:: 3.8 3.11
+      Support for :meth:`__getitem__` method has been removed.
 
    .. versionchanged:: 3.8
       The keyword parameter *mode* and *openhook* are now keyword-only.

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -170,9 +170,6 @@ available for subclassing as well:
    .. versionchanged:: 3.2
       Can be used as a context manager.
 
-   .. deprecated:: 3.8
-      Support for :meth:`__getitem__` method is deprecated.
-
    .. versionchanged:: 3.8
       The keyword parameter *mode* and *openhook* are now keyword-only.
 
@@ -180,10 +177,8 @@ available for subclassing as well:
       The keyword-only parameter *encoding* and *errors* are added.
 
    .. versionchanged:: 3.11
-      The ``'rU'`` and ``'U'`` modes have been removed.
-
-   .. versionchanged:: 3.11
-      Support for :meth:`__getitem__` method has been removed.
+      The ``'rU'`` and ``'U'`` modes and the :meth:`__getitem__` method have
+      been removed.
 
 
 **Optional in-place filtering:** if the keyword argument ``inplace=True`` is

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -146,10 +146,10 @@ available for subclassing as well:
    Class :class:`FileInput` is the implementation; its methods :meth:`filename`,
    :meth:`fileno`, :meth:`lineno`, :meth:`filelineno`, :meth:`isfirstline`,
    :meth:`isstdin`, :meth:`nextfile` and :meth:`close` correspond to the
-   functions of the same name in the module. In addition it has a
-   :meth:`~io.TextIOBase.readline` method which returns the next input line.
-   The sequence must be accessed in strictly sequential order; random access
-   and :meth:`~io.TextIOBase.readline` cannot be mixed.
+   functions of the same name in the module. In addition it is :term:`iterable`
+   and has a :meth:`~io.TextIOBase.readline` method which returns the next
+   input line. The sequence must be accessed in strictly sequential order;
+   random access and :meth:`~io.TextIOBase.readline` cannot be mixed.
 
    With *mode* you can specify which file mode will be passed to :func:`open`. It
    must be one of ``'r'`` and ``'rb'``.
@@ -170,8 +170,8 @@ available for subclassing as well:
    .. versionchanged:: 3.2
       Can be used as a context manager.
 
-   .. versionchanged:: 3.11
-      Support for :meth:`__getitem__` method has been removed.
+   .. deprecated:: 3.8
+      Support for :meth:`__getitem__` method is deprecated.
 
    .. versionchanged:: 3.8
       The keyword parameter *mode* and *openhook* are now keyword-only.
@@ -181,6 +181,9 @@ available for subclassing as well:
 
    .. versionchanged:: 3.11
       The ``'rU'`` and ``'U'`` modes have been removed.
+
+   .. versionchanged:: 3.11
+      Support for :meth:`__getitem__` method has been removed.
 
 
 **Optional in-place filtering:** if the keyword argument ``inplace=True`` is

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -151,8 +151,7 @@ also provides these miscellaneous utilities:
 .. class:: FileWrapper(filelike, blksize=8192)
 
    A wrapper to convert a file-like object to an :term:`iterator`.  The resulting objects
-   support both :meth:`__getitem__` and :meth:`__iter__` iteration styles, for
-   compatibility with Python 2.1 and Jython. As the object is iterated over, the
+   support the :meth:`__iter__` iteration style. As the object is iterated over, the
    optional *blksize* parameter will be repeatedly passed to the *filelike*
    object's :meth:`read` method to obtain bytestrings to yield.  When :meth:`read`
    returns an empty bytestring, iteration is ended and is not resumable.
@@ -173,8 +172,8 @@ also provides these miscellaneous utilities:
       for chunk in wrapper:
           print(chunk)
 
-   .. deprecated:: 3.8
-      Support for :meth:`sequence protocol <__getitem__>` is deprecated.
+   .. deprecated-removed:: 3.8 3.11
+      Support for sequence protocol :meth:`__getitem__` has been removed.
 
 
 :mod:`wsgiref.headers` -- WSGI response header tools

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -172,6 +172,9 @@ also provides these miscellaneous utilities:
       for chunk in wrapper:
           print(chunk)
 
+   .. deprecated:: 3.8
+      Support for :meth:`__getitem__` method is deprecated.
+
    .. versionchanged:: 3.11
       Support for :meth:`__getitem__` method has been removed.
 

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -172,9 +172,6 @@ also provides these miscellaneous utilities:
       for chunk in wrapper:
           print(chunk)
 
-   .. deprecated:: 3.8
-      Support for :meth:`__getitem__` method is deprecated.
-
    .. versionchanged:: 3.11
       Support for :meth:`__getitem__` method has been removed.
 

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -151,7 +151,7 @@ also provides these miscellaneous utilities:
 .. class:: FileWrapper(filelike, blksize=8192)
 
    A wrapper to convert a file-like object to an :term:`iterator`.  The resulting objects
-   support the :meth:`__iter__` iteration style. As the object is iterated over, the
+   are :term`iterable`\ s. As the object is iterated over, the
    optional *blksize* parameter will be repeatedly passed to the *filelike*
    object's :meth:`read` method to obtain bytestrings to yield.  When :meth:`read`
    returns an empty bytestring, iteration is ended and is not resumable.
@@ -172,8 +172,8 @@ also provides these miscellaneous utilities:
       for chunk in wrapper:
           print(chunk)
 
-   .. deprecated-removed:: 3.8 3.11
-      Support for sequence protocol :meth:`__getitem__` has been removed.
+   .. versionchanged:: 3.11
+      Support for :meth:`__getitem__` method has been removed.
 
 
 :mod:`wsgiref.headers` -- WSGI response header tools

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -114,9 +114,6 @@ DOMEventStream Objects
 
 .. class:: DOMEventStream(stream, parser, bufsize)
 
-   .. deprecated:: 3.8
-      Support for :meth:`__getitem__` method is deprecated.
-
    .. versionchanged:: 3.11
       Support for :meth:`__getitem__` method has been removed.
 

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -114,8 +114,8 @@ DOMEventStream Objects
 
 .. class:: DOMEventStream(stream, parser, bufsize)
 
-   .. deprecated:: 3.8
-      Support for :meth:`sequence protocol <__getitem__>` is deprecated.
+   .. deprecated-removed:: 3.8 3.11
+      Support for sequence protocol :meth:`__getitem__` has been removed.
 
    .. method:: getEvent()
 

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -114,6 +114,9 @@ DOMEventStream Objects
 
 .. class:: DOMEventStream(stream, parser, bufsize)
 
+   .. deprecated:: 3.8
+      Support for :meth:`__getitem__` method is deprecated.
+
    .. versionchanged:: 3.11
       Support for :meth:`__getitem__` method has been removed.
 
@@ -144,4 +147,3 @@ DOMEventStream Objects
                   print(node.toxml())
 
    .. method:: DOMEventStream.reset()
-

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -114,8 +114,8 @@ DOMEventStream Objects
 
 .. class:: DOMEventStream(stream, parser, bufsize)
 
-   .. deprecated-removed:: 3.8 3.11
-      Support for sequence protocol :meth:`__getitem__` has been removed.
+   .. versionchanged:: 3.11
+      Support for :meth:`__getitem__` method has been removed.
 
    .. method:: getEvent()
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -254,6 +254,12 @@ Removed
   Use ``bdist_wheel`` (wheel packages) instead.
   (Contributed by Hugo van Kemenade in :issue:`45124`.)
 
+* Remove :meth:`__getitem__` methods of
+  :class:`xml.dom.pulldom.DOMEventStream`, :class:`wsgiref.util.FileWrapper`
+  and :class:`fileinput.FileInput`, deprecated since Python 3.9.
+  (Contributed by Hugo van Kemenade in :issue:`45132`.)
+
+
 Optimizations
 =============
 

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -257,21 +257,6 @@ class FileInput:
             self.nextfile()
             # repeat with next file
 
-    def __getitem__(self, i):
-        import warnings
-        warnings.warn(
-            "Support for indexing FileInput objects is deprecated. "
-            "Use iterator protocol instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        if i != self.lineno():
-            raise RuntimeError("accessing lines out of order")
-        try:
-            return self.__next__()
-        except StopIteration:
-            raise IndexError("end of input reached")
-
     def nextfile(self):
         savestdout = self._savestdout
         self._savestdout = None

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -29,7 +29,6 @@ from test.support import verbose
 from test.support.os_helper import TESTFN
 from test.support.os_helper import unlink as safe_unlink
 from test.support import os_helper
-from test.support import warnings_helper
 from test import support
 from unittest import mock
 
@@ -356,44 +355,6 @@ class FileInputTests(BaseTests, unittest.TestCase):
     def test_empty_files_list_specified_to_constructor(self):
         with FileInput(files=[], encoding="utf-8") as fi:
             self.assertEqual(fi._files, ('-',))
-
-    @warnings_helper.ignore_warnings(category=DeprecationWarning)
-    def test__getitem__(self):
-        """Tests invoking FileInput.__getitem__() with the current
-           line number"""
-        t = self.writeTmp("line1\nline2\n")
-        with FileInput(files=[t], encoding="utf-8") as fi:
-            retval1 = fi[0]
-            self.assertEqual(retval1, "line1\n")
-            retval2 = fi[1]
-            self.assertEqual(retval2, "line2\n")
-
-    def test__getitem___deprecation(self):
-        t = self.writeTmp("line1\nline2\n")
-        with self.assertWarnsRegex(DeprecationWarning,
-                                   r'Use iterator protocol instead'):
-            with FileInput(files=[t]) as fi:
-                self.assertEqual(fi[0], "line1\n")
-
-    @warnings_helper.ignore_warnings(category=DeprecationWarning)
-    def test__getitem__invalid_key(self):
-        """Tests invoking FileInput.__getitem__() with an index unequal to
-           the line number"""
-        t = self.writeTmp("line1\nline2\n")
-        with FileInput(files=[t], encoding="utf-8") as fi:
-            with self.assertRaises(RuntimeError) as cm:
-                fi[1]
-        self.assertEqual(cm.exception.args, ("accessing lines out of order",))
-
-    @warnings_helper.ignore_warnings(category=DeprecationWarning)
-    def test__getitem__eof(self):
-        """Tests invoking FileInput.__getitem__() with the line number but at
-           end-of-input"""
-        t = self.writeTmp('')
-        with FileInput(files=[t], encoding="utf-8") as fi:
-            with self.assertRaises(IndexError) as cm:
-                fi[0]
-        self.assertEqual(cm.exception.args, ("end of input reached",))
 
     def test_nextfile_oserror_deleting_backup(self):
         """Tests invoking FileInput.nextfile() when the attempt to delete

--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -160,13 +160,6 @@ class PullDOMTestCase(unittest.TestCase):
             self.fail(
                 "Ran out of events, but should have received END_DOCUMENT")
 
-    def test_getitem_deprecation(self):
-        parser = pulldom.parseString(SMALL_SAMPLE)
-        with self.assertWarnsRegex(DeprecationWarning,
-                                   r'Use iterator protocol instead'):
-            # This should have returned 'END_ELEMENT'.
-            self.assertEqual(parser[-1][0], pulldom.START_DOCUMENT)
-
     def test_external_ges_default(self):
         parser = pulldom.parseString(SMALL_SAMPLE)
         saxparser = parser.parser

--- a/Lib/wsgiref/util.py
+++ b/Lib/wsgiref/util.py
@@ -17,19 +17,6 @@ class FileWrapper:
         if hasattr(filelike,'close'):
             self.close = filelike.close
 
-    def __getitem__(self,key):
-        import warnings
-        warnings.warn(
-            "FileWrapper's __getitem__ method ignores 'key' parameter. "
-            "Use iterator protocol instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        data = self.filelike.read(self.blksize)
-        if data:
-            return data
-        raise IndexError
-
     def __iter__(self):
         return self
 

--- a/Lib/xml/dom/pulldom.py
+++ b/Lib/xml/dom/pulldom.py
@@ -216,19 +216,6 @@ class DOMEventStream:
         self.parser.setFeature(xml.sax.handler.feature_namespaces, 1)
         self.parser.setContentHandler(self.pulldom)
 
-    def __getitem__(self, pos):
-        import warnings
-        warnings.warn(
-            "DOMEventStream's __getitem__ method ignores 'pos' parameter. "
-            "Use iterator protocol instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        rc = self.getEvent()
-        if rc:
-            return rc
-        raise IndexError
-
     def __next__(self):
         rc = self.getEvent()
         if rc:

--- a/Misc/NEWS.d/next/Library/2021-09-07-16-33-51.bpo-45132.WI9zQY.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-07-16-33-51.bpo-45132.WI9zQY.rst
@@ -1,0 +1,5 @@
+Remove :meth:`__getitem__` methods of
+:class:`xml.dom.pulldom.DOMEventStream`, :class:`wsgiref.util.FileWrapper`
+and :class:`fileinput.FileInput`, deprecated since Python 3.9.
+
+Patch by Hugo van Kemenade.


### PR DESCRIPTION
Remove deprecated `__getitem__` methods of `xml.dom.pulldom.DOMEventStream`, `wsgiref.util.FileWrapper` and `fileinput.FileInput`, deprecated since Python 3.9.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45132](https://bugs.python.org/issue45132) -->
https://bugs.python.org/issue45132
<!-- /issue-number -->
