### PR TITLE
[docs] Use full names for time units

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -57,7 +57,7 @@ When the debug mode is enabled:
 * The execution time of the I/O selector is logged if it takes too long to
   perform an I/O operation.
 
-* Callbacks taking longer than 100ms are logged.  The
+* Callbacks taking longer than 100 milliseconds are logged.  The
   :attr:`loop.slow_callback_duration` attribute can be used to set the
   minimum execution duration in seconds that is considered "slow".
 

--- a/Doc/library/asyncio-platforms.rst
+++ b/Doc/library/asyncio-platforms.rst
@@ -63,7 +63,7 @@ All event loops on Windows do not support the following methods:
   methods are not supported.
 
 The resolution of the monotonic clock on Windows is usually around 15.6
-msec.  The best resolution is 0.5 msec. The resolution depends on the
+milliseconds.  The best resolution is 0.5 milliseconds. The resolution depends on the
 hardware (availability of `HPET
 <https://en.wikipedia.org/wiki/High_Precision_Event_Timer>`_) and on the
 Windows configuration.

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -368,7 +368,7 @@ The module :mod:`curses` defines the following functions:
 
    Set the maximum time in milliseconds that can elapse between press and release
    events in order for them to be recognized as a click, and return the previous
-   interval value.  The default value is 200 msec, or one fifth of a second.
+   interval value.  The default value is 200 milliseconds, or one fifth of a second.
 
 
 .. function:: mousemask(mousemask)

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -412,7 +412,7 @@ For example::
            multiple_results = [pool.apply_async(os.getpid, ()) for i in range(4)]
            print([res.get(timeout=1) for res in multiple_results])
 
-           # make a single worker sleep for 10 secs
+           # make a single worker sleep for 10 seconds
            res = pool.apply_async(time.sleep, (10,))
            try:
                print(res.get(timeout=1))

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -366,11 +366,11 @@ Functions
 
    Unix implementation:
 
-   * Use ``clock_nanosleep()`` if available (resolution: 1 ns);
-   * Or use ``nanosleep()`` if available (resolution: 1 ns);
-   * Or use ``select()`` (resolution: 1 us).
+   * Use ``clock_nanosleep()`` if available (resolution: 1 nanosecond);
+   * Or use ``nanosleep()`` if available (resolution: 1 nanosecond);
+   * Or use ``select()`` (resolution: 1 microsecond).
 
-   On Windows, a waitable timer is used (resolution: 100 ns). If *secs* is
+   On Windows, a waitable timer is used (resolution: 100 nanosecond). If *secs* is
    zero, ``Sleep(0)`` is used.
 
    .. versionchanged:: 3.11

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -233,7 +233,7 @@ Where the following options are understood:
 
 .. cmdoption:: -u, --unit=U
 
-   specify a time unit for timer output; can select nsec, usec, msec, or sec
+   specify a time unit for timer output; can select ``nsec``, ``usec``, ``msec``, or ``sec``
 
    .. versionadded:: 3.5
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -243,14 +243,14 @@ time
 ----
 
 * On Unix, :func:`time.sleep` now uses the ``clock_nanosleep()`` or
-  ``nanosleep()`` function, if available, which has a resolution of 1 ns
-  (10\ :sup:`-9` sec), rather than using ``select()`` which has a resolution
-  of 1 us (10\ :sup:`-6` sec).
+  ``nanosleep()`` function, if available, which has a resolution of 1 nanosecond
+  (10\ :sup:`-9` seconds), rather than using ``select()`` which has a resolution
+  of 1 microsecond (10\ :sup:`-6` seconds).
   (Contributed by Livius and Victor Stinner in :issue:`21302`.)
 
 * On Windows, :func:`time.sleep` now uses a waitable timer which has a
-  resolution of 100 ns (10\ :sup:`-7` sec). Previously, it had a solution of 1 ms
-  (10\ :sup:`-3` sec).
+  resolution of 100 nanoseconds (10\ :sup:`-7` seconds). Previously, it had
+  a resolution of 1 millisecond (10\ :sup:`-3` seconds).
   (Contributed by Livius and Victor Stinner in :issue:`21302`.)
 
 unicodedata

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -671,7 +671,7 @@ time
 
 On AIX, :func:`~time.thread_time` is now implemented with ``thread_cputime()``
 which has nanosecond resolution, rather than
-``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` which has a resolution of 10 ms.
+``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` which has a resolution of 10 milliseconds.
 (Contributed by Batuhan Taskaya in :issue:`40192`)
 
 sys

--- a/Misc/NEWS.d/3.10.0a4.rst
+++ b/Misc/NEWS.d/3.10.0a4.rst
@@ -786,7 +786,7 @@ Skip some asyncio tests on VxWorks.
 .. nonce: uzwlF_
 .. section: Tests
 
-Enhance ``test_select.test_select()``: it now takes 500 ms rather than 10
+Enhance ``test_select.test_select()``: it now takes 500 milliseconds rather than 10
 seconds. Use Python rather than a shell to make the test more portable.
 
 ..

--- a/Misc/NEWS.d/3.7.0a4.rst
+++ b/Misc/NEWS.d/3.7.0a4.rst
@@ -473,7 +473,7 @@ match.
 .. nonce: uxVOpk
 .. section: Library
 
-Abort asyncio SSLProtocol connection if handshake not complete within 10s
+Abort asyncio SSLProtocol connection if handshake not complete within 10 seconds.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0b1.rst
+++ b/Misc/NEWS.d/3.9.0b1.rst
@@ -641,7 +641,7 @@ than alphabetical.
 
 On AIX, :func:`~time.thread_time` is now implemented with
 ``thread_cputime()`` which has nanosecond resolution, rather than
-``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` which has a resolution of 10 ms.
+``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` which has a resolution of 10 milliseconds.
 Patch by Batuhan Taskaya.
 
 ..

--- a/Misc/NEWS.d/next/Library/2021-09-20-22-46-40.bpo-21302.h56430.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-20-22-46-40.bpo-21302.h56430.rst
@@ -1,3 +1,4 @@
 On Windows, :func:`time.sleep` now uses a waitable timer which has a resolution
-of 100 ns (10\ :sup:`-7` sec). Previously, it had a solution of 1 ms (10\ :sup:`-3` sec).
+of 100 nanoseconds (10\ :sup:`-7` seconds). Previously, it had a resolution of
+1 millisecond (10\ :sup:`-3` seconds).
 Patch by Livius and Victor Stinner.

--- a/Misc/NEWS.d/next/Windows/2021-06-06-16-36-13.bpo-41299.Rg-vb_.rst
+++ b/Misc/NEWS.d/next/Windows/2021-06-06-16-36-13.bpo-41299.Rg-vb_.rst
@@ -1,1 +1,1 @@
-Fix 16ms jitter when using timeouts in :mod:`threading`, such as with :meth:`threading.Lock.acquire` or :meth:`threading.Condition.wait`.
+Fix 16 milliseconds jitter when using timeouts in :mod:`threading`, such as with :meth:`threading.Lock.acquire` or :meth:`threading.Condition.wait`.


### PR DESCRIPTION
Use "second", "millisecond", "microsecond", "nanosecond" instead of
"sec", "ms", "msec", "us", "ns", etc.
