### PR TITLE
bpo-45254: Reuse `multiprocessing.managers.HAS_SHMEM` in tests

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -62,12 +62,6 @@ except ImportError:
     HAS_SHAREDCTYPES = False
 
 try:
-    from multiprocessing import shared_memory
-    HAS_SHMEM = True
-except ImportError:
-    HAS_SHMEM = False
-
-try:
     import msvcrt
 except ImportError:
     msvcrt = None
@@ -3758,7 +3752,8 @@ class _TestSharedCTypes(BaseTestCase):
         self.assertEqual(bar.z, 2 ** 33)
 
 
-@unittest.skipUnless(HAS_SHMEM, "requires multiprocessing.shared_memory")
+@unittest.skipUnless(multiprocessing.managers.HAS_SHMEM,
+                     'requires multiprocessing.shared_memory')
 @hashlib_helper.requires_hashdigest('md5')
 class _TestSharedMemory(BaseTestCase):
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -49,6 +49,9 @@ import multiprocessing.queues
 
 from multiprocessing import util
 
+if multiprocessing.managers.HAS_SHMEM:
+    from multiprocessing import shared_memory
+
 try:
     from multiprocessing import reduction
     HAS_REDUCTION = reduction.HAVE_SEND_HANDLE

--- a/Misc/NEWS.d/next/Tests/2021-09-21-10-53-43.bpo-45254.bd-ai5.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-21-10-53-43.bpo-45254.bd-ai5.rst
@@ -1,0 +1,1 @@
+Reuse ``multiprocessing.managers.HAS_SHMEM`` in ``_test_multiprocessing``.


### PR DESCRIPTION


<!-- issue-number: [bpo-45254](https://bugs.python.org/issue45254) -->
https://bugs.python.org/issue45254
<!-- /issue-number -->
