### PR TITLE
bpo-45167: Fix deepcopying of GenericAlias

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -2,6 +2,7 @@
 
 import unittest
 import pickle
+import copy
 from collections import (
     defaultdict, deque, OrderedDict, Counter, UserDict, UserList
 )
@@ -270,11 +271,30 @@ class BaseTest(unittest.TestCase):
 
     def test_pickle(self):
         alias = GenericAlias(list, T)
-        s = pickle.dumps(alias)
-        loaded = pickle.loads(s)
-        self.assertEqual(alias.__origin__, loaded.__origin__)
-        self.assertEqual(alias.__args__, loaded.__args__)
-        self.assertEqual(alias.__parameters__, loaded.__parameters__)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            s = pickle.dumps(alias, proto)
+            loaded = pickle.loads(s)
+            self.assertEqual(loaded.__origin__, alias.__origin__)
+            self.assertEqual(loaded.__args__, alias.__args__)
+            self.assertEqual(loaded.__parameters__, alias.__parameters__)
+
+    def test_copy(self):
+        class X(list):
+            def __copy__(self):
+                return self
+            def __deepcopy__(self, memo):
+                return self
+
+        for origin in list, deque, X:
+            alias = GenericAlias(origin, T)
+            copied = copy.copy(alias)
+            self.assertEqual(copied.__origin__, alias.__origin__)
+            self.assertEqual(copied.__args__, alias.__args__)
+            self.assertEqual(copied.__parameters__, alias.__parameters__)
+            copied = copy.deepcopy(alias)
+            self.assertEqual(copied.__origin__, alias.__origin__)
+            self.assertEqual(copied.__args__, alias.__args__)
+            self.assertEqual(copied.__parameters__, alias.__parameters__)
 
     def test_union(self):
         a = typing.Union[list[int], list[str]]

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-14-09-23-59.bpo-45167.CPSSoV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-14-09-23-59.bpo-45167.CPSSoV.rst
@@ -1,0 +1,1 @@
+Fix deepcopying of :class:`types.GenericAlias` objects.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -418,6 +418,8 @@ static const char* const attr_exceptions[] = {
     "__mro_entries__",
     "__reduce_ex__",  // needed so we don't look up object.__reduce_ex__
     "__reduce__",
+    "__copy__",
+    "__deepcopy__",
     NULL,
 };
 


### PR DESCRIPTION


<!-- issue-number: [bpo-45167](https://bugs.python.org/issue45167) -->
https://bugs.python.org/issue45167
<!-- /issue-number -->
