### PR TITLE
bpo-45181: Simplify loading sqlite3 tests

### DIFF
--- a/Lib/sqlite3/test/test_backup.py
+++ b/Lib/sqlite3/test/test_backup.py
@@ -160,8 +160,5 @@ class BackupTests(unittest.TestCase):
             self.verify_backup(bck)
 
 
-def suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BackupTests)
-
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/sqlite3/test/test_dbapi.py
+++ b/Lib/sqlite3/test/test_dbapi.py
@@ -1156,28 +1156,5 @@ class MultiprocessTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0)
 
 
-def suite():
-    tests = [
-        ClosedConTests,
-        ClosedCurTests,
-        ConnectionTests,
-        ConstructorTests,
-        CursorTests,
-        ExtensionTests,
-        ModuleTests,
-        MultiprocessTests,
-        OpenTests,
-        SqliteOnConflictTests,
-        ThreadTests,
-        UninitialisedConnectionTests,
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
-
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/sqlite3/test/test_dump.py
+++ b/Lib/sqlite3/test/test_dump.py
@@ -70,17 +70,6 @@ class DumpTests(unittest.TestCase):
         got = list(self.cx.iterdump())
         self.assertEqual(expected, got)
 
-def suite():
-    tests = [
-        DumpTests,
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
 
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/sqlite3/test/test_factory.py
+++ b/Lib/sqlite3/test/test_factory.py
@@ -305,22 +305,6 @@ class TextFactoryTestsWithEmbeddedZeroBytes(unittest.TestCase):
     def tearDown(self):
         self.con.close()
 
-def suite():
-    tests = [
-        ConnectionFactoryTests,
-        CursorFactoryTests,
-        RowFactoryTests,
-        RowFactoryTestsBackwardsCompat,
-        TextFactoryTests,
-        TextFactoryTestsWithEmbeddedZeroBytes,
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
 
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/sqlite3/test/test_hooks.py
+++ b/Lib/sqlite3/test/test_hooks.py
@@ -24,7 +24,7 @@ import unittest
 import sqlite3 as sqlite
 
 from test.support.os_helper import TESTFN, unlink
-from .userfunctions import with_tracebacks
+from .test_userfunctions import with_tracebacks
 
 class CollationTests(unittest.TestCase):
     def test_create_collation_not_string(self):
@@ -290,19 +290,5 @@ class TraceCallbackTests(unittest.TestCase):
         self.assertEqual(traced_statements, queries)
 
 
-def suite():
-    tests = [
-        CollationTests,
-        ProgressTests,
-        TraceCallbackTests,
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
-
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/sqlite3/test/test_regression.py
+++ b/Lib/sqlite3/test/test_regression.py
@@ -436,17 +436,5 @@ class RegressionTests(unittest.TestCase):
         self.assertEqual(val, b'')
 
 
-def suite():
-    tests = [
-        RegressionTests
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
-
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/sqlite3/test/test_transactions.py
+++ b/Lib/sqlite3/test/test_transactions.py
@@ -195,19 +195,6 @@ class TransactionalDDL(unittest.TestCase):
     def tearDown(self):
         self.con.close()
 
-def suite():
-    tests = [
-        SpecialCommandTests,
-        TransactionTests,
-        TransactionalDDL,
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
 
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/sqlite3/test/test_types.py
+++ b/Lib/sqlite3/test/test_types.py
@@ -530,23 +530,6 @@ class DateTimeTests(unittest.TestCase):
         ts2 = self.cur.fetchone()[0]
         self.assertEqual(ts, ts2)
 
-def suite():
-    tests = [
-        BinaryConverterTests,
-        ColNamesTests,
-        CommonTableExpressionTests,
-        DateTimeTests,
-        DeclTypesTests,
-        ObjectAdaptationTests,
-        SqliteTypeTests,
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
 
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/sqlite3/test/test_userfunctions.py
+++ b/Lib/sqlite3/test/test_userfunctions.py
@@ -661,22 +661,5 @@ class AuthorizerLargeIntegerTests(AuthorizerTests):
         return sqlite.SQLITE_OK
 
 
-def suite():
-    tests = [
-        AggregateTests,
-        AuthorizerIllegalTypeTests,
-        AuthorizerLargeIntegerTests,
-        AuthorizerRaiseExceptionTests,
-        AuthorizerTests,
-        FunctionTests,
-    ]
-    return unittest.TestSuite(
-        [unittest.TestLoader().loadTestsFromTestCase(t) for t in tests]
-    )
-
-def test():
-    runner = unittest.TextTestRunner()
-    runner.run(suite())
-
 if __name__ == "__main__":
-    test()
+    unittest.main()

--- a/Lib/test/test_sqlite.py
+++ b/Lib/test/test_sqlite.py
@@ -1,26 +1,20 @@
 import test.support
 from test.support import import_helper
+from test.support import load_package_tests
 
 # Skip test if _sqlite3 module not installed
 import_helper.import_module('_sqlite3')
 
 import unittest
-import sqlite3
-from sqlite3.test import (dbapi, types, userfunctions,
-                                factory, transactions, hooks, regression,
-                                dump, backup)
+import os
+import sqlite3.test
 
-def load_tests(*args):
+def load_tests(loader, tests, pattern):
     if test.support.verbose:
         print("test_sqlite: testing with version",
               "{!r}, sqlite_version {!r}".format(sqlite3.version,
                                                  sqlite3.sqlite_version))
-    return unittest.TestSuite([dbapi.suite(), types.suite(),
-                               userfunctions.suite(),
-                               factory.suite(), transactions.suite(),
-                               hooks.suite(), regression.suite(),
-                               dump.suite(),
-                               backup.suite()])
+    return load_package_tests(os.path.dirname(sqlite3.test.__file__), loader, tests, pattern)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Use unittest discover instead of manually enumerating all
test modules and classes.
Also add support for filtering them by pattern.


<!-- issue-number: [bpo-45181](https://bugs.python.org/issue45181) -->
https://bugs.python.org/issue45181
<!-- /issue-number -->
