### PR TITLE
bpo-44019: Add missing comma to operator.call doc

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -253,7 +253,7 @@ Operations which work with sequences (some of them with mappings too) include:
 
 The following operation works with callables:
 
-.. function:: call(obj, / *args, **kwargs)
+.. function:: call(obj, /, *args, **kwargs)
               __call__(obj, /, *args, **kwargs)
 
    Return ``obj(*args, **kwargs)``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44019](https://bugs.python.org/issue44019) -->
https://bugs.python.org/issue44019
<!-- /issue-number -->
