### PR TITLE
bpo-41710: Fix PY_TIMEOUT_MAX on Windows

### DIFF
--- a/Include/pythread.h
+++ b/Include/pythread.h
@@ -61,11 +61,11 @@ PyAPI_FUNC(int) _PyThread_at_fork_reinit(PyThread_type_lock *lock);
       convert microseconds to nanoseconds. */
 #  define PY_TIMEOUT_MAX (LLONG_MAX / 1000)
 #elif defined (NT_THREADS)
-   /* In the NT API, the timeout is a DWORD and is expressed in milliseconds,
-    * a positive number between 0 and 0x7FFFFFFF (see WaitForSingleObject()
-    * documentation). */
-#  if 0x7FFFFFFFLL * 1000 < LLONG_MAX
-#    define PY_TIMEOUT_MAX (0x7FFFFFFFLL * 1000)
+   // WaitForSingleObject() accepts timeout in milliseconds in the range
+   // [0; 0xFFFFFFFE] (DWORD type). INFINITE value (0xFFFFFFFF) means no
+   // timeout. 0xFFFFFFFE milliseconds is around 49.7 days.
+#  if 0xFFFFFFFELL * 1000 < LLONG_MAX
+#    define PY_TIMEOUT_MAX (0xFFFFFFFELL * 1000)
 #  else
 #    define PY_TIMEOUT_MAX LLONG_MAX
 #  endif

--- a/Misc/NEWS.d/next/Library/2021-09-30-08-57-50.bpo-41710.JMsPAW.rst
+++ b/Misc/NEWS.d/next/Library/2021-09-30-08-57-50.bpo-41710.JMsPAW.rst
@@ -1,3 +1,0 @@
-Fix :data:`_thread.TIMEOUT_MAX` value on Windows: the maximum timeout is
-0x7FFFFFFF milliseconds (around 24.9 days), not 0xFFFFFFFF milliseconds (around
-49.7 days).

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -318,7 +318,7 @@ PyThread_acquire_lock_timed(PyThread_type_lock aLock,
         if (microseconds % 1000 > 0) {
             milliseconds++;
         }
-        if (milliseconds > TIMEOUT_MS_MAX) {
+        if (milliseconds > (PY_TIMEOUT_T)TIMEOUT_MS_MAX) {
             // bpo-41710: PyThread_acquire_lock_timed() cannot report timeout
             // overflow to the caller, so clamp the timeout to
             // [0, TIMEOUT_MS_MAX] milliseconds.

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -292,9 +292,10 @@ PyThread_free_lock(PyThread_type_lock aLock)
     FreeNonRecursiveMutex(aLock) ;
 }
 
-// WaitForSingleObject() documentation: "The time-out value needs to be a
-// positive number between 0 and 0x7FFFFFFF." INFINITE is equal to 0xFFFFFFFF.
-const DWORD TIMEOUT_MS_MAX = 0x7FFFFFFF;
+// WaitForSingleObject() accepts timeout in milliseconds in the range
+// [0; 0xFFFFFFFE] (DWORD type). INFINITE value (0xFFFFFFFF) means no
+// timeout. 0xFFFFFFFE milliseconds is around 49.7 days.
+const DWORD TIMEOUT_MS_MAX = 0xFFFFFFFE;
 
 /*
  * Return 1 on success if the lock was acquired
@@ -317,17 +318,16 @@ PyThread_acquire_lock_timed(PyThread_type_lock aLock,
         if (microseconds % 1000 > 0) {
             milliseconds++;
         }
-        if (milliseconds > (PY_TIMEOUT_T)TIMEOUT_MS_MAX) {
+        if (milliseconds > TIMEOUT_MS_MAX) {
             // bpo-41710: PyThread_acquire_lock_timed() cannot report timeout
             // overflow to the caller, so clamp the timeout to
             // [0, TIMEOUT_MS_MAX] milliseconds.
-            //
-            // TIMEOUT_MS_MAX milliseconds is around 24.9 days.
             //
             // _thread.Lock.acquire() and _thread.RLock.acquire() raise an
             // OverflowError if microseconds is greater than PY_TIMEOUT_MAX.
             milliseconds = TIMEOUT_MS_MAX;
         }
+        assert(milliseconds != INFINITE);
     }
     else {
         milliseconds = INFINITE;


### PR DESCRIPTION
WaitForSingleObject() accepts timeout in milliseconds in the range
[0; 0xFFFFFFFE] (DWORD type). INFINITE value (0xFFFFFFFF) means no
timeout. 0xFFFFFFFE milliseconds is around 49.7 days.

PY_TIMEOUT_MAX is (0xFFFFFFFE * 1000) milliseconds on Windows, around
49.7 days.

Partially revert commit 37b8294d6295ca12553fd7c98778be71d24f4b24.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-41710](https://bugs.python.org/issue41710) -->
https://bugs.python.org/issue41710
<!-- /issue-number -->
