### PR TITLE
bpo-5846: Do not use obsolete unittest functions.

### DIFF
--- a/Lib/distutils/tests/test_archive_util.py
+++ b/Lib/distutils/tests/test_archive_util.py
@@ -390,7 +390,7 @@ class ArchiveUtilTestCase(support.TempdirManager,
             archive.close()
 
 def test_suite():
-    return unittest.makeSuite(ArchiveUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(ArchiveUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_bdist.py
+++ b/Lib/distutils/tests/test_bdist.py
@@ -45,7 +45,7 @@ class BuildTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(BuildTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildTestCase)
 
 
 if __name__ == '__main__':

--- a/Lib/distutils/tests/test_bdist_dumb.py
+++ b/Lib/distutils/tests/test_bdist_dumb.py
@@ -91,7 +91,7 @@ class BuildDumbTestCase(support.TempdirManager,
         self.assertEqual(contents, sorted(wanted))
 
 def test_suite():
-    return unittest.makeSuite(BuildDumbTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildDumbTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_bdist_rpm.py
+++ b/Lib/distutils/tests/test_bdist_rpm.py
@@ -129,7 +129,7 @@ class BuildRpmTestCase(support.TempdirManager,
         os.remove(os.path.join(pkg_dir, 'dist', 'foo-0.1-1.noarch.rpm'))
 
 def test_suite():
-    return unittest.makeSuite(BuildRpmTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildRpmTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_build.py
+++ b/Lib/distutils/tests/test_build.py
@@ -50,7 +50,7 @@ class BuildTestCase(support.TempdirManager,
         self.assertEqual(cmd.executable, os.path.normpath(sys.executable))
 
 def test_suite():
-    return unittest.makeSuite(BuildTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_build_clib.py
+++ b/Lib/distutils/tests/test_build_clib.py
@@ -138,7 +138,7 @@ class BuildCLibTestCase(support.TempdirManager,
         self.assertIn('libfoo.a', os.listdir(build_temp))
 
 def test_suite():
-    return unittest.makeSuite(BuildCLibTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildCLibTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -545,8 +545,8 @@ class ParallelBuildExtTestCase(BuildExtTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(BuildExtTestCase))
-    suite.addTest(unittest.makeSuite(ParallelBuildExtTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(BuildExtTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ParallelBuildExtTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/Lib/distutils/tests/test_build_py.py
+++ b/Lib/distutils/tests/test_build_py.py
@@ -173,7 +173,7 @@ class BuildPyTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(BuildPyTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildPyTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_build_scripts.py
+++ b/Lib/distutils/tests/test_build_scripts.py
@@ -106,7 +106,7 @@ class BuildScriptsTestCase(support.TempdirManager,
             self.assertIn(name, built)
 
 def test_suite():
-    return unittest.makeSuite(BuildScriptsTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildScriptsTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_check.py
+++ b/Lib/distutils/tests/test_check.py
@@ -157,7 +157,7 @@ class CheckTestCase(support.LoggingSilencer,
                                  'restructuredtext': 1})
 
 def test_suite():
-    return unittest.makeSuite(CheckTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CheckTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_clean.py
+++ b/Lib/distutils/tests/test_clean.py
@@ -43,7 +43,7 @@ class cleanTestCase(support.TempdirManager,
         cmd.run()
 
 def test_suite():
-    return unittest.makeSuite(cleanTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(cleanTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_cmd.py
+++ b/Lib/distutils/tests/test_cmd.py
@@ -120,7 +120,7 @@ class CommandTestCase(unittest.TestCase):
             debug.DEBUG = False
 
 def test_suite():
-    return unittest.makeSuite(CommandTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CommandTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_config.py
+++ b/Lib/distutils/tests/test_config.py
@@ -135,7 +135,7 @@ class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(PyPIRCCommandTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(PyPIRCCommandTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_config_cmd.py
+++ b/Lib/distutils/tests/test_config_cmd.py
@@ -94,7 +94,7 @@ class ConfigTestCase(support.LoggingSilencer,
             self.assertFalse(os.path.exists(f))
 
 def test_suite():
-    return unittest.makeSuite(ConfigTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(ConfigTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_core.py
+++ b/Lib/distutils/tests/test_core.py
@@ -134,7 +134,7 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertEqual(stdout.readlines()[0], wanted)
 
 def test_suite():
-    return unittest.makeSuite(CoreTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CoreTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_cygwinccompiler.py
+++ b/Lib/distutils/tests/test_cygwinccompiler.py
@@ -148,7 +148,7 @@ class CygwinCCompilerTestCase(support.TempdirManager,
         self.assertRaises(ValueError, get_msvcr)
 
 def test_suite():
-    return unittest.makeSuite(CygwinCCompilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CygwinCCompilerTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_dep_util.py
+++ b/Lib/distutils/tests/test_dep_util.py
@@ -74,7 +74,7 @@ class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(DepUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(DepUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_dir_util.py
+++ b/Lib/distutils/tests/test_dir_util.py
@@ -133,7 +133,7 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(DirUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(DirUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -521,8 +521,8 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(DistributionTestCase))
-    suite.addTest(unittest.makeSuite(MetadataTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(DistributionTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(MetadataTestCase))
     return suite
 
 if __name__ == "__main__":

--- a/Lib/distutils/tests/test_extension.py
+++ b/Lib/distutils/tests/test_extension.py
@@ -64,7 +64,7 @@ class ExtensionTestCase(unittest.TestCase):
                           "Unknown Extension options: 'chic'")
 
 def test_suite():
-    return unittest.makeSuite(ExtensionTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(ExtensionTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_file_util.py
+++ b/Lib/distutils/tests/test_file_util.py
@@ -118,7 +118,7 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(FileUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(FileUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_filelist.py
+++ b/Lib/distutils/tests/test_filelist.py
@@ -331,8 +331,8 @@ class FindAllTestCase(unittest.TestCase):
 
 def test_suite():
     return unittest.TestSuite([
-        unittest.makeSuite(FileListTestCase),
-        unittest.makeSuite(FindAllTestCase),
+        unittest.TestLoader().loadTestsFromTestCase(FileListTestCase),
+        unittest.TestLoader().loadTestsFromTestCase(FindAllTestCase),
     ])
 
 

--- a/Lib/distutils/tests/test_install.py
+++ b/Lib/distutils/tests/test_install.py
@@ -254,7 +254,7 @@ class InstallTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(InstallTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_install_data.py
+++ b/Lib/distutils/tests/test_install_data.py
@@ -69,7 +69,7 @@ class InstallDataTestCase(support.TempdirManager,
         self.assertTrue(os.path.exists(os.path.join(inst, rone)))
 
 def test_suite():
-    return unittest.makeSuite(InstallDataTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallDataTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_install_headers.py
+++ b/Lib/distutils/tests/test_install_headers.py
@@ -33,7 +33,7 @@ class InstallHeadersTestCase(support.TempdirManager,
         self.assertEqual(len(cmd.get_outputs()), 2)
 
 def test_suite():
-    return unittest.makeSuite(InstallHeadersTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallHeadersTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_install_lib.py
+++ b/Lib/distutils/tests/test_install_lib.py
@@ -109,7 +109,7 @@ class InstallLibTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(InstallLibTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallLibTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_install_scripts.py
+++ b/Lib/distutils/tests/test_install_scripts.py
@@ -76,7 +76,7 @@ class InstallScriptsTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(InstallScriptsTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallScriptsTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_log.py
+++ b/Lib/distutils/tests/test_log.py
@@ -40,7 +40,7 @@ class TestLog(unittest.TestCase):
                         'Fαtal\t\\xc8rr\\u014dr')
 
 def test_suite():
-    return unittest.makeSuite(TestLog)
+    return unittest.TestLoader().loadTestsFromTestCase(TestLog)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_msvc9compiler.py
+++ b/Lib/distutils/tests/test_msvc9compiler.py
@@ -178,7 +178,7 @@ class msvc9compilerTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(msvc9compilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(msvc9compilerTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_msvccompiler.py
+++ b/Lib/distutils/tests/test_msvccompiler.py
@@ -75,7 +75,7 @@ class msvccompilerTestCase(support.TempdirManager,
             raise unittest.SkipTest("VS 2015 is not installed")
 
 def test_suite():
-    return unittest.makeSuite(msvccompilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(msvccompilerTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_register.py
+++ b/Lib/distutils/tests/test_register.py
@@ -318,7 +318,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(RegisterTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(RegisterTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_sdist.py
+++ b/Lib/distutils/tests/test_sdist.py
@@ -487,7 +487,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             archive.close()
 
 def test_suite():
-    return unittest.makeSuite(SDistTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(SDistTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_spawn.py
+++ b/Lib/distutils/tests/test_spawn.py
@@ -131,7 +131,7 @@ class SpawnTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(SpawnTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(SpawnTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -269,7 +269,7 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(SysconfigTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(SysconfigTestCase))
     return suite
 
 

--- a/Lib/distutils/tests/test_text_file.py
+++ b/Lib/distutils/tests/test_text_file.py
@@ -101,7 +101,7 @@ class TextFileTestCase(support.TempdirManager, unittest.TestCase):
             in_file.close()
 
 def test_suite():
-    return unittest.makeSuite(TextFileTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(TextFileTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_unixccompiler.py
+++ b/Lib/distutils/tests/test_unixccompiler.py
@@ -139,7 +139,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(UnixCCompilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(UnixCCompilerTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -217,7 +217,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(uploadTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(uploadTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_util.py
+++ b/Lib/distutils/tests/test_util.py
@@ -304,7 +304,7 @@ class UtilTestCase(support.EnvironGuard, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(UtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(UtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/distutils/tests/test_version.py
+++ b/Lib/distutils/tests/test_version.py
@@ -81,7 +81,7 @@ class VersionTestCase(unittest.TestCase):
                           (v1, v2, res))
 
 def test_suite():
-    return unittest.makeSuite(VersionTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(VersionTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1108,17 +1108,18 @@ def _compile_match_function(patterns):
 def run_unittest(*classes):
     """Run tests from unittest.TestCase-derived classes."""
     valid_types = (unittest.TestSuite, unittest.TestCase)
+    loader = unittest.TestLoader()
     suite = unittest.TestSuite()
     for cls in classes:
         if isinstance(cls, str):
             if cls in sys.modules:
-                suite.addTest(unittest.findTestCases(sys.modules[cls]))
+                suite.addTest(loader.loadTestsFromModule(sys.modules[cls]))
             else:
                 raise ValueError("str arguments must be keys in sys.modules")
         elif isinstance(cls, valid_types):
             suite.addTest(cls)
         else:
-            suite.addTest(unittest.makeSuite(cls))
+            suite.addTest(loader.loadTestsFromTestCase(cls))
     _filter_suite(suite, match_test)
     _run_suite(suite)
 

--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
             raise RuntimeError('error message')
 
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestTests))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestTests))
     stream = io.StringIO()
     runner_cls = get_test_runner_class(sum(a == '-v' for a in sys.argv))
     runner = runner_cls(sys.stdout)

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -221,9 +221,8 @@ def load_tests(loader, tests, pattern):
         classes.append(type("TestCase-" + mod.__name__,
                             (AnyDBMTestCase, unittest.TestCase),
                             {'module': mod}))
-    suites = [unittest.makeSuite(c) for c in classes]
-
-    tests.addTests(suites)
+    for c in classes:
+        tests.addTest(loader.loadTestsFromTestCase(c))
     return tests
 
 if __name__ == "__main__":

--- a/Lib/test/test_email/torture_test.py
+++ b/Lib/test/test_email/torture_test.py
@@ -12,7 +12,6 @@ import unittest
 from io import StringIO
 
 from test.test_email import TestEmailBase
-from test.support import run_unittest
 
 import email
 from email import __file__ as testfile
@@ -24,10 +23,11 @@ def openfile(filename):
     return open(path, 'r')
 
 # Prevent this test from running in the Python distro
-try:
-    openfile('crispin-torture.txt')
-except OSError:
-    raise unittest.SkipTest
+def setUpModule():
+    try:
+        openfile('crispin-torture.txt')
+    except OSError:
+        raise unittest.SkipTest
 
 
 
@@ -117,17 +117,11 @@ def _testclasses():
     return [getattr(mod, name) for name in dir(mod) if name.startswith('Test')]
 
 
-def suite():
-    suite = unittest.TestSuite()
+def load_tests(loader, tests, pattern):
+    suite = loader.suiteClass()
     for testclass in _testclasses():
-        suite.addTest(unittest.makeSuite(testclass))
+        suite.addTest(loader.loadTestsFromTestCase(testclass))
     return suite
 
-
-def test_main():
-    for testclass in _testclasses():
-        run_unittest(testclass)
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4604,7 +4604,7 @@ class PySignalsTest(SignalsTest):
     test_reentrant_write_text = None
 
 
-def load_tests(*args):
+def load_tests(loader, tests, pattern):
     tests = (CIOTest, PyIOTest, APIMismatchTest,
              CBufferedReaderTest, PyBufferedReaderTest,
              CBufferedWriterTest, PyBufferedWriterTest,
@@ -4636,7 +4636,9 @@ def load_tests(*args):
             for name, obj in py_io_ns.items():
                 setattr(test, name, obj)
 
-    suite = unittest.TestSuite([unittest.makeSuite(test) for test in tests])
+    suite = loader.suiteClass()
+    for test in tests:
+        suite.addTest(loader.loadTestsFromTestCase(test))
     return suite
 
 if __name__ == "__main__":

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1,7 +1,7 @@
 # Python test set -- math module
 # XXXX Should not do tests around zero only
 
-from test.support import run_unittest, verbose, requires_IEEE_754
+from test.support import verbose, requires_IEEE_754
 from test import support
 import unittest
 import itertools
@@ -2225,13 +2225,10 @@ class IsCloseTests(unittest.TestCase):
         self.assertAllNotClose(fraction_examples, rel_tol=1e-9)
 
 
-def test_main():
+def load_tests(loader, tests, pattern):
     from doctest import DocFileSuite
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(MathTests))
-    suite.addTest(unittest.makeSuite(IsCloseTests))
-    suite.addTest(DocFileSuite("ieee754.txt"))
-    run_unittest(suite)
+    tests.addTest(DocFileSuite("ieee754.txt"))
+    return tests
 
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1975,14 +1975,10 @@ class ChecklineTests(unittest.TestCase):
             self.assertFalse(db.checkline(os_helper.TESTFN, lineno))
 
 
-def load_tests(*args):
+def load_tests(loader, tests, pattern):
     from test import test_pdb
-    suites = [
-        unittest.makeSuite(PdbTestCase),
-        unittest.makeSuite(ChecklineTests),
-        doctest.DocTestSuite(test_pdb)
-    ]
-    return unittest.TestSuite(suites)
+    tests.addTest(doctest.DocTestSuite(test_pdb))
+    return tests
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_threading_local.py
+++ b/Lib/test/test_threading_local.py
@@ -201,22 +201,19 @@ class PyThreadingLocalTest(unittest.TestCase, BaseLocalTest):
     _local = _threading_local.local
 
 
-def test_main():
-    suite = unittest.TestSuite()
-    suite.addTest(DocTestSuite('_threading_local'))
-    suite.addTest(unittest.makeSuite(ThreadLocalTest))
-    suite.addTest(unittest.makeSuite(PyThreadingLocalTest))
+def load_tests(loader, tests, pattern):
+    tests.addTest(DocTestSuite('_threading_local'))
 
     local_orig = _threading_local.local
     def setUp(test):
         _threading_local.local = _thread._local
     def tearDown(test):
         _threading_local.local = local_orig
-    suite.addTest(DocTestSuite('_threading_local',
-                               setUp=setUp, tearDown=tearDown)
-                  )
+    tests.addTests(DocTestSuite('_threading_local',
+                                setUp=setUp, tearDown=tearDown)
+                   )
+    return tests
 
-    support.run_unittest(suite)
 
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -155,7 +155,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         # zlib.decompress function object, after which the problem being
         # tested here wouldn't be a problem anymore...
         # (Hence the 'A' in the test method name: to make it the first
-        # item in a list sorted by name, like unittest.makeSuite() does.)
+        # item in a list sorted by name, like
+        # unittest.TestLoader.getTestCaseNames() does.)
         #
         # This test fails on platforms on which the zlib module is
         # statically linked, but the problem it tests for can't

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -440,7 +440,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
 
         result = unittest.TestResult()
         result.failfast = True
-        suite = unittest.makeSuite(Foo)
+        suite = unittest.TestLoader().loadTestsFromTestCase(Foo)
         suite.run(result)
 
         expected = ['a1', 'a2', 'b1']


### PR DESCRIPTION
Get rid of use of makeSuite() and findTestCases().
Also make test_math and test_threading_local discoverable.


<!-- issue-number: [bpo-5846](https://bugs.python.org/issue5846) -->
https://bugs.python.org/issue5846
<!-- /issue-number -->
