### PR TITLE
bpo-45246: Docs: sorted() uses only the '<' operator

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1573,7 +1573,8 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: sorted(iterable, *, key=None, reverse=False)
 
-   Return a new sorted list from the items in *iterable*.
+   Return a new sorted list from the items in *iterable*, using only ``<``
+   comparisons between items.
 
    Has two optional arguments which must be specified as keyword arguments.
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2324,7 +2324,8 @@ sorted as builtin_sorted
     key as keyfunc: object = None
     reverse: object = False
 
-Return a new list containing all items from the iterable in ascending order.
+Return a new list containing all items from the iterable, sorted in ascending
+order, using only < comparisons between items.
 
 A custom key function can be supplied to customize the sort order, and the
 reverse flag can be set to request the result in descending order.


### PR DESCRIPTION
The reference documentation of [`list.sort()`](https://docs.python.org/3/library/stdtypes.html#list.sort) does refer to this important property of the sorting mechanism:
> [...] using only `<` comparisons between items.

The reference documentation of [`sorted()`](https://docs.python.org/3/library/functions.html#sorted) lacks a similar notice.

Granted, the "_Sorting HOW TO_" does mention it under "[_Odd and Ends_](https://docs.python.org/3/howto/sorting.html#odd-and-ends)", but that's "a brief sorting tutorial". This important property needs to appear in the reference documentation.

<!-- issue-number: [bpo-45246](https://bugs.python.org/issue45246) -->
https://bugs.python.org/issue45246
<!-- /issue-number -->
