### PR TITLE
bpo-45359: Support TopologicalSorter type subscript

### DIFF
--- a/Lib/graphlib.py
+++ b/Lib/graphlib.py
@@ -1,3 +1,5 @@
+from types import GenericAlias
+
 __all__ = ["TopologicalSorter", "CycleError"]
 
 _NODE_OUT = -1
@@ -244,3 +246,5 @@ class TopologicalSorter:
             node_group = self.get_ready()
             yield from node_group
             self.done(*node_group)
+
+    __class_getitem__ = classmethod(GenericAlias)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -13,6 +13,7 @@ from contextlib import AbstractContextManager, AbstractAsyncContextManager
 from contextvars import ContextVar, Token
 from dataclasses import Field
 from functools import partial, partialmethod, cached_property
+from graphlib import TopologicalSorter
 from mailbox import Mailbox, _PartialFile
 try:
     import ctypes
@@ -56,6 +57,7 @@ class BaseTest(unittest.TestCase):
                      OrderedDict, Counter, UserDict, UserList,
                      Pattern, Match,
                      partial, partialmethod, cached_property,
+                     TopologicalSorter,
                      AbstractContextManager, AbstractAsyncContextManager,
                      Awaitable, Coroutine,
                      AsyncIterable, AsyncIterator,

--- a/Misc/NEWS.d/next/Library/2021-10-03-22-27-35.bpo-45359.LX_uxe.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-03-22-27-35.bpo-45359.LX_uxe.rst
@@ -1,1 +1,1 @@
-Support :class:`graphlib.TopologicalSorter` type subscript
+Implement :pep:`585` for :class:`graphlib.TopologicalSorter`.

--- a/Misc/NEWS.d/next/Library/2021-10-03-22-27-35.bpo-45359.LX_uxe.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-03-22-27-35.bpo-45359.LX_uxe.rst
@@ -1,0 +1,1 @@
+Support :class:`graphlib.TopologicalSorter` type subscript


### PR DESCRIPTION
Add `TopologicalSorter.__class_getitem__ = classmethod(GenericAlias)` to support runtime subscription.


<!-- issue-number: [bpo-45359](https://bugs.python.org/issue45359) -->
https://bugs.python.org/issue45359
<!-- /issue-number -->

Automerge-Triggered-By: GH:isidentical