### PR TITLE
bpo-45204: Reduce verbosity of test_peg_generator

### DIFF
--- a/Lib/test/test_peg_generator/test_pegen.py
+++ b/Lib/test/test_peg_generator/test_pegen.py
@@ -797,25 +797,25 @@ class TestPegen(unittest.TestCase):
             | SOFT_KEYWORD l=NAME n=(NUMBER | NAME | STRING) { f"{l.string} = {n.string}"}
         """
         parser_class = make_parser(grammar)
-        self.assertEqual(parse_string("number 1", parser_class, verbose=True), 1)
-        self.assertEqual(parse_string("string 'b'", parser_class, verbose=True), "'b'")
+        self.assertEqual(parse_string("number 1", parser_class), 1)
+        self.assertEqual(parse_string("string 'b'", parser_class), "'b'")
         self.assertEqual(
-            parse_string("number test 1", parser_class, verbose=True), "test = 1"
+            parse_string("number test 1", parser_class), "test = 1"
         )
         assert (
-            parse_string("string test 'b'", parser_class, verbose=True) == "test = 'b'"
+            parse_string("string test 'b'", parser_class) == "test = 'b'"
         )
         with self.assertRaises(SyntaxError):
-            parse_string("test 1", parser_class, verbose=True)
+            parse_string("test 1", parser_class)
 
     def test_forced(self) -> None:
         grammar = """
         start: NAME &&':' | NAME
         """
         parser_class = make_parser(grammar)
-        self.assertTrue(parse_string("number :", parser_class, verbose=True))
+        self.assertTrue(parse_string("number :", parser_class))
         with self.assertRaises(SyntaxError) as e:
-            parse_string("a", parser_class, verbose=True)
+            parse_string("a", parser_class)
 
         self.assertIn("expected ':'", str(e.exception))
 
@@ -824,10 +824,10 @@ class TestPegen(unittest.TestCase):
         start: NAME &&(':' | ';') | NAME
         """
         parser_class = make_parser(grammar)
-        self.assertTrue(parse_string("number :", parser_class, verbose=True))
-        self.assertTrue(parse_string("number ;", parser_class, verbose=True))
+        self.assertTrue(parse_string("number :", parser_class))
+        self.assertTrue(parse_string("number ;", parser_class))
         with self.assertRaises(SyntaxError) as e:
-            parse_string("a", parser_class, verbose=True)
+            parse_string("a", parser_class)
         self.assertIn("expected (':' | ';')", e.exception.args[0])
 
     def test_unreachable_explicit(self) -> None:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45204](https://bugs.python.org/issue45204) -->
https://bugs.python.org/issue45204
<!-- /issue-number -->
