### PR TITLE
bpo-45342: Set the ciphers before load_cert_chain

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1439,10 +1439,10 @@ def wrap_socket(sock, keyfile=None, certfile=None,
     context.verify_mode = cert_reqs
     if ca_certs:
         context.load_verify_locations(ca_certs)
-    if certfile:
-        context.load_cert_chain(certfile, keyfile)
     if ciphers:
         context.set_ciphers(ciphers)
+    if certfile:
+        context.load_cert_chain(certfile, keyfile)
     return context.wrap_socket(
         sock=sock, server_side=server_side,
         do_handshake_on_connect=do_handshake_on_connect,


### PR DESCRIPTION
Example: 
```
self.socket = ssl.wrap_socket(socket.socket(self.address_family, self.socket_type),
                                              keyfile=keys, certfile=certs, server_side=True, ciphers="DEFAULT@SECLEVEL=1")
```
Gives the following exception - 
```
 File "ssl.py", line 1402, in wrap_socket
    context.load_cert_chain(certfile, keyfile)
ssl.SSLError: [SSL: EE_KEY_TOO_SMALL] ee key too small (_ssl.c:4023)
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

--> 

<!-- issue-number: [bpo-45342](https://bugs.python.org/issue45342) -->
https://bugs.python.org/issue45342
<!-- /issue-number -->
