### PR TITLE
bpo-20524: adds better error message for `.format()`

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -542,5 +542,11 @@ class FormatTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, str_err):
             "{a:%k}".format(a='a')
 
+    def test_unicode_in_error_message(self):
+        str_err = re.escape(
+            "Invalid format specifier '{a:%ЫйЯЧ}' for object of type 'str'")
+        with self.assertRaisesRegex(ValueError, str_err):
+            "{a:%ЫйЯЧ}".format(a='a')
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -519,27 +519,28 @@ class FormatTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, error_msg):
             '{:_,}'.format(1)
 
-    @support.cpython_only
     def test_better_error_message(self):
-        with self.assertRaises(ValueError) as e:
+        # https://bugs.python.org/issue20524
+        complex_err = re.escape(
+            "Invalid format specifier '{l:%M}' for object of type 'complex'")
+        with self.assertRaisesRegex(ValueError, complex_err):
             "{l:%M}".format(l=complex(12))
-        self.assertEqual(str(e.exception),
-            "Invalid format specifier: '{l:%M}' for object of type 'complex'")
 
-        with self.assertRaises(ValueError) as e:
+        int_err = re.escape(
+            "Invalid format specifier '{length:%M:%S}' "
+            "for object of type 'int'")
+        with self.assertRaisesRegex(ValueError, int_err):
             "{length:%M:%S}".format(length=12)
-        self.assertEqual(str(e.exception),
-            "Invalid format specifier: '{length:%M:%S}' for object of type 'int'")
 
-        with self.assertRaises(ValueError) as e:
+        float_err = re.escape(
+            "Invalid format specifier '{0:%S}' for object of type 'float'")
+        with self.assertRaisesRegex(ValueError, float_err):
             "{0:%S}".format(12.5)
-        self.assertEqual(str(e.exception),
-            "Invalid format specifier: '{0:%S}' for object of type 'float'")
 
-        with self.assertRaises(ValueError) as e:
+        str_err = re.escape(
+            "Invalid format specifier '{a:%k}' for object of type 'str'")
+        with self.assertRaisesRegex(ValueError, str_err):
             "{a:%k}".format(a='a')
-        self.assertEqual(str(e.exception),
-            "Invalid format specifier: '{a:%k}' for object of type 'str'")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -519,5 +519,27 @@ class FormatTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, error_msg):
             '{:_,}'.format(1)
 
+    @support.cpython_only
+    def test_better_error_message(self):
+        with self.assertRaises(ValueError) as e:
+            "{l:%M}".format(l=complex(12))
+        self.assertEqual(str(e.exception),
+            "Invalid format specifier: '{l:%M}' for object of type 'complex'")
+
+        with self.assertRaises(ValueError) as e:
+            "{length:%M:%S}".format(length=12)
+        self.assertEqual(str(e.exception),
+            "Invalid format specifier: '{length:%M:%S}' for object of type 'int'")
+
+        with self.assertRaises(ValueError) as e:
+            "{0:%S}".format(12.5)
+        self.assertEqual(str(e.exception),
+            "Invalid format specifier: '{0:%S}' for object of type 'float'")
+
+        with self.assertRaises(ValueError) as e:
+            "{a:%k}".format(a='a')
+        self.assertEqual(str(e.exception),
+            "Invalid format specifier: '{a:%k}' for object of type 'str'")
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -521,64 +521,30 @@ class FormatTest(unittest.TestCase):
 
     def test_better_error_message_format(self):
         # https://bugs.python.org/issue20524
-        complex_err = re.escape(
-            "Invalid format specifier '%M' for object of type 'complex'")
-        with self.assertRaisesRegex(ValueError, complex_err):
-            "{l:%M}".format(l=complex(12))
+        for value in [12j, 12, 12.0, "12"]:
+            with self.subTest(value=value):
+                # The format spec must be invalid for all types we're testing.
+                # '%M' will suffice.
+                bad_format_spec = '%M'
+                err = re.escape("Invalid format specifier "
+                                f"'{bad_format_spec}' for object of type "
+                                f"'{type(value).__name__}'")
+                with self.assertRaisesRegex(ValueError, err):
+                    f"xx{{value:{bad_format_spec}}}yy".format(value=value)
 
-        int_err = re.escape(
-            "Invalid format specifier '%M:%S' "
-            "for object of type 'int'")
-        with self.assertRaisesRegex(ValueError, int_err):
-            "{length:%M:%S}".format(length=12)
+                # Also test the builtin format() function.
+                with self.assertRaisesRegex(ValueError, err):
+                    format(value, bad_format_spec)
 
-        float_err = re.escape(
-            "Invalid format specifier '%S' for object of type 'float'")
-        with self.assertRaisesRegex(ValueError, float_err):
-            "{0:%S}".format(12.5)
-
-        str_err = re.escape(
-            "Invalid format specifier '%%k' for object of type 'str'")
-        with self.assertRaisesRegex(ValueError, str_err):
-            "{a:%%k}".format(a='a')
+                # Also test f-strings.
+                with self.assertRaisesRegex(ValueError, err):
+                    eval("f'xx{value:{bad_format_spec}}yy'")
 
     def test_unicode_in_error_message(self):
         str_err = re.escape(
             "Invalid format specifier '%ЫйЯЧ' for object of type 'str'")
         with self.assertRaisesRegex(ValueError, str_err):
             "{a:%ЫйЯЧ}".format(a='a')
-
-    def test_better_error_message_format_function(self):
-        str_err = re.escape(
-            "Unknown format code 'q' for object of type 'str'")
-        with self.assertRaisesRegex(ValueError, str_err):
-            format('abc', 'q')
-
-        int_err = re.escape(
-            "Invalid format specifier '%d' for object of type 'int'")
-        with self.assertRaisesRegex(ValueError, int_err):
-            format(12, '%d')
-
-        float_err = re.escape(
-            "Invalid format specifier '%%d' for object of type 'float'")
-        with self.assertRaisesRegex(ValueError, float_err):
-            format(12.5, '%%d')
-
-    def test_better_error_message_fstring(self):
-        str_err = re.escape(
-            "Invalid format specifier 'str' for object of type 'str'")
-        with self.assertRaisesRegex(ValueError, str_err):
-            f'{"a":str}'
-
-        int_err = re.escape(
-            "Invalid format specifier '%d' for object of type 'int'")
-        with self.assertRaisesRegex(ValueError, int_err):
-            f'{1:%d}'
-
-        float_err = re.escape(
-            "Invalid format specifier 'fl:ac' for object of type 'float'")
-        with self.assertRaisesRegex(ValueError, float_err):
-            f'{0.5:fl:ac}'
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -519,34 +519,67 @@ class FormatTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, error_msg):
             '{:_,}'.format(1)
 
-    def test_better_error_message(self):
+    def test_better_error_message_format(self):
         # https://bugs.python.org/issue20524
         complex_err = re.escape(
-            "Invalid format specifier '{l:%M}' for object of type 'complex'")
+            "Invalid format specifier '%M' for object of type 'complex'")
         with self.assertRaisesRegex(ValueError, complex_err):
             "{l:%M}".format(l=complex(12))
 
         int_err = re.escape(
-            "Invalid format specifier '{length:%M:%S}' "
+            "Invalid format specifier '%M:%S' "
             "for object of type 'int'")
         with self.assertRaisesRegex(ValueError, int_err):
             "{length:%M:%S}".format(length=12)
 
         float_err = re.escape(
-            "Invalid format specifier '{0:%S}' for object of type 'float'")
+            "Invalid format specifier '%S' for object of type 'float'")
         with self.assertRaisesRegex(ValueError, float_err):
             "{0:%S}".format(12.5)
 
         str_err = re.escape(
-            "Invalid format specifier '{a:%k}' for object of type 'str'")
+            "Invalid format specifier '%%k' for object of type 'str'")
         with self.assertRaisesRegex(ValueError, str_err):
-            "{a:%k}".format(a='a')
+            "{a:%%k}".format(a='a')
 
     def test_unicode_in_error_message(self):
         str_err = re.escape(
-            "Invalid format specifier '{a:%ЫйЯЧ}' for object of type 'str'")
+            "Invalid format specifier '%ЫйЯЧ' for object of type 'str'")
         with self.assertRaisesRegex(ValueError, str_err):
             "{a:%ЫйЯЧ}".format(a='a')
+
+    def test_better_error_message_format_function(self):
+        str_err = re.escape(
+            "Unknown format code 'q' for object of type 'str'")
+        with self.assertRaisesRegex(ValueError, str_err):
+            format('abc', 'q')
+
+        int_err = re.escape(
+            "Invalid format specifier '%d' for object of type 'int'")
+        with self.assertRaisesRegex(ValueError, int_err):
+            format(12, '%d')
+
+        float_err = re.escape(
+            "Invalid format specifier '%%d' for object of type 'float'")
+        with self.assertRaisesRegex(ValueError, float_err):
+            format(12.5, '%%d')
+
+    def test_better_error_message_fstring(self):
+        str_err = re.escape(
+            "Invalid format specifier 'str' for object of type 'str'")
+        with self.assertRaisesRegex(ValueError, str_err):
+            f'{"a":str}'
+
+        int_err = re.escape(
+            "Invalid format specifier '%d' for object of type 'int'")
+        with self.assertRaisesRegex(ValueError, int_err):
+            f'{1:%d}'
+
+        float_err = re.escape(
+            "Invalid format specifier 'fl:ac' for object of type 'float'")
+        with self.assertRaisesRegex(ValueError, float_err):
+            f'{0.5:fl:ac}'
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2021-09-13-14-59-01.bpo-20524.PMQ1Fh.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-13-14-59-01.bpo-20524.PMQ1Fh.rst
@@ -1,0 +1,3 @@
+Improves error messages on ``.format()`` operation for ``str``, ``float``,
+``int``, and ``complex``. New format now shows the problematic pattern and
+the object type.

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -282,8 +282,8 @@ parse_internal_render_format_spec(PyObject *obj,
     if (end-pos > 1) {
         /* More than one char remain, invalid format specifier. */
         PyErr_Format(PyExc_ValueError,
-                     "Invalid format specifier: '%s' for object of type '%s'",
-                     PyUnicode_AsUTF8AndSize(format_spec, NULL),
+                     "Invalid format specifier '%s' for object of type '%.200s'",
+                     PyUnicode_AsUTF8(format_spec),
                      Py_TYPE(obj)->tp_name);
         return 0;
     }

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -162,7 +162,8 @@ DEBUG_PRINT_FORMAT_SPEC(InternalFormatSpec *format)
   if failure, sets the exception
 */
 static int
-parse_internal_render_format_spec(PyObject *format_spec,
+parse_internal_render_format_spec(PyObject *obj,
+                                  PyObject *format_spec,
                                   Py_ssize_t start, Py_ssize_t end,
                                   InternalFormatSpec *format,
                                   char default_type,
@@ -280,7 +281,10 @@ parse_internal_render_format_spec(PyObject *format_spec,
 
     if (end-pos > 1) {
         /* More than one char remain, invalid format specifier. */
-        PyErr_Format(PyExc_ValueError, "Invalid format specifier");
+        PyErr_Format(PyExc_ValueError,
+                     "Invalid format specifier: '%s' for object of type '%s'",
+                     PyUnicode_AsUTF8AndSize(format_spec, NULL),
+                     Py_TYPE(obj)->tp_name);
         return 0;
     }
 
@@ -1444,7 +1448,7 @@ _PyUnicode_FormatAdvancedWriter(_PyUnicodeWriter *writer,
     }
 
     /* parse the format_spec */
-    if (!parse_internal_render_format_spec(format_spec, start, end,
+    if (!parse_internal_render_format_spec(obj, format_spec, start, end,
                                            &format, 's', '<'))
         return -1;
 
@@ -1480,7 +1484,7 @@ _PyLong_FormatAdvancedWriter(_PyUnicodeWriter *writer,
     }
 
     /* parse the format_spec */
-    if (!parse_internal_render_format_spec(format_spec, start, end,
+    if (!parse_internal_render_format_spec(obj, format_spec, start, end,
                                            &format, 'd', '>'))
         goto done;
 
@@ -1536,7 +1540,7 @@ _PyFloat_FormatAdvancedWriter(_PyUnicodeWriter *writer,
         return format_obj(obj, writer);
 
     /* parse the format_spec */
-    if (!parse_internal_render_format_spec(format_spec, start, end,
+    if (!parse_internal_render_format_spec(obj, format_spec, start, end,
                                            &format, '\0', '>'))
         return -1;
 
@@ -1575,7 +1579,7 @@ _PyComplex_FormatAdvancedWriter(_PyUnicodeWriter *writer,
         return format_obj(obj, writer);
 
     /* parse the format_spec */
-    if (!parse_internal_render_format_spec(format_spec, start, end,
+    if (!parse_internal_render_format_spec(obj, format_spec, start, end,
                                            &format, '\0', '>'))
         return -1;
 

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -280,11 +280,19 @@ parse_internal_render_format_spec(PyObject *obj,
     /* Finally, parse the type field. */
 
     if (end-pos > 1) {
-        /* More than one char remain, invalid format specifier. */
-        PyErr_Format(PyExc_ValueError,
-                     "Invalid format specifier '%s' for object of type '%.200s'",
-                     PyUnicode_AsUTF8(format_spec),
-                     Py_TYPE(obj)->tp_name);
+        /* More than one char remains, so this is an invalid format
+           specifier. */
+        /* Create a temporary object that contains the format spec we're
+           operating on.  It's format_spec[start:end] (in Python syntax). */
+        PyObject* actual_format_spec = PyUnicode_FromKindAndData(kind,
+                                         (char*)data + kind*start,
+                                         end-start);
+        if (actual_format_spec != NULL) {
+            PyErr_Format(PyExc_ValueError,
+                "Invalid format specifier '%U' for object of type '%.200s'",
+                actual_format_spec, Py_TYPE(obj)->tp_name);
+            Py_DECREF(actual_format_spec);
+        }
         return 0;
     }
 


### PR DESCRIPTION
This is most likely can be considered as WIP, because I'm still not very familiar with C-API.
Would be happy to learn / address review comments though 🙂 

https://bugs.python.org/issue20524

<!-- issue-number: [bpo-20524](https://bugs.python.org/issue20524) -->
https://bugs.python.org/issue20524
<!-- /issue-number -->
