### PR TITLE
bpo-45235: Fix argparse overrides namespace with subparser defaults

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1209,7 +1209,8 @@ class _SubParsersAction(Action):
         # namespace for the relevant parts.
         subnamespace, arg_strings = parser.parse_known_args(arg_strings, None)
         for key, value in vars(subnamespace).items():
-            setattr(namespace, key, value)
+            if not hasattr(namespace, key):
+                setattr(namespace, key, value)
 
         if arg_strings:
             vars(namespace).setdefault(_UNRECOGNIZED_ARGS_ATTR, [])
@@ -1843,11 +1844,6 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                     if action.default is not SUPPRESS:
                         setattr(namespace, action.dest, action.default)
 
-        # add any parser defaults that aren't present
-        for dest in self._defaults:
-            if not hasattr(namespace, dest):
-                setattr(namespace, dest, self._defaults[dest])
-
         # parse the arguments and exit if there are any errors
         if self.exit_on_error:
             try:
@@ -1857,6 +1853,11 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 self.error(str(err))
         else:
             namespace, args = self._parse_known_args(args, namespace)
+
+        # add any parser defaults that aren't present
+        for dest in self._defaults:
+            if not hasattr(namespace, dest):
+                setattr(namespace, dest, self._defaults[dest])
 
         if hasattr(namespace, _UNRECOGNIZED_ARGS_ATTR):
             args.extend(getattr(namespace, _UNRECOGNIZED_ARGS_ATTR))

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -3079,6 +3079,12 @@ class TestSetDefaults(TestCase):
         xparser.set_defaults(foo=2)
         self.assertEqual(NS(foo=2), parser.parse_args(['X']))
 
+    def test_set_defaults_on_subparser_with_namespace(self):
+        parser = argparse.ArgumentParser()
+        xparser = parser.add_subparsers().add_parser('X')
+        xparser.set_defaults(foo=1)
+        self.assertEqual(NS(foo=2), parser.parse_args(['X'], NS(foo=2)))
+
     def test_set_defaults_same_as_add_argument(self):
         parser = ErrorRaisingArgumentParser()
         parser.set_defaults(w='W', x='X', y='Y', z='Z')

--- a/Misc/NEWS.d/next/Library/2021-09-17-16-55-37.bpo-45235.sXnmPA.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-17-16-55-37.bpo-45235.sXnmPA.rst
@@ -1,0 +1,2 @@
+Fix an issue where argparse would not preserve values in a provided namespace
+when using a subparser with defaults.


### PR DESCRIPTION
argparse will now preserve existing values in a provided namespace
even if a subparser has a default for a value in the namespace. For
example:

    import argparse
    parser = argparse.ArgumentParser()
    sub = parser.add_subparsers()
    example_subparser = sub.add_parser("example")
    example_subparser.add_argument("--flag", default=10)
    print(parser.parse_args(["example"], argparse.Namespace(flag=20)))

This snippet now returns 'Namespace(flag=20)' instead of
'Namespace(flag=10)'.

<!-- issue-number: [bpo-45235](https://bugs.python.org/issue45235) -->
https://bugs.python.org/issue45235
<!-- /issue-number -->
