### PR TITLE
bpo-45355: More use of sizeof(_Py_CODEUNIT)

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -656,15 +656,13 @@ _PyCode_Addr2Offset(PyCodeObject* co, int addrq)
     if (co->co_columntable == Py_None || addrq < 0) {
         return -1;
     }
-    if (addrq % 2 == 1) {
-        --addrq;
-    }
-    if (addrq >= PyBytes_GET_SIZE(co->co_columntable)) {
+    addrq /= sizeof(_Py_CODEUNIT);
+    if (addrq*2 >= PyBytes_GET_SIZE(co->co_columntable)) {
         return -1;
     }
 
     unsigned char* bytes = (unsigned char*)PyBytes_AS_STRING(co->co_columntable);
-    return bytes[addrq] - 1;
+    return bytes[addrq*2] - 1;
 }
 
 int
@@ -673,15 +671,13 @@ _PyCode_Addr2EndOffset(PyCodeObject* co, int addrq)
     if (co->co_columntable == Py_None || addrq < 0) {
         return -1;
     }
-    if (addrq % 2 == 0) {
-        ++addrq;
-    }
-    if (addrq >= PyBytes_GET_SIZE(co->co_columntable)) {
+    addrq /= sizeof(_Py_CODEUNIT);
+    if (addrq*2+1 >= PyBytes_GET_SIZE(co->co_columntable)) {
         return -1;
     }
 
     unsigned char* bytes = (unsigned char*)PyBytes_AS_STRING(co->co_columntable);
-    return bytes[addrq] - 1;
+    return bytes[addrq*2+1] - 1;
 }
 
 void

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -373,8 +373,8 @@ marklines(PyCodeObject *code, int len)
     }
 
     while (PyLineTable_NextAddressRange(&bounds)) {
-        assert(bounds.ar_start/2 < len);
-        linestarts[bounds.ar_start/2] = bounds.ar_line;
+        assert(bounds.ar_start/(int)sizeof(_Py_CODEUNIT) < len);
+        linestarts[bounds.ar_start/sizeof(_Py_CODEUNIT)] = bounds.ar_line;
     }
     return linestarts;
 }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7081,7 +7081,7 @@ assemble_line_range(struct assembler* a, int current, PyObject** table,
                     int* prev, int* start, int* offset)
 {
     int ldelta, bdelta;
-    bdelta = (a->a_offset - *start) * 2;
+    bdelta = (a->a_offset - *start) * sizeof(_Py_CODEUNIT);
     if (bdelta == 0) {
         return 1;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-45355](https://bugs.python.org/issue45355) -->
https://bugs.python.org/issue45355
<!-- /issue-number -->
