### PR TITLE
bpo-36674: Honour the skipping decorators in TestCase.debug()

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -653,8 +653,16 @@ class TestCase(object):
 
     def debug(self):
         """Run the test without collecting errors in a TestResult"""
+        testMethod = getattr(self, self._testMethodName)
+        if (getattr(self.__class__, "__unittest_skip__", False) or
+            getattr(testMethod, "__unittest_skip__", False)):
+            # If the class or method was skipped.
+            skip_why = (getattr(self.__class__, '__unittest_skip_why__', '')
+                        or getattr(testMethod, '__unittest_skip_why__', ''))
+            raise SkipTest(skip_why)
+
         self.setUp()
-        getattr(self, self._testMethodName)()
+        testMethod()
         self.tearDown()
         while self._cleanups:
             function, args, kwargs = self._cleanups.pop(-1)

--- a/Misc/NEWS.d/next/Library/2021-09-18-13-14-57.bpo-36674.a2k5Zb.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-18-13-14-57.bpo-36674.a2k5Zb.rst
@@ -1,0 +1,2 @@
+:meth:`unittest.TestCase.debug` raises now a :class:`unittest.SkipTest` if
+the class or the test method are decorated with the skipping decorator.


### PR DESCRIPTION
unittest.TestCase.debug() raises now a SkipTest if the class or
the test method are decorated with the skipping decorator.

Previously it only raised a SkipTest if the test method was decorated
with other decorator in addition to the skipping decorator, or
if SkipTest was explicitly raised in the test or setup methods.


<!-- issue-number: [bpo-36674](https://bugs.python.org/issue36674) -->
https://bugs.python.org/issue36674
<!-- /issue-number -->
