### PR TITLE
bpo-45280: Add test for empty `NamedTuple` in `test_typing`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4099,6 +4099,19 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(a.typename, 'foo')
         self.assertEqual(a.fields, [('bar', tuple)])
 
+    def test_empty_namedtuple(self):
+        NT = NamedTuple('NT')
+
+        class CNT(NamedTuple):
+            pass  # empty body
+
+        for struct in [NT, CNT]:
+            with self.subTest(struct=struct):
+                self.assertEqual(struct._fields, ())
+                self.assertEqual(struct._field_defaults, {})
+                self.assertEqual(struct.__annotations__, {})
+                self.assertIsInstance(struct(), struct)
+
     def test_namedtuple_errors(self):
         with self.assertRaises(TypeError):
             NamedTuple.__new__()

--- a/Misc/NEWS.d/next/Tests/2021-09-25-11-05-31.bpo-45280.3MA6lC.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-25-11-05-31.bpo-45280.3MA6lC.rst
@@ -1,0 +1,1 @@
+Adds a test case for empty ``typing.NamedTuple`` in ``test_typing``.

--- a/Misc/NEWS.d/next/Tests/2021-09-25-11-05-31.bpo-45280.3MA6lC.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-25-11-05-31.bpo-45280.3MA6lC.rst
@@ -1,1 +1,1 @@
-Adds a test case for empty ``typing.NamedTuple`` in ``test_typing``.
+Adds a test case for empty :class:`typing.NamedTuple`.

--- a/Misc/NEWS.d/next/Tests/2021-09-25-11-05-31.bpo-45280.3MA6lC.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-25-11-05-31.bpo-45280.3MA6lC.rst
@@ -1,1 +1,1 @@
-Adds a test case for empty :class:`typing.NamedTuple`.
+Add a test case for empty :class:`typing.NamedTuple`.


### PR DESCRIPTION


<!-- issue-number: [bpo-45280](https://bugs.python.org/issue45280) -->
https://bugs.python.org/issue45280
<!-- /issue-number -->
