### PR TITLE
bpo-42135 Correct version slated for importlib.find_loader removal

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -79,7 +79,7 @@ def find_loader(name, path=None):
 
     """
     warnings.warn('Deprecated since Python 3.4 and slated for removal in '
-                  'Python 3.10; use importlib.util.find_spec() instead',
+                  'Python 3.12; use importlib.util.find_spec() instead',
                   DeprecationWarning, stacklevel=2)
     try:
         loader = sys.modules[name].__loader__

--- a/Misc/NEWS.d/next/Library/2021-09-13-19-32-58.bpo-42135.1ZAHqR.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-13-19-32-58.bpo-42135.1ZAHqR.rst
@@ -1,0 +1,3 @@
+Fix typo: ``importlib.find_loader`` is really slated for removal in Python 3.12 not 3.10, like the others in GH-25169.
+
+Patch by Hugo van Kemenade.


### PR DESCRIPTION
`importlib.find_loader` should also be slated for removal in Python 3.12 instead of Python 3.10, like the others in GH-25169, and as documented in:

* https://docs.python.org/3.10/whatsnew/3.10.html#deprecated
* https://docs.python.org/3.11/whatsnew/3.10.html#deprecated

<!-- issue-number: [bpo-42135](https://bugs.python.org/issue42135) -->
https://bugs.python.org/issue42135
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon