### PR TITLE
[3.9] bpo-45121: Fix RecursionError when calling Protocol.__init__ from a subclass' __init__ (GH-28206)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1459,13 +1459,6 @@ class ProtocolTests(BaseTestCase):
         class CustomContextManager(typing.ContextManager, Protocol):
             pass
 
-    def test_non_runtime_protocol_isinstance_check(self):
-        class P(Protocol):
-            x: int
-
-        with self.assertRaisesRegex(TypeError, "@runtime_checkable"):
-            isinstance(1, P)
-
     def test_super_call_init(self):
         class P(Protocol):
             x: int

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1459,6 +1459,24 @@ class ProtocolTests(BaseTestCase):
         class CustomContextManager(typing.ContextManager, Protocol):
             pass
 
+    def test_non_runtime_protocol_isinstance_check(self):
+        class P(Protocol):
+            x: int
+
+        with self.assertRaisesRegex(TypeError, "@runtime_checkable"):
+            isinstance(1, P)
+
+    def test_super_call_init(self):
+        class P(Protocol):
+            x: int
+
+        class Foo(P):
+            def __init__(self):
+                super().__init__()
+
+        Foo()  # Previously triggered RecursionError
+
+
 class GenericTests(BaseTestCase):
 
     def test_basics(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1085,6 +1085,11 @@ def _no_init_or_replace_init(self, *args, **kwargs):
     if cls._is_protocol:
         raise TypeError('Protocols cannot be instantiated')
 
+    # Already using a custom `__init__`. No need to calculate correct
+    # `__init__` to call. This can lead to RecursionError. See bpo-45121.
+    if cls.__init__ is not _no_init_or_replace_init:
+        return
+
     # Initially, `__init__` of a protocol subclass is set to `_no_init_or_replace_init`.
     # The first instantiation of the subclass will call `_no_init_or_replace_init` which
     # searches for a proper new `__init__` in the MRO. The new `__init__`

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-07-17-10-16.bpo-45121.iG-Hsf.rst
@@ -1,0 +1,2 @@
+Fix issue where ``Protocol.__init__`` raises ``RecursionError`` when it's
+called directly or via ``super()``. Patch provided by Yurii Karabas.


### PR DESCRIPTION
(cherry picked from commit c11956a8bddd75f02ccc7b4da7e4d8123e1f3c5f)


Co-authored-by: Yurii Karabas <1998uriyyo@gmail.com>

<!-- issue-number: [bpo-45121](https://bugs.python.org/issue45121) -->
https://bugs.python.org/issue45121
<!-- /issue-number -->
