### PR TITLE
bpo-45128: fixes `test_multiprocessing_fork` mysterious crash

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4432,12 +4432,17 @@ class LogRecordTest(BaseTest):
     def _extract_logrecord_process_name(key, logMultiprocessing, conn=None):
         prev_logMultiprocessing = logging.logMultiprocessing
         logging.logMultiprocessing = logMultiprocessing
+        old_mp = None
         try:
             import multiprocessing as mp
             name = mp.current_process().name
 
             r1 = logging.makeLogRecord({'msg': f'msg1_{key}'})
+
+            old_mp = sys.modules['multiprocessing']
             del sys.modules['multiprocessing']
+            assert old_mp
+
             r2 = logging.makeLogRecord({'msg': f'msg2_{key}'})
 
             results = {'processName'  : name,
@@ -4446,6 +4451,10 @@ class LogRecordTest(BaseTest):
                       }
         finally:
             logging.logMultiprocessing = prev_logMultiprocessing
+            if old_mp is not None:
+                # We need to restore the previous `multiprocessing` module:
+                # https://bugs.python.org/issue45128
+                sys.modules['multiprocessing'] = old_mp
         if conn:
             conn.send(results)
         else:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4438,9 +4438,8 @@ class LogRecordTest(BaseTest):
 
             r1 = logging.makeLogRecord({'msg': f'msg1_{key}'})
 
+            # https://bugs.python.org/issue45128
             with support.swap_item(sys.modules, 'multiprocessing', None):
-                # We need to restore the previous `multiprocessing` module:
-                # https://bugs.python.org/issue45128
                 r2 = logging.makeLogRecord({'msg': f'msg2_{key}'})
 
             results = {'processName'  : name,
@@ -4454,7 +4453,7 @@ class LogRecordTest(BaseTest):
         else:
             return results
 
-    def test_multiprocessing(self, first_pass=True):
+    def test_multiprocessing(self):
         multiprocessing_imported = 'multiprocessing' in sys.modules
         try:
             # logMultiprocessing is True by default
@@ -4489,16 +4488,6 @@ class LogRecordTest(BaseTest):
         finally:
             if multiprocessing_imported:
                 import multiprocessing
-
-        if first_pass:  # https://bugs.python.org/issue45128
-            import multiprocessing.queues
-
-            self.test_multiprocessing(first_pass=False)
-
-            import multiprocessing
-            import multiprocessing.connection
-            from multiprocessing.connection import wait
-            multiprocessing.connection   # It was AttributeError here
 
     def test_optional(self):
         r = logging.makeLogRecord({})

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4506,7 +4506,7 @@ class LogRecordTest(BaseTest):
         import multiprocessing
         import multiprocessing.connection
         from multiprocessing.connection import wait
-        connection = multiprocessing.connection   # It was AttributeError here
+        multiprocessing.connection   # It was AttributeError here
 
     def test_optional(self):
         r = logging.makeLogRecord({})

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4496,6 +4496,17 @@ class LogRecordTest(BaseTest):
             if multiprocessing_imported:
                 import multiprocessing
 
+    def test_multiprocessing_again(self):
+        # https://bugs.python.org/issue45128
+        import sys
+        import multiprocessing.queues
+
+        self.test_multiprocessing()
+
+        import multiprocessing
+        import multiprocessing.connection
+        from multiprocessing.connection import wait
+        connection = multiprocessing.connection   # It was AttributeError here
 
     def test_optional(self):
         r = logging.makeLogRecord({})

--- a/Misc/NEWS.d/next/Tests/2021-09-16-17-22-35.bpo-45128.Jz6fl2.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-16-17-22-35.bpo-45128.Jz6fl2.rst
@@ -1,2 +1,2 @@
-Fix crash ``test_multiprocessing_fork`` due to ``test_logging`` and
+Fix ``test_multiprocessing_fork`` failure due to ``test_logging`` and
 ``sys.modules`` manipulation.

--- a/Misc/NEWS.d/next/Tests/2021-09-16-17-22-35.bpo-45128.Jz6fl2.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-16-17-22-35.bpo-45128.Jz6fl2.rst
@@ -1,0 +1,2 @@
+Fix crash ``test_multiprocessing_fork`` due to ``LogRecordTest`` and
+``sys.modules`` manipulation.

--- a/Misc/NEWS.d/next/Tests/2021-09-16-17-22-35.bpo-45128.Jz6fl2.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-16-17-22-35.bpo-45128.Jz6fl2.rst
@@ -1,2 +1,2 @@
-Fix crash ``test_multiprocessing_fork`` due to ``LogRecordTest`` and
+Fix crash ``test_multiprocessing_fork`` due to ``test_logging`` and
 ``sys.modules`` manipulation.


### PR DESCRIPTION
Several thoughts on this:
1. Thanks a lot for @vstinner and @pablogsal for providing extra information about this crash
2. I feel obligated to fix this due to https://github.com/python/cpython/pull/28182#issuecomment-914293274
3. This is not a trivial test flow, I hope that I got it right, but very careful review is required (we cannot even catch this in CI, what was the initial problem)
4. I hope, that this won't happen again! 👍

<!-- issue-number: [bpo-45128](https://bugs.python.org/issue45128) -->
https://bugs.python.org/issue45128
<!-- /issue-number -->
