### PR TITLE
gh-89386: Lib/pty.py: handle stdin I/O errors same way as master I/O errors

### DIFF
--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -154,7 +154,10 @@ def _copy(master_fd, master_read=_read, stdin_read=_read):
                 os.write(STDOUT_FILENO, data)
 
         if STDIN_FILENO in rfds:
-            data = stdin_read(STDIN_FILENO)
+            try:
+                data = stdin_read(STDIN_FILENO)
+            except OSError:
+                data = b""
             if not data:
                 fds.remove(STDIN_FILENO)
             else:

--- a/Misc/NEWS.d/next/Library/2022-12-07-08-35-38.gh-issue-45223.PET2I5.rst
+++ b/Misc/NEWS.d/next/Library/2022-12-07-08-35-38.gh-issue-45223.PET2I5.rst
@@ -1,0 +1,1 @@
+Lib/pty.py: handle stdin I/O errors same way as master I/O error


### PR DESCRIPTION
reading stdin can throw the same I/O errors as reading from master fd does,
e.g. when running under Yocto's test harness:
======================================================================
ERROR: test_spawn_doesnt_hang (test.test_pty.PtyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.10/test/test_pty.py", line 316, in test_spawn_doesnt_hang
    pty.spawn([sys.executable, '-c', 'print("hi there")'])
  File "/usr/lib/python3.10/pty.py", line 181, in spawn
    _copy(master_fd, master_read, stdin_read)
  File "/usr/lib/python3.10/pty.py", line 157, in _copy
    data = stdin_read(STDIN_FILENO)
  File "/usr/lib/python3.10/pty.py", line 132, in _read
    return os.read(fd, 1024)
OSError: [Errno 5] Input/output error

So let's treat both channels the same.


Signed-off-by: Alexander Kanavin <alex@linutronix.de>


<!-- issue-number: [bpo-45223](https://bugs.python.org/issue45223) -->
https://bugs.python.org/issue45223
<!-- /issue-number -->

<!-- gh-issue-number: gh-89386 -->
* Issue: gh-89386
<!-- /gh-issue-number -->
