### PR TITLE
bpo-45295: Speed up C classmethod calls via unbound classmethods

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1630,8 +1630,8 @@ order (MRO) for bases """
             spam_cm()
         self.assertEqual(
             str(cm.exception),
-            "descriptor 'classmeth' of 'xxsubtype.spamlist' "
-            "object needs an argument")
+            "unbound method spamlist.classmeth() "
+            "needs an argument")
 
         with self.assertRaises(TypeError) as cm:
             spam_cm(spam.spamlist())

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -890,7 +890,9 @@ id(42)
         ):
             for obj in (
                 '_testcapi',
-                '_testcapi.MethClass',
+                # From bpo-45295, classmethods are unbound and don't give
+                # nice tracebacks.
+                # '_testcapi.MethClass',
                 '_testcapi.MethClass()',
                 '_testcapi.MethStatic()',
 

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-27-18-09-46.bpo-45295.bfj5cj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-27-18-09-46.bpo-45295.bfj5cj.rst
@@ -1,0 +1,3 @@
+Speed up C classmethod calls such as ``int.from_bytes``. 1.
+``_PyObject_GetMethod`` now supports unbound C classmethods. 2.
+``PyClassMethodDescr_Type`` now supports vectorcall.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-27-18-09-46.bpo-45295.bfj5cj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-27-18-09-46.bpo-45295.bfj5cj.rst
@@ -1,3 +1,3 @@
-Speed up C classmethod calls such as ``int.from_bytes``. 1.
-``_PyObject_GetMethod`` now supports unbound C classmethods. 2.
-``PyClassMethodDescr_Type`` now supports vectorcall.
+Speed up C classmethod calls such as ``int.from_bytes``.
+``_PyObject_GetMethod`` now supports unbound C classmethods.
+``PyClassMethodDescr_Type`` now supports vectorcall. Patch by Ken Jin.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1121,9 +1121,10 @@ _PyObject_NextNotImplemented(PyObject *self)
    `method` will point to the resolved attribute or NULL.  In the
    latter case, an error will be set.
 
-   Also works with C METH_CLASS methods, such as dict.fromkeys or int.from_bytes.
+   Also works with C METH_CLASS methods, such as dict.fromkeys.
 
-   When a method is found, *method* is set to an unbound method or unbound classmethod.
+   When a method is found, *method* is set to an unbound method, unbound
+   classmethod or wrapper descriptor.
 */
 int
 _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -566,10 +566,10 @@ analyze_descriptor(PyTypeObject *type, PyObject *name, PyObject **descr, int sto
     }
     if (desc_cls->tp_descr_get) {
         if (desc_cls->tp_flags & Py_TPFLAGS_METHOD_DESCRIPTOR) {
+            if (Py_IS_TYPE(descriptor, &PyClassMethodDescr_Type)) {
+                return BUILTIN_CLASSMETHOD;
+            }
             return METHOD;
-        }
-        if (Py_IS_TYPE(descriptor, &PyClassMethodDescr_Type)) {
-            return BUILTIN_CLASSMETHOD;
         }
         if (Py_IS_TYPE(descriptor, &PyClassMethod_Type)) {
             return PYTHON_CLASSMETHOD;


### PR DESCRIPTION
1. `_PyObject_GetMethod` now supports C classmethods.
2. `PyClassMethodDescr_Type` now supports vectorcall.

This PR has two changes because supporting vectorcall made it easier to call unbound cclassmethods. Without vectorcall, I'd need to write a lot of custom code.

Moving to vectorcall also means we can get rid of the old calling code :).

Microbench on Windows Release, pyperformance coming later (once tests pass):
```
python.exe -m timeit "int.from_bytes(b'')"
Main:
2000000 loops, best of 5: 107 nsec per loop
Patched:
5000000 loops, best of 5: 72.4 nsec per loop
```

This is **without** specialization support. That will come in another PR.

<!-- issue-number: [bpo-45295](https://bugs.python.org/issue45295) -->
https://bugs.python.org/issue45295
<!-- /issue-number -->
