### PR TITLE
[3.10] bpo-43914: What's New 3.10: add new SyntaxError attributes (GH-28558)

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -883,7 +883,12 @@ Other Language Changes
   collisions when creating dictionaries and sets containing multiple NaNs.
   (Contributed by Raymond Hettinger in :issue:`43475`.)
 
-*  A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting the :const:`__debug__` constant. (Contributed by Dong-hee Na in :issue:`45000`.)
+* A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting
+  the :const:`__debug__` constant.  (Contributed by Dong-hee Na in :issue:`45000`.)
+
+* :exc:`SyntaxError` exceptions now have ``end_lineno`` and
+  ``end_offset`` attributes.  They will be ``None`` if not determined.
+  (Contributed by Pablo Galindo in :issue:`43914`.)
 
 New Modules
 ===========


### PR DESCRIPTION
Co-authored-by: Ken Jin <28750310+Fidget-Spinner@users.noreply.github.com>
(cherry picked from commit 71f8ff45c62bd6b792919ac7c3804a8628ae12cb)

Co-authored-by: Terry Jan Reedy <tjreedy@udel.edu>


<!-- issue-number: [bpo-43914](https://bugs.python.org/issue43914) -->
https://bugs.python.org/issue43914
<!-- /issue-number -->
