### PR TITLE
bpo-45324: Capture data in FrozenImporter.find_spec() to use in exec_module().

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -858,7 +858,7 @@ class FrozenImporter:
         name = spec.name
         try:
             data = spec.loader_state
-        except Exception:
+        except AttributeError:
             if not _imp.is_frozen(name):
                 raise ImportError('{!r} is not a frozen module'.format(name),
                                   name=name)

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -833,7 +833,7 @@ class FrozenImporter:
         spec = spec_from_loader(fullname, cls,
                                 origin=cls._ORIGIN,
                                 is_package=ispkg)
-        spec.loader_state = (data,)
+        spec.loader_state = data
         return spec
 
     @classmethod
@@ -857,7 +857,7 @@ class FrozenImporter:
         spec = module.__spec__
         name = spec.name
         try:
-            data, = spec.loader_state
+            data = spec.loader_state
         except Exception:
             if not _imp.is_frozen(name):
                 raise ImportError('{!r} is not a frozen module'.format(name),

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -863,6 +863,9 @@ class FrozenImporter:
             data, = spec.loader_state
         except Exception:
             data = None
+        else:
+            # We clear the extra data we got from the finder, to save memory.
+            spec.loader_state = None
         code = _call_with_frames_removed(_imp.get_frozen_object, name, data)
         exec(code, module.__dict__)
 

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -865,6 +865,9 @@ class FrozenImporter:
             data = None
         else:
             # We clear the extra data we got from the finder, to save memory.
+            # Note that if this method is called again (e.g. by
+            # importlib.reload()) then _imp.get_frozen_object() will notice
+            # no data was provided and will look it up.
             spec.loader_state = None
         code = _call_with_frames_removed(_imp.get_frozen_object, name, data)
         exec(code, module.__dict__)

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -856,12 +856,12 @@ class FrozenImporter:
     def exec_module(module):
         spec = module.__spec__
         name = spec.name
-        if not _imp.is_frozen(name):
-            raise ImportError('{!r} is not a frozen module'.format(name),
-                              name=name)
         try:
             data, = spec.loader_state
         except Exception:
+            if not _imp.is_frozen(name):
+                raise ImportError('{!r} is not a frozen module'.format(name),
+                                  name=name)
             data = None
         else:
             # We clear the extra data we got from the finder, to save memory.

--- a/Lib/test/test_importlib/frozen/test_finder.py
+++ b/Lib/test/test_importlib/frozen/test_finder.py
@@ -3,6 +3,7 @@ from .. import util
 
 machinery = util.import_importlib('importlib.machinery')
 
+import _imp
 import marshal
 import os.path
 import unittest
@@ -11,7 +12,7 @@ import warnings
 from test.support import import_helper, REPO_ROOT, STDLIB_DIR
 
 
-def get_frozen_code(name, source=None, ispkg=False):
+def get_frozen_code(name, source=None, ispkg=False, *, useimp=True):
     """Return the code object for the given module.
 
     This should match the data stored in the frozen .h file used
@@ -19,6 +20,10 @@ def get_frozen_code(name, source=None, ispkg=False):
 
     "source" is the original module name or a .py filename.
     """
+    if useimp:
+        with import_helper.frozen_modules():
+            return _imp.get_frozen_object(name)
+
     if not source:
         source = name
     else:

--- a/Lib/test/test_importlib/frozen/test_finder.py
+++ b/Lib/test/test_importlib/frozen/test_finder.py
@@ -33,7 +33,7 @@ class FindSpecTests(abc.FinderTests):
         self.assertIsNotNone(spec.loader_state)
 
     def check_search_location(self, spec, source=None):
-        # For now frozen packages do not have any path entries.
+        # Frozen packages do not have any path entries.
         # (See https://bugs.python.org/issue21736.)
         expected = []
         self.assertListEqual(spec.submodule_search_locations, expected)

--- a/Lib/test/test_importlib/frozen/test_finder.py
+++ b/Lib/test/test_importlib/frozen/test_finder.py
@@ -41,7 +41,7 @@ class FindSpecTests(abc.FinderTests):
     def check_data(self, spec, source=None, ispkg=None):
         with import_helper.frozen_modules():
             expected = _imp.get_frozen_object(spec.name)
-        data, = spec.loader_state
+        data = spec.loader_state
         # We can't compare the marshaled data directly because
         # marshal.dumps() would mark "expected" as a ref, which slightly
         # changes the output.  (See https://bugs.python.org/issue34093.)

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -4,7 +4,9 @@ from .. import util
 machinery = util.import_importlib('importlib.machinery')
 
 from test.support import captured_stdout, import_helper
+import _imp
 import contextlib
+import marshal
 import types
 import unittest
 import warnings
@@ -33,11 +35,14 @@ class ExecModuleTests(abc.LoaderTests):
     def exec_module(self, name):
         with import_helper.frozen_modules():
             is_package = self.machinery.FrozenImporter.is_package(name)
+            code = _imp.get_frozen_object(name)
+        data = marshal.dumps(code)
         spec = self.machinery.ModuleSpec(
             name,
             self.machinery.FrozenImporter,
             origin='frozen',
             is_package=is_package,
+            loader_state=(data,),
         )
         module = types.ModuleType(name)
         module.__spec__ = spec
@@ -61,6 +66,7 @@ class ExecModuleTests(abc.LoaderTests):
             self.assertEqual(getattr(module, attr), value)
         self.assertEqual(output, 'Hello world!\n')
         self.assertTrue(hasattr(module, '__spec__'))
+        self.assertIsNone(module.__spec__.loader_state)
 
     def test_package(self):
         name = '__phello__'
@@ -73,6 +79,7 @@ class ExecModuleTests(abc.LoaderTests):
                                  name=name, attr=attr, given=attr_value,
                                  expected=value))
         self.assertEqual(output, 'Hello world!\n')
+        self.assertIsNone(module.__spec__.loader_state)
 
     def test_lacking_parent(self):
         name = '__phello__.spam'

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -42,7 +42,7 @@ class ExecModuleTests(abc.LoaderTests):
             self.machinery.FrozenImporter,
             origin='frozen',
             is_package=is_package,
-            loader_state=(data,),
+            loader_state=data,
         )
         module = types.ModuleType(name)
         module.__spec__ = spec

--- a/Misc/NEWS.d/next/Core and Builtins/2021-09-29-12-02-39.bpo-45324.BTQElX.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-09-29-12-02-39.bpo-45324.BTQElX.rst
@@ -1,0 +1,3 @@
+In FrozenImporter.find_spec(), we now preserve the information needed in
+exec_module() to load the module.  This change mostly impacts internal
+details, rather than changing the importer's behavior.

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -170,32 +170,42 @@ exit:
 }
 
 PyDoc_STRVAR(_imp_get_frozen_object__doc__,
-"get_frozen_object($module, name, /)\n"
+"get_frozen_object($module, name, data=None, /)\n"
 "--\n"
 "\n"
 "Create a code object for a frozen module.");
 
 #define _IMP_GET_FROZEN_OBJECT_METHODDEF    \
-    {"get_frozen_object", (PyCFunction)_imp_get_frozen_object, METH_O, _imp_get_frozen_object__doc__},
+    {"get_frozen_object", (PyCFunction)(void(*)(void))_imp_get_frozen_object, METH_FASTCALL, _imp_get_frozen_object__doc__},
 
 static PyObject *
-_imp_get_frozen_object_impl(PyObject *module, PyObject *name);
+_imp_get_frozen_object_impl(PyObject *module, PyObject *name,
+                            PyObject *dataobj);
 
 static PyObject *
-_imp_get_frozen_object(PyObject *module, PyObject *arg)
+_imp_get_frozen_object(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *name;
+    PyObject *dataobj = Py_None;
 
-    if (!PyUnicode_Check(arg)) {
-        _PyArg_BadArgument("get_frozen_object", "argument", "str", arg);
+    if (!_PyArg_CheckPositional("get_frozen_object", nargs, 1, 2)) {
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
+    if (!PyUnicode_Check(args[0])) {
+        _PyArg_BadArgument("get_frozen_object", "argument 1", "str", args[0]);
         goto exit;
     }
-    name = arg;
-    return_value = _imp_get_frozen_object_impl(module, name);
+    if (PyUnicode_READY(args[0]) == -1) {
+        goto exit;
+    }
+    name = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    dataobj = args[1];
+skip_optional:
+    return_value = _imp_get_frozen_object_impl(module, name, dataobj);
 
 exit:
     return return_value;
@@ -498,4 +508,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=96038c277119d6e3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3689300c18fe73a5 input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -169,6 +169,43 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_imp_find_frozen__doc__,
+"find_frozen($module, name, /)\n"
+"--\n"
+"\n"
+"Return info about the corresponding frozen module (if there is one) or None.\n"
+"\n"
+"The returned info (a 2-tuple):\n"
+"\n"
+" * data         the raw marshalled bytes\n"
+" * is_package   whether or not it is a package");
+
+#define _IMP_FIND_FROZEN_METHODDEF    \
+    {"find_frozen", (PyCFunction)_imp_find_frozen, METH_O, _imp_find_frozen__doc__},
+
+static PyObject *
+_imp_find_frozen_impl(PyObject *module, PyObject *name);
+
+static PyObject *
+_imp_find_frozen(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *name;
+
+    if (!PyUnicode_Check(arg)) {
+        _PyArg_BadArgument("find_frozen", "argument", "str", arg);
+        goto exit;
+    }
+    if (PyUnicode_READY(arg) == -1) {
+        goto exit;
+    }
+    name = arg;
+    return_value = _imp_find_frozen_impl(module, name);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_imp_get_frozen_object__doc__,
 "get_frozen_object($module, name, data=None, /)\n"
 "--\n"
@@ -508,4 +545,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=3689300c18fe73a5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a31e1c00653359ff input=a9049054013a1b77]*/

--- a/Python/import.c
+++ b/Python/import.c
@@ -1991,6 +1991,43 @@ _imp_init_frozen_impl(PyObject *module, PyObject *name)
 }
 
 /*[clinic input]
+_imp.find_frozen
+
+    name: unicode
+    /
+
+Return info about the corresponding frozen module (if there is one) or None.
+
+The returned info (a 2-tuple):
+
+ * data         the raw marshalled bytes
+ * is_package   whether or not it is a package
+[clinic start generated code]*/
+
+static PyObject *
+_imp_find_frozen_impl(PyObject *module, PyObject *name)
+/*[clinic end generated code: output=3fd17da90d417e4e input=4e52b3ac95f6d7ab]*/
+{
+    struct frozen_info info;
+    frozen_status status = find_frozen(name, &info);
+    if (status == FROZEN_NOT_FOUND || status == FROZEN_DISABLED) {
+        Py_RETURN_NONE;
+    }
+    else if (status != FROZEN_OKAY) {
+        set_frozen_error(status, name);
+        return NULL;
+    }
+    PyObject *data = PyBytes_FromStringAndSize(info.data, info.size);
+    if (data == NULL) {
+        return NULL;
+    }
+    PyObject *result = PyTuple_Pack(2, data,
+                                    info.is_package ? Py_True : Py_False);
+    Py_DECREF(data);
+    return result;
+}
+
+/*[clinic input]
 _imp.get_frozen_object
 
     name: unicode
@@ -2276,6 +2313,7 @@ static PyMethodDef imp_methods[] = {
     _IMP_LOCK_HELD_METHODDEF
     _IMP_ACQUIRE_LOCK_METHODDEF
     _IMP_RELEASE_LOCK_METHODDEF
+    _IMP_FIND_FROZEN_METHODDEF
     _IMP_GET_FROZEN_OBJECT_METHODDEF
     _IMP_IS_FROZEN_PACKAGE_METHODDEF
     _IMP_CREATE_BUILTIN_METHODDEF

--- a/Python/import.c
+++ b/Python/import.c
@@ -1158,7 +1158,7 @@ struct frozen_info {
     bool is_package;
 };
 
-frozen_status
+static frozen_status
 find_frozen(PyObject *nameobj, struct frozen_info *info)
 {
     if (info != NULL) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -1194,9 +1194,7 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
     if (info != NULL) {
         info->name = nameobj;  // borrowed
         info->data = (const char *)p->code;
-        int size = p->size < 0 ? -(p->size) : p->size;
-        assert(size <= PY_SSIZE_T_MAX);
-        info->size = (Py_ssize_t)size;
+        info->size = p->size < 0 ? -(p->size) : p->size;
         info->is_package = p->size < 0 ? true : false;
     }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -1154,7 +1154,7 @@ set_frozen_error(frozen_status status, PyObject *modname)
 struct frozen_info {
     PyObject *name;
     const char *data;
-    int size;
+    Py_ssize_t size;
     bool is_package;
 };
 
@@ -1194,7 +1194,9 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
     if (info != NULL) {
         info->name = nameobj;  // borrowed
         info->data = (const char *)p->code;
-        info->size = p->size < 0 ? -(p->size) : p->size;
+        int size = p->size < 0 ? -(p->size) : p->size;
+        assert(size <= PY_SSIZE_T_MAX);
+        info->size = (Py_ssize_t)size;
         info->is_package = p->size < 0 ? true : false;
     }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -1125,29 +1125,32 @@ typedef enum {
 static inline void
 set_frozen_error(frozen_status status, PyObject *modname)
 {
+    const char *err = NULL;
     switch (status) {
         case FROZEN_BAD_NAME:
         case FROZEN_NOT_FOUND:
         case FROZEN_DISABLED:
-            PyErr_Format(PyExc_ImportError,
-                         "No such frozen object named %R",
-                         modname);
+            err = "No such frozen object named %R";
             break;
         case FROZEN_EXCLUDED:
-            PyErr_Format(PyExc_ImportError,
-                         "Excluded frozen object named %R",
-                         modname);
+            err = "Excluded frozen object named %R";
             break;
         case FROZEN_INVALID:
-            PyErr_Format(PyExc_ImportError,
-                         "Frozen object named %R is invalid",
-                         modname);
+            err = "Frozen object named %R is invalid";
             break;
         case FROZEN_OKAY:
             // There was no error.
             break;
         default:
             Py_UNREACHABLE();
+    }
+    if (err != NULL) {
+        PyObject *msg = PyUnicode_FromFormat(err, modname);
+        if (msg == NULL) {
+            PyErr_Clear();
+        }
+        PyErr_SetImportError(msg, modname, NULL);
+        Py_XDECREF(msg);
     }
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -1244,6 +1244,9 @@ PyImport_ImportFrozenModuleObject(PyObject *name)
     if (status == FROZEN_NOT_FOUND || status == FROZEN_DISABLED) {
         return 0;
     }
+    else if (status == FROZEN_BAD_NAME) {
+        return 0;
+    }
     else if (status != FROZEN_OKAY) {
         set_frozen_error(status, name);
         return -1;
@@ -2011,6 +2014,9 @@ _imp_find_frozen_impl(PyObject *module, PyObject *name)
     struct frozen_info info;
     frozen_status status = find_frozen(name, &info);
     if (status == FROZEN_NOT_FOUND || status == FROZEN_DISABLED) {
+        Py_RETURN_NONE;
+    }
+    else if (status == FROZEN_BAD_NAME) {
         Py_RETURN_NONE;
     }
     else if (status != FROZEN_OKAY) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -1176,6 +1176,10 @@ find_frozen(PyObject *nameobj, struct frozen_info *info)
     }
     const char *name = PyUnicode_AsUTF8(nameobj);
     if (name == NULL) {
+        // Note that this function previously used
+        // _PyUnicode_EqualToASCIIString().  We clear the error here
+        // (instead of propagating it) to match the earlier behavior
+        // more closely.
         PyErr_Clear();
         return FROZEN_BAD_NAME;
     }


### PR DESCRIPTION
Currently we end up duplicating effort and throwing away data in `FrozenImporter.find_spec()`.  With this change we do the work once in `find_spec()` and the only thing we do in `FrozenImporter.exec_module()` is turn the raw frozen data into a code object and then exec it.

The change involves adding `_imp.find_frozen()`, adding an arg to `_imp.get_frozen_object()`, and updating `FrozenImporter`.  We also move some code around to reduce some duplication, get a little more consistency in outcomes, and be more efficient.

Note that this change is mostly necessary if we want to set `__file__` on frozen stdlib modules.  (See https://bugs.python.org/issue21736.)

<!-- issue-number: [bpo-45324](https://bugs.python.org/issue45324) -->
https://bugs.python.org/issue45324
<!-- /issue-number -->
