### PR TITLE
bpo-45234: Fix FileNotFound exception raised instead of IsADirectoryError in shutil.copyfile()

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -253,36 +253,37 @@ def copyfile(src, dst, *, follow_symlinks=True):
     if not follow_symlinks and _islink(src):
         os.symlink(os.readlink(src), dst)
     else:
-        try:
-            with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
-                # macOS
-                if _HAS_FCOPYFILE:
-                    try:
-                        _fastcopy_fcopyfile(fsrc, fdst, posix._COPYFILE_DATA)
+        with open(src, 'rb') as fsrc:
+            try:
+                with open(dst, 'wb') as fdst:
+                    # macOS
+                    if _HAS_FCOPYFILE:
+                        try:
+                            _fastcopy_fcopyfile(fsrc, fdst, posix._COPYFILE_DATA)
+                            return dst
+                        except _GiveupOnFastCopy:
+                            pass
+                    # Linux
+                    elif _USE_CP_SENDFILE:
+                        try:
+                            _fastcopy_sendfile(fsrc, fdst)
+                            return dst
+                        except _GiveupOnFastCopy:
+                            pass
+                    # Windows, see:
+                    # https://github.com/python/cpython/pull/7160#discussion_r195405230
+                    elif _WINDOWS and file_size > 0:
+                        _copyfileobj_readinto(fsrc, fdst, min(file_size, COPY_BUFSIZE))
                         return dst
-                    except _GiveupOnFastCopy:
-                        pass
-                # Linux
-                elif _USE_CP_SENDFILE:
-                    try:
-                        _fastcopy_sendfile(fsrc, fdst)
-                        return dst
-                    except _GiveupOnFastCopy:
-                        pass
-                # Windows, see:
-                # https://github.com/python/cpython/pull/7160#discussion_r195405230
-                elif _WINDOWS and file_size > 0:
-                    _copyfileobj_readinto(fsrc, fdst, min(file_size, COPY_BUFSIZE))
-                    return dst
 
-                copyfileobj(fsrc, fdst)
+                    copyfileobj(fsrc, fdst)
 
-        # Issue 43219, raise a less confusing exception
-        except IsADirectoryError as e:
-            if os.path.isdir(src) or os.path.isdir(dst):
-                raise
-            else:
-                raise FileNotFoundError(f'Directory does not exist: {dst}') from e
+            # Issue 43219, raise a less confusing exception
+            except IsADirectoryError as e:
+                if not os.path.exists(dst):
+                    raise FileNotFoundError(f'Directory does not exist: {dst}') from e
+                else:
+                    raise
 
     return dst
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -279,7 +279,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
 
         # Issue 43219, raise a less confusing exception
         except IsADirectoryError as e:
-            if os.path.exists(dst):
+            if os.path.isdir(src) or os.path.isdir(dst):
                 raise
             else:
                 raise FileNotFoundError(f'Directory does not exist: {dst}') from e

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1259,6 +1259,27 @@ class TestCopy(BaseTest, unittest.TestCase):
         write_file(src_file, 'foo')
         self.assertRaises(FileNotFoundError, shutil.copyfile, src_file, dst)
 
+    def test_copyfile_copy_dir(self):
+        # Issue 45234
+        # test copy() and copyfile() raising proper exceptions when src and/or
+        # dst are directories
+        src_dir = self.mkdtemp()
+        src_file = os.path.join(src_dir, 'foo')
+        dir2 = self.mkdtemp()
+        dst = os.path.join(src_dir, 'does_not_exist/')
+        write_file(src_file, 'foo')
+
+        self.assertRaises(IsADirectoryError, shutil.copyfile, src_dir, dst)
+        self.assertRaises(IsADirectoryError, shutil.copyfile, src_file, src_dir)
+        self.assertRaises(IsADirectoryError, shutil.copyfile, dir2, src_dir)
+        self.assertRaises(IsADirectoryError, shutil.copy, dir2, src_dir)
+        self.assertRaises(IsADirectoryError, shutil.copy2, dir2, src_dir)
+
+        # raise IsADirectoryError because of src rather than FileNotFoundError
+        # because of dst
+        self.assertRaises(IsADirectoryError, shutil.copy, dir2, dst)
+        shutil.copy(src_file, dir2)     # should not raise exceptions
+
 
 class TestArchives(BaseTest, unittest.TestCase):
 

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1151,6 +1151,28 @@ class TestCopy(BaseTest, unittest.TestCase):
             rv = fn(src, os.path.join(dst_dir, 'bar'))
             self.assertEqual(rv, os.path.join(dst_dir, 'bar'))
 
+    def test_copy_dir(self):
+        self._test_copy_dir(shutil.copy)
+
+    def test_copy2_dir(self):
+        self._test_copy_dir(shutil.copy2)
+
+    def _test_copy_dir(self, copy_func):
+        src_dir = self.mkdtemp()
+        src_file = os.path.join(src_dir, 'foo')
+        dir2 = self.mkdtemp()
+        dst = os.path.join(src_dir, 'does_not_exist/')
+        write_file(src_file, 'foo')
+        if sys.platform == "win32":
+            err = PermissionError
+        else:
+            err = IsADirectoryError
+        self.assertRaises(err, copy_func, dir2, src_dir)
+
+        # raise *err* because of src rather than FileNotFoundError because of dst
+        self.assertRaises(err, copy_func, dir2, dst)
+        copy_func(src_file, dir2)     # should not raise exceptions
+
     ### shutil.copyfile
 
     @os_helper.skip_unless_symlink
@@ -1276,12 +1298,6 @@ class TestCopy(BaseTest, unittest.TestCase):
         self.assertRaises(err, shutil.copyfile, src_dir, dst)
         self.assertRaises(err, shutil.copyfile, src_file, src_dir)
         self.assertRaises(err, shutil.copyfile, dir2, src_dir)
-        self.assertRaises(err, shutil.copy, dir2, src_dir)
-        self.assertRaises(err, shutil.copy2, dir2, src_dir)
-
-        # raise *err* because of src rather than FileNotFoundError because of dst
-        self.assertRaises(err, shutil.copy, dir2, dst)
-        shutil.copy(src_file, dir2)     # should not raise exceptions
 
 
 class TestArchives(BaseTest, unittest.TestCase):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1268,16 +1268,19 @@ class TestCopy(BaseTest, unittest.TestCase):
         dir2 = self.mkdtemp()
         dst = os.path.join(src_dir, 'does_not_exist/')
         write_file(src_file, 'foo')
+        if sys.platform == "win32":
+            err = PermissionError
+        else:
+            err = IsADirectoryError
 
-        self.assertRaises(IsADirectoryError, shutil.copyfile, src_dir, dst)
-        self.assertRaises(IsADirectoryError, shutil.copyfile, src_file, src_dir)
-        self.assertRaises(IsADirectoryError, shutil.copyfile, dir2, src_dir)
-        self.assertRaises(IsADirectoryError, shutil.copy, dir2, src_dir)
-        self.assertRaises(IsADirectoryError, shutil.copy2, dir2, src_dir)
+        self.assertRaises(err, shutil.copyfile, src_dir, dst)
+        self.assertRaises(err, shutil.copyfile, src_file, src_dir)
+        self.assertRaises(err, shutil.copyfile, dir2, src_dir)
+        self.assertRaises(err, shutil.copy, dir2, src_dir)
+        self.assertRaises(err, shutil.copy2, dir2, src_dir)
 
-        # raise IsADirectoryError because of src rather than FileNotFoundError
-        # because of dst
-        self.assertRaises(IsADirectoryError, shutil.copy, dir2, dst)
+        # raise *err* because of src rather than FileNotFoundError because of dst
+        self.assertRaises(err, shutil.copy, dir2, dst)
         shutil.copy(src_file, dir2)     # should not raise exceptions
 
 

--- a/Misc/NEWS.d/next/Library/2021-09-17-11-20-55.bpo-45234.qUcTVt.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-17-11-20-55.bpo-45234.qUcTVt.rst
@@ -1,0 +1,3 @@
+Fixed a regression in :func:`~shutil.copyfile`, :func:`~shutil.copy`,
+:func:`~shutil.copy2` raising :exc:`FileNotFoundError` when source is a
+directory, which should raise :exc:`IsADirectoryError`


### PR DESCRIPTION
Note that os.path.isdir() correctly handles non-existent 'foo/' paths, returning False, unlike open() which on some platforms raises IsADirectoryError for such path.

Also note that I chose to raise IsADirectory error in cases when src is a dir, and dst is a 'does_not_exist/' path, when in theory either error could be raised, but IsADirectory is more backwards-compatible. (and a bit more logical because it's the first error encountered).

<!-- issue-number: [bpo-45234](https://bugs.python.org/issue45234) -->
https://bugs.python.org/issue45234
<!-- /issue-number -->
