### PR TITLE
[3.10] bpo-45126: Fix ref. leak in `sqlite3.Connection.__init__` (GH-28231)

### DIFF
--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -87,6 +87,7 @@ pysqlite_connection_init(pysqlite_Connection *self, PyObject *args,
     }
 
     if (PySys_Audit("sqlite3.connect", "O", database_obj) < 0) {
+        Py_DECREF(database_obj);
         return -1;
     }
 


### PR DESCRIPTION
(cherry picked from commit c78d5ca3806d02e26f9f3fa92ff567f0805eac4c)

Co-authored-by: Erlend Egeberg Aasland <erlend.aasland@innova.no>

Resolves #89289
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45126](https://bugs.python.org/issue45126) -->
https://bugs.python.org/issue45126
<!-- /issue-number -->
