### PR TITLE
Fix doctest doc examples for syntax errors

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -485,7 +485,7 @@ Some details you should read once, but won't need to remember:
 
 .. index:: single: ^ (caret); marker
 
-* For some exceptions, Python displays the position of the error, using ``^``
+* For some exceptions, Python displays the position of the error using ``^``
   markers and tildes::
 
      >>> 1 + None

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -485,25 +485,24 @@ Some details you should read once, but won't need to remember:
 
 .. index:: single: ^ (caret); marker
 
-* For some :exc:`SyntaxError`\ s, Python displays the position range of the
-  syntax error, using ``^`` markers::
+* For some exceptions, Python displays the position of the
+  syntax error, using ``^`` markers and tildes::
 
-     >>> 1, 1 1
+     >>> 1 + None
        File "<stdin>", line 1
-         1, 1 1
-            ^^^
-     SyntaxError: invalid syntax
+         1 + None
+         ~~^~~~~~
+     TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
 
   Since the lines showing the position of the error come before the exception type
   and detail, they are not checked by doctest.  For example, the following test
-  would pass, even though it puts the ``^`` markers in the wrong location::
+  would pass, even though it puts the ``^`` marker in the wrong location::
 
-     >>> 1, 1 1
-     Traceback (most recent call last):
+     >>> 1 + None
        File "<stdin>", line 1
-         1, 1 1
-         ^^^
-     SyntaxError: invalid syntax
+         1 + None
+         ^~~~~~~~
+     TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
 
 
 .. _option-flags-and-directives:

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -485,24 +485,24 @@ Some details you should read once, but won't need to remember:
 
 .. index:: single: ^ (caret); marker
 
-* For some :exc:`SyntaxError`\ s, Python displays the character position of the
-  syntax error, using a ``^`` marker::
+* For some :exc:`SyntaxError`\ s, Python displays the position range of the
+  syntax error, using ``^`` markers::
 
-     >>> 1 1
+     >>> 1, 1 1
        File "<stdin>", line 1
-         1 1
-           ^
+         1, 1 1
+            ^^^
      SyntaxError: invalid syntax
 
   Since the lines showing the position of the error come before the exception type
   and detail, they are not checked by doctest.  For example, the following test
-  would pass, even though it puts the ``^`` marker in the wrong location::
+  would pass, even though it puts the ``^`` markers in the wrong location::
 
-     >>> 1 1
+     >>> 1, 1 1
      Traceback (most recent call last):
        File "<stdin>", line 1
-         1 1
-         ^
+         1, 1 1
+         ^^^
      SyntaxError: invalid syntax
 
 

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -485,8 +485,8 @@ Some details you should read once, but won't need to remember:
 
 .. index:: single: ^ (caret); marker
 
-* For some exceptions, Python displays the position of the
-  syntax error, using ``^`` markers and tildes::
+* For some exceptions, Python displays the position of the error, using ``^``
+  markers and tildes::
 
      >>> 1 + None
        File "<stdin>", line 1


### PR DESCRIPTION
Not sure if this needs a bpo issue, I can add if needed.

This can be backported to 3.10,  but not to 3.9  or earlier.

With introduction of SyntaxError error range indication with carets (^^^), two examples in doctests are inaccurate and confusing.

Note that while it's indexed as `single: ^ (caret)`, that doesn't need to be updated as in the index it's listed under caret (marker), which works fine for this doc section.