### PR TITLE
bpo-37529: delete duplicate mimetype for bmp files

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -501,7 +501,6 @@ def _default_mime_types():
         '.tif'    : 'image/tiff',
         '.ico'    : 'image/vnd.microsoft.icon',
         '.ras'    : 'image/x-cmu-raster',
-        '.bmp'    : 'image/x-ms-bmp',
         '.pnm'    : 'image/x-portable-anymap',
         '.pbm'    : 'image/x-portable-bitmap',
         '.pgm'    : 'image/x-portable-graymap',


### PR DESCRIPTION
This is in effect a backport of #26300 to 3.9 .

I'm not sure I'm doing this right, this is the first time I'm doing a backport. (but the change is one deleted line so it's probably the easiest way?)

Not adding news entry because #26300 didn't have one.

<!-- issue-number: [bpo-37529](https://bugs.python.org/issue37529) -->
https://bugs.python.org/issue37529
<!-- /issue-number -->
