### PR TITLE
bpo-21736: Set __file__ on frozen stdlib modules.

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -541,6 +541,7 @@ def _init_module_attrs(spec, module, *, override=False):
     # __path__
     if override or getattr(module, '__path__', None) is None:
         if spec.submodule_search_locations is not None:
+            # XXX We () should extend __path__ if it's already a list.
             try:
                 module.__path__ = spec.submodule_search_locations
             except AttributeError:
@@ -859,7 +860,6 @@ class FrozenImporter:
             if ispkg:
                 if module.__path__ != __path__:
                     assert module.__path__ == [], module.__path__
-                    # XXX _init_module_attrs() should copy like this too.
                     module.__path__.extend(__path__)
         else:
             # These checks ensure that _fix_up_module() is only called

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -924,6 +924,18 @@ class FrozenImporter:
         info = _call_with_frames_removed(_imp.find_frozen, fullname)
         if info is None:
             return None
+        # We get the marshaled data in exec_module() (the loader
+        # part of the importer), instead of here (the finder part).
+        # The loader is the usual place to get the data that will
+        # be loaded into the module.  (For example, see _LoaderBasics
+        # in _bootstra_external.py.)  Most importantly, this importer
+        # is simpler if we wait to get the data.
+        # However, getting as much data in the finder as possible
+        # to later load the module is okay, and sometimes important.
+        # (That's why ModuleSpec.loader_state exists.)  This is
+        # especially true if it avoids throwing away expensive data
+        # the loader would otherwise duplicate later and can be done
+        # efficiently.  In this case it isn't worth it.
         _, ispkg, origname = info
         spec = spec_from_loader(fullname, cls,
                                 origin=cls._ORIGIN,

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -541,7 +541,7 @@ def _init_module_attrs(spec, module, *, override=False):
     # __path__
     if override or getattr(module, '__path__', None) is None:
         if spec.submodule_search_locations is not None:
-            # XXX We () should extend __path__ if it's already a list.
+            # XXX We should extend __path__ if it's already a list.
             try:
                 module.__path__ = spec.submodule_search_locations
             except AttributeError:

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -837,7 +837,7 @@ class FrozenImporter:
             ispkg = hasattr(module, '__path__')
             assert _imp.is_frozen_package(module.__name__) == ispkg, ispkg
             filename, pkgdir = cls._resolve_filename(origname, spec.name, ispkg)
-            spec.loader_state = state = type(sys.implementation)(
+            spec.loader_state = type(sys.implementation)(
                 filename=filename,
                 origname=origname,
             )
@@ -864,7 +864,6 @@ class FrozenImporter:
         else:
             # These checks ensure that _fix_up_module() is only called
             # in the right places.
-            assert state is not None
             assert sorted(vars(state)) == ['filename', 'origname'], state
             assert state.origname
             __path__ = spec.submodule_search_locations

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -841,6 +841,16 @@ class FrozenImporter:
             origname = vars(module).pop('__origname__', None)
             assert origname, 'see PyImport_ImportFrozenModuleObject()'
             spec.loader_state.origname = origname
+        if not getattr(spec.loader_state, 'filename', None):
+            # Note that this happens early in runtime initialization.
+            # So sys._stdlib_dir isn't set yet...
+            filename, pkgdir = cls._resolve_filename(origname, ispkg)
+            if filename:
+                module.__file__ = filename
+                if pkgdir:
+                    spec.submodule_search_locations.insert(0, pkgdir)
+                    module.__path__.insert(0, pkgdir)
+            spec.loader_state.filename = filename or None
 
     @classmethod
     def _resolve_filename(cls, fullname, alias=None, ispkg=False):

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -484,7 +484,7 @@ def _spec_from_module(module, loader=None, origin=None):
         submodule_search_locations = None
 
     spec = ModuleSpec(name, loader, origin=origin)
-    spec._set_fileattr = origin == location
+    spec._set_fileattr = False if location is None else (origin == location)
     spec.cached = cached
     spec.submodule_search_locations = submodule_search_locations
     return spec

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -858,7 +858,7 @@ class FrozenImporter:
                     pass
             if ispkg:
                 if module.__path__ != __path__:
-                    assert not module.__path__, module.__path__
+                    assert module.__path__ == [], module.__path__
                     # XXX _init_module_attrs() should copy like this too.
                     module.__path__.extend(__path__)
         else:

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -951,9 +951,6 @@ class FrozenImporter:
         # Warning about deprecation implemented in _load_module_shim().
         return _load_module_shim(cls, fullname)
 
-    # XXX We should also add get_filename(), but when we do we need
-    # to fix spec_from_loader().
-
     @classmethod
     @_requires_frozen
     def get_code(cls, fullname):

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -843,7 +843,7 @@ class FrozenImporter:
             spec.loader_state.origname = origname
 
     @classmethod
-    def _resolve_filename(cls, fullname, ispkg):
+    def _resolve_filename(cls, fullname, alias=None, ispkg=False):
         if not fullname or not getattr(sys, '_stdlib_dir', None):
             return None, None
         try:
@@ -851,6 +851,13 @@ class FrozenImporter:
         except AttributeError:
             sep = cls._SEP = '\\' if sys.platform == 'win32' else '/'
 
+        if fullname != alias:
+            if fullname.startswith('<'):
+                fullname = fullname[1:]
+                if not ispkg:
+                    fullname = f'{fullname}.__init__'
+            else:
+                ispkg = False
         relfile = fullname.replace('.', sep)
         if ispkg:
             pkgdir = f'{sys._stdlib_dir}{sep}{relfile}'
@@ -869,7 +876,7 @@ class FrozenImporter:
         spec = spec_from_loader(fullname, cls,
                                 origin=cls._ORIGIN,
                                 is_package=ispkg)
-        filename, pkgdir = cls._resolve_filename(origname, ispkg)
+        filename, pkgdir = cls._resolve_filename(origname, fullname, ispkg)
         spec.loader_state = type(sys.implementation)(
             data=data,
             filename=filename,

--- a/Lib/test/test_frozen.py
+++ b/Lib/test/test_frozen.py
@@ -39,9 +39,6 @@ class TestFrozen(unittest.TestCase):
         self.assertIs(spam.__spec__.loader,
                       importlib.machinery.FrozenImporter)
 
-    # This is not possible until frozen packages have __path__ set properly.
-    # See https://bugs.python.org/issue21736.
-    @unittest.expectedFailure
     def test_unfrozen_submodule_in_frozen_package(self):
         with import_helper.CleanImport('__phello__', '__phello__.spam'):
             with import_helper.frozen_modules(enabled=True):

--- a/Lib/test/test_importlib/frozen/test_finder.py
+++ b/Lib/test/test_importlib/frozen/test_finder.py
@@ -48,17 +48,6 @@ class FindSpecTests(abc.FinderTests):
 
         actual = dict(vars(spec.loader_state))
 
-        # Check the code object used to import the frozen module.
-        # We can't compare the marshaled data directly because
-        # marshal.dumps() would mark "expected" (below) as a ref,
-        # which slightly changes the output.
-        # (See https://bugs.python.org/issue34093.)
-        data = actual.pop('data')
-        with import_helper.frozen_modules():
-            expected = _imp.get_frozen_object(spec.name)
-        code = marshal.loads(data)
-        self.assertEqual(code, expected)
-
         # Check the rest of spec.loader_state.
         expected = dict(
             origname=origname,

--- a/Lib/test/test_importlib/frozen/test_finder.py
+++ b/Lib/test/test_importlib/frozen/test_finder.py
@@ -62,17 +62,24 @@ class FindSpecTests(abc.FinderTests):
         # Check the rest of spec.loader_state.
         expected = dict(
             origname=origname,
-            filename=filename,
+            filename=filename if origname else None,
         )
         self.assertDictEqual(actual, expected)
 
-    def check_search_location(self, spec):
+    def check_search_locations(self, spec):
+        """This is only called when testing packages."""
         missing = object()
         filename = getattr(spec.loader_state, 'filename', missing)
-        if filename is missing:
+        origname = getattr(spec.loader_state, 'origname', None)
+        if not origname or filename is missing:
             # We deal with this in check_loader_state().
             return
-        expected = [os.path.dirname(filename)] if filename else []
+        if not filename:
+            expected = []
+        elif origname != spec.name and not origname.startswith('<'):
+            expected = []
+        else:
+            expected = [os.path.dirname(filename)]
         self.assertListEqual(spec.submodule_search_locations, expected)
 
     def test_module(self):

--- a/Lib/test/test_importlib/frozen/test_finder.py
+++ b/Lib/test/test_importlib/frozen/test_finder.py
@@ -44,6 +44,7 @@ class FindSpecTests(abc.FinderTests):
         if not filename:
             if not origname:
                 origname = spec.name
+            filename = resolve_stdlib_file(origname)
 
         actual = dict(vars(spec.loader_state))
 
@@ -61,13 +62,17 @@ class FindSpecTests(abc.FinderTests):
         # Check the rest of spec.loader_state.
         expected = dict(
             origname=origname,
+            filename=filename,
         )
         self.assertDictEqual(actual, expected)
 
-    def check_search_locations(self, spec):
-        # Frozen packages do not have any path entries.
-        # (See https://bugs.python.org/issue21736.)
-        expected = []
+    def check_search_location(self, spec):
+        missing = object()
+        filename = getattr(spec.loader_state, 'filename', missing)
+        if filename is missing:
+            # We deal with this in check_loader_state().
+            return
+        expected = [os.path.dirname(filename)] if filename else []
         self.assertListEqual(spec.submodule_search_locations, expected)
 
     def test_module(self):

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -149,36 +149,41 @@ class LoaderTests(abc.LoaderTests):
 
     def test_module(self):
         module, stdout = self.load_module('__hello__')
+        filename = resolve_stdlib_file('__hello__')
         check = {'__name__': '__hello__',
                 '__package__': '',
                 '__loader__': self.machinery.FrozenImporter,
+                '__file__': filename,
                 }
         for attr, value in check.items():
-            self.assertEqual(getattr(module, attr), value)
+            self.assertEqual(getattr(module, attr, None), value)
         self.assertEqual(stdout.getvalue(), 'Hello world!\n')
-        self.assertFalse(hasattr(module, '__file__'))
 
     def test_package(self):
         module, stdout = self.load_module('__phello__')
+        filename = resolve_stdlib_file('__phello__', ispkg=True)
+        pkgdir = os.path.dirname(filename)
         check = {'__name__': '__phello__',
                  '__package__': '__phello__',
-                 '__path__': [],
+                 '__path__': [pkgdir],
                  '__loader__': self.machinery.FrozenImporter,
+                 '__file__': filename,
                  }
         for attr, value in check.items():
-            attr_value = getattr(module, attr)
+            attr_value = getattr(module, attr, None)
             self.assertEqual(attr_value, value,
                              "for __phello__.%s, %r != %r" %
                              (attr, attr_value, value))
         self.assertEqual(stdout.getvalue(), 'Hello world!\n')
-        self.assertFalse(hasattr(module, '__file__'))
 
     def test_lacking_parent(self):
         with util.uncache('__phello__'):
             module, stdout = self.load_module('__phello__.spam')
+        filename = resolve_stdlib_file('__phello__.spam')
         check = {'__name__': '__phello__.spam',
                 '__package__': '__phello__',
                 '__loader__': self.machinery.FrozenImporter,
+                '__file__': filename,
                 }
         for attr, value in check.items():
             attr_value = getattr(module, attr)
@@ -186,7 +191,6 @@ class LoaderTests(abc.LoaderTests):
                              "for __phello__.spam.%s, %r != %r" %
                              (attr, attr_value, value))
         self.assertEqual(stdout.getvalue(), 'Hello world!\n')
-        self.assertFalse(hasattr(module, '__file__'))
 
     def test_module_reuse(self):
         with fresh('__hello__', oldapi=True):

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -3,10 +3,11 @@ from .. import util
 
 machinery = util.import_importlib('importlib.machinery')
 
-from test.support import captured_stdout, import_helper
+from test.support import captured_stdout, import_helper, STDLIB_DIR
 import _imp
 import contextlib
 import marshal
+import os.path
 import types
 import unittest
 import warnings
@@ -30,6 +31,14 @@ def fresh(name, *, oldapi=False):
                 yield
 
 
+def resolve_stdlib_file(name, ispkg=False):
+    assert name
+    if ispkg:
+        return os.path.join(STDLIB_DIR, *name.split('.'), '__init__.py')
+    else:
+        return os.path.join(STDLIB_DIR, *name.split('.')) + '.py'
+
+
 class ExecModuleTests(abc.LoaderTests):
 
     def exec_module(self, name, origname=None):
@@ -44,6 +53,7 @@ class ExecModuleTests(abc.LoaderTests):
             loader_state=types.SimpleNamespace(
                 data=marshal.dumps(code),
                 origname=origname or name,
+                filename=resolve_stdlib_file(origname or name, is_package),
             ),
         )
         module = types.ModuleType(name)

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -44,14 +44,12 @@ class ExecModuleTests(abc.LoaderTests):
     def exec_module(self, name, origname=None):
         with import_helper.frozen_modules():
             is_package = self.machinery.FrozenImporter.is_package(name)
-            code = _imp.get_frozen_object(name)
         spec = self.machinery.ModuleSpec(
             name,
             self.machinery.FrozenImporter,
             origin='frozen',
             is_package=is_package,
             loader_state=types.SimpleNamespace(
-                data=marshal.dumps(code),
                 origname=origname or name,
                 filename=resolve_stdlib_file(origname or name, is_package),
             ),
@@ -78,7 +76,6 @@ class ExecModuleTests(abc.LoaderTests):
             self.assertEqual(getattr(module, attr), value)
         self.assertEqual(output, 'Hello world!\n')
         self.assertTrue(hasattr(module, '__spec__'))
-        self.assertIsNone(module.__spec__.loader_state.data)
         self.assertEqual(module.__spec__.loader_state.origname, name)
 
     def test_package(self):
@@ -92,7 +89,6 @@ class ExecModuleTests(abc.LoaderTests):
                                  name=name, attr=attr, given=attr_value,
                                  expected=value))
         self.assertEqual(output, 'Hello world!\n')
-        self.assertIsNone(module.__spec__.loader_state.data)
         self.assertEqual(module.__spec__.loader_state.origname, name)
 
     def test_lacking_parent(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-01-09-21-02.bpo-21736.RI47BU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-01-09-21-02.bpo-21736.RI47BU.rst
@@ -1,0 +1,9 @@
+Frozen stdlib modules now have ``__file__`` to the .py file they would
+otherwise be loaded from, if possible.  For packages, ``__path__`` now has
+the correct entry instead of being an empty list, which allows unfrozen
+submodules to be imported.  These are set only if the stdlib directory is
+known when the runtime is initialized.  Note that the file at ``__file__``
+is not guaranteed to exist.  None of this affects non-stdlib frozen modules
+nor, for now, frozen modules imported using
+``PyImport_ImportFrozenModule()``.  Also, at the moment ``co_filename`` is
+not updated for the module.

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -170,7 +170,7 @@ exit:
 }
 
 PyDoc_STRVAR(_imp_find_frozen__doc__,
-"find_frozen($module, name, /)\n"
+"find_frozen($module, name, /, *, withdata=False)\n"
 "--\n"
 "\n"
 "Return info about the corresponding frozen module (if there is one) or None.\n"
@@ -184,26 +184,43 @@ PyDoc_STRVAR(_imp_find_frozen__doc__,
 "                the module\'s current name)");
 
 #define _IMP_FIND_FROZEN_METHODDEF    \
-    {"find_frozen", (PyCFunction)_imp_find_frozen, METH_O, _imp_find_frozen__doc__},
+    {"find_frozen", (PyCFunction)(void(*)(void))_imp_find_frozen, METH_FASTCALL|METH_KEYWORDS, _imp_find_frozen__doc__},
 
 static PyObject *
-_imp_find_frozen_impl(PyObject *module, PyObject *name);
+_imp_find_frozen_impl(PyObject *module, PyObject *name, int withdata);
 
 static PyObject *
-_imp_find_frozen(PyObject *module, PyObject *arg)
+_imp_find_frozen(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "withdata", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "find_frozen", 0};
+    PyObject *argsbuf[2];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *name;
+    int withdata = 0;
 
-    if (!PyUnicode_Check(arg)) {
-        _PyArg_BadArgument("find_frozen", "argument", "str", arg);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
         goto exit;
     }
-    if (PyUnicode_READY(arg) == -1) {
+    if (!PyUnicode_Check(args[0])) {
+        _PyArg_BadArgument("find_frozen", "argument 1", "str", args[0]);
         goto exit;
     }
-    name = arg;
-    return_value = _imp_find_frozen_impl(module, name);
+    if (PyUnicode_READY(args[0]) == -1) {
+        goto exit;
+    }
+    name = args[0];
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    withdata = PyObject_IsTrue(args[1]);
+    if (withdata < 0) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    return_value = _imp_find_frozen_impl(module, name, withdata);
 
 exit:
     return return_value;
@@ -548,4 +565,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=8c8dd08158f9ac7c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=adcf787969a11353 input=a9049054013a1b77]*/

--- a/Python/import.c
+++ b/Python/import.c
@@ -2121,8 +2121,8 @@ _imp_get_frozen_object_impl(PyObject *module, PyObject *name,
                             PyObject *dataobj)
 /*[clinic end generated code: output=54368a673a35e745 input=034bdb88f6460b7b]*/
 {
-    struct frozen_info info = {};
-    Py_buffer buf = {};
+    struct frozen_info info = {0};
+    Py_buffer buf = {0};
     if (PyObject_CheckBuffer(dataobj)) {
         if (PyObject_GetBuffer(dataobj, &buf, PyBUF_READ) != 0) {
             return NULL;

--- a/Python/import.c
+++ b/Python/import.c
@@ -2050,6 +2050,8 @@ _imp.find_frozen
 
     name: unicode
     /
+    *
+    withdata: bool = False
 
 Return info about the corresponding frozen module (if there is one) or None.
 
@@ -2063,8 +2065,8 @@ The returned info (a 2-tuple):
 [clinic start generated code]*/
 
 static PyObject *
-_imp_find_frozen_impl(PyObject *module, PyObject *name)
-/*[clinic end generated code: output=3fd17da90d417e4e input=6aa7b9078a89280a]*/
+_imp_find_frozen_impl(PyObject *module, PyObject *name, int withdata)
+/*[clinic end generated code: output=8c1c3c7f925397a5 input=22a8847c201542fd]*/
 {
     struct frozen_info info;
     frozen_status status = find_frozen(name, &info);
@@ -2079,10 +2081,12 @@ _imp_find_frozen_impl(PyObject *module, PyObject *name)
         return NULL;
     }
 
-    PyObject *data = PyMemoryView_FromMemory((char *)info.data, info.size,
-                                             PyBUF_READ);
-    if (data == NULL) {
-        return NULL;
+    PyObject *data = NULL;
+    if (withdata) {
+        data = PyMemoryView_FromMemory((char *)info.data, info.size, PyBUF_READ);
+        if (data == NULL) {
+            return NULL;
+        }
     }
 
     PyObject *origname = NULL;
@@ -2094,11 +2098,11 @@ _imp_find_frozen_impl(PyObject *module, PyObject *name)
         }
     }
 
-    PyObject *result = PyTuple_Pack(3, data,
+    PyObject *result = PyTuple_Pack(3, data ? data : Py_None,
                                     info.is_package ? Py_True : Py_False,
                                     origname ? origname : Py_None);
     Py_XDECREF(origname);
-    Py_DECREF(data);
+    Py_XDECREF(data);
     return result;
 }
 


### PR DESCRIPTION
Currently frozen modules do not have `__file__` set.  In their spec, `origin` is set to "frozen" and they are marked as not having a location.  (Similarly, for frozen packages `__path__` is set to an empty list.)  However, for frozen *stdlib* modules we are able to extrapolate `__file__` as long as we can determine the stdlib directory at runtime.  (We now do so since gh-28586.)  Having `__file__` set is helpful for a number of reasons.  Likewise, having a non-empty `__path__` means we can import submodules of a frozen package from the filesystem (e.g. we could partially freeze the `encodings` module).

This change sets `__file__` (and adds to `__path__`) for frozen stdlib modules.  It uses `sys._stdlibdir` (from gh-28586) and the frozen module alias information (from gh-28655).  All that work is done in `FrozenImporter` (in `Lib/importlib/_bootstrap.py`).  Also, if a frozen module is imported before importlib is bootstrapped (during interpreter initialization) then we fix up that module and its spec during the importlib bootstrapping step (i.e. `imporlib._bootstrap._setup()`) to match what gets set by `FrozenImporter`, including setting the file info (if the stdlib dir is known).  To facilitate this, modules imported using `PyImport_ImportFrozenModule()` have `__origname__` set using the frozen module alias info.  `__origname__` is popped off during importlib bootstrap.

(To be clear, even with this PR the new code to set `__file__` during fixups in `imporlib._bootstrap._setup()` doesn't actually get triggered yet.  This is because `sys._stdlibdir` hasn't been set yet in interpreter initialization at the point importlib is bootstrapped.  However, we *do* fix up such modules at that point to otherwise match the result of importing through `FrozenImporter`, just not the `__file__` and `__path__` parts.  Doing so will require changes in the order in which things happen during interpreter initialization.  That can be addressed separately.  Once it is, the file-related fixup code from this PR will kick in.)

Here are things this PR does not do:

* set `__file__` for non-stdlib modules (no way of knowing the parent dir)
* set `__file__` if the stdlib dir is not known (nor assume the expense of finding it)
* relatedly, set `__file__` if the stdlib is in a zip file
* verify that the filename set to `__file__` actually exists (too expensive)
* update `__path__` for frozen packages that alias a non-package (since there is no package dir)

Other things this PR skips, but we may do later:

* set `__file__` on modules imported using `PyImport_ImportFrozenModule()`
* set `co_filename` when we unmarshal the frozen code object while importing the module (e.g. in `FrozenImporter.exec_module()`) -- this would allow tracebacks to show source lines
* implement `FrozenImporter.get_filename()` and `FrozenImporter.get_source()`

<!-- issue-number: [bpo-21736](https://bugs.python.org/issue21736) -->
https://bugs.python.org/issue21736
<!-- /issue-number -->
