### PR TITLE
bpo-20499: Rounding error in statistics.pvariance

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -833,6 +833,9 @@ def stdev(data, xbar=None):
     1.0810874155219827
 
     """
+    # Fixme: Despite the exact sum of squared deviations, some inaccuracy
+    # remain because there are two rounding steps.  The first occurs in
+    # the _convert() step for variance(), the second occurs in math.sqrt().
     var = variance(data, xbar)
     try:
         return var.sqrt()
@@ -849,6 +852,9 @@ def pstdev(data, mu=None):
     0.986893273527251
 
     """
+    # Fixme: Despite the exact sum of squared deviations, some inaccuracy
+    # remain because there are two rounding steps.  The first occurs in
+    # the _convert() step for pvariance(), the second occurs in math.sqrt().
     var = pvariance(data, mu)
     try:
         return var.sqrt()

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -731,20 +731,19 @@ def _ss(data, c=None):
         T, total, count = _sum((d := x - c) * d for x in data)
         return (T, total)
     T, total, count = _sum(data)
-    c = total / count                # Exact fraction
-    cn, cd = c.as_integer_ratio()
+    mean_n, mean_d = (total / count).as_integer_ratio()
     partials = Counter()
     for n, d in map(_exact_ratio, data):
-        dev_numerator = n * cd - cn * d
-        dev_denominator = d * cd     # Defer squaring until summation
-        partials[dev_denominator] += dev_numerator * dev_numerator
+        diff_n = n * mean_d - mean_n * d
+        diff_d = d * mean_d
+        partials[diff_d * diff_d] += diff_n * diff_n
     if None in partials:
         # The sum will be a NAN or INF. We can ignore all the finite
         # partials, and just look at this special one.
         total = partials[None]
         assert not _isfinite(total)
     else:
-        total = sum(Fraction(n, d*d) for d, n in partials.items())
+        total = sum(Fraction(n, d) for d, n in partials.items())
     return (T, total)
 
 

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -732,23 +732,19 @@ def _ss(data, c=None):
         return (T, total)
     T, total, count = _sum(data)
     c = total / count                # Exact fraction
-    cn = c.numerator
-    cd = c.denominator
-    partials = {}
-    partials_get = partials.get
+    cn, cd = c.as_integer_ratio()
+    partials = Counter()
     for n, d in map(_exact_ratio, data):
         dev_numerator = n * cd - cn * d
-        dev_denominator = d * cd
-        dev_numerator *= dev_numerator
-        dev_denominator *= dev_denominator
-        partials[dev_denominator] = partials_get(dev_denominator, 0) + dev_numerator
+        dev_denominator = d * cd     # Defer squaring until summation
+        partials[dev_denominator] += dev_numerator * dev_numerator
     if None in partials:
         # The sum will be a NAN or INF. We can ignore all the finite
         # partials, and just look at this special one.
         total = partials[None]
         assert not _isfinite(total)
     else:
-        total = sum(Fraction(n, d) for d, n in partials.items())
+        total = sum(Fraction(n, d*d) for d, n in partials.items())
     return (T, total)
 
 

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -734,7 +734,7 @@ def _ss(data, c=None):
     mean_n, mean_d = (total / count).as_integer_ratio()
     partials = Counter()
     for n, d in map(_exact_ratio, data):
-        diff_n = n * mean_d - mean_n * d
+        diff_n = n * mean_d - d * mean_n
         diff_d = d * mean_d
         partials[diff_d * diff_d] += diff_n * diff_n
     if None in partials:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -147,21 +147,17 @@ class StatisticsError(ValueError):
 
 # === Private utilities ===
 
-def _sum(data, start=0):
-    """_sum(data [, start]) -> (type, sum, count)
+def _sum(data):
+    """_sum(data) -> (type, sum, count)
 
     Return a high-precision sum of the given numeric data as a fraction,
     together with the type to be converted to and the count of items.
 
-    If optional argument ``start`` is given, it is added to the total.
-    If ``data`` is empty, ``start`` (defaulting to 0) is returned.
-
-
     Examples
     --------
 
-    >>> _sum([3, 2.25, 4.5, -0.5, 1.0], 0.75)
-    (<class 'float'>, Fraction(11, 1), 5)
+    >>> _sum([3, 2.25, 4.5, -0.5, 0.25])
+    (<class 'float'>, Fraction(19, 2), 5)
 
     Some sources of round-off error will be avoided:
 
@@ -184,10 +180,9 @@ def _sum(data, start=0):
     allowed.
     """
     count = 0
-    n, d = _exact_ratio(start)
-    partials = {d: n}
+    partials = {}
     partials_get = partials.get
-    T = _coerce(int, type(start))
+    T = int
     for typ, values in groupby(data, type):
         T = _coerce(T, typ)  # or raise TypeError
         for n, d in map(_exact_ratio, values):

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -247,27 +247,19 @@ def _exact_ratio(x):
     x is expected to be an int, Fraction, Decimal or float.
     """
     try:
-        # Optimise the common case of floats. We expect that the most often
-        # used numeric type will be builtin floats, so try to make this as
-        # fast as possible.
-        if type(x) is float or type(x) is Decimal:
-            return x.as_integer_ratio()
-        try:
-            # x may be an int, Fraction, or Integral ABC.
-            return (x.numerator, x.denominator)
-        except AttributeError:
-            try:
-                # x may be a float or Decimal subclass.
-                return x.as_integer_ratio()
-            except AttributeError:
-                # Just give up?
-                pass
+        return x.as_integer_ratio()
+    except AttributeError:
+        pass
     except (OverflowError, ValueError):
         # float NAN or INF.
         assert not _isfinite(x)
         return (x, None)
-    msg = "can't convert type '{}' to numerator/denominator"
-    raise TypeError(msg.format(type(x).__name__))
+    try:
+        # x may be an Integral ABC.
+        return (x.numerator, x.denominator)
+    except AttributeError:
+        msg = f"can't convert type '{type(x).__name__}' to numerator/denominator"
+        raise TypeError(msg)
 
 
 def _convert(value, T):

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -195,8 +195,7 @@ def _sum(data):
         assert not _isfinite(total)
     else:
         # Sum all the partial sums using builtin sum.
-        # FIXME is this faster if we sum them in order of the denominator?
-        total = sum(Fraction(n, d) for d, n in sorted(partials.items()))
+        total = sum(Fraction(n, d) for d, n in partials.items())
     return (T, total, count)
 
 

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -739,16 +739,16 @@ def _ss(data, c=None):
     for n, d in map(_exact_ratio, data):
         dev_numerator = n * cd - cn * d
         dev_denominator = d * cd
-        dev_numerator *=  dev_numerator
+        dev_numerator *= dev_numerator
         dev_denominator *= dev_denominator
-        partials[d] = partials_get(dev_denominator, 0) + dev_numerator
+        partials[dev_denominator] = partials_get(dev_denominator, 0) + dev_numerator
     if None in partials:
         # The sum will be a NAN or INF. We can ignore all the finite
         # partials, and just look at this special one.
         total = partials[None]
         assert not _isfinite(total)
     else:
-        total = sum(Fraction(n, d) for d, n in sorted(partials.items()))
+        total = sum(Fraction(n, d) for d, n in partials.items())
     return (T, total)
 
 

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -188,7 +188,7 @@ def _sum(data, start=0):
     partials = {d: n}
     partials_get = partials.get
     T = _coerce(int, type(start))
-    for typ, values in groupby(data, type):        # XXX Are these sorted
+    for typ, values in groupby(data, type):
         T = _coerce(T, typ)  # or raise TypeError
         for n, d in map(_exact_ratio, values):
             count += 1

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2148,6 +2148,13 @@ class TestVariance(VarianceStdevMixin, NumericTestCase, UnivariateTypeMixin):
         self.assertEqual(self.func(data), 0.5)
         self.assertEqual(self.func(data, xbar=2.0), 1.0)
 
+    def test_accuracy_bug_20499(self):
+        data = [0, 0, 2]
+        exact = 4 / 3
+        result = self.func(data)
+        self.assertEqual(result, exact)
+        self.assertIsInstance(result, float)
+
 class TestPStdev(VarianceStdevMixin, NumericTestCase):
     # Tests for population standard deviation.
     def setUp(self):

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2101,6 +2101,13 @@ class TestPVariance(VarianceStdevMixin, NumericTestCase, UnivariateTypeMixin):
         self.assertEqual(result, exact)
         self.assertIsInstance(result, Decimal)
 
+    def test_accuracy_bug_20499(self):
+        data = [0, 0, 1]
+        exact = 2 / 9
+        result = self.func(data)
+        self.assertEqual(result, exact)
+        self.assertIsInstance(result, float)
+
 
 class TestVariance(VarianceStdevMixin, NumericTestCase, UnivariateTypeMixin):
     # Tests for sample variance.

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -1250,20 +1250,14 @@ class TestSum(NumericTestCase):
         # Override test for empty data.
         for data in ([], (), iter([])):
             self.assertEqual(self.func(data), (int, Fraction(0), 0))
-            self.assertEqual(self.func(data, 23), (int, Fraction(23), 0))
-            self.assertEqual(self.func(data, 2.3), (float, Fraction(2.3), 0))
 
     def test_ints(self):
         self.assertEqual(self.func([1, 5, 3, -4, -8, 20, 42, 1]),
                          (int, Fraction(60), 8))
-        self.assertEqual(self.func([4, 2, 3, -8, 7], 1000),
-                         (int, Fraction(1008), 5))
 
     def test_floats(self):
         self.assertEqual(self.func([0.25]*20),
                          (float, Fraction(5.0), 20))
-        self.assertEqual(self.func([0.125, 0.25, 0.5, 0.75], 1.5),
-                         (float, Fraction(3.125), 4))
 
     def test_fractions(self):
         self.assertEqual(self.func([Fraction(1, 1000)]*500),
@@ -1283,14 +1277,6 @@ class TestSum(NumericTestCase):
         # we differ by a very slight amount :-(
         data = [random.uniform(-100, 1000) for _ in range(1000)]
         self.assertApproxEqual(float(self.func(data)[1]), math.fsum(data), rel=2e-16)
-
-    def test_start_argument(self):
-        # Test that the optional start argument works correctly.
-        data = [random.uniform(1, 1000) for _ in range(100)]
-        t = self.func(data)[1]
-        self.assertEqual(t+42, self.func(data, 42)[1])
-        self.assertEqual(t-23, self.func(data, -23)[1])
-        self.assertEqual(t+Fraction(1e20), self.func(data, 1e20)[1])
 
     def test_strings_fail(self):
         # Sum of strings should fail.

--- a/Misc/NEWS.d/next/Library/2021-09-08-01-19-31.bpo-20499.tSxx8Y.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-08-01-19-31.bpo-20499.tSxx8Y.rst
@@ -1,0 +1,1 @@
+Improve the speed and accuracy of statistics.pvariance().


### PR DESCRIPTION
Make the `_ss()` function exact.

Also improve the speed:

    $ python -m timeit -r 11 -s 'from statistics import variance' -s 'from random import random, seed' -s 'seed(8564399)' -s 'data = [random() for i in range(1_000)]' 'variance(data)'

    100 loops, best of 11: 2.16 msec per loop   # Baseline
    200 loops, best of 11: 1.71 msec per loop   # Patched

<!-- issue-number: [bpo-20499](https://bugs.python.org/issue20499) -->
https://bugs.python.org/issue20499
<!-- /issue-number -->
