### PR TITLE
gh-89562: Remove hostflags from PySSLContext

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2022-12-29-19-10-36.gh-issue-89562.g8m8RC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2022-12-29-19-10-36.gh-issue-89562.g8m8RC.rst
@@ -1,0 +1,1 @@
+Remove ``hostflags`` member from ``PySSLContext`` struct.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -293,10 +293,6 @@ typedef struct {
     unsigned int alpn_protocols_len;
     PyObject *set_sni_cb;
     int check_hostname;
-    /* OpenSSL has no API to get hostflags from X509_VERIFY_PARAM* struct.
-     * We have to maintain our own copy. OpenSSL's hostflags default to 0.
-     */
-    unsigned int hostflags;
     int protocol;
 #if defined(PySSL_HAVE_POST_HS_AUTH)
     int post_handshake_auth;
@@ -824,15 +820,15 @@ _ssl_configure_hostname(PySSLSocket *self, const char* server_hostname)
         }
     }
     if (self->ctx->check_hostname) {
-        X509_VERIFY_PARAM *param = SSL_get0_param(self->ssl);
+        X509_VERIFY_PARAM *ssl_verification_params = SSL_get0_param(self->ssl);
         if (ip == NULL) {
-            if (!X509_VERIFY_PARAM_set1_host(param, server_hostname,
+            if (!X509_VERIFY_PARAM_set1_host(ssl_verification_params, server_hostname,
                                              strlen(server_hostname))) {
                 _setSSLError(get_state_sock(self), NULL, 0, __FILE__, __LINE__);
                 goto error;
             }
         } else {
-            if (!X509_VERIFY_PARAM_set1_ip(param, ASN1_STRING_get0_data(ip),
+            if (!X509_VERIFY_PARAM_set1_ip(ssl_verification_params, ASN1_STRING_get0_data(ip),
                                            ASN1_STRING_length(ip))) {
                 _setSSLError(get_state_sock(self), NULL, 0, __FILE__, __LINE__);
                 goto error;
@@ -909,8 +905,11 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
 
     /* bpo43522 and OpenSSL < 1.1.1l: copy hostflags manually */
 #if OPENSSL_VERSION < 0x101010cf
-    X509_VERIFY_PARAM *ssl_params = SSL_get0_param(self->ssl);
-    X509_VERIFY_PARAM_set_hostflags(ssl_params, sslctx->hostflags);
+    X509_VERIFY_PARAM *ssl_verification_params = SSL_get0_param(self->ssl);
+    X509_VERIFY_PARAM *ssl_ctx_verification_params = SSL_CTX_get0_param(ctx);
+
+    unsigned int ssl_ctx_host_flags = X509_VERIFY_PARAM_get_hostflags(ssl_ctx_verification_params);
+    X509_VERIFY_PARAM_set_hostflags(ssl_verification_params, ssl_ctx_host_flags);
 #endif
     SSL_set_app_data(self->ssl, self);
     if (sock) {
@@ -3097,7 +3096,7 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
     uint64_t options;
     const SSL_METHOD *method = NULL;
     SSL_CTX *ctx = NULL;
-    X509_VERIFY_PARAM *params;
+    X509_VERIFY_PARAM *ssl_verification_params;
     int result;
 
    /* slower approach, walk MRO and get borrowed reference to module.
@@ -3181,7 +3180,6 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
         return NULL;
     }
     self->ctx = ctx;
-    self->hostflags = X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
     self->protocol = proto_version;
     self->msg_cb = NULL;
     self->keylog_filename = NULL;
@@ -3271,11 +3269,11 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
        usage for no cost at all. */
     SSL_CTX_set_mode(self->ctx, SSL_MODE_RELEASE_BUFFERS);
 
-    params = SSL_CTX_get0_param(self->ctx);
+    ssl_verification_params = SSL_CTX_get0_param(self->ctx);
     /* Improve trust chain building when cross-signed intermediate
        certificates are present. See https://bugs.python.org/issue23476. */
-    X509_VERIFY_PARAM_set_flags(params, X509_V_FLAG_TRUSTED_FIRST);
-    X509_VERIFY_PARAM_set_hostflags(params, self->hostflags);
+    X509_VERIFY_PARAM_set_flags(ssl_verification_params, X509_V_FLAG_TRUSTED_FIRST);
+    X509_VERIFY_PARAM_set_hostflags(ssl_verification_params, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
 
 #if defined(PySSL_HAVE_POST_HS_AUTH)
     self->post_handshake_auth = 0;
@@ -3530,11 +3528,11 @@ static PyObject *
 _ssl__SSLContext_verify_flags_get_impl(PySSLContext *self)
 /*[clinic end generated code: output=fbbf8ba28ad6e56e input=c1ec36d610b3f391]*/
 {
-    X509_VERIFY_PARAM *param;
+    X509_VERIFY_PARAM *ssl_verification_params;
     unsigned long flags;
 
-    param = SSL_CTX_get0_param(self->ctx);
-    flags = X509_VERIFY_PARAM_get_flags(param);
+    ssl_verification_params = SSL_CTX_get0_param(self->ctx);
+    flags = X509_VERIFY_PARAM_get_flags(ssl_verification_params);
     return PyLong_FromUnsignedLong(flags);
 }
 
@@ -3548,23 +3546,23 @@ static int
 _ssl__SSLContext_verify_flags_set_impl(PySSLContext *self, PyObject *value)
 /*[clinic end generated code: output=a3e3b2a0ce6c2e99 input=b2a0c42583d4f34e]*/
 {
-    X509_VERIFY_PARAM *param;
+    X509_VERIFY_PARAM *ssl_verification_params;
     unsigned long new_flags, flags, set, clear;
 
     if (!PyArg_Parse(value, "k", &new_flags))
         return -1;
-    param = SSL_CTX_get0_param(self->ctx);
-    flags = X509_VERIFY_PARAM_get_flags(param);
+    ssl_verification_params = SSL_CTX_get0_param(self->ctx);
+    flags = X509_VERIFY_PARAM_get_flags(ssl_verification_params);
     clear = flags & ~new_flags;
     set = ~flags & new_flags;
     if (clear) {
-        if (!X509_VERIFY_PARAM_clear_flags(param, clear)) {
+        if (!X509_VERIFY_PARAM_clear_flags(ssl_verification_params, clear)) {
             _setSSLError(get_state_ctx(self), NULL, 0, __FILE__, __LINE__);
             return -1;
         }
     }
     if (set) {
-        if (!X509_VERIFY_PARAM_set_flags(param, set)) {
+        if (!X509_VERIFY_PARAM_set_flags(ssl_verification_params, set)) {
             _setSSLError(get_state_ctx(self), NULL, 0, __FILE__, __LINE__);
             return -1;
         }
@@ -3859,7 +3857,12 @@ static PyObject *
 _ssl__SSLContext__host_flags_get_impl(PySSLContext *self)
 /*[clinic end generated code: output=0f9db6654ce32582 input=8e3c49499eefd0e5]*/
 {
-    return PyLong_FromUnsignedLong(self->hostflags);
+    X509_VERIFY_PARAM *ssl_verification_params;
+    unsigned int host_flags;
+
+    ssl_verification_params = SSL_CTX_get0_param(self->ctx);
+    host_flags = X509_VERIFY_PARAM_get_hostflags(ssl_verification_params);
+    return PyLong_FromUnsignedLong(host_flags);
 }
 
 /*[clinic input]
@@ -3872,15 +3875,14 @@ static int
 _ssl__SSLContext__host_flags_set_impl(PySSLContext *self, PyObject *value)
 /*[clinic end generated code: output=1ed6f4027aaf2e3e input=28caf1fb9c32f6cb]*/
 {
-    X509_VERIFY_PARAM *param;
+    X509_VERIFY_PARAM *ssl_verification_params;
     unsigned int new_flags = 0;
 
     if (!PyArg_Parse(value, "I", &new_flags))
         return -1;
 
-    param = SSL_CTX_get0_param(self->ctx);
-    self->hostflags = new_flags;
-    X509_VERIFY_PARAM_set_hostflags(param, new_flags);
+    ssl_verification_params = SSL_CTX_get0_param(self->ctx);
+    X509_VERIFY_PARAM_set_hostflags(ssl_verification_params, new_flags);
     return 0;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
The `PySSLContext` struct in `Modules/_ssl.c` mentions that "OpenSSL has no API to get hostflags from X509_VERIFY_PARAM* struct. We have to maintain our own copy".
Since OpenSSL 1.1.0i added the function `X509_VERIFY_PARAM_get_hostflags`, this statement is no longer true.
Because Python 3.10 requires OpenSSL 1.1.1 ([PEP 644](https://www.python.org/dev/peps/pep-0644/)), we no longer have to maintain a copy of the host flags.

This PR removes the `hostflags` member from the `PySSLContext` struct.

<!-- issue-number: [bpo-45399](https://bugs.python.org/issue45399) -->
https://bugs.python.org/issue45399
<!-- /issue-number -->


<!-- gh-issue-number: gh-89562 -->
* Issue: gh-89562
<!-- /gh-issue-number -->
