### PR TITLE
bpo-45209: fix `UserWarning: resource_tracker` in test_multiprocessing

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4177,14 +4177,14 @@ class _TestSharedMemory(BaseTestCase):
                 raise AssertionError("A SharedMemory segment was leaked after"
                                      " a process was abruptly terminated.")
 
-            # Without this line it was raising warnings like:
-            #   UserWarning: resource_tracker:
-            #   There appear to be 1 leaked shared_memory
-            #   objects to clean up at shutdown
-            # See: https://bugs.python.org/issue45209
-            resource_tracker.unregister(f"/{name}", "shared_memory")
-
             if os.name == 'posix':
+                # Without this line it was raising warnings like:
+                #   UserWarning: resource_tracker:
+                #   There appear to be 1 leaked shared_memory
+                #   objects to clean up at shutdown
+                # See: https://bugs.python.org/issue45209
+                resource_tracker.unregister(f"/{name}", "shared_memory")
+
                 # A warning was emitted by the subprocess' own
                 # resource_tracker (on Windows, shared memory segments
                 # are released automatically by the OS).

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4177,6 +4177,13 @@ class _TestSharedMemory(BaseTestCase):
                 raise AssertionError("A SharedMemory segment was leaked after"
                                      " a process was abruptly terminated.")
 
+            # Without this line it was raising warnings like:
+            #   UserWarning: resource_tracker:
+            #   There appear to be 1 leaked shared_memory
+            #   objects to clean up at shutdown
+            # See: https://bugs.python.org/issue45209
+            resource_tracker.unregister(f"/{name}", "shared_memory")
+
             if os.name == 'posix':
                 # A warning was emitted by the subprocess' own
                 # resource_tracker (on Windows, shared memory segments

--- a/Misc/NEWS.d/next/Tests/2021-09-15-23-32-39.bpo-45209.55ntL5.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-15-23-32-39.bpo-45209.55ntL5.rst
@@ -1,2 +1,2 @@
-Fixes ``UserWarning: resource_tracker`` warning in
+Fix ``UserWarning: resource_tracker`` warning in
 ``test_shared_memory_cleaned_after_process_termination``

--- a/Misc/NEWS.d/next/Tests/2021-09-15-23-32-39.bpo-45209.55ntL5.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-15-23-32-39.bpo-45209.55ntL5.rst
@@ -1,2 +1,2 @@
 Fix ``UserWarning: resource_tracker`` warning in
-``test_shared_memory_cleaned_after_process_termination``
+``_test_multiprocessing._TestSharedMemory.test_shared_memory_cleaned_after_process_termination``

--- a/Misc/NEWS.d/next/Tests/2021-09-15-23-32-39.bpo-45209.55ntL5.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-15-23-32-39.bpo-45209.55ntL5.rst
@@ -1,0 +1,2 @@
+Fixes ``UserWarning: resource_tracker`` warning in
+``test_shared_memory_cleaned_after_process_termination``


### PR DESCRIPTION

<!-- issue-number: [bpo-45209](https://bugs.python.org/issue45209) -->
https://bugs.python.org/issue45209
<!-- /issue-number -->

<img width="752" alt="Снимок экрана 2021-09-15 в 23 40 49" src="https://user-images.githubusercontent.com/4660275/133506360-7ae75b6f-5bcf-4fc3-8f1d-b1ae1b97ef83.png">
