### PR TITLE
bpo-45020: Make "make all" output less noisy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,8 @@ Tools/ssl/win32
 Python/frozen_modules/*.h
 # The manifest can be generated at any time with "make regen-frozen".
 Python/frozen_modules/MANIFEST
+Python/frozen_modules/ready-stamp
+Python/frozen_modules/generated-stamp
 
 # Two-trick pony for OSX and other case insensitive file systems:
 # Ignore ./python binary on Unix but still look into ./Python/ directory.

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -838,237 +838,46 @@ Programs/_freeze_module.o: Programs/_freeze_module.c Makefile
 Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) $(FROZEN_READY)
 	$(LINKCC) $(PY_CORE_LDFLAGS) -o $@ Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
-$(FROZEN_FILES_OUT): Programs/_freeze_module
-
 have_frozen_files=$(wildcard $(FROZEN_FILES_OUT))
 
+$(FROZEN_DATA)/%.h: Programs/_freeze_module
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile = Lib/$(subst .,/,$(*F)).py)
+	$(eval pyfilefull = $(srcdir)/$(pyfile))
+	@if ( mkdir $(FROZEN_GENERATED) ) 2> /dev/null; then \
+		chmod 555 $(FROZEN_GENERATED); \
+		echo "=== Re-generating the frozen modules. ==="; \
+		echo "(For verbose output, run make regen-frozen.)"; \
+	else \
+		touch $(FROZEN_GENERATED); \
+	fi
+	@rm -f $(FROZEN_READY)
+	@Programs/_freeze_module $(*F) "$(pyfilefull)" $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot "$(pyfilefull)"; then touch -r "$(pyfilefull)" $@; fi; \
+	fi
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
+	else echo -n "."; fi
+
 # BEGIN: freezing modules
-
 Python/frozen_modules/importlib._bootstrap.h: $(srcdir)/Lib/importlib/_bootstrap.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/importlib/_bootstrap.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module importlib._bootstrap "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/importlib._bootstrap_external.h: $(srcdir)/Lib/importlib/_bootstrap_external.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/importlib/_bootstrap_external.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module importlib._bootstrap_external "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/zipimport.h: $(srcdir)/Lib/zipimport.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/zipimport.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module zipimport "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/abc.h: $(srcdir)/Lib/abc.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/abc.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module abc "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/codecs.h: $(srcdir)/Lib/codecs.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/codecs.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module codecs "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/io.h: $(srcdir)/Lib/io.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/io.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module io "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/_collections_abc.h: $(srcdir)/Lib/_collections_abc.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/_collections_abc.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module _collections_abc "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/_sitebuiltins.h: $(srcdir)/Lib/_sitebuiltins.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/_sitebuiltins.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module _sitebuiltins "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/genericpath.h: $(srcdir)/Lib/genericpath.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/genericpath.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module genericpath "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/ntpath.h: $(srcdir)/Lib/ntpath.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/ntpath.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module ntpath "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/posixpath.h: $(srcdir)/Lib/posixpath.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/posixpath.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module posixpath "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/os.h: $(srcdir)/Lib/os.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/os.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module os "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/site.h: $(srcdir)/Lib/site.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/site.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module site "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/stat.h: $(srcdir)/Lib/stat.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/stat.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module stat "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 Python/frozen_modules/__hello__.h: $(srcdir)/Lib/__hello__.py
-	$(eval exists = $(wildcard $@))
-	$(eval pyfile_dep = Lib/__hello__.py)
-	$(eval pyfile = $(srcdir)/$(pyfile_dep))
-	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module __hello__ "$(pyfile)" $@.new
-	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
-		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
-	fi
-	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
-	elif test -z "$(have_frozen_files)"; then echo -n "."; \
-	elif test -z "$(exists)"; then echo -n " $(@F) "; \
-	else echo -n "."; fi
-
 # END: freezing modules
 
 Tools/scripts/freeze_modules.py: Programs/_freeze_module

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -840,171 +840,233 @@ Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) $
 
 $(FROZEN_FILES_OUT): Programs/_freeze_module
 
+have_frozen_files=$(wildcard $(FROZEN_FILES_OUT))
+
 # BEGIN: freezing modules
 
-Python/frozen_modules/importlib._bootstrap.h: Lib/importlib/_bootstrap.py
-	$(eval pyfile = "$(srcdir)/Lib/importlib/_bootstrap.py")
+Python/frozen_modules/importlib._bootstrap.h: $(srcdir)/Lib/importlib/_bootstrap.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/importlib/_bootstrap.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module importlib._bootstrap $(pyfile) $@.new
+	@Programs/_freeze_module importlib._bootstrap "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/importlib._bootstrap_external.h: Lib/importlib/_bootstrap_external.py
-	$(eval pyfile = "$(srcdir)/Lib/importlib/_bootstrap_external.py")
+Python/frozen_modules/importlib._bootstrap_external.h: $(srcdir)/Lib/importlib/_bootstrap_external.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/importlib/_bootstrap_external.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module importlib._bootstrap_external $(pyfile) $@.new
+	@Programs/_freeze_module importlib._bootstrap_external "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/zipimport.h: Lib/zipimport.py
-	$(eval pyfile = "$(srcdir)/Lib/zipimport.py")
+Python/frozen_modules/zipimport.h: $(srcdir)/Lib/zipimport.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/zipimport.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module zipimport $(pyfile) $@.new
+	@Programs/_freeze_module zipimport "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/abc.h: Lib/abc.py
-	$(eval pyfile = "$(srcdir)/Lib/abc.py")
+Python/frozen_modules/abc.h: $(srcdir)/Lib/abc.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/abc.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module abc $(pyfile) $@.new
+	@Programs/_freeze_module abc "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/codecs.h: Lib/codecs.py
-	$(eval pyfile = "$(srcdir)/Lib/codecs.py")
+Python/frozen_modules/codecs.h: $(srcdir)/Lib/codecs.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/codecs.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module codecs $(pyfile) $@.new
+	@Programs/_freeze_module codecs "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/io.h: Lib/io.py
-	$(eval pyfile = "$(srcdir)/Lib/io.py")
+Python/frozen_modules/io.h: $(srcdir)/Lib/io.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/io.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module io $(pyfile) $@.new
+	@Programs/_freeze_module io "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/_collections_abc.h: Lib/_collections_abc.py
-	$(eval pyfile = "$(srcdir)/Lib/_collections_abc.py")
+Python/frozen_modules/_collections_abc.h: $(srcdir)/Lib/_collections_abc.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/_collections_abc.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module _collections_abc $(pyfile) $@.new
+	@Programs/_freeze_module _collections_abc "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/_sitebuiltins.h: Lib/_sitebuiltins.py
-	$(eval pyfile = "$(srcdir)/Lib/_sitebuiltins.py")
+Python/frozen_modules/_sitebuiltins.h: $(srcdir)/Lib/_sitebuiltins.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/_sitebuiltins.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module _sitebuiltins $(pyfile) $@.new
+	@Programs/_freeze_module _sitebuiltins "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/genericpath.h: Lib/genericpath.py
-	$(eval pyfile = "$(srcdir)/Lib/genericpath.py")
+Python/frozen_modules/genericpath.h: $(srcdir)/Lib/genericpath.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/genericpath.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module genericpath $(pyfile) $@.new
+	@Programs/_freeze_module genericpath "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/ntpath.h: Lib/ntpath.py
-	$(eval pyfile = "$(srcdir)/Lib/ntpath.py")
+Python/frozen_modules/ntpath.h: $(srcdir)/Lib/ntpath.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/ntpath.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module ntpath $(pyfile) $@.new
+	@Programs/_freeze_module ntpath "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/posixpath.h: Lib/posixpath.py
-	$(eval pyfile = "$(srcdir)/Lib/posixpath.py")
+Python/frozen_modules/posixpath.h: $(srcdir)/Lib/posixpath.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/posixpath.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module posixpath $(pyfile) $@.new
+	@Programs/_freeze_module posixpath "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/os.h: Lib/os.py
-	$(eval pyfile = "$(srcdir)/Lib/os.py")
+Python/frozen_modules/os.h: $(srcdir)/Lib/os.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/os.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module os $(pyfile) $@.new
+	@Programs/_freeze_module os "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/site.h: Lib/site.py
-	$(eval pyfile = "$(srcdir)/Lib/site.py")
+Python/frozen_modules/site.h: $(srcdir)/Lib/site.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/site.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module site $(pyfile) $@.new
+	@Programs/_freeze_module site "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/stat.h: Lib/stat.py
-	$(eval pyfile = "$(srcdir)/Lib/stat.py")
+Python/frozen_modules/stat.h: $(srcdir)/Lib/stat.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/stat.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module stat $(pyfile) $@.new
+	@Programs/_freeze_module stat "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
-Python/frozen_modules/__hello__.h: Lib/__hello__.py
-	$(eval pyfile = "$(srcdir)/Lib/__hello__.py")
+Python/frozen_modules/__hello__.h: $(srcdir)/Lib/__hello__.py
+	$(eval exists = $(wildcard $@))
+	$(eval pyfile_dep = Lib/__hello__.py)
+	$(eval pyfile = $(srcdir)/$(pyfile_dep))
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module __hello__ $(pyfile) $@.new
+	@Programs/_freeze_module __hello__ "$(pyfile)" $@.new
 	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \
 	fi
-	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \
+	elif test -z "$(have_frozen_files)"; then echo -n "."; \
+	elif test -z "$(exists)"; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 # END: freezing modules

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -772,72 +772,225 @@ FROZEN_FILES_OUT = \
 		Python/frozen_modules/__hello__.h
 # End FROZEN_FILES_OUT
 
+# the 3.0 release (6046c5e0298c25515ea58abc8ab87f7413e3f743)
+OLD_TIMESTAMP=200812031729.10
+
+FROZEN_DATA=Python/frozen_modules
+FROZEN_READY=$(FROZEN_DATA)/ready-stamp
+FROZEN_GENERATED=$(FROZEN_DATA)/generated-stamp
+
+.PHONY: clean-frozen
+clean-frozen:
+	rm -rf $(FROZEN_DATA)/*-stamp
+#	rm -f $(FROZEN_DATA)/*.h
+#	rm -f $(FROZEN_FILES_OUT)
+
+.FORCE:
+
+# This should always run before any frozen module .h rules.
+# It gets all the frozen-related stamp files in the proper state.
+#
+# This file is created by this rule, with an old timestamp.
+# It is deleted as soon as the state of the files changes.
+$(FROZEN_READY): .FORCE
+	@mkdir -p $(FROZEN_DATA)
+	@touch -t $(OLD_TIMESTAMP) $@
+	@rm -rf $(FROZEN_GENERATED)
+
+# This records that one or more frozen module .h files was built.  It also
+# prints an informative header when the first frozen module is handled.
+# It is run at the beginning of the recipe for each frozen module .h file.
+# Note that the rule for each module will print a progress marker on
+# the same line as the others.
+.PHONY: .generating-frozen-module
+.generating-frozen-module:
+	@if ( mkdir $(FROZEN_GENERATED) ) 2> /dev/null; then \
+		chmod 555 $(FROZEN_GENERATED); \
+		echo "=== Re-generating the frozen modules. ==="; \
+		echo "(For verbose output, run make regen-frozen.)"; \
+	else \
+		touch $(FROZEN_GENERATED); \
+	fi
+	@rm -f $(FROZEN_READY)
+
+# This should always run after all frozen module .h rules finish.
+# If at least one frozen module rules actually ran then this rule
+# finishes printing the line where the progress markers were printed.
+# This rule also removes all the other frozen-related stamp files.
+#
+# This file is created by the .generating-frozen-module rule if at least
+# one of the frozen module rules is run.  Otherwise it is created here,
+# with an old timestamp.  It is always an empty directory.
+# timestamp.  It is updated to "now" in each frozem module .h rule
+# if the module was actually updated.
+$(FROZEN_GENERATED): $(FROZEN_FILES_OUT) .FORCE
+	@if test -e $(FROZEN_GENERATED); then \
+		echo ""; \
+	else \
+		touch $@; \
+		chmod 555 $(FROZEN_GENERATED); \
+	fi
+	@touch -t $(OLD_TIMESTAMP) $@
+	@rm -f $(FROZEN_READY)
+
 Programs/_freeze_module.o: Programs/_freeze_module.c Makefile
 
-Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN)
+Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) $(FROZEN_READY)
 	$(LINKCC) $(PY_CORE_LDFLAGS) -o $@ Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) $(LIBS) $(MODLIBS) $(SYSLIBS)
+
+$(FROZEN_FILES_OUT): Programs/_freeze_module
 
 # BEGIN: freezing modules
 
-Python/frozen_modules/importlib._bootstrap.h: Programs/_freeze_module Lib/importlib/_bootstrap.py
-	Programs/_freeze_module importlib._bootstrap $(srcdir)/Lib/importlib/_bootstrap.py $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/importlib._bootstrap.h $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new
+Python/frozen_modules/importlib._bootstrap.h: Lib/importlib/_bootstrap.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module importlib._bootstrap $(srcdir)/Lib/importlib/_bootstrap.py $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/importlib._bootstrap.h $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/importlib/_bootstrap.py; then touch -r Lib/importlib/_bootstrap.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/importlib/_bootstrap.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/importlib._bootstrap_external.h: Programs/_freeze_module Lib/importlib/_bootstrap_external.py
-	Programs/_freeze_module importlib._bootstrap_external $(srcdir)/Lib/importlib/_bootstrap_external.py $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new
+Python/frozen_modules/importlib._bootstrap_external.h: Lib/importlib/_bootstrap_external.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module importlib._bootstrap_external $(srcdir)/Lib/importlib/_bootstrap_external.py $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/importlib/_bootstrap_external.py; then touch -r Lib/importlib/_bootstrap_external.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/importlib/_bootstrap_external.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/zipimport.h: Programs/_freeze_module Lib/zipimport.py
-	Programs/_freeze_module zipimport $(srcdir)/Lib/zipimport.py $(srcdir)/Python/frozen_modules/zipimport.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/zipimport.h $(srcdir)/Python/frozen_modules/zipimport.h.new
+Python/frozen_modules/zipimport.h: Lib/zipimport.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module zipimport $(srcdir)/Lib/zipimport.py $(srcdir)/Python/frozen_modules/zipimport.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/zipimport.h $(srcdir)/Python/frozen_modules/zipimport.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/zipimport.py; then touch -r Lib/zipimport.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/zipimport.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/abc.h: Programs/_freeze_module Lib/abc.py
-	Programs/_freeze_module abc $(srcdir)/Lib/abc.py $(srcdir)/Python/frozen_modules/abc.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/abc.h $(srcdir)/Python/frozen_modules/abc.h.new
+Python/frozen_modules/abc.h: Lib/abc.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module abc $(srcdir)/Lib/abc.py $(srcdir)/Python/frozen_modules/abc.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/abc.h $(srcdir)/Python/frozen_modules/abc.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/abc.py; then touch -r Lib/abc.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/abc.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/codecs.h: Programs/_freeze_module Lib/codecs.py
-	Programs/_freeze_module codecs $(srcdir)/Lib/codecs.py $(srcdir)/Python/frozen_modules/codecs.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/codecs.h $(srcdir)/Python/frozen_modules/codecs.h.new
+Python/frozen_modules/codecs.h: Lib/codecs.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module codecs $(srcdir)/Lib/codecs.py $(srcdir)/Python/frozen_modules/codecs.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/codecs.h $(srcdir)/Python/frozen_modules/codecs.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/codecs.py; then touch -r Lib/codecs.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/codecs.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/io.h: Programs/_freeze_module Lib/io.py
-	Programs/_freeze_module io $(srcdir)/Lib/io.py $(srcdir)/Python/frozen_modules/io.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/io.h $(srcdir)/Python/frozen_modules/io.h.new
+Python/frozen_modules/io.h: Lib/io.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module io $(srcdir)/Lib/io.py $(srcdir)/Python/frozen_modules/io.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/io.h $(srcdir)/Python/frozen_modules/io.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/io.py; then touch -r Lib/io.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/io.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/_collections_abc.h: Programs/_freeze_module Lib/_collections_abc.py
-	Programs/_freeze_module _collections_abc $(srcdir)/Lib/_collections_abc.py $(srcdir)/Python/frozen_modules/_collections_abc.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/_collections_abc.h $(srcdir)/Python/frozen_modules/_collections_abc.h.new
+Python/frozen_modules/_collections_abc.h: Lib/_collections_abc.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module _collections_abc $(srcdir)/Lib/_collections_abc.py $(srcdir)/Python/frozen_modules/_collections_abc.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/_collections_abc.h $(srcdir)/Python/frozen_modules/_collections_abc.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/_collections_abc.py; then touch -r Lib/_collections_abc.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/_collections_abc.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/_sitebuiltins.h: Programs/_freeze_module Lib/_sitebuiltins.py
-	Programs/_freeze_module _sitebuiltins $(srcdir)/Lib/_sitebuiltins.py $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/_sitebuiltins.h $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new
+Python/frozen_modules/_sitebuiltins.h: Lib/_sitebuiltins.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module _sitebuiltins $(srcdir)/Lib/_sitebuiltins.py $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/_sitebuiltins.h $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/_sitebuiltins.py; then touch -r Lib/_sitebuiltins.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/_sitebuiltins.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/genericpath.h: Programs/_freeze_module Lib/genericpath.py
-	Programs/_freeze_module genericpath $(srcdir)/Lib/genericpath.py $(srcdir)/Python/frozen_modules/genericpath.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/genericpath.h $(srcdir)/Python/frozen_modules/genericpath.h.new
+Python/frozen_modules/genericpath.h: Lib/genericpath.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module genericpath $(srcdir)/Lib/genericpath.py $(srcdir)/Python/frozen_modules/genericpath.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/genericpath.h $(srcdir)/Python/frozen_modules/genericpath.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/genericpath.py; then touch -r Lib/genericpath.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/genericpath.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/ntpath.h: Programs/_freeze_module Lib/ntpath.py
-	Programs/_freeze_module ntpath $(srcdir)/Lib/ntpath.py $(srcdir)/Python/frozen_modules/ntpath.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/ntpath.h $(srcdir)/Python/frozen_modules/ntpath.h.new
+Python/frozen_modules/ntpath.h: Lib/ntpath.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module ntpath $(srcdir)/Lib/ntpath.py $(srcdir)/Python/frozen_modules/ntpath.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/ntpath.h $(srcdir)/Python/frozen_modules/ntpath.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/ntpath.py; then touch -r Lib/ntpath.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/ntpath.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/posixpath.h: Programs/_freeze_module Lib/posixpath.py
-	Programs/_freeze_module posixpath $(srcdir)/Lib/posixpath.py $(srcdir)/Python/frozen_modules/posixpath.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/posixpath.h $(srcdir)/Python/frozen_modules/posixpath.h.new
+Python/frozen_modules/posixpath.h: Lib/posixpath.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module posixpath $(srcdir)/Lib/posixpath.py $(srcdir)/Python/frozen_modules/posixpath.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/posixpath.h $(srcdir)/Python/frozen_modules/posixpath.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/posixpath.py; then touch -r Lib/posixpath.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/posixpath.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/os.h: Programs/_freeze_module Lib/os.py
-	Programs/_freeze_module os $(srcdir)/Lib/os.py $(srcdir)/Python/frozen_modules/os.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/os.h $(srcdir)/Python/frozen_modules/os.h.new
+Python/frozen_modules/os.h: Lib/os.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module os $(srcdir)/Lib/os.py $(srcdir)/Python/frozen_modules/os.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/os.h $(srcdir)/Python/frozen_modules/os.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/os.py; then touch -r Lib/os.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/os.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/site.h: Programs/_freeze_module Lib/site.py
-	Programs/_freeze_module site $(srcdir)/Lib/site.py $(srcdir)/Python/frozen_modules/site.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/site.h $(srcdir)/Python/frozen_modules/site.h.new
+Python/frozen_modules/site.h: Lib/site.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module site $(srcdir)/Lib/site.py $(srcdir)/Python/frozen_modules/site.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/site.h $(srcdir)/Python/frozen_modules/site.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/site.py; then touch -r Lib/site.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/site.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/stat.h: Programs/_freeze_module Lib/stat.py
-	Programs/_freeze_module stat $(srcdir)/Lib/stat.py $(srcdir)/Python/frozen_modules/stat.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/stat.h $(srcdir)/Python/frozen_modules/stat.h.new
+Python/frozen_modules/stat.h: Lib/stat.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module stat $(srcdir)/Lib/stat.py $(srcdir)/Python/frozen_modules/stat.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/stat.h $(srcdir)/Python/frozen_modules/stat.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/stat.py; then touch -r Lib/stat.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/stat.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
-Python/frozen_modules/__hello__.h: Programs/_freeze_module Lib/__hello__.py
-	Programs/_freeze_module __hello__ $(srcdir)/Lib/__hello__.py $(srcdir)/Python/frozen_modules/__hello__.h.new
-	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/__hello__.h $(srcdir)/Python/frozen_modules/__hello__.h.new
+Python/frozen_modules/__hello__.h: Lib/__hello__.py
+	@$(MAKE) --quiet .generating-frozen-module
+	@Programs/_freeze_module __hello__ $(srcdir)/Lib/__hello__.py $(srcdir)/Python/frozen_modules/__hello__.h.new
+	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/__hello__.h $(srcdir)/Python/frozen_modules/__hello__.h.new; then \
+		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
+		if test $@ -ot Lib/__hello__.py; then touch -r Lib/__hello__.py $@; fi; \
+	fi
+	@if test -n "$(findstring Lib/__hello__.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	else echo -n "."; fi
 
 # END: freezing modules
 
@@ -1077,7 +1230,7 @@ regen-opcode-targets:
 Python/ceval.o: $(srcdir)/Python/opcode_targets.h $(srcdir)/Python/ceval_gil.h \
 		$(srcdir)/Python/condvar.h
 
-Python/frozen.o: $(FROZEN_FILES_OUT)
+Python/frozen.o: $(FROZEN_FILES_OUT) $(FROZEN_GENERATED)
 
 # Generate DTrace probe macros, then rename them (PYTHON_ -> PyDTrace_) to
 # follow our naming conventions. dtrace(1) uses the output filename to generate
@@ -2003,6 +2156,7 @@ clean-retain-profile: pycremoval
 	-find build -type f -a ! -name '*.gc??' -exec rm -f {} ';'
 	-rm -f Include/pydtrace_probes.h
 	-rm -f profile-gen-stamp
+	-rm -rf $(FROZEN_DATA)/*-stamp
 
 profile-removal:
 	find . -name '*.gc??' -exec rm -f {} ';'

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -780,49 +780,64 @@ Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN)
 # BEGIN: freezing modules
 
 Python/frozen_modules/importlib._bootstrap.h: Programs/_freeze_module Lib/importlib/_bootstrap.py
-	Programs/_freeze_module importlib._bootstrap $(srcdir)/Lib/importlib/_bootstrap.py $(srcdir)/Python/frozen_modules/importlib._bootstrap.h
+	Programs/_freeze_module importlib._bootstrap $(srcdir)/Lib/importlib/_bootstrap.py $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/importlib._bootstrap.h $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new
 
 Python/frozen_modules/importlib._bootstrap_external.h: Programs/_freeze_module Lib/importlib/_bootstrap_external.py
-	Programs/_freeze_module importlib._bootstrap_external $(srcdir)/Lib/importlib/_bootstrap_external.py $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h
+	Programs/_freeze_module importlib._bootstrap_external $(srcdir)/Lib/importlib/_bootstrap_external.py $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new
 
 Python/frozen_modules/zipimport.h: Programs/_freeze_module Lib/zipimport.py
-	Programs/_freeze_module zipimport $(srcdir)/Lib/zipimport.py $(srcdir)/Python/frozen_modules/zipimport.h
+	Programs/_freeze_module zipimport $(srcdir)/Lib/zipimport.py $(srcdir)/Python/frozen_modules/zipimport.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/zipimport.h $(srcdir)/Python/frozen_modules/zipimport.h.new
 
 Python/frozen_modules/abc.h: Programs/_freeze_module Lib/abc.py
-	Programs/_freeze_module abc $(srcdir)/Lib/abc.py $(srcdir)/Python/frozen_modules/abc.h
+	Programs/_freeze_module abc $(srcdir)/Lib/abc.py $(srcdir)/Python/frozen_modules/abc.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/abc.h $(srcdir)/Python/frozen_modules/abc.h.new
 
 Python/frozen_modules/codecs.h: Programs/_freeze_module Lib/codecs.py
-	Programs/_freeze_module codecs $(srcdir)/Lib/codecs.py $(srcdir)/Python/frozen_modules/codecs.h
+	Programs/_freeze_module codecs $(srcdir)/Lib/codecs.py $(srcdir)/Python/frozen_modules/codecs.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/codecs.h $(srcdir)/Python/frozen_modules/codecs.h.new
 
 Python/frozen_modules/io.h: Programs/_freeze_module Lib/io.py
-	Programs/_freeze_module io $(srcdir)/Lib/io.py $(srcdir)/Python/frozen_modules/io.h
+	Programs/_freeze_module io $(srcdir)/Lib/io.py $(srcdir)/Python/frozen_modules/io.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/io.h $(srcdir)/Python/frozen_modules/io.h.new
 
 Python/frozen_modules/_collections_abc.h: Programs/_freeze_module Lib/_collections_abc.py
-	Programs/_freeze_module _collections_abc $(srcdir)/Lib/_collections_abc.py $(srcdir)/Python/frozen_modules/_collections_abc.h
+	Programs/_freeze_module _collections_abc $(srcdir)/Lib/_collections_abc.py $(srcdir)/Python/frozen_modules/_collections_abc.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/_collections_abc.h $(srcdir)/Python/frozen_modules/_collections_abc.h.new
 
 Python/frozen_modules/_sitebuiltins.h: Programs/_freeze_module Lib/_sitebuiltins.py
-	Programs/_freeze_module _sitebuiltins $(srcdir)/Lib/_sitebuiltins.py $(srcdir)/Python/frozen_modules/_sitebuiltins.h
+	Programs/_freeze_module _sitebuiltins $(srcdir)/Lib/_sitebuiltins.py $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/_sitebuiltins.h $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new
 
 Python/frozen_modules/genericpath.h: Programs/_freeze_module Lib/genericpath.py
-	Programs/_freeze_module genericpath $(srcdir)/Lib/genericpath.py $(srcdir)/Python/frozen_modules/genericpath.h
+	Programs/_freeze_module genericpath $(srcdir)/Lib/genericpath.py $(srcdir)/Python/frozen_modules/genericpath.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/genericpath.h $(srcdir)/Python/frozen_modules/genericpath.h.new
 
 Python/frozen_modules/ntpath.h: Programs/_freeze_module Lib/ntpath.py
-	Programs/_freeze_module ntpath $(srcdir)/Lib/ntpath.py $(srcdir)/Python/frozen_modules/ntpath.h
+	Programs/_freeze_module ntpath $(srcdir)/Lib/ntpath.py $(srcdir)/Python/frozen_modules/ntpath.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/ntpath.h $(srcdir)/Python/frozen_modules/ntpath.h.new
 
 Python/frozen_modules/posixpath.h: Programs/_freeze_module Lib/posixpath.py
-	Programs/_freeze_module posixpath $(srcdir)/Lib/posixpath.py $(srcdir)/Python/frozen_modules/posixpath.h
+	Programs/_freeze_module posixpath $(srcdir)/Lib/posixpath.py $(srcdir)/Python/frozen_modules/posixpath.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/posixpath.h $(srcdir)/Python/frozen_modules/posixpath.h.new
 
 Python/frozen_modules/os.h: Programs/_freeze_module Lib/os.py
-	Programs/_freeze_module os $(srcdir)/Lib/os.py $(srcdir)/Python/frozen_modules/os.h
+	Programs/_freeze_module os $(srcdir)/Lib/os.py $(srcdir)/Python/frozen_modules/os.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/os.h $(srcdir)/Python/frozen_modules/os.h.new
 
 Python/frozen_modules/site.h: Programs/_freeze_module Lib/site.py
-	Programs/_freeze_module site $(srcdir)/Lib/site.py $(srcdir)/Python/frozen_modules/site.h
+	Programs/_freeze_module site $(srcdir)/Lib/site.py $(srcdir)/Python/frozen_modules/site.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/site.h $(srcdir)/Python/frozen_modules/site.h.new
 
 Python/frozen_modules/stat.h: Programs/_freeze_module Lib/stat.py
-	Programs/_freeze_module stat $(srcdir)/Lib/stat.py $(srcdir)/Python/frozen_modules/stat.h
+	Programs/_freeze_module stat $(srcdir)/Lib/stat.py $(srcdir)/Python/frozen_modules/stat.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/stat.h $(srcdir)/Python/frozen_modules/stat.h.new
 
 Python/frozen_modules/__hello__.h: Programs/_freeze_module Lib/__hello__.py
-	Programs/_freeze_module __hello__ $(srcdir)/Lib/__hello__.py $(srcdir)/Python/frozen_modules/__hello__.h
+	Programs/_freeze_module __hello__ $(srcdir)/Lib/__hello__.py $(srcdir)/Python/frozen_modules/__hello__.h.new
+	$(UPDATE_FILE) --create $(srcdir)/Python/frozen_modules/__hello__.h $(srcdir)/Python/frozen_modules/__hello__.h.new
 
 # END: freezing modules
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -843,153 +843,168 @@ $(FROZEN_FILES_OUT): Programs/_freeze_module
 # BEGIN: freezing modules
 
 Python/frozen_modules/importlib._bootstrap.h: Lib/importlib/_bootstrap.py
+	$(eval pyfile = "$(srcdir)/Lib/importlib/_bootstrap.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module importlib._bootstrap $(srcdir)/Lib/importlib/_bootstrap.py $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/importlib._bootstrap.h $(srcdir)/Python/frozen_modules/importlib._bootstrap.h.new; then \
+	@Programs/_freeze_module importlib._bootstrap $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/importlib/_bootstrap.py; then touch -r Lib/importlib/_bootstrap.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/importlib/_bootstrap.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/importlib._bootstrap_external.h: Lib/importlib/_bootstrap_external.py
+	$(eval pyfile = "$(srcdir)/Lib/importlib/_bootstrap_external.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module importlib._bootstrap_external $(srcdir)/Lib/importlib/_bootstrap_external.py $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h.new; then \
+	@Programs/_freeze_module importlib._bootstrap_external $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/importlib/_bootstrap_external.py; then touch -r Lib/importlib/_bootstrap_external.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/importlib/_bootstrap_external.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/zipimport.h: Lib/zipimport.py
+	$(eval pyfile = "$(srcdir)/Lib/zipimport.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module zipimport $(srcdir)/Lib/zipimport.py $(srcdir)/Python/frozen_modules/zipimport.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/zipimport.h $(srcdir)/Python/frozen_modules/zipimport.h.new; then \
+	@Programs/_freeze_module zipimport $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/zipimport.py; then touch -r Lib/zipimport.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/zipimport.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/abc.h: Lib/abc.py
+	$(eval pyfile = "$(srcdir)/Lib/abc.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module abc $(srcdir)/Lib/abc.py $(srcdir)/Python/frozen_modules/abc.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/abc.h $(srcdir)/Python/frozen_modules/abc.h.new; then \
+	@Programs/_freeze_module abc $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/abc.py; then touch -r Lib/abc.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/abc.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/codecs.h: Lib/codecs.py
+	$(eval pyfile = "$(srcdir)/Lib/codecs.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module codecs $(srcdir)/Lib/codecs.py $(srcdir)/Python/frozen_modules/codecs.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/codecs.h $(srcdir)/Python/frozen_modules/codecs.h.new; then \
+	@Programs/_freeze_module codecs $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/codecs.py; then touch -r Lib/codecs.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/codecs.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/io.h: Lib/io.py
+	$(eval pyfile = "$(srcdir)/Lib/io.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module io $(srcdir)/Lib/io.py $(srcdir)/Python/frozen_modules/io.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/io.h $(srcdir)/Python/frozen_modules/io.h.new; then \
+	@Programs/_freeze_module io $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/io.py; then touch -r Lib/io.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/io.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/_collections_abc.h: Lib/_collections_abc.py
+	$(eval pyfile = "$(srcdir)/Lib/_collections_abc.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module _collections_abc $(srcdir)/Lib/_collections_abc.py $(srcdir)/Python/frozen_modules/_collections_abc.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/_collections_abc.h $(srcdir)/Python/frozen_modules/_collections_abc.h.new; then \
+	@Programs/_freeze_module _collections_abc $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/_collections_abc.py; then touch -r Lib/_collections_abc.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/_collections_abc.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/_sitebuiltins.h: Lib/_sitebuiltins.py
+	$(eval pyfile = "$(srcdir)/Lib/_sitebuiltins.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module _sitebuiltins $(srcdir)/Lib/_sitebuiltins.py $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/_sitebuiltins.h $(srcdir)/Python/frozen_modules/_sitebuiltins.h.new; then \
+	@Programs/_freeze_module _sitebuiltins $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/_sitebuiltins.py; then touch -r Lib/_sitebuiltins.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/_sitebuiltins.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/genericpath.h: Lib/genericpath.py
+	$(eval pyfile = "$(srcdir)/Lib/genericpath.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module genericpath $(srcdir)/Lib/genericpath.py $(srcdir)/Python/frozen_modules/genericpath.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/genericpath.h $(srcdir)/Python/frozen_modules/genericpath.h.new; then \
+	@Programs/_freeze_module genericpath $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/genericpath.py; then touch -r Lib/genericpath.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/genericpath.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/ntpath.h: Lib/ntpath.py
+	$(eval pyfile = "$(srcdir)/Lib/ntpath.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module ntpath $(srcdir)/Lib/ntpath.py $(srcdir)/Python/frozen_modules/ntpath.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/ntpath.h $(srcdir)/Python/frozen_modules/ntpath.h.new; then \
+	@Programs/_freeze_module ntpath $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/ntpath.py; then touch -r Lib/ntpath.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/ntpath.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/posixpath.h: Lib/posixpath.py
+	$(eval pyfile = "$(srcdir)/Lib/posixpath.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module posixpath $(srcdir)/Lib/posixpath.py $(srcdir)/Python/frozen_modules/posixpath.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/posixpath.h $(srcdir)/Python/frozen_modules/posixpath.h.new; then \
+	@Programs/_freeze_module posixpath $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/posixpath.py; then touch -r Lib/posixpath.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/posixpath.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/os.h: Lib/os.py
+	$(eval pyfile = "$(srcdir)/Lib/os.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module os $(srcdir)/Lib/os.py $(srcdir)/Python/frozen_modules/os.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/os.h $(srcdir)/Python/frozen_modules/os.h.new; then \
+	@Programs/_freeze_module os $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/os.py; then touch -r Lib/os.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/os.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/site.h: Lib/site.py
+	$(eval pyfile = "$(srcdir)/Lib/site.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module site $(srcdir)/Lib/site.py $(srcdir)/Python/frozen_modules/site.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/site.h $(srcdir)/Python/frozen_modules/site.h.new; then \
+	@Programs/_freeze_module site $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/site.py; then touch -r Lib/site.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/site.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/stat.h: Lib/stat.py
+	$(eval pyfile = "$(srcdir)/Lib/stat.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module stat $(srcdir)/Lib/stat.py $(srcdir)/Python/frozen_modules/stat.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/stat.h $(srcdir)/Python/frozen_modules/stat.h.new; then \
+	@Programs/_freeze_module stat $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/stat.py; then touch -r Lib/stat.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/stat.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 Python/frozen_modules/__hello__.h: Lib/__hello__.py
+	$(eval pyfile = "$(srcdir)/Lib/__hello__.py")
 	@$(MAKE) --quiet .generating-frozen-module
-	@Programs/_freeze_module __hello__ $(srcdir)/Lib/__hello__.py $(srcdir)/Python/frozen_modules/__hello__.h.new
-	@if $(UPDATE_FILE) --create --exitcode $(srcdir)/Python/frozen_modules/__hello__.h $(srcdir)/Python/frozen_modules/__hello__.h.new; then \
+	@Programs/_freeze_module __hello__ $(pyfile) $@.new
+	@if $(UPDATE_FILE) --create --exitcode $@ $@.new; then \
 		if test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \
-		if test $@ -ot Lib/__hello__.py; then touch -r Lib/__hello__.py $@; fi; \
+		if test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \
 	fi
-	@if test -n "$(findstring Lib/__hello__.py,$?)" -a -e $@; then echo -n " $(@F) "; \
+	@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \
 	else echo -n "."; fi
 
 # END: freezing modules

--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -553,19 +553,18 @@ def regen_makefile(modules):
         pyfile = relpath_for_posix_display(src.pyfile, ROOT_DIR)
         pyfiles.append(f'\t\t{pyfile} \\')
 
-        freeze = (f'Programs/_freeze_module {src.frozenid} '
-                  f'$(srcdir)/{pyfile} $(srcdir)/{header}.new')
-        update = (f'$(UPDATE_FILE) --create --exitcode '
-                  f'$(srcdir)/{header} $(srcdir)/{header}.new')
+        freeze = f'Programs/_freeze_module {src.frozenid} $(pyfile) $@.new'
+        update = '$(UPDATE_FILE) --create --exitcode $@ $@.new'
         rules.extend([
             f'{header}: {pyfile}',
+            f'\t$(eval pyfile = "$(srcdir)/{pyfile}")',
             '\t@$(MAKE) --quiet .generating-frozen-module',
             f'\t@{freeze}',
             f'\t@if {update}; then \\',
             '\t\tif test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \\',
-            f'\t\tif test $@ -ot {pyfile}; then touch -r {pyfile} $@; fi; \\',
+            f'\t\tif test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \\',
             '\tfi',
-            f'\t@if test -n "$(findstring {pyfile},$?)" -a -e $@; then echo -n " $(@F) "; \\',
+            f'\t@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \\',
             '\telse echo -n "."; fi',
             '',
         ])

--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -545,7 +545,7 @@ def regen_frozen(modules):
 def regen_makefile(modules):
     pyfiles = []
     frozenfiles = []
-    rules = ['']
+    rules = []
     for src in _iter_sources(modules):
         header = relpath_for_posix_display(src.frozenfile, ROOT_DIR)
         frozenfiles.append(f'\t\t{header} \\')
@@ -553,24 +553,8 @@ def regen_makefile(modules):
         pyfile = relpath_for_posix_display(src.pyfile, ROOT_DIR)
         pyfiles.append(f'\t\t{pyfile} \\')
 
-        freeze = f'Programs/_freeze_module {src.frozenid} "$(pyfile)" $@.new'
-        update = '$(UPDATE_FILE) --create --exitcode $@ $@.new'
         rules.extend([
             f'{header}: $(srcdir)/{pyfile}',
-            f'\t$(eval exists = $(wildcard $@))',
-            f'\t$(eval pyfile_dep = {pyfile})',
-            f'\t$(eval pyfile = $(srcdir)/$(pyfile_dep))',
-            '\t@$(MAKE) --quiet .generating-frozen-module',
-            f'\t@{freeze}',
-            f'\t@if {update}; then \\',
-            '\t\tif test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \\',
-            f'\t\tif test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \\',
-            '\tfi',
-            f'\t@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \\',
-            '\telif test -z "$(have_frozen_files)"; then echo -n "."; \\',
-            '\telif test -z "$(exists)"; then echo -n " $(@F) "; \\',
-            '\telse echo -n "."; fi',
-            '',
         ])
     pyfiles[-1] = pyfiles[-1].rstrip(" \\")
     frozenfiles[-1] = frozenfiles[-1].rstrip(" \\")

--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -553,18 +553,22 @@ def regen_makefile(modules):
         pyfile = relpath_for_posix_display(src.pyfile, ROOT_DIR)
         pyfiles.append(f'\t\t{pyfile} \\')
 
-        freeze = f'Programs/_freeze_module {src.frozenid} $(pyfile) $@.new'
+        freeze = f'Programs/_freeze_module {src.frozenid} "$(pyfile)" $@.new'
         update = '$(UPDATE_FILE) --create --exitcode $@ $@.new'
         rules.extend([
-            f'{header}: {pyfile}',
-            f'\t$(eval pyfile = "$(srcdir)/{pyfile}")',
+            f'{header}: $(srcdir)/{pyfile}',
+            f'\t$(eval exists = $(wildcard $@))',
+            f'\t$(eval pyfile_dep = {pyfile})',
+            f'\t$(eval pyfile = $(srcdir)/$(pyfile_dep))',
             '\t@$(MAKE) --quiet .generating-frozen-module',
             f'\t@{freeze}',
             f'\t@if {update}; then \\',
             '\t\tif test $@ -ot Python/frozen.o; then touch -r Python/frozen.o $@; fi; \\',
-            f'\t\tif test $@ -ot $(pyfile); then touch -r $(pyfile) $@; fi; \\',
+            f'\t\tif test $@ -ot $(pyfile); then touch -r "$(pyfile)" $@; fi; \\',
             '\tfi',
-            f'\t@if test -n "$(findstring $(pyfile),$?)" -a -e $@; then echo -n " $(@F) "; \\',
+            f'\t@if test -n "$(exists)" && test -n "$(findstring $(pyfile_dep),$?)"; then echo -n " $(@F) "; \\',
+            '\telif test -z "$(have_frozen_files)"; then echo -n "."; \\',
+            '\telif test -z "$(exists)"; then echo -n " $(@F) "; \\',
             '\telse echo -n "."; fi',
             '',
         ])

--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -554,10 +554,13 @@ def regen_makefile(modules):
         pyfiles.append(f'\t\t{pyfile} \\')
 
         freeze = (f'Programs/_freeze_module {src.frozenid} '
-                  f'$(srcdir)/{pyfile} $(srcdir)/{header}')
+                  f'$(srcdir)/{pyfile} $(srcdir)/{header}.new')
+        update = (f'$(UPDATE_FILE) --create $(srcdir)/{header} '
+                  f'$(srcdir)/{header}.new')
         rules.extend([
             f'{header}: Programs/_freeze_module {pyfile}',
             f'\t{freeze}',
+            f'\t{update}',
             '',
         ])
     pyfiles[-1] = pyfiles[-1].rstrip(" \\")


### PR DESCRIPTION
The focus here is on the output from generating frozen modules.  Now we only print 3 lines when generating them.  This is especially important as we freeze more modules.

<!-- issue-number: [bpo-45020](https://bugs.python.org/issue45020) -->
https://bugs.python.org/issue45020
<!-- /issue-number -->
