### PR TITLE
[3.9] bpo-39039: tarfile raises descriptive exception from zlib.error (GH-27766)

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2345,6 +2345,15 @@ class TarFile(object):
                     raise ReadError(str(e))
             except SubsequentHeaderError as e:
                 raise ReadError(str(e))
+            except Exception as e:
+                try:
+                    import zlib
+                    if isinstance(e, zlib.error):
+                        raise ReadError(f'zlib error: {e}')
+                    else:
+                        raise e
+                except ImportError:
+                    raise e
             break
 
         if tarinfo is not None:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -19,6 +19,10 @@ try:
 except ImportError:
     gzip = None
 try:
+    import zlib
+except ImportError:
+    zlib = None
+try:
     import bz2
 except ImportError:
     bz2 = None
@@ -685,6 +689,16 @@ class MiscReadTestBase(CommonReadTest):
             for m1, m2 in zip(tar, tar):
                 self.assertEqual(m1.offset, m2.offset)
                 self.assertEqual(m1.get_info(), m2.get_info())
+
+    @unittest.skipIf(zlib is None, "requires zlib")
+    def test_zlib_error_does_not_leak(self):
+        # bpo-39039: tarfile.open allowed zlib exceptions to bubble up when
+        # parsing certain types of invalid data
+        with unittest.mock.patch("tarfile.TarInfo.fromtarfile") as mock:
+            mock.side_effect = zlib.error
+            with self.assertRaises(tarfile.ReadError):
+                tarfile.open(self.tarname)
+
 
 class MiscReadTest(MiscReadTestBase, unittest.TestCase):
     test_fail_comp = None

--- a/Misc/NEWS.d/next/Library/2021-08-18-10-36-14.bpo-39039.A63LYh.rst
+++ b/Misc/NEWS.d/next/Library/2021-08-18-10-36-14.bpo-39039.A63LYh.rst
@@ -1,0 +1,2 @@
+tarfile.open raises :exc:`~tarfile.ReadError` when a zlib error occurs
+during file extraction.


### PR DESCRIPTION
* during tarfile parsing, a zlib error indicates invalid data
* tarfile.open now raises a descriptive exception from the zlib error
* this makes it clear to the user that they may be trying to open a
  corrupted tar file.
(cherry picked from commit b6fe8572509b77d2002eaddf99d718e9b4835684)

Note: since BPO-39717 wasn't backported to 3.9, this backport PR doesn't use `from None` in the new `raise` statement either.

Co-authored-by: Jack DeVries <58614260+jdevries3133@users.noreply.github.com>


<!-- issue-number: [bpo-39039](https://bugs.python.org/issue39039) -->
https://bugs.python.org/issue39039
<!-- /issue-number -->
