### PR TITLE
bpo-45269: test wrong `markers` type to `c_make_encoder`

### DIFF
--- a/Lib/test/test_json/test_speedups.py
+++ b/Lib/test/test_json/test_speedups.py
@@ -59,6 +59,15 @@ class TestEncode(CTest):
         with self.assertRaises(ZeroDivisionError):
             enc('spam', 4)
 
+    def test_bad_markers_argument_to_encoder(self):
+        # https://bugs.python.org/issue45269
+        with self.assertRaisesRegex(
+            TypeError,
+            r'make_encoder\(\) argument 1 must be dict or None, not int',
+        ):
+            self.json.encoder.c_make_encoder(1, None, None, None, ': ', ', ',
+                                             False, False, False)
+
     def test_bad_bool_args(self):
         def test(name):
             self.json.encoder.JSONEncoder(**{name: BadBool()}).encode({'a': 1})

--- a/Misc/NEWS.d/next/Tests/2021-09-24-10-41-49.bpo-45269.8jKEr8.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-24-10-41-49.bpo-45269.8jKEr8.rst
@@ -1,0 +1,1 @@
+Cover case when invalid ``markers`` type is supplied to ``c_make_encoder``.


### PR DESCRIPTION


<!-- issue-number: [bpo-45269](https://bugs.python.org/issue45269) -->
https://bugs.python.org/issue45269
<!-- /issue-number -->
