### PR TITLE
bpo-45288: Inspect - Added `sort_result` parameter on `getmembers` function.

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -323,7 +323,7 @@ def isabstract(object):
                 return True
     return False
 
-def getmembers(object, predicate=None):
+def getmembers(object, predicate=None, sort_result: bool=True):
     """Return all members of an object as (name, value) pairs sorted by name.
     Optionally, only return members that satisfy a given predicate."""
     if isclass(object):
@@ -364,7 +364,10 @@ def getmembers(object, predicate=None):
         if not predicate or predicate(value):
             results.append((key, value))
         processed.add(key)
-    results.sort(key=lambda pair: pair[0])
+    
+    if sort_result:
+        results.sort(key=lambda pair: pair[0])
+    
     return results
 
 Attribute = namedtuple('Attribute', 'name kind defining_class object')


### PR DESCRIPTION
Added `sort_result` parameter (`bool=True`)  on `getmembers` function inside `Lib/inspect.py`, that, as it name says, allows you to `getmembers` result without sorting it.
I'm needed of this and it seems impossible to achieve because of [`367` line](https://github.com/python/cpython/blob/3.9/Lib/inspect.py#L367): 
```py
results.sort(key=lambda pair: pair[0])
```
Any other solution is very welcomed.

(I need it because I'm working on an [API Reference creator](https://github.com/Patitotective/PyAPIReference) and I think it would be better if it the members are ordered in the same order you define them.)
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45288](https://bugs.python.org/issue45288) -->
https://bugs.python.org/issue45288
<!-- /issue-number -->
