### PR TITLE
bpo-45067 - Verify the version of ncurses for extended color support feature usage.

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-09-09-16-45-26.bpo-45067.mFmY92.rst
+++ b/Misc/NEWS.d/next/Build/2021-09-09-16-45-26.bpo-45067.mFmY92.rst
@@ -1,0 +1,2 @@
+The ncurses function `extended_color_content` was introduced in 2017.
+https://invisible-island.net/ncurses/NEWS.html#index-t20170401) The ncurses-devel package in CentOS 7 had a older version ncurses resulted in compilation error.  For compiling ncurses with extended color support, we verify the version of the ncurses library >= 20170401.

--- a/Misc/NEWS.d/next/Build/2021-09-09-16-45-26.bpo-45067.mFmY92.rst
+++ b/Misc/NEWS.d/next/Build/2021-09-09-16-45-26.bpo-45067.mFmY92.rst
@@ -1,2 +1,5 @@
-The ncurses function `extended_color_content` was introduced in 2017.
-https://invisible-island.net/ncurses/NEWS.html#index-t20170401) The ncurses-devel package in CentOS 7 had a older version ncurses resulted in compilation error.  For compiling ncurses with extended color support, we verify the version of the ncurses library >= 20170401.
+The ncurses function extended_color_content was introduced in 2017.
+https://invisible-island.net/ncurses/NEWS.html#index-t20170401) The
+ncurses-devel package in CentOS 7 had a older version ncurses resulted in
+compilation error.  For compiling ncurses with extended color support, we
+verify the version of the ncurses library >= 20170401.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -139,7 +139,7 @@ typedef chtype attr_t;           /* No attr_t type is available */
 #define _NCURSES_EXTENDED_COLOR_FUNCS   1
 #else
 #define _NCURSES_EXTENDED_COLOR_FUNCS   0
-#endif  /* defined(NCURSES_EXT_COLORS) && defined(NCURSES_EXT_FUNCS)  */
+#endif
 
 #if _NCURSES_EXTENDED_COLOR_FUNCS
 #define _CURSES_COLOR_VAL_TYPE          int

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -135,8 +135,7 @@ typedef chtype attr_t;           /* No attr_t type is available */
 #define STRICT_SYSV_CURSES
 #endif
 
-#if (defined(NCURSES_EXT_FUNCS) && NCURSES_EXT_FUNCS >= 20170401) && \
-    (defined(NCURSES_EXT_COLORS) && NCURSES_EXT_COLORS >= 20170401)
+#if NCURSES_EXT_FUNCS+0 >= 20170401 && NCURSES_EXT_COLORS+0 >= 20170401
 #define _NCURSES_EXTENDED_COLOR_FUNCS   1
 #else
 #define _NCURSES_EXTENDED_COLOR_FUNCS   0

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -135,7 +135,8 @@ typedef chtype attr_t;           /* No attr_t type is available */
 #define STRICT_SYSV_CURSES
 #endif
 
-#if NCURSES_EXT_COLORS+0 && NCURSES_EXT_FUNCS+0
+#if (defined(NCURSES_EXT_FUNCS) && NCURSES_EXT_FUNCS >= 20170401) && \
+    (defined(NCURSES_EXT_COLORS) && NCURSES_EXT_COLORS >= 20170401)
 #define _NCURSES_EXTENDED_COLOR_FUNCS   1
 #else
 #define _NCURSES_EXTENDED_COLOR_FUNCS   0


### PR DESCRIPTION
```
[bpo-45067](https://bugs.python.org/issue45067): Fix ncurses compilation in CentOS7. Verify ncurses version for extended color content support.
```

[The function `extended_color_content` was introduced in 2017.](https://invisible-island.net/ncurses/NEWS.html#index-t20170401) 
The ncurses-devel package in CentOS 7 had a older version ncurses resulted in
compilation error.  For compiling ncurses with extended color support, we
verify the version of the ncurses library.


<!-- issue-number: [bpo-45067](https://bugs.python.org/issue45067) -->
https://bugs.python.org/issue45067
<!-- /issue-number -->
