### PR TITLE
bpo-4356: Mention the new key arguments for the bisect module APIs in the 3.10 What's new

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -932,6 +932,12 @@ bdb
 Add :meth:`~bdb.Breakpoint.clearBreakpoints` to reset all set breakpoints.
 (Contributed by Irit Katriel in :issue:`24160`.)
 
+bisect
+------
+
+Added the possibility of providing a *key* function to the APIs in the :mod:`bisect`
+module. (Contributed by Raymond Hettinger in :issue:`4356`.)
+
 codecs
 ------
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-4356](https://bugs.python.org/issue4356) -->
https://bugs.python.org/issue4356
<!-- /issue-number -->
