### PR TITLE
[3.10] bpo-45246: Document that sorted() only uses "<" comparisons (GH-28494)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1603,6 +1603,15 @@ are always available.  They are listed here in alphabetical order.
    compare equal --- this is helpful for sorting in multiple passes (for
    example, sort by department, then by salary grade).
 
+   The sort algorithm uses only ``<`` comparisons between items.  While
+   defining an :meth:`~object.__lt__` method will suffice for sorting,
+   :PEP:`8` recommends that all six :ref:`rich comparisons
+   <comparisons>` be implemented.  This will help avoid bugs when using
+   the same data with other ordering tools such as :func:`max` that rely
+   on a different underlying method.  Implementing all six comparisons
+   also helps avoid confusion for mixed type comparisons which can call
+   reflected the :meth:`~object.__gt__` method.
+
    For sorting examples and a brief sorting tutorial, see :ref:`sortinghowto`.
 
 .. decorator:: staticmethod


### PR DESCRIPTION
(cherry picked from commit 9a0dcc5b2e04d9c51350107734f12a1cbc0284a7)

Co-authored-by: Raymond Hettinger <rhettinger@users.noreply.github.com>


<!-- issue-number: [bpo-45246](https://bugs.python.org/issue45246) -->
https://bugs.python.org/issue45246
<!-- /issue-number -->
