### PR TITLE
bpo-45116: Add the Py_ALWAYS_INLINE macro

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -124,9 +124,7 @@ complete listing.
    worse performances (due to increased code size for example). The compiler is
    usually smarter than the developer for the cost/benefit analysis.
 
-   It must be specified before the function return type.
-
-   Usage::
+   It must be specified before the function return type. Usage::
 
        static inline Py_ALWAYS_INLINE int random(void) { return 4; }
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -111,6 +111,28 @@ complete listing.
 
    .. versionadded:: 3.3
 
+.. c:macro:: Py_ALWAYS_INLINE
+
+   Ask the compiler to always inline a static inline function. The compiler can
+   ignore it and decides to not inline the function.
+
+   This attribute can be used to avoid increasing the stack memory usage when
+   building Python in debug mode with function inlining disabled. For example,
+   MSC disables function inlining when building in debug mode. It should be
+   used on the most commonly used static inline functions.
+
+   Marking blindly a static inline function with Py_ALWAYS_INLINE can result in
+   worse performances (due to increased code size for example). The compiler is
+   usually smarter than the developer for the cost/benefit analysis.
+
+   It must be specified before the function return type.
+
+   Usage::
+
+       static inline Py_ALWAYS_INLINE int random(void) { return 4; }
+
+   .. versionadded:: 3.11
+
 .. c:macro:: Py_CHARMASK(c)
 
    Argument must be a character or an integer in the range [-128, 127] or [0,

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -116,10 +116,9 @@ complete listing.
    Ask the compiler to always inline a static inline function. The compiler can
    ignore it and decides to not inline the function.
 
-   This attribute can be used to avoid increasing the stack memory usage when
+   It can be used to inline performance critical static inline functions when
    building Python in debug mode with function inlining disabled. For example,
-   MSC disables function inlining when building in debug mode. It should be
-   used on the most commonly used static inline functions.
+   MSC disables function inlining when building in debug mode.
 
    Marking blindly a static inline function with Py_ALWAYS_INLINE can result in
    worse performances (due to increased code size for example). The compiler is

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -568,9 +568,7 @@ extern "C" {
 // worse performances (due to increased code size for example). The compiler is
 // usually smarter than the developer for the cost/benefit analysis.
 //
-// It must be specified before the function return type.
-//
-// Usage:
+// It must be specified before the function return type. Usage:
 //
 //     static inline Py_ALWAYS_INLINE int random(void) { return 4; }
 #if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -557,6 +557,31 @@ extern "C" {
 #define _Py_HOT_FUNCTION
 #endif
 
+// Ask the compiler to always inline a static inline function. The compiler can
+// ignore it and decides to not inline the function.
+//
+// This attribute can be used to avoid increasing the stack memory usage when
+// building Python in debug mode with function inlining disabled. For example,
+// MSC disables function inlining when building in debug mode. It should be
+// used on the most commonly used static inline functions.
+//
+// Marking blindly a static inline function with Py_ALWAYS_INLINE can result in
+// worse performances (due to increased code size for example). The compiler is
+// usually smarter than the developer for the cost/benefit analysis.
+//
+// It must be specified before the function return type.
+//
+// Usage:
+//
+//     static inline Py_ALWAYS_INLINE int random(void) { return 4; }
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#  define Py_ALWAYS_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#  define Py_ALWAYS_INLINE __forceinline
+#else
+#  define Py_ALWAYS_INLINE
+#endif
+
 // Py_NO_INLINE
 // Disable inlining on a function. For example, it reduces the C stack
 // consumption: useful on LTO+PGO builds which heavily inline code (see

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -560,10 +560,9 @@ extern "C" {
 // Ask the compiler to always inline a static inline function. The compiler can
 // ignore it and decides to not inline the function.
 //
-// This attribute can be used to avoid increasing the stack memory usage when
+// It can be used to inline performance critical static inline functions when
 // building Python in debug mode with function inlining disabled. For example,
-// MSC disables function inlining when building in debug mode. It should be
-// used on the most commonly used static inline functions.
+// MSC disables function inlining when building in debug mode.
 //
 // Marking blindly a static inline function with Py_ALWAYS_INLINE can result in
 // worse performances (due to increased code size for example). The compiler is

--- a/Misc/NEWS.d/next/C API/2021-09-16-18-05-20.bpo-45116.WxXewl.rst
+++ b/Misc/NEWS.d/next/C API/2021-09-16-18-05-20.bpo-45116.WxXewl.rst
@@ -1,0 +1,3 @@
+Add the :c:macro:`Py_ALWAYS_INLINE` macro to ask the compiler to always
+inline a static inline function. The compiler can ignore it and decides to
+not inline the function. Patch by Victor Stinner.


### PR DESCRIPTION
Add the Py_ALWAYS_INLINE macro to ask the compiler to always inline a
static inline function. The compiler can ignore it and decides to not
inline the function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45116](https://bugs.python.org/issue45116) -->
https://bugs.python.org/issue45116
<!-- /issue-number -->
