### PR TITLE
bpo-43914: Whats New 310: add new SyntaxError attributes

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -883,12 +883,12 @@ Other Language Changes
   collisions when creating dictionaries and sets containing multiple NaNs.
   (Contributed by Raymond Hettinger in :issue:`43475`.)
 
-*  A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting
-   the :const:`__debug__` constant.  (Contributed by Dong-hee Na in :issue:`45000`.)
+* A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting
+  the :const:`__debug__` constant.  (Contributed by Dong-hee Na in :issue:`45000`.)
 
-*  :exc:`SyntaxError` exceptions now have ``end_lineno`` and
-    ``end_offset`` attributes.  They will be ``None`` if not determined.
-    (Contributed by Pablo Galindo in :issue:`43914`.)
+* :exc:`SyntaxError` exceptions now have ``end_lineno`` and
+  ``end_offset`` attributes.  They will be ``None`` if not determined.
+  (Contributed by Pablo Galindo in :issue:`43914`.)
 
 New Modules
 ===========

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -887,8 +887,8 @@ Other Language Changes
    the :const:`__debug__` constant.  (Contributed by Dong-hee Na in :issue:`45000`.)
 
 *  :exc:`SyntaxError` exceptions now have ``end_lineno`` and
-``end_offset`` attributes.  They will be None if not determined.
-(Contributed by Pablo Galindo in :issue:`43914`.)
+    ``end_offset`` attributes.  They will be ``None`` if not determined.
+    (Contributed by Pablo Galindo in :issue:`43914`.)
 
 New Modules
 ===========

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -883,7 +883,8 @@ Other Language Changes
   collisions when creating dictionaries and sets containing multiple NaNs.
   (Contributed by Raymond Hettinger in :issue:`43475`.)
 
-*  A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting the :const:`__debug__` constant. (Contributed by Dong-hee Na in :issue:`45000`.)
+*  A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting
+   the :const:`__debug__` constant.  (Contributed by Dong-hee Na in :issue:`45000`.)
 
 *  :exc:`SyntaxError` exceptions now have ``end_lineno`` and
 ``end_offset`` attributes.  They will be None if not determined.

--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -885,6 +885,10 @@ Other Language Changes
 
 *  A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting the :const:`__debug__` constant. (Contributed by Dong-hee Na in :issue:`45000`.)
 
+*  :exc:`SyntaxError` exceptions now have ``end_lineno`` and
+``end_offset`` attributes.  They will be None if not determined.
+(Contributed by Pablo Galindo in :issue:`43914`.)
+
 New Modules
 ===========
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-43914](https://bugs.python.org/issue43914) -->
https://bugs.python.org/issue43914
<!-- /issue-number -->
