### PR TITLE
[3.7] bpo-42406: Fix whichmodule() with multiprocessing (pythonGH-23403)

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -307,7 +307,9 @@ def whichmodule(obj, name):
     # Protect the iteration by using a list copy of sys.modules against dynamic
     # modules that trigger imports of other modules upon calls to getattr.
     for module_name, module in list(sys.modules.items()):
-        if module_name == '__main__' or module is None:
+        if (module_name == '__main__'
+             or module_name == '__mp_main__'  # bpo-42406
+             or module is None):
             continue
         try:
             if _getattribute(module, name)[0] is obj:


### PR DESCRIPTION
We have hit this issue in 3.7 as well.

<!-- issue-number: [bpo-42406](https://bugs.python.org/issue42406) -->
https://bugs.python.org/issue42406
<!-- /issue-number -->
