### PR TITLE
bpo-45020: Use a common recipe for freezing modules.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -777,8 +777,8 @@ Programs/_freeze_module.o: Programs/_freeze_module.c Makefile
 Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN)
 	$(LINKCC) $(PY_CORE_LDFLAGS) -o $@ Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
-$(FROZEN_DATA)/%.h: Programs/_freeze_module
-	$(eval frozenid = $(*F))
+$(FROZEN_FILES_OUT): Programs/_freeze_module
+	$(eval frozenid = $(basename $(@F)))
 	$(eval pyfile = "$(srcdir)/Lib/$(subst .,/,$(frozenid)).py")
 	Programs/_freeze_module $(frozenid) $(pyfile) $@
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -777,53 +777,27 @@ Programs/_freeze_module.o: Programs/_freeze_module.c Makefile
 Programs/_freeze_module: Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN)
 	$(LINKCC) $(PY_CORE_LDFLAGS) -o $@ Programs/_freeze_module.o $(LIBRARY_OBJS_OMIT_FROZEN) $(LIBS) $(MODLIBS) $(SYSLIBS)
 
+$(FROZEN_DATA)/%.h: Programs/_freeze_module
+	$(eval frozenid = $(*F))
+	$(eval pyfile = "$(srcdir)/Lib/$(subst .,/,$(frozenid)).py")
+	Programs/_freeze_module $(frozenid) $(pyfile) $@
+
 # BEGIN: freezing modules
-
-Python/frozen_modules/importlib._bootstrap.h: Programs/_freeze_module Lib/importlib/_bootstrap.py
-	Programs/_freeze_module importlib._bootstrap $(srcdir)/Lib/importlib/_bootstrap.py $(srcdir)/Python/frozen_modules/importlib._bootstrap.h
-
-Python/frozen_modules/importlib._bootstrap_external.h: Programs/_freeze_module Lib/importlib/_bootstrap_external.py
-	Programs/_freeze_module importlib._bootstrap_external $(srcdir)/Lib/importlib/_bootstrap_external.py $(srcdir)/Python/frozen_modules/importlib._bootstrap_external.h
-
-Python/frozen_modules/zipimport.h: Programs/_freeze_module Lib/zipimport.py
-	Programs/_freeze_module zipimport $(srcdir)/Lib/zipimport.py $(srcdir)/Python/frozen_modules/zipimport.h
-
-Python/frozen_modules/abc.h: Programs/_freeze_module Lib/abc.py
-	Programs/_freeze_module abc $(srcdir)/Lib/abc.py $(srcdir)/Python/frozen_modules/abc.h
-
-Python/frozen_modules/codecs.h: Programs/_freeze_module Lib/codecs.py
-	Programs/_freeze_module codecs $(srcdir)/Lib/codecs.py $(srcdir)/Python/frozen_modules/codecs.h
-
-Python/frozen_modules/io.h: Programs/_freeze_module Lib/io.py
-	Programs/_freeze_module io $(srcdir)/Lib/io.py $(srcdir)/Python/frozen_modules/io.h
-
-Python/frozen_modules/_collections_abc.h: Programs/_freeze_module Lib/_collections_abc.py
-	Programs/_freeze_module _collections_abc $(srcdir)/Lib/_collections_abc.py $(srcdir)/Python/frozen_modules/_collections_abc.h
-
-Python/frozen_modules/_sitebuiltins.h: Programs/_freeze_module Lib/_sitebuiltins.py
-	Programs/_freeze_module _sitebuiltins $(srcdir)/Lib/_sitebuiltins.py $(srcdir)/Python/frozen_modules/_sitebuiltins.h
-
-Python/frozen_modules/genericpath.h: Programs/_freeze_module Lib/genericpath.py
-	Programs/_freeze_module genericpath $(srcdir)/Lib/genericpath.py $(srcdir)/Python/frozen_modules/genericpath.h
-
-Python/frozen_modules/ntpath.h: Programs/_freeze_module Lib/ntpath.py
-	Programs/_freeze_module ntpath $(srcdir)/Lib/ntpath.py $(srcdir)/Python/frozen_modules/ntpath.h
-
-Python/frozen_modules/posixpath.h: Programs/_freeze_module Lib/posixpath.py
-	Programs/_freeze_module posixpath $(srcdir)/Lib/posixpath.py $(srcdir)/Python/frozen_modules/posixpath.h
-
-Python/frozen_modules/os.h: Programs/_freeze_module Lib/os.py
-	Programs/_freeze_module os $(srcdir)/Lib/os.py $(srcdir)/Python/frozen_modules/os.h
-
-Python/frozen_modules/site.h: Programs/_freeze_module Lib/site.py
-	Programs/_freeze_module site $(srcdir)/Lib/site.py $(srcdir)/Python/frozen_modules/site.h
-
-Python/frozen_modules/stat.h: Programs/_freeze_module Lib/stat.py
-	Programs/_freeze_module stat $(srcdir)/Lib/stat.py $(srcdir)/Python/frozen_modules/stat.h
-
-Python/frozen_modules/__hello__.h: Programs/_freeze_module Lib/__hello__.py
-	Programs/_freeze_module __hello__ $(srcdir)/Lib/__hello__.py $(srcdir)/Python/frozen_modules/__hello__.h
-
+Python/frozen_modules/importlib._bootstrap.h: Lib/importlib/_bootstrap.py
+Python/frozen_modules/importlib._bootstrap_external.h: Lib/importlib/_bootstrap_external.py
+Python/frozen_modules/zipimport.h: Lib/zipimport.py
+Python/frozen_modules/abc.h: Lib/abc.py
+Python/frozen_modules/codecs.h: Lib/codecs.py
+Python/frozen_modules/io.h: Lib/io.py
+Python/frozen_modules/_collections_abc.h: Lib/_collections_abc.py
+Python/frozen_modules/_sitebuiltins.h: Lib/_sitebuiltins.py
+Python/frozen_modules/genericpath.h: Lib/genericpath.py
+Python/frozen_modules/ntpath.h: Lib/ntpath.py
+Python/frozen_modules/posixpath.h: Lib/posixpath.py
+Python/frozen_modules/os.h: Lib/os.py
+Python/frozen_modules/site.h: Lib/site.py
+Python/frozen_modules/stat.h: Lib/stat.py
+Python/frozen_modules/__hello__.h: Lib/__hello__.py
 # END: freezing modules
 
 Tools/scripts/freeze_modules.py: Programs/_freeze_module

--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -545,7 +545,7 @@ def regen_frozen(modules):
 def regen_makefile(modules):
     pyfiles = []
     frozenfiles = []
-    rules = ['']
+    rules = []
     for src in _iter_sources(modules):
         header = relpath_for_posix_display(src.frozenfile, ROOT_DIR)
         frozenfiles.append(f'\t\t{header} \\')
@@ -556,9 +556,7 @@ def regen_makefile(modules):
         freeze = (f'Programs/_freeze_module {src.frozenid} '
                   f'$(srcdir)/{pyfile} $(srcdir)/{header}')
         rules.extend([
-            f'{header}: Programs/_freeze_module {pyfile}',
-            f'\t{freeze}',
-            '',
+            f'{header}: {pyfile}',
         ])
     pyfiles[-1] = pyfiles[-1].rstrip(" \\")
     frozenfiles[-1] = frozenfiles[-1].rstrip(" \\")


### PR DESCRIPTION
This means less generated code and less noise in the make file.

<!-- issue-number: [bpo-45020](https://bugs.python.org/issue45020) -->
https://bugs.python.org/issue45020
<!-- /issue-number -->
