### PR TITLE
bpo-44219: Release the GIL during isatty syscalls

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-09-10-32-33.bpo-44219.WiYyjz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-09-10-32-33.bpo-44219.WiYyjz.rst
@@ -1,0 +1,4 @@
+Release the GIL while performing ``isatty`` system calls on arbitrary file
+descriptors. In particular, this affects :func:`os.isatty`,
+:func:`os.device_encoding` and :class:`io.TextIOWrapper`. By extension,
+:func:`io.open` in text mode is also affected.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -10066,9 +10066,11 @@ os_isatty_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=6a48c8b4e644ca00 input=08ce94aa1eaf7b5e]*/
 {
     int return_value;
+    Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
     return_value = isatty(fd);
     _Py_END_SUPPRESS_IPH
+    Py_END_ALLOW_THREADS
     return return_value;
 }
 

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -67,9 +67,11 @@ PyObject *
 _Py_device_encoding(int fd)
 {
     int valid;
+    Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
     valid = isatty(fd);
     _Py_END_SUPPRESS_IPH
+    Py_END_ALLOW_THREADS
     if (!valid)
         Py_RETURN_NONE;
 
@@ -1776,12 +1778,22 @@ _Py_write_impl(int fd, const void *buf, size_t count, int gil_held)
 
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef MS_WINDOWS
-    if (count > 32767 && isatty(fd)) {
+    if (count > 32767) {
         /* Issue #11395: the Windows console returns an error (12: not
            enough space error) on writing into stdout if stdout mode is
            binary and the length is greater than 66,000 bytes (or less,
            depending on heap usage). */
-        count = 32767;
+        if (gil_held) {
+            Py_BEGIN_ALLOW_THREADS
+            if (isatty(fd)) {
+                count = 32767;
+            }
+            Py_END_ALLOW_THREADS
+        } else {
+            if (isatty(fd)) {
+                count = 32767;
+            }
+        }
     }
 #endif
     if (count > _PY_WRITE_MAX) {


### PR DESCRIPTION
Release the GIL while performing ``isatty`` system calls on arbitrary file descriptors. 

In particular, this affects `os.isatty`, `os.device_encoding` and `io.TextIOWrapper`. By extension, `io.open` in text mode is also affected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44219](https://bugs.python.org/issue44219) -->
https://bugs.python.org/issue44219
<!-- /issue-number -->
