### PR TITLE
[3.9] Revert "[3.9] bpo-45229: Make datetime tests discoverable (GH-28615) (GH-28645)"

### DIFF
--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -1,57 +1,57 @@
 import unittest
 import sys
 
-from test.support import import_fresh_module
-
+from test.support import import_fresh_module, run_unittest
 
 TESTS = 'test.datetimetester'
 
-def load_tests(loader, tests, pattern):
-    try:
-        pure_tests = import_fresh_module(TESTS, fresh=['datetime', '_strptime'],
-                                        blocked=['_datetime'])
-        fast_tests = import_fresh_module(TESTS, fresh=['datetime',
-                                                    '_datetime', '_strptime'])
-    finally:
-        # XXX: import_fresh_module() is supposed to leave sys.module cache untouched,
-        # XXX: but it does not, so we have to cleanup ourselves.
-        for modname in ['datetime', '_datetime', '_strptime']:
-            sys.modules.pop(modname, None)
+try:
+    pure_tests = import_fresh_module(TESTS, fresh=['datetime', '_strptime'],
+                                     blocked=['_datetime'])
+    fast_tests = import_fresh_module(TESTS, fresh=['datetime',
+                                                   '_datetime', '_strptime'])
+finally:
+    # XXX: import_fresh_module() is supposed to leave sys.module cache untouched,
+    # XXX: but it does not, so we have to cleanup ourselves.
+    for modname in ['datetime', '_datetime', '_strptime']:
+        sys.modules.pop(modname, None)
+test_modules = [pure_tests, fast_tests]
+test_suffixes = ["_Pure", "_Fast"]
+# XXX(gb) First run all the _Pure tests, then all the _Fast tests.  You might
+# not believe this, but in spite of all the sys.modules trickery running a _Pure
+# test last will leave a mix of pure and native datetime stuff lying around.
+all_test_classes = []
 
-    test_modules = [pure_tests, fast_tests]
-    test_suffixes = ["_Pure", "_Fast"]
-    # XXX(gb) First run all the _Pure tests, then all the _Fast tests.  You might
-    # not believe this, but in spite of all the sys.modules trickery running a _Pure
-    # test last will leave a mix of pure and native datetime stuff lying around.
-    for module, suffix in zip(test_modules, test_suffixes):
-        test_classes = []
-        for name, cls in module.__dict__.items():
-            if not isinstance(cls, type):
-                continue
-            if issubclass(cls, unittest.TestCase):
-                test_classes.append(cls)
-            elif issubclass(cls, unittest.TestSuite):
-                suit = cls()
-                test_classes.extend(type(test) for test in suit)
-        test_classes = sorted(set(test_classes), key=lambda cls: cls.__qualname__)
-        for cls in test_classes:
-            cls.__name__ += suffix
-            cls.__qualname__ += suffix
-            @classmethod
-            def setUpClass(cls_, module=module):
-                cls_._save_sys_modules = sys.modules.copy()
-                sys.modules[TESTS] = module
-                sys.modules['datetime'] = module.datetime_module
-                sys.modules['_strptime'] = module._strptime
-            @classmethod
-            def tearDownClass(cls_):
-                sys.modules.clear()
-                sys.modules.update(cls_._save_sys_modules)
-            cls.setUpClass = setUpClass
-            cls.tearDownClass = tearDownClass
-            tests.addTests(loader.loadTestsFromTestCase(cls))
-    return tests
+for module, suffix in zip(test_modules, test_suffixes):
+    test_classes = []
+    for name, cls in module.__dict__.items():
+        if not isinstance(cls, type):
+            continue
+        if issubclass(cls, unittest.TestCase):
+            test_classes.append(cls)
+        elif issubclass(cls, unittest.TestSuite):
+            suit = cls()
+            test_classes.extend(type(test) for test in suit)
+    test_classes = sorted(set(test_classes), key=lambda cls: cls.__qualname__)
+    for cls in test_classes:
+        cls.__name__ += suffix
+        cls.__qualname__ += suffix
+        @classmethod
+        def setUpClass(cls_, module=module):
+            cls_._save_sys_modules = sys.modules.copy()
+            sys.modules[TESTS] = module
+            sys.modules['datetime'] = module.datetime_module
+            sys.modules['_strptime'] = module._strptime
+        @classmethod
+        def tearDownClass(cls_):
+            sys.modules.clear()
+            sys.modules.update(cls_._save_sys_modules)
+        cls.setUpClass = setUpClass
+        cls.tearDownClass = tearDownClass
+    all_test_classes.extend(test_classes)
 
+def test_main():
+    run_unittest(*all_test_classes)
 
 if __name__ == "__main__":
-    unittest.main()
+    test_main()


### PR DESCRIPTION
This reverts commit 993a130d3abe7684dc9c999874b4dd1d8ea55a2a.


<!-- issue-number: [bpo-45229](https://bugs.python.org/issue45229) -->
https://bugs.python.org/issue45229
<!-- /issue-number -->
