### PR TITLE
bpo-45385: Fix reference leak from descr_check

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-06-21-20-11.bpo-45385.CTUT8s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-06-21-20-11.bpo-45385.CTUT8s.rst
@@ -1,0 +1,1 @@
+Fix reference leak from descr_check. Patch by Dong-hee Na.


### PR DESCRIPTION
motivation: 
- GH detects the compiler warnings while executing the CI pipeline.
- Fix possible reference leak for the method_check_args use-case.

<!-- issue-number: [bpo-45385](https://bugs.python.org/issue45385) -->
https://bugs.python.org/issue45385
<!-- /issue-number -->
