### PR TITLE
Makefile: Fix missing slashes

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1418,13 +1418,13 @@ altbininstall: $(BUILDPYTHON) @FRAMEWORKPYTHONW@
 		fi; \
 	fi
 	if test "x$(LIPO_32BIT_FLAGS)" != "x" ; then \
-		rm -f $(DESTDIR)$(BINDIR)python$(VERSION)-32$(EXE); \
+		rm -f $(DESTDIR)$(BINDIR)/python$(VERSION)-32$(EXE); \
 		lipo $(LIPO_32BIT_FLAGS) \
 			-output $(DESTDIR)$(BINDIR)/python$(VERSION)-32$(EXE) \
 			$(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
 	fi
 	if test "x$(LIPO_INTEL64_FLAGS)" != "x" ; then \
-		rm -f $(DESTDIR)$(BINDIR)python$(VERSION)-intel64$(EXE); \
+		rm -f $(DESTDIR)$(BINDIR)/python$(VERSION)-intel64$(EXE); \
 		lipo $(LIPO_INTEL64_FLAGS) \
 			-output $(DESTDIR)$(BINDIR)/python$(VERSION)-intel64$(EXE) \
 			$(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \

--- a/Misc/NEWS.d/next/Build/2021-10-01-12-20-05.bpo-0.2ykYK2.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-01-12-20-05.bpo-0.2ykYK2.rst
@@ -1,1 +1,1 @@
-Makefile: fix missing slashes in some invocations cleaning previous build results when builing a macOS universal binary
+Makefile: fix missing slashes in some invocations cleaning previous build results when builing a macOS universal binary.

--- a/Misc/NEWS.d/next/Build/2021-10-01-12-20-05.bpo-0.2ykYK2.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-01-12-20-05.bpo-0.2ykYK2.rst
@@ -1,1 +1,1 @@
-Makefile: fix missing slashes
+Makefile: fix missing slashes in some invocations cleaning previous build results when builing a macOS universal binary

--- a/Misc/NEWS.d/next/Build/2021-10-01-12-20-05.bpo-0.2ykYK2.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-01-12-20-05.bpo-0.2ykYK2.rst
@@ -1,0 +1,1 @@
+Makefile: fix missing slashes


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

There are missing slashes in the two command lines, resulting in invocations like this:

```
if test "x" != "x" ; then \
		rm -f /Users/Daniel/.pyenv/versions/3.9.1/binpython3.9-32; \
		lipo  \
			-output /Users/Daniel/.pyenv/versions/3.9.1/bin/python3.9-32 \
			/Users/Daniel/.pyenv/versions/3.9.1/bin/python3.9; \
	fi
```

Applies to everything since 3.4.