### PR TITLE
Modest speed-ups for the _sum() helper function in statistics module

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -137,7 +137,7 @@ from itertools import groupby, repeat
 from bisect import bisect_left, bisect_right
 from math import hypot, sqrt, fabs, exp, erf, tau, log, fsum
 from operator import itemgetter, mul
-from collections import Counter, namedtuple
+from collections import Counter, namedtuple, defaultdict
 
 # === Exceptions ===
 
@@ -180,14 +180,13 @@ def _sum(data):
     allowed.
     """
     count = 0
-    partials = {}
-    partials_get = partials.get
+    partials = defaultdict(int)
     T = int
     for typ, values in groupby(data, type):
         T = _coerce(T, typ)  # or raise TypeError
         for n, d in map(_exact_ratio, values):
             count += 1
-            partials[d] = partials_get(d, 0) + n
+            partials[d] += n
     if None in partials:
         # The sum will be a NAN or INF. We can ignore all the finite
         # partials, and just look at this special one.

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -184,7 +184,11 @@ def _sum(data):
     T = int
     for typ, values in groupby(data, type):
         T = _coerce(T, typ)  # or raise TypeError
-        for n, d in map(_exact_ratio, values):
+        for value in values:
+            try:
+                n, d = value.as_integer_ratio()
+            except Exception:
+                n, d = _exact_ratio(value)
             count += 1
             partials[d] += n
     if None in partials:

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -194,8 +194,9 @@ def _sum(data):
         total = partials[None]
         assert not _isfinite(total)
     else:
-        # Sum all the partial sums using builtin sum.
-        total = sum(Fraction(n, d) for d, n in partials.items())
+        common_multiple = math.lcm(*partials)
+        numerators = sum(common_multiple // d * n for d, n in partials.items())
+        total = Fraction(numerators, common_multiple)
     return (T, total, count)
 
 


### PR DESCRIPTION
Three small speed-ups for our slowest helper method:

1) Replace the ``dict.partials.get`` call with ``defaultdict(int)``.  On bigger datasets, this is about a 25% win. On smaller datasets, it is a little slower that the ``get()`` approach. The reason is that *get* loads the constant zero regardless of whether denominator has been seen before.  In contrast, the *defaultdict* constructs a zero with the slow call to ``int()`` but only does so when the denominator has not been seen before.  So, datasets with many repeated denominators avoid this cost.

2) Now that *int*, *float*, *Decimal*, and *Fraction* all support ``as_integer_ratio()``, it makes sense to inline that common case from ``exact_ratio()``.  This avoids function call overhead for every datum.

3) Eliminate overhead of repeated calls to ``Fraction.__new__`` and ``Fraction.__add__`` by summing directly to the least common multiple using fast inline integer arithmetic.  The final *Fraction()* instance reduces the fraction if needed.

**Baseline timings**

```
# baseline: small run with 10 elements
$ python -m timeit -r 11 -s 'from random import expovariate' -s 'from statistics import _sum' -s 'data=[expovariate(1.0) for i in range(10)]' '_sum(data)'
10000 loops, best of 11: 28.4 usec per loop

# baseline:  medium run with 100 elements
$ python -m timeit -r 11 -s 'from random import expovariate' -s 'from statistics import _sum' -s 'data=[expovariate(1.0) for i in range(100)]' '_sum(data)'
5000 loops, best of 11: 61.6 usec per loop

#baseline: long run with 10,000 elements
$ python -m timeit -r 11 -s 'from random import expovariate' -s 'from statistics import _sum' -s 'data=[expovariate(1.0) for i in range(10_000)]' '_sum(data)'
50 loops, best of 11: 5.28 msec per loop
```

**Patched timings**

```
# patched: small run with 10 elements
$ python -m timeit -r 11 -s 'from random import expovariate' -s 'from statistics import _sum' -s 'data=[expovariate(1.0) for i in range(10)]' '_sum(data)'  
20000 loops, best of 11: 9.97 usec per loop

# patched: medium run with 100 elements
$ python -m timeit -r 11 -s 'from random import expovariate' -s 'from statistics import _sum' -s 'data=[expovariate(1.0) for i in range(100)]' '_sum(data)'   
5000 loops, best of 11: 54.3 usec per loop

# patched: long run with 10,000 elements
$ python -m timeit -r 11 -s 'from random import expovariate' -s 'from statistics import _sum' -s 'data=[expovariate(1.0) for i in range(10_000)]' '_sum(data)'
50 loops, best of 11: 4.74 msec per loop
```
