### PR TITLE
bpo-45183: don't raise an exception when calling zipimport.zipimporter.find_spec() when the zip file is missing and the internal cache has been reset

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -548,8 +548,9 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         # Check that the cached data is removed if the file is deleted
         os.remove(TEMP_ZIP)
         zi.invalidate_caches()
-        self.assertIsNone(zi._files)
+        self.assertFalse(zi._files)
         self.assertIsNone(zipimport._zip_directory_cache.get(zi.archive))
+        self.assertIsNone(zi.find_spec("name_does_not_matter"))
 
     def testZipImporterMethodsInSubDirectory(self):
         packdir = TESTPACK + os.sep

--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -334,7 +334,7 @@ class zipimporter(_bootstrap_external._LoaderBasics):
             _zip_directory_cache[self.archive] = self._files
         except ZipImportError:
             _zip_directory_cache.pop(self.archive, None)
-            self._files = None
+            self._files = {}
 
 
     def __repr__(self):

--- a/Misc/NEWS.d/next/Library/2021-09-17-15-58-53.bpo-45183.Vv_vch.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-17-15-58-53.bpo-45183.Vv_vch.rst
@@ -1,0 +1,2 @@
+Have zipimport.find_spec() not raise an exception when the underlying zip
+file has been deleted.

--- a/Misc/NEWS.d/next/Library/2021-09-17-15-58-53.bpo-45183.Vv_vch.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-17-15-58-53.bpo-45183.Vv_vch.rst
@@ -1,2 +1,3 @@
-Have zipimport.find_spec() not raise an exception when the underlying zip
-file has been deleted.
+Have zipimport.zipimporter.find_spec() not raise an exception when the underlying zip
+file has been deleted and the internal cache has been reset via
+invalidate_cache().


### PR DESCRIPTION
This can occur when the zip file gets deleted, you call zipimport.zipimporter.invalidate_cache(), and then try to use zipimport.zipimporter.find_spec() (i.e. you left the zip file path on sys.path).

<!-- issue-number: [bpo-45183](https://bugs.python.org/issue45183) -->
https://bugs.python.org/issue45183
<!-- /issue-number -->

Automerge-Triggered-By: GH:brettcannon