### PR TITLE
bpo-44958: Fix ref. leak introduced in GH-27844

### DIFF
--- a/Lib/sqlite3/test/test_dbapi.py
+++ b/Lib/sqlite3/test/test_dbapi.py
@@ -38,13 +38,14 @@ from test.support.os_helper import TESTFN, unlink, temp_dir
 
 # Helper for tests using TESTFN
 @contextlib.contextmanager
-def managed_connect(*args, **kwargs):
+def managed_connect(*args, in_mem=False, **kwargs):
     cx = sqlite.connect(*args, **kwargs)
     try:
         yield cx
     finally:
         cx.close()
-        unlink(TESTFN)
+        if not in_mem:
+            unlink(TESTFN)
 
 
 class ModuleTests(unittest.TestCase):

--- a/Lib/sqlite3/test/test_regression.py
+++ b/Lib/sqlite3/test/test_regression.py
@@ -469,6 +469,7 @@ class RegressionTests(unittest.TestCase):
         del cur
         con.execute("drop table t")
         con.commit()
+        con.close()
 
 
 if __name__ == "__main__":

--- a/Lib/sqlite3/test/test_regression.py
+++ b/Lib/sqlite3/test/test_regression.py
@@ -28,6 +28,8 @@ import weakref
 import functools
 from test import support
 
+from .test_dbapi import managed_connect
+
 class RegressionTests(unittest.TestCase):
     def setUp(self):
         self.con = sqlite.connect(":memory:")
@@ -437,39 +439,41 @@ class RegressionTests(unittest.TestCase):
         self.assertEqual(val, b'')
 
     def test_table_lock_cursor_replace_stmt(self):
-        con = sqlite.connect(":memory:")
-        cur = con.cursor()
-        cur.execute("create table t(t)")
-        cur.executemany("insert into t values(?)", ((v,) for v in range(5)))
-        con.commit()
-        cur.execute("select t from t")
-        cur.execute("drop table t")
-        con.commit()
+        with managed_connect(":memory:", in_mem=True) as con:
+            cur = con.cursor()
+            cur.execute("create table t(t)")
+            cur.executemany("insert into t values(?)",
+                            ((v,) for v in range(5)))
+            con.commit()
+            cur.execute("select t from t")
+            cur.execute("drop table t")
+            con.commit()
 
     def test_table_lock_cursor_dealloc(self):
-        con = sqlite.connect(":memory:")
-        con.execute("create table t(t)")
-        con.executemany("insert into t values(?)", ((v,) for v in range(5)))
-        con.commit()
-        cur = con.execute("select t from t")
-        del cur
-        con.execute("drop table t")
-        con.commit()
+        with managed_connect(":memory:", in_mem=True) as con:
+            con.execute("create table t(t)")
+            con.executemany("insert into t values(?)",
+                            ((v,) for v in range(5)))
+            con.commit()
+            cur = con.execute("select t from t")
+            del cur
+            con.execute("drop table t")
+            con.commit()
 
     def test_table_lock_cursor_non_readonly_select(self):
-        con = sqlite.connect(":memory:")
-        con.execute("create table t(t)")
-        con.executemany("insert into t values(?)", ((v,) for v in range(5)))
-        con.commit()
-        def dup(v):
-            con.execute("insert into t values(?)", (v,))
-            return
-        con.create_function("dup", 1, dup)
-        cur = con.execute("select dup(t) from t")
-        del cur
-        con.execute("drop table t")
-        con.commit()
-        con.close()
+        with managed_connect(":memory:", in_mem=True) as con:
+            con.execute("create table t(t)")
+            con.executemany("insert into t values(?)",
+                            ((v,) for v in range(5)))
+            con.commit()
+            def dup(v):
+                con.execute("insert into t values(?)", (v,))
+                return
+            con.create_function("dup", 1, dup)
+            cur = con.execute("select dup(t) from t")
+            del cur
+            con.execute("drop table t")
+            con.commit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Modify managed_connect() helper to support in-memory databases. Use it
for the regression tests added in GH-27844.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44958](https://bugs.python.org/issue44958) -->
https://bugs.python.org/issue44958
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal