### PR TITLE
bpo-45020: Default to using frozen modules only on non-debug builds.

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -436,6 +436,9 @@ def _generate_posix_vars():
     if _PYTHON_BUILD:
         vars['BLDSHARED'] = vars['LDSHARED']
 
+    Py_DEBUG = bool(vars['Py_DEBUG'])
+    vars['FROZEN_MODULES_DEFAULT'] = 0 if Py_DEBUG else 1
+
     # There's a chicken-and-egg situation on OS X with regards to the
     # _sysconfigdata module after the changes introduced by #15298:
     # get_config_vars() is called by get_platform() as part of the
@@ -490,6 +493,10 @@ def _init_non_posix(vars):
     vars['VERSION'] = _PY_VERSION_SHORT_NO_DOT
     vars['BINDIR'] = os.path.dirname(_safe_realpath(sys.executable))
     vars['TZPATH'] = ''
+    # infer build vars
+    Py_DEBUG = hasattr(sys, 'gettotalrefcount')
+    vars['Py_DEBUG'] = 1 if Py_DEBUG else 0
+    vars['FROZEN_MODULES_DEFAULT'] = 0 if Py_DEBUG else 1
 
 #
 # public APIs

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -106,6 +106,8 @@ TEST_HOME_DIR = os.path.dirname(TEST_SUPPORT_DIR)
 STDLIB_DIR = os.path.dirname(TEST_HOME_DIR)
 REPO_ROOT = os.path.dirname(STDLIB_DIR)
 
+Py_DEBUG = hasattr(sys, 'gettotalrefcount')
+
 
 class Error(Exception):
     """Base class for regression test exceptions."""

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -434,7 +434,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'pathconfig_warnings': 1,
         '_init_main': 1,
         '_isolated_interpreter': 0,
-        'use_frozen_modules': 0,
+        'use_frozen_modules': 0 if support.Py_DEBUG else 1,
     }
     if MS_WINDOWS:
         CONFIG_COMPAT.update({

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2089,9 +2089,12 @@ config_init_import(PyConfig *config, int compute_path_config)
     /* -X frozen_modules=[on|off] */
     const wchar_t *value = config_get_xoption_value(config, L"frozen_modules");
     if (value == NULL) {
-        // For now we always default to "off".
-        // In the near future we will be factoring in PGO and in-development.
+        // Default to "off" on debug builds and "on" otherwise.
+#ifdef Py_DEBUG
         config->use_frozen_modules = 0;
+#else
+        config->use_frozen_modules = 1;
+#endif
     }
     else if (wcscmp(value, L"on") == 0) {
         config->use_frozen_modules = 1;


### PR DESCRIPTION
This should give us the default we normally want, "on", without disrupting contributors too much.  This should be a good-enough place to start.  We can adjust the heuristic (e.g. PGO or running-in-source-tree) later if needed.

<!-- issue-number: [bpo-45020](https://bugs.python.org/issue45020) -->
https://bugs.python.org/issue45020
<!-- /issue-number -->
