### PR TITLE
bpo-45215: In Mock class, deprecate invalid name parent args and expand docs

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -288,8 +288,8 @@ the *new_callable* argument to :func:`patch`.
       :meth:`configure_mock`.
 
     * *parent*: Make current mock a child of *parent*, which should be a
-      :class:`Mock` or :class:`MagicMock` instance. To set the *name* attribute
-      to an arbitrary value, use :meth:`configure_mock`.
+      :class:`Mock` or :class:`MagicMock` instance. To set the *parent*
+      attribute to an arbitrary value, use :meth:`configure_mock`.
 
 
     Mocks can also be called with arbitrary keyword arguments. These will be

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -282,10 +282,15 @@ the *new_callable* argument to :func:`patch`.
 
     * *name*: If the mock has a name then it will be used in the repr of the
       mock. This can be useful for debugging. The name is propagated to child
-      mocks. This argument should be a string.
+      mocks. This argument should be a string. Note that the mock's attribute
+      *name* created on the current Mock is an instance of :class:`Mock`. To
+      set the *name* attribute to an arbitrary value, use
+      :meth:`configure_mock`.
 
     * *parent*: Make current mock a child of *parent*, which should be a
-      :class:`Mock` or :class:`MagicMock` instance.
+      :class:`Mock` or :class:`MagicMock` instance. To set the *name* attribute
+      to an arbitrary value, use :meth:`configure_mock`.
+
 
     Mocks can also be called with arbitrary keyword arguments. These will be
     used to set attributes on the mock after it is created. See the

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -225,7 +225,8 @@ a :class:`MagicMock` for you. You can specify an alternative class of :class:`Mo
 the *new_callable* argument to :func:`patch`.
 
 
-.. class:: Mock(spec=None, side_effect=None, return_value=DEFAULT, wraps=None, name=None, spec_set=None, unsafe=False, **kwargs)
+.. class:: Mock(spec=None, side_effect=None, return_value=DEFAULT, wraps=None,
+   name=None, spec_set=None, unsafe=False, parent=None, **kwargs)
 
     Create a new :class:`Mock` object. :class:`Mock` takes several optional arguments
     that specify the behaviour of the Mock object:
@@ -281,7 +282,10 @@ the *new_callable* argument to :func:`patch`.
 
     * *name*: If the mock has a name then it will be used in the repr of the
       mock. This can be useful for debugging. The name is propagated to child
-      mocks.
+      mocks. This argument should be a string.
+
+    * *parent*: Make current mock a child of *parent*, which should be a
+      :class:`Mock` or :class:`MagicMock` instance.
 
     Mocks can also be called with arbitrary keyword arguments. These will be
     used to set attributes on the mock after it is created. See the

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -489,3 +489,7 @@ Removed
 * The behavior of returning a value from a :class:`~unittest.TestCase` and
   :class:`~unittest.IsolatedAsyncioTestCase` test methods (other than the default ``None``
   value), is now deprecated.
+
+* In :meth:`~unittest.mock.Mock.__init__` and :meth:`~unittest.mock.MagicMock.__init__`,
+  the behavior of accepting arbitrary types of objects as *name* and *parent* args is
+  deprecated -- only valid object types will be accepted; see :class:`~unittest.mock.Mock`.

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -423,6 +423,24 @@ class NonCallableMock(Base):
             parent=None, _spec_state=None, _new_name='', _new_parent=None,
             _spec_as_instance=False, _eat_self=None, unsafe=False, **kwargs
         ):
+        if parent is not None and not isinstance(parent, NonCallableMock):
+            import warnings
+            if isinstance(self, MagicMock):
+                stacklevel = 4
+            else:
+                stacklevel = 3
+            warnings.warn('parents argument should be a Mock instance',
+                          DeprecationWarning, stacklevel=stacklevel)
+
+        if name is not None and not isinstance(name, str):
+            import warnings
+            if isinstance(self, MagicMock):
+                stacklevel = 4
+            else:
+                stacklevel = 3
+            warnings.warn('name argument should be a string',
+                          DeprecationWarning, stacklevel=stacklevel)
+
         if _new_parent is None:
             _new_parent = parent
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1253,6 +1253,8 @@ class Mock(CallableMixin, NonCallableMock):
       mock. This can be useful for debugging. The name is propagated to child
       mocks.
 
+    * `parent`: the mock will be set as the child of the `parent` mock object.
+
     Mocks can also be called with arbitrary keyword arguments. These will be
     used to set attributes on the mock after it is created.
     """

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -425,19 +425,31 @@ class NonCallableMock(Base):
         ):
         if parent is not None and not isinstance(parent, NonCallableMock):
             import warnings
-            if isinstance(self, MagicMock):
-                stacklevel = 4
-            else:
+            if isinstance(self, NonCallableMagicMock):
                 stacklevel = 3
-            warnings.warn('parents argument should be a Mock instance',
+            elif isinstance(self, MagicMock):
+                stacklevel = 4
+            elif isinstance(self, Mock):
+                stacklevel = 3
+            elif isinstance(self, NonCallableMock):
+                stacklevel = 2
+            else:
+                stacklevel = 1
+            warnings.warn('parent argument should be a Mock instance',
                           DeprecationWarning, stacklevel=stacklevel)
 
         if name is not None and not isinstance(name, str):
             import warnings
-            if isinstance(self, MagicMock):
-                stacklevel = 4
-            else:
+            if isinstance(self, NonCallableMagicMock):
                 stacklevel = 3
+            elif isinstance(self, MagicMock):
+                stacklevel = 4
+            elif isinstance(self, Mock):
+                stacklevel = 3
+            elif isinstance(self, NonCallableMock):
+                stacklevel = 2
+            else:
+                stacklevel = 1
             warnings.warn('name argument should be a string',
                           DeprecationWarning, stacklevel=stacklevel)
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -83,6 +83,17 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock._mock_children, {},
                          "children not initialised incorrectly")
 
+        msg = 'should be a string'
+        with self.assertWarnsRegex(DeprecationWarning, msg) as w:
+            Mock(name=1)
+        with self.assertWarnsRegex(DeprecationWarning, msg) as w:
+            MagicMock(name=1)
+        msg = 'should be a Mock instance'
+        with self.assertWarnsRegex(DeprecationWarning, msg) as w:
+            Mock(parent='foo')
+        with self.assertWarnsRegex(DeprecationWarning, msg) as w:
+            MagicMock(parent='foo')
+
 
     def test_return_value_in_constructor(self):
         mock = Mock(return_value=None)

--- a/Misc/NEWS.d/next/Library/2021-09-15-22-22-30.bpo-45215.DRE_pS.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-15-22-22-30.bpo-45215.DRE_pS.rst
@@ -1,0 +1,2 @@
+Expanded docs for :class:`~unittest.mock.Mock` *name* and *parent* arguments
+and deprecated passing of invalid object types for these arguments.


### PR DESCRIPTION


<!-- issue-number: [bpo-45215](https://bugs.python.org/issue45215) -->
https://bugs.python.org/issue45215
<!-- /issue-number -->
