### PR TITLE
[3.10] bpo-45355: More use of sizeof(_Py_CODEUNIT) (GH-28720).

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -275,8 +275,8 @@ marklines(PyCodeObject *code, int len)
     }
 
     while (PyLineTable_NextAddressRange(&bounds)) {
-        assert(bounds.ar_start/2 < len);
-        linestarts[bounds.ar_start/2] = bounds.ar_line;
+        assert(bounds.ar_start/(int)sizeof(_Py_CODEUNIT) < len);
+        linestarts[bounds.ar_start/sizeof(_Py_CODEUNIT)] = bounds.ar_line;
     }
     return linestarts;
 }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6619,7 +6619,7 @@ static int
 assemble_line_range(struct assembler *a)
 {
     int ldelta, bdelta;
-    bdelta =  (a->a_offset - a->a_lineno_start) * 2;
+    bdelta =  (a->a_offset - a->a_lineno_start) * sizeof(_Py_CODEUNIT);
     if (bdelta == 0) {
         return 1;
     }


### PR DESCRIPTION
(cherry picked from commit 252b7bcb236dc261f3af1275bc90f9a303d9648f)


<!-- issue-number: [bpo-45355](https://bugs.python.org/issue45355) -->
https://bugs.python.org/issue45355
<!-- /issue-number -->
