### PR TITLE
bpo-45041: Restore `sqlite3` executescript behaviour for `SELECT` queries

### DIFF
--- a/Lib/sqlite3/test/test_regression.py
+++ b/Lib/sqlite3/test/test_regression.py
@@ -475,6 +475,17 @@ class RegressionTests(unittest.TestCase):
             con.execute("drop table t")
             con.commit()
 
+    def test_executescript_step_through_select(self):
+        with managed_connect(":memory:", in_mem=True) as con:
+            values = [(v,) for v in range(5)]
+            with con:
+                con.execute("create table t(t)")
+                con.executemany("insert into t values(?)", values)
+            steps = []
+            con.create_function("step", 1, lambda x: steps.append((x,)))
+            con.executescript("select step(t) from t")
+            self.assertEqual(steps, values)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -758,7 +758,7 @@ pysqlite_cursor_executescript_impl(pysqlite_Cursor *self,
                                 &tail);
         if (rc == SQLITE_OK) {
             do {
-                (void)sqlite3_step(stmt);
+                rc = sqlite3_step(stmt);
             } while (rc == SQLITE_ROW);
             rc = sqlite3_finalize(stmt);
         }


### PR DESCRIPTION
- Make sure executescript() steps through SELECT queries
- Add regression test

This regression was introduced by GH-28020.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45041](https://bugs.python.org/issue45041) -->
https://bugs.python.org/issue45041
<!-- /issue-number -->
