### PR TITLE
[doc] Fix copy & paste mistake in gethostbyname_ex

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -827,8 +827,8 @@ The :mod:`socket` module also offers various network-related services:
 .. function:: gethostbyname_ex(hostname)
 
    Translate a host name to IPv4 address format, extended interface. Return a
-   triple ``(hostname, aliaslist, ipaddrlist)`` where *hostname* is the primary
-   host name responding to the given *ip_address*, *aliaslist* is a (possibly
+   triple ``(hostname, aliaslist, ipaddrlist)`` where *hostname* is the host's
+   primary host name, *aliaslist* is a (possibly
    empty) list of alternative host names for the same address, and *ipaddrlist* is
    a list of IPv4 addresses for the same interface on the same host (often but not
    always a single address). :func:`gethostbyname_ex` does not support IPv6 name


### PR DESCRIPTION
It seems part of gethostbyname_ex doc was copied from gethostbyaddr (which has an ip_address parameter).

Not sure if the proposed wording is correct, though, as it not clear to me what is going on with the hostname returned. Not sure if it's exactly the hostname passed as argument. Tried to read the C, but, yeah..