### PR TITLE
bpo-45192: Fix a bug that infers the type of an os.PathLike[bytes] object as str

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -88,6 +88,10 @@ def _infer_return_type(*args):
     for arg in args:
         if arg is None:
             continue
+
+        if isinstance(arg, _os.PathLike):
+            arg = _os.fspath(arg)
+
         if isinstance(arg, bytes):
             if return_type is str:
                 raise TypeError("Can't mix bytes and non-bytes in "

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -62,6 +62,25 @@ class TestLowLevelInternals(unittest.TestCase):
     def test_infer_return_type_pathlib(self):
         self.assertIs(str, tempfile._infer_return_type(pathlib.Path('/')))
 
+    def test_infer_return_type_pathlike(self):
+        class Path:
+            def __init__(self, path):
+                self.path = path
+
+            def __fspath__(self):
+                return self.path
+
+        self.assertIs(str, tempfile._infer_return_type(Path('/')))
+        self.assertIs(bytes, tempfile._infer_return_type(Path(b'/')))
+        self.assertIs(str, tempfile._infer_return_type('', Path('')))
+        self.assertIs(bytes, tempfile._infer_return_type(b'', Path(b'')))
+        self.assertIs(bytes, tempfile._infer_return_type(None, Path(b'')))
+        self.assertIs(str, tempfile._infer_return_type(None, Path('')))
+
+        with self.assertRaises(TypeError):
+            tempfile._infer_return_type('', Path(b''))
+        with self.assertRaises(TypeError):
+            tempfile._infer_return_type(b'', Path(''))
 
 # Common functionality.
 

--- a/Misc/NEWS.d/next/Library/2021-09-14-15-52-47.bpo-45192.DjA-BI.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-14-15-52-47.bpo-45192.DjA-BI.rst
@@ -1,0 +1,5 @@
+Fix the ``tempfile.__infer_return_type`` function so that the ``dir``
+argument of the :mod:`tempfile` functions accepts an object implementing the
+``os.PathLike[bytes]`` protocol.
+
+Patch by Kyungmin Lee.

--- a/Misc/NEWS.d/next/Library/2021-09-14-15-52-47.bpo-45192.DjA-BI.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-14-15-52-47.bpo-45192.DjA-BI.rst
@@ -1,4 +1,4 @@
-Fix the ``tempfile.__infer_return_type`` function so that the ``dir``
+Fix the ``tempfile._infer_return_type`` function so that the ``dir``
 argument of the :mod:`tempfile` functions accepts an object implementing the
 ``os.PathLike[bytes]`` protocol.
 

--- a/Misc/NEWS.d/next/Library/2021-09-14-15-52-47.bpo-45192.DjA-BI.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-14-15-52-47.bpo-45192.DjA-BI.rst
@@ -1,5 +1,5 @@
 Fix the ``tempfile._infer_return_type`` function so that the ``dir``
 argument of the :mod:`tempfile` functions accepts an object implementing the
-``os.PathLike[bytes]`` protocol.
+``os.PathLike`` protocol.
 
 Patch by Kyungmin Lee.


### PR DESCRIPTION
The tempfile module has been updated to accept an object implementing `os.PathLike` protocol for path-related parameters as of Python 3.6 (e.g. `dir` parameter). An `os.PathLike` object represents a filesystem path as a `str` or `bytes` object (i.e. `def __fspath__(self) -> Union[str, bytes]:`). However, if an object implementing `os.PathLike[bytes]` is passed as a `dir` argument, a `TypeError` is raised:
```python
from typing import Union


class FakePath:
    def __init__(self, path):
        self.path = path

    def __fspath__(self) -> Union[str, bytes]:
        return self.path


if __name__ == "__main__":
    from tempfile import TemporaryDirectory

    # You need to create `existing_path` directory

    with TemporaryDirectory(dir=FakePath("existing_path")) as str_path:
        print(str_path)  # 'existing_path/...'

    with TemporaryDirectory(dir=FakePath(b"existing_path")) as byte_path:
        print(byte_path)  # expected b'existing_path/...' but raised TypeError

```

This bug occurs because the `tempfile._infer_return_type` function considers all non-bytes objects as `str`.

`_infer_return_type` function should infer `os.PathLike[str]` object as `str` type and `os.PathLike[bytes]` object as `bytes type`.

<!-- issue-number: [bpo-45192](https://bugs.python.org/issue45192) -->
https://bugs.python.org/issue45192
<!-- /issue-number -->
