### PR TITLE
[typo] Fix threading.Barrier comment that used confusing punctuation

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -649,7 +649,7 @@ class Barrier:
         self._action = action
         self._timeout = timeout
         self._parties = parties
-        self._state = 0 #0 filling, 1, draining, -1 resetting, -2 broken
+        self._state = 0 # 0 filling, 1 draining, -1 resetting, -2 broken
         self._count = 0
 
     def __repr__(self):

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -649,7 +649,7 @@ class Barrier:
         self._action = action
         self._timeout = timeout
         self._parties = parties
-        self._state = 0 # 0 filling, 1 draining, -1 resetting, -2 broken
+        self._state = 0  # 0 filling, 1 draining, -1 resetting, -2 broken
         self._count = 0
 
     def __repr__(self):


### PR DESCRIPTION
Removed extra comma in comment that indicates state of a `Barrier` as it was confusing and breaking the flow while reading.

Originally done in GH-23755 but for the wrong branch then.