### PR TITLE
bpo-45283: Run `_type_check` on `get_type_hints()`

### DIFF
--- a/Lib/test/ann_module.py
+++ b/Lib/test/ann_module.py
@@ -8,7 +8,7 @@ Empty lines above are for good reason (testing for correct line numbers)
 from typing import Optional
 from functools import wraps
 
-__annotations__[1] = 2
+__annotations__[1] = int
 
 class C:
 
@@ -19,7 +19,7 @@ x: int = 5; y: str = x; f: Tuple[int, int]
 
 class M(type):
 
-    __annotations__['123'] = 123
+    __annotations__['123'] = int
     o: type = object
 
 (pars): bool = True

--- a/Lib/test/ann_module7.py
+++ b/Lib/test/ann_module7.py
@@ -4,5 +4,3 @@
 from typing import ClassVar, Final
 
 wrong: ClassVar[int] = 1
-def final_var_arg(arg: Final): pass
-def final_var_return_type() -> Final: pass

--- a/Lib/test/ann_module7.py
+++ b/Lib/test/ann_module7.py
@@ -1,0 +1,8 @@
+# Ensures that top-level ``ClassVar`` is not allowed.
+# We test this explicitly without ``from __future__ import annotations``
+
+from typing import ClassVar, Final
+
+wrong: ClassVar[int] = 1
+def final_var_arg(arg: Final): pass
+def final_var_return_type() -> Final: pass

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -473,9 +473,9 @@ class GrammarTests(unittest.TestCase):
     def test_var_annot_module_semantics(self):
         self.assertEqual(test.__annotations__, {})
         self.assertEqual(ann_module.__annotations__,
-                     {1: 2, 'x': int, 'y': str, 'f': typing.Tuple[int, int], 'u': int | float})
+                     {1: int, 'x': int, 'y': str, 'f': typing.Tuple[int, int], 'u': int | float})
         self.assertEqual(ann_module.M.__annotations__,
-                              {'123': 123, 'o': type})
+                              {'123': int, 'o': type})
         self.assertEqual(ann_module2.__annotations__, {})
 
     def test_var_annot_in_module(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3286,7 +3286,7 @@ class GetTypeHintTests(BaseTestCase):
         with self.assertRaisesRegex(
             TypeError,
             re.escape(
-                'get_type_hint() got invalid type annotation. Got (1, 2).',
+                'get_type_hints() got invalid type annotation. Got (1, 2).',
             ),
         ):
             get_type_hints(InvalidTupleAnnotation)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3341,25 +3341,6 @@ class GetTypeHintTests(BaseTestCase):
                 with self.assertRaises(TypeError):
                     get_type_hints(func)
 
-    def test_forward_ref_and_final(self):
-        # https://bugs.python.org/issue45166
-        hints = get_type_hints(ann_module5)
-        self.assertEqual(hints, {'name': Final[str]})
-
-        hints = get_type_hints(ann_module5.MyClass)
-        self.assertEqual(hints, {'value': Final})
-
-    def test_top_level_class_var(self):
-        # https://bugs.python.org/issue45166
-        # https://bugs.python.org/issue45283
-        for obj in [ann_module6, ann_module7]:
-            with self.subTest(obj=obj):
-                with self.assertRaisesRegex(
-                    TypeError,
-                    r'typing.ClassVar\[int\] is not valid as type argument',
-                ):
-                    get_type_hints(obj)
-
 
 class GetUtilitiesTestCase(TestCase):
     def test_get_origin(self):
@@ -3422,6 +3403,25 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(Callable[Concatenate[int, P], int]),
                          (Concatenate[int, P], int))
         self.assertEqual(get_args(list | str), (list, str))
+
+    def test_forward_ref_and_final(self):
+        # https://bugs.python.org/issue45166
+        hints = get_type_hints(ann_module5)
+        self.assertEqual(hints, {'name': Final[str]})
+
+        hints = get_type_hints(ann_module5.MyClass)
+        self.assertEqual(hints, {'value': Final})
+
+    def test_top_level_class_var(self):
+        # https://bugs.python.org/issue45166
+        # https://bugs.python.org/issue45283
+        for obj in [ann_module6, ann_module7]:
+            with self.subTest(obj=obj):
+                with self.assertRaisesRegex(
+                    TypeError,
+                    r'typing.ClassVar\[int\] is not valid as type argument',
+                ):
+                    get_type_hints(obj)
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -170,11 +170,12 @@ def _type_check(arg, msg, is_argument=True, module=None, *, is_class=False):
             invalid_generic_forms += (Final,)
 
     arg = _type_convert(arg, module=module)
-    if (
-        (isinstance(arg, _GenericAlias) and
-            arg.__origin__ in invalid_generic_forms) or
-        (is_argument and arg == Final)  # Raw `Final` is not `_GenericAlias`
-    ):
+    is_invalid_generic = (
+        isinstance(arg, _GenericAlias)
+        and arg.__origin__ in invalid_generic_forms
+    )
+    is_invalid_bare_final = is_argument and arg is Final
+    if is_invalid_generic or is_invalid_bare_final:
         raise TypeError(f"{arg} is not valid as type argument")
     if arg in (Any, NoReturn, Final):
         return arg
@@ -1784,7 +1785,7 @@ def get_type_hints(obj, globalns=None, localns=None, include_extras=False):
     if getattr(obj, '__no_type_check__', None):
         return {}
 
-    error_msg = "get_type_hint() got invalid type annotation."
+    error_msg = "get_type_hints() got invalid type annotation."
 
     # Classes require a special treatment.
     if isinstance(obj, type):

--- a/Misc/NEWS.d/next/Library/2021-09-25-13-28-44.bpo-45283.ooE1jy.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-25-13-28-44.bpo-45283.ooE1jy.rst
@@ -1,2 +1,2 @@
-Runs ``_type_check()`` on all ``get_type_hints()`` calls. This catches cases
+Run ``_type_check()`` on all ``get_type_hints()`` calls. This catches cases
 when any invalid annotations are used.

--- a/Misc/NEWS.d/next/Library/2021-09-25-13-28-44.bpo-45283.ooE1jy.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-25-13-28-44.bpo-45283.ooE1jy.rst
@@ -1,0 +1,2 @@
+Runs ``_type_check()`` on all ``get_type_hints()`` calls. This catches cases
+when any invalid annotations are used.


### PR DESCRIPTION
This PR contains quite a lot of changes, but they are all related.

1. First of all, I've fixed the core issue: `ClassVar` is now forbidden on module level during `get_type_hints()`
2. But, I had to use `_type_check()` for that
3. After running tests, I realised that several old ([commit](https://github.com/python/cpython/commit/f8cb8a16a344ab208fd46876c4b63604987347b8)) annotations are not valid, for example:`__annotations__['123'] = 1`, so I changed them -> `__annotations__['123'] = int`
4. Then, I realized that `Final` and `ClassVar` are not tested together with `get_type_hints()` and functions
5. After that I wrote several other test cases for classes to check that the same feature works for them as well
6. I also moved tests from https://github.com/python/cpython/pull/28279, because I accidentally created them in the wrong class

I am pretty sure that this change can cause multiple problems for people with wrong annotations, because `get_type_hints()` was much more forgiving before this change. But, as a heavy typing user, I believe that this is a good thing, because correctness is very important in this area.

<!-- issue-number: [bpo-45283](https://bugs.python.org/issue45283) -->
https://bugs.python.org/issue45283
<!-- /issue-number -->
