### PR TITLE
bpo-45160: Ttk optionmenu only set variable once

### DIFF
--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -301,6 +301,19 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         optmenu.destroy()
         optmenu2.destroy()
 
+    def test_trace_variable(self):
+        # prior to bpo45160, tracing a variable would cause the callback to be made twice
+        success = []
+        items = ('a', 'b', 'c')
+        textvar = tkinter.StringVar(self.root)
+        def cb_test(*args):
+            self.assertEqual(textvar.get(), items[1])
+            success.append(True)
+        optmenu = ttk.OptionMenu(self.root, textvar, "a", *items)
+        textvar.trace("w", cb_test)
+        optmenu['menu'].invoke(1)
+        self.assertEqual(success, [True])
+
 
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
 

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1643,7 +1643,10 @@ class OptionMenu(Menubutton):
         menu.delete(0, 'end')
         for val in values:
             menu.add_radiobutton(label=val,
-                command=tkinter._setit(self._variable, val, self._callback),
+                command=(
+                    None if self._callback is None
+                    else lambda val=val: self._callback(val)
+                ),
                 variable=self._variable)
 
         if default:

--- a/Misc/NEWS.d/next/Library/2021-09-11-14-47-05.bpo-45160.VzMXbW.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-11-14-47-05.bpo-45160.VzMXbW.rst
@@ -1,0 +1,1 @@
+When tracing a tkinter variable used by a ttk OptionMenu, callbacks are no longer made twice.


### PR DESCRIPTION
Since we were manually setting the variable (as well as the radiobutton), callbacks registered using the variable's `trace` method would be called twice.

TODO: Tests

Note: I probably won't be able to look at this now for ~ a week.

<!-- issue-number: [bpo-45160](https://bugs.python.org/issue45160) -->
https://bugs.python.org/issue45160
<!-- /issue-number -->
