### PR TITLE
Add missing autojunk parameter to docstring

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -118,7 +118,7 @@ class SequenceMatcher:
 
     Methods:
 
-    __init__(isjunk=None, a='', b='')
+    __init__(isjunk=None, a='', b='', autojunk=True)
         Construct a SequenceMatcher.
 
     set_seqs(a, b)


### PR DESCRIPTION
The docstring of difflib.SequenceMatcher was missing the autjunk
parameter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
