### PR TITLE
bpo-45196 ./configure --with-address-sanitizer; make test; cause test case crash.

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -43,6 +43,17 @@ from test.support import warnings_helper
 import random
 import inspect
 import threading
+import sysconfig
+_cflags = sysconfig.get_config_var('CFLAGS') or ''
+_config_args = sysconfig.get_config_var('CONFIG_ARGS') or ''
+MEMORY_SANITIZER = (
+    '-fsanitize=memory' in _cflags or
+    '--with-memory-sanitizer' in _config_args
+)
+
+ADDRESS_SANITIZER = (
+    '-fsanitize=address' in _cflags
+)
 
 
 if sys.platform == 'darwin':
@@ -5500,6 +5511,8 @@ class CWhitebox(unittest.TestCase):
     # Issue 41540:
     @unittest.skipIf(sys.platform.startswith("aix"),
                      "AIX: default ulimit: test is flaky because of extreme over-allocation")
+    @unittest.skipIf(MEMORY_SANITIZER or ADDRESS_SANITIZER, "sanitizer defaults to crashing "
+                     "instead of returning NULL for malloc failure.")
     def test_maxcontext_exact_arith(self):
 
         # Make sure that exact operations do not raise MemoryError due

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -73,6 +73,10 @@ MEMORY_SANITIZER = (
     '--with-memory-sanitizer' in _config_args
 )
 
+ADDRESS_SANITIZER = (
+    '-fsanitize=address' in _cflags
+)
+
 # Does io.IOBase finalizer log the exception if the close() method fails?
 # The exception is ignored silently by default in release build.
 IOBASE_EMITS_UNRAISABLE = (hasattr(sys, "gettotalrefcount") or sys.flags.dev_mode)
@@ -1546,7 +1550,7 @@ class BufferedReaderTest(unittest.TestCase, CommonBufferedTests):
 class CBufferedReaderTest(BufferedReaderTest, SizeofTest):
     tp = io.BufferedReader
 
-    @unittest.skipIf(MEMORY_SANITIZER, "MSan defaults to crashing "
+    @unittest.skipIf(MEMORY_SANITIZER or ADDRESS_SANITIZER, "sanitizer defaults to crashing "
                      "instead of returning NULL for malloc failure.")
     def test_constructor(self):
         BufferedReaderTest.test_constructor(self)
@@ -1911,7 +1915,7 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
 class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
     tp = io.BufferedWriter
 
-    @unittest.skipIf(MEMORY_SANITIZER, "MSan defaults to crashing "
+    @unittest.skipIf(MEMORY_SANITIZER or ADDRESS_SANITIZER, "sanitizer defaults to crashing "
                      "instead of returning NULL for malloc failure.")
     def test_constructor(self):
         BufferedWriterTest.test_constructor(self)
@@ -2410,7 +2414,7 @@ class BufferedRandomTest(BufferedReaderTest, BufferedWriterTest):
 class CBufferedRandomTest(BufferedRandomTest, SizeofTest):
     tp = io.BufferedRandom
 
-    @unittest.skipIf(MEMORY_SANITIZER, "MSan defaults to crashing "
+    @unittest.skipIf(MEMORY_SANITIZER or ADDRESS_SANITIZER, "sanitizer defaults to crashing "
                      "instead of returning NULL for malloc failure.")
     def test_constructor(self):
         BufferedRandomTest.test_constructor(self)


### PR DESCRIPTION
test_io.py
```
=================================================================
==54932==ERROR: AddressSanitizer: requested allocation size 0x7fffffffffffffff (0x8000000000001000 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000 (thread T0)
  #0 0x102f1fa6c in wrap_malloc+0x94 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3fa6c)
  #1 0x102565fcc in _buffered_init bufferedio.c:730
  #2 0x10255bba4 in _io_BufferedReader___init__ bufferedio.c.h:435
  #3 0x10226c8c8 in wrap_init typeobject.c:6941
  #4 0x10216d3f8 in _PyObject_Call call.c:305
  #5 0x102387a6c in _PyEval_EvalFrameDefault ceval.c:4285
  #6 0x10237eaa8 in _PyEval_Vector ceval.c:5073
  #7 0x102396860 in call_function ceval.c:5888
  #8 0x102385444 in _PyEval_EvalFrameDefault ceval.c:4206
  #9 0x10237eaa8 in _PyEval_Vector ceval.c:5073
  #10 0x102396860 in call_function ceval.c:5888
  #11 0x102385444 in _PyEval_EvalFrameDefault ceval.c:4206
  #12 0x10237eaa8 in _PyEval_Vector ceval.c:5073
  #13 0x102172bec in method_vectorcall classobject.c:53
  #14 0x102396860 in call_function ceval.c:5888
  #15 0x1023885e4 in _PyEval_EvalFrameDefault ceval.c:4221
  #16 0x10237eaa8 in _PyEval_Vector ceval.c:5073
  #17 0x102396860 in call_function ceval.c:5888
  #18 0x102385444 in _PyEval_EvalFrameDefault ceval.c:4206
  #19 0x10237eaa8 in _PyEval_Vector ceval.c:5073
  #20 0x102172af4 in method_vectorcall classobject.c:83
  #21 0x10216d0a8 in PyVectorcall_Call call.c:255
  #22 0x102387a6c in _PyEval_EvalFrameDefault ceval.c:4285
  #23 0x10237eaa8 in _PyEval_Vector ceval.c:5073
  #24 0x10216c248 in _PyObject_FastCallDictTstate call.c:142
  #25 0x10216dc00 in _PyObject_Call_Prepend call.c:431
  #26 0x102268740 in slot_tp_call typeobject.c:7481
  #27 0x10216c5d4 in _PyObject_MakeTpCall call.c:215
  #28 0x102396b88 in call_function ceval.c
  #29 0x1023885e4 in _PyEval_EvalFrameDefault ceval.c:4221

==54932==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: AddressSanitizer: allocation-size-too-big (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3fa6c) in wrap_malloc+0x94
==54932==ABORTING
Fatal Python error: Aborted

Current thread 0x0000000102e93d40 (most recent call first):
 File "/Users/xiejunyi/github-cpython/Lib/unittest/case.py", line 201 in handle
 File "/Users/xiejunyi/github-cpython/Lib/unittest/case.py", line 730 in assertRaises
 File "/Users/xiejunyi/github-cpython/Lib/test/test_io.py", line 1558 in test_constructor
 File "/Users/xiejunyi/github-cpython/Lib/unittest/case.py", line 549 in _callTestMethod
 File "/Users/xiejunyi/github-cpython/Lib/unittest/case.py", line 591 in run
 File "/Users/xiejunyi/github-cpython/Lib/unittest/case.py", line 650 in __call__
 File "/Users/xiejunyi/github-cpython/Lib/unittest/suite.py", line 122 in run
 File "/Users/xiejunyi/github-cpython/Lib/unittest/suite.py", line 84 in __call__
 File "/Users/xiejunyi/github-cpython/Lib/unittest/suite.py", line 122 in run
 File "/Users/xiejunyi/github-cpython/Lib/unittest/suite.py", line 84 in __call__
 File "/Users/xiejunyi/github-cpython/Lib/unittest/suite.py", line 122 in run
 File "/Users/xiejunyi/github-cpython/Lib/unittest/suite.py", line 84 in __call__
 File "/Users/xiejunyi/github-cpython/Lib/test/support/testresult.py", line 140 in run
 File "/Users/xiejunyi/github-cpython/Lib/test/support/__init__.py", line 990 in _run_suite
 File "/Users/xiejunyi/github-cpython/Lib/test/support/__init__.py", line 1115 in run_unittest
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/runtest.py", line 261 in _test_module
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/runtest.py", line 297 in _runtest_inner2
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/runtest.py", line 335 in _runtest_inner
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/runtest.py", line 215 in _runtest
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/runtest.py", line 245 in runtest
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/runtest_mp.py", line 83 in run_tests_worker
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/main.py", line 678 in _main
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/main.py", line 658 in main
 File "/Users/xiejunyi/github-cpython/Lib/test/libregrtest/main.py", line 736 in main
 File "/Users/xiejunyi/github-cpython/Lib/test/regrtest.py", line 43 in _main
 File "/Users/xiejunyi/github-cpython/Lib/test/regrtest.py", line 47 in <module>
 File "/Users/xiejunyi/github-cpython/Lib/runpy.py", line 86 in _run_code
 File "/Users/xiejunyi/github-cpython/Lib/runpy.py", line 196 in _run_module_as_main
```

test_decimal.py
```
0:05:09 load avg: 159.57 [287/427/30] test_decimal crashed (Exit code -6) -- running: test_pickle (1 min 35 sec), test_tokenize (3 min 14 sec), test_unparse (4 min 32 sec), test_peg_generator (48.6 sec), test_subprocess (1 min 50 sec), test_faulthandler (36.0 sec), test_capi (3 min 3 sec), test_pdb (2 min 27 sec)
```

<!-- issue-number: [bpo-45196](https://bugs.python.org/issue45196) -->
https://bugs.python.org/issue45196
<!-- /issue-number -->
