### PR TITLE
bpo-45329: Fix freed memory access in pyexpat.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-01-11-17-45.bpo-45329.vtqRvA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-01-11-17-45.bpo-45329.vtqRvA.rst
@@ -1,1 +1,0 @@
-Fix freed memory access in :file:`Modules/pyexpat.c`

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-01-11-17-45.bpo-45329.vtqRvA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-01-11-17-45.bpo-45329.vtqRvA.rst
@@ -1,0 +1,1 @@
+Fix freed memory access in :file:`Modules/pyexpat.c`

--- a/Misc/NEWS.d/next/Library/2021-10-01-13-09-53.bpo-45329.9iMYaO.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-01-13-09-53.bpo-45329.9iMYaO.rst
@@ -1,1 +1,2 @@
-Fix freed memory access in :class:`pyexpat.xmlparser`
+Fix freed memory access in :class:`pyexpat.xmlparser` when building it with an
+installed expat library <= 2.2.0.

--- a/Misc/NEWS.d/next/Library/2021-10-01-13-09-53.bpo-45329.9iMYaO.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-01-13-09-53.bpo-45329.9iMYaO.rst
@@ -1,0 +1,1 @@
+Fix freed memory access in :class:`pyexpat.xmlparser`

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1204,10 +1204,10 @@ static void
 xmlparse_dealloc(xmlparseobject *self)
 {
     PyObject_GC_UnTrack(self);
+    (void)xmlparse_clear(self);
     if (self->itself != NULL)
         XML_ParserFree(self->itself);
     self->itself = NULL;
-    (void)xmlparse_clear(self);
 
     if (self->handlers != NULL) {
         PyMem_Free(self->handlers);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
https://bugs.python.org/issue45329

- `xmlparse_clear(self)` calls `clear_handlers(self, 0)`
- `clear_handlers(self, 0)` accesses `self->itself`
- Therefore `xmlparse_clear(self)` would be done before `XML_ParserFree(self->itself)`

<!-- issue-number: [bpo-45329](https://bugs.python.org/issue45329) -->
https://bugs.python.org/issue45329
<!-- /issue-number -->
