### PR TITLE
bpo-45061: Revert unicode_is_singleton() change

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1994,8 +1994,10 @@ unicode_is_singleton(PyObject *unicode)
     if (unicode == state->empty_string) {
         return 1;
     }
-    for (Py_ssize_t i = 0; i < 256; i++) {
-        if (unicode == state->latin1[i]) {
+    PyASCIIObject *ascii = (PyASCIIObject *)unicode;
+    if (ascii->state.kind != PyUnicode_WCHAR_KIND && ascii->length == 1) {
+        Py_UCS4 ch = PyUnicode_READ_CHAR(unicode, 0);
+        if (ch < 256 && state->latin1[ch] == unicode) {
             return 1;
         }
     }


### PR DESCRIPTION
Don't use a loop over 256 items, only checks for a single singleton.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45061](https://bugs.python.org/issue45061) -->
https://bugs.python.org/issue45061
<!-- /issue-number -->
