### PR TITLE
bpo-44219: Mention GH-28250 is a deadlock bugfix

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-09-10-32-33.bpo-44219.WiYyjz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-09-10-32-33.bpo-44219.WiYyjz.rst
@@ -1,4 +1,5 @@
 Release the GIL while performing ``isatty`` system calls on arbitrary file
 descriptors. In particular, this affects :func:`os.isatty`,
 :func:`os.device_encoding` and :class:`io.TextIOWrapper`. By extension,
-:func:`io.open` in text mode is also affected.
+:func:`io.open` in text mode is also affected. This change solves
+a deadlock in :func:`os.isatty`. Patch by Vincent Michel in :issue:`44219`.


### PR DESCRIPTION
Otherwise the change looks like a performance enhancement which isn't eligible for bugfix release backports.

<!-- issue-number: [bpo-44219](https://bugs.python.org/issue44219) -->
https://bugs.python.org/issue44219
<!-- /issue-number -->
