### PR TITLE
Also install __phello__, in addition to __hello__.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1544,7 +1544,8 @@ LIBSUBDIRS=	asyncio \
 		wsgiref \
 		$(XMLLIBSUBDIRS) \
 		xmlrpc \
-		zoneinfo
+		zoneinfo \
+		__phello__
 TESTSUBDIRS=	ctypes/test \
 		distutils/tests \
 		idlelib/idle_test \


### PR DESCRIPTION
(I was going to revert gh-28664, but realized what the problem was.)

I broke some buildbots by not adding __phello__ to the list of installed packages.

<!-- issue-number: [bpo-45020](https://bugs.python.org/issue45020) -->
https://bugs.python.org/issue45020
<!-- /issue-number -->
