### PR TITLE
bpo-41203: Replace Mac OS X and OS X with macOS

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -486,7 +486,7 @@ Process-wide parameters
    (set by :c:func:`Py_SetProgramName` above) and some environment variables.
    The returned string consists of a series of directory names separated by a
    platform dependent delimiter character.  The delimiter character is ``':'``
-   on Unix and Mac OS X, ``';'`` on Windows.  The returned string points into
+   on Unix and macOS, ``';'`` on Windows.  The returned string points into
    static storage; the caller should not modify its value.  The list
    :data:`sys.path` is initialized with this value on interpreter startup; it
    can be (and usually is) modified later to change the search path for loading
@@ -518,7 +518,7 @@ Process-wide parameters
    default search path but uses the one provided instead.  This is useful if
    Python is embedded by an application that has full knowledge of the location
    of all modules.  The path components should be separated by the platform
-   dependent delimiter character, which is ``':'`` on Unix and Mac OS X, ``';'``
+   dependent delimiter character, which is ``':'`` on Unix and macOS, ``';'``
    on Windows.
 
    This also causes :data:`sys.executable` to be set to the program
@@ -561,7 +561,7 @@ Process-wide parameters
    Return the platform identifier for the current platform.  On Unix, this is
    formed from the "official" name of the operating system, converted to lower
    case, followed by the major revision number; e.g., for Solaris 2.x, which is
-   also known as SunOS 5.x, the value is ``'sunos5'``.  On Mac OS X, it is
+   also known as SunOS 5.x, the value is ``'sunos5'``.  On macOS, it is
    ``'darwin'``.  On Windows, it is ``'win'``.  The returned string points into
    static storage; the caller should not modify its value.  The value is available
    to Python code as ``sys.platform``.

--- a/Doc/distributing/index.rst
+++ b/Doc/distributing/index.rst
@@ -101,7 +101,7 @@ by invoking the ``pip`` module at the command line::
 
 .. note::
 
-   For POSIX users (including Mac OS X and Linux users), these instructions
+   For POSIX users (including macOS and Linux users), these instructions
    assume the use of a :term:`virtual environment`.
 
    For Windows users, these instructions assume that the option to

--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -373,7 +373,7 @@ This module provides the following functions.
    compiler object under Unix---if you supply a value for *compiler*, *plat* is
    ignored.
 
-   .. % Is the posix/nt only thing still true? Mac OS X seems to work, and
+   .. % Is the posix/nt only thing still true? macOS seems to work, and
    .. % returns a UnixCCompiler instance. How to document this... hmm.
 
 
@@ -1119,11 +1119,11 @@ other utility module.
 
    For non-POSIX platforms, currently just returns ``sys.platform``.
 
-   For Mac OS X systems the OS version reflects the minimal version on which
+   For macOS systems the OS version reflects the minimal version on which
    binaries will run (that is, the value of ``MACOSX_DEPLOYMENT_TARGET``
    during the build of Python), not the OS version of the current system.
 
-   For universal binary builds on Mac OS X the architecture value reflects
+   For universal binary builds on macOS the architecture value reflects
    the universal binary status instead of the architecture of the current
    processor. For 32-bit universal binaries the architecture is ``fat``,
    for 64-bit universal binaries the architecture is ``fat64``, and
@@ -1132,7 +1132,7 @@ other utility module.
    a 3-way universal build (ppc, i386, x86_64) and ``intel`` is used for
    a universal build with the i386 and x86_64 architectures
 
-   Examples of returned values on Mac OS X:
+   Examples of returned values on macOS:
 
    * ``macosx-10.3-ppc``
 

--- a/Doc/faq/gui.rst
+++ b/Doc/faq/gui.rst
@@ -23,7 +23,7 @@ install (since it comes included with most
 `binary distributions <https://www.python.org/downloads/>`_ of Python) and use.
 For more info about Tk, including pointers to the source, see the
 `Tcl/Tk home page <https://www.tcl.tk>`_.  Tcl/Tk is fully portable to the
-Mac OS X, Windows, and Unix platforms.
+macOS, Windows, and Unix platforms.
 
 Depending on what platform(s) you are aiming at, there are also several
 alternatives. A `list of cross-platform

--- a/Doc/faq/installed.rst
+++ b/Doc/faq/installed.rst
@@ -29,7 +29,7 @@ there are several possible ways it could have gotten there.
 * Some Windows machines also have Python installed.  At this writing we're aware
   of computers from Hewlett-Packard and Compaq that include Python.  Apparently
   some of HP/Compaq's administrative tools are written in Python.
-* Many Unix-compatible operating systems, such as Mac OS X and some Linux
+* Many Unix-compatible operating systems, such as macOS and some Linux
   distributions, have Python installed by default; it's included in the base
   installation.
 

--- a/Doc/install/index.rst
+++ b/Doc/install/index.rst
@@ -206,7 +206,7 @@ directory.
 If you don't choose an installation directory---i.e., if you just run ``setup.py
 install``\ ---then the :command:`install` command installs to the standard
 location for third-party Python modules.  This location varies by platform and
-by how you built/installed Python itself.  On Unix (and Mac OS X, which is also
+by how you built/installed Python itself.  On Unix (and macOS, which is also
 Unix-based), it also depends on whether the module distribution being installed
 is pure Python or contains extensions ("non-pure"):
 
@@ -236,7 +236,7 @@ Notes:
 
 :file:`{prefix}` and :file:`{exec-prefix}` stand for the directories that Python
 is installed to, and where it finds its libraries at run-time.  They are always
-the same under Windows, and very often the same under Unix and Mac OS X.  You
+the same under Windows, and very often the same under Unix and macOS.  You
 can find out what your Python installation uses for :file:`{prefix}` and
 :file:`{exec-prefix}` by running Python in interactive mode and typing a few
 simple commands. Under Unix, just type ``python`` at the shell prompt.  Under
@@ -312,7 +312,7 @@ install into it.  It is enabled with a simple option::
 Files will be installed into subdirectories of :data:`site.USER_BASE` (written
 as :file:`{userbase}` hereafter).  This scheme installs pure Python modules and
 extension modules in the same location (also known as :data:`site.USER_SITE`).
-Here are the values for UNIX, including Mac OS X:
+Here are the values for UNIX, including macOS:
 
 =============== ===========================================================
 Type of file    Installation directory
@@ -735,7 +735,7 @@ Location and names of config files
 ----------------------------------
 
 The names and locations of the configuration files vary slightly across
-platforms.  On Unix and Mac OS X, the three configuration files (in the order
+platforms.  On Unix and macOS, the three configuration files (in the order
 they are processed) are:
 
 +--------------+----------------------------------------------------------+-------+

--- a/Doc/installing/index.rst
+++ b/Doc/installing/index.rst
@@ -84,7 +84,7 @@ dependencies from the Python Packaging Index::
 
 .. note::
 
-   For POSIX users (including Mac OS X and Linux users), the examples in
+   For POSIX users (including macOS and Linux users), the examples in
    this guide assume the use of a :term:`virtual environment`.
 
    For Windows users, the examples in this guide assume that the option to
@@ -163,7 +163,7 @@ rather than attempting to install them with ``pip``.
 ... work with multiple versions of Python installed in parallel?
 ----------------------------------------------------------------
 
-On Linux, Mac OS X, and other POSIX systems, use the versioned Python commands
+On Linux, macOS, and other POSIX systems, use the versioned Python commands
 in combination with the ``-m`` switch to run the appropriate copy of
 ``pip``::
 
@@ -225,7 +225,7 @@ users being expected to compile extension modules from source as part of
 the installation process.
 
 With the introduction of support for the binary ``wheel`` format, and the
-ability to publish wheels for at least Windows and Mac OS X through the
+ability to publish wheels for at least Windows and macOS through the
 Python Packaging Index, this problem is expected to diminish over time,
 as users are more regularly able to install pre-built extensions rather
 than needing to build them themselves.

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -20,7 +20,7 @@ ctypes tutorial
 
 Note: The code samples in this tutorial use :mod:`doctest` to make sure that
 they actually work.  Since some code samples behave differently under Linux,
-Windows, or Mac OS X, they contain doctest directives in comments.
+Windows, or macOS, they contain doctest directives in comments.
 
 Note: Some code samples reference the ctypes :class:`c_int` type.  On platforms
 where ``sizeof(long) == sizeof(int)`` it is an alias to :class:`c_long`.
@@ -80,7 +80,7 @@ the library by creating an instance of CDLL by calling the constructor::
    <CDLL 'libc.so.6', handle ... at ...>
    >>>
 
-.. XXX Add section for Mac OS X.
+.. XXX Add section for macOS.
 
 
 .. _ctypes-accessing-functions-from-loaded-dlls:
@@ -1287,7 +1287,7 @@ Here are some examples::
    'libbz2.so.1.0'
    >>>
 
-On OS X, :func:`find_library` tries several predefined naming schemes and paths
+On macOS, :func:`find_library` tries several predefined naming schemes and paths
 to locate the library, and returns a full pathname if successful::
 
    >>> from ctypes.util import find_library

--- a/Doc/library/intro.rst
+++ b/Doc/library/intro.rst
@@ -58,5 +58,5 @@ Notes on availability
   operating system.
 
 * If not separately noted, all functions that claim "Availability: Unix" are
-  supported on Mac OS X, which builds on a Unix core.
+  supported on macOS, which builds on a Unix core.
 

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -102,7 +102,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
    To ensure validity of the created memory mapping the file specified
    by the descriptor *fileno* is internally automatically synchronized
-   with physical backing store on Mac OS X and OpenVMS.
+   with physical backing store on macOS and OpenVMS.
 
    This example shows a simple way of using :class:`~mmap.mmap`::
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -783,7 +783,7 @@ For an example of the usage of queues for interprocess communication see
       multithreading/multiprocessing semantics, this number is not reliable.
 
       Note that this may raise :exc:`NotImplementedError` on Unix platforms like
-      Mac OS X where ``sem_getvalue()`` is not implemented.
+      macOS where ``sem_getvalue()`` is not implemented.
 
    .. method:: empty()
 
@@ -1235,7 +1235,7 @@ object -- see :ref:`multiprocessing-managers`.
    first argument is named *block*, as is consistent with :meth:`Lock.acquire`.
 
    .. note::
-      On Mac OS X, this is indistinguishable from :class:`Semaphore` because
+      On macOS, this is indistinguishable from :class:`Semaphore` because
       ``sem_getvalue()`` is not implemented on that platform.
 
 .. class:: Condition([lock])
@@ -1374,7 +1374,7 @@ object -- see :ref:`multiprocessing-managers`.
 
 .. note::
 
-   On Mac OS X, ``sem_timedwait`` is unsupported, so calling ``acquire()`` with
+   On macOS, ``sem_timedwait`` is unsupported, so calling ``acquire()`` with
    a timeout will emulate that function's behavior using a sleeping loop.
 
 .. note::

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2789,7 +2789,7 @@ features:
       String that uniquely identifies the type of the filesystem that
       contains the file.
 
-   On Mac OS systems, the following attributes may also be available:
+   On macOS systems, the following attributes may also be available:
 
    .. attribute:: st_rsize
 

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -226,7 +226,7 @@ Windows Platform
 
 
 macOS Platform
----------------
+--------------
 
 
 .. function:: mac_ver(release='', versioninfo=('','',''), machine='')

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -225,13 +225,13 @@ Windows Platform
    .. versionadded:: 3.8
 
 
-Mac OS Platform
+macOS Platform
 ---------------
 
 
 .. function:: mac_ver(release='', versioninfo=('','',''), machine='')
 
-   Get Mac OS version information and return it as tuple ``(release, versioninfo,
+   Get macOS version information and return it as tuple ``(release, versioninfo,
    machine)`` with *versioninfo* being a tuple ``(version, dev_stage,
    non_release_version)``.
 

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -622,7 +622,7 @@ procedure can be used to obtain a better constant for a given platform (see
 The method executes the number of Python calls given by the argument, directly
 and again under the profiler, measuring the time for both. It then computes the
 hidden overhead per profiler event, and returns that as a float.  For example,
-on a 1.8Ghz Intel Core i5 running Mac OS X, and using Python's time.process_time() as
+on a 1.8Ghz Intel Core i5 running macOS, and using Python's time.process_time() as
 the timer, the magical number is about 4.04e-6.
 
 The object of this exercise is to get a fairly consistent result. If your

--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -534,7 +534,7 @@ https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
    | :const:`KQ_FILTER_PROC`   | Watch for events on a process id            |
    +---------------------------+---------------------------------------------+
    | :const:`KQ_FILTER_NETDEV` | Watch for events on a network device        |
-   |                           | [not available on Mac OS X]                 |
+   |                           | [not available on macOS]                    |
    +---------------------------+---------------------------------------------+
    | :const:`KQ_FILTER_SIGNAL` | Returns whenever the watched signal is      |
    |                           | delivered to the process                    |
@@ -626,7 +626,7 @@ https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
    | :const:`KQ_NOTE_TRACKERR`  | unable to attach to a child                |
    +----------------------------+--------------------------------------------+
 
-   :const:`KQ_FILTER_NETDEV` filter flags (not available on Mac OS X):
+   :const:`KQ_FILTER_NETDEV` filter flags (not available on macOS):
 
    +----------------------------+--------------------------------------------+
    | Constant                   | Meaning                                    |

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -32,7 +32,7 @@ It starts by constructing up to four directories from a head and a tail part.
 For the head part, it uses ``sys.prefix`` and ``sys.exec_prefix``; empty heads
 are skipped.  For the tail part, it uses the empty string and then
 :file:`lib/site-packages` (on Windows) or
-:file:`lib/python{X.Y}/site-packages` (on Unix and Macintosh).  For each
+:file:`lib/python{X.Y}/site-packages` (on Unix and Mac).  For each
 of the distinct head-tail combinations, it sees if it refers to an existing
 directory, and if so, adds it to ``sys.path`` and also inspects the newly
 added path for configuration files.
@@ -176,8 +176,8 @@ Module contents
 
    Path to the user site-packages for the running Python.  Can be ``None`` if
    :func:`getusersitepackages` hasn't been called yet.  Default value is
-   :file:`~/.local/lib/python{X.Y}/site-packages` for UNIX and non-framework Mac
-   OS X builds, :file:`~/Library/Python/{X.Y}/lib/python/site-packages` for Mac
+   :file:`~/.local/lib/python{X.Y}/site-packages` for UNIX and non-framework
+   macOS builds, :file:`~/Library/Python/{X.Y}/lib/python/site-packages` for Mac
    framework builds, and :file:`{%APPDATA%}\\Python\\Python{XY}\\site-packages`
    on Windows.  This directory is a site directory, which means that
    :file:`.pth` files in it will be processed.
@@ -187,7 +187,7 @@ Module contents
 
    Path to the base directory for the user site-packages.  Can be ``None`` if
    :func:`getuserbase` hasn't been called yet.  Default value is
-   :file:`~/.local` for UNIX and Mac OS X non-framework builds,
+   :file:`~/.local` for UNIX and macOS non-framework builds,
    :file:`~/Library/Python/{X.Y}` for Mac framework builds, and
    :file:`{%APPDATA%}\\Python` for Windows.  This value is used by Distutils to
    compute the installation directories for scripts, data files, Python modules,

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -32,7 +32,7 @@ It starts by constructing up to four directories from a head and a tail part.
 For the head part, it uses ``sys.prefix`` and ``sys.exec_prefix``; empty heads
 are skipped.  For the tail part, it uses the empty string and then
 :file:`lib/site-packages` (on Windows) or
-:file:`lib/python{X.Y}/site-packages` (on Unix and Mac).  For each
+:file:`lib/python{X.Y}/site-packages` (on Unix and macOS).  For each
 of the distinct head-tail combinations, it sees if it refers to an existing
 directory, and if so, adds it to ``sys.path`` and also inspects the newly
 added path for configuration files.
@@ -177,7 +177,7 @@ Module contents
    Path to the user site-packages for the running Python.  Can be ``None`` if
    :func:`getusersitepackages` hasn't been called yet.  Default value is
    :file:`~/.local/lib/python{X.Y}/site-packages` for UNIX and non-framework
-   macOS builds, :file:`~/Library/Python/{X.Y}/lib/python/site-packages` for Mac
+   macOS builds, :file:`~/Library/Python/{X.Y}/lib/python/site-packages` for macOS
    framework builds, and :file:`{%APPDATA%}\\Python\\Python{XY}\\site-packages`
    on Windows.  This directory is a site directory, which means that
    :file:`.pth` files in it will be processed.
@@ -188,7 +188,7 @@ Module contents
    Path to the base directory for the user site-packages.  Can be ``None`` if
    :func:`getuserbase` hasn't been called yet.  Default value is
    :file:`~/.local` for UNIX and macOS non-framework builds,
-   :file:`~/Library/Python/{X.Y}` for Mac framework builds, and
+   :file:`~/Library/Python/{X.Y}` for macOS framework builds, and
    :file:`{%APPDATA%}\\Python` for Windows.  This value is used by Distutils to
    compute the installation directories for scripts, data files, Python modules,
    etc. for the :ref:`user installation scheme <inst-alt-install-user>`.

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -516,7 +516,7 @@ Constants
 
 .. data:: AF_LINK
 
-  .. availability:: BSD, OSX.
+  .. availability:: BSD, macOS.
 
   .. versionadded:: 3.4
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1132,7 +1132,7 @@ committed:
 .. rubric:: Footnotes
 
 .. [#f1] The sqlite3 module is not built with loadable extension support by
-   default, because some platforms (notably Mac OS X) have SQLite
+   default, because some platforms (notably macOS) have SQLite
    libraries which are compiled without this feature. To get loadable
    extension support, you must pass the
    :option:`--enable-loadable-sqlite-extensions` option to configure.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -18,7 +18,7 @@
 This module provides access to Transport Layer Security (often known as "Secure
 Sockets Layer") encryption and peer authentication facilities for network
 sockets, both client-side and server-side.  This module uses the OpenSSL
-library. It is available on all modern Unix systems, Windows, Mac OS X, and
+library. It is available on all modern Unix systems, Windows, macOS, and
 probably additional platforms, as long as OpenSSL is installed on that platform.
 
 .. note::

--- a/Doc/library/stat.rst
+++ b/Doc/library/stat.rst
@@ -372,11 +372,11 @@ The following flags can be used in the *flags* argument of :func:`os.chflags`:
 
 .. data:: UF_COMPRESSED
 
-   The file is stored compressed (Mac OS X 10.6+).
+   The file is stored compressed (macOS 10.6+).
 
 .. data:: UF_HIDDEN
 
-   The file should not be displayed in a GUI (Mac OS X 10.5+).
+   The file should not be displayed in a GUI (macOS 10.5+).
 
 .. data:: SF_ARCHIVED
 
@@ -398,7 +398,7 @@ The following flags can be used in the *flags* argument of :func:`os.chflags`:
 
    The file is a snapshot file.
 
-See the \*BSD or Mac OS systems man page :manpage:`chflags(2)` for more information.
+See the \*BSD or macOS systems man page :manpage:`chflags(2)` for more information.
 
 On Windows, the following file attribute constants are available for use when
 testing bits in the ``st_file_attributes`` member returned by :func:`os.stat`.

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -74,7 +74,7 @@ places.
 
 Python currently supports seven schemes:
 
-- *posix_prefix*: scheme for POSIX platforms like Linux or Mac OS X.  This is
+- *posix_prefix*: scheme for POSIX platforms like Linux or macOS.  This is
   the default scheme used when Python or a component is installed.
 - *posix_home*: scheme for POSIX platforms used when a *home* option is used
   upon installation.  This scheme is used when a component is installed through
@@ -225,7 +225,7 @@ Other functions
    - win-amd64 (64bit Windows on AMD64, aka x86_64, Intel64, and EM64T)
    - win32 (all others - specifically, sys.platform is returned)
 
-   Mac OS X can return:
+   macOS can return:
 
    - macosx-10.6-ppc
    - macosx-10.4-ppc64

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -684,8 +684,8 @@ The :mod:`test.support` module defines the following functions:
 
 .. decorator:: requires_mac_version(*min_version)
 
-   Decorator for the minimum version when running test on Mac OS X.  If the
-   MAC OS X version is less than the minimum, raise :exc:`unittest.SkipTest`.
+   Decorator for the minimum version when running test on macOS.  If the
+   macOS version is less than the minimum, raise :exc:`unittest.SkipTest`.
 
 
 .. decorator:: requires_IEEE_754

--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -759,7 +759,7 @@ ones inherited from :class:`ttk.Widget`.
 Platform-specific notes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-* On MacOS X, toplevel windows automatically include a built-in size grip
+* On macOS, toplevel windows automatically include a built-in size grip
   by default. Adding a :class:`Sizegrip` is harmless, since the built-in
   grip will just mask the widget.
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -169,8 +169,8 @@ The :mod:`urllib.request` module defines the following functions:
    This helper function returns a dictionary of scheme to proxy server URL
    mappings. It scans the environment for variables named ``<scheme>_proxy``,
    in a case insensitive approach, for all operating systems first, and when it
-   cannot find it, looks for proxy information from Mac OSX System
-   Configuration for Mac OS X and Windows Systems Registry for Windows.
+   cannot find it, looks for proxy information from macOS System
+   Configuration for macOS and Windows Systems Registry for Windows.
    If both lowercase and uppercase environment variables exist (and disagree),
    lowercase is preferred.
 
@@ -303,8 +303,8 @@ The following classes are provided:
    the list of proxies from the environment variables
    ``<protocol>_proxy``.  If no proxy environment variables are set, then
    in a Windows environment proxy settings are obtained from the registry's
-   Internet Settings section, and in a Mac OS X environment proxy information
-   is retrieved from the OS X System Configuration Framework.
+   Internet Settings section, and in a macOS environment proxy information
+   is retrieved from the macOS System Configuration Framework.
 
    To disable autodetected proxy pass an empty dictionary.
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -169,7 +169,7 @@ The :mod:`urllib.request` module defines the following functions:
    This helper function returns a dictionary of scheme to proxy server URL
    mappings. It scans the environment for variables named ``<scheme>_proxy``,
    in a case insensitive approach, for all operating systems first, and when it
-   cannot find it, looks for proxy information from macOS System
+   cannot find it, looks for proxy information from System
    Configuration for macOS and Windows Systems Registry for Windows.
    If both lowercase and uppercase environment variables exist (and disagree),
    lowercase is preferred.
@@ -304,7 +304,7 @@ The following classes are provided:
    ``<protocol>_proxy``.  If no proxy environment variables are set, then
    in a Windows environment proxy settings are obtained from the registry's
    Internet Settings section, and in a macOS environment proxy information
-   is retrieved from the macOS System Configuration Framework.
+   is retrieved from the System Configuration Framework.
 
    To disable autodetected proxy pass an empty dictionary.
 

--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -169,7 +169,7 @@ Notes:
    Only on Windows platforms.
 
 (3)
-   Only on Mac OS X platform.
+   Only on macOS platform.
 
 .. versionadded:: 3.3
    Support for Chrome/Chromium has been added.

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -655,7 +655,7 @@ OpenSSL
 
 The modules :mod:`hashlib`, :mod:`posix`, :mod:`ssl`, :mod:`crypt` use
 the OpenSSL library for added performance if made available by the
-operating system. Additionally, the Windows and Mac OS X installers for
+operating system. Additionally, the Windows and macOS installers for
 Python may include a copy of the OpenSSL libraries, so we include a copy
 of the OpenSSL license here::
 

--- a/Doc/tutorial/appetite.rst
+++ b/Doc/tutorial/appetite.rst
@@ -23,7 +23,7 @@ You could write a Unix shell script or Windows batch files for some of these
 tasks, but shell scripts are best at moving around files and changing text data,
 not well-suited for GUI applications or games. You could write a C/C++/Java
 program, but it can take a lot of development time to get even a first-draft
-program.  Python is simpler to use, available on Windows, Mac OS X, and Unix
+program.  Python is simpler to use, available on Windows, macOS, and Unix
 operating systems, and will help you get the job done more quickly.
 
 Python is simple to use, but it is a real programming language, offering much

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -656,7 +656,7 @@ conflict.
 .. envvar:: PYTHONCASEOK
 
    If this is set, Python ignores case in :keyword:`import` statements.  This
-   only works on Windows and OS X.
+   only works on Windows and macOS.
 
 
 .. envvar:: PYTHONDONTWRITEBYTECODE
@@ -739,7 +739,7 @@ conflict.
 
    If this environment variable is set, ``sys.argv[0]`` will be set to its
    value instead of the value got through the C runtime.  Only works on
-   Mac OS X.
+   macOS.
 
 .. envvar:: PYTHONWARNINGS
 

--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -1,9 +1,9 @@
 
 .. _using-on-mac:
 
-***************************
+*********************
 Using Python on a Mac
-***************************
+*********************
 
 :Author: Bob Savage <bobsavage@mac.com>
 
@@ -17,7 +17,7 @@ the IDE and the Package Manager that are worth pointing out.
 Getting and Installing MacPython
 ================================
 
-macOS 10.8 comes with Python 2.7 pre-installed by Apple.  If you wish, you
+macOS since version 10.8 comes with Python 2.7 pre-installed by Apple.  If you wish, you
 are invited to install the most recent version of Python 3 from the Python
 website (https://www.python.org).  A current "universal binary" build of Python,
 which runs natively on the Mac's new Intel and legacy PPC CPU's, is available
@@ -150,7 +150,7 @@ https://www.activestate.com; it can also be built from source.
 *wxPython* is another popular cross-platform GUI toolkit that runs natively on
 macOS. Packages and documentation are available from https://www.wxpython.org.
 
-*PyQt* is another popular cross-platform GUI toolkit that runs natively on Mac
+*PyQt* is another popular cross-platform GUI toolkit that runs natively on
 macOS. More information can be found at
 https://riverbankcomputing.com/software/pyqt/intro.
 

--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -2,13 +2,13 @@
 .. _using-on-mac:
 
 ***************************
-Using Python on a Macintosh
+Using Python on a Mac
 ***************************
 
 :Author: Bob Savage <bobsavage@mac.com>
 
 
-Python on a Macintosh running Mac OS X is in principle very similar to Python on
+Python on a Mac running macOS is in principle very similar to Python on
 any other Unix platform, but there are a number of additional features such as
 the IDE and the Package Manager that are worth pointing out.
 
@@ -17,7 +17,7 @@ the IDE and the Package Manager that are worth pointing out.
 Getting and Installing MacPython
 ================================
 
-Mac OS X 10.8 comes with Python 2.7 pre-installed by Apple.  If you wish, you
+macOS 10.8 comes with Python 2.7 pre-installed by Apple.  If you wish, you
 are invited to install the most recent version of Python 3 from the Python
 website (https://www.python.org).  A current "universal binary" build of Python,
 which runs natively on the Mac's new Intel and legacy PPC CPU's, is available
@@ -54,12 +54,12 @@ section on running Python scripts from the Unix shell.
 How to run a Python script
 --------------------------
 
-Your best way to get started with Python on Mac OS X is through the IDLE
+Your best way to get started with Python on macOS is through the IDLE
 integrated development environment, see section :ref:`ide` and use the Help menu
 when the IDE is running.
 
 If you want to run Python scripts from the Terminal window command line or from
-the Finder you first need an editor to create your script. Mac OS X comes with a
+the Finder you first need an editor to create your script. macOS comes with a
 number of standard Unix command line editors, :program:`vim` and
 :program:`emacs` among them. If you want a more Mac-like editor,
 :program:`BBEdit` or :program:`TextWrangler` from Bare Bones Software (see
@@ -87,7 +87,7 @@ To run your script from the Finder you have two options:
 Running scripts with a GUI
 --------------------------
 
-With older versions of Python, there is one Mac OS X quirk that you need to be
+With older versions of Python, there is one macOS quirk that you need to be
 aware of: programs that talk to the Aqua window manager (in other words,
 anything that has a GUI) need to be run in a special way. Use :program:`pythonw`
 instead of :program:`python` to start such scripts.
@@ -98,7 +98,7 @@ With Python 3.9, you can use either :program:`python` or :program:`pythonw`.
 Configuration
 -------------
 
-Python on OS X honors all standard Unix environment variables such as
+Python on macOS honors all standard Unix environment variables such as
 :envvar:`PYTHONPATH`, but setting these variables for programs started from the
 Finder is non-standard as the Finder does not read your :file:`.profile` or
 :file:`.cshrc` at startup. You need to create a file
@@ -148,10 +148,10 @@ X by Apple, and the latest version can be downloaded and installed from
 https://www.activestate.com; it can also be built from source.
 
 *wxPython* is another popular cross-platform GUI toolkit that runs natively on
-Mac OS X. Packages and documentation are available from https://www.wxpython.org.
+macOS. Packages and documentation are available from https://www.wxpython.org.
 
 *PyQt* is another popular cross-platform GUI toolkit that runs natively on Mac
-OS X. More information can be found at
+macOS. More information can be found at
 https://riverbankcomputing.com/software/pyqt/intro.
 
 


### PR DESCRIPTION
Replace old names when they refer to actual versions of macOS.
Keep historical names in references to older versions.

Based on #21316.

<!-- issue-number: [bpo-41203](https://bugs.python.org/issue41203) -->
https://bugs.python.org/issue41203
<!-- /issue-number -->
