### PR TITLE
bpo-45205: Make test_compileall quiet

### DIFF
--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -91,7 +91,8 @@ class CompileallTestsBase:
             os.utime(self.source_path, (2**32 - 1, 2**32 - 1))
         except (OverflowError, OSError):
             self.skipTest("filesystem doesn't support timestamps near 2**32")
-        self.assertTrue(compileall.compile_file(self.source_path))
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(compileall.compile_file(self.source_path))
 
     def test_larger_than_32_bit_times(self):
         # This is similar to the test above but we skip it if the OS doesn't
@@ -100,7 +101,8 @@ class CompileallTestsBase:
             os.utime(self.source_path, (2**35, 2**35))
         except (OverflowError, OSError):
             self.skipTest("filesystem doesn't support large timestamps")
-        self.assertTrue(compileall.compile_file(self.source_path))
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(compileall.compile_file(self.source_path))
 
     def recreation_check(self, metadata):
         """Check that compileall recreates bytecode when the new metadata is


### PR DESCRIPTION
Make test_compileall quiet: test_year_2038_mtime_compilation() and
test_larger_than_32_bit_times() of test_compileall no longer log
"Compiling ..." messages to stdout.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45205](https://bugs.python.org/issue45205) -->
https://bugs.python.org/issue45205
<!-- /issue-number -->
