### PR TITLE
IDLE: adjust Python version in doc url for 3.10+

### DIFF
--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -10,6 +10,8 @@ from tkinter import SUNKEN, TOP, BOTTOM, LEFT, X, BOTH, W, EW, NSEW, E
 
 from idlelib import textview
 
+version = python_version()
+
 
 def build_bits():
     "Return bits for platform."
@@ -42,7 +44,7 @@ class AboutDialog(Toplevel):
         self.create_widgets()
         self.resizable(height=False, width=False)
         self.title(title or
-                   f'About IDLE {python_version()} ({build_bits()} bit)')
+                   f'About IDLE {version} ({build_bits()} bit)')
         self.transient(parent)
         self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self.ok)
@@ -88,9 +90,9 @@ class AboutDialog(Toplevel):
         email = Label(frame_background, text='email:  idle-dev@python.org',
                       justify=LEFT, fg=self.fg, bg=self.bg)
         email.grid(row=6, column=0, columnspan=2, sticky=W, padx=10, pady=0)
-        docs = Label(frame_background, text='https://docs.python.org/' +
-                     str(sys.version_info[0]) + '.' + str(sys.version_info[1]) +
-                     '/library/idle.html', justify=LEFT, fg=self.fg, bg=self.bg)
+        docs = Label(frame_background, text="https://docs.python.org/"
+                     f"{version[:version.rindex('.')]}/library/idle.html",
+                     justify=LEFT, fg=self.fg, bg=self.bg)
         docs.grid(row=7, column=0, columnspan=2, sticky=W, padx=10, pady=0)
 
         Frame(frame_background, borderwidth=1, relief=SUNKEN,
@@ -98,7 +100,7 @@ class AboutDialog(Toplevel):
                                          columnspan=3, padx=5, pady=5)
 
         pyver = Label(frame_background,
-                      text='Python version:  ' + python_version(),
+                      text='Python version:  ' + version,
                       fg=self.fg, bg=self.bg)
         pyver.grid(row=9, column=0, sticky=W, padx=10, pady=0)
         tkver = Label(frame_background, text='Tk version:  ' + tk_patchlevel,
@@ -124,7 +126,7 @@ class AboutDialog(Toplevel):
                                          columnspan=3, padx=5, pady=5)
 
         idlever = Label(frame_background,
-                        text='IDLE version:   ' + python_version(),
+                        text='IDLE version:   ' + version,
                         fg=self.fg, bg=self.bg)
         idlever.grid(row=12, column=0, sticky=W, padx=10, pady=0)
         idle_buttons = Frame(frame_background, bg=self.bg)

--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -89,8 +89,8 @@ class AboutDialog(Toplevel):
                       justify=LEFT, fg=self.fg, bg=self.bg)
         email.grid(row=6, column=0, columnspan=2, sticky=W, padx=10, pady=0)
         docs = Label(frame_background, text='https://docs.python.org/' +
-                     python_version()[:3] + '/library/idle.html',
-                     justify=LEFT, fg=self.fg, bg=self.bg)
+                     str(sys.version_info[0]) + '.' + str(sys.version_info[1]) +
+                     '/library/idle.html', justify=LEFT, fg=self.fg, bg=self.bg)
         docs.grid(row=7, column=0, columnspan=2, sticky=W, padx=10, pady=0)
 
         Frame(frame_background, borderwidth=1, relief=SUNKEN,


### PR DESCRIPTION
Expression 'python_version()[:3]' truncated '3.10.0' to '3.1' instead of '3.10'.
