### PR TITLE
bpo-45212: Add a comment for time.sleep() in tests

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -6207,7 +6207,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
     def testWithTimeoutTriggeredSend(self):
         conn = self.accept_conn()
         conn.recv(88192)
-        # the wait here needs to be longer than the client-side timeout (0.01s)
+        # bpo-45212: the wait here needs to be longer than the client-side timeout (0.01s)
         time.sleep(1)
 
     # errors

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -6207,6 +6207,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
     def testWithTimeoutTriggeredSend(self):
         conn = self.accept_conn()
         conn.recv(88192)
+        # the wait here needs to be longer than the client-side timeout (0.01s)
         time.sleep(1)
 
     # errors


### PR DESCRIPTION


<!-- issue-number: [bpo-45212](https://bugs.python.org/issue45212) -->
https://bugs.python.org/issue45212
<!-- /issue-number -->
