### PR TITLE
bpo-45239: Fix parsedate_tz when time has more than 2 dots in it

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -126,6 +126,8 @@ def _parsedate_tz(data):
             tss = 0
         elif len(tm) == 3:
             [thh, tmm, tss] = tm
+        else:
+            return None
     else:
         return None
     try:

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3007,6 +3007,7 @@ class TestMiscellaneous(TestEmailBase):
         self.assertIsNone(utils.parsedate_tz('0'))
         self.assertIsNone(utils.parsedate('A Complete Waste of Time'))
         self.assertIsNone(utils.parsedate_tz('A Complete Waste of Time'))
+        self.assertIsNone(utils.parsedate_tz('Wed, 3 Apr 2002 12.34.56.78+0800'))
         # Not a part of the spec but, but this has historically worked:
         self.assertIsNone(utils.parsedate(None))
         self.assertIsNone(utils.parsedate_tz(None))

--- a/Misc/NEWS.d/next/Library/2021-10-13-17-52-48.bpo-45239.7li1_0.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-13-17-52-48.bpo-45239.7li1_0.rst
@@ -1,0 +1,3 @@
+Fixed :func:`email.utils.parsedate_tz` crashing with
+:exc:`UnboundLocalError` on certain invalid input instead of returning
+``None``. Patch by Ben Hoyt.


### PR DESCRIPTION
Fixes issue 45239: https://bugs.python.org/issue45239

More details in the issue, but here's the repro case:

```
$ python3.10 -c 'import email.utils; \
    email.utils.parsedate_tz("Wed, 3 Apr 2002 12.34.56.78+0800")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.10/email/_parseaddr.py", line 50, in parsedate_tz
    res = _parsedate_tz(data)
  File "/usr/local/lib/python3.10/email/_parseaddr.py", line 134, in _parsedate_tz
    thh = int(thh)
UnboundLocalError: local variable 'thh' referenced before assignment
```

<!-- issue-number: [bpo-45239](https://bugs.python.org/issue45239) -->
https://bugs.python.org/issue45239
<!-- /issue-number -->
