### PR TITLE
bpo-45171: Fix stacklevel handling in logging. (GH-28287)

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4997,9 +4997,10 @@ class LoggerTest(BaseTest, AssertErrorMessage):
 
     def test_find_caller_with_stacklevel(self):
         the_level = 1
+        trigger = self.logger.warning
 
         def innermost():
-            self.logger.warning('test', stacklevel=the_level)
+            trigger('test', stacklevel=the_level)
 
         def inner():
             innermost()
@@ -5021,6 +5022,16 @@ class LoggerTest(BaseTest, AssertErrorMessage):
         self.assertEqual(records[-1].funcName, 'outer')
         self.assertGreater(records[-1].lineno, lineno)
         lineno = records[-1].lineno
+        trigger = self.logger.warn
+        outer()
+        self.assertEqual(records[-1].funcName, 'outer')
+        root_logger = logging.getLogger()
+        root_logger.addHandler(self.recording)
+        trigger = logging.warning
+        outer()
+        self.assertEqual(records[-1].funcName, 'outer')
+        root_logger.removeHandler(self.recording)
+        trigger = self.logger.warning
         the_level += 1
         outer()
         self.assertEqual(records[-1].funcName, 'test_find_caller_with_stacklevel')

--- a/Misc/NEWS.d/next/Library/2021-09-11-16-06-54.bpo-45171.ec597j.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-11-16-06-54.bpo-45171.ec597j.rst
@@ -1,0 +1,4 @@
+Fix handling of the ``stacklevel`` argument to logging functions in the
+:mod:`logging` module so that it is consistent accross all logging functions
+and, as advertised, similar to the ``stacklevel`` argument used in
+:meth:`~warnings.warn`.


### PR DESCRIPTION
I identified a few problems with the `stacklevel` handling code in the logging module:

- `currentframe` was not marked as 'private', which would be desirable.
- The fallback implementation of `currentframe` was different from the default implementation in that it did not skip any frames.
- The number of frames skipped did not account for any direct calls to `findCaller` (and it did not provide a measurable speed-up).
- `stacklevel` skipping did not use the same logic as in the `warnings` module, despite the documentation describing the argument as "The name of this parameter mirrors the equivalent one in the warnings module."

Regarding the last point, I did not know what to do in case more frames are to be skipped than the height of the stack. I listed three possibilities in the code which I think would all be sensible. The current behavior of using the top of the stack seems very odd to me.

<!-- issue-number: [bpo-45171](https://bugs.python.org/issue45171) -->
https://bugs.python.org/issue45171
<!-- /issue-number -->
