### PR TITLE
bpo-45229: Use doctest.DocTestSuite instead of run_doctest

### DIFF
--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -6,6 +6,7 @@ Original by Michael Schneider
 
 import cmd
 import sys
+import doctest
 import unittest
 import io
 from test import support
@@ -219,10 +220,9 @@ class TestAlternateInput(unittest.TestCase):
              "(Cmd) *** Unknown syntax: EOF\n"))
 
 
-def test_main(verbose=None):
-    from test import test_cmd
-    support.run_doctest(test_cmd, verbose)
-    support.run_unittest(TestAlternateInput)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
 def test_coverage(coverdir):
     trace = support.import_module('trace')
@@ -239,4 +239,4 @@ if __name__ == "__main__":
     elif "-i" in sys.argv:
         samplecmdclass().cmdloop()
     else:
-        test_main()
+        unittest.main()

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -128,6 +128,7 @@ consts: ('None',)
 import inspect
 import sys
 import threading
+import doctest
 import unittest
 import textwrap
 import weakref
@@ -136,7 +137,7 @@ try:
     import ctypes
 except ImportError:
     ctypes = None
-from test.support import (run_doctest, run_unittest, cpython_only,
+from test.support import (cpython_only,
                           check_impl_detail, requires_debug_ranges,
                           gc_collect)
 from test.support.script_helper import assert_python_ok
@@ -609,13 +610,10 @@ if check_impl_detail(cpython=True) and ctypes is not None:
             self.assertEqual(LAST_FREED, 500)
 
 
-def test_main(verbose=None):
-    from test import test_code
-    run_doctest(test_code, verbose)
-    tests = [CodeTest, CodeConstsTest, CodeWeakRefTest]
-    if check_impl_detail(cpython=True) and ctypes is not None:
-        tests.append(CoExtra)
-    run_unittest(*tests)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
+
 
 if __name__ == "__main__":
-    test_main()
+    unittest.main()

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -2351,19 +2351,10 @@ class TestCounter(unittest.TestCase):
         self.assertFalse(Counter(a=2, b=1, c=0) > Counter('aab'))
 
 
-################################################################################
-### Run tests
-################################################################################
-
-def test_main(verbose=None):
-    NamedTupleDocs = doctest.DocTestSuite(module=collections)
-    test_classes = [TestNamedTuple, NamedTupleDocs, TestOneTrickPonyABCs,
-                    TestCollectionABCs, TestCounter, TestChainMap,
-                    TestUserObjects,
-                    ]
-    support.run_unittest(*test_classes)
-    support.run_doctest(collections, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite(collections))
+    return tests
 
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -1,4 +1,5 @@
 from collections import deque
+import doctest
 import unittest
 from test import support, seq_tests
 import gc
@@ -1033,31 +1034,10 @@ h
 
 __test__ = {'libreftest' : libreftest}
 
-def test_main(verbose=None):
-    import sys
-    test_classes = (
-        TestBasic,
-        TestVariousIteratorArgs,
-        TestSubclass,
-        TestSubclassWithKwargs,
-        TestSequence,
-    )
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
-    support.run_unittest(*test_classes)
-
-    # verify reference counting
-    if verbose and hasattr(sys, "gettotalrefcount"):
-        import gc
-        counts = [None] * 5
-        for i in range(len(counts)):
-            support.run_unittest(*test_classes)
-            gc.collect()
-            counts[i] = sys.gettotalrefcount()
-        print(counts)
-
-    # doctests
-    from test import test_deque
-    support.run_doctest(test_deque, verbose)
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_descrtut.py
+++ b/Lib/test/test_descrtut.py
@@ -10,6 +10,9 @@
 
 from test.support import sortdict
 import pprint
+import doctest
+import unittest
+
 
 class defaultdict(dict):
     def __init__(self, default=None):
@@ -469,19 +472,10 @@ __test__ = {"tut1": test_1,
             "tut7": test_7,
             "tut8": test_8}
 
-# Magic test name that regrtest.py invokes *after* importing this module.
-# This worms around a bootstrap problem.
-# Note that doctest and regrtest both look in sys.argv for a "-v" argument,
-# so this works as expected in both ways of running regrtest.
-def test_main(verbose=None):
-    # Obscure:  import this module as test.test_descrtut instead of as
-    # plain test_descrtut because the name of this module works its way
-    # into the doctest examples, and unless the full test.test_descrtut
-    # business is used the name can change depending on how the test is
-    # invoked.
-    from test import support, test_descrtut
-    support.run_doctest(test_descrtut, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
-# This part isn't needed for regrtest, but for running the test directly.
+
 if __name__ == "__main__":
-    test_main(1)
+    unittest.main()

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -520,11 +520,14 @@ Same with keyword only args:
 
 """
 
-import sys
+import doctest
+import unittest
 from test import support
 
-def test_main():
-    support.run_doctest(sys.modules[__name__], True)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
+
 
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -2,6 +2,7 @@ import copy
 import gc
 import pickle
 import sys
+import doctest
 import unittest
 import weakref
 import inspect
@@ -2371,15 +2372,10 @@ __test__ = {"tut":      tutorial_tests,
             "refleaks": refleaks_tests,
             }
 
-# Magic test name that regrtest.py invokes *after* importing this module.
-# This worms around a bootstrap problem.
-# Note that doctest and regrtest both look in sys.argv for a "-v" argument,
-# so this works as expected in both ways of running regrtest.
-def test_main(verbose=None):
-    from test import support, test_generators
-    support.run_unittest(__name__)
-    support.run_doctest(test_generators, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
-# This part isn't needed for regrtest, but for running the test directly.
+
 if __name__ == "__main__":
-    test_main(1)
+    unittest.main()

--- a/Lib/test/test_genexps.py
+++ b/Lib/test/test_genexps.py
@@ -1,3 +1,8 @@
+import sys
+import doctest
+import unittest
+
+
 doctests = """
 
 Test simple loop with conditional
@@ -274,28 +279,16 @@ Verify that genexps are weakly referencable
 
 """
 
-import sys
-
 # Trace function can throw off the tuple reuse test.
 if hasattr(sys, 'gettrace') and sys.gettrace():
     __test__ = {}
 else:
     __test__ = {'doctests' : doctests}
 
-def test_main(verbose=None):
-    from test import support
-    from test import test_genexps
-    support.run_doctest(test_genexps, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
-    # verify reference counting
-    if verbose and hasattr(sys, "gettotalrefcount"):
-        import gc
-        counts = [None] * 5
-        for i in range(len(counts)):
-            support.run_doctest(test_genexps, verbose)
-            gc.collect()
-            counts[i] = sys.gettotalrefcount()
-        print(counts)
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -1,8 +1,8 @@
 # Simple test suite for http/cookies.py
 
 import copy
-from test.support import run_unittest, run_doctest
 import unittest
+import doctest
 from http import cookies
 import pickle
 
@@ -479,9 +479,11 @@ class MorselTests(unittest.TestCase):
                 r'Set-Cookie: key=coded_val; '
                 r'expires=\w+, \d+ \w+ \d+ \d+:\d+:\d+ \w+')
 
-def test_main():
-    run_unittest(CookieTests, MorselTests)
-    run_doctest(cookies)
+
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite(cookies))
+    return tests
+
 
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1,3 +1,4 @@
+import doctest
 import unittest
 from test import support
 from itertools import *
@@ -2689,26 +2690,10 @@ True
 
 __test__ = {'libreftest' : libreftest}
 
-def test_main(verbose=None):
-    test_classes = (TestBasicOps, TestVariousIteratorArgs, TestGC,
-                    RegressionTests, LengthTransparency,
-                    SubclassWithKwargsTest, TestExamples,
-                    TestPurePythonRoughEquivalents,
-                    SizeofTest)
-    support.run_unittest(*test_classes)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
-    # verify reference counting
-    if verbose and hasattr(sys, "gettotalrefcount"):
-        import gc
-        counts = [None] * 5
-        for i in range(len(counts)):
-            support.run_unittest(*test_classes)
-            gc.collect()
-            counts[i] = sys.gettotalrefcount()
-        print(counts)
-
-    # doctest the examples in the library reference
-    support.run_doctest(sys.modules[__name__], verbose)
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -1,3 +1,7 @@
+import doctest
+import unittest
+
+
 doctests = """
 ########### Tests borrowed from or inspired by test_genexps.py ############
 
@@ -144,21 +148,10 @@ We also repeat each of the above scoping tests inside a function
 
 __test__ = {'doctests' : doctests}
 
-def test_main(verbose=None):
-    import sys
-    from test import support
-    from test import test_listcomps
-    support.run_doctest(test_listcomps, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
-    # verify reference counting
-    if verbose and hasattr(sys, "gettotalrefcount"):
-        import gc
-        counts = [None] * 5
-        for i in range(len(counts)):
-            support.run_doctest(test_listcomps, verbose)
-            gc.collect()
-            counts[i] = sys.gettotalrefcount()
-        print(counts)
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_metaclass.py
+++ b/Lib/test/test_metaclass.py
@@ -1,3 +1,7 @@
+import doctest
+import unittest
+
+
 doctests = """
 
 Basic class construction.
@@ -256,10 +260,10 @@ if hasattr(sys, 'gettrace') and sys.gettrace():
 else:
     __test__ = {'doctests' : doctests}
 
-def test_main(verbose=False):
-    from test import support
-    from test import test_metaclass
-    support.run_doctest(test_metaclass, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
+
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_setcomps.py
+++ b/Lib/test/test_setcomps.py
@@ -1,3 +1,7 @@
+import doctest
+import unittest
+
+
 doctests = """
 ########### Tests mostly copied from test_listcomps.py ############
 
@@ -147,21 +151,10 @@ We also repeat each of the above scoping tests inside a function
 
 __test__ = {'doctests' : doctests}
 
-def test_main(verbose=None):
-    import sys
-    from test import support
-    from test import test_setcomps
-    support.run_doctest(test_setcomps, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
-    # verify reference counting
-    if verbose and hasattr(sys, "gettotalrefcount"):
-        import gc
-        counts = [None] * 5
-        for i in range(len(counts)):
-            support.run_doctest(test_setcomps, verbose)
-            gc.collect()
-            counts[i] = sys.gettotalrefcount()
-        print(counts)
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1266,6 +1266,7 @@ Corner-cases that used to crash:
 """
 
 import re
+import doctest
 import unittest
 
 from test import support
@@ -1554,10 +1555,10 @@ while 1:
         self._check_error(source, "too many statically nested blocks")
 
 
-def test_main():
-    support.run_unittest(SyntaxTestCase)
-    from test import test_syntax
-    support.run_doctest(test_syntax, verbosity=True)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
+
 
 if __name__ == "__main__":
-    test_main()
+    unittest.main()

--- a/Lib/test/test_unpack.py
+++ b/Lib/test/test_unpack.py
@@ -1,3 +1,7 @@
+import doctest
+import unittest
+
+
 doctests = """
 
 Unpack tuple
@@ -142,10 +146,10 @@ Unpacking to an empty iterable should raise ValueError
 
 __test__ = {'doctests' : doctests}
 
-def test_main(verbose=False):
-    from test import support
-    from test import test_unpack
-    support.run_doctest(test_unpack, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
+
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -1,5 +1,9 @@
 # Tests for extended unpacking, starred expressions.
 
+import doctest
+import unittest
+
+
 doctests = """
 
 Unpack tuple
@@ -392,10 +396,10 @@ Some size constraints (all fail.)
 
 __test__ = {'doctests' : doctests}
 
-def test_main(verbose=False):
-    from test import support
-    from test import test_unpack_ex
-    support.run_doctest(test_unpack_ex, verbose)
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
+
 
 if __name__ == "__main__":
-    test_main(verbose=True)
+    unittest.main()

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1,5 +1,6 @@
 import gc
 import sys
+import doctest
 import unittest
 import collections
 import weakref
@@ -2233,18 +2234,10 @@ OK
 
 __test__ = {'libreftest' : libreftest}
 
-def test_main():
-    support.run_unittest(
-        ReferencesTestCase,
-        WeakMethodTestCase,
-        MappingTestCase,
-        WeakValueDictionaryTestCase,
-        WeakKeyDictionaryTestCase,
-        SubclassableWeakrefTestCase,
-        FinalizeTestCase,
-        )
-    support.run_doctest(sys.modules[__name__])
+def load_tests(loader, tests, pattern):
+    tests.addTest(doctest.DocTestSuite())
+    return tests
 
 
 if __name__ == "__main__":
-    test_main()
+    unittest.main()


### PR DESCRIPTION
Also use load_tests() for adding tests.


<!-- issue-number: [bpo-45229](https://bugs.python.org/issue45229) -->
https://bugs.python.org/issue45229
<!-- /issue-number -->
