### PR TITLE
bpo-41299: QueryPerformanceFrequency() cannot fail

### DIFF
--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1049,7 +1049,7 @@ py_win_perf_counter_frequency(LONGLONG *pfrequency, int raise)
 {
     LONGLONG frequency;
 
-    LARGE_INTEGER freq = 0;
+    LARGE_INTEGER freq;
     // Since Windows XP, the function cannot fail.
     (void)QueryPerformanceFrequency(&freq);
     frequency = freq.QuadPart;

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1049,27 +1049,15 @@ py_win_perf_counter_frequency(LONGLONG *pfrequency, int raise)
 {
     LONGLONG frequency;
 
-    LARGE_INTEGER freq;
-    if (!QueryPerformanceFrequency(&freq)) {
-        if (raise) {
-            PyErr_SetFromWindowsErr(0);
-        }
-        return -1;
-    }
+    LARGE_INTEGER freq = 0;
+    // Since Windows XP, the function cannot fail.
+    (void)QueryPerformanceFrequency(&freq);
     frequency = freq.QuadPart;
 
-    /* Sanity check: should never occur in practice */
-    if (frequency < 1) {
-        if (raise) {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "invalid QueryPerformanceFrequency");
-        }
-        return -1;
-    }
+    // Since Windows XP, frequency cannot be zero.
+    assert(frequency >= 1);
 
-    /* Check that frequency can be casted to _PyTime_t.
-
-       Make also sure that (ticks * SEC_TO_NS) cannot overflow in
+    /* Make also sure that (ticks * SEC_TO_NS) cannot overflow in
        _PyTime_MulDiv(), with ticks < frequency.
 
        Known QueryPerformanceFrequency() values:
@@ -1078,10 +1066,8 @@ py_win_perf_counter_frequency(LONGLONG *pfrequency, int raise)
        * 3,579,545 Hz (3.6 MHz): 279 ns resolution
 
        None of these frequencies can overflow with 64-bit _PyTime_t, but
-       check for overflow, just in case. */
-    if (frequency > _PyTime_MAX
-        || frequency > (LONGLONG)_PyTime_MAX / (LONGLONG)SEC_TO_NS)
-    {
+       check for integer overflow just in case. */
+    if (frequency > _PyTime_MAX / SEC_TO_NS) {
         if (raise) {
             PyErr_SetString(PyExc_OverflowError,
                             "QueryPerformanceFrequency is too large");


### PR DESCRIPTION
py_win_perf_counter_frequency() no longer checks for
QueryPerformanceFrequency() failure. According to the
QueryPerformanceFrequency() documentation, the function can no longer
fails since Windows XP.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-41299](https://bugs.python.org/issue41299) -->
https://bugs.python.org/issue41299
<!-- /issue-number -->
