### PR TITLE
gh-81022: JSONEncoder call self.default for unsupported floats

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -176,6 +176,11 @@ class JSONEncoder(object):
                 return JSONEncoder.default(self, o)
 
         """
+        if isinstance(o, float):
+            raise ValueError(
+                "Out of range float values are not JSON compliant: " +
+                repr(o)
+            )
         raise TypeError(f'Object of type {o.__class__.__name__} '
                         f'is not JSON serializable')
 
@@ -236,9 +241,7 @@ class JSONEncoder(object):
                 return _repr(o)
 
             if not allow_nan:
-                raise ValueError(
-                    "Out of range float values are not JSON compliant: " +
-                    repr(o))
+                return self.default(o)
 
             return text
 


### PR DESCRIPTION
allows `default` option to override unsupported float behavior, instead of unconditional ValueError.

A smaller change than #13233, though the default ValueError is preserved in the default `default` method. Since we already have `default` for expanding what can be serialized, it seems to make sense that it would be called for unsupported values.

I think the same change needs to be added to the corresponding C code produced by `c_make_encoder`, but I haven't found it yet.

<!-- issue-number: [bpo-36841](https://bugs.python.org/issue36841) -->
https://bugs.python.org/issue36841
<!-- /issue-number -->

<!-- gh-issue-number: gh-81022 -->
* Issue: gh-81022
<!-- /gh-issue-number -->
