### PR TITLE
bpo-45156: fixes inifite loop on `mock.seal()`

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1006,7 +1006,7 @@ class NonCallableMock(Base):
             return AsyncMock(**kw)
 
         if self._mock_sealed:
-            attribute = "." + kw["name"] if "name" in kw else "()"
+            attribute = f".{kw['name']} if "name" in kw else "()"
             mock_name = self._extract_mock_name() + attribute
             raise AttributeError(mock_name)
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1006,7 +1006,7 @@ class NonCallableMock(Base):
             return AsyncMock(**kw)
 
         if self._mock_sealed:
-            attribute = f".{kw['name']} if "name" in kw else "()"
+            attribute = f".{kw['name']}" if "name" in kw else "()"
             mock_name = self._extract_mock_name() + attribute
             raise AttributeError(mock_name)
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1005,6 +1005,11 @@ class NonCallableMock(Base):
         if _new_name in self.__dict__['_spec_asyncs']:
             return AsyncMock(**kw)
 
+        if self._mock_sealed:
+            attribute = "." + kw["name"] if "name" in kw else "()"
+            mock_name = self._extract_mock_name() + attribute
+            raise AttributeError(mock_name)
+
         _type = type(self)
         if issubclass(_type, MagicMock) and _new_name in _async_method_magics:
             # Any asynchronous magic becomes an AsyncMock
@@ -1023,12 +1028,6 @@ class NonCallableMock(Base):
                 klass = Mock
         else:
             klass = _type.__mro__[1]
-
-        if self._mock_sealed:
-            attribute = "." + kw["name"] if "name" in kw else "()"
-            mock_name = self._extract_mock_name() + attribute
-            raise AttributeError(mock_name)
-
         return klass(**kw)
 
 
@@ -2912,6 +2911,8 @@ def seal(mock):
         except AttributeError:
             continue
         if not isinstance(m, NonCallableMock):
+            continue
+        if isinstance(m._mock_children.get(attr), _SpecState):
             continue
         if m._mock_new_parent is mock:
             seal(m)

--- a/Lib/unittest/test/testmock/testsealable.py
+++ b/Lib/unittest/test/testmock/testsealable.py
@@ -171,66 +171,64 @@ class TestSealable(unittest.TestCase):
             m.test1().test2.test3().test4()
         self.assertIn("mock.test1().test2.test3().test4", str(cm.exception))
 
-    def test_seal_with_attr_autospec(self):
+    def test_seal_with_autospec(self):
         # https://bugs.python.org/issue45156
         class Foo:
             foo = 0
+            def bar1(self):
+                return 1
+            def bar2(self):
+                return 2
+
+            class Baz:
+                baz = 3
+                def ban(self):
+                    return 4
 
         for spec_set in (True, False):
             with self.subTest(spec_set=spec_set):
                 foo = mock.create_autospec(Foo, spec_set=spec_set)
+                foo.bar1.return_value = 'a'
+                foo.Baz.ban.return_value = 'b'
+
                 mock.seal(foo)
 
                 self.assertIsInstance(foo.foo, mock.NonCallableMagicMock)
+                self.assertIsInstance(foo.bar1, mock.MagicMock)
+                self.assertIsInstance(foo.bar2, mock.MagicMock)
+                self.assertIsInstance(foo.Baz, mock.MagicMock)
+                self.assertIsInstance(foo.Baz.baz, mock.NonCallableMagicMock)
+                self.assertIsInstance(foo.Baz.ban, mock.MagicMock)
+
+                self.assertEqual(foo.bar1(), 'a')
+                foo.bar1.return_value = 'new_a'
+                self.assertEqual(foo.bar1(), 'new_a')
+                self.assertEqual(foo.Baz.ban(), 'b')
+                foo.Baz.ban.return_value = 'new_b'
+                self.assertEqual(foo.Baz.ban(), 'new_b')
+
                 with self.assertRaises(TypeError):
                     foo.foo()
                 with self.assertRaises(AttributeError):
                     foo.bar = 1
                 with self.assertRaises(AttributeError):
-                    foo.missing_attr
-                with self.assertRaises(AttributeError):
-                    foo.missing_method()
+                    foo.bar2()
 
-    def test_seal_with_method_autospec(self):
-        # https://bugs.python.org/issue45156
-        class Foo:
-            def foo(self):
-                return 1
+                foo.bar2.return_value = 'bar2'
+                self.assertEqual(foo.bar2(), 'bar2')
 
-        for spec_set in (True, False):
-            with self.subTest(spec_set=spec_set):
-                foo = mock.create_autospec(Foo, spec_set=spec_set)
-                foo.foo.return_value = 0
-                mock.seal(foo)
-
-                self.assertIsInstance(foo.foo, mock.MagicMock)
-                self.assertEqual(foo.foo(), 0)
-                with self.assertRaises(AttributeError):
-                    foo.bar = 1
                 with self.assertRaises(AttributeError):
                     foo.missing_attr
                 with self.assertRaises(AttributeError):
+                    foo.missing_attr = 1
+                with self.assertRaises(AttributeError):
                     foo.missing_method()
-
-    def test_seal_with_nested_class_autospec(self):
-        # https://bugs.python.org/issue45156
-        class Foo:
-            class Baz:
-                def baz(self):
-                    return 1
-
-        for spec_set in (True, False):
-            with self.subTest(spec_set=spec_set):
-                foo = mock.create_autospec(Foo, spec_set=spec_set)
-                foo.Baz.baz.return_value = 0
-                mock.seal(foo)
-
-                self.assertIsInstance(foo.Baz.baz, mock.MagicMock)
-                self.assertEqual(foo.Baz.baz(), 0)
+                with self.assertRaises(TypeError):
+                    foo.Baz.baz()
                 with self.assertRaises(AttributeError):
-                    foo.bar = 1
+                    foo.Baz.missing_attr
                 with self.assertRaises(AttributeError):
-                    foo.Baz.bar = 1
+                    foo.Baz.missing_attr = 1
                 with self.assertRaises(AttributeError):
                     foo.Baz.missing_method()
 

--- a/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
@@ -1,0 +1,2 @@
+Fixes infinite loop on ``unittest.seal()`` of mocks created by
+``mock.create_autospec()``.

--- a/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
@@ -1,2 +1,2 @@
 Fixes infinite loop on ``unittest.seal()`` of mocks created by
-``mock.create_autospec()``.
+:func:`~unittest. create_autospec `.

--- a/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
@@ -1,2 +1,2 @@
 Fixes infinite loop on :func:`unittest.mock.seal` of mocks created by
-:func:`~unittest. create_autospec `.
+:func:`~unittest.create_autospec`.

--- a/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-13-00-28-17.bpo-45156.8oomV3.rst
@@ -1,2 +1,2 @@
-Fixes infinite loop on ``unittest.seal()`` of mocks created by
+Fixes infinite loop on :func:`unittest.mock.seal` of mocks created by
 :func:`~unittest. create_autospec `.


### PR DESCRIPTION


<!-- issue-number: [bpo-45156](https://bugs.python.org/issue45156) -->
https://bugs.python.org/issue45156
<!-- /issue-number -->
