### PR TITLE
bpo-45116: Py_DEBUG ignores Py_ALWAYS_INLINE

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -124,6 +124,9 @@ complete listing.
    worse performances (due to increased code size for example). The compiler is
    usually smarter than the developer for the cost/benefit analysis.
 
+   If Python is :ref:`built in debug mode <debug-build>` (if the ``Py_DEBUG``
+   macro is defined), the :c:macro:`Py_ALWAYS_INLINE` macro does nothing.
+
    It must be specified before the function return type. Usage::
 
        static inline Py_ALWAYS_INLINE int random(void) { return 4; }

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -568,10 +568,19 @@ extern "C" {
 // worse performances (due to increased code size for example). The compiler is
 // usually smarter than the developer for the cost/benefit analysis.
 //
+// If Python is built in debug mode (if the Py_DEBUG macro is defined), the
+// Py_ALWAYS_INLINE macro does nothing.
+//
 // It must be specified before the function return type. Usage:
 //
 //     static inline Py_ALWAYS_INLINE int random(void) { return 4; }
-#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#if defined(Py_DEBUG)
+   // If Python is built in debug mode, usually compiler optimizations are
+   // disabled. In this case, Py_ALWAYS_INLINE can increase a lot the stack
+   // memory usage. For example, forcing inlining using gcc -O0 increases the
+   // stack usage from 6 KB to 15 KB per Python function call.
+#  define Py_ALWAYS_INLINE
+#elif defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
 #  define Py_ALWAYS_INLINE __attribute__((always_inline))
 #elif defined(_MSC_VER)
 #  define Py_ALWAYS_INLINE __forceinline


### PR DESCRIPTION
If the Py_DEBUG macro is defined, the Py_ALWAYS_INLINE macro does
nothing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45116](https://bugs.python.org/issue45116) -->
https://bugs.python.org/issue45116
<!-- /issue-number -->
