### PR TITLE
bpo-45195: Fix test_readline.test_nonascii()

### DIFF
--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -255,7 +255,9 @@ print("history", ascii(readline.get_history_item(1)))
             self.assertIn(b"matches ['t\\xebnt', 't\\xebxt']\r\n", output)
         expected = br"'[\xefnserted]|t\xebxt[after]'"
         self.assertIn(b"result " + expected + b"\r\n", output)
-        self.assertIn(b"history " + expected + b"\r\n", output)
+        # bpo-45195: Sometimes, the newline character is not written at the
+        # end, so don't expect it in the output.
+        self.assertIn(b"history " + expected, output)
 
     # We have 2 reasons to skip this test:
     # - readline: history size was added in 6.0

--- a/Misc/NEWS.d/next/Tests/2021-09-14-13-16-18.bpo-45195.EyQR1G.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-14-13-16-18.bpo-45195.EyQR1G.rst
@@ -1,0 +1,3 @@
+Fix test_readline.test_nonascii(): sometimes, the newline character is not
+written at the end, so don't expect it in the output. Patch by Victor
+Stinner.


### PR DESCRIPTION
Fix test_readline.test_nonascii(): sometimes, the newline character
is not written at the end, so don't expect it in the output.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45195](https://bugs.python.org/issue45195) -->
https://bugs.python.org/issue45195
<!-- /issue-number -->
