### PR TITLE
bpo-44394: Ensure libexpat is linked against libm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1767,7 +1767,7 @@ class PyBuildExt(build_ext):
                 ('XML_POOR_ENTROPY', '1'),
             ]
             extra_compile_args = []
-            expat_lib = []
+            expat_lib = ['m']
             expat_sources = ['expat/xmlparse.c',
                              'expat/xmlrole.c',
                              'expat/xmltok.c']

--- a/setup.py
+++ b/setup.py
@@ -1767,6 +1767,8 @@ class PyBuildExt(build_ext):
                 ('XML_POOR_ENTROPY', '1'),
             ]
             extra_compile_args = []
+            # bpo-44394: libexpact uses isnan() of math.h and needs linkage
+            # against the libm
             expat_lib = ['m']
             expat_sources = ['expat/xmlparse.c',
                              'expat/xmlrole.c',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44394](https://bugs.python.org/issue44394) -->
https://bugs.python.org/issue44394
<!-- /issue-number -->

We need to link against `libm` to have `isnan`. See https://github.com/libexpat/libexpat/pull/510