### PR TITLE
bpo-28206: Document signals Handlers, Sigmasks and Signals enums

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -68,10 +68,34 @@ Module contents
    signal (SIG*), handler (:const:`SIG_DFL`, :const:`SIG_IGN`) and sigmask
    (:const:`SIG_BLOCK`, :const:`SIG_UNBLOCK`, :const:`SIG_SETMASK`)
    related constants listed below were turned into
-   :class:`enums <enum.IntEnum>` (:class:`Handlers` and :class:`Sigmasks` respectively).
+   :class:`enums <enum.IntEnum>` (:class:`Signals`, :class:`Handlers` and :class:`Sigmasks` respectively).
    :func:`getsignal`, :func:`pthread_sigmask`, :func:`sigpending` and
    :func:`sigwait` functions return human-readable
    :class:`enums <enum.IntEnum>` as :class:`Signals` objects.
+
+
+The signal module defines three enums:
+
+.. class:: Signals
+
+   :class:`enum.IntEnum` collection of SIG* constants and the CTRL_* constants.
+
+   .. versionadded:: 3.5
+
+.. class:: Handlers
+
+   :class:`enum.IntEnum` collection the constants :const:`SIG_DFL` and :const:`SIG_IGN`.
+
+   .. versionadded:: 3.5
+
+.. class:: Sigmasks
+
+   :class:`enum.IntEnum` collection the constants :const:`SIG_BLOCK`, :const:`SIG_UNBLOCK` and :const:`SIG_SETMASK`.
+
+   Availability: Unix. See the man page :manpage:`sigprocmask(3)` and
+   :manpage:`pthread_sigmask(3)` for further information.
+
+   .. versionadded:: 3.5
 
 
 The variables defined in the :mod:`signal` module are:
@@ -631,7 +655,8 @@ be sent, and the handler raises an exception. ::
    import signal, os
 
    def handler(signum, frame):
-       print('Signal handler called with signal', signum)
+       signame = signal.Signals(signum).name
+       print(f'Signal handler called with signal {signame} ({signum})')
        raise OSError("Couldn't open device!")
 
    # Set the signal handler and a 5-second alarm
@@ -642,21 +667,6 @@ be sent, and the handler raises an exception. ::
    fd = os.open('/dev/ttyS0', os.O_RDWR)
 
    signal.alarm(0)          # Disable the alarm
-
-:class:`enums <enum.IntEnum>` types can be used to convert from signal code to string, or the reverse::
-
-   import signal, os
-
-   def handler(signum, frame):
-       # signum is an integer code, get the signal name using the signal.Signal enum
-       signame = signal.Signals(signum).name
-       print(f'Signal handler called with signal {signame} of code {signum}')
-
-   # attach a handler for signal.SIGINT
-   signame = 'SIGINT'
-   signal.signal(signal.Signals[signame], handler)
-
-
 
 Note on SIGPIPE
 ---------------

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -68,7 +68,7 @@ Module contents
    signal (SIG*), handler (:const:`SIG_DFL`, :const:`SIG_IGN`) and sigmask
    (:const:`SIG_BLOCK`, :const:`SIG_UNBLOCK`, :const:`SIG_SETMASK`)
    related constants listed below were turned into
-   :class:`enums <enum.IntEnum>` (respectively :class:`Handlers` and :class:`Sigmasks`).
+   :class:`enums <enum.IntEnum>` (:class:`Handlers` and :class:`Sigmasks` respectively).
    :func:`getsignal`, :func:`pthread_sigmask`, :func:`sigpending` and
    :func:`sigwait` functions return human-readable
    :class:`enums <enum.IntEnum>` as :class:`Signals` objects.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -68,10 +68,10 @@ Module contents
    signal (SIG*), handler (:const:`SIG_DFL`, :const:`SIG_IGN`) and sigmask
    (:const:`SIG_BLOCK`, :const:`SIG_UNBLOCK`, :const:`SIG_SETMASK`)
    related constants listed below were turned into
-   :class:`enums <enum.IntEnum>`.
+   :class:`enums <enum.IntEnum>` (respectively :class:`Handlers` and :class:`Sigmasks`).
    :func:`getsignal`, :func:`pthread_sigmask`, :func:`sigpending` and
    :func:`sigwait` functions return human-readable
-   :class:`enums <enum.IntEnum>`.
+   :class:`enums <enum.IntEnum>` as :class:`Signals` objects.
 
 
 The variables defined in the :mod:`signal` module are:

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -618,8 +618,8 @@ The :mod:`signal` module defines the following functions:
 
 .. _signal-example:
 
-Example
--------
+Examples
+--------
 
 Here is a minimal example program. It uses the :func:`alarm` function to limit
 the time spent waiting to open a file; this is useful if the file is for a
@@ -642,6 +642,21 @@ be sent, and the handler raises an exception. ::
    fd = os.open('/dev/ttyS0', os.O_RDWR)
 
    signal.alarm(0)          # Disable the alarm
+
+:class:`enums <enum.IntEnum>` types can be used to convert from signal code to string, or the reverse::
+
+   import signal, os
+
+   def handler(signum, frame):
+       # signum is an integer code, get the signal name using the signal.Signal enum
+       signame = signal.Signals(signum).name
+       print(f'Signal handler called with signal {signame} of code {signum}')
+
+   # attach a handler for signal.SIGINT
+   signame = 'SIGINT'
+   signal.signal(signal.Signals[signame], handler)
+
+
 
 Note on SIGPIPE
 ---------------


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

See http://bugs.python.org/issue28206

This PR is a replacement/extension of #1939 which was closed incompleted. I tried to address the reviewers comments.
This change is relevant for versions 3.5+, though IISC only 3.9 still accepts bugfixes.

**edit:** The description of the enums is based on the docs of [`ssl.VerifyMode`](https://docs.python.org/3/library/ssl.html?highlight=verifymode#ssl.VerifyMode)

<!-- issue-number: [bpo-28206](https://bugs.python.org/issue28206) -->
https://bugs.python.org/issue28206
<!-- /issue-number -->
