### PR TITLE
bpo-45228: Fix stack buffer overflow in parsing J1939 address

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-09-17-09-59-33.bpo-45228.WV1dcT.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-17-09-59-33.bpo-45228.WV1dcT.rst
@@ -1,0 +1,1 @@
+Fix stack buffer overflow in parsing J1939 network address.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1513,10 +1513,10 @@ makesockaddr(SOCKET_T sockfd, struct sockaddr *addr, size_t addrlen, int proto)
 #ifdef CAN_J1939
           case CAN_J1939:
           {
-              return Py_BuildValue("O&KkB", PyUnicode_DecodeFSDefault,
+              return Py_BuildValue("O&KIB", PyUnicode_DecodeFSDefault,
                                           ifname,
-                                          a->can_addr.j1939.name,
-                                          a->can_addr.j1939.pgn,
+                                          (unsigned long long)a->can_addr.j1939.name,
+                                          (unsigned int)a->can_addr.j1939.pgn,
                                           a->can_addr.j1939.addr);
           }
 #endif /* CAN_J1939 */
@@ -2207,13 +2207,13 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             PyObject *interfaceName;
             struct ifreq ifr;
             Py_ssize_t len;
-            uint64_t j1939_name;
-            uint32_t j1939_pgn;
+            unsigned long long j1939_name; /* at least 64 bits */
+            unsigned int j1939_pgn; /* at least 32 bits */
             uint8_t j1939_addr;
 
             struct sockaddr_can *addr = &addrbuf->can;
 
-            if (!PyArg_ParseTuple(args, "O&KkB", PyUnicode_FSConverter,
+            if (!PyArg_ParseTuple(args, "O&KIB", PyUnicode_FSConverter,
                                               &interfaceName,
                                               &j1939_name,
                                               &j1939_pgn,
@@ -2241,8 +2241,8 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
 
             addr->can_family = AF_CAN;
             addr->can_ifindex = ifr.ifr_ifindex;
-            addr->can_addr.j1939.name = j1939_name;
-            addr->can_addr.j1939.pgn = j1939_pgn;
+            addr->can_addr.j1939.name = (uint64_t)j1939_name;
+            addr->can_addr.j1939.pgn = (uint32_t)j1939_pgn;
             addr->can_addr.j1939.addr = j1939_addr;
 
             *len_ret = sizeof(*addr);


### PR DESCRIPTION


<!-- issue-number: [bpo-45228](https://bugs.python.org/issue45228) -->
https://bugs.python.org/issue45228
<!-- /issue-number -->
