### PR TITLE
gh-89521: Add new cookie attributes

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -282,9 +282,10 @@ class Morsel(dict):
         "httponly" : "HttpOnly",
         "version"  : "Version",
         "samesite" : "SameSite",
+        "priority" : "Priority"
     }
 
-    _flags = {'secure', 'httponly'}
+    _flags = {'secure', 'httponly', 'sameparty'}
 
     def __init__(self):
         # Set defaults
@@ -578,10 +579,6 @@ class BaseCookie(dict):
                 else:
                     parsed_items.append((TYPE_ATTRIBUTE, key, _unquote(value)))
             elif value is not None:
-                if morsel_seen:
-                    # Only the first item should be the actual key/value pair
-                    # ignore invalid keys but keep the cookie valid
-                    continue
                 parsed_items.append((TYPE_KEYVALUE, key, self.value_decode(value)))
                 morsel_seen = True
             else:

--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -578,6 +578,10 @@ class BaseCookie(dict):
                 else:
                     parsed_items.append((TYPE_ATTRIBUTE, key, _unquote(value)))
             elif value is not None:
+                if morsel_seen:
+                    # Only the first item should be the actual key/value pair
+                    # ignore invalid keys but keep the cookie valid
+                    continue
                 parsed_items.append((TYPE_KEYVALUE, key, self.value_decode(value)))
                 morsel_seen = True
             else:

--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -585,6 +585,8 @@ class BaseCookie(dict):
                 parsed_items.append((TYPE_KEYVALUE, key, self.value_decode(value)))
                 morsel_seen = True
             else:
+                if morsel_seen:
+                    continue
                 # Invalid cookie string
                 return
 

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -194,8 +194,7 @@ class CookieTests(unittest.TestCase):
         # Accepting these could be a security issue
         C = cookies.SimpleCookie()
         for s in (']foo=x', '[foo=x', 'blah]foo=x', 'blah[foo=x',
-                  'Set-Cookie: foo=bar', 'Set-Cookie: foo',
-                  'foo=bar; baz', 'baz; foo=bar',
+                  'Set-Cookie: foo=bar', 'Set-Cookie: foo', 'baz; foo=bar',
                   'secure;foo=bar', 'Version=1;foo=bar'):
             C.load(s)
             self.assertEqual(dict(C), {})

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -200,6 +200,20 @@ class CookieTests(unittest.TestCase):
             self.assertEqual(dict(C), {})
             self.assertEqual(C.output(), '')
 
+    def test_ignore_unknown_attribute(self):
+        # Ignore unknown attributes, but keep the cookie valid
+        C = cookies.SimpleCookie()
+        C.load('foo=bar; baz')
+        self.assertIsNone(C.get('baz'))
+        self.assertEqual(C.output(), 'Set-Cookie: foo=bar')
+        C.clear()
+        C.load('foo=bar; bar=Low; baz; Priority=High')
+        self.assertEqual(C['foo'].output(), 'Set-Cookie: foo=bar')
+        self.assertIsNone(C['foo'].get('baz'))
+        self.assertEqual(C['bar'].output(), 'Set-Cookie: bar=Low; Priority=High')
+        self.assertIsNone(C['bar'].get('baz'))
+        self.assertNotIn(C.output(), 'baz')
+
     def test_pickle(self):
         rawdata = 'Customer="WILE_E_COYOTE"; Path=/acme; Version=1'
         expected_output = 'Set-Cookie: %s' % rawdata

--- a/Misc/NEWS.d/next/Library/2021-10-05-19-58-54.bpo-45358.6XK5um.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-05-19-58-54.bpo-45358.6XK5um.rst
@@ -1,0 +1,1 @@
+Add "Priority" and "SameParty" to known cookie attributes.


### PR DESCRIPTION
https://bugs.python.org/issue45358

Google (more specifically Youtube) sometimes generates cookie headers with `Priority=Level` and `SameParty` attributes which are non-standard. 

* Discarding cookies after encountering an unknown attribute altogether might become problematic for some use cases (web browsers do not drop the cookie but simply ignore the unexpected attribute).

* After parsing `Priority=High` attribute (for example), a bogus cookie (morsel) is generated with its key/value set to `Priority=High`, which is an unexpected behaviour. 
Adding these two keys to the list of reserved attributes seems to be the only way to avoid generating such incorrect morsel whenever we encounter a key=value pair that is actually meant to be an attribute.

<!-- issue-number: [bpo-45358](https://bugs.python.org/issue45358) -->
https://bugs.python.org/issue45358
<!-- /issue-number -->

<!-- gh-issue-number: gh-89521 -->
* Issue: gh-89521
<!-- /gh-issue-number -->
