### PR TITLE
bpo-45291: Explicitly set --libdir=lib when configure OpenSSL

### DIFF
--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -162,6 +162,7 @@ Custom OpenSSL
          $ pushd openssl-VERSION
          $ ./config \
               --prefix=/usr/local/custom-openssl \
+              --libdir=lib \
               --openssldir=/etc/ssl
          $ make -j1 depend
          $ make -j8


### PR DESCRIPTION
<!-- issue-number: [bpo-45291](https://bugs.python.org/issue45291) -->
https://bugs.python.org/issue45291
<!-- /issue-number -->
