### PR TITLE
bpo-24076: Inline single digit unpacking in the integer fastpath of sum()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-20-10-02-12.bpo-24076.ZFgFSj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-20-10-02-12.bpo-24076.ZFgFSj.rst
@@ -1,0 +1,1 @@
+sum() was further optimised for summing up single digit integers.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2481,6 +2481,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
             if (PyLong_CheckExact(item) || PyBool_Check(item)) {
                 long b;
                 overflow = 0;
+                /* Single digits are common, fast, and cannot overflow on unpacking. */
                 switch (Py_SIZE(item)) {
                     case -1: b = -(sdigit) ((PyLongObject*)item)->ob_digit[0]; break;
                     case  0: continue;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2479,7 +2479,14 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                 return PyLong_FromLong(i_result);
             }
             if (PyLong_CheckExact(item) || PyBool_Check(item)) {
-                long b = PyLong_AsLongAndOverflow(item, &overflow);
+                long b;
+                overflow = 0;
+                switch (Py_SIZE(item)) {
+                    case -1: b = -(sdigit) ((PyLongObject*)item)->ob_digit[0]; break;
+                    case  0: continue;
+                    case  1: b = ((PyLongObject*)item)->ob_digit[0]; break;
+                    default: b = PyLong_AsLongAndOverflow(item, &overflow); break;
+                }
                 if (overflow == 0 &&
                     (i_result >= 0 ? (b <= LONG_MAX - i_result)
                                    : (b >= LONG_MIN - i_result)))


### PR DESCRIPTION
This gave me a 17% speedup last time I tried (3 years ago). Most integers that go into sum() should fit into a single PyLong digit, so this seems worth it.

<!-- issue-number: [bpo-24076](https://bugs.python.org/issue24076) -->
https://bugs.python.org/issue24076
<!-- /issue-number -->
