### PR TITLE
bpo-45163: Restrict added libnetwork check to builds on Haiku.

### DIFF
--- a/configure
+++ b/configure
@@ -10573,8 +10573,9 @@ if test "x$ac_cv_lib_socket_socket" = xyes; then :
 fi
  # SVR4 sockets
 
-# Haiku system library
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for socket in -lnetwork" >&5
+case $ac_sys_system/$ac_sys_release in
+    Haiku*)
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for socket in -lnetwork" >&5
 $as_echo_n "checking for socket in -lnetwork... " >&6; }
 if ${ac_cv_lib_network_socket+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -10614,6 +10615,8 @@ if test "x$ac_cv_lib_network_socket" = xyes; then :
   LIBS="-lnetwork $LIBS"
 fi
 
+    ;;
+esac
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-libs" >&5
 $as_echo_n "checking for --with-libs... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -3099,8 +3099,11 @@ AC_SUBST(TZPATH)
 AC_CHECK_LIB(nsl, t_open, [LIBS="-lnsl $LIBS"]) # SVR4
 AC_CHECK_LIB(socket, socket, [LIBS="-lsocket $LIBS"], [], $LIBS) # SVR4 sockets
 
-# Haiku system library
-AC_CHECK_LIB(network, socket, [LIBS="-lnetwork $LIBS"], [], $LIBS)
+case $ac_sys_system/$ac_sys_release in
+    Haiku*)
+        AC_CHECK_LIB(network, socket, [LIBS="-lnetwork $LIBS"], [], $LIBS)
+    ;;
+esac
 
 AC_MSG_CHECKING(for --with-libs)
 AC_ARG_WITH(libs,


### PR DESCRIPTION
For example, without the guard the check could cause macOS
installer builds to fail to install on older supported macOS
releases where libnetwork is not available and is not needed
on any release.


<!-- issue-number: [bpo-45163](https://bugs.python.org/issue45163) -->
https://bugs.python.org/issue45163
<!-- /issue-number -->
