### PR TITLE
[3.10] bpo-45307: Restore private C API function _PyImport_FindExtensionObject()

### DIFF
--- a/Include/cpython/import.h
+++ b/Include/cpython/import.h
@@ -13,7 +13,8 @@ PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
 PyAPI_FUNC(void) _PyImport_AcquireLock(void);
 PyAPI_FUNC(int) _PyImport_ReleaseLock(void);
 
-PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObject(PyObject *, PyObject *);
+/* Obsolete since 3.5, will be removed in 3.11. */
+Py_DEPRECATED(3.10) PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObject(PyObject *, PyObject *);
 
 PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     PyObject *mod,

--- a/Include/cpython/import.h
+++ b/Include/cpython/import.h
@@ -13,6 +13,8 @@ PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
 PyAPI_FUNC(void) _PyImport_AcquireLock(void);
 PyAPI_FUNC(int) _PyImport_ReleaseLock(void);
 
+PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObject(PyObject *, PyObject *);
+
 PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     PyObject *mod,
     const char *name,            /* UTF-8 encoded string */

--- a/Misc/NEWS.d/next/C API/2021-09-28-12-00-55.bpo-45307.3ETFfX.rst
+++ b/Misc/NEWS.d/next/C API/2021-09-28-12-00-55.bpo-45307.3ETFfX.rst
@@ -1,2 +1,2 @@
-Restore private C API function :func:`_PyImport_FindExtensionObject`. It
+Restore the private C API function :func:`_PyImport_FindExtensionObject`. It
 will be removed in Python 3.11.

--- a/Misc/NEWS.d/next/C API/2021-09-28-12-00-55.bpo-45307.3ETFfX.rst
+++ b/Misc/NEWS.d/next/C API/2021-09-28-12-00-55.bpo-45307.3ETFfX.rst
@@ -1,0 +1,2 @@
+Restore private C API function :func:`_PyImport_FindExtensionObject`. It
+will be removed in Python 3.11.

--- a/Python/import.c
+++ b/Python/import.c
@@ -556,6 +556,23 @@ import_find_extension(PyThreadState *tstate, PyObject *name,
     return mod;
 }
 
+PyObject *
+_PyImport_FindExtensionObject(PyObject *name, PyObject *filename)
+{
+    PyThreadState *tstate = _PyThreadState_GET();
+    PyObject *mod = import_find_extension(tstate, name, filename);
+    if (mod) {
+        PyObject *ref = PyWeakref_NewRef(mod, NULL);
+        Py_DECREF(mod);
+        if (ref == NULL) {
+            return NULL;
+        }
+        mod = PyWeakref_GetObject(ref);
+        Py_DECREF(ref);
+    }
+    return mod; /* borrowed reference */
+}
+
 
 /* Get the module object corresponding to a module name.
    First check the modules dictionary if there's one there,


### PR DESCRIPTION
py2exe and PyOxidizer rely on this API.
It will be removed in Python 3.11.


<!-- issue-number: [bpo-45307](https://bugs.python.org/issue45307) -->
https://bugs.python.org/issue45307
<!-- /issue-number -->
