### PR TITLE
bpo-41914: Fix issue running test_pdb inside GNU `screen`

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1844,7 +1844,8 @@ def bœr():
         ])
         stdout, _ = self.run_pdb_script('pass', commands + '\n')
 
-        self.assertEqual(stdout.splitlines()[1:], [
+        stdout_lines = stdout.splitlines()[1:]
+        expected_lines = [
             '-> pass',
             '(Pdb) *** SyntaxError: \'(\' was never closed',
 
@@ -1857,7 +1858,9 @@ def bœr():
             "((Pdb)) *** NameError: name 'doesnotexist' is not defined",
             'LEAVING RECURSIVE DEBUGGER',
             '(Pdb) ',
-        ])
+        ]
+        self.assertTrue(all(e == s for (e, s) in zip(stdout_lines, expected_lines)))
+        self.assertTrue(len(expected_lines) <= len(stdout_lines) <= len(expected_lines) + 1)
 
     def test_issue34266(self):
         '''do_run handles exceptions from parsing its arg'''
@@ -1867,11 +1870,7 @@ def bœr():
                 'q',
             ])
             stdout, _ = self.run_pdb_script('pass', commands + '\n')
-            self.assertEqual(stdout.splitlines()[1:], [
-                '-> pass',
-                f'(Pdb) *** Cannot run {bad_arg}: {msg}',
-                '(Pdb) ',
-            ])
+            self.assertIn(f'(Pdb) *** Cannot run {bad_arg}: {msg}', stdout)
         check('\\', 'No escaped character')
         check('"', 'No closing quotation')
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1382,6 +1382,7 @@ Zero Piraeus
 Antoine Pitrou
 Jean-François Piéronne
 Oleg Plakhotnyuk
+Léon Planken
 Anatoliy Platonov
 Marcel Plch
 Remi Pointel

--- a/Misc/NEWS.d/next/Tests/2021-09-25-22-22-40.bpo-41914.O-QsyY.rst
+++ b/Misc/NEWS.d/next/Tests/2021-09-25-22-22-40.bpo-41914.O-QsyY.rst
@@ -1,0 +1,4 @@
+Fix issue running test_pdb inside GNU `screen`: for some reason, two tests
+in test_pdb failed when running inside GNU `screen`.  The `screen`
+environment injects an ANSI control sequence into the output from `pdb`,
+which did not match the expected output.


### PR DESCRIPTION
For some reason, two tests in test_pdb failed when running inside GNU
`screen`.  The `screen` environment injects an ANSI control sequence into
the output from `pdb`, which did not match the expected output.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-41914](https://bugs.python.org/issue41914) -->
https://bugs.python.org/issue41914
<!-- /issue-number -->
