### PR TITLE
bpo-45155: Apply new byteorder default values for int.to/from_bytes

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -182,7 +182,7 @@ def _b32encode(alphabet, s):
     from_bytes = int.from_bytes
     b32tab2 = _b32tab2[alphabet]
     for i in range(0, len(s), 5):
-        c = from_bytes(s[i: i + 5], 'big')
+        c = from_bytes(s[i: i + 5])              # big endian
         encoded += (b32tab2[c >> 30] +           # bits 1 - 10
                     b32tab2[(c >> 20) & 0x3ff] + # bits 11 - 20
                     b32tab2[(c >> 10) & 0x3ff] + # bits 21 - 30
@@ -234,13 +234,13 @@ def _b32decode(alphabet, s, casefold=False, map01=None):
                 acc = (acc << 5) + b32rev[c]
         except KeyError:
             raise binascii.Error('Non-base32 digit found') from None
-        decoded += acc.to_bytes(5, 'big')
+        decoded += acc.to_bytes(5)  # big endian
     # Process the last, partial quanta
     if l % 8 or padchars not in {0, 1, 3, 4, 6}:
         raise binascii.Error('Incorrect padding')
     if padchars and decoded:
         acc <<= 5 * padchars
-        last = acc.to_bytes(5, 'big')
+        last = acc.to_bytes(5)  # big endian
         leftover = (43 - 5 * padchars) // 8  # 1: 4, 3: 3, 4: 2, 6: 1
         decoded[-5:] = last[:leftover]
     return bytes(decoded)

--- a/Lib/hashlib.py
+++ b/Lib/hashlib.py
@@ -237,7 +237,7 @@ except ImportError:
         while len(dkey) < dklen:
             prev = prf(salt + loop.to_bytes(4))
             # endianness doesn't matter here as long to / from use the same
-            rkey = int.from_bytes(prev)
+            rkey = from_bytes(prev)
             for i in range(iterations - 1):
                 prev = prf(prev)
                 # rkey = rkey ^ prev

--- a/Lib/hashlib.py
+++ b/Lib/hashlib.py
@@ -235,7 +235,7 @@ except ImportError:
         loop = 1
         from_bytes = int.from_bytes
         while len(dkey) < dklen:
-            prev = prf(salt + loop.to_bytes(4))  # big endian
+            prev = prf(salt + loop.to_bytes(4))
             # endianness doesn't matter here as long to / from use the same
             rkey = int.from_bytes(prev)
             for i in range(iterations - 1):

--- a/Lib/hashlib.py
+++ b/Lib/hashlib.py
@@ -235,15 +235,15 @@ except ImportError:
         loop = 1
         from_bytes = int.from_bytes
         while len(dkey) < dklen:
-            prev = prf(salt + loop.to_bytes(4, 'big'))
+            prev = prf(salt + loop.to_bytes(4))  # big endian
             # endianness doesn't matter here as long to / from use the same
-            rkey = int.from_bytes(prev, 'big')
+            rkey = int.from_bytes(prev)
             for i in range(iterations - 1):
                 prev = prf(prev)
                 # rkey = rkey ^ prev
-                rkey ^= from_bytes(prev, 'big')
+                rkey ^= from_bytes(prev)
             loop += 1
-            dkey += rkey.to_bytes(inner.digest_size, 'big')
+            dkey += rkey.to_bytes(inner.digest_size)
 
         return dkey[:dklen]
 

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -135,7 +135,7 @@ def v4_int_to_packed(address):
 
     """
     try:
-        return address.to_bytes(4, 'big')
+        return address.to_bytes(4)  # big endian
     except OverflowError:
         raise ValueError("Address negative or too large for IPv4")
 
@@ -151,7 +151,7 @@ def v6_int_to_packed(address):
 
     """
     try:
-        return address.to_bytes(16, 'big')
+        return address.to_bytes(16)  # big endian
     except OverflowError:
         raise ValueError("Address negative or too large for IPv6")
 
@@ -1297,7 +1297,7 @@ class IPv4Address(_BaseV4, _BaseAddress):
         # Constructing from a packed address
         if isinstance(address, bytes):
             self._check_packed_address(address, 4)
-            self._ip = int.from_bytes(address, 'big')
+            self._ip = int.from_bytes(address)  # big endian
             return
 
         # Assume input argument to be string or any object representation

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -154,7 +154,7 @@ class Random(_random.Random):
         elif version == 2 and isinstance(a, (str, bytes, bytearray)):
             if isinstance(a, str):
                 a = a.encode()
-            a = int.from_bytes(a + _sha512(a).digest(), 'big')
+            a = int.from_bytes(a + _sha512(a).digest())
 
         elif not isinstance(a, (type(None), int, float, str, bytes, bytearray)):
             raise TypeError('The only supported seed types are: None,\n'
@@ -795,14 +795,14 @@ class SystemRandom(Random):
 
     def random(self):
         """Get the next random number in the range [0.0, 1.0)."""
-        return (int.from_bytes(_urandom(7), 'big') >> 3) * RECIP_BPF
+        return (int.from_bytes(_urandom(7)) >> 3) * RECIP_BPF
 
     def getrandbits(self, k):
         """getrandbits(k) -> x.  Generates an int with k random bits."""
         if k < 0:
             raise ValueError('number of bits must be non-negative')
         numbytes = (k + 7) // 8                       # bits / 8 and rounded up
-        x = int.from_bytes(_urandom(numbytes), 'big')
+        x = int.from_bytes(_urandom(numbytes))
         return x >> (numbytes * 8 - k)                # trim excess bits
 
     def randbytes(self, n):

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -186,7 +186,7 @@ class UUID:
             if len(bytes) != 16:
                 raise ValueError('bytes is not a 16-char string')
             assert isinstance(bytes, bytes_), repr(bytes)
-            int = int_.from_bytes(bytes)  # big_endian
+            int = int_.from_bytes(bytes)  # big endian
         if fields is not None:
             if len(fields) != 6:
                 raise ValueError('fields is not a 6-tuple')

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -186,7 +186,7 @@ class UUID:
             if len(bytes) != 16:
                 raise ValueError('bytes is not a 16-char string')
             assert isinstance(bytes, bytes_), repr(bytes)
-            int = int_.from_bytes(bytes, byteorder='big')
+            int = int_.from_bytes(bytes)  # big_endian
         if fields is not None:
             if len(fields) != 6:
                 raise ValueError('fields is not a 6-tuple')
@@ -284,7 +284,7 @@ class UUID:
 
     @property
     def bytes(self):
-        return self.int.to_bytes(16, 'big')
+        return self.int.to_bytes(16)  # big endian
 
     @property
     def bytes_le(self):


### PR DESCRIPTION
The code is a little faster and a little more readable with the new default value for byteorder.

Added comments to point of endianess in cases where it might matter.

<!-- issue-number: [bpo-45155](https://bugs.python.org/issue45155) -->
https://bugs.python.org/issue45155
<!-- /issue-number -->
