### PR TITLE
bpo-45320 Remove deprecated inspect methods

### DIFF
--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -567,9 +567,6 @@ expression.  Currently the following are explicitly supported:
 * Simple symbolic constants like ``sys.maxsize``, which must
   start with the name of the module
 
-In case you're curious, this is implemented in  ``from_builtin()``
-in ``Lib/inspect.py``.
-
 (In the future, this may need to get even more elaborate,
 to allow full expressions like ``CONSTANT - 1``.)
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -935,26 +935,6 @@ Classes and functions
    times.
 
 
-.. function:: getargspec(func)
-
-   Get the names and default values of a Python function's parameters. A
-   :term:`named tuple` ``ArgSpec(args, varargs, keywords, defaults)`` is
-   returned. *args* is a list of the parameter names. *varargs* and *keywords*
-   are the names of the ``*`` and ``**`` parameters or ``None``. *defaults* is a
-   tuple of default argument values or ``None`` if there are no default
-   arguments; if this tuple has *n* elements, they correspond to the last
-   *n* elements listed in *args*.
-
-   .. deprecated:: 3.0
-      Use :func:`getfullargspec` for an updated API that is usually a drop-in
-      replacement, but also correctly handles function annotations and
-      keyword-only parameters.
-
-      Alternatively, use :func:`signature` and
-      :ref:`Signature Object <inspect-signature-object>`, which provide a
-      more structured introspection API for callables.
-
-
 .. function:: getfullargspec(func)
 
    Get the names and default values of a Python function's parameters.  A
@@ -1013,33 +993,6 @@ Classes and functions
 
    .. note::
       This function was inadvertently marked as deprecated in Python 3.5.
-
-
-.. function:: formatargspec(args[, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations[, formatarg, formatvarargs, formatvarkw, formatvalue, formatreturns, formatannotations]])
-
-   Format a pretty argument spec from the values returned by
-   :func:`getfullargspec`.
-
-   The first seven arguments are (``args``, ``varargs``, ``varkw``,
-   ``defaults``, ``kwonlyargs``, ``kwonlydefaults``, ``annotations``).
-
-   The other six arguments are functions that are called to turn argument names,
-   ``*`` argument name, ``**`` argument name, default values, return annotation
-   and individual annotations into strings, respectively.
-
-   For example:
-
-   >>> from inspect import formatargspec, getfullargspec
-   >>> def f(a: int, b: float):
-   ...     pass
-   ...
-   >>> formatargspec(*getfullargspec(f))
-   '(a: int, b: float)'
-
-   .. deprecated:: 3.5
-      Use :func:`signature` and
-      :ref:`Signature Object <inspect-signature-object>`, which provide a
-      better introspecting API for callables.
 
 
 .. function:: formatargvalues(args[, varargs, varkw, locals, formatarg, formatvarargs, formatvarkw, formatvalue])

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -348,7 +348,7 @@ Removed
   ``SO_REUSEADDR`` in UDP.
   (Contributed by Hugo van Kemenade in :issue:`45129`.)
 
-* Remove :meth:`__getitem__` methods of
+* Removed :meth:`__getitem__` methods of
   :class:`xml.dom.pulldom.DOMEventStream`, :class:`wsgiref.util.FileWrapper`
   and :class:`fileinput.FileInput`, deprecated since Python 3.9.
   (Contributed by Hugo van Kemenade in :issue:`45132`.)
@@ -387,7 +387,7 @@ Removed
   the ``l*gettext()`` functions.
   (Contributed by Dong-hee Na and Serhiy Storchaka in :issue:`44235`.)
 
-* Remove from the :mod:`configparser` module:
+* Removed from the :mod:`configparser` module:
   the :class:`SafeConfigParser` class,
   the :attr:`filename` property of the :class:`ParsingError` class,
   the :meth:`readfp` method of the :class:`ConfigParser` class,
@@ -404,8 +404,24 @@ Removed
   generator-based coroutine objects in the debug mode.
   (Contributed by Illia Volochii in :issue:`43216`.)
 
-* Remove the deprecated ``split()`` method of :class:`_tkinter.TkappType`.
+* Removed the deprecated ``split()`` method of :class:`_tkinter.TkappType`.
   (Contributed by Erlend E. Aasland in :issue:`38371`.)
+
+* Removed from the :mod:`inspect` module:
+
+  * the ``getargspec`` function, deprecated since Python 3.0;
+    use :func:`inspect.signature` or :func:`inspect.getfullargspec` instead.
+
+  * the ``formatargspec`` function, deprecated since Python 3.5;
+    use the :func:`inspect.signature` function and :class:`Signature` object
+    directly.
+
+  * the undocumented ``Signature.from_callable`` and ``Signature.from_function``
+    functions, deprecated since Python 3.5; use the
+    :meth:`Signature.from_callable() <inspect.Signature.from_callable>` method
+    instead.
+
+  (Contributed by Hugo van Kemenade in :issue:`45320`.)
 
 
 Porting to Python 3.11

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -43,7 +43,7 @@ from test.test_import import _ready_to_import
 # ismodule, isclass, ismethod, isfunction, istraceback, isframe, iscode,
 # isbuiltin, isroutine, isgenerator, isgeneratorfunction, getmembers,
 # getdoc, getfile, getmodule, getsourcefile, getcomments, getsource,
-# getclasstree, getargvalues, formatargspec, formatargvalues,
+# getclasstree, getargvalues, formatargvalues,
 # currentframe, stack, trace, isdatadescriptor
 
 # NOTE: There are some additional tests relating to interaction with
@@ -844,24 +844,11 @@ class TestClassesAndFunctions(unittest.TestCase):
         got = inspect.getmro(D)
         self.assertEqual(expected, got)
 
-    def assertArgSpecEquals(self, routine, args_e, varargs_e=None,
-                            varkw_e=None, defaults_e=None, formatted=None):
-        with self.assertWarns(DeprecationWarning):
-            args, varargs, varkw, defaults = inspect.getargspec(routine)
-        self.assertEqual(args, args_e)
-        self.assertEqual(varargs, varargs_e)
-        self.assertEqual(varkw, varkw_e)
-        self.assertEqual(defaults, defaults_e)
-        if formatted is not None:
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults),
-                                 formatted)
-
     def assertFullArgSpecEquals(self, routine, args_e, varargs_e=None,
                                     varkw_e=None, defaults_e=None,
                                     posonlyargs_e=[], kwonlyargs_e=[],
                                     kwonlydefaults_e=None,
-                                    ann_e={}, formatted=None):
+                                    ann_e={}):
         args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, ann = \
             inspect.getfullargspec(routine)
         self.assertEqual(args, args_e)
@@ -871,58 +858,30 @@ class TestClassesAndFunctions(unittest.TestCase):
         self.assertEqual(kwonlyargs, kwonlyargs_e)
         self.assertEqual(kwonlydefaults, kwonlydefaults_e)
         self.assertEqual(ann, ann_e)
-        if formatted is not None:
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults,
-                                                       kwonlyargs, kwonlydefaults, ann),
-                                 formatted)
-
-    def test_getargspec(self):
-        self.assertArgSpecEquals(mod.eggs, ['x', 'y'], formatted='(x, y)')
-
-        self.assertArgSpecEquals(mod.spam,
-                                 ['a', 'b', 'c', 'd', 'e', 'f'],
-                                 'g', 'h', (3, 4, 5),
-                                 '(a, b, c, d=3, e=4, f=5, *g, **h)')
-
-        self.assertRaises(ValueError, self.assertArgSpecEquals,
-                          mod2.keyworded, [])
-
-        self.assertRaises(ValueError, self.assertArgSpecEquals,
-                          mod2.annotated, [])
-        self.assertRaises(ValueError, self.assertArgSpecEquals,
-                          mod2.keyword_only_arg, [])
-
 
     def test_getfullargspec(self):
         self.assertFullArgSpecEquals(mod2.keyworded, [], varargs_e='arg1',
                                      kwonlyargs_e=['arg2'],
-                                     kwonlydefaults_e={'arg2':1},
-                                     formatted='(*arg1, arg2=1)')
+                                     kwonlydefaults_e={'arg2':1})
 
         self.assertFullArgSpecEquals(mod2.annotated, ['arg1'],
-                                     ann_e={'arg1' : list},
-                                     formatted='(arg1: list)')
+                                     ann_e={'arg1' : list})
         self.assertFullArgSpecEquals(mod2.keyword_only_arg, [],
-                                     kwonlyargs_e=['arg'],
-                                     formatted='(*, arg)')
+                                     kwonlyargs_e=['arg'])
 
         self.assertFullArgSpecEquals(mod2.all_markers, ['a', 'b', 'c', 'd'],
-                                     kwonlyargs_e=['e', 'f'],
-                                     formatted='(a, b, c, d, *, e, f)')
+                                     kwonlyargs_e=['e', 'f'])
 
         self.assertFullArgSpecEquals(mod2.all_markers_with_args_and_kwargs,
                                      ['a', 'b', 'c', 'd'],
                                      varargs_e='args',
                                      varkw_e='kwargs',
-                                     kwonlyargs_e=['e', 'f'],
-                                     formatted='(a, b, c, d, *args, e, f, **kwargs)')
+                                     kwonlyargs_e=['e', 'f'])
 
         self.assertFullArgSpecEquals(mod2.all_markers_with_defaults, ['a', 'b', 'c', 'd'],
                                      defaults_e=(1,2,3),
                                      kwonlyargs_e=['e', 'f'],
-                                     kwonlydefaults_e={'e': 4, 'f': 5},
-                                     formatted='(a, b=1, c=2, d=3, *, e=4, f=5)')
+                                     kwonlydefaults_e={'e': 4, 'f': 5})
 
     def test_argspec_api_ignores_wrapped(self):
         # Issue 20684: low level introspection API must ignore __wrapped__
@@ -930,39 +889,9 @@ class TestClassesAndFunctions(unittest.TestCase):
         def ham(x, y):
             pass
         # Basic check
-        self.assertArgSpecEquals(ham, ['x', 'y'], formatted='(x, y)')
-        self.assertFullArgSpecEquals(ham, ['x', 'y'], formatted='(x, y)')
+        self.assertFullArgSpecEquals(ham, ['x', 'y'])
         self.assertFullArgSpecEquals(functools.partial(ham),
-                                     ['x', 'y'], formatted='(x, y)')
-        # Other variants
-        def check_method(f):
-            self.assertArgSpecEquals(f, ['self', 'x', 'y'],
-                                        formatted='(self, x, y)')
-        class C:
-            @functools.wraps(mod.spam)
-            def ham(self, x, y):
-                pass
-            pham = functools.partialmethod(ham)
-            @functools.wraps(mod.spam)
-            def __call__(self, x, y):
-                pass
-        check_method(C())
-        check_method(C.ham)
-        check_method(C().ham)
-        check_method(C.pham)
-        check_method(C().pham)
-
-        class C_new:
-            @functools.wraps(mod.spam)
-            def __new__(self, x, y):
-                pass
-        check_method(C_new)
-
-        class C_init:
-            @functools.wraps(mod.spam)
-            def __init__(self, x, y):
-                pass
-        check_method(C_init)
+                                     ['x', 'y'])
 
     def test_getfullargspec_signature_attr(self):
         def test():
@@ -970,7 +899,7 @@ class TestClassesAndFunctions(unittest.TestCase):
         spam_param = inspect.Parameter('spam', inspect.Parameter.POSITIONAL_ONLY)
         test.__signature__ = inspect.Signature(parameters=(spam_param,))
 
-        self.assertFullArgSpecEquals(test, ['spam'], formatted='(spam)')
+        self.assertFullArgSpecEquals(test, ['spam'])
 
     def test_getfullargspec_signature_annos(self):
         def test(a:'spam') -> 'ham': pass
@@ -984,18 +913,15 @@ class TestClassesAndFunctions(unittest.TestCase):
     @unittest.skipIf(MISSING_C_DOCSTRINGS,
                      "Signature information for builtins requires docstrings")
     def test_getfullargspec_builtin_methods(self):
-        self.assertFullArgSpecEquals(_pickle.Pickler.dump, ['self', 'obj'],
-                                     formatted='(self, obj)')
+        self.assertFullArgSpecEquals(_pickle.Pickler.dump, ['self', 'obj'])
 
-        self.assertFullArgSpecEquals(_pickle.Pickler(io.BytesIO()).dump, ['self', 'obj'],
-                                     formatted='(self, obj)')
+        self.assertFullArgSpecEquals(_pickle.Pickler(io.BytesIO()).dump, ['self', 'obj'])
 
         self.assertFullArgSpecEquals(
              os.stat,
              args_e=['path'],
              kwonlyargs_e=['dir_fd', 'follow_symlinks'],
-             kwonlydefaults_e={'dir_fd': None, 'follow_symlinks': True},
-             formatted='(path, *, dir_fd=None, follow_symlinks=True)')
+             kwonlydefaults_e={'dir_fd': None, 'follow_symlinks': True})
 
     @cpython_only
     @unittest.skipIf(MISSING_C_DOCSTRINGS,
@@ -1025,12 +951,6 @@ class TestClassesAndFunctions(unittest.TestCase):
         signature = inspect.getfullargspec(unsorted_keyword_only_parameters_fn)
         l = list(signature.kwonlyargs)
         self.assertEqual(l, unsorted_keyword_only_parameters)
-
-    def test_getargspec_method(self):
-        class A(object):
-            def m(self):
-                pass
-        self.assertArgSpecEquals(A.m, ['self'])
 
     def test_classify_newstyle(self):
         class A(object):

--- a/Misc/NEWS.d/next/Library/2021-09-15-10-21-10.bpo-45320.4qaf5x.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-15-10-21-10.bpo-45320.4qaf5x.rst
@@ -1,0 +1,15 @@
+Removed from the :mod:`inspect` module:
+
+* the ``getargspec`` function, deprecated since Python 3.0;
+    use :func:`inspect.signature` or :func:`inspect.getfullargspec` instead.
+
+* the ``formatargspec`` function, deprecated since Python 3.5;
+  use the :func:`inspect.signature` function and :class:`Signature` object
+  directly.
+
+* the undocumented ``Signature.from_callable`` and ``Signature.from_function``
+  functions, deprecated since Python 3.5; use the
+  :meth:`Signature.from_callable() <inspect.Signature.from_callable>` method
+  instead.
+
+Patch by Hugo van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


* `inspect.getargspec` was deprecated in docs since 3.0 (https://docs.python.org/3.0/library/inspect.html?highlight=getargspec#inspect.getargspec), raising a `DeprecationWarning` since 3.5 ([bpo-20438](https://bugs.python.org/issue20438), https://github.com/python/cpython/commit/3cfec2e2fcab9f39121cec362b78ac235093ca1c).  

* `inspect.formatargspec` was deprecated in docs since 3.5 (https://docs.python.org/3.5/library/inspect.html?highlight=getargspec#inspect.formatargspec), raising a `DeprecationWarning` since 3.8 ([bpo-33582](https://bugs.python.org/issue33582), https://github.com/python/cpython/commit/46c5cd0f6e22bdfbdd3f0b18f1d01eda754e7e11).  Undocumented 

* `inspect.Signature.from_function` and `inspect.Signature.from_builtin` in docs and by raising a `DeprecationWarning` since 3.5 ([bpo-20438](https://bugs.python.org/issue20438), https://github.com/python/cpython/commit/3cfec2e2fcab9f39121cec362b78ac235093ca1c).

These can be removed in Python 3.11.


<!-- issue-number: [bpo-45320](https://bugs.python.org/issue45320) -->
https://bugs.python.org/issue45320
<!-- /issue-number -->
