### PR TITLE
bpo-37529: Add test for guessing extensions

### DIFF
--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -153,6 +153,8 @@ class MimeTypesTestCase(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith("win"), "Non-Windows only")
     def test_guess_known_extensions(self):
         # Issue 37529
+        # The test fails on Windows because Windows adds mime types from the Registry
+        # and that creates some duplicates.
         from mimetypes import types_map
         for v in types_map.values():
             self.assertIsNotNone(mimetypes.guess_extension(v))

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -150,6 +150,7 @@ class MimeTypesTestCase(unittest.TestCase):
         # Poison should be gone.
         self.assertEqual(mimetypes.guess_extension('foo/bar'), None)
 
+    @unittest.skipIf(sys.platform.startswith("win"), "Non-Windows only")
     def test_guess_known_extensions(self):
         # Issue 37529
         from mimetypes import types_map

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -150,6 +150,12 @@ class MimeTypesTestCase(unittest.TestCase):
         # Poison should be gone.
         self.assertEqual(mimetypes.guess_extension('foo/bar'), None)
 
+    def test_guess_known_extensions(self):
+        # Issue 37529
+        from mimetypes import types_map
+        for v in types_map.values():
+            self.assertIsNotNone(mimetypes.guess_extension(v))
+
     def test_preferred_extension(self):
         def check_extensions():
             self.assertEqual(mimetypes.guess_extension('application/octet-stream'), '.bin')


### PR DESCRIPTION
Note that this test is for duplicated extensions, in which case `guess_extension()` returns None, so it's enough to test for this returned value for all known mime types.

Skipping on windows because there windows adds mime types from its registry and that creates some duplicates; I don't have windows system available so I can't determine which types get duplicated or how many.

<!-- issue-number: [bpo-37529](https://bugs.python.org/issue37529) -->
https://bugs.python.org/issue37529
<!-- /issue-number -->
