### PR TITLE
bpo-45155 : Default arguments for int.to_bytes(length=1, byteorder=sys.byteorder)

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -552,7 +552,7 @@ class`. In addition, it provides a few more methods:
     .. versionchanged:: 3.11
        Added default argument values for ``length`` and ``byteorder``.
 
-.. classmethod:: int.from_bytes(bytes, byteorder, *, signed=False)
+.. classmethod:: int.from_bytes(bytes, byteorder=sys.byteorder, *, signed=False)
 
     Return the integer represented by the given array of bytes.
 
@@ -571,18 +571,18 @@ class`. In addition, it provides a few more methods:
     iterable producing bytes.
 
     The *byteorder* argument determines the byte order used to represent the
-    integer.  If *byteorder* is ``"big"``, the most significant byte is at the
-    beginning of the byte array.  If *byteorder* is ``"little"``, the most
-    significant byte is at the end of the byte array.  To request the native
-    byte order of the host system, use :data:`sys.byteorder` as the byte order
-    value.
+    integer, and defaults to :data:`sys.byteorder`.  If *byteorder* is
+    ``"big"``, the most significant byte is at the beginning of the byte
+    array.  If *byteorder* is ``"little"``, the most significant byte is at
+    the end of the byte array.  To request the native byte order of the host
+    system, use :data:`sys.byteorder` as the byte order value.
 
     The *signed* argument indicates whether two's complement is used to
     represent the integer.
 
     Equivalent to::
 
-        def from_bytes(bytes, byteorder, signed=False):
+        def from_bytes(bytes, byteorder=sys.byteorder, signed=False):
             if byteorder == 'little':
                 little_ordered = list(bytes)
             elif byteorder == 'big':
@@ -597,6 +597,8 @@ class`. In addition, it provides a few more methods:
             return n
 
     .. versionadded:: 3.2
+    .. versionchanged:: 3.11
+       Added default argument value for ``byteorder``.
 
 .. method:: int.as_integer_ratio()
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -521,8 +521,7 @@ class`. In addition, it provides a few more methods:
     integer, and defaults to :data:`sys.byteorder`.  If *byteorder* is
     ``"big"``, the most significant byte is at the beginning of the byte
     array.  If *byteorder* is ``"little"``, the most significant byte is at
-    the end of the byte array.  To request the native byte order of the host
-    system, use :data:`sys.byteorder` as the byte order value.
+    the end of the byte array.
 
     The *signed* argument determines whether two's complement is used to
     represent the integer.  If *signed* is ``False`` and a negative integer is

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -530,7 +530,7 @@ class`. In addition, it provides a few more methods:
 
     The default values can be used to conveniently turn an integer into a
     single byte object.  However, when using the default arguments, don't try
-    to convert a value greater than 255 or you'll get an :exc:`OverflowError`.::
+    to convert a value greater than 255 or you'll get an :exc:`OverflowError`::
 
         >>> (65).to_bytes()
         b'A'

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -499,7 +499,7 @@ class`. In addition, it provides a few more methods:
 
     .. versionadded:: 3.10
 
-.. method:: int.to_bytes(length, byteorder, *, signed=False)
+.. method:: int.to_bytes(length=1, byteorder=sys.byteorder, *, signed=False)
 
     Return an array of bytes representing an integer.
 
@@ -513,25 +513,32 @@ class`. In addition, it provides a few more methods:
         >>> x.to_bytes((x.bit_length() + 7) // 8, byteorder='little')
         b'\xe8\x03'
 
-    The integer is represented using *length* bytes.  An :exc:`OverflowError`
-    is raised if the integer is not representable with the given number of
-    bytes.
+    The integer is represented using *length* bytes, and defaults to 1.  An
+    :exc:`OverflowError` is raised if the integer is not representable with
+    the given number of bytes.
 
     The *byteorder* argument determines the byte order used to represent the
-    integer.  If *byteorder* is ``"big"``, the most significant byte is at the
-    beginning of the byte array.  If *byteorder* is ``"little"``, the most
-    significant byte is at the end of the byte array.  To request the native
-    byte order of the host system, use :data:`sys.byteorder` as the byte order
-    value.
+    integer, and defaults to :data:`sys.byteorder`.  If *byteorder* is
+    ``"big"``, the most significant byte is at the beginning of the byte
+    array.  If *byteorder* is ``"little"``, the most significant byte is at
+    the end of the byte array.  To request the native byte order of the host
+    system, use :data:`sys.byteorder` as the byte order value.
 
     The *signed* argument determines whether two's complement is used to
     represent the integer.  If *signed* is ``False`` and a negative integer is
     given, an :exc:`OverflowError` is raised. The default value for *signed*
     is ``False``.
 
+    The default values can be used to conveniently turn an integer into a
+    single byte object.  However, when using the default arguments, don't try
+    to convert a value greater than 255 or you'll get an :exc:`OverflowError`.::
+
+        >>> (65).to_bytes()
+        b'A'
+
     Equivalent to::
 
-        def to_bytes(n, length, byteorder, signed=False):
+        def to_bytes(n, length=1, byteorder=sys.byteorder, signed=False):
             if byteorder == 'little':
                 order = range(length)
             elif byteorder == 'big':
@@ -542,6 +549,8 @@ class`. In addition, it provides a few more methods:
             return bytes((n >> i*8) & 0xff for i in order)
 
     .. versionadded:: 3.2
+    .. versionchanged:: 3.11
+       Added default argument values for ``length`` and ``byteorder``.
 
 .. classmethod:: int.from_bytes(bytes, byteorder, *, signed=False)
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -537,7 +537,7 @@ class`. In addition, it provides a few more methods:
 
     Equivalent to::
 
-        def to_bytes(n, length=1, byteorder=sys.byteorder, signed=False):
+        def to_bytes(n, length=1, byteorder='big', signed=False):
             if byteorder == 'little':
                 order = range(length)
             elif byteorder == 'big':

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -570,7 +570,7 @@ class`. In addition, it provides a few more methods:
     iterable producing bytes.
 
     The *byteorder* argument determines the byte order used to represent the
-    integer, and defaults to :data:`sys.byteorder`.  If *byteorder* is
+    integer, and defaults to ``"big"``.  If *byteorder* is
     ``"big"``, the most significant byte is at the beginning of the byte
     array.  If *byteorder* is ``"little"``, the most significant byte is at
     the end of the byte array.  To request the native byte order of the host

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -499,7 +499,7 @@ class`. In addition, it provides a few more methods:
 
     .. versionadded:: 3.10
 
-.. method:: int.to_bytes(length=1, byteorder=sys.byteorder, *, signed=False)
+.. method:: int.to_bytes(length=1, byteorder='big', *, signed=False)
 
     Return an array of bytes representing an integer.
 
@@ -551,7 +551,7 @@ class`. In addition, it provides a few more methods:
     .. versionchanged:: 3.11
        Added default argument values for ``length`` and ``byteorder``.
 
-.. classmethod:: int.from_bytes(bytes, byteorder=sys.byteorder, *, signed=False)
+.. classmethod:: int.from_bytes(bytes, byteorder='big', *, signed=False)
 
     Return the integer represented by the given array of bytes.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -581,7 +581,7 @@ class`. In addition, it provides a few more methods:
 
     Equivalent to::
 
-        def from_bytes(bytes, byteorder=sys.byteorder, signed=False):
+        def from_bytes(bytes, byteorder='big', signed=False):
             if byteorder == 'little':
                 little_ordered = list(bytes)
             elif byteorder == 'big':

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -518,7 +518,7 @@ class`. In addition, it provides a few more methods:
     the given number of bytes.
 
     The *byteorder* argument determines the byte order used to represent the
-    integer, and defaults to :data:`sys.byteorder`.  If *byteorder* is
+    integer, and defaults to ``"big"``.  If *byteorder* is
     ``"big"``, the most significant byte is at the beginning of the byte
     array.  If *byteorder* is ``"little"``, the most significant byte is at
     the end of the byte array.

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -39,7 +39,7 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         self.assertRaisesRegex(TypeError, msg, {}.__contains__, 0, 1)
 
     def test_varargs3(self):
-        msg = r"^from_bytes\(\) takes exactly 2 positional arguments \(3 given\)"
+        msg = r"^from_bytes\(\) takes at most 2 positional arguments \(3 given\)"
         self.assertRaisesRegex(TypeError, msg, int.from_bytes, b'a', 'little', False)
 
     def test_varargs1min(self):

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1251,8 +1251,19 @@ class LongTest(unittest.TestCase):
                         expected)
                 except Exception as err:
                     raise AssertionError(
-                        "failed to convert {0} with byteorder={1!r} and signed={2}"
+                        "failed to convert {} with byteorder={!r} and signed={}"
                         .format(test, byteorder, signed)) from err
+
+                # Test for all default arguments.
+                if byteorder == sys.byteorder and not signed:
+                    try:
+                        self.assertEqual(
+                            int.from_bytes(test),
+                            expected)
+                    except Exception as err:
+                        raise AssertionError(
+                            "failed to convert {} with default arugments"
+                            .format(test)) from err
 
                 try:
                     self.assertEqual(

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1117,8 +1117,19 @@ class LongTest(unittest.TestCase):
                         expected)
                 except Exception as err:
                     raise AssertionError(
-                        "failed to convert {0} with byteorder={1} and signed={2}"
+                        "failed to convert {} with byteorder={} and signed={}"
                         .format(test, byteorder, signed)) from err
+
+                # Test for all default arguments.
+                if (len(expected) == 1
+                        and byteorder == sys.byteorder
+                        and not signed):
+                    try:
+                        self.assertEqual(test.to_bytes(), expected)
+                    except Exception as err:
+                        raise AssertionError(
+                            "failed to convert {} with default arguments"
+                            .format(test)) from err
 
                 try:
                     self.assertEqual(

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1121,9 +1121,7 @@ class LongTest(unittest.TestCase):
                         .format(test, byteorder, signed)) from err
 
                 # Test for all default arguments.
-                if (len(expected) == 1
-                        and byteorder == sys.byteorder
-                        and not signed):
+                if len(expected) == 1 and byteorder == 'big' and not signed:
                     try:
                         self.assertEqual(test.to_bytes(), expected)
                     except Exception as err:
@@ -1255,7 +1253,7 @@ class LongTest(unittest.TestCase):
                         .format(test, byteorder, signed)) from err
 
                 # Test for all default arguments.
-                if byteorder == sys.byteorder and not signed:
+                if byteorder == 'big' and not signed:
                     try:
                         self.assertEqual(
                             int.from_bytes(test),

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
@@ -1,0 +1,2 @@
+int.to_bytes() now takes default arguments for ``length`` and ``byteorder``,
+defaulting to ``1`` and ``sys.byteorder`` respectively.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
@@ -1,2 +1,3 @@
-int.to_bytes() now takes default arguments for ``length`` and ``byteorder``,
-defaulting to ``1`` and ``sys.byteorder`` respectively.
+:meth:`int.to_bytes` and :meth:`int.from_bytes` now take a default value of
+``sys.byteorder`` for the ``byteorder`` argument.  :meth:`int.to_bytes` also
+takes a default value of 1 for the ``length`` argument.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
@@ -1,3 +1,3 @@
 :meth:`int.to_bytes` and :meth:`int.from_bytes` now take a default value of
 ``"big"`` for the ``byteorder`` argument.  :meth:`int.to_bytes` also takes a
-default value of 1 for the ``length`` argument.
+default value of ``1`` for the ``length`` argument.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-09-15-05-17.bpo-45155.JRw9TG.rst
@@ -1,3 +1,3 @@
 :meth:`int.to_bytes` and :meth:`int.from_bytes` now take a default value of
-``sys.byteorder`` for the ``byteorder`` argument.  :meth:`int.to_bytes` also
-takes a default value of 1 for the ``length`` argument.
+``"big"`` for the ``byteorder`` argument.  :meth:`int.to_bytes` also takes a
+default value of 1 for the ``length`` argument.

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -226,7 +226,8 @@ int_as_integer_ratio(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(int_to_bytes__doc__,
-"to_bytes($self, /, length, byteorder, *, signed=False)\n"
+"to_bytes($self, /, length=1, byteorder=<unrepresentable>, *,\n"
+"         signed=False)\n"
 "--\n"
 "\n"
 "Return an array of bytes representing an integer.\n"
@@ -259,35 +260,49 @@ int_to_bytes(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *
     static const char * const _keywords[] = {"length", "byteorder", "signed", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "to_bytes", 0};
     PyObject *argsbuf[3];
-    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
-    Py_ssize_t length;
-    PyObject *byteorder;
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
+    Py_ssize_t length = 1;
+    PyObject *byteorder = NULL;
     int is_signed = 0;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 2, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 2, 0, argsbuf);
     if (!args) {
         goto exit;
     }
-    {
-        Py_ssize_t ival = -1;
-        PyObject *iobj = _PyNumber_Index(args[0]);
-        if (iobj != NULL) {
-            ival = PyLong_AsSsize_t(iobj);
-            Py_DECREF(iobj);
+    if (!noptargs) {
+        goto skip_optional_pos;
+    }
+    if (args[0]) {
+        {
+            Py_ssize_t ival = -1;
+            PyObject *iobj = _PyNumber_Index(args[0]);
+            if (iobj != NULL) {
+                ival = PyLong_AsSsize_t(iobj);
+                Py_DECREF(iobj);
+            }
+            if (ival == -1 && PyErr_Occurred()) {
+                goto exit;
+            }
+            length = ival;
         }
-        if (ival == -1 && PyErr_Occurred()) {
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
+    }
+    if (args[1]) {
+        if (!PyUnicode_Check(args[1])) {
+            _PyArg_BadArgument("to_bytes", "argument 'byteorder'", "str", args[1]);
             goto exit;
         }
-        length = ival;
+        if (PyUnicode_READY(args[1]) == -1) {
+            goto exit;
+        }
+        byteorder = args[1];
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
     }
-    if (!PyUnicode_Check(args[1])) {
-        _PyArg_BadArgument("to_bytes", "argument 'byteorder'", "str", args[1]);
-        goto exit;
-    }
-    if (PyUnicode_READY(args[1]) == -1) {
-        goto exit;
-    }
-    byteorder = args[1];
+skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
@@ -367,4 +382,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ea18e51af5b53591 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bc853442451f79a6 input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -318,7 +318,8 @@ exit:
 }
 
 PyDoc_STRVAR(int_from_bytes__doc__,
-"from_bytes($type, /, bytes, byteorder, *, signed=False)\n"
+"from_bytes($type, /, bytes, byteorder=<unrepresentable>, *,\n"
+"           signed=False)\n"
 "--\n"
 "\n"
 "Return the integer represented by the given array of bytes.\n"
@@ -351,24 +352,33 @@ int_from_bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyOb
     static const char * const _keywords[] = {"bytes", "byteorder", "signed", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "from_bytes", 0};
     PyObject *argsbuf[3];
-    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *bytes_obj;
-    PyObject *byteorder;
+    PyObject *byteorder = NULL;
     int is_signed = 0;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 2, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
     if (!args) {
         goto exit;
     }
     bytes_obj = args[0];
-    if (!PyUnicode_Check(args[1])) {
-        _PyArg_BadArgument("from_bytes", "argument 'byteorder'", "str", args[1]);
-        goto exit;
+    if (!noptargs) {
+        goto skip_optional_pos;
     }
-    if (PyUnicode_READY(args[1]) == -1) {
-        goto exit;
+    if (args[1]) {
+        if (!PyUnicode_Check(args[1])) {
+            _PyArg_BadArgument("from_bytes", "argument 'byteorder'", "str", args[1]);
+            goto exit;
+        }
+        if (PyUnicode_READY(args[1]) == -1) {
+            goto exit;
+        }
+        byteorder = args[1];
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
     }
-    byteorder = args[1];
+skip_optional_pos:
     if (!noptargs) {
         goto skip_optional_kwonly;
     }
@@ -382,4 +392,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=bc853442451f79a6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=078e5ad8fa273312 input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -234,13 +234,14 @@ PyDoc_STRVAR(int_to_bytes__doc__,
 "\n"
 "  length\n"
 "    Length of bytes object to use.  An OverflowError is raised if the\n"
-"    integer is not representable with the given number of bytes.\n"
+"    integer is not representable with the given number of bytes.  Default\n"
+"    is length 1.\n"
 "  byteorder\n"
 "    The byte order used to represent the integer.  If byteorder is \'big\',\n"
 "    the most significant byte is at the beginning of the byte array.  If\n"
 "    byteorder is \'little\', the most significant byte is at the end of the\n"
 "    byte array.  To request the native byte order of the host system, use\n"
-"    `sys.byteorder\' as the byte order value.\n"
+"    `sys.byteorder\' as the byte order value.  Default is to use \'big\'.\n"
 "  signed\n"
 "    Determines whether two\'s complement is used to represent the integer.\n"
 "    If signed is False and a negative integer is given, an OverflowError\n"
@@ -334,7 +335,7 @@ PyDoc_STRVAR(int_from_bytes__doc__,
 "    the most significant byte is at the beginning of the byte array.  If\n"
 "    byteorder is \'little\', the most significant byte is at the end of the\n"
 "    byte array.  To request the native byte order of the host system, use\n"
-"    `sys.byteorder\' as the byte order value.\n"
+"    `sys.byteorder\' as the byte order value.  Default is to use \'big\'.\n"
 "  signed\n"
 "    Indicates whether two\'s complement is used to represent the integer.");
 
@@ -392,4 +393,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=078e5ad8fa273312 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6760da18d2cc99fe input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -226,8 +226,7 @@ int_as_integer_ratio(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(int_to_bytes__doc__,
-"to_bytes($self, /, length=1, byteorder=<unrepresentable>, *,\n"
-"         signed=False)\n"
+"to_bytes($self, /, length=1, byteorder=\'big\', *, signed=False)\n"
 "--\n"
 "\n"
 "Return an array of bytes representing an integer.\n"
@@ -319,8 +318,7 @@ exit:
 }
 
 PyDoc_STRVAR(int_from_bytes__doc__,
-"from_bytes($type, /, bytes, byteorder=<unrepresentable>, *,\n"
-"           signed=False)\n"
+"from_bytes($type, /, bytes, byteorder=\'big\', *, signed=False)\n"
 "--\n"
 "\n"
 "Return the integer represented by the given array of bytes.\n"
@@ -393,4 +391,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6760da18d2cc99fe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=16a375d93769b227 input=a9049054013a1b77]*/

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5548,9 +5548,11 @@ int_to_bytes_impl(PyObject *self, Py_ssize_t length, PyObject *byteorder,
     PyObject *bytes;
 
     if (byteorder == NULL)
-        byteorder = PySys_GetObject("byteorder");
-
-    if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
+        // PY_LITTLE_ENDIAN is 1 on little-endian systems, and 0 on big-endian
+        // systems. In the default case, it's significantly faster than looking
+        // up sys.byteorder and performing the string comparisons below:
+        little_endian = PY_LITTLE_ENDIAN;
+    else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
         little_endian = 1;
     else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_big))
         little_endian = 0;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5589,7 +5589,7 @@ int.from_bytes
         support the buffer protocol or be an iterable object producing bytes.
         Bytes and bytearray are examples of built-in objects that support the
         buffer protocol.
-    byteorder: unicode
+    byteorder: unicode = NULL
         The byte order used to represent the integer.  If byteorder is 'big',
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the
@@ -5605,10 +5605,13 @@ Return the integer represented by the given array of bytes.
 static PyObject *
 int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
                     PyObject *byteorder, int is_signed)
-/*[clinic end generated code: output=efc5d68e31f9314f input=cdf98332b6a821b0]*/
+/*[clinic end generated code: output=efc5d68e31f9314f input=2562febe16a92f7a]*/
 {
     int little_endian;
     PyObject *long_obj, *bytes;
+
+    if (byteorder == NULL)
+        byteorder = PySys_GetObject("byteorder");
 
     if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
         little_endian = 1;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5521,10 +5521,10 @@ int_as_integer_ratio_impl(PyObject *self)
 /*[clinic input]
 int.to_bytes
 
-    length: Py_ssize_t
+    length: Py_ssize_t = 1
         Length of bytes object to use.  An OverflowError is raised if the
         integer is not representable with the given number of bytes.
-    byteorder: unicode
+    byteorder: unicode = NULL
         The byte order used to represent the integer.  If byteorder is 'big',
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the
@@ -5542,10 +5542,13 @@ Return an array of bytes representing an integer.
 static PyObject *
 int_to_bytes_impl(PyObject *self, Py_ssize_t length, PyObject *byteorder,
                   int is_signed)
-/*[clinic end generated code: output=89c801df114050a3 input=ddac63f4c7bf414c]*/
+/*[clinic end generated code: output=89c801df114050a3 input=d6b9571b1ee1fd05]*/
 {
     int little_endian;
     PyObject *bytes;
+
+    if (byteorder == NULL)
+        byteorder = PySys_GetObject("byteorder");
 
     if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
         little_endian = 1;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5613,9 +5613,11 @@ int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
     PyObject *long_obj, *bytes;
 
     if (byteorder == NULL)
-        byteorder = PySys_GetObject("byteorder");
-
-    if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
+        // PY_LITTLE_ENDIAN is 1 on little-endian systems, and 0 on big-endian
+        // systems. In the default case, using it is significantly faster than
+        // looking up sys.byteorder and performing the string comparisons below:
+        little_endian = PY_LITTLE_ENDIAN;
+    else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
         little_endian = 1;
     else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_big))
         little_endian = 0;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5589,7 +5589,7 @@ int.from_bytes
         support the buffer protocol or be an iterable object producing bytes.
         Bytes and bytearray are examples of built-in objects that support the
         buffer protocol.
-    byteorder: unicode = NULL
+    byteorder: unicode(c_default="NULL") = "big"
         The byte order used to represent the integer.  If byteorder is 'big',
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5523,13 +5523,14 @@ int.to_bytes
 
     length: Py_ssize_t = 1
         Length of bytes object to use.  An OverflowError is raised if the
-        integer is not representable with the given number of bytes.
+        integer is not representable with the given number of bytes.  Default
+        is length 1.
     byteorder: unicode = NULL
         The byte order used to represent the integer.  If byteorder is 'big',
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the
         byte array.  To request the native byte order of the host system, use
-        `sys.byteorder' as the byte order value.
+        `sys.byteorder' as the byte order value.  Default is to use 'big'.
     *
     signed as is_signed: bool = False
         Determines whether two's complement is used to represent the integer.
@@ -5542,16 +5543,13 @@ Return an array of bytes representing an integer.
 static PyObject *
 int_to_bytes_impl(PyObject *self, Py_ssize_t length, PyObject *byteorder,
                   int is_signed)
-/*[clinic end generated code: output=89c801df114050a3 input=d6b9571b1ee1fd05]*/
+/*[clinic end generated code: output=89c801df114050a3 input=5af4e767317e06a4]*/
 {
     int little_endian;
     PyObject *bytes;
 
     if (byteorder == NULL)
-        // PY_LITTLE_ENDIAN is 1 on little-endian systems, and 0 on big-endian
-        // systems. In the default case, it's significantly faster than looking
-        // up sys.byteorder and performing the string comparisons below:
-        little_endian = PY_LITTLE_ENDIAN;
+        little_endian = 0;
     else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
         little_endian = 1;
     else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_big))
@@ -5596,7 +5594,7 @@ int.from_bytes
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the
         byte array.  To request the native byte order of the host system, use
-        `sys.byteorder' as the byte order value.
+        `sys.byteorder' as the byte order value.  Default is to use 'big'.
     *
     signed as is_signed: bool = False
         Indicates whether two's complement is used to represent the integer.
@@ -5607,16 +5605,13 @@ Return the integer represented by the given array of bytes.
 static PyObject *
 int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
                     PyObject *byteorder, int is_signed)
-/*[clinic end generated code: output=efc5d68e31f9314f input=2562febe16a92f7a]*/
+/*[clinic end generated code: output=efc5d68e31f9314f input=495a43f81a11a00f]*/
 {
     int little_endian;
     PyObject *long_obj, *bytes;
 
     if (byteorder == NULL)
-        // PY_LITTLE_ENDIAN is 1 on little-endian systems, and 0 on big-endian
-        // systems. In the default case, using it is significantly faster than
-        // looking up sys.byteorder and performing the string comparisons below:
-        little_endian = PY_LITTLE_ENDIAN;
+        little_endian = 0;
     else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
         little_endian = 1;
     else if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_big))

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5543,7 +5543,7 @@ Return an array of bytes representing an integer.
 static PyObject *
 int_to_bytes_impl(PyObject *self, Py_ssize_t length, PyObject *byteorder,
                   int is_signed)
-/*[clinic end generated code: output=89c801df114050a3 input=5af4e767317e06a4]*/
+/*[clinic end generated code: output=89c801df114050a3 input=d42ecfb545039d71]*/
 {
     int little_endian;
     PyObject *bytes;
@@ -5605,7 +5605,7 @@ Return the integer represented by the given array of bytes.
 static PyObject *
 int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
                     PyObject *byteorder, int is_signed)
-/*[clinic end generated code: output=efc5d68e31f9314f input=495a43f81a11a00f]*/
+/*[clinic end generated code: output=efc5d68e31f9314f input=33326dccdd655553]*/
 {
     int little_endian;
     PyObject *long_obj, *bytes;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5525,7 +5525,7 @@ int.to_bytes
         Length of bytes object to use.  An OverflowError is raised if the
         integer is not representable with the given number of bytes.  Default
         is length 1.
-    byteorder: unicode = NULL
+    byteorder: unicode(c_default="NULL") = "big"
         The byte order used to represent the integer.  If byteorder is 'big',
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the


### PR DESCRIPTION
In the [PEP 467](https://www.python.org/dev/peps/pep-0467/) discussion, [I proposed](https://mail.python.org/archives/list/python-dev@python.org/message/PUR7UCOITMMH6TZVVJA5LKRCBYS4RBMR/) being able to use

```
>>> (65).to_bytes()
b'A'
```

IOW, adding default arguments for the `length` and `byteorder` arguments to `int.to_bytes()`

It occurs to me that this is (1) useful on its own merits; (2) easy to do.  So I've done it.

<!-- issue-number: [bpo-45155](https://bugs.python.org/issue45155) -->
https://bugs.python.org/issue45155
<!-- /issue-number -->
