### PR TITLE
bpo-45279: avoid redundant _commit_removals self._pending_removals guard

### DIFF
--- a/Lib/_weakrefset.py
+++ b/Lib/_weakrefset.py
@@ -84,21 +84,18 @@ class WeakSet:
                 getattr(self, '__dict__', None))
 
     def add(self, item):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         self.data.add(ref(item, self._remove))
 
     def clear(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         self.data.clear()
 
     def copy(self):
         return self.__class__(self)
 
     def pop(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         while True:
             try:
                 itemref = self.data.pop()
@@ -109,18 +106,15 @@ class WeakSet:
                 return item
 
     def remove(self, item):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         self.data.remove(ref(item))
 
     def discard(self, item):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         self.data.discard(ref(item))
 
     def update(self, other):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         for element in other:
             self.add(element)
 
@@ -137,8 +131,7 @@ class WeakSet:
     def difference_update(self, other):
         self.__isub__(other)
     def __isub__(self, other):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         if self is other:
             self.data.clear()
         else:
@@ -152,8 +145,7 @@ class WeakSet:
     def intersection_update(self, other):
         self.__iand__(other)
     def __iand__(self, other):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         self.data.intersection_update(ref(item) for item in other)
         return self
 
@@ -185,8 +177,7 @@ class WeakSet:
     def symmetric_difference_update(self, other):
         self.__ixor__(other)
     def __ixor__(self, other):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         if self is other:
             self.data.clear()
         else:

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -132,8 +132,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
             _atomic_removal(d, key)
 
     def __getitem__(self, key):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         o = self.data[key]()
         if o is None:
             raise KeyError(key)
@@ -141,18 +140,15 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
             return o
 
     def __delitem__(self, key):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         del self.data[key]
 
     def __len__(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         return len(self.data)
 
     def __contains__(self, key):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         try:
             o = self.data[key]()
         except KeyError:
@@ -163,13 +159,11 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
         return "<%s at %#x>" % (self.__class__.__name__, id(self))
 
     def __setitem__(self, key, value):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         self.data[key] = KeyedRef(value, self._remove, key)
 
     def copy(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         new = WeakValueDictionary()
         with _IterationGuard(self):
             for key, wr in self.data.items():
@@ -182,8 +176,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
 
     def __deepcopy__(self, memo):
         from copy import deepcopy
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         new = self.__class__()
         with _IterationGuard(self):
             for key, wr in self.data.items():
@@ -193,8 +186,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
         return new
 
     def get(self, key, default=None):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         try:
             wr = self.data[key]
         except KeyError:
@@ -208,8 +200,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
                 return o
 
     def items(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         with _IterationGuard(self):
             for k, wr in self.data.items():
                 v = wr()
@@ -217,8 +208,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
                     yield k, v
 
     def keys(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         with _IterationGuard(self):
             for k, wr in self.data.items():
                 if wr() is not None:
@@ -236,14 +226,12 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
         keep the values around longer than needed.
 
         """
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         with _IterationGuard(self):
             yield from self.data.values()
 
     def values(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         with _IterationGuard(self):
             for wr in self.data.values():
                 obj = wr()
@@ -251,8 +239,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
                     yield obj
 
     def popitem(self):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         while True:
             key, wr = self.data.popitem()
             o = wr()
@@ -260,8 +247,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
                 return key, o
 
     def pop(self, key, *args):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         try:
             o = self.data.pop(key)()
         except KeyError:
@@ -280,16 +266,14 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
         except KeyError:
             o = None
         if o is None:
-            if self._pending_removals:
-                self._commit_removals()
+            self._commit_removals()
             self.data[key] = KeyedRef(default, self._remove, key)
             return default
         else:
             return o
 
     def update(self, other=None, /, **kwargs):
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         d = self.data
         if other is not None:
             if not hasattr(other, "items"):
@@ -309,8 +293,7 @@ class WeakValueDictionary(_collections_abc.MutableMapping):
         keep the values around longer than needed.
 
         """
-        if self._pending_removals:
-            self._commit_removals()
+        self._commit_removals()
         return list(self.data.values())
 
     def __ior__(self, other):

--- a/Misc/NEWS.d/next/Library/2021-09-24-11-08-38.bpo-45279.OIauJH.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-24-11-08-38.bpo-45279.OIauJH.rst
@@ -1,0 +1,1 @@
+refactor to avoid redundant _pending_removals guard for _commit_removals in weak collections


### PR DESCRIPTION
<!-- issue-number: [bpo-45279](https://bugs.python.org/issue45279) -->
https://bugs.python.org/issue45279
<!-- /issue-number -->

`_commit_removals` already checks if pending_removals is empty via `pop()`
https://github.com/python/cpython/blob/3f8b23f8ddab75d9b77a3997d54e663187e12cc8/Lib/_weakrefset.py#L53-L61