### PR TITLE
bpo-45193: Restore IDLE completion boxes on Ubuntu

### DIFF
--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -206,7 +206,7 @@ class AutoCompleteWindow:
         scrollbar.config(command=listbox.yview)
         scrollbar.pack(side=RIGHT, fill=Y)
         listbox.pack(side=LEFT, fill=BOTH, expand=True)
-        acw.update_idletasks() # Need for tk8.6.8 on macOS: #40128.
+        #acw.update_idletasks() # Need for tk8.6.8 on macOS: #40128.
         acw.lift()  # work around bug in Tk 8.5.18+ (issue #24570)
 
         # Initialize the listbox selection


### PR DESCRIPTION
The line that should not have been needed on macOS tk 8.6.8 but was,
should not be a problem on Ubuntu, but is.  It is not needed on macOS
tk 8.6.11, installed with 3.10.  Disable it but leave it for
now in case some system needs it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45193](https://bugs.python.org/issue45193) -->
https://bugs.python.org/issue45193
<!-- /issue-number -->
