### PR TITLE
bpo-44860: Update test_sysconfig for posix_user platlib

### DIFF
--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -96,6 +96,7 @@ def collect_sys(info_add):
         'maxunicode',
         'path',
         'platform',
+        'platlibdir',
         'prefix',
         'thread_info',
         'version',

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -296,7 +296,11 @@ class TestSysConfig(unittest.TestCase):
                 base = base.replace(sys.base_prefix, sys.prefix)
             if HAS_USER_BASE:
                 user_path = get_path(name, 'posix_user')
-                self.assertEqual(user_path, global_path.replace(base, user, 1))
+                expected = global_path.replace(base, user, 1)
+                # bpo-44860: platlib of posix_user doesn't use sys.platlibdir
+                if name == 'platlib' and sys.platlibdir != 'lib':
+                    expected = expected.replace(f'/{sys.platlibdir}/', '/lib/')
+                self.assertEqual(user_path, expected)
 
     def test_main(self):
         # just making sure _main() runs and returns things in the stdout

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -297,9 +297,15 @@ class TestSysConfig(unittest.TestCase):
             if HAS_USER_BASE:
                 user_path = get_path(name, 'posix_user')
                 expected = global_path.replace(base, user, 1)
-                # bpo-44860: platlib of posix_user doesn't use sys.platlibdir
-                if name == 'platlib' and sys.platlibdir != 'lib':
-                    expected = expected.replace(f'/{sys.platlibdir}/', '/lib/')
+                # bpo-44860: platlib of posix_user doesn't use sys.platlibdir,
+                # whereas posix_prefix does.
+                if name == 'platlib':
+                    # Replace "/lib64/python3.11/site-packages" suffix
+                    # with "/lib/python3.11/site-packages".
+                    py_version_short = sysconfig.get_python_version()
+                    suffix = f'python{py_version_short}/site-packages'
+                    expected = expected.replace(f'/{sys.platlibdir}/{suffix}',
+                                                f'/lib/{suffix}')
                 self.assertEqual(user_path, expected)
 
     def test_main(self):

--- a/Misc/NEWS.d/next/Tests/2021-09-08-13-01-37.bpo-44860.qXd0kx.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-08-13-01-37.bpo-44860.qXd0kx.rst
@@ -1,0 +1,2 @@
+Update ``test_sysconfig.test_user_similar()`` for the posix_user scheme:
+``platlib`` doesn't use :data:`sys.platlibdir`. Patch by Victor Stinner.


### PR DESCRIPTION
Update test_sysconfig.test_user_similar() for the posix_user scheme:
"platlib" doesn't use sys.platlibdir.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44860](https://bugs.python.org/issue44860) -->
https://bugs.python.org/issue44860
<!-- /issue-number -->
