### PR TITLE
bpo-45020: Do not freeze <pkg>/__init__.py twice.

### DIFF
--- a/Tools/scripts/freeze_modules.py
+++ b/Tools/scripts/freeze_modules.py
@@ -221,6 +221,7 @@ def _parse_spec(spec, knownids=None, section=None):
         if ispkg:
             pkgid = frozenid
             pkgname = modname
+            pkgfiles = {pyfile: pkgid}
             def iter_subs():
                 for frozenid, pyfile, ispkg in resolved:
                     assert not knownids or frozenid not in knownids, (frozenid, spec)
@@ -228,6 +229,12 @@ def _parse_spec(spec, knownids=None, section=None):
                         modname = frozenid.replace(pkgid, pkgname, 1)
                     else:
                         modname = frozenid
+                    if pyfile:
+                        if pyfile in pkgfiles:
+                            frozenid = pkgfiles[pyfile]
+                            pyfile = None
+                        elif ispkg:
+                            pkgfiles[pyfile] = frozenid
                     yield frozenid, pyfile, modname, ispkg, section
             submodules = iter_subs()
 


### PR DESCRIPTION
Currently we're freezing the `__init__.py` twice, duplicating the built data unnecessarily  With this change we do it once.  There is no change in runtime behavior.

FYI, this slipped through partly because we aren't freezing any packages.  We were freezing `encodings.*` but temporarily stopped.  I noticed this as I was adding `encodings.*` back in.

<!-- issue-number: [bpo-45020](https://bugs.python.org/issue45020) -->
https://bugs.python.org/issue45020
<!-- /issue-number -->
