### PR TITLE
[3.10] bpo-39039: tarfile raises descriptive exception from zlib.error (GH-27766)

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2349,6 +2349,15 @@ class TarFile(object):
                     raise ReadError(str(e)) from None
             except SubsequentHeaderError as e:
                 raise ReadError(str(e)) from None
+            except Exception as e:
+                try:
+                    import zlib
+                    if isinstance(e, zlib.error):
+                        raise ReadError(f'zlib error: {e}') from None
+                    else:
+                        raise e
+                except ImportError:
+                    raise e
             break
 
         if tarinfo is not None:

--- a/Misc/NEWS.d/next/Library/2021-08-18-10-36-14.bpo-39039.A63LYh.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-18-10-36-14.bpo-39039.A63LYh.rst
@@ -1,0 +1,2 @@
+tarfile.open raises :exc:`~tarfile.ReadError` when a zlib error occurs
+during file extraction.


### PR DESCRIPTION
* during tarfile parsing, a zlib error indicates invalid data
* tarfile.open now raises a descriptive exception from the zlib error
* this makes it clear to the user that they may be trying to open a
  corrupted tar file
(cherry picked from commit b6fe8572509b77d2002eaddf99d718e9b4835684)

Co-authored-by: Jack DeVries <58614260+jdevries3133@users.noreply.github.com>


<!-- issue-number: [bpo-39039](https://bugs.python.org/issue39039) -->
https://bugs.python.org/issue39039
<!-- /issue-number -->
