### PR TITLE
bpo-44394: [typo] s/libexpact/libexpat/ in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1767,7 +1767,7 @@ class PyBuildExt(build_ext):
                 ('XML_POOR_ENTROPY', '1'),
             ]
             extra_compile_args = []
-            # bpo-44394: libexpact uses isnan() of math.h and needs linkage
+            # bpo-44394: libexpat uses isnan() of math.h and needs linkage
             # against the libm
             expat_lib = ['m']
             expat_sources = ['expat/xmlparse.c',


### PR DESCRIPTION
Introduced in GH-28617. Needs backport to 3.9 only since I managed to get the fix into the original 3.10 and 3.8 backport PRs before they auto-merged.

<!-- issue-number: [bpo-44394](https://bugs.python.org/issue44394) -->
https://bugs.python.org/issue44394
<!-- /issue-number -->
