### PR TITLE
bpo-45116 Fix another performance regression on Windows

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1308,7 +1308,7 @@ eval_frame_handle_pending(PyThreadState *tstate)
     }
 #else
 #define TARGET(op) op
-#define DISPATCH() goto predispatch;
+#define DISPATCH() goto tracing_dispatch;
 #endif
 
 
@@ -1826,16 +1826,7 @@ main_loop:
             }
         }
 #endif
-#if USE_COMPUTED_GOTOS == 0
-    goto dispatch_opcode;
 
-    predispatch:
-        if (trace_info.cframe.use_tracing OR_DTRACE_LINE OR_LLTRACE) {
-            goto tracing_dispatch;
-        }
-        f->f_lasti = INSTR_OFFSET();
-        NEXTOPARG();
-#endif
     dispatch_opcode:
 #ifdef DYNAMIC_EXECUTION_PROFILE
 #ifdef DXPAIRS


### PR DESCRIPTION
Currently, MSVC tends to share the same code blocks in a too big function.
In the ceval-loop, `NEXTOPARG()` or `DISPATCH()` macros are unexpectedly shared and joined with (long) jump instructions, which disturb PGO profiling.

With this PR, MSVC seems to generate expected codes for #25244.

<!-- issue-number: [bpo-45116](https://bugs.python.org/issue45116) -->
https://bugs.python.org/issue45116
<!-- /issue-number -->
