### PR TITLE
[3.10] bpo-43760: Ensure that older Cython generated code compiles under 3.10

### DIFF
--- a/Doc/data/python3.10.abi
+++ b/Doc/data/python3.10.abi
@@ -1675,7 +1675,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Parser/myreadline.c' comp-dir-path='/src' language='LANG_C99'>
-    <class-decl name='_ts' size-in-bits='2240' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-9'>
+    <class-decl name='_ts' size-in-bits='2304' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-9'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='prev' type-id='type-id-10' visibility='default' filepath='./Include/cpython/pystate.h' line='65' column='1'/>
       </data-member>
@@ -1774,6 +1774,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='2112'>
         <var-decl name='root_cframe' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='use_tracing' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='151' column='1'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-10'/>
@@ -3533,7 +3536,7 @@
       <parameter is-variadic='yes'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <class-decl name='_ts' size-in-bits='2240' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-221'>
+    <class-decl name='_ts' size-in-bits='2304' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-221'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='prev' type-id='type-id-10' visibility='default' filepath='./Include/cpython/pystate.h' line='65' column='1'/>
       </data-member>
@@ -3632,6 +3635,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='2112'>
         <var-decl name='root_cframe' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='use_tracing' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='151' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='_is' size-in-bits='908160' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='220' column='1' id='type-id-224'>
@@ -3885,27 +3891,27 @@
         <var-decl name='next' type-id='type-id-265' visibility='default' filepath='./Include/internal/pycore_interp.h' line='331' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_xid' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='257' column='1' id='type-id-268'>
+    <class-decl name='_xid' size-in-bits='320' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='258' column='1' id='type-id-268'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='data' type-id='type-id-20' visibility='default' filepath='./Include/cpython/pystate.h' line='261' column='1'/>
+        <var-decl name='data' type-id='type-id-20' visibility='default' filepath='./Include/cpython/pystate.h' line='262' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='obj' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='268' column='1'/>
+        <var-decl name='obj' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='269' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='interp' type-id='type-id-227' visibility='default' filepath='./Include/cpython/pystate.h' line='278' column='1'/>
+        <var-decl name='interp' type-id='type-id-227' visibility='default' filepath='./Include/cpython/pystate.h' line='279' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='new_object' type-id='type-id-269' visibility='default' filepath='./Include/cpython/pystate.h' line='283' column='1'/>
+        <var-decl name='new_object' type-id='type-id-269' visibility='default' filepath='./Include/cpython/pystate.h' line='284' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='free' type-id='type-id-19' visibility='default' filepath='./Include/cpython/pystate.h' line='293' column='1'/>
+        <var-decl name='free' type-id='type-id-19' visibility='default' filepath='./Include/cpython/pystate.h' line='294' column='1'/>
       </data-member>
     </class-decl>
     <pointer-type-def type-id='type-id-268' size-in-bits='64' id='type-id-270'/>
     <pointer-type-def type-id='type-id-271' size-in-bits='64' id='type-id-269'/>
     <pointer-type-def type-id='type-id-272' size-in-bits='64' id='type-id-273'/>
-    <typedef-decl name='crossinterpdatafunc' type-id='type-id-273' filepath='./Include/cpython/pystate.h' line='304' column='1' id='type-id-267'/>
+    <typedef-decl name='crossinterpdatafunc' type-id='type-id-273' filepath='./Include/cpython/pystate.h' line='305' column='1' id='type-id-267'/>
     <pointer-type-def type-id='type-id-266' size-in-bits='64' id='type-id-265'/>
     <pointer-type-def type-id='type-id-274' size-in-bits='64' id='type-id-275'/>
 
@@ -4637,7 +4643,7 @@
     <typedef-decl name='PyFrameObject' type-id='type-id-332' filepath='./Include/pyframe.h' line='12' column='1' id='type-id-347'/>
     <pointer-type-def type-id='type-id-347' size-in-bits='64' id='type-id-223'/>
     <pointer-type-def type-id='type-id-348' size-in-bits='64' id='type-id-349'/>
-    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-349' filepath='./Include/cpython/pystate.h' line='205' column='1' id='type-id-232'/>
+    <typedef-decl name='_PyFrameEvalFunction' type-id='type-id-349' filepath='./Include/cpython/pystate.h' line='206' column='1' id='type-id-232'/>
 
     <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='16320' id='type-id-233'>
       <subrange length='255' type-id='type-id-18' id='type-id-350'/>
@@ -6574,7 +6580,7 @@
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Objects/genericaliasobject.c' comp-dir-path='/src' language='LANG_C99'>
     <var-decl name='Py_GenericAliasType' type-id='type-id-149' mangled-name='Py_GenericAliasType' visibility='default' filepath='./Include/genericaliasobject.h' line='9' column='1' elf-symbol-id='Py_GenericAliasType'/>
-    <function-decl name='Py_GenericAlias' mangled-name='Py_GenericAlias' filepath='Objects/genericaliasobject.c' line='658' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GenericAlias'>
+    <function-decl name='Py_GenericAlias' mangled-name='Py_GenericAlias' filepath='Objects/genericaliasobject.c' line='660' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GenericAlias'>
       <parameter type-id='type-id-15' name='callable' filepath='Objects/call.c' line='387' column='1'/>
       <parameter type-id='type-id-15' name='args' filepath='Objects/call.c' line='387' column='1'/>
       <return type-id='type-id-15'/>
@@ -8724,37 +8730,37 @@
     <var-decl name='PyType_Type' type-id='type-id-149' mangled-name='PyType_Type' visibility='default' filepath='./Include/object.h' line='251' column='1' elf-symbol-id='PyType_Type'/>
     <var-decl name='PyBaseObject_Type' type-id='type-id-149' mangled-name='PyBaseObject_Type' visibility='default' filepath='./Include/object.h' line='252' column='1' elf-symbol-id='PyBaseObject_Type'/>
     <var-decl name='PySuper_Type' type-id='type-id-149' mangled-name='PySuper_Type' visibility='default' filepath='./Include/object.h' line='253' column='1' elf-symbol-id='PySuper_Type'/>
-    <function-decl name='PyType_Ready' mangled-name='PyType_Ready' filepath='Objects/typeobject.c' line='6343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Ready'>
-      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='6343' column='1'/>
+    <function-decl name='PyType_Ready' mangled-name='PyType_Ready' filepath='Objects/typeobject.c' line='6351' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_Ready'>
+      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='6351' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyType_LookupId' mangled-name='_PyType_LookupId' filepath='Objects/typeobject.c' line='3845' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_LookupId'>
-      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3845' column='1'/>
-      <parameter type-id='type-id-219' name='name' filepath='Objects/typeobject.c' line='3845' column='1'/>
+    <function-decl name='_PyType_LookupId' mangled-name='_PyType_LookupId' filepath='Objects/typeobject.c' line='3853' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_LookupId'>
+      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3853' column='1'/>
+      <parameter type-id='type-id-219' name='name' filepath='Objects/typeobject.c' line='3853' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyType_Lookup' mangled-name='_PyType_Lookup' filepath='Objects/typeobject.c' line='3787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_Lookup'>
-      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3787' column='1'/>
-      <parameter type-id='type-id-15' name='name' filepath='Objects/typeobject.c' line='3787' column='1'/>
+    <function-decl name='_PyType_Lookup' mangled-name='_PyType_Lookup' filepath='Objects/typeobject.c' line='3795' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_Lookup'>
+      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3795' column='1'/>
+      <parameter type-id='type-id-15' name='name' filepath='Objects/typeobject.c' line='3795' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <pointer-type-def type-id='type-id-458' size-in-bits='64' id='type-id-505'/>
-    <function-decl name='_PyType_GetModuleByDef' mangled-name='_PyType_GetModuleByDef' filepath='Objects/typeobject.c' line='3685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_GetModuleByDef'>
-      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3685' column='1'/>
-      <parameter type-id='type-id-505' name='def' filepath='Objects/typeobject.c' line='3685' column='1'/>
+    <function-decl name='_PyType_GetModuleByDef' mangled-name='_PyType_GetModuleByDef' filepath='Objects/typeobject.c' line='3693' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyType_GetModuleByDef'>
+      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3693' column='1'/>
+      <parameter type-id='type-id-505' name='def' filepath='Objects/typeobject.c' line='3693' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyType_GetModuleState' mangled-name='PyType_GetModuleState' filepath='Objects/typeobject.c' line='3667' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleState'>
-      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3667' column='1'/>
+    <function-decl name='PyType_GetModuleState' mangled-name='PyType_GetModuleState' filepath='Objects/typeobject.c' line='3675' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModuleState'>
+      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3675' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='PyType_GetModule' mangled-name='PyType_GetModule' filepath='Objects/typeobject.c' line='3643' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModule'>
+    <function-decl name='PyType_GetModule' mangled-name='PyType_GetModule' filepath='Objects/typeobject.c' line='3651' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetModule'>
       <parameter type-id='type-id-31' name='tp' filepath='Objects/object.c' line='181' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyType_GetSlot' mangled-name='PyType_GetSlot' filepath='Objects/typeobject.c' line='3621' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetSlot'>
-      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3621' column='1'/>
-      <parameter type-id='type-id-8' name='slot' filepath='Objects/typeobject.c' line='3621' column='1'/>
+    <function-decl name='PyType_GetSlot' mangled-name='PyType_GetSlot' filepath='Objects/typeobject.c' line='3629' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyType_GetSlot'>
+      <parameter type-id='type-id-31' name='type' filepath='Objects/typeobject.c' line='3629' column='1'/>
+      <parameter type-id='type-id-8' name='slot' filepath='Objects/typeobject.c' line='3629' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <class-decl name='__anonymous_struct__' size-in-bits='256' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-506' visibility='default' filepath='./Include/object.h' line='222' column='1' id='type-id-507'>
@@ -9868,32 +9874,32 @@
     <var-decl name='PyZip_Type' type-id='type-id-149' mangled-name='PyZip_Type' visibility='default' filepath='./Include/bltinmodule.h' line='9' column='1' elf-symbol-id='PyZip_Type'/>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/ceval.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='Py_LeaveRecursiveCall' mangled-name='Py_LeaveRecursiveCall' filepath='Python/ceval.c' line='6520' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_LeaveRecursiveCall'>
+    <function-decl name='Py_LeaveRecursiveCall' mangled-name='Py_LeaveRecursiveCall' filepath='Python/ceval.c' line='6523' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_LeaveRecursiveCall'>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='Py_EnterRecursiveCall' mangled-name='Py_EnterRecursiveCall' filepath='Python/ceval.c' line='6513' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EnterRecursiveCall'>
-      <parameter type-id='type-id-3' name='where' filepath='Python/ceval.c' line='6513' column='1'/>
+    <function-decl name='Py_EnterRecursiveCall' mangled-name='Py_EnterRecursiveCall' filepath='Python/ceval.c' line='6516' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EnterRecursiveCall'>
+      <parameter type-id='type-id-3' name='where' filepath='Python/ceval.c' line='6516' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_RequestCodeExtraIndex' mangled-name='_PyEval_RequestCodeExtraIndex' filepath='Python/ceval.c' line='6435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_RequestCodeExtraIndex'>
-      <parameter type-id='type-id-64' name='free' filepath='Python/ceval.c' line='6435' column='1'/>
+    <function-decl name='_PyEval_RequestCodeExtraIndex' mangled-name='_PyEval_RequestCodeExtraIndex' filepath='Python/ceval.c' line='6438' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_RequestCodeExtraIndex'>
+      <parameter type-id='type-id-64' name='free' filepath='Python/ceval.c' line='6438' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='_PyEval_SliceIndexNotNone' mangled-name='_PyEval_SliceIndexNotNone' filepath='Python/ceval.c' line='5972' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SliceIndexNotNone'>
+    <function-decl name='_PyEval_SliceIndexNotNone' mangled-name='_PyEval_SliceIndexNotNone' filepath='Python/ceval.c' line='5975' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SliceIndexNotNone'>
       <parameter type-id='type-id-15' name='exc' filepath='Objects/exceptions.c' line='1887' column='1'/>
       <parameter type-id='type-id-125' name='end' filepath='Objects/exceptions.c' line='1887' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_SliceIndex' mangled-name='_PyEval_SliceIndex' filepath='Python/ceval.c' line='5950' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SliceIndex'>
-      <parameter type-id='type-id-15' name='v' filepath='Python/ceval.c' line='5950' column='1'/>
-      <parameter type-id='type-id-125' name='pi' filepath='Python/ceval.c' line='5950' column='1'/>
+    <function-decl name='_PyEval_SliceIndex' mangled-name='_PyEval_SliceIndex' filepath='Python/ceval.c' line='5953' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SliceIndex'>
+      <parameter type-id='type-id-15' name='v' filepath='Python/ceval.c' line='5953' column='1'/>
+      <parameter type-id='type-id-125' name='pi' filepath='Python/ceval.c' line='5953' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyEval_GetFuncDesc' mangled-name='PyEval_GetFuncDesc' filepath='Python/ceval.c' line='5790' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncDesc'>
+    <function-decl name='PyEval_GetFuncDesc' mangled-name='PyEval_GetFuncDesc' filepath='Python/ceval.c' line='5793' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncDesc'>
       <parameter type-id='type-id-15' name='ob' filepath='Objects/exceptions.c' line='368' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='PyEval_GetFuncName' mangled-name='PyEval_GetFuncName' filepath='Python/ceval.c' line='5777' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncName'>
+    <function-decl name='PyEval_GetFuncName' mangled-name='PyEval_GetFuncName' filepath='Python/ceval.c' line='5780' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFuncName'>
       <parameter type-id='type-id-15' name='ob' filepath='Objects/exceptions.c' line='368' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
@@ -9907,21 +9913,21 @@
     </class-decl>
     <typedef-decl name='PyCompilerFlags' type-id='type-id-521' filepath='./Include/cpython/compile.h' line='27' column='1' id='type-id-520'/>
     <pointer-type-def type-id='type-id-520' size-in-bits='64' id='type-id-522'/>
-    <function-decl name='PyEval_MergeCompilerFlags' mangled-name='PyEval_MergeCompilerFlags' filepath='Python/ceval.c' line='5752' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_MergeCompilerFlags'>
-      <parameter type-id='type-id-522' name='cf' filepath='Python/ceval.c' line='5752' column='1'/>
+    <function-decl name='PyEval_MergeCompilerFlags' mangled-name='PyEval_MergeCompilerFlags' filepath='Python/ceval.c' line='5755' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_MergeCompilerFlags'>
+      <parameter type-id='type-id-522' name='cf' filepath='Python/ceval.c' line='5755' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyEval_GetGlobals' mangled-name='PyEval_GetGlobals' filepath='Python/ceval.c' line='5739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetGlobals'>
+    <function-decl name='PyEval_GetGlobals' mangled-name='PyEval_GetGlobals' filepath='Python/ceval.c' line='5742' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetGlobals'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyEval_GetLocals' mangled-name='PyEval_GetLocals' filepath='Python/ceval.c' line='5721' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetLocals'>
+    <function-decl name='PyEval_GetLocals' mangled-name='PyEval_GetLocals' filepath='Python/ceval.c' line='5724' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetLocals'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyEval_GetBuiltinId' mangled-name='_PyEval_GetBuiltinId' filepath='Python/ceval.c' line='5707' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetBuiltinId'>
-      <parameter type-id='type-id-453' name='name' filepath='Python/ceval.c' line='5707' column='1'/>
+    <function-decl name='_PyEval_GetBuiltinId' mangled-name='_PyEval_GetBuiltinId' filepath='Python/ceval.c' line='5710' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetBuiltinId'>
+      <parameter type-id='type-id-453' name='name' filepath='Python/ceval.c' line='5710' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyEval_GetBuiltins' mangled-name='PyEval_GetBuiltins' filepath='Python/ceval.c' line='5699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetBuiltins'>
+    <function-decl name='PyEval_GetBuiltins' mangled-name='PyEval_GetBuiltins' filepath='Python/ceval.c' line='5702' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetBuiltins'>
       <return type-id='type-id-15'/>
     </function-decl>
     <class-decl name='_frame' size-in-bits='2880' is-struct='yes' visibility='default' filepath='./Include/cpython/frameobject.h' line='28' column='1' id='type-id-523'>
@@ -9982,27 +9988,27 @@
     </class-decl>
     <typedef-decl name='PyFrameObject' type-id='type-id-523' filepath='./Include/pyframe.h' line='12' column='1' id='type-id-524'/>
     <pointer-type-def type-id='type-id-524' size-in-bits='64' id='type-id-525'/>
-    <function-decl name='PyEval_GetFrame' mangled-name='PyEval_GetFrame' filepath='Python/ceval.c' line='5682' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFrame'>
+    <function-decl name='PyEval_GetFrame' mangled-name='PyEval_GetFrame' filepath='Python/ceval.c' line='5685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_GetFrame'>
       <return type-id='type-id-525'/>
     </function-decl>
-    <function-decl name='_PyEval_GetAsyncGenFinalizer' mangled-name='_PyEval_GetAsyncGenFinalizer' filepath='Python/ceval.c' line='5675' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetAsyncGenFinalizer'>
+    <function-decl name='_PyEval_GetAsyncGenFinalizer' mangled-name='_PyEval_GetAsyncGenFinalizer' filepath='Python/ceval.c' line='5678' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetAsyncGenFinalizer'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyEval_SetAsyncGenFinalizer' mangled-name='_PyEval_SetAsyncGenFinalizer' filepath='Python/ceval.c' line='5661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetAsyncGenFinalizer'>
-      <parameter type-id='type-id-15' name='finalizer' filepath='Python/ceval.c' line='5661' column='1'/>
+    <function-decl name='_PyEval_SetAsyncGenFinalizer' mangled-name='_PyEval_SetAsyncGenFinalizer' filepath='Python/ceval.c' line='5664' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetAsyncGenFinalizer'>
+      <parameter type-id='type-id-15' name='finalizer' filepath='Python/ceval.c' line='5664' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_GetAsyncGenFirstiter' mangled-name='_PyEval_GetAsyncGenFirstiter' filepath='Python/ceval.c' line='5654' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetAsyncGenFirstiter'>
+    <function-decl name='_PyEval_GetAsyncGenFirstiter' mangled-name='_PyEval_GetAsyncGenFirstiter' filepath='Python/ceval.c' line='5657' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetAsyncGenFirstiter'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyEval_SetAsyncGenFirstiter' mangled-name='_PyEval_SetAsyncGenFirstiter' filepath='Python/ceval.c' line='5640' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetAsyncGenFirstiter'>
-      <parameter type-id='type-id-15' name='finalizer' filepath='Python/ceval.c' line='5661' column='1'/>
+    <function-decl name='_PyEval_SetAsyncGenFirstiter' mangled-name='_PyEval_SetAsyncGenFirstiter' filepath='Python/ceval.c' line='5643' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetAsyncGenFirstiter'>
+      <parameter type-id='type-id-15' name='finalizer' filepath='Python/ceval.c' line='5664' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyEval_GetCoroutineOriginTrackingDepth' mangled-name='_PyEval_GetCoroutineOriginTrackingDepth' filepath='Python/ceval.c' line='5633' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetCoroutineOriginTrackingDepth'>
+    <function-decl name='_PyEval_GetCoroutineOriginTrackingDepth' mangled-name='_PyEval_GetCoroutineOriginTrackingDepth' filepath='Python/ceval.c' line='5636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_GetCoroutineOriginTrackingDepth'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <class-decl name='_ts' size-in-bits='2240' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-526'>
+    <class-decl name='_ts' size-in-bits='2304' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-526'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='prev' type-id='type-id-10' visibility='default' filepath='./Include/cpython/pystate.h' line='65' column='1'/>
       </data-member>
@@ -10101,6 +10107,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='2112'>
         <var-decl name='root_cframe' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='use_tracing' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='151' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='_is' size-in-bits='908160' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='220' column='1' id='type-id-527'>
@@ -10320,31 +10329,31 @@
     </class-decl>
     <typedef-decl name='PyThreadState' type-id='type-id-526' filepath='./Include/pystate.h' line='20' column='1' id='type-id-532'/>
     <pointer-type-def type-id='type-id-532' size-in-bits='64' id='type-id-533'/>
-    <function-decl name='_PyEval_SetCoroutineOriginTrackingDepth' mangled-name='_PyEval_SetCoroutineOriginTrackingDepth' filepath='Python/ceval.c' line='5626' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetCoroutineOriginTrackingDepth'>
-      <parameter type-id='type-id-533' name='tstate' filepath='Python/ceval.c' line='5626' column='1'/>
-      <parameter type-id='type-id-8' name='new_depth' filepath='Python/ceval.c' line='5626' column='1'/>
+    <function-decl name='_PyEval_SetCoroutineOriginTrackingDepth' mangled-name='_PyEval_SetCoroutineOriginTrackingDepth' filepath='Python/ceval.c' line='5629' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetCoroutineOriginTrackingDepth'>
+      <parameter type-id='type-id-533' name='tstate' filepath='Python/ceval.c' line='5629' column='1'/>
+      <parameter type-id='type-id-8' name='new_depth' filepath='Python/ceval.c' line='5629' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyEval_SetTrace' mangled-name='PyEval_SetTrace' filepath='Python/ceval.c' line='5615' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_SetTrace'>
-      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5615' column='1'/>
-      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5615' column='1'/>
+    <function-decl name='PyEval_SetTrace' mangled-name='PyEval_SetTrace' filepath='Python/ceval.c' line='5618' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_SetTrace'>
+      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5618' column='1'/>
+      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5618' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PyEval_SetTrace' mangled-name='_PyEval_SetTrace' filepath='Python/ceval.c' line='5582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetTrace'>
-      <parameter type-id='type-id-533' name='tstate' filepath='Python/ceval.c' line='5582' column='1'/>
-      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5582' column='1'/>
-      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5582' column='1'/>
+    <function-decl name='_PyEval_SetTrace' mangled-name='_PyEval_SetTrace' filepath='Python/ceval.c' line='5584' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetTrace'>
+      <parameter type-id='type-id-533' name='tstate' filepath='Python/ceval.c' line='5584' column='1'/>
+      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5584' column='1'/>
+      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5584' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyEval_SetProfile' mangled-name='PyEval_SetProfile' filepath='Python/ceval.c' line='5572' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_SetProfile'>
-      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5615' column='1'/>
-      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5615' column='1'/>
+    <function-decl name='PyEval_SetProfile' mangled-name='PyEval_SetProfile' filepath='Python/ceval.c' line='5574' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyEval_SetProfile'>
+      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5618' column='1'/>
+      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5618' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='_PyEval_SetProfile' mangled-name='_PyEval_SetProfile' filepath='Python/ceval.c' line='5541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_SetProfile'>
-      <parameter type-id='type-id-533' name='tstate' filepath='Python/ceval.c' line='5582' column='1'/>
-      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5582' column='1'/>
-      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5582' column='1'/>
+      <parameter type-id='type-id-533' name='tstate' filepath='Python/ceval.c' line='5584' column='1'/>
+      <parameter type-id='type-id-14' name='func' filepath='Python/ceval.c' line='5584' column='1'/>
+      <parameter type-id='type-id-15' name='arg' filepath='Python/ceval.c' line='5584' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyEval_CallTracing' mangled-name='_PyEval_CallTracing' filepath='Python/ceval.c' line='5496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyEval_CallTracing'>
@@ -10582,11 +10591,11 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/compile.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='PyCode_Optimize' mangled-name='PyCode_Optimize' filepath='Python/compile.c' line='7879' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCode_Optimize'>
-      <parameter type-id='type-id-15' name='code' filepath='Python/compile.c' line='7879' column='1'/>
-      <parameter type-id='type-id-15' name='_unused_consts' filepath='Python/compile.c' line='7879' column='1'/>
-      <parameter type-id='type-id-15' name='_unused_names' filepath='Python/compile.c' line='7880' column='1'/>
-      <parameter type-id='type-id-15' name='_unused_lnotab_obj' filepath='Python/compile.c' line='7880' column='1'/>
+    <function-decl name='PyCode_Optimize' mangled-name='PyCode_Optimize' filepath='Python/compile.c' line='7912' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCode_Optimize'>
+      <parameter type-id='type-id-15' name='code' filepath='Python/compile.c' line='7912' column='1'/>
+      <parameter type-id='type-id-15' name='_unused_consts' filepath='Python/compile.c' line='7912' column='1'/>
+      <parameter type-id='type-id-15' name='_unused_names' filepath='Python/compile.c' line='7913' column='1'/>
+      <parameter type-id='type-id-15' name='_unused_lnotab_obj' filepath='Python/compile.c' line='7913' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='PyCompile_OpcodeStackEffect' mangled-name='PyCompile_OpcodeStackEffect' filepath='Python/compile.c' line='1226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyCompile_OpcodeStackEffect'>
@@ -11967,797 +11976,130 @@
       <parameter type-id='type-id-15' name='obj' filepath='Python/errors.c' line='1454' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyErr_NewExceptionWithDoc' mangled-name='PyErr_NewExceptionWithDoc' filepath='Python/errors.c' line='1164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NewExceptionWithDoc'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/errors.c' line='1164' column='1'/>
-      <parameter type-id='type-id-3' name='doc' filepath='Python/errors.c' line='1164' column='1'/>
-      <parameter type-id='type-id-15' name='base' filepath='Python/errors.c' line='1165' column='1'/>
-      <parameter type-id='type-id-15' name='dict' filepath='Python/errors.c' line='1165' column='1'/>
+    <function-decl name='PyErr_NewExceptionWithDoc' mangled-name='PyErr_NewExceptionWithDoc' filepath='Python/errors.c' line='1165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NewExceptionWithDoc'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/errors.c' line='1165' column='1'/>
+      <parameter type-id='type-id-3' name='doc' filepath='Python/errors.c' line='1165' column='1'/>
+      <parameter type-id='type-id-15' name='base' filepath='Python/errors.c' line='1166' column='1'/>
+      <parameter type-id='type-id-15' name='dict' filepath='Python/errors.c' line='1166' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyErr_NewException' mangled-name='PyErr_NewException' filepath='Python/errors.c' line='1107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NewException'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/errors.c' line='1107' column='1'/>
-      <parameter type-id='type-id-15' name='base' filepath='Python/errors.c' line='1107' column='1'/>
-      <parameter type-id='type-id-15' name='dict' filepath='Python/errors.c' line='1107' column='1'/>
+    <function-decl name='PyErr_NewException' mangled-name='PyErr_NewException' filepath='Python/errors.c' line='1108' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NewException'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/errors.c' line='1108' column='1'/>
+      <parameter type-id='type-id-15' name='base' filepath='Python/errors.c' line='1108' column='1'/>
+      <parameter type-id='type-id-15' name='dict' filepath='Python/errors.c' line='1108' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyErr_Format' mangled-name='PyErr_Format' filepath='Python/errors.c' line='1091' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Format'>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1091' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1091' column='1'/>
+    <function-decl name='PyErr_Format' mangled-name='PyErr_Format' filepath='Python/errors.c' line='1092' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Format'>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1092' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1092' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyErr_Format' mangled-name='_PyErr_Format' filepath='Python/errors.c' line='1075' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Format'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='1075' column='1'/>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1075' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1076' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_FormatV' mangled-name='PyErr_FormatV' filepath='Python/errors.c' line='1067' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_FormatV'>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1067' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1067' column='1'/>
-      <parameter type-id='type-id-217' name='vargs' filepath='Python/errors.c' line='1067' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_BadInternalCall' mangled-name='PyErr_BadInternalCall' filepath='Python/errors.c' line='1038' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_BadInternalCall'>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_BadInternalCall' mangled-name='_PyErr_BadInternalCall' filepath='Python/errors.c' line='1026' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_BadInternalCall'>
-      <parameter type-id='type-id-3' name='filename' filepath='Python/errors.c' line='1026' column='1'/>
-      <parameter type-id='type-id-8' name='lineno' filepath='Python/errors.c' line='1026' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_SetImportError' mangled-name='PyErr_SetImportError' filepath='Python/errors.c' line='1020' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetImportError'>
-      <parameter type-id='type-id-15' name='v' filepath='Objects/abstract.c' line='1328' column='1'/>
-      <parameter type-id='type-id-15' name='w' filepath='Objects/abstract.c' line='1328' column='1'/>
-      <parameter type-id='type-id-15' name='z' filepath='Objects/abstract.c' line='1328' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_SetImportErrorSubclass' mangled-name='PyErr_SetImportErrorSubclass' filepath='Python/errors.c' line='967' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetImportErrorSubclass'>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='967' column='1'/>
-      <parameter type-id='type-id-15' name='msg' filepath='Python/errors.c' line='967' column='1'/>
-      <parameter type-id='type-id-15' name='name' filepath='Python/errors.c' line='968' column='1'/>
-      <parameter type-id='type-id-15' name='path' filepath='Python/errors.c' line='968' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_SetFromErrno' mangled-name='PyErr_SetFromErrno' filepath='Python/errors.c' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrno'>
-      <parameter type-id='type-id-15' name='input' filepath='Objects/bytearrayobject.c' line='80' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_SetFromErrnoWithFilename' mangled-name='PyErr_SetFromErrnoWithFilename' filepath='Python/errors.c' line='797' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrnoWithFilename'>
-      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2349' column='1'/>
-      <parameter type-id='type-id-3' name='key' filepath='Objects/abstract.c' line='2349' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_SetFromErrnoWithFilenameObjects' mangled-name='PyErr_SetFromErrnoWithFilenameObjects' filepath='Python/errors.c' line='698' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrnoWithFilenameObjects'>
-      <parameter type-id='type-id-15' name='exc' filepath='Python/errors.c' line='698' column='1'/>
-      <parameter type-id='type-id-15' name='filenameObject' filepath='Python/errors.c' line='698' column='1'/>
-      <parameter type-id='type-id-15' name='filenameObject2' filepath='Python/errors.c' line='698' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_SetFromErrnoWithFilenameObject' mangled-name='PyErr_SetFromErrnoWithFilenameObject' filepath='Python/errors.c' line='692' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrnoWithFilenameObject'>
-      <parameter type-id='type-id-15' name='v' filepath='Objects/abstract.c' line='1321' column='1'/>
-      <parameter type-id='type-id-15' name='w' filepath='Objects/abstract.c' line='1321' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_NoMemory' mangled-name='PyErr_NoMemory' filepath='Python/errors.c' line='685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NoMemory'>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='_PyErr_NoMemory' mangled-name='_PyErr_NoMemory' filepath='Python/errors.c' line='672' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_NoMemory'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='672' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_BadArgument' mangled-name='PyErr_BadArgument' filepath='Python/errors.c' line='663' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_BadArgument'>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyErr_FormatFromCause' mangled-name='_PyErr_FormatFromCause' filepath='Python/errors.c' line='646' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_FormatFromCause'>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1091' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1091' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='_PyErr_FormatFromCauseTstate' mangled-name='_PyErr_FormatFromCauseTstate' filepath='Python/errors.c' line='631' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_FormatFromCauseTstate'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='1075' column='1'/>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1075' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1076' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='_PyErr_ChainStackItem' mangled-name='_PyErr_ChainStackItem' filepath='Python/errors.c' line='555' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_ChainStackItem'>
-      <parameter type-id='type-id-17' name='exc_info' filepath='Python/errors.c' line='555' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_ChainExceptions' mangled-name='_PyErr_ChainExceptions' filepath='Python/errors.c' line='513' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_ChainExceptions'>
-      <parameter type-id='type-id-15' name='exc' filepath='Python/errors.c' line='513' column='1'/>
-      <parameter type-id='type-id-15' name='val' filepath='Python/errors.c' line='513' column='1'/>
-      <parameter type-id='type-id-15' name='tb' filepath='Python/errors.c' line='513' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_SetExcInfo' mangled-name='PyErr_SetExcInfo' filepath='Python/errors.c' line='489' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetExcInfo'>
-      <parameter type-id='type-id-15' name='p_type' filepath='Python/errors.c' line='489' column='1'/>
-      <parameter type-id='type-id-15' name='p_value' filepath='Python/errors.c' line='489' column='1'/>
-      <parameter type-id='type-id-15' name='p_traceback' filepath='Python/errors.c' line='489' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_GetExcInfo' mangled-name='PyErr_GetExcInfo' filepath='Python/errors.c' line='482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_GetExcInfo'>
-      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='482' column='1'/>
-      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='482' column='1'/>
-      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='482' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_GetExcInfo' mangled-name='_PyErr_GetExcInfo' filepath='Python/errors.c' line='467' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_GetExcInfo'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='467' column='1'/>
-      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='468' column='1'/>
-      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='468' column='1'/>
-      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='468' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_Clear' mangled-name='PyErr_Clear' filepath='Python/errors.c' line='459' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Clear'>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_Clear' mangled-name='_PyErr_Clear' filepath='Python/errors.c' line='452' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Clear'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='452' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_Fetch' mangled-name='PyErr_Fetch' filepath='Python/errors.c' line='444' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Fetch'>
-      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='482' column='1'/>
-      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='482' column='1'/>
-      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='482' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_Fetch' mangled-name='_PyErr_Fetch' filepath='Python/errors.c' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Fetch'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='430' column='1'/>
-      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='430' column='1'/>
-      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='430' column='1'/>
-      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='431' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_NormalizeException' mangled-name='PyErr_NormalizeException' filepath='Python/errors.c' line='422' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NormalizeException'>
-      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='482' column='1'/>
-      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='482' column='1'/>
-      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='482' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_NormalizeException' mangled-name='_PyErr_NormalizeException' filepath='Python/errors.c' line='315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_NormalizeException'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='315' column='1'/>
-      <parameter type-id='type-id-86' name='exc' filepath='Python/errors.c' line='315' column='1'/>
-      <parameter type-id='type-id-86' name='val' filepath='Python/errors.c' line='316' column='1'/>
-      <parameter type-id='type-id-86' name='tb' filepath='Python/errors.c' line='316' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_ExceptionMatches' mangled-name='PyErr_ExceptionMatches' filepath='Python/errors.c' line='297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_ExceptionMatches'>
-      <parameter type-id='type-id-15' name='obj' filepath='Objects/abstract.c' line='2847' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyErr_ExceptionMatches' mangled-name='_PyErr_ExceptionMatches' filepath='Python/errors.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_ExceptionMatches'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='290' column='1'/>
-      <parameter type-id='type-id-15' name='exc' filepath='Python/errors.c' line='290' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyErr_GivenExceptionMatches' mangled-name='PyErr_GivenExceptionMatches' filepath='Python/errors.c' line='258' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_GivenExceptionMatches'>
-      <parameter type-id='type-id-15' name='op' filepath='Objects/funcobject.c' line='235' column='1'/>
-      <parameter type-id='type-id-15' name='annotations' filepath='Objects/funcobject.c' line='235' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyErr_Occurred' mangled-name='PyErr_Occurred' filepath='Python/errors.c' line='247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Occurred'>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyErr_SetString' mangled-name='PyErr_SetString' filepath='Python/errors.c' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetString'>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='239' column='1'/>
-      <parameter type-id='type-id-3' name='string' filepath='Python/errors.c' line='239' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_SetString' mangled-name='_PyErr_SetString' filepath='Python/errors.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetString'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='230' column='1'/>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='230' column='1'/>
-      <parameter type-id='type-id-3' name='string' filepath='Python/errors.c' line='231' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_SetNone' mangled-name='PyErr_SetNone' filepath='Python/errors.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetNone'>
-      <parameter type-id='type-id-15' name='m' filepath='Objects/moduleobject.c' line='565' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_SetNone' mangled-name='_PyErr_SetNone' filepath='Python/errors.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetNone'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='215' column='1'/>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='215' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_SetKeyError' mangled-name='_PyErr_SetKeyError' filepath='Python/errors.c' line='202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetKeyError'>
-      <parameter type-id='type-id-15' name='op' filepath='Objects/object.c' line='2100' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='PyErr_SetObject' mangled-name='PyErr_SetObject' filepath='Python/errors.c' line='192' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetObject'>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='192' column='1'/>
-      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='192' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_SetObject' mangled-name='_PyErr_SetObject' filepath='Python/errors.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetObject'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='114' column='1'/>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='114' column='1'/>
-      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='114' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_GetTopmostException' mangled-name='_PyErr_GetTopmostException' filepath='Python/errors.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_GetTopmostException'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='76' column='1'/>
-      <return type-id='type-id-17'/>
-    </function-decl>
-    <function-decl name='PyErr_Restore' mangled-name='PyErr_Restore' filepath='Python/errors.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Restore'>
-      <parameter type-id='type-id-15' name='type' filepath='Python/errors.c' line='68' column='1'/>
-      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='68' column='1'/>
-      <parameter type-id='type-id-15' name='traceback' filepath='Python/errors.c' line='68' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyErr_Restore' mangled-name='_PyErr_Restore' filepath='Python/errors.c' line='40' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Restore'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='40' column='1'/>
-      <parameter type-id='type-id-15' name='type' filepath='Python/errors.c' line='40' column='1'/>
-      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='40' column='1'/>
-      <parameter type-id='type-id-15' name='traceback' filepath='Python/errors.c' line='41' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/frozenmain.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='Py_FrozenMain' mangled-name='Py_FrozenMain' filepath='Python/frozenmain.c' line='17' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FrozenMain'>
-      <parameter type-id='type-id-8' name='argc' filepath='Python/frozenmain.c' line='17' column='1'/>
-      <parameter type-id='type-id-215' name='argv' filepath='Python/frozenmain.c' line='17' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/getargs.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='_PyArg_NoKwnames' mangled-name='_PyArg_NoKwnames' filepath='Python/getargs.c' line='2761' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoKwnames'>
-      <parameter type-id='type-id-3' name='funcname' filepath='Python/getargs.c' line='2761' column='1'/>
-      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2761' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_NoPositional' mangled-name='_PyArg_NoPositional' filepath='Python/getargs.c' line='2744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoPositional'>
-      <parameter type-id='type-id-3' name='funcname' filepath='Python/getargs.c' line='2761' column='1'/>
-      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2761' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_NoKeywords' mangled-name='_PyArg_NoKeywords' filepath='Python/getargs.c' line='2725' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoKeywords'>
-      <parameter type-id='type-id-3' name='funcname' filepath='Python/getargs.c' line='2761' column='1'/>
-      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2761' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_UnpackStack' mangled-name='_PyArg_UnpackStack' filepath='Python/getargs.c' line='2698' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_UnpackStack'>
-      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='2698' column='1'/>
-      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='2698' column='1'/>
-      <parameter type-id='type-id-3' name='name' filepath='Python/getargs.c' line='2698' column='1'/>
-      <parameter type-id='type-id-30' name='min' filepath='Python/getargs.c' line='2699' column='1'/>
-      <parameter type-id='type-id-30' name='max' filepath='Python/getargs.c' line='2699' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyArg_UnpackTuple' mangled-name='PyArg_UnpackTuple' filepath='Python/getargs.c' line='2672' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_UnpackTuple'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='2672' column='1'/>
-      <parameter type-id='type-id-3' name='name' filepath='Python/getargs.c' line='2672' column='1'/>
-      <parameter type-id='type-id-30' name='min' filepath='Python/getargs.c' line='2672' column='1'/>
-      <parameter type-id='type-id-30' name='max' filepath='Python/getargs.c' line='2672' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_CheckPositional' mangled-name='_PyArg_CheckPositional' filepath='Python/getargs.c' line='2610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_CheckPositional'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/getargs.c' line='2610' column='1'/>
-      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='2610' column='1'/>
-      <parameter type-id='type-id-30' name='min' filepath='Python/getargs.c' line='2611' column='1'/>
-      <parameter type-id='type-id-30' name='max' filepath='Python/getargs.c' line='2611' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <class-decl name='_PyArg_Parser' size-in-bits='512' is-struct='yes' visibility='default' filepath='./Include/modsupport.h' line='92' column='1' id='type-id-700'>
+    <class-decl name='_ts' size-in-bits='2304' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-700'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='format' type-id='type-id-3' visibility='default' filepath='./Include/modsupport.h' line='93' column='1'/>
+        <var-decl name='prev' type-id='type-id-10' visibility='default' filepath='./Include/cpython/pystate.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='keywords' type-id='type-id-701' visibility='default' filepath='./Include/modsupport.h' line='94' column='1'/>
+        <var-decl name='next' type-id='type-id-10' visibility='default' filepath='./Include/cpython/pystate.h' line='66' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='fname' type-id='type-id-3' visibility='default' filepath='./Include/modsupport.h' line='95' column='1'/>
+        <var-decl name='interp' type-id='type-id-222' visibility='default' filepath='./Include/cpython/pystate.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='custom_msg' type-id='type-id-3' visibility='default' filepath='./Include/modsupport.h' line='96' column='1'/>
+        <var-decl name='frame' type-id='type-id-12' visibility='default' filepath='./Include/cpython/pystate.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pos' type-id='type-id-8' visibility='default' filepath='./Include/modsupport.h' line='97' column='1'/>
+        <var-decl name='recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='min' type-id='type-id-8' visibility='default' filepath='./Include/modsupport.h' line='98' column='1'/>
+        <var-decl name='recursion_headroom' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='max' type-id='type-id-8' visibility='default' filepath='./Include/modsupport.h' line='99' column='1'/>
+        <var-decl name='stackcheck_counter' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='tracing' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='kwtuple' type-id='type-id-15' visibility='default' filepath='./Include/modsupport.h' line='100' column='1'/>
+        <var-decl name='cframe' type-id='type-id-13' visibility='default' filepath='./Include/cpython/pystate.h' line='82' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='next' type-id='type-id-702' visibility='default' filepath='./Include/modsupport.h' line='101' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-701'/>
-    <pointer-type-def type-id='type-id-700' size-in-bits='64' id='type-id-702'/>
-    <function-decl name='_PyArg_UnpackKeywords' mangled-name='_PyArg_UnpackKeywords' filepath='Python/getargs.c' line='2268' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_UnpackKeywords'>
-      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='2268' column='1'/>
-      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='2268' column='1'/>
-      <parameter type-id='type-id-15' name='kwargs' filepath='Python/getargs.c' line='2269' column='1'/>
-      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2269' column='1'/>
-      <parameter type-id='type-id-702' name='parser' filepath='Python/getargs.c' line='2270' column='1'/>
-      <parameter type-id='type-id-8' name='minpos' filepath='Python/getargs.c' line='2271' column='1'/>
-      <parameter type-id='type-id-8' name='maxpos' filepath='Python/getargs.c' line='2271' column='1'/>
-      <parameter type-id='type-id-8' name='minkw' filepath='Python/getargs.c' line='2271' column='1'/>
-      <parameter type-id='type-id-86' name='buf' filepath='Python/getargs.c' line='2272' column='1'/>
-      <return type-id='type-id-156'/>
-    </function-decl>
-    <function-decl name='PyArg_ValidateKeywordArguments' mangled-name='PyArg_ValidateKeywordArguments' filepath='Python/getargs.c' line='1557' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ValidateKeywordArguments'>
-      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2310' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast_SizeT'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1543' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1543' column='1'/>
-      <parameter type-id='type-id-702' name='parser' filepath='Python/getargs.c' line='1544' column='1'/>
-      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1544' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast' mangled-name='_PyArg_VaParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1529' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1543' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1543' column='1'/>
-      <parameter type-id='type-id-702' name='parser' filepath='Python/getargs.c' line='1544' column='1'/>
-      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1544' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseStackAndKeywords_SizeT' mangled-name='_PyArg_ParseStackAndKeywords_SizeT' filepath='Python/getargs.c' line='1515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords_SizeT'>
-      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='1515' column='1'/>
-      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='1515' column='1'/>
-      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='1515' column='1'/>
-      <parameter type-id='type-id-702' name='parser' filepath='Python/getargs.c' line='1516' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseStackAndKeywords' mangled-name='_PyArg_ParseStackAndKeywords' filepath='Python/getargs.c' line='1502' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords'>
-      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='1515' column='1'/>
-      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='1515' column='1'/>
-      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='1515' column='1'/>
-      <parameter type-id='type-id-702' name='parser' filepath='Python/getargs.c' line='1516' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_ParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1489' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast_SizeT'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1489' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1489' column='1'/>
-      <parameter type-id='type-id-702' name='parser' filepath='Python/getargs.c' line='1490' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseTupleAndKeywordsFast' mangled-name='_PyArg_ParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1489' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1489' column='1'/>
-      <parameter type-id='type-id-702' name='parser' filepath='Python/getargs.c' line='1490' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_VaParseTupleAndKeywords_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywords_SizeT' filepath='Python/getargs.c' line='1450' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywords_SizeT'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1450' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1451' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1452' column='1'/>
-      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1453' column='1'/>
-      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1453' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyArg_VaParseTupleAndKeywords' mangled-name='PyArg_VaParseTupleAndKeywords' filepath='Python/getargs.c' line='1425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParseTupleAndKeywords'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1450' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1451' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1452' column='1'/>
-      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1453' column='1'/>
-      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1453' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseTupleAndKeywords_SizeT' mangled-name='_PyArg_ParseTupleAndKeywords_SizeT' filepath='Python/getargs.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywords_SizeT'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1399' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1400' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1401' column='1'/>
-      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1402' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyArg_ParseTupleAndKeywords' mangled-name='PyArg_ParseTupleAndKeywords' filepath='Python/getargs.c' line='1375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ParseTupleAndKeywords'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1399' column='1'/>
-      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1400' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1401' column='1'/>
-      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1402' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_BadArgument' mangled-name='_PyArg_BadArgument' filepath='Python/getargs.c' line='617' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_BadArgument'>
-      <parameter type-id='type-id-3' name='fname' filepath='Python/getargs.c' line='617' column='1'/>
-      <parameter type-id='type-id-3' name='displayname' filepath='Python/getargs.c' line='617' column='1'/>
-      <parameter type-id='type-id-3' name='expected' filepath='Python/getargs.c' line='618' column='1'/>
-      <parameter type-id='type-id-15' name='arg' filepath='Python/getargs.c' line='618' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_PyArg_VaParse_SizeT' mangled-name='_PyArg_VaParse_SizeT' filepath='Python/getargs.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParse_SizeT'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='186' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='186' column='1'/>
-      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='186' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyArg_VaParse' mangled-name='PyArg_VaParse' filepath='Python/getargs.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParse'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='186' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='186' column='1'/>
-      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='186' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseStack_SizeT' mangled-name='_PyArg_ParseStack_SizeT' filepath='Python/getargs.c' line='160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack_SizeT'>
-      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='160' column='1'/>
-      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='160' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='160' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseStack' mangled-name='_PyArg_ParseStack' filepath='Python/getargs.c' line='148' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack'>
-      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='160' column='1'/>
-      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='160' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='160' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_ParseTuple_SizeT' mangled-name='_PyArg_ParseTuple_SizeT' filepath='Python/getargs.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTuple_SizeT'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyArg_ParseTuple' mangled-name='PyArg_ParseTuple' filepath='Python/getargs.c' line='123' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ParseTuple'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyArg_Parse_SizeT' mangled-name='_PyArg_Parse_SizeT' filepath='Python/getargs.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_Parse_SizeT'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyArg_Parse' mangled-name='PyArg_Parse' filepath='Python/getargs.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_Parse'>
-      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/getcompiler.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='Py_GetCompiler' mangled-name='Py_GetCompiler' filepath='Python/getcompiler.c' line='24' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetCompiler'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/getcopyright.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='Py_GetCopyright' mangled-name='Py_GetCopyright' filepath='Python/getcopyright.c' line='20' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetCopyright'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='./Python/getplatform.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='Py_GetPlatform' mangled-name='Py_GetPlatform' filepath='./Python/getplatform.c' line='9' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetPlatform'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/getversion.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='Py_GetVersion' mangled-name='Py_GetVersion' filepath='Python/getversion.c' line='9' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetVersion'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/hamt.c' comp-dir-path='/src' language='LANG_C99'>
-    <var-decl name='_PyHamtItems_Type' type-id='type-id-149' mangled-name='_PyHamtItems_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='70' column='1' elf-symbol-id='_PyHamtItems_Type'/>
-    <var-decl name='_PyHamtKeys_Type' type-id='type-id-149' mangled-name='_PyHamtKeys_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='68' column='1' elf-symbol-id='_PyHamtKeys_Type'/>
-    <var-decl name='_PyHamtValues_Type' type-id='type-id-149' mangled-name='_PyHamtValues_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='69' column='1' elf-symbol-id='_PyHamtValues_Type'/>
-    <var-decl name='_PyHamt_Type' type-id='type-id-149' mangled-name='_PyHamt_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='64' column='1' elf-symbol-id='_PyHamt_Type'/>
-    <var-decl name='_PyHamt_ArrayNode_Type' type-id='type-id-149' mangled-name='_PyHamt_ArrayNode_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='65' column='1' elf-symbol-id='_PyHamt_ArrayNode_Type'/>
-    <var-decl name='_PyHamt_BitmapNode_Type' type-id='type-id-149' mangled-name='_PyHamt_BitmapNode_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='66' column='1' elf-symbol-id='_PyHamt_BitmapNode_Type'/>
-    <var-decl name='_PyHamt_CollisionNode_Type' type-id='type-id-149' mangled-name='_PyHamt_CollisionNode_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='67' column='1' elf-symbol-id='_PyHamt_CollisionNode_Type'/>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/hashtable.c' comp-dir-path='/src' language='LANG_C99'>
-    <class-decl name='_Py_hashtable_t' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='60' column='1' id='type-id-703'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='nentries' type-id='type-id-157' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='61' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='nbuckets' type-id='type-id-157' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='62' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='buckets' type-id='type-id-704' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='63' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='get_entry_func' type-id='type-id-705' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='hash_func' type-id='type-id-706' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='compare_func' type-id='type-id-707' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='key_destroy_func' type-id='type-id-708' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='68' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='value_destroy_func' type-id='type-id-708' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='69' column='1'/>
+        <var-decl name='c_profilefunc' type-id='type-id-14' visibility='default' filepath='./Include/cpython/pystate.h' line='84' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='alloc' type-id='type-id-709' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='70' column='1'/>
+        <var-decl name='c_tracefunc' type-id='type-id-14' visibility='default' filepath='./Include/cpython/pystate.h' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='c_profileobj' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='c_traceobj' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='curexc_type' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='90' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='curexc_value' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='curexc_traceback' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='exc_state' type-id='type-id-16' visibility='default' filepath='./Include/cpython/pystate.h' line='97' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='exc_info' type-id='type-id-17' visibility='default' filepath='./Include/cpython/pystate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='dict' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='gilstate_counter' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='async_exc' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='thread_id' type-id='type-id-18' visibility='default' filepath='./Include/cpython/pystate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='trash_delete_nesting' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='trash_delete_later' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='on_delete' type-id='type-id-19' visibility='default' filepath='./Include/cpython/pystate.h' line='136' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='on_delete_data' type-id='type-id-20' visibility='default' filepath='./Include/cpython/pystate.h' line='137' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1728'>
+        <var-decl name='coroutine_origin_tracking_depth' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='139' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='async_gen_firstiter' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='141' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1856'>
+        <var-decl name='async_gen_finalizer' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='context' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1984'>
+        <var-decl name='context_ver' type-id='type-id-21' visibility='default' filepath='./Include/cpython/pystate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='id' type-id='type-id-21' visibility='default' filepath='./Include/cpython/pystate.h' line='148' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='root_cframe' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='use_tracing' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='151' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-710' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='17' column='1' id='type-id-711'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='head' type-id='type-id-712' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='18' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='_Py_slist_item_s' size-in-bits='64' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='13' column='1' id='type-id-713'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next' type-id='type-id-714' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='14' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-713' size-in-bits='64' id='type-id-714'/>
-    <typedef-decl name='_Py_slist_item_t' type-id='type-id-713' filepath='./Include/internal/pycore_hashtable.h' line='15' column='1' id='type-id-715'/>
-    <pointer-type-def type-id='type-id-715' size-in-bits='64' id='type-id-712'/>
-    <typedef-decl name='_Py_slist_t' type-id='type-id-711' filepath='./Include/internal/pycore_hashtable.h' line='19' column='1' id='type-id-710'/>
-    <pointer-type-def type-id='type-id-710' size-in-bits='64' id='type-id-704'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='256' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-716' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='28' column='1' id='type-id-717'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_Py_slist_item' type-id='type-id-715' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='30' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='key_hash' type-id='type-id-718' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='32' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='key' type-id='type-id-20' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='33' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='value' type-id='type-id-20' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='34' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Py_uhash_t' type-id='type-id-157' filepath='./Include/pyport.h' line='119' column='1' id='type-id-718'/>
-    <typedef-decl name='_Py_hashtable_entry_t' type-id='type-id-717' filepath='./Include/internal/pycore_hashtable.h' line='35' column='1' id='type-id-716'/>
-    <pointer-type-def type-id='type-id-716' size-in-bits='64' id='type-id-719'/>
-    <typedef-decl name='_Py_hashtable_t' type-id='type-id-703' filepath='./Include/internal/pycore_hashtable.h' line='42' column='1' id='type-id-720'/>
-    <pointer-type-def type-id='type-id-720' size-in-bits='64' id='type-id-721'/>
-    <pointer-type-def type-id='type-id-722' size-in-bits='64' id='type-id-723'/>
-    <typedef-decl name='_Py_hashtable_get_entry_func' type-id='type-id-723' filepath='./Include/internal/pycore_hashtable.h' line='47' column='1' id='type-id-705'/>
-    <pointer-type-def type-id='type-id-724' size-in-bits='64' id='type-id-725'/>
-    <typedef-decl name='_Py_hashtable_hash_func' type-id='type-id-725' filepath='./Include/internal/pycore_hashtable.h' line='44' column='1' id='type-id-706'/>
-    <pointer-type-def type-id='type-id-726' size-in-bits='64' id='type-id-727'/>
-    <typedef-decl name='_Py_hashtable_compare_func' type-id='type-id-727' filepath='./Include/internal/pycore_hashtable.h' line='45' column='1' id='type-id-707'/>
-    <typedef-decl name='_Py_hashtable_destroy_func' type-id='type-id-19' filepath='./Include/internal/pycore_hashtable.h' line='46' column='1' id='type-id-708'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-709' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='50' column='1' id='type-id-728'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='malloc' type-id='type-id-729' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='52' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='free' type-id='type-id-19' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='55' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-730' size-in-bits='64' id='type-id-729'/>
-    <typedef-decl name='_Py_hashtable_allocator_t' type-id='type-id-728' filepath='./Include/internal/pycore_hashtable.h' line='56' column='1' id='type-id-709'/>
-    <function-decl name='_Py_hashtable_destroy' mangled-name='_Py_hashtable_destroy' filepath='Python/hashtable.c' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_destroy'>
-      <parameter type-id='type-id-721' name='ht' filepath='Python/hashtable.c' line='404' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_Py_hashtable_clear' mangled-name='_Py_hashtable_clear' filepath='Python/hashtable.c' line='385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_clear'>
-      <parameter type-id='type-id-721' name='ht' filepath='Python/hashtable.c' line='404' column='1'/>
-      <return type-id='type-id-69'/>
-    </function-decl>
-    <function-decl name='_Py_hashtable_new' mangled-name='_Py_hashtable_new' filepath='Python/hashtable.c' line='363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_new'>
-      <parameter type-id='type-id-706' name='hash_func' filepath='Python/hashtable.c' line='363' column='1'/>
-      <parameter type-id='type-id-707' name='compare_func' filepath='Python/hashtable.c' line='364' column='1'/>
-      <return type-id='type-id-721'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-709' size-in-bits='64' id='type-id-731'/>
-    <function-decl name='_Py_hashtable_new_full' mangled-name='_Py_hashtable_new_full' filepath='Python/hashtable.c' line='316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_new_full'>
-      <parameter type-id='type-id-706' name='hash_func' filepath='Python/hashtable.c' line='316' column='1'/>
-      <parameter type-id='type-id-707' name='compare_func' filepath='Python/hashtable.c' line='317' column='1'/>
-      <parameter type-id='type-id-708' name='key_destroy_func' filepath='Python/hashtable.c' line='318' column='1'/>
-      <parameter type-id='type-id-708' name='value_destroy_func' filepath='Python/hashtable.c' line='319' column='1'/>
-      <parameter type-id='type-id-731' name='allocator' filepath='Python/hashtable.c' line='320' column='1'/>
-      <return type-id='type-id-721'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-732' size-in-bits='64' id='type-id-733'/>
-    <typedef-decl name='_Py_hashtable_foreach_func' type-id='type-id-733' filepath='./Include/internal/pycore_hashtable.h' line='96' column='1' id='type-id-734'/>
-    <function-decl name='_Py_hashtable_foreach' mangled-name='_Py_hashtable_foreach' filepath='Python/hashtable.c' line='261' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_foreach'>
-      <parameter type-id='type-id-721' name='ht' filepath='Python/hashtable.c' line='261' column='1'/>
-      <parameter type-id='type-id-734' name='func' filepath='Python/hashtable.c' line='262' column='1'/>
-      <parameter type-id='type-id-20' name='user_data' filepath='Python/hashtable.c' line='263' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_Py_hashtable_get' mangled-name='_Py_hashtable_get' filepath='Python/hashtable.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_get'>
-      <parameter type-id='type-id-721' name='ht' filepath='Python/hashtable.c' line='248' column='1'/>
-      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='248' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='_Py_hashtable_set' mangled-name='_Py_hashtable_set' filepath='Python/hashtable.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_set'>
-      <parameter type-id='type-id-721' name='ht' filepath='Python/hashtable.c' line='209' column='1'/>
-      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='209' column='1'/>
-      <parameter type-id='type-id-20' name='value' filepath='Python/hashtable.c' line='209' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_Py_hashtable_steal' mangled-name='_Py_hashtable_steal' filepath='Python/hashtable.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_steal'>
-      <parameter type-id='type-id-721' name='ht' filepath='Python/hashtable.c' line='174' column='1'/>
-      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='174' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-720' const='yes' id='type-id-735'/>
-    <pointer-type-def type-id='type-id-735' size-in-bits='64' id='type-id-736'/>
-    <function-decl name='_Py_hashtable_size' mangled-name='_Py_hashtable_size' filepath='Python/hashtable.c' line='120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_size'>
-      <parameter type-id='type-id-736' name='ht' filepath='Python/hashtable.c' line='120' column='1'/>
-      <return type-id='type-id-157'/>
-    </function-decl>
-    <function-decl name='_Py_hashtable_compare_direct' mangled-name='_Py_hashtable_compare_direct' filepath='Python/hashtable.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_compare_direct'>
-      <parameter type-id='type-id-20' name='key1' filepath='Python/hashtable.c' line='99' column='1'/>
-      <parameter type-id='type-id-20' name='key2' filepath='Python/hashtable.c' line='99' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_Py_hashtable_hash_ptr' mangled-name='_Py_hashtable_hash_ptr' filepath='Python/hashtable.c' line='92' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_hash_ptr'>
-      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='92' column='1'/>
-      <return type-id='type-id-718'/>
-    </function-decl>
-    <function-type size-in-bits='64' id='type-id-722'>
-      <parameter type-id='type-id-721'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-719'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-732'>
-      <parameter type-id='type-id-721'/>
-      <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-726'>
-      <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-8'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-724'>
-      <parameter type-id='type-id-20'/>
-      <return type-id='type-id-718'/>
-    </function-type>
-    <function-type size-in-bits='64' id='type-id-730'>
-      <parameter type-id='type-id-157'/>
-      <return type-id='type-id-20'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='Python/import.c' comp-dir-path='/src' language='LANG_C99'>
-    <class-decl name='_inittab' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/cpython/import.h' line='24' column='1' id='type-id-737'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-3' visibility='default' filepath='./Include/cpython/import.h' line='25' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='initfunc' type-id='type-id-462' visibility='default' filepath='./Include/cpython/import.h' line='26' column='1'/>
-      </data-member>
-    </class-decl>
-    <pointer-type-def type-id='type-id-737' size-in-bits='64' id='type-id-738'/>
-    <var-decl name='PyImport_Inittab' type-id='type-id-738' mangled-name='PyImport_Inittab' visibility='default' filepath='./Include/cpython/import.h' line='28' column='1' elf-symbol-id='PyImport_Inittab'/>
-    <function-decl name='PyImport_AppendInittab' mangled-name='PyImport_AppendInittab' filepath='Python/import.c' line='2266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AppendInittab'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='2266' column='1'/>
-      <parameter type-id='type-id-462' name='initfunc' filepath='Python/import.c' line='2266' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyImport_ExtendInittab' mangled-name='PyImport_ExtendInittab' filepath='Python/import.c' line='2220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExtendInittab'>
-      <parameter type-id='type-id-738' name='newtab' filepath='Python/import.c' line='2220' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyInit__imp' mangled-name='PyInit__imp' filepath='Python/import.c' line='2159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__imp'>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_Import' mangled-name='PyImport_Import' filepath='Python/import.c' line='1746' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_Import'>
-      <parameter type-id='type-id-15' name='module_name' filepath='Python/import.c' line='1746' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ReloadModule' mangled-name='PyImport_ReloadModule' filepath='Python/import.c' line='1713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ReloadModule'>
-      <parameter type-id='type-id-15' name='m' filepath='Python/import.c' line='1713' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ImportModuleLevel' mangled-name='PyImport_ImportModuleLevel' filepath='Python/import.c' line='1695' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleLevel'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='1695' column='1'/>
-      <parameter type-id='type-id-15' name='globals' filepath='Python/import.c' line='1695' column='1'/>
-      <parameter type-id='type-id-15' name='locals' filepath='Python/import.c' line='1695' column='1'/>
-      <parameter type-id='type-id-15' name='fromlist' filepath='Python/import.c' line='1696' column='1'/>
-      <parameter type-id='type-id-8' name='level' filepath='Python/import.c' line='1696' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ImportModuleLevelObject' mangled-name='PyImport_ImportModuleLevelObject' filepath='Python/import.c' line='1543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleLevelObject'>
-      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='1543' column='1'/>
-      <parameter type-id='type-id-15' name='globals' filepath='Python/import.c' line='1543' column='1'/>
-      <parameter type-id='type-id-15' name='locals' filepath='Python/import.c' line='1544' column='1'/>
-      <parameter type-id='type-id-15' name='fromlist' filepath='Python/import.c' line='1544' column='1'/>
-      <parameter type-id='type-id-8' name='level' filepath='Python/import.c' line='1545' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_GetModule' mangled-name='PyImport_GetModule' filepath='Python/import.c' line='1526' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetModule'>
-      <parameter type-id='type-id-15' name='v' filepath='Objects/abstract.c' line='2129' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ImportModuleNoBlock' mangled-name='PyImport_ImportModuleNoBlock' filepath='Python/import.c' line='1231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleNoBlock'>
-      <parameter type-id='type-id-3' name='encoding' filepath='Python/codecs.c' line='355' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ImportModule' mangled-name='PyImport_ImportModule' filepath='Python/import.c' line='1207' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModule'>
-      <parameter type-id='type-id-3' name='utf8path' filepath='Objects/fileobject.c' line='562' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ImportFrozenModule' mangled-name='PyImport_ImportFrozenModule' filepath='Python/import.c' line='1190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportFrozenModule'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='1190' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyImport_ImportFrozenModuleObject' mangled-name='PyImport_ImportFrozenModuleObject' filepath='Python/import.c' line='1121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportFrozenModuleObject'>
-      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='1121' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyImport_GetImporter' mangled-name='PyImport_GetImporter' filepath='Python/import.c' line='966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetImporter'>
-      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2819' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ExecCodeModuleObject' mangled-name='PyImport_ExecCodeModuleObject' filepath='Python/import.c' line='792' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleObject'>
-      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='792' column='1'/>
-      <parameter type-id='type-id-15' name='co' filepath='Python/import.c' line='792' column='1'/>
-      <parameter type-id='type-id-15' name='pathname' filepath='Python/import.c' line='792' column='1'/>
-      <parameter type-id='type-id-15' name='cpathname' filepath='Python/import.c' line='793' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ExecCodeModuleWithPathnames' mangled-name='PyImport_ExecCodeModuleWithPathnames' filepath='Python/import.c' line='687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleWithPathnames'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='687' column='1'/>
-      <parameter type-id='type-id-15' name='co' filepath='Python/import.c' line='687' column='1'/>
-      <parameter type-id='type-id-3' name='pathname' filepath='Python/import.c' line='688' column='1'/>
-      <parameter type-id='type-id-3' name='cpathname' filepath='Python/import.c' line='689' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ExecCodeModuleEx' mangled-name='PyImport_ExecCodeModuleEx' filepath='Python/import.c' line='680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleEx'>
-      <parameter type-id='type-id-3' name='encoding' filepath='Python/codecs.c' line='379' column='1'/>
-      <parameter type-id='type-id-15' name='stream' filepath='Python/codecs.c' line='380' column='1'/>
-      <parameter type-id='type-id-3' name='errors' filepath='Python/codecs.c' line='381' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_ExecCodeModule' mangled-name='PyImport_ExecCodeModule' filepath='Python/import.c' line='673' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModule'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='673' column='1'/>
-      <parameter type-id='type-id-15' name='co' filepath='Python/import.c' line='673' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_AddModule' mangled-name='PyImport_AddModule' filepath='Python/import.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModule'>
-      <parameter type-id='type-id-3' name='utf8path' filepath='Objects/fileobject.c' line='562' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='PyImport_AddModuleObject' mangled-name='PyImport_AddModuleObject' filepath='Python/import.c' line='606' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModuleObject'>
-      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2793' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='_PyImport_FixupBuiltin' mangled-name='_PyImport_FixupBuiltin' filepath='Python/import.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_FixupBuiltin'>
-      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2366' column='1'/>
-      <parameter type-id='type-id-3' name='key' filepath='Objects/abstract.c' line='2366' column='1'/>
-      <parameter type-id='type-id-15' name='value' filepath='Objects/abstract.c' line='2366' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyImport_FixupExtensionObject' mangled-name='_PyImport_FixupExtensionObject' filepath='Python/import.c' line='421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_FixupExtensionObject'>
-      <parameter type-id='type-id-15' name='mod' filepath='Python/import.c' line='421' column='1'/>
-      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='421' column='1'/>
-      <parameter type-id='type-id-15' name='filename' filepath='Python/import.c' line='422' column='1'/>
-      <parameter type-id='type-id-15' name='modules' filepath='Python/import.c' line='422' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='PyImport_GetMagicTag' mangled-name='PyImport_GetMagicTag' filepath='Python/import.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicTag'>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <function-decl name='PyImport_GetMagicNumber' mangled-name='PyImport_GetMagicNumber' filepath='Python/import.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicNumber'>
-      <return type-id='type-id-32'/>
-    </function-decl>
-    <function-decl name='_PyImport_SetModuleString' mangled-name='_PyImport_SetModuleString' filepath='Python/import.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_SetModuleString'>
-      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='311' column='1'/>
-      <parameter type-id='type-id-15' name='m' filepath='Python/import.c' line='311' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyImport_SetModule' mangled-name='_PyImport_SetModule' filepath='Python/import.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_SetModule'>
-      <parameter type-id='type-id-15' name='od' filepath='Objects/odictobject.c' line='1675' column='1'/>
-      <parameter type-id='type-id-15' name='key' filepath='Objects/odictobject.c' line='1675' column='1'/>
-      <return type-id='type-id-8'/>
-    </function-decl>
-    <function-decl name='_PyImport_GetModuleId' mangled-name='_PyImport_GetModuleId' filepath='Python/import.c' line='293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_GetModuleId'>
-      <parameter type-id='type-id-219' name='nameid' filepath='Python/import.c' line='293' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <class-decl name='_is' size-in-bits='908160' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='220' column='1' id='type-id-739'>
+    <class-decl name='_is' size-in-bits='908160' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_interp.h' line='220' column='1' id='type-id-701'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='next' type-id='type-id-225' visibility='default' filepath='./Include/internal/pycore_interp.h' line='222' column='1'/>
       </data-member>
@@ -12909,6 +12251,779 @@
         <var-decl name='type_cache' type-id='type-id-249' visibility='default' filepath='./Include/internal/pycore_interp.h' line='313' column='1'/>
       </data-member>
     </class-decl>
+    <typedef-decl name='PyThreadState' type-id='type-id-700' filepath='./Include/pystate.h' line='20' column='1' id='type-id-702'/>
+    <pointer-type-def type-id='type-id-702' size-in-bits='64' id='type-id-703'/>
+    <function-decl name='_PyErr_Format' mangled-name='_PyErr_Format' filepath='Python/errors.c' line='1076' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Format'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='1076' column='1'/>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1076' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1077' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_FormatV' mangled-name='PyErr_FormatV' filepath='Python/errors.c' line='1068' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_FormatV'>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1068' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1068' column='1'/>
+      <parameter type-id='type-id-217' name='vargs' filepath='Python/errors.c' line='1068' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_BadInternalCall' mangled-name='PyErr_BadInternalCall' filepath='Python/errors.c' line='1039' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_BadInternalCall'>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_BadInternalCall' mangled-name='_PyErr_BadInternalCall' filepath='Python/errors.c' line='1027' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_BadInternalCall'>
+      <parameter type-id='type-id-3' name='filename' filepath='Python/errors.c' line='1027' column='1'/>
+      <parameter type-id='type-id-8' name='lineno' filepath='Python/errors.c' line='1027' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_SetImportError' mangled-name='PyErr_SetImportError' filepath='Python/errors.c' line='1021' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetImportError'>
+      <parameter type-id='type-id-15' name='v' filepath='Objects/abstract.c' line='1328' column='1'/>
+      <parameter type-id='type-id-15' name='w' filepath='Objects/abstract.c' line='1328' column='1'/>
+      <parameter type-id='type-id-15' name='z' filepath='Objects/abstract.c' line='1328' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_SetImportErrorSubclass' mangled-name='PyErr_SetImportErrorSubclass' filepath='Python/errors.c' line='968' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetImportErrorSubclass'>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='968' column='1'/>
+      <parameter type-id='type-id-15' name='msg' filepath='Python/errors.c' line='968' column='1'/>
+      <parameter type-id='type-id-15' name='name' filepath='Python/errors.c' line='969' column='1'/>
+      <parameter type-id='type-id-15' name='path' filepath='Python/errors.c' line='969' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_SetFromErrno' mangled-name='PyErr_SetFromErrno' filepath='Python/errors.c' line='818' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrno'>
+      <parameter type-id='type-id-15' name='input' filepath='Objects/bytearrayobject.c' line='80' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_SetFromErrnoWithFilename' mangled-name='PyErr_SetFromErrnoWithFilename' filepath='Python/errors.c' line='798' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrnoWithFilename'>
+      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2349' column='1'/>
+      <parameter type-id='type-id-3' name='key' filepath='Objects/abstract.c' line='2349' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_SetFromErrnoWithFilenameObjects' mangled-name='PyErr_SetFromErrnoWithFilenameObjects' filepath='Python/errors.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrnoWithFilenameObjects'>
+      <parameter type-id='type-id-15' name='exc' filepath='Python/errors.c' line='699' column='1'/>
+      <parameter type-id='type-id-15' name='filenameObject' filepath='Python/errors.c' line='699' column='1'/>
+      <parameter type-id='type-id-15' name='filenameObject2' filepath='Python/errors.c' line='699' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_SetFromErrnoWithFilenameObject' mangled-name='PyErr_SetFromErrnoWithFilenameObject' filepath='Python/errors.c' line='693' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetFromErrnoWithFilenameObject'>
+      <parameter type-id='type-id-15' name='v' filepath='Objects/abstract.c' line='1321' column='1'/>
+      <parameter type-id='type-id-15' name='w' filepath='Objects/abstract.c' line='1321' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_NoMemory' mangled-name='PyErr_NoMemory' filepath='Python/errors.c' line='686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NoMemory'>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_PyErr_NoMemory' mangled-name='_PyErr_NoMemory' filepath='Python/errors.c' line='673' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_NoMemory'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='673' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_BadArgument' mangled-name='PyErr_BadArgument' filepath='Python/errors.c' line='664' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_BadArgument'>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyErr_FormatFromCause' mangled-name='_PyErr_FormatFromCause' filepath='Python/errors.c' line='647' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_FormatFromCause'>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1092' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1092' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_PyErr_FormatFromCauseTstate' mangled-name='_PyErr_FormatFromCauseTstate' filepath='Python/errors.c' line='632' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_FormatFromCauseTstate'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='1076' column='1'/>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='1076' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/errors.c' line='1077' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_PyErr_ChainStackItem' mangled-name='_PyErr_ChainStackItem' filepath='Python/errors.c' line='556' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_ChainStackItem'>
+      <parameter type-id='type-id-17' name='exc_info' filepath='Python/errors.c' line='556' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_ChainExceptions' mangled-name='_PyErr_ChainExceptions' filepath='Python/errors.c' line='514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_ChainExceptions'>
+      <parameter type-id='type-id-15' name='exc' filepath='Python/errors.c' line='514' column='1'/>
+      <parameter type-id='type-id-15' name='val' filepath='Python/errors.c' line='514' column='1'/>
+      <parameter type-id='type-id-15' name='tb' filepath='Python/errors.c' line='514' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_SetExcInfo' mangled-name='PyErr_SetExcInfo' filepath='Python/errors.c' line='490' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetExcInfo'>
+      <parameter type-id='type-id-15' name='p_type' filepath='Python/errors.c' line='490' column='1'/>
+      <parameter type-id='type-id-15' name='p_value' filepath='Python/errors.c' line='490' column='1'/>
+      <parameter type-id='type-id-15' name='p_traceback' filepath='Python/errors.c' line='490' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_GetExcInfo' mangled-name='PyErr_GetExcInfo' filepath='Python/errors.c' line='483' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_GetExcInfo'>
+      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='483' column='1'/>
+      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='483' column='1'/>
+      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='483' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_GetExcInfo' mangled-name='_PyErr_GetExcInfo' filepath='Python/errors.c' line='468' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_GetExcInfo'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='468' column='1'/>
+      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='469' column='1'/>
+      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='469' column='1'/>
+      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='469' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_Clear' mangled-name='PyErr_Clear' filepath='Python/errors.c' line='460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Clear'>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_Clear' mangled-name='_PyErr_Clear' filepath='Python/errors.c' line='453' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Clear'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='453' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_Fetch' mangled-name='PyErr_Fetch' filepath='Python/errors.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Fetch'>
+      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='483' column='1'/>
+      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='483' column='1'/>
+      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='483' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_Fetch' mangled-name='_PyErr_Fetch' filepath='Python/errors.c' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Fetch'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='431' column='1'/>
+      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='431' column='1'/>
+      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='431' column='1'/>
+      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='432' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_NormalizeException' mangled-name='PyErr_NormalizeException' filepath='Python/errors.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_NormalizeException'>
+      <parameter type-id='type-id-86' name='p_type' filepath='Python/errors.c' line='483' column='1'/>
+      <parameter type-id='type-id-86' name='p_value' filepath='Python/errors.c' line='483' column='1'/>
+      <parameter type-id='type-id-86' name='p_traceback' filepath='Python/errors.c' line='483' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_NormalizeException' mangled-name='_PyErr_NormalizeException' filepath='Python/errors.c' line='316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_NormalizeException'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='316' column='1'/>
+      <parameter type-id='type-id-86' name='exc' filepath='Python/errors.c' line='316' column='1'/>
+      <parameter type-id='type-id-86' name='val' filepath='Python/errors.c' line='317' column='1'/>
+      <parameter type-id='type-id-86' name='tb' filepath='Python/errors.c' line='317' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_ExceptionMatches' mangled-name='PyErr_ExceptionMatches' filepath='Python/errors.c' line='298' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_ExceptionMatches'>
+      <parameter type-id='type-id-15' name='obj' filepath='Objects/abstract.c' line='2847' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyErr_ExceptionMatches' mangled-name='_PyErr_ExceptionMatches' filepath='Python/errors.c' line='291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_ExceptionMatches'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='291' column='1'/>
+      <parameter type-id='type-id-15' name='exc' filepath='Python/errors.c' line='291' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyErr_GivenExceptionMatches' mangled-name='PyErr_GivenExceptionMatches' filepath='Python/errors.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_GivenExceptionMatches'>
+      <parameter type-id='type-id-15' name='op' filepath='Objects/funcobject.c' line='235' column='1'/>
+      <parameter type-id='type-id-15' name='annotations' filepath='Objects/funcobject.c' line='235' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyErr_Occurred' mangled-name='PyErr_Occurred' filepath='Python/errors.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Occurred'>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyErr_SetString' mangled-name='PyErr_SetString' filepath='Python/errors.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetString'>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='240' column='1'/>
+      <parameter type-id='type-id-3' name='string' filepath='Python/errors.c' line='240' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_SetString' mangled-name='_PyErr_SetString' filepath='Python/errors.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetString'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='231' column='1'/>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='231' column='1'/>
+      <parameter type-id='type-id-3' name='string' filepath='Python/errors.c' line='232' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_SetNone' mangled-name='PyErr_SetNone' filepath='Python/errors.c' line='223' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetNone'>
+      <parameter type-id='type-id-15' name='m' filepath='Objects/moduleobject.c' line='565' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_SetNone' mangled-name='_PyErr_SetNone' filepath='Python/errors.c' line='216' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetNone'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='216' column='1'/>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='216' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_SetKeyError' mangled-name='_PyErr_SetKeyError' filepath='Python/errors.c' line='203' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetKeyError'>
+      <parameter type-id='type-id-15' name='op' filepath='Objects/object.c' line='2100' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='PyErr_SetObject' mangled-name='PyErr_SetObject' filepath='Python/errors.c' line='193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_SetObject'>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='193' column='1'/>
+      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='193' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_SetObject' mangled-name='_PyErr_SetObject' filepath='Python/errors.c' line='115' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_SetObject'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='115' column='1'/>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/errors.c' line='115' column='1'/>
+      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='115' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_GetTopmostException' mangled-name='_PyErr_GetTopmostException' filepath='Python/errors.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_GetTopmostException'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='77' column='1'/>
+      <return type-id='type-id-17'/>
+    </function-decl>
+    <function-decl name='PyErr_Restore' mangled-name='PyErr_Restore' filepath='Python/errors.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Restore'>
+      <parameter type-id='type-id-15' name='type' filepath='Python/errors.c' line='69' column='1'/>
+      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='69' column='1'/>
+      <parameter type-id='type-id-15' name='traceback' filepath='Python/errors.c' line='69' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyErr_Restore' mangled-name='_PyErr_Restore' filepath='Python/errors.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Restore'>
+      <parameter type-id='type-id-703' name='tstate' filepath='Python/errors.c' line='41' column='1'/>
+      <parameter type-id='type-id-15' name='type' filepath='Python/errors.c' line='41' column='1'/>
+      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='41' column='1'/>
+      <parameter type-id='type-id-15' name='traceback' filepath='Python/errors.c' line='42' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/frozenmain.c' comp-dir-path='/src' language='LANG_C99'>
+    <function-decl name='Py_FrozenMain' mangled-name='Py_FrozenMain' filepath='Python/frozenmain.c' line='17' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_FrozenMain'>
+      <parameter type-id='type-id-8' name='argc' filepath='Python/frozenmain.c' line='17' column='1'/>
+      <parameter type-id='type-id-215' name='argv' filepath='Python/frozenmain.c' line='17' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/getargs.c' comp-dir-path='/src' language='LANG_C99'>
+    <function-decl name='_PyArg_NoKwnames' mangled-name='_PyArg_NoKwnames' filepath='Python/getargs.c' line='2761' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoKwnames'>
+      <parameter type-id='type-id-3' name='funcname' filepath='Python/getargs.c' line='2761' column='1'/>
+      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2761' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_NoPositional' mangled-name='_PyArg_NoPositional' filepath='Python/getargs.c' line='2744' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoPositional'>
+      <parameter type-id='type-id-3' name='funcname' filepath='Python/getargs.c' line='2761' column='1'/>
+      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2761' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_NoKeywords' mangled-name='_PyArg_NoKeywords' filepath='Python/getargs.c' line='2725' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_NoKeywords'>
+      <parameter type-id='type-id-3' name='funcname' filepath='Python/getargs.c' line='2761' column='1'/>
+      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2761' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_UnpackStack' mangled-name='_PyArg_UnpackStack' filepath='Python/getargs.c' line='2698' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_UnpackStack'>
+      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='2698' column='1'/>
+      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='2698' column='1'/>
+      <parameter type-id='type-id-3' name='name' filepath='Python/getargs.c' line='2698' column='1'/>
+      <parameter type-id='type-id-30' name='min' filepath='Python/getargs.c' line='2699' column='1'/>
+      <parameter type-id='type-id-30' name='max' filepath='Python/getargs.c' line='2699' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyArg_UnpackTuple' mangled-name='PyArg_UnpackTuple' filepath='Python/getargs.c' line='2672' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_UnpackTuple'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='2672' column='1'/>
+      <parameter type-id='type-id-3' name='name' filepath='Python/getargs.c' line='2672' column='1'/>
+      <parameter type-id='type-id-30' name='min' filepath='Python/getargs.c' line='2672' column='1'/>
+      <parameter type-id='type-id-30' name='max' filepath='Python/getargs.c' line='2672' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_CheckPositional' mangled-name='_PyArg_CheckPositional' filepath='Python/getargs.c' line='2610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_CheckPositional'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/getargs.c' line='2610' column='1'/>
+      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='2610' column='1'/>
+      <parameter type-id='type-id-30' name='min' filepath='Python/getargs.c' line='2611' column='1'/>
+      <parameter type-id='type-id-30' name='max' filepath='Python/getargs.c' line='2611' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <class-decl name='_PyArg_Parser' size-in-bits='512' is-struct='yes' visibility='default' filepath='./Include/modsupport.h' line='92' column='1' id='type-id-704'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='format' type-id='type-id-3' visibility='default' filepath='./Include/modsupport.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='keywords' type-id='type-id-705' visibility='default' filepath='./Include/modsupport.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fname' type-id='type-id-3' visibility='default' filepath='./Include/modsupport.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='custom_msg' type-id='type-id-3' visibility='default' filepath='./Include/modsupport.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pos' type-id='type-id-8' visibility='default' filepath='./Include/modsupport.h' line='97' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='min' type-id='type-id-8' visibility='default' filepath='./Include/modsupport.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='max' type-id='type-id-8' visibility='default' filepath='./Include/modsupport.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='kwtuple' type-id='type-id-15' visibility='default' filepath='./Include/modsupport.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-706' visibility='default' filepath='./Include/modsupport.h' line='101' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-705'/>
+    <pointer-type-def type-id='type-id-704' size-in-bits='64' id='type-id-706'/>
+    <function-decl name='_PyArg_UnpackKeywords' mangled-name='_PyArg_UnpackKeywords' filepath='Python/getargs.c' line='2268' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_UnpackKeywords'>
+      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='2268' column='1'/>
+      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='2268' column='1'/>
+      <parameter type-id='type-id-15' name='kwargs' filepath='Python/getargs.c' line='2269' column='1'/>
+      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='2269' column='1'/>
+      <parameter type-id='type-id-706' name='parser' filepath='Python/getargs.c' line='2270' column='1'/>
+      <parameter type-id='type-id-8' name='minpos' filepath='Python/getargs.c' line='2271' column='1'/>
+      <parameter type-id='type-id-8' name='maxpos' filepath='Python/getargs.c' line='2271' column='1'/>
+      <parameter type-id='type-id-8' name='minkw' filepath='Python/getargs.c' line='2271' column='1'/>
+      <parameter type-id='type-id-86' name='buf' filepath='Python/getargs.c' line='2272' column='1'/>
+      <return type-id='type-id-156'/>
+    </function-decl>
+    <function-decl name='PyArg_ValidateKeywordArguments' mangled-name='PyArg_ValidateKeywordArguments' filepath='Python/getargs.c' line='1557' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ValidateKeywordArguments'>
+      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2310' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast_SizeT'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1543' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1543' column='1'/>
+      <parameter type-id='type-id-706' name='parser' filepath='Python/getargs.c' line='1544' column='1'/>
+      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1544' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_VaParseTupleAndKeywordsFast' mangled-name='_PyArg_VaParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1529' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywordsFast'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1543' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1543' column='1'/>
+      <parameter type-id='type-id-706' name='parser' filepath='Python/getargs.c' line='1544' column='1'/>
+      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1544' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseStackAndKeywords_SizeT' mangled-name='_PyArg_ParseStackAndKeywords_SizeT' filepath='Python/getargs.c' line='1515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords_SizeT'>
+      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='1515' column='1'/>
+      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='1515' column='1'/>
+      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='1515' column='1'/>
+      <parameter type-id='type-id-706' name='parser' filepath='Python/getargs.c' line='1516' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseStackAndKeywords' mangled-name='_PyArg_ParseStackAndKeywords' filepath='Python/getargs.c' line='1502' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStackAndKeywords'>
+      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='1515' column='1'/>
+      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='1515' column='1'/>
+      <parameter type-id='type-id-15' name='kwnames' filepath='Python/getargs.c' line='1515' column='1'/>
+      <parameter type-id='type-id-706' name='parser' filepath='Python/getargs.c' line='1516' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseTupleAndKeywordsFast_SizeT' mangled-name='_PyArg_ParseTupleAndKeywordsFast_SizeT' filepath='Python/getargs.c' line='1489' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast_SizeT'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1489' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1489' column='1'/>
+      <parameter type-id='type-id-706' name='parser' filepath='Python/getargs.c' line='1490' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseTupleAndKeywordsFast' mangled-name='_PyArg_ParseTupleAndKeywordsFast' filepath='Python/getargs.c' line='1476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywordsFast'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1489' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1489' column='1'/>
+      <parameter type-id='type-id-706' name='parser' filepath='Python/getargs.c' line='1490' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_VaParseTupleAndKeywords_SizeT' mangled-name='_PyArg_VaParseTupleAndKeywords_SizeT' filepath='Python/getargs.c' line='1450' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParseTupleAndKeywords_SizeT'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1450' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1451' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1452' column='1'/>
+      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1453' column='1'/>
+      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1453' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyArg_VaParseTupleAndKeywords' mangled-name='PyArg_VaParseTupleAndKeywords' filepath='Python/getargs.c' line='1425' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParseTupleAndKeywords'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1450' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1451' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1452' column='1'/>
+      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1453' column='1'/>
+      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='1453' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseTupleAndKeywords_SizeT' mangled-name='_PyArg_ParseTupleAndKeywords_SizeT' filepath='Python/getargs.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTupleAndKeywords_SizeT'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1399' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1400' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1401' column='1'/>
+      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1402' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyArg_ParseTupleAndKeywords' mangled-name='PyArg_ParseTupleAndKeywords' filepath='Python/getargs.c' line='1375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ParseTupleAndKeywords'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='1399' column='1'/>
+      <parameter type-id='type-id-15' name='keywords' filepath='Python/getargs.c' line='1400' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='1401' column='1'/>
+      <parameter type-id='type-id-215' name='kwlist' filepath='Python/getargs.c' line='1402' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_BadArgument' mangled-name='_PyArg_BadArgument' filepath='Python/getargs.c' line='617' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_BadArgument'>
+      <parameter type-id='type-id-3' name='fname' filepath='Python/getargs.c' line='617' column='1'/>
+      <parameter type-id='type-id-3' name='displayname' filepath='Python/getargs.c' line='617' column='1'/>
+      <parameter type-id='type-id-3' name='expected' filepath='Python/getargs.c' line='618' column='1'/>
+      <parameter type-id='type-id-15' name='arg' filepath='Python/getargs.c' line='618' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_PyArg_VaParse_SizeT' mangled-name='_PyArg_VaParse_SizeT' filepath='Python/getargs.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_VaParse_SizeT'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='186' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='186' column='1'/>
+      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='186' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyArg_VaParse' mangled-name='PyArg_VaParse' filepath='Python/getargs.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_VaParse'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='186' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='186' column='1'/>
+      <parameter type-id='type-id-217' name='va' filepath='Python/getargs.c' line='186' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseStack_SizeT' mangled-name='_PyArg_ParseStack_SizeT' filepath='Python/getargs.c' line='160' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack_SizeT'>
+      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='160' column='1'/>
+      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='160' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='160' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseStack' mangled-name='_PyArg_ParseStack' filepath='Python/getargs.c' line='148' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseStack'>
+      <parameter type-id='type-id-156' name='args' filepath='Python/getargs.c' line='160' column='1'/>
+      <parameter type-id='type-id-30' name='nargs' filepath='Python/getargs.c' line='160' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='160' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_ParseTuple_SizeT' mangled-name='_PyArg_ParseTuple_SizeT' filepath='Python/getargs.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_ParseTuple_SizeT'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyArg_ParseTuple' mangled-name='PyArg_ParseTuple' filepath='Python/getargs.c' line='123' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_ParseTuple'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyArg_Parse_SizeT' mangled-name='_PyArg_Parse_SizeT' filepath='Python/getargs.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArg_Parse_SizeT'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyArg_Parse' mangled-name='PyArg_Parse' filepath='Python/getargs.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyArg_Parse'>
+      <parameter type-id='type-id-15' name='args' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter type-id='type-id-3' name='format' filepath='Python/getargs.c' line='135' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/getcompiler.c' comp-dir-path='/src' language='LANG_C99'>
+    <function-decl name='Py_GetCompiler' mangled-name='Py_GetCompiler' filepath='Python/getcompiler.c' line='24' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetCompiler'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/getcopyright.c' comp-dir-path='/src' language='LANG_C99'>
+    <function-decl name='Py_GetCopyright' mangled-name='Py_GetCopyright' filepath='Python/getcopyright.c' line='20' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetCopyright'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='./Python/getplatform.c' comp-dir-path='/src' language='LANG_C99'>
+    <function-decl name='Py_GetPlatform' mangled-name='Py_GetPlatform' filepath='./Python/getplatform.c' line='9' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetPlatform'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/getversion.c' comp-dir-path='/src' language='LANG_C99'>
+    <function-decl name='Py_GetVersion' mangled-name='Py_GetVersion' filepath='Python/getversion.c' line='9' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetVersion'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/hamt.c' comp-dir-path='/src' language='LANG_C99'>
+    <var-decl name='_PyHamtItems_Type' type-id='type-id-149' mangled-name='_PyHamtItems_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='70' column='1' elf-symbol-id='_PyHamtItems_Type'/>
+    <var-decl name='_PyHamtKeys_Type' type-id='type-id-149' mangled-name='_PyHamtKeys_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='68' column='1' elf-symbol-id='_PyHamtKeys_Type'/>
+    <var-decl name='_PyHamtValues_Type' type-id='type-id-149' mangled-name='_PyHamtValues_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='69' column='1' elf-symbol-id='_PyHamtValues_Type'/>
+    <var-decl name='_PyHamt_Type' type-id='type-id-149' mangled-name='_PyHamt_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='64' column='1' elf-symbol-id='_PyHamt_Type'/>
+    <var-decl name='_PyHamt_ArrayNode_Type' type-id='type-id-149' mangled-name='_PyHamt_ArrayNode_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='65' column='1' elf-symbol-id='_PyHamt_ArrayNode_Type'/>
+    <var-decl name='_PyHamt_BitmapNode_Type' type-id='type-id-149' mangled-name='_PyHamt_BitmapNode_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='66' column='1' elf-symbol-id='_PyHamt_BitmapNode_Type'/>
+    <var-decl name='_PyHamt_CollisionNode_Type' type-id='type-id-149' mangled-name='_PyHamt_CollisionNode_Type' visibility='default' filepath='./Include/internal/pycore_hamt.h' line='67' column='1' elf-symbol-id='_PyHamt_CollisionNode_Type'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/hashtable.c' comp-dir-path='/src' language='LANG_C99'>
+    <class-decl name='_Py_hashtable_t' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='60' column='1' id='type-id-707'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nentries' type-id='type-id-157' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='nbuckets' type-id='type-id-157' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='buckets' type-id='type-id-708' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='get_entry_func' type-id='type-id-709' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='hash_func' type-id='type-id-710' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='66' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='compare_func' type-id='type-id-711' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='key_destroy_func' type-id='type-id-712' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='68' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='value_destroy_func' type-id='type-id-712' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='alloc' type-id='type-id-713' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='70' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-714' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='17' column='1' id='type-id-715'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='head' type-id='type-id-716' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='18' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_Py_slist_item_s' size-in-bits='64' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='13' column='1' id='type-id-717'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-718' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='14' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-717' size-in-bits='64' id='type-id-718'/>
+    <typedef-decl name='_Py_slist_item_t' type-id='type-id-717' filepath='./Include/internal/pycore_hashtable.h' line='15' column='1' id='type-id-719'/>
+    <pointer-type-def type-id='type-id-719' size-in-bits='64' id='type-id-716'/>
+    <typedef-decl name='_Py_slist_t' type-id='type-id-715' filepath='./Include/internal/pycore_hashtable.h' line='19' column='1' id='type-id-714'/>
+    <pointer-type-def type-id='type-id-714' size-in-bits='64' id='type-id-708'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='256' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-720' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='28' column='1' id='type-id-721'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_Py_slist_item' type-id='type-id-719' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='30' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='key_hash' type-id='type-id-722' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='key' type-id='type-id-20' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='33' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='value' type-id='type-id-20' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='34' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Py_uhash_t' type-id='type-id-157' filepath='./Include/pyport.h' line='119' column='1' id='type-id-722'/>
+    <typedef-decl name='_Py_hashtable_entry_t' type-id='type-id-721' filepath='./Include/internal/pycore_hashtable.h' line='35' column='1' id='type-id-720'/>
+    <pointer-type-def type-id='type-id-720' size-in-bits='64' id='type-id-723'/>
+    <typedef-decl name='_Py_hashtable_t' type-id='type-id-707' filepath='./Include/internal/pycore_hashtable.h' line='42' column='1' id='type-id-724'/>
+    <pointer-type-def type-id='type-id-724' size-in-bits='64' id='type-id-725'/>
+    <pointer-type-def type-id='type-id-726' size-in-bits='64' id='type-id-727'/>
+    <typedef-decl name='_Py_hashtable_get_entry_func' type-id='type-id-727' filepath='./Include/internal/pycore_hashtable.h' line='47' column='1' id='type-id-709'/>
+    <pointer-type-def type-id='type-id-728' size-in-bits='64' id='type-id-729'/>
+    <typedef-decl name='_Py_hashtable_hash_func' type-id='type-id-729' filepath='./Include/internal/pycore_hashtable.h' line='44' column='1' id='type-id-710'/>
+    <pointer-type-def type-id='type-id-730' size-in-bits='64' id='type-id-731'/>
+    <typedef-decl name='_Py_hashtable_compare_func' type-id='type-id-731' filepath='./Include/internal/pycore_hashtable.h' line='45' column='1' id='type-id-711'/>
+    <typedef-decl name='_Py_hashtable_destroy_func' type-id='type-id-19' filepath='./Include/internal/pycore_hashtable.h' line='46' column='1' id='type-id-712'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-713' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='50' column='1' id='type-id-732'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='malloc' type-id='type-id-733' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='52' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='free' type-id='type-id-19' visibility='default' filepath='./Include/internal/pycore_hashtable.h' line='55' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-734' size-in-bits='64' id='type-id-733'/>
+    <typedef-decl name='_Py_hashtable_allocator_t' type-id='type-id-732' filepath='./Include/internal/pycore_hashtable.h' line='56' column='1' id='type-id-713'/>
+    <function-decl name='_Py_hashtable_destroy' mangled-name='_Py_hashtable_destroy' filepath='Python/hashtable.c' line='404' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_destroy'>
+      <parameter type-id='type-id-725' name='ht' filepath='Python/hashtable.c' line='404' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_Py_hashtable_clear' mangled-name='_Py_hashtable_clear' filepath='Python/hashtable.c' line='385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_clear'>
+      <parameter type-id='type-id-725' name='ht' filepath='Python/hashtable.c' line='404' column='1'/>
+      <return type-id='type-id-69'/>
+    </function-decl>
+    <function-decl name='_Py_hashtable_new' mangled-name='_Py_hashtable_new' filepath='Python/hashtable.c' line='363' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_new'>
+      <parameter type-id='type-id-710' name='hash_func' filepath='Python/hashtable.c' line='363' column='1'/>
+      <parameter type-id='type-id-711' name='compare_func' filepath='Python/hashtable.c' line='364' column='1'/>
+      <return type-id='type-id-725'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-713' size-in-bits='64' id='type-id-735'/>
+    <function-decl name='_Py_hashtable_new_full' mangled-name='_Py_hashtable_new_full' filepath='Python/hashtable.c' line='316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_new_full'>
+      <parameter type-id='type-id-710' name='hash_func' filepath='Python/hashtable.c' line='316' column='1'/>
+      <parameter type-id='type-id-711' name='compare_func' filepath='Python/hashtable.c' line='317' column='1'/>
+      <parameter type-id='type-id-712' name='key_destroy_func' filepath='Python/hashtable.c' line='318' column='1'/>
+      <parameter type-id='type-id-712' name='value_destroy_func' filepath='Python/hashtable.c' line='319' column='1'/>
+      <parameter type-id='type-id-735' name='allocator' filepath='Python/hashtable.c' line='320' column='1'/>
+      <return type-id='type-id-725'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-736' size-in-bits='64' id='type-id-737'/>
+    <typedef-decl name='_Py_hashtable_foreach_func' type-id='type-id-737' filepath='./Include/internal/pycore_hashtable.h' line='96' column='1' id='type-id-738'/>
+    <function-decl name='_Py_hashtable_foreach' mangled-name='_Py_hashtable_foreach' filepath='Python/hashtable.c' line='261' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_foreach'>
+      <parameter type-id='type-id-725' name='ht' filepath='Python/hashtable.c' line='261' column='1'/>
+      <parameter type-id='type-id-738' name='func' filepath='Python/hashtable.c' line='262' column='1'/>
+      <parameter type-id='type-id-20' name='user_data' filepath='Python/hashtable.c' line='263' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_Py_hashtable_get' mangled-name='_Py_hashtable_get' filepath='Python/hashtable.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_get'>
+      <parameter type-id='type-id-725' name='ht' filepath='Python/hashtable.c' line='248' column='1'/>
+      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='248' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='_Py_hashtable_set' mangled-name='_Py_hashtable_set' filepath='Python/hashtable.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_set'>
+      <parameter type-id='type-id-725' name='ht' filepath='Python/hashtable.c' line='209' column='1'/>
+      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='209' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='Python/hashtable.c' line='209' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_Py_hashtable_steal' mangled-name='_Py_hashtable_steal' filepath='Python/hashtable.c' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_steal'>
+      <parameter type-id='type-id-725' name='ht' filepath='Python/hashtable.c' line='174' column='1'/>
+      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='174' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-724' const='yes' id='type-id-739'/>
+    <pointer-type-def type-id='type-id-739' size-in-bits='64' id='type-id-740'/>
+    <function-decl name='_Py_hashtable_size' mangled-name='_Py_hashtable_size' filepath='Python/hashtable.c' line='120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_size'>
+      <parameter type-id='type-id-740' name='ht' filepath='Python/hashtable.c' line='120' column='1'/>
+      <return type-id='type-id-157'/>
+    </function-decl>
+    <function-decl name='_Py_hashtable_compare_direct' mangled-name='_Py_hashtable_compare_direct' filepath='Python/hashtable.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_compare_direct'>
+      <parameter type-id='type-id-20' name='key1' filepath='Python/hashtable.c' line='99' column='1'/>
+      <parameter type-id='type-id-20' name='key2' filepath='Python/hashtable.c' line='99' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_Py_hashtable_hash_ptr' mangled-name='_Py_hashtable_hash_ptr' filepath='Python/hashtable.c' line='92' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_hashtable_hash_ptr'>
+      <parameter type-id='type-id-20' name='key' filepath='Python/hashtable.c' line='92' column='1'/>
+      <return type-id='type-id-722'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-726'>
+      <parameter type-id='type-id-725'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-723'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-736'>
+      <parameter type-id='type-id-725'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-8'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-730'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-8'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-728'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-722'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-734'>
+      <parameter type-id='type-id-157'/>
+      <return type-id='type-id-20'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='Python/import.c' comp-dir-path='/src' language='LANG_C99'>
+    <class-decl name='_inittab' size-in-bits='128' is-struct='yes' visibility='default' filepath='./Include/cpython/import.h' line='24' column='1' id='type-id-741'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name' type-id='type-id-3' visibility='default' filepath='./Include/cpython/import.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='initfunc' type-id='type-id-462' visibility='default' filepath='./Include/cpython/import.h' line='26' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-741' size-in-bits='64' id='type-id-742'/>
+    <var-decl name='PyImport_Inittab' type-id='type-id-742' mangled-name='PyImport_Inittab' visibility='default' filepath='./Include/cpython/import.h' line='28' column='1' elf-symbol-id='PyImport_Inittab'/>
+    <function-decl name='PyImport_AppendInittab' mangled-name='PyImport_AppendInittab' filepath='Python/import.c' line='2266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AppendInittab'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='2266' column='1'/>
+      <parameter type-id='type-id-462' name='initfunc' filepath='Python/import.c' line='2266' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyImport_ExtendInittab' mangled-name='PyImport_ExtendInittab' filepath='Python/import.c' line='2220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExtendInittab'>
+      <parameter type-id='type-id-742' name='newtab' filepath='Python/import.c' line='2220' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyInit__imp' mangled-name='PyInit__imp' filepath='Python/import.c' line='2159' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit__imp'>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_Import' mangled-name='PyImport_Import' filepath='Python/import.c' line='1746' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_Import'>
+      <parameter type-id='type-id-15' name='module_name' filepath='Python/import.c' line='1746' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ReloadModule' mangled-name='PyImport_ReloadModule' filepath='Python/import.c' line='1713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ReloadModule'>
+      <parameter type-id='type-id-15' name='m' filepath='Python/import.c' line='1713' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ImportModuleLevel' mangled-name='PyImport_ImportModuleLevel' filepath='Python/import.c' line='1695' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleLevel'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='1695' column='1'/>
+      <parameter type-id='type-id-15' name='globals' filepath='Python/import.c' line='1695' column='1'/>
+      <parameter type-id='type-id-15' name='locals' filepath='Python/import.c' line='1695' column='1'/>
+      <parameter type-id='type-id-15' name='fromlist' filepath='Python/import.c' line='1696' column='1'/>
+      <parameter type-id='type-id-8' name='level' filepath='Python/import.c' line='1696' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ImportModuleLevelObject' mangled-name='PyImport_ImportModuleLevelObject' filepath='Python/import.c' line='1543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleLevelObject'>
+      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='1543' column='1'/>
+      <parameter type-id='type-id-15' name='globals' filepath='Python/import.c' line='1543' column='1'/>
+      <parameter type-id='type-id-15' name='locals' filepath='Python/import.c' line='1544' column='1'/>
+      <parameter type-id='type-id-15' name='fromlist' filepath='Python/import.c' line='1544' column='1'/>
+      <parameter type-id='type-id-8' name='level' filepath='Python/import.c' line='1545' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_GetModule' mangled-name='PyImport_GetModule' filepath='Python/import.c' line='1526' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetModule'>
+      <parameter type-id='type-id-15' name='v' filepath='Objects/abstract.c' line='2129' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ImportModuleNoBlock' mangled-name='PyImport_ImportModuleNoBlock' filepath='Python/import.c' line='1231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModuleNoBlock'>
+      <parameter type-id='type-id-3' name='encoding' filepath='Python/codecs.c' line='355' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ImportModule' mangled-name='PyImport_ImportModule' filepath='Python/import.c' line='1207' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportModule'>
+      <parameter type-id='type-id-3' name='utf8path' filepath='Objects/fileobject.c' line='562' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ImportFrozenModule' mangled-name='PyImport_ImportFrozenModule' filepath='Python/import.c' line='1190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportFrozenModule'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='1190' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyImport_ImportFrozenModuleObject' mangled-name='PyImport_ImportFrozenModuleObject' filepath='Python/import.c' line='1121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ImportFrozenModuleObject'>
+      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='1121' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyImport_GetImporter' mangled-name='PyImport_GetImporter' filepath='Python/import.c' line='966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetImporter'>
+      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2819' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ExecCodeModuleObject' mangled-name='PyImport_ExecCodeModuleObject' filepath='Python/import.c' line='792' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleObject'>
+      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='792' column='1'/>
+      <parameter type-id='type-id-15' name='co' filepath='Python/import.c' line='792' column='1'/>
+      <parameter type-id='type-id-15' name='pathname' filepath='Python/import.c' line='792' column='1'/>
+      <parameter type-id='type-id-15' name='cpathname' filepath='Python/import.c' line='793' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ExecCodeModuleWithPathnames' mangled-name='PyImport_ExecCodeModuleWithPathnames' filepath='Python/import.c' line='687' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleWithPathnames'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='687' column='1'/>
+      <parameter type-id='type-id-15' name='co' filepath='Python/import.c' line='687' column='1'/>
+      <parameter type-id='type-id-3' name='pathname' filepath='Python/import.c' line='688' column='1'/>
+      <parameter type-id='type-id-3' name='cpathname' filepath='Python/import.c' line='689' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ExecCodeModuleEx' mangled-name='PyImport_ExecCodeModuleEx' filepath='Python/import.c' line='680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModuleEx'>
+      <parameter type-id='type-id-3' name='encoding' filepath='Python/codecs.c' line='379' column='1'/>
+      <parameter type-id='type-id-15' name='stream' filepath='Python/codecs.c' line='380' column='1'/>
+      <parameter type-id='type-id-3' name='errors' filepath='Python/codecs.c' line='381' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_ExecCodeModule' mangled-name='PyImport_ExecCodeModule' filepath='Python/import.c' line='673' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_ExecCodeModule'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='673' column='1'/>
+      <parameter type-id='type-id-15' name='co' filepath='Python/import.c' line='673' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_AddModule' mangled-name='PyImport_AddModule' filepath='Python/import.c' line='624' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModule'>
+      <parameter type-id='type-id-3' name='utf8path' filepath='Objects/fileobject.c' line='562' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='PyImport_AddModuleObject' mangled-name='PyImport_AddModuleObject' filepath='Python/import.c' line='606' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_AddModuleObject'>
+      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2793' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_PyImport_FixupBuiltin' mangled-name='_PyImport_FixupBuiltin' filepath='Python/import.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_FixupBuiltin'>
+      <parameter type-id='type-id-15' name='o' filepath='Objects/abstract.c' line='2366' column='1'/>
+      <parameter type-id='type-id-3' name='key' filepath='Objects/abstract.c' line='2366' column='1'/>
+      <parameter type-id='type-id-15' name='value' filepath='Objects/abstract.c' line='2366' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyImport_FixupExtensionObject' mangled-name='_PyImport_FixupExtensionObject' filepath='Python/import.c' line='421' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_FixupExtensionObject'>
+      <parameter type-id='type-id-15' name='mod' filepath='Python/import.c' line='421' column='1'/>
+      <parameter type-id='type-id-15' name='name' filepath='Python/import.c' line='421' column='1'/>
+      <parameter type-id='type-id-15' name='filename' filepath='Python/import.c' line='422' column='1'/>
+      <parameter type-id='type-id-15' name='modules' filepath='Python/import.c' line='422' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='PyImport_GetMagicTag' mangled-name='PyImport_GetMagicTag' filepath='Python/import.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicTag'>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='PyImport_GetMagicNumber' mangled-name='PyImport_GetMagicNumber' filepath='Python/import.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyImport_GetMagicNumber'>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='_PyImport_SetModuleString' mangled-name='_PyImport_SetModuleString' filepath='Python/import.c' line='311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_SetModuleString'>
+      <parameter type-id='type-id-3' name='name' filepath='Python/import.c' line='311' column='1'/>
+      <parameter type-id='type-id-15' name='m' filepath='Python/import.c' line='311' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyImport_SetModule' mangled-name='_PyImport_SetModule' filepath='Python/import.c' line='303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_SetModule'>
+      <parameter type-id='type-id-15' name='od' filepath='Objects/odictobject.c' line='1675' column='1'/>
+      <parameter type-id='type-id-15' name='key' filepath='Objects/odictobject.c' line='1675' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='_PyImport_GetModuleId' mangled-name='_PyImport_GetModuleId' filepath='Python/import.c' line='293' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_GetModuleId'>
+      <parameter type-id='type-id-219' name='nameid' filepath='Python/import.c' line='293' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
     <function-decl name='_PyImport_IsInitialized' mangled-name='_PyImport_IsInitialized' filepath='Python/import.c' line='285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyImport_IsInitialized'>
       <parameter type-id='type-id-222' name='interp' filepath='Python/import.c' line='285' column='1'/>
       <return type-id='type-id-8'/>
@@ -12943,9 +13058,9 @@
     <function-decl name='_Py_GetConfigsAsDict' mangled-name='_Py_GetConfigsAsDict' filepath='./Python/initconfig.c' line='2898' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfigsAsDict'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='256' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-740' visibility='default' filepath='./Include/cpython/initconfig.h' line='7' column='1' id='type-id-741'>
+    <class-decl name='__anonymous_struct__' size-in-bits='256' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-743' visibility='default' filepath='./Include/cpython/initconfig.h' line='7' column='1' id='type-id-744'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_type' type-id='type-id-742' visibility='default' filepath='./Include/cpython/initconfig.h' line='12' column='1'/>
+        <var-decl name='_type' type-id='type-id-745' visibility='default' filepath='./Include/cpython/initconfig.h' line='12' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='func' type-id='type-id-3' visibility='default' filepath='./Include/cpython/initconfig.h' line='13' column='1'/>
@@ -12957,83 +13072,83 @@
         <var-decl name='exitcode' type-id='type-id-8' visibility='default' filepath='./Include/cpython/initconfig.h' line='15' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/cpython/initconfig.h' line='8' column='1' id='type-id-742'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/cpython/initconfig.h' line='8' column='1' id='type-id-745'>
       <underlying-type type-id='type-id-83'/>
       <enumerator name='_PyStatus_TYPE_OK' value='0'/>
       <enumerator name='_PyStatus_TYPE_ERROR' value='1'/>
       <enumerator name='_PyStatus_TYPE_EXIT' value='2'/>
     </enum-decl>
-    <typedef-decl name='PyStatus' type-id='type-id-741' filepath='./Include/cpython/initconfig.h' line='16' column='1' id='type-id-740'/>
-    <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-743'/>
+    <typedef-decl name='PyStatus' type-id='type-id-744' filepath='./Include/cpython/initconfig.h' line='16' column='1' id='type-id-743'/>
+    <pointer-type-def type-id='type-id-231' size-in-bits='64' id='type-id-746'/>
     <function-decl name='PyConfig_Read' mangled-name='PyConfig_Read' filepath='./Python/initconfig.c' line='2891' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Read'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='2891' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='2891' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-744'/>
+    <pointer-type-def type-id='type-id-326' size-in-bits='64' id='type-id-747'/>
     <function-decl name='PyConfig_SetWideStringList' mangled-name='PyConfig_SetWideStringList' filepath='./Python/initconfig.c' line='2808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetWideStringList'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='2808' column='1'/>
-      <parameter type-id='type-id-744' name='list' filepath='./Python/initconfig.c' line='2808' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='2808' column='1'/>
+      <parameter type-id='type-id-747' name='list' filepath='./Python/initconfig.c' line='2808' column='1'/>
       <parameter type-id='type-id-30' name='length' filepath='./Python/initconfig.c' line='2809' column='1'/>
       <parameter type-id='type-id-329' name='items' filepath='./Python/initconfig.c' line='2809' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-325' const='yes' id='type-id-745'/>
-    <pointer-type-def type-id='type-id-745' size-in-bits='64' id='type-id-746'/>
+    <qualified-type-def type-id='type-id-325' const='yes' id='type-id-748'/>
+    <pointer-type-def type-id='type-id-748' size-in-bits='64' id='type-id-749'/>
     <function-decl name='PyConfig_SetArgv' mangled-name='PyConfig_SetArgv' filepath='./Python/initconfig.c' line='2796' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetArgv'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='2796' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='2796' column='1'/>
       <parameter type-id='type-id-30' name='argc' filepath='./Python/initconfig.c' line='2796' column='1'/>
-      <parameter type-id='type-id-746' name='argv' filepath='./Python/initconfig.c' line='2796' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-749' name='argv' filepath='./Python/initconfig.c' line='2796' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyConfig_SetBytesArgv' mangled-name='PyConfig_SetBytesArgv' filepath='./Python/initconfig.c' line='2784' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetBytesArgv'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='2784' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='2784' column='1'/>
       <parameter type-id='type-id-30' name='argc' filepath='./Python/initconfig.c' line='2784' column='1'/>
       <parameter type-id='type-id-192' name='argv' filepath='./Python/initconfig.c' line='2784' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='_PyConfig_FromDict' mangled-name='_PyConfig_FromDict' filepath='./Python/initconfig.c' line='1211' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_FromDict'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='1211' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='1211' column='1'/>
       <parameter type-id='type-id-15' name='dict' filepath='./Python/initconfig.c' line='1211' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-231' const='yes' id='type-id-747'/>
-    <pointer-type-def type-id='type-id-747' size-in-bits='64' id='type-id-748'/>
+    <qualified-type-def type-id='type-id-231' const='yes' id='type-id-750'/>
+    <pointer-type-def type-id='type-id-750' size-in-bits='64' id='type-id-751'/>
     <function-decl name='_PyConfig_AsDict' mangled-name='_PyConfig_AsDict' filepath='./Python/initconfig.c' line='949' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_AsDict'>
-      <parameter type-id='type-id-748' name='config' filepath='./Python/initconfig.c' line='949' column='1'/>
+      <parameter type-id='type-id-751' name='config' filepath='./Python/initconfig.c' line='949' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='PyConfig_SetBytesString' mangled-name='PyConfig_SetBytesString' filepath='./Python/initconfig.c' line='847' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetBytesString'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='847' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='847' column='1'/>
       <parameter type-id='type-id-329' name='config_str' filepath='./Python/initconfig.c' line='847' column='1'/>
       <parameter type-id='type-id-3' name='str' filepath='./Python/initconfig.c' line='848' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyConfig_SetString' mangled-name='PyConfig_SetString' filepath='./Python/initconfig.c' line='785' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_SetString'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='785' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='785' column='1'/>
       <parameter type-id='type-id-329' name='config_str' filepath='./Python/initconfig.c' line='785' column='1'/>
       <parameter type-id='type-id-478' name='str' filepath='./Python/initconfig.c' line='785' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyConfig_InitIsolatedConfig' mangled-name='PyConfig_InitIsolatedConfig' filepath='./Python/initconfig.c' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_InitIsolatedConfig'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='PyConfig_InitPythonConfig' mangled-name='PyConfig_InitPythonConfig' filepath='./Python/initconfig.c' line='752' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_InitPythonConfig'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='_PyConfig_InitCompatConfig' mangled-name='_PyConfig_InitCompatConfig' filepath='./Python/initconfig.c' line='688' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyConfig_InitCompatConfig'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='PyConfig_Clear' mangled-name='PyConfig_Clear' filepath='./Python/initconfig.c' line='646' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyConfig_Clear'>
-      <parameter type-id='type-id-743' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
+      <parameter type-id='type-id-746' name='config' filepath='./Python/initconfig.c' line='763' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-329' size-in-bits='64' id='type-id-749'/>
+    <pointer-type-def type-id='type-id-329' size-in-bits='64' id='type-id-752'/>
     <function-decl name='Py_GetArgcArgv' mangled-name='Py_GetArgcArgv' filepath='./Python/initconfig.c' line='569' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetArgcArgv'>
       <parameter type-id='type-id-452' name='argc' filepath='./Python/initconfig.c' line='569' column='1'/>
-      <parameter type-id='type-id-749' name='argv' filepath='./Python/initconfig.c' line='569' column='1'/>
+      <parameter type-id='type-id-752' name='argv' filepath='./Python/initconfig.c' line='569' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='_Py_ClearArgcArgv' mangled-name='_Py_ClearArgcArgv' filepath='./Python/initconfig.c' line='540' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ClearArgcArgv'>
@@ -13047,62 +13162,62 @@
       <parameter type-id='type-id-3' name='errors' filepath='./Python/initconfig.c' line='458' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-326' const='yes' id='type-id-750'/>
-    <pointer-type-def type-id='type-id-750' size-in-bits='64' id='type-id-751'/>
+    <qualified-type-def type-id='type-id-326' const='yes' id='type-id-753'/>
+    <pointer-type-def type-id='type-id-753' size-in-bits='64' id='type-id-754'/>
     <function-decl name='_PyWideStringList_AsList' mangled-name='_PyWideStringList_AsList' filepath='./Python/initconfig.c' line='427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_AsList'>
-      <parameter type-id='type-id-751' name='list' filepath='./Python/initconfig.c' line='427' column='1'/>
+      <parameter type-id='type-id-754' name='list' filepath='./Python/initconfig.c' line='427' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='_PyWideStringList_Extend' mangled-name='_PyWideStringList_Extend' filepath='./Python/initconfig.c' line='402' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Extend'>
-      <parameter type-id='type-id-744' name='list' filepath='./Python/initconfig.c' line='402' column='1'/>
-      <parameter type-id='type-id-751' name='list2' filepath='./Python/initconfig.c' line='402' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-747' name='list' filepath='./Python/initconfig.c' line='402' column='1'/>
+      <parameter type-id='type-id-754' name='list2' filepath='./Python/initconfig.c' line='402' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyWideStringList_Append' mangled-name='PyWideStringList_Append' filepath='./Python/initconfig.c' line='395' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Append'>
-      <parameter type-id='type-id-744' name='list' filepath='./Python/initconfig.c' line='395' column='1'/>
+      <parameter type-id='type-id-747' name='list' filepath='./Python/initconfig.c' line='395' column='1'/>
       <parameter type-id='type-id-478' name='item' filepath='./Python/initconfig.c' line='395' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyWideStringList_Insert' mangled-name='PyWideStringList_Insert' filepath='./Python/initconfig.c' line='354' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyWideStringList_Insert'>
-      <parameter type-id='type-id-744' name='list' filepath='./Python/initconfig.c' line='354' column='1'/>
+      <parameter type-id='type-id-747' name='list' filepath='./Python/initconfig.c' line='354' column='1'/>
       <parameter type-id='type-id-30' name='index' filepath='./Python/initconfig.c' line='355' column='1'/>
       <parameter type-id='type-id-478' name='item' filepath='./Python/initconfig.c' line='355' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='_PyWideStringList_Copy' mangled-name='_PyWideStringList_Copy' filepath='./Python/initconfig.c' line='319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Copy'>
-      <parameter type-id='type-id-744' name='list' filepath='./Python/initconfig.c' line='319' column='1'/>
-      <parameter type-id='type-id-751' name='list2' filepath='./Python/initconfig.c' line='319' column='1'/>
+      <parameter type-id='type-id-747' name='list' filepath='./Python/initconfig.c' line='319' column='1'/>
+      <parameter type-id='type-id-754' name='list2' filepath='./Python/initconfig.c' line='319' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyWideStringList_Clear' mangled-name='_PyWideStringList_Clear' filepath='./Python/initconfig.c' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyWideStringList_Clear'>
-      <parameter type-id='type-id-744' name='list' filepath='./Python/initconfig.c' line='306' column='1'/>
+      <parameter type-id='type-id-747' name='list' filepath='./Python/initconfig.c' line='306' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='PyStatus_Exception' mangled-name='PyStatus_Exception' filepath='./Python/initconfig.c' line='266' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Exception'>
-      <parameter type-id='type-id-740' name='status' filepath='./Python/initconfig.c' line='266' column='1'/>
+      <parameter type-id='type-id-743' name='status' filepath='./Python/initconfig.c' line='266' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='PyStatus_IsExit' mangled-name='PyStatus_IsExit' filepath='./Python/initconfig.c' line='263' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsExit'>
-      <parameter type-id='type-id-740' name='status' filepath='./Python/initconfig.c' line='266' column='1'/>
+      <parameter type-id='type-id-743' name='status' filepath='./Python/initconfig.c' line='266' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='PyStatus_IsError' mangled-name='PyStatus_IsError' filepath='./Python/initconfig.c' line='260' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_IsError'>
-      <parameter type-id='type-id-740' name='status' filepath='./Python/initconfig.c' line='266' column='1'/>
+      <parameter type-id='type-id-743' name='status' filepath='./Python/initconfig.c' line='266' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='PyStatus_Exit' mangled-name='PyStatus_Exit' filepath='./Python/initconfig.c' line='256' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Exit'>
       <parameter type-id='type-id-8' name='exitcode' filepath='./Python/initconfig.c' line='256' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyStatus_NoMemory' mangled-name='PyStatus_NoMemory' filepath='./Python/initconfig.c' line='253' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_NoMemory'>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyStatus_Error' mangled-name='PyStatus_Error' filepath='./Python/initconfig.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Error'>
       <parameter type-id='type-id-3' name='err_msg' filepath='./Python/initconfig.c' line='246' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='PyStatus_Ok' mangled-name='PyStatus_Ok' filepath='./Python/initconfig.c' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyStatus_Ok'>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/marshal.c' comp-dir-path='/src' language='LANG_C99'>
@@ -13252,7 +13367,7 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pathconfig.c' comp-dir-path='/src' language='LANG_C99'>
-    <class-decl name='_PyPathConfig' size-in-bits='384' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pathconfig.h' line='11' column='1' id='type-id-752'>
+    <class-decl name='_PyPathConfig' size-in-bits='384' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_pathconfig.h' line='11' column='1' id='type-id-755'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='program_full_path' type-id='type-id-325' visibility='default' filepath='./Include/internal/pycore_pathconfig.h' line='13' column='1'/>
       </data-member>
@@ -13272,8 +13387,8 @@
         <var-decl name='home' type-id='type-id-325' visibility='default' filepath='./Include/internal/pycore_pathconfig.h' line='21' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyPathConfig' type-id='type-id-752' filepath='./Include/internal/pycore_pathconfig.h' line='31' column='1' id='type-id-753'/>
-    <var-decl name='_Py_path_config' type-id='type-id-753' mangled-name='_Py_path_config' visibility='default' filepath='./Include/internal/pycore_pathconfig.h' line='44' column='1' elf-symbol-id='_Py_path_config'/>
+    <typedef-decl name='_PyPathConfig' type-id='type-id-755' filepath='./Include/internal/pycore_pathconfig.h' line='31' column='1' id='type-id-756'/>
+    <var-decl name='_Py_path_config' type-id='type-id-756' mangled-name='_Py_path_config' visibility='default' filepath='./Include/internal/pycore_pathconfig.h' line='44' column='1' elf-symbol-id='_Py_path_config'/>
     <function-decl name='Py_GetProgramName' mangled-name='Py_GetProgramName' filepath='Python/pathconfig.c' line='604' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_GetProgramName'>
       <return type-id='type-id-325'/>
     </function-decl>
@@ -13314,7 +13429,7 @@
     <var-decl name='Py_HasFileSystemDefaultEncoding' type-id='type-id-8' mangled-name='Py_HasFileSystemDefaultEncoding' visibility='default' filepath='./Include/fileobject.h' line='26' column='1' elf-symbol-id='Py_HasFileSystemDefaultEncoding'/>
     <var-decl name='Py_FileSystemDefaultEncodeErrors' type-id='type-id-3' mangled-name='Py_FileSystemDefaultEncodeErrors' visibility='default' filepath='./Include/fileobject.h' line='24' column='1' elf-symbol-id='Py_FileSystemDefaultEncodeErrors'/>
     <function-decl name='_Py_get_xoption' mangled-name='_Py_get_xoption' filepath='Python/preconfig.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_get_xoption'>
-      <parameter type-id='type-id-751' name='xoptions' filepath='Python/preconfig.c' line='583' column='1'/>
+      <parameter type-id='type-id-754' name='xoptions' filepath='Python/preconfig.c' line='583' column='1'/>
       <parameter type-id='type-id-478' name='name' filepath='Python/preconfig.c' line='583' column='1'/>
       <return type-id='type-id-478'/>
     </function-decl>
@@ -13334,20 +13449,20 @@
       <parameter type-id='type-id-3' name='name' filepath='Python/preconfig.c' line='528' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-257' size-in-bits='64' id='type-id-754'/>
+    <pointer-type-def type-id='type-id-257' size-in-bits='64' id='type-id-757'/>
     <function-decl name='PyPreConfig_InitIsolatedConfig' mangled-name='PyPreConfig_InitIsolatedConfig' filepath='Python/preconfig.c' line='340' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyPreConfig_InitIsolatedConfig'>
-      <parameter type-id='type-id-754' name='config' filepath='Python/preconfig.c' line='340' column='1'/>
+      <parameter type-id='type-id-757' name='config' filepath='Python/preconfig.c' line='340' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='PyPreConfig_InitPythonConfig' mangled-name='PyPreConfig_InitPythonConfig' filepath='Python/preconfig.c' line='319' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyPreConfig_InitPythonConfig'>
-      <parameter type-id='type-id-754' name='config' filepath='Python/preconfig.c' line='340' column='1'/>
+      <parameter type-id='type-id-757' name='config' filepath='Python/preconfig.c' line='340' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='_PyPreConfig_InitCompatConfig' mangled-name='_PyPreConfig_InitCompatConfig' filepath='Python/preconfig.c' line='281' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyPreConfig_InitCompatConfig'>
-      <parameter type-id='type-id-754' name='config' filepath='Python/preconfig.c' line='340' column='1'/>
+      <parameter type-id='type-id-757' name='config' filepath='Python/preconfig.c' line='340' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <class-decl name='_PyArgv' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='66' column='1' id='type-id-755'>
+    <class-decl name='_PyArgv' size-in-bits='256' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='66' column='1' id='type-id-758'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='argc' type-id='type-id-30' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='67' column='1'/>
       </data-member>
@@ -13358,31 +13473,31 @@
         <var-decl name='bytes_argv' type-id='type-id-192' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='wchar_argv' type-id='type-id-746' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='70' column='1'/>
+        <var-decl name='wchar_argv' type-id='type-id-749' visibility='default' filepath='./Include/internal/pycore_initconfig.h' line='70' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_PyArgv' type-id='type-id-755' filepath='./Include/internal/pycore_initconfig.h' line='71' column='1' id='type-id-756'/>
-    <qualified-type-def type-id='type-id-756' const='yes' id='type-id-757'/>
-    <pointer-type-def type-id='type-id-757' size-in-bits='64' id='type-id-758'/>
+    <typedef-decl name='_PyArgv' type-id='type-id-758' filepath='./Include/internal/pycore_initconfig.h' line='71' column='1' id='type-id-759'/>
+    <qualified-type-def type-id='type-id-759' const='yes' id='type-id-760'/>
+    <pointer-type-def type-id='type-id-760' size-in-bits='64' id='type-id-761'/>
     <function-decl name='_PyArgv_AsWstrList' mangled-name='_PyArgv_AsWstrList' filepath='Python/preconfig.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArgv_AsWstrList'>
-      <parameter type-id='type-id-758' name='args' filepath='Python/preconfig.c' line='75' column='1'/>
-      <parameter type-id='type-id-744' name='list' filepath='Python/preconfig.c' line='75' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-761' name='args' filepath='Python/preconfig.c' line='75' column='1'/>
+      <parameter type-id='type-id-747' name='list' filepath='Python/preconfig.c' line='75' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pyarena.c' comp-dir-path='/src' language='LANG_C99'>
     <class-decl name='_arena' size-in-bits='192' is-struct='yes' visibility='default' filepath='Python/pyarena.c' line='46' column='1' id='type-id-697'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='a_head' type-id='type-id-759' visibility='default' filepath='Python/pyarena.c' line='51' column='1'/>
+        <var-decl name='a_head' type-id='type-id-762' visibility='default' filepath='Python/pyarena.c' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='a_cur' type-id='type-id-759' visibility='default' filepath='Python/pyarena.c' line='58' column='1'/>
+        <var-decl name='a_cur' type-id='type-id-762' visibility='default' filepath='Python/pyarena.c' line='58' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='a_objects' type-id='type-id-15' visibility='default' filepath='Python/pyarena.c' line='64' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='_block' size-in-bits='256' is-struct='yes' visibility='default' filepath='Python/pyarena.c' line='17' column='1' id='type-id-760'>
+    <class-decl name='_block' size-in-bits='256' is-struct='yes' visibility='default' filepath='Python/pyarena.c' line='17' column='1' id='type-id-763'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ab_size' type-id='type-id-157' visibility='default' filepath='Python/pyarena.c' line='22' column='1'/>
       </data-member>
@@ -13390,15 +13505,15 @@
         <var-decl name='ab_offset' type-id='type-id-157' visibility='default' filepath='Python/pyarena.c' line='27' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ab_next' type-id='type-id-761' visibility='default' filepath='Python/pyarena.c' line='33' column='1'/>
+        <var-decl name='ab_next' type-id='type-id-764' visibility='default' filepath='Python/pyarena.c' line='33' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='ab_mem' type-id='type-id-20' visibility='default' filepath='Python/pyarena.c' line='38' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-760' size-in-bits='64' id='type-id-761'/>
-    <typedef-decl name='block' type-id='type-id-760' filepath='Python/pyarena.c' line='39' column='1' id='type-id-762'/>
-    <pointer-type-def type-id='type-id-762' size-in-bits='64' id='type-id-759'/>
+    <pointer-type-def type-id='type-id-763' size-in-bits='64' id='type-id-764'/>
+    <typedef-decl name='block' type-id='type-id-763' filepath='Python/pyarena.c' line='39' column='1' id='type-id-765'/>
+    <pointer-type-def type-id='type-id-765' size-in-bits='64' id='type-id-762'/>
     <function-decl name='_PyArena_AddPyObject' mangled-name='_PyArena_AddPyObject' filepath='Python/pyarena.c' line='204' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyArena_AddPyObject'>
       <parameter type-id='type-id-699' name='arena' filepath='Python/pyarena.c' line='204' column='1'/>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pyarena.c' line='204' column='1'/>
@@ -13418,47 +13533,47 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pyctype.c' comp-dir-path='/src' language='LANG_C99'>
-    <qualified-type-def type-id='type-id-65' const='yes' id='type-id-763'/>
+    <qualified-type-def type-id='type-id-65' const='yes' id='type-id-766'/>
 
-    <array-type-def dimensions='1' type-id='type-id-763' size-in-bits='8192' id='type-id-764'>
+    <array-type-def dimensions='1' type-id='type-id-766' size-in-bits='8192' id='type-id-767'>
       <subrange length='256' type-id='type-id-18' id='type-id-362'/>
 
     </array-type-def>
-    <qualified-type-def type-id='type-id-764' const='yes' id='type-id-765'/>
-    <var-decl name='_Py_ctype_table' type-id='type-id-765' mangled-name='_Py_ctype_table' visibility='default' filepath='./Include/cpython/pyctype.h' line='16' column='1' elf-symbol-id='_Py_ctype_table'/>
+    <qualified-type-def type-id='type-id-767' const='yes' id='type-id-768'/>
+    <var-decl name='_Py_ctype_table' type-id='type-id-768' mangled-name='_Py_ctype_table' visibility='default' filepath='./Include/cpython/pyctype.h' line='16' column='1' elf-symbol-id='_Py_ctype_table'/>
 
-    <array-type-def dimensions='1' type-id='type-id-439' size-in-bits='2048' id='type-id-766'>
+    <array-type-def dimensions='1' type-id='type-id-439' size-in-bits='2048' id='type-id-769'>
       <subrange length='256' type-id='type-id-18' id='type-id-362'/>
 
     </array-type-def>
-    <qualified-type-def type-id='type-id-766' const='yes' id='type-id-767'/>
-    <var-decl name='_Py_ctype_tolower' type-id='type-id-767' mangled-name='_Py_ctype_tolower' visibility='default' filepath='./Include/cpython/pyctype.h' line='29' column='1' elf-symbol-id='_Py_ctype_tolower'/>
-    <var-decl name='_Py_ctype_toupper' type-id='type-id-767' mangled-name='_Py_ctype_toupper' visibility='default' filepath='./Include/cpython/pyctype.h' line='30' column='1' elf-symbol-id='_Py_ctype_toupper'/>
+    <qualified-type-def type-id='type-id-769' const='yes' id='type-id-770'/>
+    <var-decl name='_Py_ctype_tolower' type-id='type-id-770' mangled-name='_Py_ctype_tolower' visibility='default' filepath='./Include/cpython/pyctype.h' line='29' column='1' elf-symbol-id='_Py_ctype_tolower'/>
+    <var-decl name='_Py_ctype_toupper' type-id='type-id-770' mangled-name='_Py_ctype_toupper' visibility='default' filepath='./Include/cpython/pyctype.h' line='30' column='1' elf-symbol-id='_Py_ctype_toupper'/>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pyhash.c' comp-dir-path='/src' language='LANG_C99'>
-    <union-decl name='__anonymous_union__' size-in-bits='192' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='55' column='1' id='type-id-768'>
+    <union-decl name='__anonymous_union__' size-in-bits='192' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='55' column='1' id='type-id-771'>
       <data-member access='private'>
-        <var-decl name='uc' type-id='type-id-769' visibility='default' filepath='./Include/pyhash.h' line='57' column='1'/>
+        <var-decl name='uc' type-id='type-id-772' visibility='default' filepath='./Include/pyhash.h' line='57' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='fnv' type-id='type-id-770' visibility='default' filepath='./Include/pyhash.h' line='62' column='1'/>
+        <var-decl name='fnv' type-id='type-id-773' visibility='default' filepath='./Include/pyhash.h' line='62' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='siphash' type-id='type-id-771' visibility='default' filepath='./Include/pyhash.h' line='67' column='1'/>
+        <var-decl name='siphash' type-id='type-id-774' visibility='default' filepath='./Include/pyhash.h' line='67' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='djbx33a' type-id='type-id-772' visibility='default' filepath='./Include/pyhash.h' line='72' column='1'/>
+        <var-decl name='djbx33a' type-id='type-id-775' visibility='default' filepath='./Include/pyhash.h' line='72' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='expat' type-id='type-id-773' visibility='default' filepath='./Include/pyhash.h' line='76' column='1'/>
+        <var-decl name='expat' type-id='type-id-776' visibility='default' filepath='./Include/pyhash.h' line='76' column='1'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-341' size-in-bits='192' id='type-id-769'>
-      <subrange length='24' type-id='type-id-18' id='type-id-774'/>
+    <array-type-def dimensions='1' type-id='type-id-341' size-in-bits='192' id='type-id-772'>
+      <subrange length='24' type-id='type-id-18' id='type-id-777'/>
 
     </array-type-def>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='59' column='1' id='type-id-770'>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='59' column='1' id='type-id-773'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='prefix' type-id='type-id-117' visibility='default' filepath='./Include/pyhash.h' line='60' column='1'/>
       </data-member>
@@ -13466,7 +13581,7 @@
         <var-decl name='suffix' type-id='type-id-117' visibility='default' filepath='./Include/pyhash.h' line='61' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='64' column='1' id='type-id-771'>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='64' column='1' id='type-id-774'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='k0' type-id='type-id-21' visibility='default' filepath='./Include/pyhash.h' line='65' column='1'/>
       </data-member>
@@ -13474,50 +13589,50 @@
         <var-decl name='k1' type-id='type-id-21' visibility='default' filepath='./Include/pyhash.h' line='66' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='69' column='1' id='type-id-772'>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='69' column='1' id='type-id-775'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='padding' type-id='type-id-775' visibility='default' filepath='./Include/pyhash.h' line='70' column='1'/>
+        <var-decl name='padding' type-id='type-id-778' visibility='default' filepath='./Include/pyhash.h' line='70' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='suffix' type-id='type-id-117' visibility='default' filepath='./Include/pyhash.h' line='71' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-341' size-in-bits='128' id='type-id-775'>
-      <subrange length='16' type-id='type-id-18' id='type-id-776'/>
+    <array-type-def dimensions='1' type-id='type-id-341' size-in-bits='128' id='type-id-778'>
+      <subrange length='16' type-id='type-id-18' id='type-id-779'/>
 
     </array-type-def>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='73' column='1' id='type-id-773'>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' filepath='./Include/pyhash.h' line='73' column='1' id='type-id-776'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='padding' type-id='type-id-775' visibility='default' filepath='./Include/pyhash.h' line='74' column='1'/>
+        <var-decl name='padding' type-id='type-id-778' visibility='default' filepath='./Include/pyhash.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='hashsalt' type-id='type-id-117' visibility='default' filepath='./Include/pyhash.h' line='75' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_Py_HashSecret_t' type-id='type-id-768' filepath='./Include/pyhash.h' line='77' column='1' id='type-id-777'/>
-    <var-decl name='_Py_HashSecret' type-id='type-id-777' mangled-name='_Py_HashSecret' visibility='default' filepath='./Include/pyhash.h' line='78' column='1' elf-symbol-id='_Py_HashSecret'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-778' visibility='default' filepath='./Include/pyhash.h' line='86' column='1' id='type-id-779'>
+    <typedef-decl name='_Py_HashSecret_t' type-id='type-id-771' filepath='./Include/pyhash.h' line='77' column='1' id='type-id-780'/>
+    <var-decl name='_Py_HashSecret' type-id='type-id-780' mangled-name='_Py_HashSecret' visibility='default' filepath='./Include/pyhash.h' line='78' column='1' elf-symbol-id='_Py_HashSecret'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-781' visibility='default' filepath='./Include/pyhash.h' line='86' column='1' id='type-id-782'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='hash' type-id='type-id-780' visibility='default' filepath='./Include/pyhash.h' line='87' column='1'/>
+        <var-decl name='hash' type-id='type-id-783' visibility='default' filepath='./Include/pyhash.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='name' type-id='type-id-3' visibility='default' filepath='./Include/pyhash.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='hash_bits' type-id='type-id-781' visibility='default' filepath='./Include/pyhash.h' line='89' column='1'/>
+        <var-decl name='hash_bits' type-id='type-id-784' visibility='default' filepath='./Include/pyhash.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='seed_bits' type-id='type-id-781' visibility='default' filepath='./Include/pyhash.h' line='90' column='1'/>
+        <var-decl name='seed_bits' type-id='type-id-784' visibility='default' filepath='./Include/pyhash.h' line='90' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-782' size-in-bits='64' id='type-id-783'/>
-    <qualified-type-def type-id='type-id-783' const='yes' id='type-id-780'/>
-    <qualified-type-def type-id='type-id-8' const='yes' id='type-id-781'/>
-    <typedef-decl name='PyHash_FuncDef' type-id='type-id-779' filepath='./Include/pyhash.h' line='91' column='1' id='type-id-778'/>
-    <pointer-type-def type-id='type-id-778' size-in-bits='64' id='type-id-784'/>
+    <pointer-type-def type-id='type-id-785' size-in-bits='64' id='type-id-786'/>
+    <qualified-type-def type-id='type-id-786' const='yes' id='type-id-783'/>
+    <qualified-type-def type-id='type-id-8' const='yes' id='type-id-784'/>
+    <typedef-decl name='PyHash_FuncDef' type-id='type-id-782' filepath='./Include/pyhash.h' line='91' column='1' id='type-id-781'/>
+    <pointer-type-def type-id='type-id-781' size-in-bits='64' id='type-id-787'/>
     <function-decl name='PyHash_GetFuncDef' mangled-name='PyHash_GetFuncDef' filepath='Python/pyhash.c' line='221' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyHash_GetFuncDef'>
-      <return type-id='type-id-784'/>
+      <return type-id='type-id-787'/>
     </function-decl>
     <function-decl name='_Py_HashBytes' mangled-name='_Py_HashBytes' filepath='Python/pyhash.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_HashBytes'>
       <parameter type-id='type-id-20' name='src' filepath='Python/pyhash.c' line='158' column='1'/>
@@ -13537,7 +13652,7 @@
       <parameter type-id='type-id-371' name='v' filepath='Python/pyhash.c' line='92' column='1'/>
       <return type-id='type-id-117'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-782'>
+    <function-type size-in-bits='64' id='type-id-785'>
       <parameter type-id='type-id-20'/>
       <parameter type-id='type-id-30'/>
       <return type-id='type-id-117'/>
@@ -13545,18 +13660,18 @@
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pylifecycle.c' comp-dir-path='/src' language='LANG_C99'>
     <var-decl name='_Py_UnhandledKeyboardInterrupt' type-id='type-id-8' mangled-name='_Py_UnhandledKeyboardInterrupt' visibility='default' filepath='./Include/internal/pycore_pylifecycle.h' line='35' column='1' elf-symbol-id='_Py_UnhandledKeyboardInterrupt'/>
-    <typedef-decl name='_PyRuntimeState' type-id='type-id-530' filepath='./Include/internal/pycore_runtime.h' line='121' column='1' id='type-id-785'/>
-    <var-decl name='_PyRuntime' type-id='type-id-785' mangled-name='_PyRuntime' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='128' column='1' elf-symbol-id='_PyRuntime'/>
-    <pointer-type-def type-id='type-id-786' size-in-bits='64' id='type-id-787'/>
-    <typedef-decl name='PyOS_sighandler_t' type-id='type-id-787' filepath='./Include/pylifecycle.h' line='61' column='1' id='type-id-788'/>
+    <typedef-decl name='_PyRuntimeState' type-id='type-id-530' filepath='./Include/internal/pycore_runtime.h' line='121' column='1' id='type-id-788'/>
+    <var-decl name='_PyRuntime' type-id='type-id-788' mangled-name='_PyRuntime' visibility='default' filepath='./Include/internal/pycore_runtime.h' line='128' column='1' elf-symbol-id='_PyRuntime'/>
+    <pointer-type-def type-id='type-id-789' size-in-bits='64' id='type-id-790'/>
+    <typedef-decl name='PyOS_sighandler_t' type-id='type-id-790' filepath='./Include/pylifecycle.h' line='61' column='1' id='type-id-791'/>
     <function-decl name='PyOS_setsig' mangled-name='PyOS_setsig' filepath='Python/pylifecycle.c' line='2942' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_setsig'>
       <parameter type-id='type-id-8' name='sig' filepath='Python/pylifecycle.c' line='2942' column='1'/>
-      <parameter type-id='type-id-788' name='handler' filepath='Python/pylifecycle.c' line='2942' column='1'/>
-      <return type-id='type-id-788'/>
+      <parameter type-id='type-id-791' name='handler' filepath='Python/pylifecycle.c' line='2942' column='1'/>
+      <return type-id='type-id-791'/>
     </function-decl>
     <function-decl name='PyOS_getsig' mangled-name='PyOS_getsig' filepath='Python/pylifecycle.c' line='2903' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_getsig'>
       <parameter type-id='type-id-8' name='sig' filepath='Python/pylifecycle.c' line='2903' column='1'/>
-      <return type-id='type-id-788'/>
+      <return type-id='type-id-791'/>
     </function-decl>
     <function-decl name='_Py_FdIsInteractive' mangled-name='_Py_FdIsInteractive' filepath='Python/pylifecycle.c' line='2886' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FdIsInteractive'>
       <parameter type-id='type-id-188' name='fp' filepath='Python/pylifecycle.c' line='2886' column='1'/>
@@ -13577,7 +13692,7 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='Py_ExitStatusException' mangled-name='Py_ExitStatusException' filepath='Python/pylifecycle.c' line='2789' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_ExitStatusException'>
-      <parameter type-id='type-id-740' name='status' filepath='Python/pylifecycle.c' line='2789' column='1'/>
+      <parameter type-id='type-id-743' name='status' filepath='Python/pylifecycle.c' line='2789' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='_Py_FatalErrorFormat' mangled-name='_Py_FatalErrorFormat' filepath='Python/pylifecycle.c' line='2755' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_FatalErrorFormat'>
@@ -13601,15 +13716,15 @@
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='Py_EndInterpreter' mangled-name='Py_EndInterpreter' filepath='Python/pylifecycle.c' line='2004' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EndInterpreter'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pylifecycle.c' line='2004' column='1'/>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pylifecycle.c' line='2004' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='Py_NewInterpreter' mangled-name='Py_NewInterpreter' filepath='Python/pylifecycle.c' line='1986' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_NewInterpreter'>
-      <return type-id='type-id-166'/>
+      <return type-id='type-id-331'/>
     </function-decl>
     <function-decl name='_Py_NewInterpreter' mangled-name='_Py_NewInterpreter' filepath='Python/pylifecycle.c' line='1974' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_NewInterpreter'>
       <parameter type-id='type-id-8' name='isolated_subinterpreter' filepath='Python/pylifecycle.c' line='1974' column='1'/>
-      <return type-id='type-id-166'/>
+      <return type-id='type-id-331'/>
     </function-decl>
     <function-decl name='Py_Finalize' mangled-name='Py_Finalize' filepath='Python/pylifecycle.c' line='1868' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Finalize'>
       <return type-id='type-id-69'/>
@@ -13618,7 +13733,7 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_Py_InitializeMain' mangled-name='_Py_InitializeMain' filepath='Python/pylifecycle.c' line='1271' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_InitializeMain'>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='Py_Initialize' mangled-name='Py_Initialize' filepath='Python/pylifecycle.c' line='1264' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_Initialize'>
       <return type-id='type-id-69'/>
@@ -13628,39 +13743,39 @@
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='Py_InitializeFromConfig' mangled-name='Py_InitializeFromConfig' filepath='Python/pylifecycle.c' line='1204' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_InitializeFromConfig'>
-      <parameter type-id='type-id-748' name='config' filepath='Python/pylifecycle.c' line='1204' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-751' name='config' filepath='Python/pylifecycle.c' line='1204' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='_Py_PreInitializeFromConfig' mangled-name='_Py_PreInitializeFromConfig' filepath='Python/pylifecycle.c' line='948' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_PreInitializeFromConfig'>
-      <parameter type-id='type-id-748' name='config' filepath='Python/pylifecycle.c' line='948' column='1'/>
-      <parameter type-id='type-id-758' name='args' filepath='Python/pylifecycle.c' line='949' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-751' name='config' filepath='Python/pylifecycle.c' line='948' column='1'/>
+      <parameter type-id='type-id-761' name='args' filepath='Python/pylifecycle.c' line='949' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-257' const='yes' id='type-id-789'/>
-    <pointer-type-def type-id='type-id-789' size-in-bits='64' id='type-id-790'/>
+    <qualified-type-def type-id='type-id-257' const='yes' id='type-id-792'/>
+    <pointer-type-def type-id='type-id-792' size-in-bits='64' id='type-id-793'/>
     <function-decl name='Py_PreInitialize' mangled-name='Py_PreInitialize' filepath='Python/pylifecycle.c' line='941' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitialize'>
-      <parameter type-id='type-id-790' name='src_config' filepath='Python/pylifecycle.c' line='941' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-793' name='src_config' filepath='Python/pylifecycle.c' line='941' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='Py_PreInitializeFromArgs' mangled-name='Py_PreInitializeFromArgs' filepath='Python/pylifecycle.c' line='933' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitializeFromArgs'>
-      <parameter type-id='type-id-790' name='src_config' filepath='Python/pylifecycle.c' line='933' column='1'/>
+      <parameter type-id='type-id-793' name='src_config' filepath='Python/pylifecycle.c' line='933' column='1'/>
       <parameter type-id='type-id-30' name='argc' filepath='Python/pylifecycle.c' line='933' column='1'/>
       <parameter type-id='type-id-329' name='argv' filepath='Python/pylifecycle.c' line='933' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='Py_PreInitializeFromBytesArgs' mangled-name='Py_PreInitializeFromBytesArgs' filepath='Python/pylifecycle.c' line='925' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_PreInitializeFromBytesArgs'>
-      <parameter type-id='type-id-790' name='src_config' filepath='Python/pylifecycle.c' line='925' column='1'/>
+      <parameter type-id='type-id-793' name='src_config' filepath='Python/pylifecycle.c' line='925' column='1'/>
       <parameter type-id='type-id-30' name='argc' filepath='Python/pylifecycle.c' line='925' column='1'/>
       <parameter type-id='type-id-215' name='argv' filepath='Python/pylifecycle.c' line='925' column='1'/>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='_Py_PreInitializeFromPyArgv' mangled-name='_Py_PreInitializeFromPyArgv' filepath='Python/pylifecycle.c' line='878' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_PreInitializeFromPyArgv'>
-      <parameter type-id='type-id-790' name='src_config' filepath='Python/pylifecycle.c' line='878' column='1'/>
-      <parameter type-id='type-id-758' name='args' filepath='Python/pylifecycle.c' line='878' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-793' name='src_config' filepath='Python/pylifecycle.c' line='878' column='1'/>
+      <parameter type-id='type-id-761' name='args' filepath='Python/pylifecycle.c' line='878' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='_PyInterpreterState_SetConfig' mangled-name='_PyInterpreterState_SetConfig' filepath='Python/pylifecycle.c' line='473' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetConfig'>
-      <parameter type-id='type-id-748' name='src_config' filepath='Python/pylifecycle.c' line='473' column='1'/>
+      <parameter type-id='type-id-751' name='src_config' filepath='Python/pylifecycle.c' line='473' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_Py_SetLocaleFromEnv' mangled-name='_Py_SetLocaleFromEnv' filepath='Python/pylifecycle.c' line='385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_SetLocaleFromEnv'>
@@ -13692,9 +13807,9 @@
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='_PyRuntime_Initialize' mangled-name='_PyRuntime_Initialize' filepath='Python/pylifecycle.c' line='92' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRuntime_Initialize'>
-      <return type-id='type-id-740'/>
+      <return type-id='type-id-743'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-786'>
+    <function-type size-in-bits='64' id='type-id-789'>
       <parameter type-id='type-id-8'/>
       <return type-id='type-id-69'/>
     </function-type>
@@ -13709,192 +13824,192 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pystate.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='_Py_GetConfig' mangled-name='_Py_GetConfig' filepath='Python/pystate.c' line='1965' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfig'>
-      <return type-id='type-id-748'/>
+    <function-decl name='_Py_GetConfig' mangled-name='_Py_GetConfig' filepath='Python/pystate.c' line='1966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetConfig'>
+      <return type-id='type-id-751'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetConfigCopy' mangled-name='_PyInterpreterState_GetConfigCopy' filepath='Python/pystate.c' line='1951' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfigCopy'>
-      <parameter type-id='type-id-743' name='config' filepath='Python/pystate.c' line='1951' column='1'/>
+    <function-decl name='_PyInterpreterState_GetConfigCopy' mangled-name='_PyInterpreterState_GetConfigCopy' filepath='Python/pystate.c' line='1952' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfigCopy'>
+      <parameter type-id='type-id-746' name='config' filepath='Python/pystate.c' line='1952' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetConfig' mangled-name='_PyInterpreterState_GetConfig' filepath='Python/pystate.c' line='1944' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfig'>
-      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1944' column='1'/>
-      <return type-id='type-id-748'/>
+    <function-decl name='_PyInterpreterState_GetConfig' mangled-name='_PyInterpreterState_GetConfig' filepath='Python/pystate.c' line='1945' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetConfig'>
+      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1945' column='1'/>
+      <return type-id='type-id-751'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_SetEvalFrameFunc' mangled-name='_PyInterpreterState_SetEvalFrameFunc' filepath='Python/pystate.c' line='1936' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetEvalFrameFunc'>
-      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1936' column='1'/>
-      <parameter type-id='type-id-232' name='eval_frame' filepath='Python/pystate.c' line='1937' column='1'/>
+    <function-decl name='_PyInterpreterState_SetEvalFrameFunc' mangled-name='_PyInterpreterState_SetEvalFrameFunc' filepath='Python/pystate.c' line='1937' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_SetEvalFrameFunc'>
+      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1937' column='1'/>
+      <parameter type-id='type-id-232' name='eval_frame' filepath='Python/pystate.c' line='1938' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PyInterpreterState_GetEvalFrameFunc' mangled-name='_PyInterpreterState_GetEvalFrameFunc' filepath='Python/pystate.c' line='1929' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetEvalFrameFunc'>
-      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1929' column='1'/>
+    <function-decl name='_PyInterpreterState_GetEvalFrameFunc' mangled-name='_PyInterpreterState_GetEvalFrameFunc' filepath='Python/pystate.c' line='1930' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_GetEvalFrameFunc'>
+      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1930' column='1'/>
       <return type-id='type-id-232'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_Lookup' mangled-name='_PyCrossInterpreterData_Lookup' filepath='Python/pystate.c' line='1779' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Lookup'>
-      <parameter type-id='type-id-15' name='obj' filepath='Python/pystate.c' line='1779' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_Lookup' mangled-name='_PyCrossInterpreterData_Lookup' filepath='Python/pystate.c' line='1780' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Lookup'>
+      <parameter type-id='type-id-15' name='obj' filepath='Python/pystate.c' line='1780' column='1'/>
       <return type-id='type-id-267'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_RegisterClass' mangled-name='_PyCrossInterpreterData_RegisterClass' filepath='Python/pystate.c' line='1749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_RegisterClass'>
-      <parameter type-id='type-id-31' name='cls' filepath='Python/pystate.c' line='1749' column='1'/>
-      <parameter type-id='type-id-267' name='getdata' filepath='Python/pystate.c' line='1750' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_RegisterClass' mangled-name='_PyCrossInterpreterData_RegisterClass' filepath='Python/pystate.c' line='1750' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_RegisterClass'>
+      <parameter type-id='type-id-31' name='cls' filepath='Python/pystate.c' line='1750' column='1'/>
+      <parameter type-id='type-id-267' name='getdata' filepath='Python/pystate.c' line='1751' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <typedef-decl name='_PyCrossInterpreterData' type-id='type-id-268' filepath='./Include/cpython/pystate.h' line='294' column='1' id='type-id-791'/>
-    <pointer-type-def type-id='type-id-791' size-in-bits='64' id='type-id-792'/>
-    <function-decl name='_PyCrossInterpreterData_NewObject' mangled-name='_PyCrossInterpreterData_NewObject' filepath='Python/pystate.c' line='1719' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_NewObject'>
-      <parameter type-id='type-id-792' name='data' filepath='Python/pystate.c' line='1719' column='1'/>
+    <typedef-decl name='_PyCrossInterpreterData' type-id='type-id-268' filepath='./Include/cpython/pystate.h' line='295' column='1' id='type-id-794'/>
+    <pointer-type-def type-id='type-id-794' size-in-bits='64' id='type-id-795'/>
+    <function-decl name='_PyCrossInterpreterData_NewObject' mangled-name='_PyCrossInterpreterData_NewObject' filepath='Python/pystate.c' line='1720' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_NewObject'>
+      <parameter type-id='type-id-795' name='data' filepath='Python/pystate.c' line='1720' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyCrossInterpreterData_Release' mangled-name='_PyCrossInterpreterData_Release' filepath='Python/pystate.c' line='1696' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Release'>
-      <parameter type-id='type-id-792' name='data' filepath='Python/pystate.c' line='1696' column='1'/>
+    <function-decl name='_PyCrossInterpreterData_Release' mangled-name='_PyCrossInterpreterData_Release' filepath='Python/pystate.c' line='1697' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyCrossInterpreterData_Release'>
+      <parameter type-id='type-id-795' name='data' filepath='Python/pystate.c' line='1697' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PyObject_GetCrossInterpreterData' mangled-name='_PyObject_GetCrossInterpreterData' filepath='Python/pystate.c' line='1627' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetCrossInterpreterData'>
-      <parameter type-id='type-id-15' name='obj' filepath='Python/pystate.c' line='1627' column='1'/>
-      <parameter type-id='type-id-792' name='data' filepath='Python/pystate.c' line='1627' column='1'/>
+    <function-decl name='_PyObject_GetCrossInterpreterData' mangled-name='_PyObject_GetCrossInterpreterData' filepath='Python/pystate.c' line='1628' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_GetCrossInterpreterData'>
+      <parameter type-id='type-id-15' name='obj' filepath='Python/pystate.c' line='1628' column='1'/>
+      <parameter type-id='type-id-795' name='data' filepath='Python/pystate.c' line='1628' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyObject_CheckCrossInterpreterData' mangled-name='_PyObject_CheckCrossInterpreterData' filepath='Python/pystate.c' line='1595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_CheckCrossInterpreterData'>
+    <function-decl name='_PyObject_CheckCrossInterpreterData' mangled-name='_PyObject_CheckCrossInterpreterData' filepath='Python/pystate.c' line='1596' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyObject_CheckCrossInterpreterData'>
       <parameter type-id='type-id-15' name='obj' filepath='Objects/abstract.c' line='2847' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/pystate.h' line='95' column='1' id='type-id-793'>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/pystate.h' line='95' column='1' id='type-id-796'>
       <underlying-type type-id='type-id-83'/>
       <enumerator name='PyGILState_LOCKED' value='0'/>
       <enumerator name='PyGILState_UNLOCKED' value='1'/>
     </enum-decl>
-    <typedef-decl name='PyGILState_STATE' type-id='type-id-793' filepath='./Include/pystate.h' line='96' column='1' id='type-id-794'/>
-    <function-decl name='PyGILState_Release' mangled-name='PyGILState_Release' filepath='Python/pystate.c' line='1530' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Release'>
-      <parameter type-id='type-id-794' name='oldstate' filepath='Python/pystate.c' line='1530' column='1'/>
+    <typedef-decl name='PyGILState_STATE' type-id='type-id-796' filepath='./Include/pystate.h' line='96' column='1' id='type-id-797'/>
+    <function-decl name='PyGILState_Release' mangled-name='PyGILState_Release' filepath='Python/pystate.c' line='1531' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Release'>
+      <parameter type-id='type-id-797' name='oldstate' filepath='Python/pystate.c' line='1531' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyGILState_Ensure' mangled-name='PyGILState_Ensure' filepath='Python/pystate.c' line='1480' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Ensure'>
-      <return type-id='type-id-794'/>
+    <function-decl name='PyGILState_Ensure' mangled-name='PyGILState_Ensure' filepath='Python/pystate.c' line='1481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Ensure'>
+      <return type-id='type-id-797'/>
     </function-decl>
-    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='Python/pystate.c' line='1460' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
+    <function-decl name='PyGILState_Check' mangled-name='PyGILState_Check' filepath='Python/pystate.c' line='1461' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_Check'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyGILState_GetThisThreadState' mangled-name='PyGILState_GetThisThreadState' filepath='Python/pystate.c' line='1454' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_GetThisThreadState'>
-      <return type-id='type-id-166'/>
+    <function-decl name='PyGILState_GetThisThreadState' mangled-name='PyGILState_GetThisThreadState' filepath='Python/pystate.c' line='1455' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyGILState_GetThisThreadState'>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <function-decl name='_PyGILState_GetInterpreterStateUnsafe' mangled-name='_PyGILState_GetInterpreterStateUnsafe' filepath='Python/pystate.c' line='1367' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGILState_GetInterpreterStateUnsafe'>
+    <function-decl name='_PyGILState_GetInterpreterStateUnsafe' mangled-name='_PyGILState_GetInterpreterStateUnsafe' filepath='Python/pystate.c' line='1368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyGILState_GetInterpreterStateUnsafe'>
       <return type-id='type-id-222'/>
     </function-decl>
-    <function-decl name='_PyThread_CurrentExceptions' mangled-name='_PyThread_CurrentExceptions' filepath='Python/pystate.c' line='1245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentExceptions'>
+    <function-decl name='_PyThread_CurrentExceptions' mangled-name='_PyThread_CurrentExceptions' filepath='Python/pystate.c' line='1246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentExceptions'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyThread_CurrentFrames' mangled-name='_PyThread_CurrentFrames' filepath='Python/pystate.c' line='1195' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentFrames'>
+    <function-decl name='_PyThread_CurrentFrames' mangled-name='_PyThread_CurrentFrames' filepath='Python/pystate.c' line='1196' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_CurrentFrames'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='Python/pystate.c' line='1185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='1185' column='1'/>
-      <return type-id='type-id-166'/>
+    <function-decl name='PyThreadState_Next' mangled-name='PyThreadState_Next' filepath='Python/pystate.c' line='1186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Next'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='1186' column='1'/>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='Python/pystate.c' line='1180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
-      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1180' column='1'/>
-      <return type-id='type-id-166'/>
+    <function-decl name='PyInterpreterState_ThreadHead' mangled-name='PyInterpreterState_ThreadHead' filepath='Python/pystate.c' line='1181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_ThreadHead'>
+      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1181' column='1'/>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='Python/pystate.c' line='1175' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
-      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1175' column='1'/>
+    <function-decl name='PyInterpreterState_Next' mangled-name='PyInterpreterState_Next' filepath='Python/pystate.c' line='1176' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Next'>
+      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1176' column='1'/>
       <return type-id='type-id-222'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Main' mangled-name='PyInterpreterState_Main' filepath='Python/pystate.c' line='1169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Main'>
+    <function-decl name='PyInterpreterState_Main' mangled-name='PyInterpreterState_Main' filepath='Python/pystate.c' line='1170' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Main'>
       <return type-id='type-id-222'/>
     </function-decl>
-    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='Python/pystate.c' line='1163' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
+    <function-decl name='PyInterpreterState_Head' mangled-name='PyInterpreterState_Head' filepath='Python/pystate.c' line='1164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_Head'>
       <return type-id='type-id-222'/>
     </function-decl>
-    <function-decl name='PyThreadState_SetAsyncExc' mangled-name='PyThreadState_SetAsyncExc' filepath='Python/pystate.c' line='1121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_SetAsyncExc'>
-      <parameter type-id='type-id-18' name='id' filepath='Python/pystate.c' line='1121' column='1'/>
-      <parameter type-id='type-id-15' name='exc' filepath='Python/pystate.c' line='1121' column='1'/>
+    <function-decl name='PyThreadState_SetAsyncExc' mangled-name='PyThreadState_SetAsyncExc' filepath='Python/pystate.c' line='1122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_SetAsyncExc'>
+      <parameter type-id='type-id-18' name='id' filepath='Python/pystate.c' line='1122' column='1'/>
+      <parameter type-id='type-id-15' name='exc' filepath='Python/pystate.c' line='1122' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetID' mangled-name='PyThreadState_GetID' filepath='Python/pystate.c' line='1105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetID'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='1105' column='1'/>
+    <function-decl name='PyThreadState_GetID' mangled-name='PyThreadState_GetID' filepath='Python/pystate.c' line='1106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetID'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='1106' column='1'/>
       <return type-id='type-id-21'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetFrame' mangled-name='PyThreadState_GetFrame' filepath='Python/pystate.c' line='1095' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetFrame'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='1095' column='1'/>
+    <function-decl name='PyThreadState_GetFrame' mangled-name='PyThreadState_GetFrame' filepath='Python/pystate.c' line='1096' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetFrame'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='1096' column='1'/>
       <return type-id='type-id-12'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetInterpreter' mangled-name='PyThreadState_GetInterpreter' filepath='Python/pystate.c' line='1087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetInterpreter'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='1087' column='1'/>
+    <function-decl name='PyThreadState_GetInterpreter' mangled-name='PyThreadState_GetInterpreter' filepath='Python/pystate.c' line='1088' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetInterpreter'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='1088' column='1'/>
       <return type-id='type-id-222'/>
     </function-decl>
-    <function-decl name='PyThreadState_GetDict' mangled-name='PyThreadState_GetDict' filepath='Python/pystate.c' line='1076' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetDict'>
+    <function-decl name='PyThreadState_GetDict' mangled-name='PyThreadState_GetDict' filepath='Python/pystate.c' line='1077' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_GetDict'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyThreadState_GetDict' mangled-name='_PyThreadState_GetDict' filepath='Python/pystate.c' line='1062' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetDict'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='1062' column='1'/>
+    <function-decl name='_PyThreadState_GetDict' mangled-name='_PyThreadState_GetDict' filepath='Python/pystate.c' line='1063' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_GetDict'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='1063' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyThreadState_Swap' mangled-name='PyThreadState_Swap' filepath='Python/pystate.c' line='1050' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Swap'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='1185' column='1'/>
-      <return type-id='type-id-166'/>
+    <function-decl name='PyThreadState_Swap' mangled-name='PyThreadState_Swap' filepath='Python/pystate.c' line='1051' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Swap'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='1186' column='1'/>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-795'/>
-    <function-decl name='_PyThreadState_Swap' mangled-name='_PyThreadState_Swap' filepath='Python/pystate.c' line='1018' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Swap'>
-      <parameter type-id='type-id-795' name='gilstate' filepath='Python/pystate.c' line='1018' column='1'/>
-      <parameter type-id='type-id-166' name='newts' filepath='Python/pystate.c' line='1018' column='1'/>
-      <return type-id='type-id-166'/>
+    <pointer-type-def type-id='type-id-256' size-in-bits='64' id='type-id-798'/>
+    <function-decl name='_PyThreadState_Swap' mangled-name='_PyThreadState_Swap' filepath='Python/pystate.c' line='1019' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Swap'>
+      <parameter type-id='type-id-798' name='gilstate' filepath='Python/pystate.c' line='1019' column='1'/>
+      <parameter type-id='type-id-331' name='newts' filepath='Python/pystate.c' line='1019' column='1'/>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <function-decl name='PyThreadState_Get' mangled-name='PyThreadState_Get' filepath='Python/pystate.c' line='1009' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Get'>
-      <return type-id='type-id-166'/>
+    <function-decl name='PyThreadState_Get' mangled-name='PyThreadState_Get' filepath='Python/pystate.c' line='1010' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Get'>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <function-decl name='_PyThreadState_UncheckedGet' mangled-name='_PyThreadState_UncheckedGet' filepath='Python/pystate.c' line='1002' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_UncheckedGet'>
-      <return type-id='type-id-166'/>
+    <function-decl name='_PyThreadState_UncheckedGet' mangled-name='_PyThreadState_UncheckedGet' filepath='Python/pystate.c' line='1003' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_UncheckedGet'>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <typedef-decl name='_PyRuntimeState' type-id='type-id-250' filepath='./Include/internal/pycore_runtime.h' line='121' column='1' id='type-id-796'/>
-    <pointer-type-def type-id='type-id-796' size-in-bits='64' id='type-id-797'/>
-    <function-decl name='_PyThreadState_DeleteExcept' mangled-name='_PyThreadState_DeleteExcept' filepath='Python/pystate.c' line='959' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_DeleteExcept'>
-      <parameter type-id='type-id-797' name='runtime' filepath='Python/pystate.c' line='959' column='1'/>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='959' column='1'/>
+    <typedef-decl name='_PyRuntimeState' type-id='type-id-250' filepath='./Include/internal/pycore_runtime.h' line='121' column='1' id='type-id-799'/>
+    <pointer-type-def type-id='type-id-799' size-in-bits='64' id='type-id-800'/>
+    <function-decl name='_PyThreadState_DeleteExcept' mangled-name='_PyThreadState_DeleteExcept' filepath='Python/pystate.c' line='960' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_DeleteExcept'>
+      <parameter type-id='type-id-800' name='runtime' filepath='Python/pystate.c' line='960' column='1'/>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='960' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThreadState_DeleteCurrent' mangled-name='PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='943' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_DeleteCurrent'>
+    <function-decl name='PyThreadState_DeleteCurrent' mangled-name='PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='944' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_DeleteCurrent'>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PyThreadState_DeleteCurrent' mangled-name='_PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='932' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_DeleteCurrent'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='932' column='1'/>
+    <function-decl name='_PyThreadState_DeleteCurrent' mangled-name='_PyThreadState_DeleteCurrent' filepath='Python/pystate.c' line='933' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_DeleteCurrent'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='933' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThreadState_Delete' mangled-name='PyThreadState_Delete' filepath='Python/pystate.c' line='925' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Delete'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='452' column='1'/>
+    <function-decl name='PyThreadState_Delete' mangled-name='PyThreadState_Delete' filepath='Python/pystate.c' line='926' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Delete'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='926' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThreadState_Clear' mangled-name='PyThreadState_Clear' filepath='Python/pystate.c' line='827' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Clear'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='827' column='1'/>
+    <function-decl name='PyThreadState_Clear' mangled-name='PyThreadState_Clear' filepath='Python/pystate.c' line='828' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_Clear'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='828' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyState_RemoveModule' mangled-name='PyState_RemoveModule' filepath='Python/pystate.c' line='770' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_RemoveModule'>
-      <parameter type-id='type-id-505' name='def' filepath='Python/pystate.c' line='770' column='1'/>
+    <function-decl name='PyState_RemoveModule' mangled-name='PyState_RemoveModule' filepath='Python/pystate.c' line='771' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_RemoveModule'>
+      <parameter type-id='type-id-505' name='def' filepath='Python/pystate.c' line='771' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyState_AddModule' mangled-name='PyState_AddModule' filepath='Python/pystate.c' line='749' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_AddModule'>
-      <parameter type-id='type-id-15' name='module' filepath='Python/pystate.c' line='749' column='1'/>
-      <parameter type-id='type-id-505' name='def' filepath='Python/pystate.c' line='749' column='1'/>
+    <function-decl name='PyState_AddModule' mangled-name='PyState_AddModule' filepath='Python/pystate.c' line='750' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_AddModule'>
+      <parameter type-id='type-id-15' name='module' filepath='Python/pystate.c' line='750' column='1'/>
+      <parameter type-id='type-id-505' name='def' filepath='Python/pystate.c' line='750' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyState_AddModule' mangled-name='_PyState_AddModule' filepath='Python/pystate.c' line='716' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyState_AddModule'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/pystate.c' line='716' column='1'/>
-      <parameter type-id='type-id-15' name='module' filepath='Python/pystate.c' line='716' column='1'/>
-      <parameter type-id='type-id-505' name='def' filepath='Python/pystate.c' line='716' column='1'/>
+    <function-decl name='_PyState_AddModule' mangled-name='_PyState_AddModule' filepath='Python/pystate.c' line='717' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyState_AddModule'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='717' column='1'/>
+      <parameter type-id='type-id-15' name='module' filepath='Python/pystate.c' line='717' column='1'/>
+      <parameter type-id='type-id-505' name='def' filepath='Python/pystate.c' line='717' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyState_FindModule' mangled-name='PyState_FindModule' filepath='Python/pystate.c' line='697' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_FindModule'>
-      <parameter type-id='type-id-505' name='module' filepath='Python/pystate.c' line='697' column='1'/>
+    <function-decl name='PyState_FindModule' mangled-name='PyState_FindModule' filepath='Python/pystate.c' line='698' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyState_FindModule'>
+      <parameter type-id='type-id-505' name='module' filepath='Python/pystate.c' line='698' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_PyThreadState_Init' mangled-name='_PyThreadState_Init' filepath='Python/pystate.c' line='691' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Init'>
-      <parameter type-id='type-id-166' name='tstate' filepath='Python/errors.c' line='452' column='1'/>
+    <function-decl name='_PyThreadState_Init' mangled-name='_PyThreadState_Init' filepath='Python/pystate.c' line='692' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Init'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pystate.c' line='926' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PyThreadState_Prealloc' mangled-name='_PyThreadState_Prealloc' filepath='Python/pystate.c' line='685' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Prealloc'>
-      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1180' column='1'/>
-      <return type-id='type-id-166'/>
+    <function-decl name='_PyThreadState_Prealloc' mangled-name='_PyThreadState_Prealloc' filepath='Python/pystate.c' line='686' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThreadState_Prealloc'>
+      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1181' column='1'/>
+      <return type-id='type-id-331'/>
     </function-decl>
-    <function-decl name='PyThreadState_New' mangled-name='PyThreadState_New' filepath='Python/pystate.c' line='679' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_New'>
-      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1180' column='1'/>
-      <return type-id='type-id-166'/>
+    <function-decl name='PyThreadState_New' mangled-name='PyThreadState_New' filepath='Python/pystate.c' line='680' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThreadState_New'>
+      <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='1181' column='1'/>
+      <return type-id='type-id-331'/>
     </function-decl>
     <function-decl name='PyInterpreterState_GetDict' mangled-name='PyInterpreterState_GetDict' filepath='Python/pystate.c' line='598' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInterpreterState_GetDict'>
       <parameter type-id='type-id-222' name='interp' filepath='Python/pystate.c' line='598' column='1'/>
@@ -13948,239 +14063,239 @@
       <return type-id='type-id-222'/>
     </function-decl>
     <function-decl name='_PyInterpreterState_Enable' mangled-name='_PyInterpreterState_Enable' filepath='Python/pystate.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyInterpreterState_Enable'>
-      <parameter type-id='type-id-797' name='runtime' filepath='Python/pystate.c' line='178' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-800' name='runtime' filepath='Python/pystate.c' line='178' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
     <function-decl name='_PyRuntimeState_Fini' mangled-name='_PyRuntimeState_Fini' filepath='Python/pystate.c' line='116' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRuntimeState_Fini'>
-      <parameter type-id='type-id-797' name='runtime' filepath='Python/pystate.c' line='116' column='1'/>
+      <parameter type-id='type-id-800' name='runtime' filepath='Python/pystate.c' line='116' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='_PyRuntimeState_Init' mangled-name='_PyRuntimeState_Init' filepath='Python/pystate.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRuntimeState_Init'>
-      <parameter type-id='type-id-797' name='runtime' filepath='Python/pystate.c' line='102' column='1'/>
-      <return type-id='type-id-740'/>
+      <parameter type-id='type-id-800' name='runtime' filepath='Python/pystate.c' line='102' column='1'/>
+      <return type-id='type-id-743'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pythonrun.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='PyRun_InteractiveLoop' mangled-name='PyRun_InteractiveLoop' filepath='Python/pythonrun.c' line='1580' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoop'>
+    <function-decl name='PyRun_InteractiveLoop' mangled-name='PyRun_InteractiveLoop' filepath='Python/pythonrun.c' line='1582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoop'>
       <parameter type-id='type-id-188' name='fp' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <parameter type-id='type-id-3' name='filename' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveOne' mangled-name='PyRun_InteractiveOne' filepath='Python/pythonrun.c' line='1573' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOne'>
+    <function-decl name='PyRun_InteractiveOne' mangled-name='PyRun_InteractiveOne' filepath='Python/pythonrun.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOne'>
       <parameter type-id='type-id-188' name='fp' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <parameter type-id='type-id-3' name='filename' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='Py_CompileStringFlags' mangled-name='Py_CompileStringFlags' filepath='Python/pythonrun.c' line='1565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringFlags'>
-      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1565' column='1'/>
-      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1565' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1565' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1566' column='1'/>
+    <function-decl name='Py_CompileStringFlags' mangled-name='Py_CompileStringFlags' filepath='Python/pythonrun.c' line='1567' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringFlags'>
+      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1567' column='1'/>
+      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1567' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1567' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1568' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='Py_CompileString' mangled-name='Py_CompileString' filepath='Python/pythonrun.c' line='1558' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileString'>
-      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1558' column='1'/>
-      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1558' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1558' column='1'/>
+    <function-decl name='Py_CompileString' mangled-name='Py_CompileString' filepath='Python/pythonrun.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileString'>
+      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1560' column='1'/>
+      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1560' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1560' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleString' mangled-name='PyRun_SimpleString' filepath='Python/pythonrun.c' line='1551' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleString'>
-      <parameter type-id='type-id-3' name='where' filepath='Python/ceval.c' line='6513' column='1'/>
+    <function-decl name='PyRun_SimpleString' mangled-name='PyRun_SimpleString' filepath='Python/pythonrun.c' line='1553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleString'>
+      <parameter type-id='type-id-3' name='where' filepath='Python/ceval.c' line='6516' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_String' mangled-name='PyRun_String' filepath='Python/pythonrun.c' line='1544' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_String'>
-      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1544' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1544' column='1'/>
-      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1544' column='1'/>
-      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1544' column='1'/>
+    <function-decl name='PyRun_String' mangled-name='PyRun_String' filepath='Python/pythonrun.c' line='1546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_String'>
+      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1546' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1546' column='1'/>
+      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1546' column='1'/>
+      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1546' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleFileEx' mangled-name='PyRun_SimpleFileEx' filepath='Python/pythonrun.c' line='1536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileEx'>
-      <parameter type-id='type-id-188' name='f' filepath='Python/pythonrun.c' line='1536' column='1'/>
-      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1536' column='1'/>
-      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1536' column='1'/>
+    <function-decl name='PyRun_SimpleFileEx' mangled-name='PyRun_SimpleFileEx' filepath='Python/pythonrun.c' line='1538' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileEx'>
+      <parameter type-id='type-id-188' name='f' filepath='Python/pythonrun.c' line='1538' column='1'/>
+      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1538' column='1'/>
+      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1538' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleFile' mangled-name='PyRun_SimpleFile' filepath='Python/pythonrun.c' line='1529' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFile'>
+    <function-decl name='PyRun_SimpleFile' mangled-name='PyRun_SimpleFile' filepath='Python/pythonrun.c' line='1531' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFile'>
       <parameter type-id='type-id-188' name='fp' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <parameter type-id='type-id-3' name='filename' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_FileFlags' mangled-name='PyRun_FileFlags' filepath='Python/pythonrun.c' line='1521' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileFlags'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1521' column='1'/>
-      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1521' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1521' column='1'/>
-      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1521' column='1'/>
-      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1521' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1522' column='1'/>
+    <function-decl name='PyRun_FileFlags' mangled-name='PyRun_FileFlags' filepath='Python/pythonrun.c' line='1523' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileFlags'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1523' column='1'/>
+      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1523' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1523' column='1'/>
+      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1523' column='1'/>
+      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1523' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1524' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyRun_FileEx' mangled-name='PyRun_FileEx' filepath='Python/pythonrun.c' line='1514' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileEx'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1514' column='1'/>
-      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1514' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1514' column='1'/>
-      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1514' column='1'/>
-      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1514' column='1'/>
-      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1514' column='1'/>
+    <function-decl name='PyRun_FileEx' mangled-name='PyRun_FileEx' filepath='Python/pythonrun.c' line='1516' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileEx'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1516' column='1'/>
+      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1516' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1516' column='1'/>
+      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1516' column='1'/>
+      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1516' column='1'/>
+      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1516' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyRun_File' mangled-name='PyRun_File' filepath='Python/pythonrun.c' line='1507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_File'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1507' column='1'/>
-      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1507' column='1'/>
-      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1507' column='1'/>
-      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1507' column='1'/>
-      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1507' column='1'/>
+    <function-decl name='PyRun_File' mangled-name='PyRun_File' filepath='Python/pythonrun.c' line='1509' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_File'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1509' column='1'/>
+      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1509' column='1'/>
+      <parameter type-id='type-id-8' name='s' filepath='Python/pythonrun.c' line='1509' column='1'/>
+      <parameter type-id='type-id-15' name='g' filepath='Python/pythonrun.c' line='1509' column='1'/>
+      <parameter type-id='type-id-15' name='l' filepath='Python/pythonrun.c' line='1509' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFileFlags' mangled-name='PyRun_AnyFileFlags' filepath='Python/pythonrun.c' line='1500' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileFlags'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1500' column='1'/>
-      <parameter type-id='type-id-3' name='name' filepath='Python/pythonrun.c' line='1500' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1500' column='1'/>
+    <function-decl name='PyRun_AnyFileFlags' mangled-name='PyRun_AnyFileFlags' filepath='Python/pythonrun.c' line='1502' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileFlags'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1502' column='1'/>
+      <parameter type-id='type-id-3' name='name' filepath='Python/pythonrun.c' line='1502' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1502' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFileEx' mangled-name='PyRun_AnyFileEx' filepath='Python/pythonrun.c' line='1493' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileEx'>
-      <parameter type-id='type-id-188' name='f' filepath='Python/pythonrun.c' line='1536' column='1'/>
-      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1536' column='1'/>
-      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1536' column='1'/>
+    <function-decl name='PyRun_AnyFileEx' mangled-name='PyRun_AnyFileEx' filepath='Python/pythonrun.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileEx'>
+      <parameter type-id='type-id-188' name='f' filepath='Python/pythonrun.c' line='1538' column='1'/>
+      <parameter type-id='type-id-3' name='p' filepath='Python/pythonrun.c' line='1538' column='1'/>
+      <parameter type-id='type-id-8' name='c' filepath='Python/pythonrun.c' line='1538' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFile' mangled-name='PyRun_AnyFile' filepath='Python/pythonrun.c' line='1486' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFile'>
+    <function-decl name='PyRun_AnyFile' mangled-name='PyRun_AnyFile' filepath='Python/pythonrun.c' line='1488' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFile'>
       <parameter type-id='type-id-188' name='fp' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <parameter type-id='type-id-3' name='filename' filepath='Python/pylifecycle.c' line='2873' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_SourceAsString' mangled-name='_Py_SourceAsString' filepath='Python/pythonrun.c' line='1397' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_SourceAsString'>
-      <parameter type-id='type-id-15' name='cmd' filepath='Python/pythonrun.c' line='1397' column='1'/>
-      <parameter type-id='type-id-3' name='funcname' filepath='Python/pythonrun.c' line='1397' column='1'/>
-      <parameter type-id='type-id-3' name='what' filepath='Python/pythonrun.c' line='1397' column='1'/>
-      <parameter type-id='type-id-522' name='cf' filepath='Python/pythonrun.c' line='1397' column='1'/>
-      <parameter type-id='type-id-86' name='cmd_copy' filepath='Python/pythonrun.c' line='1397' column='1'/>
+    <function-decl name='_Py_SourceAsString' mangled-name='_Py_SourceAsString' filepath='Python/pythonrun.c' line='1399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_SourceAsString'>
+      <parameter type-id='type-id-15' name='cmd' filepath='Python/pythonrun.c' line='1399' column='1'/>
+      <parameter type-id='type-id-3' name='funcname' filepath='Python/pythonrun.c' line='1399' column='1'/>
+      <parameter type-id='type-id-3' name='what' filepath='Python/pythonrun.c' line='1399' column='1'/>
+      <parameter type-id='type-id-522' name='cf' filepath='Python/pythonrun.c' line='1399' column='1'/>
+      <parameter type-id='type-id-86' name='cmd_copy' filepath='Python/pythonrun.c' line='1399' column='1'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <function-decl name='Py_CompileStringExFlags' mangled-name='Py_CompileStringExFlags' filepath='Python/pythonrun.c' line='1384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringExFlags'>
-      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1384' column='1'/>
-      <parameter type-id='type-id-3' name='filename_str' filepath='Python/pythonrun.c' line='1384' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1384' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1385' column='1'/>
-      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1385' column='1'/>
+    <function-decl name='Py_CompileStringExFlags' mangled-name='Py_CompileStringExFlags' filepath='Python/pythonrun.c' line='1386' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringExFlags'>
+      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1386' column='1'/>
+      <parameter type-id='type-id-3' name='filename_str' filepath='Python/pythonrun.c' line='1386' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1386' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1387' column='1'/>
+      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1387' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='Py_CompileStringObject' mangled-name='Py_CompileStringObject' filepath='Python/pythonrun.c' line='1359' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringObject'>
-      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1359' column='1'/>
-      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='1359' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1359' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1360' column='1'/>
-      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1360' column='1'/>
+    <function-decl name='Py_CompileStringObject' mangled-name='Py_CompileStringObject' filepath='Python/pythonrun.c' line='1361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_CompileStringObject'>
+      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1361' column='1'/>
+      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='1361' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1361' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1362' column='1'/>
+      <parameter type-id='type-id-8' name='optimize' filepath='Python/pythonrun.c' line='1362' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyRun_FileExFlags' mangled-name='PyRun_FileExFlags' filepath='Python/pythonrun.c' line='1218' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileExFlags'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1218' column='1'/>
-      <parameter type-id='type-id-3' name='filename' filepath='Python/pythonrun.c' line='1218' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1218' column='1'/>
-      <parameter type-id='type-id-15' name='globals' filepath='Python/pythonrun.c' line='1218' column='1'/>
-      <parameter type-id='type-id-15' name='locals' filepath='Python/pythonrun.c' line='1219' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1219' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1219' column='1'/>
+    <function-decl name='PyRun_FileExFlags' mangled-name='PyRun_FileExFlags' filepath='Python/pythonrun.c' line='1220' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_FileExFlags'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='1220' column='1'/>
+      <parameter type-id='type-id-3' name='filename' filepath='Python/pythonrun.c' line='1220' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1220' column='1'/>
+      <parameter type-id='type-id-15' name='globals' filepath='Python/pythonrun.c' line='1220' column='1'/>
+      <parameter type-id='type-id-15' name='locals' filepath='Python/pythonrun.c' line='1221' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='1221' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1221' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyRun_StringFlags' mangled-name='PyRun_StringFlags' filepath='Python/pythonrun.c' line='1162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_StringFlags'>
-      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1162' column='1'/>
-      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1162' column='1'/>
-      <parameter type-id='type-id-15' name='globals' filepath='Python/pythonrun.c' line='1162' column='1'/>
-      <parameter type-id='type-id-15' name='locals' filepath='Python/pythonrun.c' line='1163' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1163' column='1'/>
+    <function-decl name='PyRun_StringFlags' mangled-name='PyRun_StringFlags' filepath='Python/pythonrun.c' line='1164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_StringFlags'>
+      <parameter type-id='type-id-3' name='str' filepath='Python/pythonrun.c' line='1164' column='1'/>
+      <parameter type-id='type-id-8' name='start' filepath='Python/pythonrun.c' line='1164' column='1'/>
+      <parameter type-id='type-id-15' name='globals' filepath='Python/pythonrun.c' line='1164' column='1'/>
+      <parameter type-id='type-id-15' name='locals' filepath='Python/pythonrun.c' line='1165' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='1165' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyErr_Display' mangled-name='PyErr_Display' filepath='Python/pythonrun.c' line='1145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Display'>
-      <parameter type-id='type-id-15' name='type' filepath='Python/errors.c' line='68' column='1'/>
-      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='68' column='1'/>
-      <parameter type-id='type-id-15' name='traceback' filepath='Python/errors.c' line='68' column='1'/>
+    <function-decl name='PyErr_Display' mangled-name='PyErr_Display' filepath='Python/pythonrun.c' line='1147' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Display'>
+      <parameter type-id='type-id-15' name='type' filepath='Python/errors.c' line='69' column='1'/>
+      <parameter type-id='type-id-15' name='value' filepath='Python/errors.c' line='69' column='1'/>
+      <parameter type-id='type-id-15' name='traceback' filepath='Python/errors.c' line='69' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PyErr_Display' mangled-name='_PyErr_Display' filepath='Python/pythonrun.c' line='1107' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Display'>
-      <parameter type-id='type-id-15' name='file' filepath='Python/pythonrun.c' line='1107' column='1'/>
-      <parameter type-id='type-id-15' name='exception' filepath='Python/pythonrun.c' line='1107' column='1'/>
-      <parameter type-id='type-id-15' name='value' filepath='Python/pythonrun.c' line='1107' column='1'/>
-      <parameter type-id='type-id-15' name='tb' filepath='Python/pythonrun.c' line='1107' column='1'/>
+    <function-decl name='_PyErr_Display' mangled-name='_PyErr_Display' filepath='Python/pythonrun.c' line='1109' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Display'>
+      <parameter type-id='type-id-15' name='file' filepath='Python/pythonrun.c' line='1109' column='1'/>
+      <parameter type-id='type-id-15' name='exception' filepath='Python/pythonrun.c' line='1109' column='1'/>
+      <parameter type-id='type-id-15' name='value' filepath='Python/pythonrun.c' line='1109' column='1'/>
+      <parameter type-id='type-id-15' name='tb' filepath='Python/pythonrun.c' line='1109' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyErr_Print' mangled-name='PyErr_Print' filepath='Python/pythonrun.c' line='883' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Print'>
+    <function-decl name='PyErr_Print' mangled-name='PyErr_Print' filepath='Python/pythonrun.c' line='884' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_Print'>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyErr_PrintEx' mangled-name='PyErr_PrintEx' filepath='Python/pythonrun.c' line='876' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_PrintEx'>
+    <function-decl name='PyErr_PrintEx' mangled-name='PyErr_PrintEx' filepath='Python/pythonrun.c' line='877' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_PrintEx'>
       <parameter type-id='type-id-8' name='new_limit' filepath='Python/ceval.c' line='848' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PyErr_Print' mangled-name='_PyErr_Print' filepath='Python/pythonrun.c' line='870' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Print'>
-      <parameter type-id='type-id-331' name='tstate' filepath='Python/pythonrun.c' line='870' column='1'/>
+    <function-decl name='_PyErr_Print' mangled-name='_PyErr_Print' filepath='Python/pythonrun.c' line='871' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_Print'>
+      <parameter type-id='type-id-331' name='tstate' filepath='Python/pythonrun.c' line='871' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_Py_HandleSystemExit' mangled-name='_Py_HandleSystemExit' filepath='Python/pythonrun.c' line='699' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_HandleSystemExit'>
-      <parameter type-id='type-id-452' name='exitcode_p' filepath='Python/pythonrun.c' line='699' column='1'/>
+    <function-decl name='_Py_HandleSystemExit' mangled-name='_Py_HandleSystemExit' filepath='Python/pythonrun.c' line='700' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_HandleSystemExit'>
+      <parameter type-id='type-id-452' name='exitcode_p' filepath='Python/pythonrun.c' line='700' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleStringFlags' mangled-name='PyRun_SimpleStringFlags' filepath='Python/pythonrun.c' line='495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleStringFlags'>
-      <parameter type-id='type-id-3' name='command' filepath='Python/pythonrun.c' line='495' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='495' column='1'/>
+    <function-decl name='PyRun_SimpleStringFlags' mangled-name='PyRun_SimpleStringFlags' filepath='Python/pythonrun.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleStringFlags'>
+      <parameter type-id='type-id-3' name='command' filepath='Python/pythonrun.c' line='496' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='496' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_SimpleFileExFlags' mangled-name='PyRun_SimpleFileExFlags' filepath='Python/pythonrun.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileExFlags'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='481' column='1'/>
-      <parameter type-id='type-id-3' name='filename' filepath='Python/pythonrun.c' line='481' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='481' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='482' column='1'/>
+    <function-decl name='PyRun_SimpleFileExFlags' mangled-name='PyRun_SimpleFileExFlags' filepath='Python/pythonrun.c' line='482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_SimpleFileExFlags'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='482' column='1'/>
+      <parameter type-id='type-id-3' name='filename' filepath='Python/pythonrun.c' line='482' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='482' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='483' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyRun_SimpleFileObject' mangled-name='_PyRun_SimpleFileObject' filepath='Python/pythonrun.c' line='398' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRun_SimpleFileObject'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='398' column='1'/>
-      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='398' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='398' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='399' column='1'/>
+    <function-decl name='_PyRun_SimpleFileObject' mangled-name='_PyRun_SimpleFileObject' filepath='Python/pythonrun.c' line='399' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRun_SimpleFileObject'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='399' column='1'/>
+      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='399' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='399' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='400' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveOneFlags' mangled-name='PyRun_InteractiveOneFlags' filepath='Python/pythonrun.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOneFlags'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='300' column='1'/>
-      <parameter type-id='type-id-3' name='filename_str' filepath='Python/pythonrun.c' line='300' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='300' column='1'/>
+    <function-decl name='PyRun_InteractiveOneFlags' mangled-name='PyRun_InteractiveOneFlags' filepath='Python/pythonrun.c' line='301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOneFlags'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='301' column='1'/>
+      <parameter type-id='type-id-3' name='filename_str' filepath='Python/pythonrun.c' line='301' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='301' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveOneObject' mangled-name='PyRun_InteractiveOneObject' filepath='Python/pythonrun.c' line='287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOneObject'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='287' column='1'/>
-      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='287' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='287' column='1'/>
+    <function-decl name='PyRun_InteractiveOneObject' mangled-name='PyRun_InteractiveOneObject' filepath='Python/pythonrun.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveOneObject'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='288' column='1'/>
+      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='288' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='288' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_InteractiveLoopFlags' mangled-name='PyRun_InteractiveLoopFlags' filepath='Python/pythonrun.c' line='177' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoopFlags'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='300' column='1'/>
-      <parameter type-id='type-id-3' name='filename_str' filepath='Python/pythonrun.c' line='300' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='300' column='1'/>
+    <function-decl name='PyRun_InteractiveLoopFlags' mangled-name='PyRun_InteractiveLoopFlags' filepath='Python/pythonrun.c' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_InteractiveLoopFlags'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='301' column='1'/>
+      <parameter type-id='type-id-3' name='filename_str' filepath='Python/pythonrun.c' line='301' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='301' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyRun_InteractiveLoopObject' mangled-name='_PyRun_InteractiveLoopObject' filepath='Python/pythonrun.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRun_InteractiveLoopObject'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='122' column='1'/>
-      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='122' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='122' column='1'/>
+    <function-decl name='_PyRun_InteractiveLoopObject' mangled-name='_PyRun_InteractiveLoopObject' filepath='Python/pythonrun.c' line='123' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRun_InteractiveLoopObject'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='123' column='1'/>
+      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='123' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='123' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyRun_AnyFileExFlags' mangled-name='PyRun_AnyFileExFlags' filepath='Python/pythonrun.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileExFlags'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='481' column='1'/>
-      <parameter type-id='type-id-3' name='filename' filepath='Python/pythonrun.c' line='481' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='481' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='482' column='1'/>
+    <function-decl name='PyRun_AnyFileExFlags' mangled-name='PyRun_AnyFileExFlags' filepath='Python/pythonrun.c' line='102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyRun_AnyFileExFlags'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='482' column='1'/>
+      <parameter type-id='type-id-3' name='filename' filepath='Python/pythonrun.c' line='482' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='482' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='483' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_PyRun_AnyFileObject' mangled-name='_PyRun_AnyFileObject' filepath='Python/pythonrun.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRun_AnyFileObject'>
-      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='68' column='1'/>
-      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='68' column='1'/>
-      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='68' column='1'/>
-      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='69' column='1'/>
+    <function-decl name='_PyRun_AnyFileObject' mangled-name='_PyRun_AnyFileObject' filepath='Python/pythonrun.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyRun_AnyFileObject'>
+      <parameter type-id='type-id-188' name='fp' filepath='Python/pythonrun.c' line='69' column='1'/>
+      <parameter type-id='type-id-15' name='filename' filepath='Python/pythonrun.c' line='69' column='1'/>
+      <parameter type-id='type-id-8' name='closeit' filepath='Python/pythonrun.c' line='69' column='1'/>
+      <parameter type-id='type-id-522' name='flags' filepath='Python/pythonrun.c' line='70' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pytime.c' comp-dir-path='/src' language='LANG_C99'>
-    <typedef-decl name='__time_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='160' column='1' id='type-id-798'/>
-    <typedef-decl name='time_t' type-id='type-id-798' filepath='/usr/include/x86_64-linux-gnu/bits/types/time_t.h' line='7' column='1' id='type-id-799'/>
-    <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='7' column='1' id='type-id-800'>
+    <typedef-decl name='__time_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='160' column='1' id='type-id-801'/>
+    <typedef-decl name='time_t' type-id='type-id-801' filepath='/usr/include/x86_64-linux-gnu/bits/types/time_t.h' line='7' column='1' id='type-id-802'/>
+    <class-decl name='tm' size-in-bits='448' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='7' column='1' id='type-id-803'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='tm_sec' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='9' column='1'/>
       </data-member>
@@ -14215,23 +14330,23 @@
         <var-decl name='tm_zone' type-id='type-id-3' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_tm.h' line='21' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-800' size-in-bits='64' id='type-id-801'/>
+    <pointer-type-def type-id='type-id-803' size-in-bits='64' id='type-id-804'/>
     <function-decl name='_PyTime_gmtime' mangled-name='_PyTime_gmtime' filepath='Python/pytime.c' line='1125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_gmtime'>
-      <parameter type-id='type-id-799' name='t' filepath='Python/pytime.c' line='1125' column='1'/>
-      <parameter type-id='type-id-801' name='tm' filepath='Python/pytime.c' line='1125' column='1'/>
+      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='1125' column='1'/>
+      <parameter type-id='type-id-804' name='tm' filepath='Python/pytime.c' line='1125' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_localtime' mangled-name='_PyTime_localtime' filepath='Python/pytime.c' line='1087' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_localtime'>
-      <parameter type-id='type-id-799' name='t' filepath='Python/pytime.c' line='1125' column='1'/>
-      <parameter type-id='type-id-801' name='tm' filepath='Python/pytime.c' line='1125' column='1'/>
+      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='1125' column='1'/>
+      <parameter type-id='type-id-804' name='tm' filepath='Python/pytime.c' line='1125' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <typedef-decl name='_PyTime_t' type-id='type-id-227' filepath='./Include/cpython/pytime.h' line='16' column='1' id='type-id-802'/>
+    <typedef-decl name='_PyTime_t' type-id='type-id-227' filepath='./Include/cpython/pytime.h' line='16' column='1' id='type-id-805'/>
     <function-decl name='_PyTime_GetPerfCounter' mangled-name='_PyTime_GetPerfCounter' filepath='Python/pytime.c' line='1068' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetPerfCounter'>
-      <return type-id='type-id-802'/>
+      <return type-id='type-id-805'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-802' size-in-bits='64' id='type-id-803'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-804' visibility='default' filepath='./Include/cpython/pytime.h' line='165' column='1' id='type-id-805'>
+    <pointer-type-def type-id='type-id-805' size-in-bits='64' id='type-id-806'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-807' visibility='default' filepath='./Include/cpython/pytime.h' line='165' column='1' id='type-id-808'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='implementation' type-id='type-id-3' visibility='default' filepath='./Include/cpython/pytime.h' line='166' column='1'/>
       </data-member>
@@ -14245,46 +14360,46 @@
         <var-decl name='resolution' type-id='type-id-371' visibility='default' filepath='./Include/cpython/pytime.h' line='169' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='_Py_clock_info_t' type-id='type-id-805' filepath='./Include/cpython/pytime.h' line='170' column='1' id='type-id-804'/>
-    <pointer-type-def type-id='type-id-804' size-in-bits='64' id='type-id-806'/>
+    <typedef-decl name='_Py_clock_info_t' type-id='type-id-808' filepath='./Include/cpython/pytime.h' line='170' column='1' id='type-id-807'/>
+    <pointer-type-def type-id='type-id-807' size-in-bits='64' id='type-id-809'/>
     <function-decl name='_PyTime_GetPerfCounterWithInfo' mangled-name='_PyTime_GetPerfCounterWithInfo' filepath='Python/pytime.c' line='1057' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetPerfCounterWithInfo'>
-      <parameter type-id='type-id-803' name='t' filepath='Python/pytime.c' line='1057' column='1'/>
-      <parameter type-id='type-id-806' name='info' filepath='Python/pytime.c' line='1057' column='1'/>
+      <parameter type-id='type-id-806' name='t' filepath='Python/pytime.c' line='1057' column='1'/>
+      <parameter type-id='type-id-809' name='info' filepath='Python/pytime.c' line='1057' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_GetMonotonicClockWithInfo' mangled-name='_PyTime_GetMonotonicClockWithInfo' filepath='Python/pytime.c' line='966' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetMonotonicClockWithInfo'>
-      <parameter type-id='type-id-803' name='t' filepath='Python/pytime.c' line='1057' column='1'/>
-      <parameter type-id='type-id-806' name='info' filepath='Python/pytime.c' line='1057' column='1'/>
+      <parameter type-id='type-id-806' name='t' filepath='Python/pytime.c' line='1057' column='1'/>
+      <parameter type-id='type-id-809' name='info' filepath='Python/pytime.c' line='1057' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_GetMonotonicClock' mangled-name='_PyTime_GetMonotonicClock' filepath='Python/pytime.c' line='954' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetMonotonicClock'>
-      <return type-id='type-id-802'/>
+      <return type-id='type-id-805'/>
     </function-decl>
     <function-decl name='_PyTime_GetSystemClockWithInfo' mangled-name='_PyTime_GetSystemClockWithInfo' filepath='Python/pytime.c' line='781' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetSystemClockWithInfo'>
-      <parameter type-id='type-id-803' name='t' filepath='Python/pytime.c' line='1057' column='1'/>
-      <parameter type-id='type-id-806' name='info' filepath='Python/pytime.c' line='1057' column='1'/>
+      <parameter type-id='type-id-806' name='t' filepath='Python/pytime.c' line='1057' column='1'/>
+      <parameter type-id='type-id-809' name='info' filepath='Python/pytime.c' line='1057' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_GetSystemClock' mangled-name='_PyTime_GetSystemClock' filepath='Python/pytime.c' line='769' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_GetSystemClock'>
-      <return type-id='type-id-802'/>
+      <return type-id='type-id-805'/>
     </function-decl>
-    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='10' column='1' id='type-id-807'>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='10' column='1' id='type-id-810'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-798' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='12' column='1'/>
+        <var-decl name='tv_sec' type-id='type-id-801' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='12' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_nsec' type-id='type-id-808' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='16' column='1'/>
+        <var-decl name='tv_nsec' type-id='type-id-811' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timespec.h' line='16' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__syscall_slong_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='196' column='1' id='type-id-808'/>
-    <pointer-type-def type-id='type-id-807' size-in-bits='64' id='type-id-809'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='196' column='1' id='type-id-811'/>
+    <pointer-type-def type-id='type-id-810' size-in-bits='64' id='type-id-812'/>
     <function-decl name='_PyTime_AsTimespec' mangled-name='_PyTime_AsTimespec' filepath='Python/pytime.c' line='636' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimespec'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='636' column='1'/>
-      <parameter type-id='type-id-809' name='ts' filepath='Python/pytime.c' line='636' column='1'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='636' column='1'/>
+      <parameter type-id='type-id-812' name='ts' filepath='Python/pytime.c' line='636' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-799' size-in-bits='64' id='type-id-810'/>
-    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/cpython/pytime.h' line='20' column='1' id='type-id-811'>
+    <pointer-type-def type-id='type-id-802' size-in-bits='64' id='type-id-813'/>
+    <enum-decl name='__anonymous_enum__' is-anonymous='yes' filepath='./Include/cpython/pytime.h' line='20' column='1' id='type-id-814'>
       <underlying-type type-id='type-id-83'/>
       <enumerator name='_PyTime_ROUND_FLOOR' value='0'/>
       <enumerator name='_PyTime_ROUND_CEILING' value='1'/>
@@ -14292,123 +14407,123 @@
       <enumerator name='_PyTime_ROUND_UP' value='3'/>
       <enumerator name='_PyTime_ROUND_TIMEOUT' value='3'/>
     </enum-decl>
-    <typedef-decl name='_PyTime_round_t' type-id='type-id-811' filepath='./Include/cpython/pytime.h' line='40' column='1' id='type-id-812'/>
+    <typedef-decl name='_PyTime_round_t' type-id='type-id-814' filepath='./Include/cpython/pytime.h' line='40' column='1' id='type-id-815'/>
     <function-decl name='_PyTime_AsTimevalTime_t' mangled-name='_PyTime_AsTimevalTime_t' filepath='Python/pytime.c' line='616' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimevalTime_t'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='616' column='1'/>
-      <parameter type-id='type-id-810' name='p_secs' filepath='Python/pytime.c' line='616' column='1'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='616' column='1'/>
+      <parameter type-id='type-id-813' name='p_secs' filepath='Python/pytime.c' line='616' column='1'/>
       <parameter type-id='type-id-452' name='us' filepath='Python/pytime.c' line='616' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='617' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='617' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <class-decl name='timeval' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='8' column='1' id='type-id-813'>
+    <class-decl name='timeval' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='8' column='1' id='type-id-816'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='tv_sec' type-id='type-id-798' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='10' column='1'/>
+        <var-decl name='tv_sec' type-id='type-id-801' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='10' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='tv_usec' type-id='type-id-814' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='11' column='1'/>
+        <var-decl name='tv_usec' type-id='type-id-817' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h' line='11' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__suseconds_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='162' column='1' id='type-id-814'/>
-    <pointer-type-def type-id='type-id-813' size-in-bits='64' id='type-id-815'/>
+    <typedef-decl name='__suseconds_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='162' column='1' id='type-id-817'/>
+    <pointer-type-def type-id='type-id-816' size-in-bits='64' id='type-id-818'/>
     <function-decl name='_PyTime_AsTimeval_noraise' mangled-name='_PyTime_AsTimeval_noraise' filepath='Python/pytime.c' line='610' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimeval_noraise'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='610' column='1'/>
-      <parameter type-id='type-id-815' name='tv' filepath='Python/pytime.c' line='610' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='610' column='1'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='610' column='1'/>
+      <parameter type-id='type-id-818' name='tv' filepath='Python/pytime.c' line='610' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='610' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_AsTimeval' mangled-name='_PyTime_AsTimeval' filepath='Python/pytime.c' line='604' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsTimeval'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='610' column='1'/>
-      <parameter type-id='type-id-815' name='tv' filepath='Python/pytime.c' line='610' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='610' column='1'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='610' column='1'/>
+      <parameter type-id='type-id-818' name='tv' filepath='Python/pytime.c' line='610' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='610' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_AsMicroseconds' mangled-name='_PyTime_AsMicroseconds' filepath='Python/pytime.c' line='533' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsMicroseconds'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='533' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='533' column='1'/>
-      <return type-id='type-id-802'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='533' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='533' column='1'/>
+      <return type-id='type-id-805'/>
     </function-decl>
     <function-decl name='_PyTime_AsMilliseconds' mangled-name='_PyTime_AsMilliseconds' filepath='Python/pytime.c' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsMilliseconds'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='533' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='533' column='1'/>
-      <return type-id='type-id-802'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='533' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='533' column='1'/>
+      <return type-id='type-id-805'/>
     </function-decl>
     <function-decl name='_PyTime_AsNanosecondsObject' mangled-name='_PyTime_AsNanosecondsObject' filepath='Python/pytime.c' line='473' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsNanosecondsObject'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='473' column='1'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='473' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='_PyTime_AsSecondsDouble' mangled-name='_PyTime_AsSecondsDouble' filepath='Python/pytime.c' line='453' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_AsSecondsDouble'>
-      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='453' column='1'/>
+      <parameter type-id='type-id-805' name='t' filepath='Python/pytime.c' line='453' column='1'/>
       <return type-id='type-id-371'/>
     </function-decl>
     <function-decl name='_PyTime_FromMillisecondsObject' mangled-name='_PyTime_FromMillisecondsObject' filepath='Python/pytime.c' line='447' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromMillisecondsObject'>
-      <parameter type-id='type-id-803' name='t' filepath='Python/pytime.c' line='447' column='1'/>
+      <parameter type-id='type-id-806' name='t' filepath='Python/pytime.c' line='447' column='1'/>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pytime.c' line='447' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='447' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='447' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromSecondsObject' mangled-name='_PyTime_FromSecondsObject' filepath='Python/pytime.c' line='441' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromSecondsObject'>
-      <parameter type-id='type-id-803' name='t' filepath='Python/pytime.c' line='447' column='1'/>
+      <parameter type-id='type-id-806' name='t' filepath='Python/pytime.c' line='447' column='1'/>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pytime.c' line='447' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='447' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='447' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromTimeval' mangled-name='_PyTime_FromTimeval' filepath='Python/pytime.c' line='380' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromTimeval'>
-      <parameter type-id='type-id-803' name='tp' filepath='Python/pytime.c' line='380' column='1'/>
-      <parameter type-id='type-id-815' name='tv' filepath='Python/pytime.c' line='380' column='1'/>
+      <parameter type-id='type-id-806' name='tp' filepath='Python/pytime.c' line='380' column='1'/>
+      <parameter type-id='type-id-818' name='tv' filepath='Python/pytime.c' line='380' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromTimespec' mangled-name='_PyTime_FromTimespec' filepath='Python/pytime.c' line='334' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromTimespec'>
-      <parameter type-id='type-id-803' name='tp' filepath='Python/pytime.c' line='334' column='1'/>
-      <parameter type-id='type-id-809' name='ts' filepath='Python/pytime.c' line='334' column='1'/>
+      <parameter type-id='type-id-806' name='tp' filepath='Python/pytime.c' line='334' column='1'/>
+      <parameter type-id='type-id-812' name='ts' filepath='Python/pytime.c' line='334' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromNanosecondsObject' mangled-name='_PyTime_FromNanosecondsObject' filepath='Python/pytime.c' line='268' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromNanosecondsObject'>
-      <parameter type-id='type-id-803' name='tp' filepath='Python/pytime.c' line='268' column='1'/>
+      <parameter type-id='type-id-806' name='tp' filepath='Python/pytime.c' line='268' column='1'/>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pytime.c' line='268' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_FromNanoseconds' mangled-name='_PyTime_FromNanoseconds' filepath='Python/pytime.c' line='261' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromNanoseconds'>
-      <parameter type-id='type-id-802' name='ns' filepath='Python/pytime.c' line='261' column='1'/>
-      <return type-id='type-id-802'/>
+      <parameter type-id='type-id-805' name='ns' filepath='Python/pytime.c' line='261' column='1'/>
+      <return type-id='type-id-805'/>
     </function-decl>
     <function-decl name='_PyTime_FromSeconds' mangled-name='_PyTime_FromSeconds' filepath='Python/pytime.c' line='244' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_FromSeconds'>
       <parameter type-id='type-id-8' name='seconds' filepath='Python/pytime.c' line='244' column='1'/>
-      <return type-id='type-id-802'/>
+      <return type-id='type-id-805'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-816'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-819'/>
     <function-decl name='_PyTime_ObjectToTimeval' mangled-name='_PyTime_ObjectToTimeval' filepath='Python/pytime.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_ObjectToTimeval'>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pytime.c' line='237' column='1'/>
-      <parameter type-id='type-id-810' name='sec' filepath='Python/pytime.c' line='237' column='1'/>
-      <parameter type-id='type-id-816' name='usec' filepath='Python/pytime.c' line='237' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='238' column='1'/>
+      <parameter type-id='type-id-813' name='sec' filepath='Python/pytime.c' line='237' column='1'/>
+      <parameter type-id='type-id-819' name='usec' filepath='Python/pytime.c' line='237' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='238' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_ObjectToTimespec' mangled-name='_PyTime_ObjectToTimespec' filepath='Python/pytime.c' line='230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_ObjectToTimespec'>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pytime.c' line='237' column='1'/>
-      <parameter type-id='type-id-810' name='sec' filepath='Python/pytime.c' line='237' column='1'/>
-      <parameter type-id='type-id-816' name='usec' filepath='Python/pytime.c' line='237' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='238' column='1'/>
+      <parameter type-id='type-id-813' name='sec' filepath='Python/pytime.c' line='237' column='1'/>
+      <parameter type-id='type-id-819' name='usec' filepath='Python/pytime.c' line='237' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='238' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyTime_ObjectToTime_t' mangled-name='_PyTime_ObjectToTime_t' filepath='Python/pytime.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_ObjectToTime_t'>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pytime.c' line='197' column='1'/>
-      <parameter type-id='type-id-810' name='sec' filepath='Python/pytime.c' line='197' column='1'/>
-      <parameter type-id='type-id-812' name='round' filepath='Python/pytime.c' line='197' column='1'/>
+      <parameter type-id='type-id-813' name='sec' filepath='Python/pytime.c' line='197' column='1'/>
+      <parameter type-id='type-id-815' name='round' filepath='Python/pytime.c' line='197' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyLong_FromTime_t' mangled-name='_PyLong_FromTime_t' filepath='Python/pytime.c' line='91' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromTime_t'>
-      <parameter type-id='type-id-799' name='t' filepath='Python/pytime.c' line='91' column='1'/>
+      <parameter type-id='type-id-802' name='t' filepath='Python/pytime.c' line='91' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='_PyLong_AsTime_t' mangled-name='_PyLong_AsTime_t' filepath='Python/pytime.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_AsTime_t'>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pytime.c' line='71' column='1'/>
-      <return type-id='type-id-799'/>
+      <return type-id='type-id-802'/>
     </function-decl>
     <function-decl name='_PyTime_MulDiv' mangled-name='_PyTime_MulDiv' filepath='Python/pytime.c' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyTime_MulDiv'>
-      <parameter type-id='type-id-802' name='ticks' filepath='Python/pytime.c' line='53' column='1'/>
-      <parameter type-id='type-id-802' name='mul' filepath='Python/pytime.c' line='53' column='1'/>
-      <parameter type-id='type-id-802' name='div' filepath='Python/pytime.c' line='53' column='1'/>
-      <return type-id='type-id-802'/>
+      <parameter type-id='type-id-805' name='ticks' filepath='Python/pytime.c' line='53' column='1'/>
+      <parameter type-id='type-id-805' name='mul' filepath='Python/pytime.c' line='53' column='1'/>
+      <parameter type-id='type-id-805' name='div' filepath='Python/pytime.c' line='53' column='1'/>
+      <return type-id='type-id-805'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/bootstrap_hash.c' comp-dir-path='/src' language='LANG_C99'>
@@ -14438,7 +14553,7 @@
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/symtable.c' comp-dir-path='/src' language='LANG_C99'>
     <var-decl name='PySTEntry_Type' type-id='type-id-149' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='71' column='1'/>
-    <class-decl name='_symtable_entry' size-in-bits='896' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='37' column='1' id='type-id-817'>
+    <class-decl name='_symtable_entry' size-in-bits='896' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='37' column='1' id='type-id-820'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ob_base' type-id='type-id-68' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='38' column='1'/>
       </data-member>
@@ -14461,7 +14576,7 @@
         <var-decl name='ste_directives' type-id='type-id-15' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='44' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='ste_type' type-id='type-id-818' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='45' column='1'/>
+        <var-decl name='ste_type' type-id='type-id-821' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='45' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
         <var-decl name='ste_nested' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='46' column='1'/>
@@ -14518,26 +14633,26 @@
         <var-decl name='ste_opt_col_offset' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='ste_table' type-id='type-id-819' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='68' column='1'/>
+        <var-decl name='ste_table' type-id='type-id-822' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='68' column='1'/>
       </data-member>
     </class-decl>
-    <enum-decl name='_block_type' filepath='./Include/internal/pycore_symtable.h' line='13' column='1' id='type-id-820'>
+    <enum-decl name='_block_type' filepath='./Include/internal/pycore_symtable.h' line='13' column='1' id='type-id-823'>
       <underlying-type type-id='type-id-83'/>
       <enumerator name='FunctionBlock' value='0'/>
       <enumerator name='ClassBlock' value='1'/>
       <enumerator name='ModuleBlock' value='2'/>
       <enumerator name='AnnotationBlock' value='3'/>
     </enum-decl>
-    <typedef-decl name='_Py_block_ty' type-id='type-id-820' filepath='./Include/internal/pycore_symtable.h' line='14' column='1' id='type-id-818'/>
-    <class-decl name='symtable' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='18' column='1' id='type-id-821'>
+    <typedef-decl name='_Py_block_ty' type-id='type-id-823' filepath='./Include/internal/pycore_symtable.h' line='14' column='1' id='type-id-821'/>
+    <class-decl name='symtable' size-in-bits='640' is-struct='yes' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='18' column='1' id='type-id-824'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='st_filename' type-id='type-id-15' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='19' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_cur' type-id='type-id-822' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='21' column='1'/>
+        <var-decl name='st_cur' type-id='type-id-825' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='21' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_top' type-id='type-id-822' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='22' column='1'/>
+        <var-decl name='st_top' type-id='type-id-825' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='22' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='st_blocks' type-id='type-id-15' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='23' column='1'/>
@@ -14555,7 +14670,7 @@
         <var-decl name='st_private' type-id='type-id-15' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='30' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_future' type-id='type-id-823' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='31' column='1'/>
+        <var-decl name='st_future' type-id='type-id-826' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='31' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
         <var-decl name='recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='33' column='1'/>
@@ -14564,8 +14679,8 @@
         <var-decl name='recursion_limit' type-id='type-id-8' visibility='default' filepath='./Include/internal/pycore_symtable.h' line='34' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-817' size-in-bits='64' id='type-id-822'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-824' visibility='default' filepath='./Include/cpython/compile.h' line='34' column='1' id='type-id-825'>
+    <pointer-type-def type-id='type-id-820' size-in-bits='64' id='type-id-825'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-827' visibility='default' filepath='./Include/cpython/compile.h' line='34' column='1' id='type-id-828'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='ff_features' type-id='type-id-8' visibility='default' filepath='./Include/cpython/compile.h' line='35' column='1'/>
       </data-member>
@@ -14573,86 +14688,86 @@
         <var-decl name='ff_lineno' type-id='type-id-8' visibility='default' filepath='./Include/cpython/compile.h' line='36' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='PyFutureFeatures' type-id='type-id-825' filepath='./Include/cpython/compile.h' line='37' column='1' id='type-id-824'/>
-    <pointer-type-def type-id='type-id-824' size-in-bits='64' id='type-id-823'/>
-    <pointer-type-def type-id='type-id-821' size-in-bits='64' id='type-id-819'/>
-    <typedef-decl name='PySTEntryObject' type-id='type-id-817' filepath='./Include/internal/pycore_symtable.h' line='69' column='1' id='type-id-826'/>
-    <pointer-type-def type-id='type-id-826' size-in-bits='64' id='type-id-827'/>
+    <typedef-decl name='PyFutureFeatures' type-id='type-id-828' filepath='./Include/cpython/compile.h' line='37' column='1' id='type-id-827'/>
+    <pointer-type-def type-id='type-id-827' size-in-bits='64' id='type-id-826'/>
+    <pointer-type-def type-id='type-id-824' size-in-bits='64' id='type-id-822'/>
+    <typedef-decl name='PySTEntryObject' type-id='type-id-820' filepath='./Include/internal/pycore_symtable.h' line='69' column='1' id='type-id-829'/>
+    <pointer-type-def type-id='type-id-829' size-in-bits='64' id='type-id-830'/>
     <function-decl name='PySymtable_Lookup' mangled-name='PySymtable_Lookup' filepath='Python/symtable.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySymtable_Lookup'>
-      <parameter type-id='type-id-819' name='st' filepath='Python/symtable.c' line='373' column='1'/>
+      <parameter type-id='type-id-822' name='st' filepath='Python/symtable.c' line='373' column='1'/>
       <parameter type-id='type-id-20' name='key' filepath='Python/symtable.c' line='373' column='1'/>
-      <return type-id='type-id-827'/>
+      <return type-id='type-id-830'/>
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='./Python/sysmodule.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='PySys_FormatStderr' mangled-name='PySys_FormatStderr' filepath='./Python/sysmodule.c' line='3345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStderr'>
-      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3345' column='1'/>
+    <function-decl name='PySys_FormatStderr' mangled-name='PySys_FormatStderr' filepath='./Python/sysmodule.c' line='3347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStderr'>
+      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3347' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_FormatStdout' mangled-name='PySys_FormatStdout' filepath='./Python/sysmodule.c' line='3335' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStdout'>
-      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3345' column='1'/>
+    <function-decl name='PySys_FormatStdout' mangled-name='PySys_FormatStdout' filepath='./Python/sysmodule.c' line='3337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_FormatStdout'>
+      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3347' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_WriteStderr' mangled-name='PySys_WriteStderr' filepath='./Python/sysmodule.c' line='3302' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStderr'>
-      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3345' column='1'/>
+    <function-decl name='PySys_WriteStderr' mangled-name='PySys_WriteStderr' filepath='./Python/sysmodule.c' line='3304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStderr'>
+      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3347' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_WriteStdout' mangled-name='PySys_WriteStdout' filepath='./Python/sysmodule.c' line='3292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStdout'>
-      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3345' column='1'/>
+    <function-decl name='PySys_WriteStdout' mangled-name='PySys_WriteStdout' filepath='./Python/sysmodule.c' line='3294' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_WriteStdout'>
+      <parameter type-id='type-id-3' name='format' filepath='./Python/sysmodule.c' line='3347' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_SetArgv' mangled-name='PySys_SetArgv' filepath='./Python/sysmodule.c' line='3199' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgv'>
-      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3199' column='1'/>
-      <parameter type-id='type-id-329' name='argv' filepath='./Python/sysmodule.c' line='3199' column='1'/>
+    <function-decl name='PySys_SetArgv' mangled-name='PySys_SetArgv' filepath='./Python/sysmodule.c' line='3201' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgv'>
+      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3201' column='1'/>
+      <parameter type-id='type-id-329' name='argv' filepath='./Python/sysmodule.c' line='3201' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_SetArgvEx' mangled-name='PySys_SetArgvEx' filepath='./Python/sysmodule.c' line='3155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgvEx'>
-      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3155' column='1'/>
-      <parameter type-id='type-id-329' name='argv' filepath='./Python/sysmodule.c' line='3155' column='1'/>
-      <parameter type-id='type-id-8' name='updatepath' filepath='./Python/sysmodule.c' line='3155' column='1'/>
+    <function-decl name='PySys_SetArgvEx' mangled-name='PySys_SetArgvEx' filepath='./Python/sysmodule.c' line='3157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetArgvEx'>
+      <parameter type-id='type-id-8' name='argc' filepath='./Python/sysmodule.c' line='3157' column='1'/>
+      <parameter type-id='type-id-329' name='argv' filepath='./Python/sysmodule.c' line='3157' column='1'/>
+      <parameter type-id='type-id-8' name='updatepath' filepath='./Python/sysmodule.c' line='3157' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_SetPath' mangled-name='PySys_SetPath' filepath='./Python/sysmodule.c' line='3123' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetPath'>
-      <parameter type-id='type-id-478' name='path' filepath='./Python/sysmodule.c' line='3123' column='1'/>
+    <function-decl name='PySys_SetPath' mangled-name='PySys_SetPath' filepath='./Python/sysmodule.c' line='3125' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_SetPath'>
+      <parameter type-id='type-id-478' name='path' filepath='./Python/sysmodule.c' line='3125' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_GetXOptions' mangled-name='PySys_GetXOptions' filepath='./Python/sysmodule.c' line='2389' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_GetXOptions'>
+    <function-decl name='PySys_GetXOptions' mangled-name='PySys_GetXOptions' filepath='./Python/sysmodule.c' line='2391' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_GetXOptions'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PySys_AddXOption' mangled-name='PySys_AddXOption' filepath='./Python/sysmodule.c' line='2375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddXOption'>
-      <parameter type-id='type-id-478' name='s' filepath='./Python/sysmodule.c' line='2375' column='1'/>
+    <function-decl name='PySys_AddXOption' mangled-name='PySys_AddXOption' filepath='./Python/sysmodule.c' line='2377' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddXOption'>
+      <parameter type-id='type-id-478' name='s' filepath='./Python/sysmodule.c' line='2377' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_HasWarnOptions' mangled-name='PySys_HasWarnOptions' filepath='./Python/sysmodule.c' line='2301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_HasWarnOptions'>
+    <function-decl name='PySys_HasWarnOptions' mangled-name='PySys_HasWarnOptions' filepath='./Python/sysmodule.c' line='2303' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_HasWarnOptions'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySys_AddWarnOption' mangled-name='PySys_AddWarnOption' filepath='./Python/sysmodule.c' line='2285' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOption'>
+    <function-decl name='PySys_AddWarnOption' mangled-name='PySys_AddWarnOption' filepath='./Python/sysmodule.c' line='2287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOption'>
       <parameter type-id='type-id-478' name='program_full_path' filepath='Python/pathconfig.c' line='548' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_AddWarnOptionUnicode' mangled-name='PySys_AddWarnOptionUnicode' filepath='./Python/sysmodule.c' line='2273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOptionUnicode'>
+    <function-decl name='PySys_AddWarnOptionUnicode' mangled-name='PySys_AddWarnOptionUnicode' filepath='./Python/sysmodule.c' line='2275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddWarnOptionUnicode'>
       <parameter type-id='type-id-15' name='m' filepath='Objects/moduleobject.c' line='565' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PySys_ResetWarnOptions' mangled-name='PySys_ResetWarnOptions' filepath='./Python/sysmodule.c' line='2245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_ResetWarnOptions'>
+    <function-decl name='PySys_ResetWarnOptions' mangled-name='PySys_ResetWarnOptions' filepath='./Python/sysmodule.c' line='2247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_ResetWarnOptions'>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_PySys_GetSizeOf' mangled-name='_PySys_GetSizeOf' filepath='./Python/sysmodule.c' line='1656' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySys_GetSizeOf'>
+    <function-decl name='_PySys_GetSizeOf' mangled-name='_PySys_GetSizeOf' filepath='./Python/sysmodule.c' line='1658' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PySys_GetSizeOf'>
       <parameter type-id='type-id-15' name='vv' filepath='Objects/longobject.c' line='583' column='1'/>
       <return type-id='type-id-157'/>
     </function-decl>
-    <function-decl name='PySys_AddAuditHook' mangled-name='PySys_AddAuditHook' filepath='./Python/sysmodule.c' line='382' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddAuditHook'>
-      <parameter type-id='type-id-306' name='hook' filepath='./Python/sysmodule.c' line='382' column='1'/>
-      <parameter type-id='type-id-20' name='userData' filepath='./Python/sysmodule.c' line='382' column='1'/>
+    <function-decl name='PySys_AddAuditHook' mangled-name='PySys_AddAuditHook' filepath='./Python/sysmodule.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_AddAuditHook'>
+      <parameter type-id='type-id-306' name='hook' filepath='./Python/sysmodule.c' line='384' column='1'/>
+      <parameter type-id='type-id-20' name='userData' filepath='./Python/sysmodule.c' line='384' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PySys_Audit' mangled-name='PySys_Audit' filepath='./Python/sysmodule.c' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_Audit'>
-      <parameter type-id='type-id-3' name='event' filepath='./Python/sysmodule.c' line='328' column='1'/>
-      <parameter type-id='type-id-3' name='argFormat' filepath='./Python/sysmodule.c' line='328' column='1'/>
+    <function-decl name='PySys_Audit' mangled-name='PySys_Audit' filepath='./Python/sysmodule.c' line='330' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PySys_Audit'>
+      <parameter type-id='type-id-3' name='event' filepath='./Python/sysmodule.c' line='330' column='1'/>
+      <parameter type-id='type-id-3' name='argFormat' filepath='./Python/sysmodule.c' line='330' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-8'/>
     </function-decl>
@@ -14679,17 +14794,17 @@
     <function-decl name='PyThread_GetInfo' mangled-name='PyThread_GetInfo' filepath='Python/thread.c' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_GetInfo'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-301' size-in-bits='64' id='type-id-828'/>
+    <pointer-type-def type-id='type-id-301' size-in-bits='64' id='type-id-831'/>
     <function-decl name='PyThread_tss_is_created' mangled-name='PyThread_tss_is_created' filepath='Python/thread.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_is_created'>
-      <parameter type-id='type-id-828' name='key' filepath='Python/thread.c' line='157' column='1'/>
+      <parameter type-id='type-id-831' name='key' filepath='Python/thread.c' line='157' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='PyThread_tss_free' mangled-name='PyThread_tss_free' filepath='Python/thread.c' line='148' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_free'>
-      <parameter type-id='type-id-828' name='key' filepath='Python/thread.c' line='148' column='1'/>
+      <parameter type-id='type-id-831' name='key' filepath='Python/thread.c' line='148' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
     <function-decl name='PyThread_tss_alloc' mangled-name='PyThread_tss_alloc' filepath='Python/thread.c' line='137' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_alloc'>
-      <return type-id='type-id-828'/>
+      <return type-id='type-id-831'/>
     </function-decl>
     <function-decl name='PyThread_set_stacksize' mangled-name='PyThread_set_stacksize' filepath='Python/thread.c' line='121' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_set_stacksize'>
       <parameter type-id='type-id-157' name='size' filepath='Python/thread.c' line='121' column='1'/>
@@ -14698,92 +14813,92 @@
     <function-decl name='PyThread_get_stacksize' mangled-name='PyThread_get_stacksize' filepath='Python/thread.c' line='110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_stacksize'>
       <return type-id='type-id-157'/>
     </function-decl>
-    <function-decl name='PyThread_tss_get' mangled-name='PyThread_tss_get' filepath='Python/thread_pthread.h' line='897' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_get'>
-      <parameter type-id='type-id-828' name='key' filepath='Python/thread_pthread.h' line='897' column='1'/>
+    <function-decl name='PyThread_tss_get' mangled-name='PyThread_tss_get' filepath='Python/thread_pthread.h' line='896' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_get'>
+      <parameter type-id='type-id-831' name='key' filepath='Python/thread_pthread.h' line='896' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='PyThread_tss_set' mangled-name='PyThread_tss_set' filepath='Python/thread_pthread.h' line='889' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_set'>
-      <parameter type-id='type-id-828' name='key' filepath='Python/thread_pthread.h' line='889' column='1'/>
-      <parameter type-id='type-id-20' name='value' filepath='Python/thread_pthread.h' line='889' column='1'/>
+    <function-decl name='PyThread_tss_set' mangled-name='PyThread_tss_set' filepath='Python/thread_pthread.h' line='888' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_set'>
+      <parameter type-id='type-id-831' name='key' filepath='Python/thread_pthread.h' line='888' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='Python/thread_pthread.h' line='888' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_tss_delete' mangled-name='PyThread_tss_delete' filepath='Python/thread_pthread.h' line='875' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_delete'>
-      <parameter type-id='type-id-828' name='key' filepath='Python/thread.c' line='148' column='1'/>
+    <function-decl name='PyThread_tss_delete' mangled-name='PyThread_tss_delete' filepath='Python/thread_pthread.h' line='874' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_delete'>
+      <parameter type-id='type-id-831' name='key' filepath='Python/thread.c' line='148' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThread_tss_create' mangled-name='PyThread_tss_create' filepath='Python/thread_pthread.h' line='858' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_create'>
-      <parameter type-id='type-id-828' name='key' filepath='Python/thread_pthread.h' line='858' column='1'/>
+    <function-decl name='PyThread_tss_create' mangled-name='PyThread_tss_create' filepath='Python/thread_pthread.h' line='857' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_tss_create'>
+      <parameter type-id='type-id-831' name='key' filepath='Python/thread_pthread.h' line='857' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_ReInitTLS' mangled-name='PyThread_ReInitTLS' filepath='Python/thread_pthread.h' line='847' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_ReInitTLS'>
+    <function-decl name='PyThread_ReInitTLS' mangled-name='PyThread_ReInitTLS' filepath='Python/thread_pthread.h' line='846' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_ReInitTLS'>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThread_get_key_value' mangled-name='PyThread_get_key_value' filepath='Python/thread_pthread.h' line='836' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='836' column='1'/>
+    <function-decl name='PyThread_get_key_value' mangled-name='PyThread_get_key_value' filepath='Python/thread_pthread.h' line='835' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='835' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='PyThread_set_key_value' mangled-name='PyThread_set_key_value' filepath='Python/thread_pthread.h' line='825' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_set_key_value'>
-      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='825' column='1'/>
-      <parameter type-id='type-id-20' name='value' filepath='Python/thread_pthread.h' line='825' column='1'/>
+    <function-decl name='PyThread_set_key_value' mangled-name='PyThread_set_key_value' filepath='Python/thread_pthread.h' line='824' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_set_key_value'>
+      <parameter type-id='type-id-8' name='key' filepath='Python/thread_pthread.h' line='824' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='Python/thread_pthread.h' line='824' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_delete_key_value' mangled-name='PyThread_delete_key_value' filepath='Python/thread_pthread.h' line='817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key_value'>
+    <function-decl name='PyThread_delete_key_value' mangled-name='PyThread_delete_key_value' filepath='Python/thread_pthread.h' line='816' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key_value'>
       <parameter type-id='type-id-8' name='sts' filepath='Python/pylifecycle.c' line='2856' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThread_delete_key' mangled-name='PyThread_delete_key' filepath='Python/thread_pthread.h' line='809' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key'>
+    <function-decl name='PyThread_delete_key' mangled-name='PyThread_delete_key' filepath='Python/thread_pthread.h' line='808' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_delete_key'>
       <parameter type-id='type-id-8' name='sts' filepath='Python/pylifecycle.c' line='2856' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThread_create_key' mangled-name='PyThread_create_key' filepath='Python/thread_pthread.h' line='789' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_create_key'>
+    <function-decl name='PyThread_create_key' mangled-name='PyThread_create_key' filepath='Python/thread_pthread.h' line='788' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_create_key'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_acquire_lock' mangled-name='PyThread_acquire_lock' filepath='Python/thread_pthread.h' line='722' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock'>
-      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='722' column='1'/>
-      <parameter type-id='type-id-8' name='waitflag' filepath='Python/thread_pthread.h' line='722' column='1'/>
+    <function-decl name='PyThread_acquire_lock' mangled-name='PyThread_acquire_lock' filepath='Python/thread_pthread.h' line='721' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock'>
+      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='721' column='1'/>
+      <parameter type-id='type-id-8' name='waitflag' filepath='Python/thread_pthread.h' line='721' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-829'/>
-    <function-decl name='_PyThread_at_fork_reinit' mangled-name='_PyThread_at_fork_reinit' filepath='Python/thread_pthread.h' line='702' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_at_fork_reinit'>
-      <parameter type-id='type-id-829' name='lock' filepath='Python/thread_pthread.h' line='702' column='1'/>
+    <pointer-type-def type-id='type-id-228' size-in-bits='64' id='type-id-832'/>
+    <function-decl name='_PyThread_at_fork_reinit' mangled-name='_PyThread_at_fork_reinit' filepath='Python/thread_pthread.h' line='701' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyThread_at_fork_reinit'>
+      <parameter type-id='type-id-832' name='lock' filepath='Python/thread_pthread.h' line='701' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='PyThread_release_lock' mangled-name='PyThread_release_lock' filepath='Python/thread_pthread.h' line='528' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_release_lock'>
-      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='528' column='1'/>
+    <function-decl name='PyThread_release_lock' mangled-name='PyThread_release_lock' filepath='Python/thread_pthread.h' line='527' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_release_lock'>
+      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='527' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <enum-decl name='PyLockStatus' filepath='./Include/pythread.h' line='13' column='1' id='type-id-830'>
+    <enum-decl name='PyLockStatus' filepath='./Include/pythread.h' line='13' column='1' id='type-id-833'>
       <underlying-type type-id='type-id-83'/>
       <enumerator name='PY_LOCK_FAILURE' value='0'/>
       <enumerator name='PY_LOCK_ACQUIRED' value='1'/>
       <enumerator name='PY_LOCK_INTR' value='2'/>
     </enum-decl>
-    <typedef-decl name='PyLockStatus' type-id='type-id-830' filepath='./Include/pythread.h' line='17' column='1' id='type-id-831'/>
-    <function-decl name='PyThread_acquire_lock_timed' mangled-name='PyThread_acquire_lock_timed' filepath='Python/thread_pthread.h' line='431' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock_timed'>
-      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='431' column='1'/>
-      <parameter type-id='type-id-286' name='microseconds' filepath='Python/thread_pthread.h' line='431' column='1'/>
-      <parameter type-id='type-id-8' name='intr_flag' filepath='Python/thread_pthread.h' line='432' column='1'/>
-      <return type-id='type-id-831'/>
+    <typedef-decl name='PyLockStatus' type-id='type-id-833' filepath='./Include/pythread.h' line='17' column='1' id='type-id-834'/>
+    <function-decl name='PyThread_acquire_lock_timed' mangled-name='PyThread_acquire_lock_timed' filepath='Python/thread_pthread.h' line='430' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_acquire_lock_timed'>
+      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='430' column='1'/>
+      <parameter type-id='type-id-286' name='microseconds' filepath='Python/thread_pthread.h' line='430' column='1'/>
+      <parameter type-id='type-id-8' name='intr_flag' filepath='Python/thread_pthread.h' line='431' column='1'/>
+      <return type-id='type-id-834'/>
     </function-decl>
-    <function-decl name='PyThread_free_lock' mangled-name='PyThread_free_lock' filepath='Python/thread_pthread.h' line='401' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_free_lock'>
-      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='528' column='1'/>
+    <function-decl name='PyThread_free_lock' mangled-name='PyThread_free_lock' filepath='Python/thread_pthread.h' line='400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_free_lock'>
+      <parameter type-id='type-id-228' name='lock' filepath='Python/thread_pthread.h' line='527' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThread_allocate_lock' mangled-name='PyThread_allocate_lock' filepath='Python/thread_pthread.h' line='375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_allocate_lock'>
+    <function-decl name='PyThread_allocate_lock' mangled-name='PyThread_allocate_lock' filepath='Python/thread_pthread.h' line='374' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_allocate_lock'>
       <return type-id='type-id-228'/>
     </function-decl>
-    <function-decl name='PyThread_exit_thread' mangled-name='PyThread_exit_thread' filepath='Python/thread_pthread.h' line='360' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_exit_thread'>
+    <function-decl name='PyThread_exit_thread' mangled-name='PyThread_exit_thread' filepath='Python/thread_pthread.h' line='359' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_exit_thread'>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='PyThread_get_thread_native_id' mangled-name='PyThread_get_thread_native_id' filepath='Python/thread_pthread.h' line='332' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_thread_native_id'>
+    <function-decl name='PyThread_get_thread_native_id' mangled-name='PyThread_get_thread_native_id' filepath='Python/thread_pthread.h' line='331' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_thread_native_id'>
       <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='PyThread_get_thread_ident' mangled-name='PyThread_get_thread_ident' filepath='Python/thread_pthread.h' line='321' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_thread_ident'>
+    <function-decl name='PyThread_get_thread_ident' mangled-name='PyThread_get_thread_ident' filepath='Python/thread_pthread.h' line='320' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_get_thread_ident'>
       <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='PyThread_start_new_thread' mangled-name='PyThread_start_new_thread' filepath='Python/thread_pthread.h' line='245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_start_new_thread'>
-      <parameter type-id='type-id-19' name='func' filepath='Python/thread_pthread.h' line='245' column='1'/>
-      <parameter type-id='type-id-20' name='arg' filepath='Python/thread_pthread.h' line='245' column='1'/>
+    <function-decl name='PyThread_start_new_thread' mangled-name='PyThread_start_new_thread' filepath='Python/thread_pthread.h' line='244' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_start_new_thread'>
+      <parameter type-id='type-id-19' name='func' filepath='Python/thread_pthread.h' line='244' column='1'/>
+      <parameter type-id='type-id-20' name='arg' filepath='Python/thread_pthread.h' line='244' column='1'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='PyThread_init_thread' mangled-name='PyThread_init_thread' filepath='Python/thread.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyThread_init_thread'>
@@ -14842,14 +14957,14 @@
       <parameter type-id='type-id-452' name='type' filepath='Python/pystrtod.c' line='1247' column='1'/>
       <return type-id='type-id-72'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-832' size-in-bits='64' id='type-id-833'/>
+    <pointer-type-def type-id='type-id-835' size-in-bits='64' id='type-id-836'/>
     <function-decl name='_Py_string_to_number_with_underscores' mangled-name='_Py_string_to_number_with_underscores' filepath='Python/pystrtod.c' line='384' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_string_to_number_with_underscores'>
       <parameter type-id='type-id-3' name='s' filepath='Python/pystrtod.c' line='385' column='1'/>
       <parameter type-id='type-id-30' name='orig_len' filepath='Python/pystrtod.c' line='385' column='1'/>
       <parameter type-id='type-id-3' name='what' filepath='Python/pystrtod.c' line='385' column='1'/>
       <parameter type-id='type-id-15' name='obj' filepath='Python/pystrtod.c' line='385' column='1'/>
       <parameter type-id='type-id-20' name='arg' filepath='Python/pystrtod.c' line='385' column='1'/>
-      <parameter type-id='type-id-833' name='innerfunc' filepath='Python/pystrtod.c' line='386' column='1'/>
+      <parameter type-id='type-id-836' name='innerfunc' filepath='Python/pystrtod.c' line='386' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='PyOS_string_to_double' mangled-name='PyOS_string_to_double' filepath='Python/pystrtod.c' line='338' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_string_to_double'>
@@ -14863,7 +14978,7 @@
       <parameter type-id='type-id-215' name='endptr' filepath='Python/pystrtod.c' line='29' column='1'/>
       <return type-id='type-id-371'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-832'>
+    <function-type size-in-bits='64' id='type-id-835'>
       <parameter type-id='type-id-3'/>
       <parameter type-id='type-id-30'/>
       <parameter type-id='type-id-20'/>
@@ -14871,20 +14986,20 @@
     </function-type>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/pystrhex.c' comp-dir-path='/src' language='LANG_C99'>
-    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-834'/>
-    <pointer-type-def type-id='type-id-834' size-in-bits='64' id='type-id-835'/>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-837'/>
+    <pointer-type-def type-id='type-id-837' size-in-bits='64' id='type-id-838'/>
     <function-decl name='_Py_strhex_bytes_with_sep' mangled-name='_Py_strhex_bytes_with_sep' filepath='Python/pystrhex.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_strhex_bytes_with_sep'>
       <parameter type-id='type-id-3' name='argbuf' filepath='Python/pystrhex.c' line='169' column='1'/>
       <parameter type-id='type-id-193' name='arglen' filepath='Python/pystrhex.c' line='169' column='1'/>
-      <parameter type-id='type-id-835' name='sep' filepath='Python/pystrhex.c' line='169' column='1'/>
-      <parameter type-id='type-id-781' name='bytes_per_group' filepath='Python/pystrhex.c' line='169' column='1'/>
+      <parameter type-id='type-id-838' name='sep' filepath='Python/pystrhex.c' line='169' column='1'/>
+      <parameter type-id='type-id-784' name='bytes_per_group' filepath='Python/pystrhex.c' line='169' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='_Py_strhex_with_sep' mangled-name='_Py_strhex_with_sep' filepath='Python/pystrhex.c' line='162' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_strhex_with_sep'>
       <parameter type-id='type-id-3' name='argbuf' filepath='Python/pystrhex.c' line='169' column='1'/>
       <parameter type-id='type-id-193' name='arglen' filepath='Python/pystrhex.c' line='169' column='1'/>
-      <parameter type-id='type-id-835' name='sep' filepath='Python/pystrhex.c' line='169' column='1'/>
-      <parameter type-id='type-id-781' name='bytes_per_group' filepath='Python/pystrhex.c' line='169' column='1'/>
+      <parameter type-id='type-id-838' name='sep' filepath='Python/pystrhex.c' line='169' column='1'/>
+      <parameter type-id='type-id-784' name='bytes_per_group' filepath='Python/pystrhex.c' line='169' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='_Py_strhex_bytes' mangled-name='_Py_strhex_bytes' filepath='Python/pystrhex.c' line='155' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_strhex_bytes'>
@@ -14961,12 +15076,12 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Python/fileutils.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='_Py_closerange' mangled-name='_Py_closerange' filepath='Python/fileutils.c' line='2381' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_closerange'>
-      <parameter type-id='type-id-8' name='first' filepath='Python/fileutils.c' line='2381' column='1'/>
-      <parameter type-id='type-id-8' name='last' filepath='Python/fileutils.c' line='2381' column='1'/>
+    <function-decl name='_Py_closerange' mangled-name='_Py_closerange' filepath='Python/fileutils.c' line='2393' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_closerange'>
+      <parameter type-id='type-id-8' name='first' filepath='Python/fileutils.c' line='2393' column='1'/>
+      <parameter type-id='type-id-8' name='last' filepath='Python/fileutils.c' line='2393' column='1'/>
       <return type-id='type-id-69'/>
     </function-decl>
-    <class-decl name='lconv' size-in-bits='768' is-struct='yes' visibility='default' filepath='/usr/include/locale.h' line='51' column='1' id='type-id-836'>
+    <class-decl name='lconv' size-in-bits='768' is-struct='yes' visibility='default' filepath='/usr/include/locale.h' line='51' column='1' id='type-id-839'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='decimal_point' type-id='type-id-72' visibility='default' filepath='/usr/include/locale.h' line='55' column='1'/>
       </data-member>
@@ -15040,230 +15155,230 @@
         <var-decl name='int_n_sign_posn' type-id='type-id-1' visibility='default' filepath='/usr/include/locale.h' line='109' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-836' size-in-bits='64' id='type-id-837'/>
-    <function-decl name='_Py_GetLocaleconvNumeric' mangled-name='_Py_GetLocaleconvNumeric' filepath='Python/fileutils.c' line='2265' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetLocaleconvNumeric'>
-      <parameter type-id='type-id-837' name='lc' filepath='Python/fileutils.c' line='2265' column='1'/>
-      <parameter type-id='type-id-86' name='decimal_point' filepath='Python/fileutils.c' line='2266' column='1'/>
-      <parameter type-id='type-id-86' name='thousands_sep' filepath='Python/fileutils.c' line='2266' column='1'/>
+    <pointer-type-def type-id='type-id-839' size-in-bits='64' id='type-id-840'/>
+    <function-decl name='_Py_GetLocaleconvNumeric' mangled-name='_Py_GetLocaleconvNumeric' filepath='Python/fileutils.c' line='2277' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetLocaleconvNumeric'>
+      <parameter type-id='type-id-840' name='lc' filepath='Python/fileutils.c' line='2277' column='1'/>
+      <parameter type-id='type-id-86' name='decimal_point' filepath='Python/fileutils.c' line='2278' column='1'/>
+      <parameter type-id='type-id-86' name='thousands_sep' filepath='Python/fileutils.c' line='2278' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_set_blocking' mangled-name='_Py_set_blocking' filepath='Python/fileutils.c' line='2188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_set_blocking'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='2188' column='1'/>
-      <parameter type-id='type-id-8' name='blocking' filepath='Python/fileutils.c' line='2188' column='1'/>
+    <function-decl name='_Py_set_blocking' mangled-name='_Py_set_blocking' filepath='Python/fileutils.c' line='2200' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_set_blocking'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='2200' column='1'/>
+      <parameter type-id='type-id-8' name='blocking' filepath='Python/fileutils.c' line='2200' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_get_blocking' mangled-name='_Py_get_blocking' filepath='Python/fileutils.c' line='2167' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_get_blocking'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='2167' column='1'/>
+    <function-decl name='_Py_get_blocking' mangled-name='_Py_get_blocking' filepath='Python/fileutils.c' line='2179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_get_blocking'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='2179' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_dup' mangled-name='_Py_dup' filepath='Python/fileutils.c' line='2101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_dup'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='2101' column='1'/>
+    <function-decl name='_Py_dup' mangled-name='_Py_dup' filepath='Python/fileutils.c' line='2113' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_dup'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='2113' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_wgetcwd' mangled-name='_Py_wgetcwd' filepath='Python/fileutils.c' line='2069' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wgetcwd'>
-      <parameter type-id='type-id-325' name='buf' filepath='Python/fileutils.c' line='2069' column='1'/>
-      <parameter type-id='type-id-157' name='buflen' filepath='Python/fileutils.c' line='2069' column='1'/>
+    <function-decl name='_Py_wgetcwd' mangled-name='_Py_wgetcwd' filepath='Python/fileutils.c' line='2081' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wgetcwd'>
+      <parameter type-id='type-id-325' name='buf' filepath='Python/fileutils.c' line='2081' column='1'/>
+      <parameter type-id='type-id-157' name='buflen' filepath='Python/fileutils.c' line='2081' column='1'/>
       <return type-id='type-id-325'/>
     </function-decl>
-    <function-decl name='_Py_abspath' mangled-name='_Py_abspath' filepath='Python/fileutils.c' line='1982' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_abspath'>
-      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1982' column='1'/>
-      <parameter type-id='type-id-329' name='abspath_p' filepath='Python/fileutils.c' line='1982' column='1'/>
+    <function-decl name='_Py_abspath' mangled-name='_Py_abspath' filepath='Python/fileutils.c' line='1994' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_abspath'>
+      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1994' column='1'/>
+      <parameter type-id='type-id-329' name='abspath_p' filepath='Python/fileutils.c' line='1994' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_isabs' mangled-name='_Py_isabs' filepath='Python/fileutils.c' line='1969' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_isabs'>
-      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1969' column='1'/>
+    <function-decl name='_Py_isabs' mangled-name='_Py_isabs' filepath='Python/fileutils.c' line='1981' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_isabs'>
+      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1981' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_wrealpath' mangled-name='_Py_wrealpath' filepath='Python/fileutils.c' line='1931' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wrealpath'>
-      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1931' column='1'/>
-      <parameter type-id='type-id-325' name='resolved_path' filepath='Python/fileutils.c' line='1932' column='1'/>
-      <parameter type-id='type-id-157' name='resolved_path_len' filepath='Python/fileutils.c' line='1932' column='1'/>
+    <function-decl name='_Py_wrealpath' mangled-name='_Py_wrealpath' filepath='Python/fileutils.c' line='1943' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wrealpath'>
+      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1943' column='1'/>
+      <parameter type-id='type-id-325' name='resolved_path' filepath='Python/fileutils.c' line='1944' column='1'/>
+      <parameter type-id='type-id-157' name='resolved_path_len' filepath='Python/fileutils.c' line='1944' column='1'/>
       <return type-id='type-id-325'/>
     </function-decl>
-    <function-decl name='_Py_wreadlink' mangled-name='_Py_wreadlink' filepath='Python/fileutils.c' line='1882' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wreadlink'>
-      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1882' column='1'/>
-      <parameter type-id='type-id-325' name='buf' filepath='Python/fileutils.c' line='1882' column='1'/>
-      <parameter type-id='type-id-157' name='buflen' filepath='Python/fileutils.c' line='1882' column='1'/>
+    <function-decl name='_Py_wreadlink' mangled-name='_Py_wreadlink' filepath='Python/fileutils.c' line='1894' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wreadlink'>
+      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1894' column='1'/>
+      <parameter type-id='type-id-325' name='buf' filepath='Python/fileutils.c' line='1894' column='1'/>
+      <parameter type-id='type-id-157' name='buflen' filepath='Python/fileutils.c' line='1894' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_write_noraise' mangled-name='_Py_write_noraise' filepath='Python/fileutils.c' line='1869' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_write_noraise'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1869' column='1'/>
-      <parameter type-id='type-id-20' name='buf' filepath='Python/fileutils.c' line='1869' column='1'/>
-      <parameter type-id='type-id-157' name='count' filepath='Python/fileutils.c' line='1869' column='1'/>
+    <function-decl name='_Py_write_noraise' mangled-name='_Py_write_noraise' filepath='Python/fileutils.c' line='1881' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_write_noraise'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1881' column='1'/>
+      <parameter type-id='type-id-20' name='buf' filepath='Python/fileutils.c' line='1881' column='1'/>
+      <parameter type-id='type-id-157' name='count' filepath='Python/fileutils.c' line='1881' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='_Py_write' mangled-name='_Py_write' filepath='Python/fileutils.c' line='1849' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_write'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1869' column='1'/>
-      <parameter type-id='type-id-20' name='buf' filepath='Python/fileutils.c' line='1869' column='1'/>
-      <parameter type-id='type-id-157' name='count' filepath='Python/fileutils.c' line='1869' column='1'/>
+    <function-decl name='_Py_write' mangled-name='_Py_write' filepath='Python/fileutils.c' line='1861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_write'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1881' column='1'/>
+      <parameter type-id='type-id-20' name='buf' filepath='Python/fileutils.c' line='1881' column='1'/>
+      <parameter type-id='type-id-157' name='count' filepath='Python/fileutils.c' line='1881' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='_Py_read' mangled-name='_Py_read' filepath='Python/fileutils.c' line='1720' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_read'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1720' column='1'/>
-      <parameter type-id='type-id-20' name='buf' filepath='Python/fileutils.c' line='1720' column='1'/>
-      <parameter type-id='type-id-157' name='count' filepath='Python/fileutils.c' line='1720' column='1'/>
+    <function-decl name='_Py_read' mangled-name='_Py_read' filepath='Python/fileutils.c' line='1722' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_read'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1722' column='1'/>
+      <parameter type-id='type-id-20' name='buf' filepath='Python/fileutils.c' line='1722' column='1'/>
+      <parameter type-id='type-id-157' name='count' filepath='Python/fileutils.c' line='1722' column='1'/>
       <return type-id='type-id-30'/>
     </function-decl>
-    <function-decl name='_Py_fopen_obj' mangled-name='_Py_fopen_obj' filepath='Python/fileutils.c' line='1621' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fopen_obj'>
-      <parameter type-id='type-id-15' name='path' filepath='Python/fileutils.c' line='1621' column='1'/>
-      <parameter type-id='type-id-3' name='mode' filepath='Python/fileutils.c' line='1621' column='1'/>
+    <function-decl name='_Py_fopen_obj' mangled-name='_Py_fopen_obj' filepath='Python/fileutils.c' line='1623' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fopen_obj'>
+      <parameter type-id='type-id-15' name='path' filepath='Python/fileutils.c' line='1623' column='1'/>
+      <parameter type-id='type-id-3' name='mode' filepath='Python/fileutils.c' line='1623' column='1'/>
       <return type-id='type-id-188'/>
     </function-decl>
-    <function-decl name='_Py_wfopen' mangled-name='_Py_wfopen' filepath='Python/fileutils.c' line='1573' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wfopen'>
-      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1573' column='1'/>
-      <parameter type-id='type-id-478' name='mode' filepath='Python/fileutils.c' line='1573' column='1'/>
+    <function-decl name='_Py_wfopen' mangled-name='_Py_wfopen' filepath='Python/fileutils.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_wfopen'>
+      <parameter type-id='type-id-478' name='path' filepath='Python/fileutils.c' line='1575' column='1'/>
+      <parameter type-id='type-id-478' name='mode' filepath='Python/fileutils.c' line='1575' column='1'/>
       <return type-id='type-id-188'/>
     </function-decl>
-    <function-decl name='_Py_open_noraise' mangled-name='_Py_open_noraise' filepath='Python/fileutils.c' line='1561' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_open_noraise'>
-      <parameter type-id='type-id-3' name='pathname' filepath='Python/fileutils.c' line='1561' column='1'/>
-      <parameter type-id='type-id-8' name='flags' filepath='Python/fileutils.c' line='1561' column='1'/>
+    <function-decl name='_Py_open_noraise' mangled-name='_Py_open_noraise' filepath='Python/fileutils.c' line='1563' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_open_noraise'>
+      <parameter type-id='type-id-3' name='pathname' filepath='Python/fileutils.c' line='1563' column='1'/>
+      <parameter type-id='type-id-8' name='flags' filepath='Python/fileutils.c' line='1563' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_open' mangled-name='_Py_open' filepath='Python/fileutils.c' line='1547' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_open'>
-      <parameter type-id='type-id-3' name='pathname' filepath='Python/fileutils.c' line='1561' column='1'/>
-      <parameter type-id='type-id-8' name='flags' filepath='Python/fileutils.c' line='1561' column='1'/>
+    <function-decl name='_Py_open' mangled-name='_Py_open' filepath='Python/fileutils.c' line='1549' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_open'>
+      <parameter type-id='type-id-3' name='pathname' filepath='Python/fileutils.c' line='1563' column='1'/>
+      <parameter type-id='type-id-8' name='flags' filepath='Python/fileutils.c' line='1563' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_set_inheritable_async_safe' mangled-name='_Py_set_inheritable_async_safe' filepath='Python/fileutils.c' line='1470' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_set_inheritable_async_safe'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1470' column='1'/>
-      <parameter type-id='type-id-8' name='inheritable' filepath='Python/fileutils.c' line='1470' column='1'/>
-      <parameter type-id='type-id-452' name='atomic_flag_works' filepath='Python/fileutils.c' line='1470' column='1'/>
+    <function-decl name='_Py_set_inheritable_async_safe' mangled-name='_Py_set_inheritable_async_safe' filepath='Python/fileutils.c' line='1472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_set_inheritable_async_safe'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1472' column='1'/>
+      <parameter type-id='type-id-8' name='inheritable' filepath='Python/fileutils.c' line='1472' column='1'/>
+      <parameter type-id='type-id-452' name='atomic_flag_works' filepath='Python/fileutils.c' line='1472' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_set_inheritable' mangled-name='_Py_set_inheritable' filepath='Python/fileutils.c' line='1461' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_set_inheritable'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1470' column='1'/>
-      <parameter type-id='type-id-8' name='inheritable' filepath='Python/fileutils.c' line='1470' column='1'/>
-      <parameter type-id='type-id-452' name='atomic_flag_works' filepath='Python/fileutils.c' line='1470' column='1'/>
+    <function-decl name='_Py_set_inheritable' mangled-name='_Py_set_inheritable' filepath='Python/fileutils.c' line='1463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_set_inheritable'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1472' column='1'/>
+      <parameter type-id='type-id-8' name='inheritable' filepath='Python/fileutils.c' line='1472' column='1'/>
+      <parameter type-id='type-id-452' name='atomic_flag_works' filepath='Python/fileutils.c' line='1472' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_get_inheritable' mangled-name='_Py_get_inheritable' filepath='Python/fileutils.c' line='1295' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_get_inheritable'>
+    <function-decl name='_Py_get_inheritable' mangled-name='_Py_get_inheritable' filepath='Python/fileutils.c' line='1297' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_get_inheritable'>
       <parameter type-id='type-id-8' name='c1' filepath='Parser/token.c' line='79' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <class-decl name='stat' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='46' column='1' id='type-id-838'>
+    <class-decl name='stat' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='46' column='1' id='type-id-841'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='st_dev' type-id='type-id-839' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='48' column='1'/>
+        <var-decl name='st_dev' type-id='type-id-842' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='48' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='st_ino' type-id='type-id-840' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='53' column='1'/>
+        <var-decl name='st_ino' type-id='type-id-843' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='st_nlink' type-id='type-id-841' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='61' column='1'/>
+        <var-decl name='st_nlink' type-id='type-id-844' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='61' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='st_mode' type-id='type-id-842' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='62' column='1'/>
+        <var-decl name='st_mode' type-id='type-id-845' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='62' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='st_uid' type-id='type-id-843' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='64' column='1'/>
+        <var-decl name='st_uid' type-id='type-id-846' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='64' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='st_gid' type-id='type-id-844' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='65' column='1'/>
+        <var-decl name='st_gid' type-id='type-id-847' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='__pad0' type-id='type-id-8' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='67' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='st_rdev' type-id='type-id-839' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='69' column='1'/>
+        <var-decl name='st_rdev' type-id='type-id-842' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='69' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
         <var-decl name='st_size' type-id='type-id-172' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='74' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='st_blksize' type-id='type-id-845' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='78' column='1'/>
+        <var-decl name='st_blksize' type-id='type-id-848' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='78' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='st_blocks' type-id='type-id-846' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='80' column='1'/>
+        <var-decl name='st_blocks' type-id='type-id-849' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='st_atim' type-id='type-id-807' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='91' column='1'/>
+        <var-decl name='st_atim' type-id='type-id-810' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='st_mtim' type-id='type-id-807' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='92' column='1'/>
+        <var-decl name='st_mtim' type-id='type-id-810' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='st_ctim' type-id='type-id-807' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='93' column='1'/>
+        <var-decl name='st_ctim' type-id='type-id-810' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='__glibc_reserved' type-id='type-id-847' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='106' column='1'/>
+        <var-decl name='__glibc_reserved' type-id='type-id-850' visibility='default' filepath='/usr/include/x86_64-linux-gnu/bits/stat.h' line='106' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__dev_t' type-id='type-id-18' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='145' column='1' id='type-id-839'/>
-    <typedef-decl name='__ino_t' type-id='type-id-18' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='148' column='1' id='type-id-840'/>
-    <typedef-decl name='__nlink_t' type-id='type-id-18' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-841'/>
-    <typedef-decl name='__mode_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-842'/>
-    <typedef-decl name='__uid_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='146' column='1' id='type-id-843'/>
-    <typedef-decl name='__gid_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='147' column='1' id='type-id-844'/>
-    <typedef-decl name='__blksize_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='174' column='1' id='type-id-845'/>
-    <typedef-decl name='__blkcnt_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='179' column='1' id='type-id-846'/>
+    <typedef-decl name='__dev_t' type-id='type-id-18' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='145' column='1' id='type-id-842'/>
+    <typedef-decl name='__ino_t' type-id='type-id-18' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='148' column='1' id='type-id-843'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-18' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='151' column='1' id='type-id-844'/>
+    <typedef-decl name='__mode_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='150' column='1' id='type-id-845'/>
+    <typedef-decl name='__uid_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='146' column='1' id='type-id-846'/>
+    <typedef-decl name='__gid_t' type-id='type-id-65' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='147' column='1' id='type-id-847'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='174' column='1' id='type-id-848'/>
+    <typedef-decl name='__blkcnt_t' type-id='type-id-32' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='179' column='1' id='type-id-849'/>
 
-    <array-type-def dimensions='1' type-id='type-id-808' size-in-bits='192' id='type-id-847'>
+    <array-type-def dimensions='1' type-id='type-id-811' size-in-bits='192' id='type-id-850'>
       <subrange length='3' type-id='type-id-18' id='type-id-322'/>
 
     </array-type-def>
-    <pointer-type-def type-id='type-id-838' size-in-bits='64' id='type-id-848'/>
-    <function-decl name='_Py_stat' mangled-name='_Py_stat' filepath='Python/fileutils.c' line='1213' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_stat'>
-      <parameter type-id='type-id-15' name='path' filepath='Python/fileutils.c' line='1213' column='1'/>
-      <parameter type-id='type-id-848' name='statbuf' filepath='Python/fileutils.c' line='1213' column='1'/>
+    <pointer-type-def type-id='type-id-841' size-in-bits='64' id='type-id-851'/>
+    <function-decl name='_Py_stat' mangled-name='_Py_stat' filepath='Python/fileutils.c' line='1215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_stat'>
+      <parameter type-id='type-id-15' name='path' filepath='Python/fileutils.c' line='1215' column='1'/>
+      <parameter type-id='type-id-851' name='statbuf' filepath='Python/fileutils.c' line='1215' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_fstat' mangled-name='_Py_fstat' filepath='Python/fileutils.c' line='1185' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fstat'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1185' column='1'/>
-      <parameter type-id='type-id-848' name='status' filepath='Python/fileutils.c' line='1185' column='1'/>
+    <function-decl name='_Py_fstat' mangled-name='_Py_fstat' filepath='Python/fileutils.c' line='1187' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fstat'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1187' column='1'/>
+      <parameter type-id='type-id-851' name='status' filepath='Python/fileutils.c' line='1187' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_fstat_noraise' mangled-name='_Py_fstat_noraise' filepath='Python/fileutils.c' line='1118' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fstat_noraise'>
-      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1118' column='1'/>
-      <parameter type-id='type-id-848' name='status' filepath='Python/fileutils.c' line='1118' column='1'/>
+    <function-decl name='_Py_fstat_noraise' mangled-name='_Py_fstat_noraise' filepath='Python/fileutils.c' line='1120' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_fstat_noraise'>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='1120' column='1'/>
+      <parameter type-id='type-id-851' name='status' filepath='Python/fileutils.c' line='1120' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_GetLocaleEncodingObject' mangled-name='_Py_GetLocaleEncodingObject' filepath='Python/fileutils.c' line='922' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetLocaleEncodingObject'>
+    <function-decl name='_Py_GetLocaleEncodingObject' mangled-name='_Py_GetLocaleEncodingObject' filepath='Python/fileutils.c' line='924' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetLocaleEncodingObject'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_Py_GetLocaleEncoding' mangled-name='_Py_GetLocaleEncoding' filepath='Python/fileutils.c' line='882' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetLocaleEncoding'>
+    <function-decl name='_Py_GetLocaleEncoding' mangled-name='_Py_GetLocaleEncoding' filepath='Python/fileutils.c' line='884' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetLocaleEncoding'>
       <return type-id='type-id-325'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-849'/>
-    <function-decl name='_Py_EncodeLocaleEx' mangled-name='_Py_EncodeLocaleEx' filepath='Python/fileutils.c' line='861' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_EncodeLocaleEx'>
-      <parameter type-id='type-id-478' name='text' filepath='Python/fileutils.c' line='861' column='1'/>
-      <parameter type-id='type-id-215' name='str' filepath='Python/fileutils.c' line='861' column='1'/>
-      <parameter type-id='type-id-849' name='error_pos' filepath='Python/fileutils.c' line='862' column='1'/>
-      <parameter type-id='type-id-198' name='reason' filepath='Python/fileutils.c' line='862' column='1'/>
-      <parameter type-id='type-id-8' name='current_locale' filepath='Python/fileutils.c' line='863' column='1'/>
-      <parameter type-id='type-id-366' name='errors' filepath='Python/fileutils.c' line='863' column='1'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='64' id='type-id-852'/>
+    <function-decl name='_Py_EncodeLocaleEx' mangled-name='_Py_EncodeLocaleEx' filepath='Python/fileutils.c' line='863' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_EncodeLocaleEx'>
+      <parameter type-id='type-id-478' name='text' filepath='Python/fileutils.c' line='863' column='1'/>
+      <parameter type-id='type-id-215' name='str' filepath='Python/fileutils.c' line='863' column='1'/>
+      <parameter type-id='type-id-852' name='error_pos' filepath='Python/fileutils.c' line='864' column='1'/>
+      <parameter type-id='type-id-198' name='reason' filepath='Python/fileutils.c' line='864' column='1'/>
+      <parameter type-id='type-id-8' name='current_locale' filepath='Python/fileutils.c' line='865' column='1'/>
+      <parameter type-id='type-id-366' name='errors' filepath='Python/fileutils.c' line='865' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_EncodeLocaleRaw' mangled-name='_Py_EncodeLocaleRaw' filepath='Python/fileutils.c' line='854' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_EncodeLocaleRaw'>
-      <parameter type-id='type-id-478' name='text' filepath='Python/fileutils.c' line='854' column='1'/>
-      <parameter type-id='type-id-849' name='error_pos' filepath='Python/fileutils.c' line='854' column='1'/>
+    <function-decl name='_Py_EncodeLocaleRaw' mangled-name='_Py_EncodeLocaleRaw' filepath='Python/fileutils.c' line='856' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_EncodeLocaleRaw'>
+      <parameter type-id='type-id-478' name='text' filepath='Python/fileutils.c' line='856' column='1'/>
+      <parameter type-id='type-id-852' name='error_pos' filepath='Python/fileutils.c' line='856' column='1'/>
       <return type-id='type-id-72'/>
     </function-decl>
-    <function-decl name='Py_EncodeLocale' mangled-name='Py_EncodeLocale' filepath='Python/fileutils.c' line='845' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EncodeLocale'>
-      <parameter type-id='type-id-478' name='text' filepath='Python/fileutils.c' line='854' column='1'/>
-      <parameter type-id='type-id-849' name='error_pos' filepath='Python/fileutils.c' line='854' column='1'/>
+    <function-decl name='Py_EncodeLocale' mangled-name='Py_EncodeLocale' filepath='Python/fileutils.c' line='847' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_EncodeLocale'>
+      <parameter type-id='type-id-478' name='text' filepath='Python/fileutils.c' line='856' column='1'/>
+      <parameter type-id='type-id-852' name='error_pos' filepath='Python/fileutils.c' line='856' column='1'/>
       <return type-id='type-id-72'/>
     </function-decl>
-    <function-decl name='Py_DecodeLocale' mangled-name='Py_DecodeLocale' filepath='Python/fileutils.c' line='643' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_DecodeLocale'>
-      <parameter type-id='type-id-3' name='arg' filepath='Python/fileutils.c' line='643' column='1'/>
-      <parameter type-id='type-id-849' name='wlen' filepath='Python/fileutils.c' line='643' column='1'/>
+    <function-decl name='Py_DecodeLocale' mangled-name='Py_DecodeLocale' filepath='Python/fileutils.c' line='645' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_DecodeLocale'>
+      <parameter type-id='type-id-3' name='arg' filepath='Python/fileutils.c' line='645' column='1'/>
+      <parameter type-id='type-id-852' name='wlen' filepath='Python/fileutils.c' line='645' column='1'/>
       <return type-id='type-id-325'/>
     </function-decl>
-    <function-decl name='_Py_DecodeLocaleEx' mangled-name='_Py_DecodeLocaleEx' filepath='Python/fileutils.c' line='581' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_DecodeLocaleEx'>
-      <parameter type-id='type-id-3' name='arg' filepath='Python/fileutils.c' line='581' column='1'/>
-      <parameter type-id='type-id-329' name='wstr' filepath='Python/fileutils.c' line='581' column='1'/>
-      <parameter type-id='type-id-849' name='wlen' filepath='Python/fileutils.c' line='581' column='1'/>
-      <parameter type-id='type-id-198' name='reason' filepath='Python/fileutils.c' line='582' column='1'/>
-      <parameter type-id='type-id-8' name='current_locale' filepath='Python/fileutils.c' line='583' column='1'/>
-      <parameter type-id='type-id-366' name='errors' filepath='Python/fileutils.c' line='583' column='1'/>
+    <function-decl name='_Py_DecodeLocaleEx' mangled-name='_Py_DecodeLocaleEx' filepath='Python/fileutils.c' line='583' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_DecodeLocaleEx'>
+      <parameter type-id='type-id-3' name='arg' filepath='Python/fileutils.c' line='583' column='1'/>
+      <parameter type-id='type-id-329' name='wstr' filepath='Python/fileutils.c' line='583' column='1'/>
+      <parameter type-id='type-id-852' name='wlen' filepath='Python/fileutils.c' line='583' column='1'/>
+      <parameter type-id='type-id-198' name='reason' filepath='Python/fileutils.c' line='584' column='1'/>
+      <parameter type-id='type-id-8' name='current_locale' filepath='Python/fileutils.c' line='585' column='1'/>
+      <parameter type-id='type-id-366' name='errors' filepath='Python/fileutils.c' line='585' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <function-decl name='_Py_ResetForceASCII' mangled-name='_Py_ResetForceASCII' filepath='Python/fileutils.c' line='300' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ResetForceASCII'>
+    <function-decl name='_Py_ResetForceASCII' mangled-name='_Py_ResetForceASCII' filepath='Python/fileutils.c' line='302' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_ResetForceASCII'>
       <return type-id='type-id-69'/>
     </function-decl>
-    <function-decl name='_Py_GetForceASCII' mangled-name='_Py_GetForceASCII' filepath='Python/fileutils.c' line='290' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetForceASCII'>
+    <function-decl name='_Py_GetForceASCII' mangled-name='_Py_GetForceASCII' filepath='Python/fileutils.c' line='292' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_GetForceASCII'>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_Py_device_encoding' mangled-name='_Py_device_encoding' filepath='Python/fileutils.c' line='67' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_device_encoding'>
-      <parameter type-id='type-id-8' name='fd' filepath='Objects/fileobject.c' line='329' column='1'/>
+      <parameter type-id='type-id-8' name='fd' filepath='Python/fileutils.c' line='67' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
   </abi-instr>
@@ -15277,11 +15392,11 @@
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='./Python/dynload_shlib.c' comp-dir-path='/src' language='LANG_C99'>
 
-    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='infinite' id='type-id-850'>
+    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='infinite' id='type-id-853'>
       <subrange length='infinite' id='type-id-6'/>
 
     </array-type-def>
-    <var-decl name='_PyImport_DynLoadFiletab' type-id='type-id-850' visibility='default' filepath='./Python/importdl.h' line='9' column='1'/>
+    <var-decl name='_PyImport_DynLoadFiletab' type-id='type-id-853' visibility='default' filepath='./Python/importdl.h' line='9' column='1'/>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='Modules/main.c' comp-dir-path='/src' language='LANG_C99'>
     <function-decl name='Py_BytesMain' mangled-name='Py_BytesMain' filepath='Modules/main.c' line='713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='Py_BytesMain'>
@@ -15362,10 +15477,10 @@
     </function-decl>
   </abi-instr>
   <abi-instr version='1.0' address-size='64' path='./Modules/posixmodule.c' comp-dir-path='/src' language='LANG_C99'>
-    <function-decl name='PyInit_posix' mangled-name='PyInit_posix' filepath='./Modules/posixmodule.c' line='15815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit_posix'>
+    <function-decl name='PyInit_posix' mangled-name='PyInit_posix' filepath='./Modules/posixmodule.c' line='15817' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyInit_posix'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='PyOS_FSPath' mangled-name='PyOS_FSPath' filepath='./Modules/posixmodule.c' line='14351' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_FSPath'>
+    <function-decl name='PyOS_FSPath' mangled-name='PyOS_FSPath' filepath='./Modules/posixmodule.c' line='14353' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_FSPath'>
       <parameter type-id='type-id-15' name='v' filepath='Objects/abstract.c' line='2129' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
@@ -15374,26 +15489,26 @@
       <parameter type-id='type-id-20' name='addr' filepath='./Modules/posixmodule.c' line='1501' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <typedef-decl name='gid_t' type-id='type-id-844' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='64' column='1' id='type-id-851'/>
-    <pointer-type-def type-id='type-id-851' size-in-bits='64' id='type-id-852'/>
+    <typedef-decl name='gid_t' type-id='type-id-847' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='64' column='1' id='type-id-854'/>
+    <pointer-type-def type-id='type-id-854' size-in-bits='64' id='type-id-855'/>
     <function-decl name='_Py_Gid_Converter' mangled-name='_Py_Gid_Converter' filepath='./Modules/posixmodule.c' line='789' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Gid_Converter'>
       <parameter type-id='type-id-15' name='obj' filepath='./Modules/posixmodule.c' line='789' column='1'/>
-      <parameter type-id='type-id-852' name='p' filepath='./Modules/posixmodule.c' line='789' column='1'/>
+      <parameter type-id='type-id-855' name='p' filepath='./Modules/posixmodule.c' line='789' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
-    <typedef-decl name='uid_t' type-id='type-id-843' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='79' column='1' id='type-id-853'/>
-    <pointer-type-def type-id='type-id-853' size-in-bits='64' id='type-id-854'/>
+    <typedef-decl name='uid_t' type-id='type-id-846' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='79' column='1' id='type-id-856'/>
+    <pointer-type-def type-id='type-id-856' size-in-bits='64' id='type-id-857'/>
     <function-decl name='_Py_Uid_Converter' mangled-name='_Py_Uid_Converter' filepath='./Modules/posixmodule.c' line='683' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_Uid_Converter'>
       <parameter type-id='type-id-15' name='obj' filepath='./Modules/posixmodule.c' line='683' column='1'/>
-      <parameter type-id='type-id-854' name='p' filepath='./Modules/posixmodule.c' line='683' column='1'/>
+      <parameter type-id='type-id-857' name='p' filepath='./Modules/posixmodule.c' line='683' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyLong_FromGid' mangled-name='_PyLong_FromGid' filepath='./Modules/posixmodule.c' line='675' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromGid'>
-      <parameter type-id='type-id-851' name='gid' filepath='./Modules/posixmodule.c' line='675' column='1'/>
+      <parameter type-id='type-id-854' name='gid' filepath='./Modules/posixmodule.c' line='675' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='_PyLong_FromUid' mangled-name='_PyLong_FromUid' filepath='./Modules/posixmodule.c' line='667' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyLong_FromUid'>
-      <parameter type-id='type-id-853' name='uid' filepath='./Modules/posixmodule.c' line='667' column='1'/>
+      <parameter type-id='type-id-856' name='uid' filepath='./Modules/posixmodule.c' line='667' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='PyOS_AfterFork' mangled-name='PyOS_AfterFork' filepath='./Modules/posixmodule.c' line='649' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_AfterFork'>
@@ -15471,111 +15586,8 @@
     <function-decl name='PyOS_InterruptOccurred' mangled-name='PyOS_InterruptOccurred' filepath='./Modules/signalmodule.c' line='1994' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyOS_InterruptOccurred'>
       <return type-id='type-id-8'/>
     </function-decl>
-    <class-decl name='_ts' size-in-bits='2240' is-struct='yes' visibility='default' filepath='./Include/cpython/pystate.h' line='62' column='1' id='type-id-855'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='prev' type-id='type-id-10' visibility='default' filepath='./Include/cpython/pystate.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='next' type-id='type-id-10' visibility='default' filepath='./Include/cpython/pystate.h' line='66' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='interp' type-id='type-id-222' visibility='default' filepath='./Include/cpython/pystate.h' line='67' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='frame' type-id='type-id-12' visibility='default' filepath='./Include/cpython/pystate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='recursion_depth' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='71' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='recursion_headroom' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='72' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='stackcheck_counter' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='73' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='tracing' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='78' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='cframe' type-id='type-id-13' visibility='default' filepath='./Include/cpython/pystate.h' line='82' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='c_profilefunc' type-id='type-id-14' visibility='default' filepath='./Include/cpython/pystate.h' line='84' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='c_tracefunc' type-id='type-id-14' visibility='default' filepath='./Include/cpython/pystate.h' line='85' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='c_profileobj' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='86' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='c_traceobj' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='curexc_type' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='90' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='curexc_value' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='curexc_traceback' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='exc_state' type-id='type-id-16' visibility='default' filepath='./Include/cpython/pystate.h' line='97' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='exc_info' type-id='type-id-17' visibility='default' filepath='./Include/cpython/pystate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='dict' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='gilstate_counter' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='105' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='async_exc' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='thread_id' type-id='type-id-18' visibility='default' filepath='./Include/cpython/pystate.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='trash_delete_nesting' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='trash_delete_later' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='on_delete' type-id='type-id-19' visibility='default' filepath='./Include/cpython/pystate.h' line='136' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='on_delete_data' type-id='type-id-20' visibility='default' filepath='./Include/cpython/pystate.h' line='137' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1728'>
-        <var-decl name='coroutine_origin_tracking_depth' type-id='type-id-8' visibility='default' filepath='./Include/cpython/pystate.h' line='139' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1792'>
-        <var-decl name='async_gen_firstiter' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='141' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1856'>
-        <var-decl name='async_gen_finalizer' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='142' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1920'>
-        <var-decl name='context' type-id='type-id-15' visibility='default' filepath='./Include/cpython/pystate.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1984'>
-        <var-decl name='context_ver' type-id='type-id-21' visibility='default' filepath='./Include/cpython/pystate.h' line='145' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='id' type-id='type-id-21' visibility='default' filepath='./Include/cpython/pystate.h' line='148' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='2112'>
-        <var-decl name='root_cframe' type-id='type-id-22' visibility='default' filepath='./Include/cpython/pystate.h' line='150' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='PyThreadState' type-id='type-id-855' filepath='./Include/pystate.h' line='20' column='1' id='type-id-856'/>
-    <pointer-type-def type-id='type-id-856' size-in-bits='64' id='type-id-857'/>
     <function-decl name='_PyOS_InterruptOccurred' mangled-name='_PyOS_InterruptOccurred' filepath='./Modules/signalmodule.c' line='1976' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyOS_InterruptOccurred'>
-      <parameter type-id='type-id-857' name='tstate' filepath='./Modules/signalmodule.c' line='1976' column='1'/>
+      <parameter type-id='type-id-703' name='tstate' filepath='./Modules/signalmodule.c' line='1976' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_Py_RestoreSignals' mangled-name='_Py_RestoreSignals' filepath='./Modules/signalmodule.c' line='1914' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Py_RestoreSignals'>
@@ -15592,7 +15604,7 @@
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='_PyErr_CheckSignalsTstate' mangled-name='_PyErr_CheckSignalsTstate' filepath='./Modules/signalmodule.c' line='1767' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_PyErr_CheckSignalsTstate'>
-      <parameter type-id='type-id-857' name='tstate' filepath='./Modules/signalmodule.c' line='1767' column='1'/>
+      <parameter type-id='type-id-703' name='tstate' filepath='./Modules/signalmodule.c' line='1767' column='1'/>
       <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='PyErr_CheckSignals' mangled-name='PyErr_CheckSignals' filepath='./Modules/signalmodule.c' line='1754' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='PyErr_CheckSignals'>

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -76,6 +76,7 @@ struct _ts {
        This is to prevent the actual trace/profile code from being recorded in
        the trace/profile. */
     int tracing;
+    int use_tracing;
 
     /* Pointer to current CFrame in the C stack frame of the currently,
      * or most recently, executing _PyEval_EvalFrameDefault. */

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -76,7 +76,6 @@ struct _ts {
        This is to prevent the actual trace/profile code from being recorded in
        the trace/profile. */
     int tracing;
-    int use_tracing;
 
     /* Pointer to current CFrame in the C stack frame of the currently,
      * or most recently, executing _PyEval_EvalFrameDefault. */
@@ -149,6 +148,7 @@ struct _ts {
     uint64_t id;
 
     CFrame root_cframe;
+    int use_tracing;
 
     /* XXX signal handlers should also be here */
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5476,7 +5476,7 @@ call_trace(Py_tracefunc func, PyObject *obj,
     if (tstate->tracing)
         return 0;
     tstate->tracing++;
-    tstate->cframe->use_tracing = 0;
+    tstate->use_tracing = tstate->cframe->use_tracing = 0;
     if (frame->f_lasti < 0) {
         frame->f_lineno = frame->f_code->co_firstlineno;
     }
@@ -5486,8 +5486,8 @@ call_trace(Py_tracefunc func, PyObject *obj,
     }
     result = func(obj, frame, what, arg);
     frame->f_lineno = 0;
-    tstate->cframe->use_tracing = ((tstate->c_tracefunc != NULL)
-                           || (tstate->c_profilefunc != NULL));
+    tstate->use_tracing = tstate->cframe->use_tracing =
+        ((tstate->c_tracefunc != NULL) || (tstate->c_profilefunc != NULL));
     tstate->tracing--;
     return result;
 }
@@ -5501,11 +5501,11 @@ _PyEval_CallTracing(PyObject *func, PyObject *args)
     PyObject *result;
 
     tstate->tracing = 0;
-    tstate->cframe->use_tracing = ((tstate->c_tracefunc != NULL)
-                           || (tstate->c_profilefunc != NULL));
+    tstate->use_tracing = tstate->cframe->use_tracing =
+        ((tstate->c_tracefunc != NULL) || (tstate->c_profilefunc != NULL));
     result = PyObject_Call(func, args, NULL);
     tstate->tracing = save_tracing;
-    tstate->cframe->use_tracing = save_use_tracing;
+    tstate->use_tracing = tstate->cframe->use_tracing = save_use_tracing;
     return result;
 }
 
@@ -5556,7 +5556,8 @@ _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
     tstate->c_profilefunc = NULL;
     tstate->c_profileobj = NULL;
     /* Must make sure that tracing is not ignored if 'profileobj' is freed */
-    tstate->cframe->use_tracing = tstate->c_tracefunc != NULL;
+    tstate->use_tracing = tstate->cframe->use_tracing =
+        tstate->c_tracefunc != NULL;
     Py_XDECREF(profileobj);
 
     Py_XINCREF(arg);
@@ -5564,7 +5565,8 @@ _PyEval_SetProfile(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
     tstate->c_profilefunc = func;
 
     /* Flag that tracing or profiling is turned on */
-    tstate->cframe->use_tracing = (func != NULL) || (tstate->c_tracefunc != NULL);
+    tstate->use_tracing = tstate->cframe->use_tracing =
+        (func != NULL) || (tstate->c_tracefunc != NULL);
     return 0;
 }
 
@@ -5597,7 +5599,8 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
     tstate->c_tracefunc = NULL;
     tstate->c_traceobj = NULL;
     /* Must make sure that profiling is not ignored if 'traceobj' is freed */
-    tstate->cframe->use_tracing = (tstate->c_profilefunc != NULL);
+    tstate->use_tracing = tstate->cframe->use_tracing =
+        (tstate->c_profilefunc != NULL);
     Py_XDECREF(traceobj);
 
     Py_XINCREF(arg);
@@ -5605,8 +5608,8 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
     tstate->c_tracefunc = func;
 
     /* Flag that tracing or profiling is turned on */
-    tstate->cframe->use_tracing = ((func != NULL)
-                           || (tstate->c_profilefunc != NULL));
+    tstate->use_tracing = tstate->cframe->use_tracing =
+        ((func != NULL) || (tstate->c_profilefunc != NULL));
 
     return 0;
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -623,6 +623,7 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->recursion_headroom = 0;
     tstate->stackcheck_counter = 0;
     tstate->tracing = 0;
+    tstate->use_tracing = 0;
     tstate->root_cframe.use_tracing = 0;
     tstate->cframe = &tstate->root_cframe;
     tstate->gilstate_counter = 0;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -253,7 +253,7 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
 
         /* Disallow tracing in hooks unless explicitly enabled */
         ts->tracing++;
-        ts->cframe->use_tracing = 0;
+        ts->use_tracing = ts->cframe->use_tracing = 0;
         while ((hook = PyIter_Next(hooks)) != NULL) {
             _Py_IDENTIFIER(__cantrace__);
             PyObject *o;
@@ -266,14 +266,15 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
                 break;
             }
             if (canTrace) {
-                ts->cframe->use_tracing = (ts->c_tracefunc || ts->c_profilefunc);
+                ts->use_tracing = ts->cframe->use_tracing =
+                    (ts->c_tracefunc || ts->c_profilefunc);
                 ts->tracing--;
             }
             PyObject* args[2] = {eventName, eventArgs};
             o = _PyObject_FastCallTstate(ts, hook, args, 2);
             if (canTrace) {
                 ts->tracing++;
-                ts->cframe->use_tracing = 0;
+                ts->use_tracing = ts->cframe->use_tracing = 0;
             }
             if (!o) {
                 break;
@@ -281,7 +282,8 @@ sys_audit_tstate(PyThreadState *ts, const char *event,
             Py_DECREF(o);
             Py_CLEAR(hook);
         }
-        ts->cframe->use_tracing = (ts->c_tracefunc || ts->c_profilefunc);
+        ts->use_tracing = ts->cframe->use_tracing =
+            (ts->c_tracefunc || ts->c_profilefunc);
         ts->tracing--;
         if (_PyErr_Occurred(ts)) {
             goto exit;


### PR DESCRIPTION
- Add tstate.use_tracing as a copy of tstate.cframe->use_tracing to minimize breakage in Cython generated modules.
- Move new field to end of struct for better binary compatibility.
- regenerate ABI file

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-43760](https://bugs.python.org/issue43760) -->
https://bugs.python.org/issue43760
<!-- /issue-number -->
