### PR TITLE
bpo-45355: Use sizeof(_Py_CODEUNIT) instead of literal 2 for the size…

### DIFF
--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -302,7 +302,7 @@ static void
 tracemalloc_get_frame(InterpreterFrame *pyframe, frame_t *frame)
 {
     frame->filename = unknown_filename;
-    int lineno = PyCode_Addr2Line(pyframe->f_code, pyframe->f_lasti*2);
+    int lineno = PyCode_Addr2Line(pyframe->f_code, pyframe->f_lasti*sizeof(_Py_CODEUNIT));
     if (lineno < 0) {
         lineno = 0;
     }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -45,7 +45,7 @@ PyFrame_GetLineNumber(PyFrameObject *f)
         return f->f_lineno;
     }
     else {
-        return PyCode_Addr2Line(f->f_frame->f_code, f->f_frame->f_lasti*2);
+        return PyCode_Addr2Line(f->f_frame->f_code, f->f_frame->f_lasti*sizeof(_Py_CODEUNIT));
     }
 }
 
@@ -67,7 +67,7 @@ frame_getlasti(PyFrameObject *f, void *closure)
     if (f->f_frame->f_lasti < 0) {
         return PyLong_FromLong(-1);
     }
-    return PyLong_FromLong(f->f_frame->f_lasti*2);
+    return PyLong_FromLong(f->f_frame->f_lasti*sizeof(_Py_CODEUNIT));
 }
 
 static PyObject *

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1284,7 +1284,7 @@ compute_cr_origin(int origin_depth)
         PyCodeObject *code = frame->f_code;
         PyObject *frameinfo = Py_BuildValue("OiO",
                                             code->co_filename,
-                                            PyCode_Addr2Line(frame->f_code, frame->f_lasti*2),
+                                            PyCode_Addr2Line(frame->f_code, frame->f_lasti*sizeof(_Py_CODEUNIT)),
                                             code->co_name);
         if (!frameinfo) {
             Py_DECREF(cr_origin);

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -240,7 +240,7 @@ _PyTraceBack_FromFrame(PyObject *tb_next, PyFrameObject *frame)
     assert(tb_next == NULL || PyTraceBack_Check(tb_next));
     assert(frame != NULL);
 
-    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_frame->f_lasti*2,
+    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_frame->f_lasti*sizeof(_Py_CODEUNIT),
                          PyFrame_GetLineNumber(frame));
 }
 
@@ -1047,7 +1047,7 @@ dump_frame(int fd, InterpreterFrame *frame)
         PUTS(fd, "???");
     }
 
-    int lineno = PyCode_Addr2Line(code, frame->f_lasti*2);
+    int lineno = PyCode_Addr2Line(code, frame->f_lasti*sizeof(_Py_CODEUNIT));
     PUTS(fd, ", line ");
     if (lineno >= 0) {
         _Py_DumpDecimal(fd, (size_t)lineno);


### PR DESCRIPTION
… of the code unit


<!-- issue-number: [bpo-45355](https://bugs.python.org/issue45355) -->
https://bugs.python.org/issue45355
<!-- /issue-number -->
