### PR TITLE
bpo-44687: Fix unintended closing file error when peeking a BufferedReader object

### DIFF
--- a/Misc/NEWS.d/next/C API/2021-09-19-17-18-25.bpo-44687.3fqDRC.rst
+++ b/Misc/NEWS.d/next/C API/2021-09-19-17-18-25.bpo-44687.3fqDRC.rst
@@ -1,0 +1,1 @@
+Add a new :c:macro:`PEEK_CHECK_CLOSED` macro to check if a file is closed using a method specific to BufferedReader.peek()

--- a/Misc/NEWS.d/next/C API/2021-09-19-17-18-25.bpo-44687.3fqDRC.rst
+++ b/Misc/NEWS.d/next/C API/2021-09-19-17-18-25.bpo-44687.3fqDRC.rst
@@ -1,1 +1,1 @@
-Added additional checks to :c:macro:`CHECK_CLOSED` macro to fix unintended closing file error when peeking a BufferedReader object
+:meth:`BufferedReader.peek` no longer raises :exc:`ValueError` when the entire file has already been buffered.

--- a/Misc/NEWS.d/next/C API/2021-09-19-17-18-25.bpo-44687.3fqDRC.rst
+++ b/Misc/NEWS.d/next/C API/2021-09-19-17-18-25.bpo-44687.3fqDRC.rst
@@ -1,1 +1,1 @@
-Add a new :c:macro:`PEEK_CHECK_CLOSED` macro to check if a file is closed using a method specific to BufferedReader.peek()
+Added additional checks to :c:macro:`CHECK_CLOSED` macro to fix unintended closing file error when peeking a BufferedReader object

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -346,6 +346,14 @@ _enter_buffered_busy(buffered *self)
         return NULL; \
     }
 
+#define CHECK_CLOSED_PEEK(self, error_msg) \
+    Py_ssize_t have; \
+    have = Py_SAFE_DOWNCAST(READAHEAD(self), Py_off_t, Py_ssize_t); \
+    if (IS_CLOSED(self) & (have == 0)) { \
+        PyErr_SetString(PyExc_ValueError, error_msg); \
+        return NULL; \
+    }
+
 
 #define VALID_READ_BUFFER(self) \
     (self->readable && self->read_end != -1)
@@ -842,7 +850,7 @@ _io__Buffered_peek_impl(buffered *self, Py_ssize_t size)
     PyObject *res = NULL;
 
     CHECK_INITIALIZED(self)
-    CHECK_CLOSED(self, "peek of closed file")
+    CHECK_CLOSED_PEEK(self, "peek of closed file")
 
     if (!ENTER_BUFFERED(self))
         return NULL;

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -848,7 +848,7 @@ _io__Buffered_peek_impl(buffered *self, Py_ssize_t size)
 
     CHECK_INITIALIZED(self)
 
-    // use a check specific to peek if the previous operation was not a read
+    // use a check specific to peek if the previous file operation was not a read
     if (Py_SAFE_DOWNCAST(self->pos, Py_off_t, Py_ssize_t) == 0) {
         PEEK_CHECK_CLOSED(self, "peek of closed file")
     } else {


### PR DESCRIPTION
When the user runs the `peek()` function twice on a BufferedReader object, a closed file error may unintentionally be raised on the second time. This PR applies a check specific to the `peek()` function which runs only when the previous file operation is a `peek()`.

<!-- issue-number: [bpo-44687](https://bugs.python.org/issue44687) -->
https://bugs.python.org/issue44687
<!-- /issue-number -->
