### PR TITLE
bpo-45231: update_file.py preserves end of line

### DIFF
--- a/Tools/scripts/update_file.py
+++ b/Tools/scripts/update_file.py
@@ -28,7 +28,19 @@ def updating_file_with_tmpfile(filename, tmpfile=None):
     elif os.path.isdir(tmpfile):
         tmpfile = os.path.join(tmpfile, filename + '.tmp')
 
-    with open(tmpfile, 'w') as outfile:
+    with open(filename, 'rb') as infile:
+        line = infile.readline()
+
+    if line.endswith(b'\r\n'):
+        newline = "\r\n"
+    elif line.endswith(b'\r'):
+        newline = "\r"
+    elif line.endswith(b'\n'):
+        newline = "\n"
+    else:
+        raise ValueError(f"unknown end of line: {filename}: {line!a}")
+
+    with open(tmpfile, 'w', newline=newline) as outfile:
         with open(filename) as infile:
             yield infile, outfile
     update_file_with_tmpfile(filename, tmpfile)


### PR DESCRIPTION
The update_file.py tool now preserves the end of line of the updated
file. Fix the "make regen-frozen" command: it no longer changes the
end of line of PCbuild/ files on Unix. Git changes the end of line
depending on the platform.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45231](https://bugs.python.org/issue45231) -->
https://bugs.python.org/issue45231
<!-- /issue-number -->
