### PR TITLE
[3.8] bpo-37788: Fix reference leak when Thread is never joined (GH-26103)

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -762,6 +762,13 @@ class ThreadTests(BaseTestCase):
                 # Daemon threads must never add it to _shutdown_locks.
                 self.assertNotIn(tstate_lock, threading._shutdown_locks)
 
+    def test_leak_without_join(self):
+        # bpo-37788: Test that a thread which is not joined explicitly
+        # does not leak. Test written for reference leak checks.
+        def noop(): pass
+        with support.wait_threads_exit():
+            threading.Thread(target=noop).start()
+            # Thread.join() is not called
 
 class ThreadJoinOnShutdown(BaseTestCase):
 

--- a/Misc/NEWS.d/next/Library/2021-05-13-19-07-28.bpo-37788.adeFcf.rst
+++ b/Misc/NEWS.d/next/Library/2021-05-13-19-07-28.bpo-37788.adeFcf.rst
@@ -1,0 +1,1 @@
+Fix a reference leak when a Thread object is never joined.


### PR DESCRIPTION
This is a backport for https://github.com/python/cpython/pull/26103, automatic backport failed due to conflicts, hopefully I've done everything correctly.

Original PR description:

When a Thread is not joined after it has stopped, its lock may remain in the _shutdown_locks set until interpreter shutdown. If many threads are created this way, the _shutdown_locks set could therefore grow endlessly. To avoid such a situation, purge expired locks each time a new one is added or removed.

Co-authored-by: @pitrou 

<!-- issue-number: [bpo-37788](https://bugs.python.org/issue37788) -->
https://bugs.python.org/issue37788
<!-- /issue-number -->
