### PR TITLE
bpo-45217: adds note that `allow_no_value` in `configparser` is optional

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -261,7 +261,8 @@ A configuration file consists of sections, each led by a ``[section]`` header,
 followed by key/value entries separated by a specific string (``=`` or ``:`` by
 default [1]_).  By default, section names are case sensitive but keys are not
 [1]_.  Leading and trailing whitespace is removed from keys and values.
-Values can be omitted, in which case the key/value delimiter may also be left
+Values optionally [1]_ can be omitted,
+in which case the key/value delimiter may also be left
 out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
 may be treated as parts of multiline values or ignored.

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -261,7 +261,7 @@ A configuration file consists of sections, each led by a ``[section]`` header,
 followed by key/value entries separated by a specific string (``=`` or ``:`` by
 default [1]_).  By default, section names are case sensitive but keys are not
 [1]_.  Leading and trailing whitespace is removed from keys and values.
-Values optionally [1]_ can be omitted,
+Values can be omitted if the parser is configured to allow it [1]_,
 in which case the key/value delimiter may also be left
 out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines


### PR DESCRIPTION
I guess it is appropriate to skip news for this change.

<!-- issue-number: [bpo-45217](https://bugs.python.org/issue45217) -->
https://bugs.python.org/issue45217
<!-- /issue-number -->
