### PR TITLE
Test exceptions: test_range_of_offsets() - add check against expected

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2298,6 +2298,7 @@ class SyntaxErrorTests(unittest.TestCase):
                 except SyntaxError as exc:
                     with support.captured_stderr() as err:
                         sys.__excepthook__(*sys.exc_info())
+                    self.assertIn(expected, err.getvalue())
                     the_exception = exc
 
     def test_encodings(self):


### PR DESCRIPTION
The expected tracebacks were added to the test but not checked against actual tracebacks.