### PR TITLE
bpo-45375: Fix assertion failure due to searching for stdlib in unnormalised paths

### DIFF
--- a/Misc/NEWS.d/next/Windows/2021-10-05-12-41-53.bpo-45375.CohPP-.rst
+++ b/Misc/NEWS.d/next/Windows/2021-10-05-12-41-53.bpo-45375.CohPP-.rst
@@ -1,0 +1,2 @@
+Fixes an assertion failure due to searching for the standard library in
+unnormalised paths.

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -265,7 +265,21 @@ canonicalize(wchar_t *buffer, const wchar_t *path)
         return _PyStatus_NO_MEMORY();
     }
 
-    if (FAILED(PathCchCanonicalizeEx(buffer, MAXPATHLEN + 1, path, 0))) {
+    if (PathIsRelativeW(path)) {
+        wchar_t cwd[MAXPATHLEN];
+        if (!GetCurrentDirectoryW(MAXPATHLEN, cwd)) {
+            return _PyStatus_ERR("unable to find current working directory");
+        }
+        if (FAILED(PathCchCombineEx(buffer, MAXPATHLEN + 1, cwd, path, PATHCCH_ALLOW_LONG_PATHS))) {
+            return INIT_ERR_BUFFER_OVERFLOW();
+        }
+        if (FAILED(PathCchCanonicalizeEx(buffer, MAXPATHLEN + 1, buffer, PATHCCH_ALLOW_LONG_PATHS))) {
+            return INIT_ERR_BUFFER_OVERFLOW();
+        }
+        return _PyStatus_OK();
+    }
+
+    if (FAILED(PathCchCanonicalizeEx(buffer, MAXPATHLEN + 1, path, PATHCCH_ALLOW_LONG_PATHS))) {
         return INIT_ERR_BUFFER_OVERFLOW();
     }
     return _PyStatus_OK();
@@ -291,6 +305,9 @@ search_for_prefix(wchar_t *prefix, const wchar_t *argv0_path)
     /* Search from argv0_path, until LANDMARK is found.
        We guarantee 'prefix' is null terminated in bounds. */
     wcscpy_s(prefix, MAXPATHLEN+1, argv0_path);
+    if (!prefix[0]) {
+        return 0;
+    }
     wchar_t stdlibdir[MAXPATHLEN+1];
     wcscpy_s(stdlibdir, Py_ARRAY_LENGTH(stdlibdir), prefix);
     /* We initialize with the longest possible path, in case it doesn't fit.
@@ -938,6 +955,7 @@ calculate_module_search_path(PyCalculatePath *calculate,
                 look--;
             nchars = lookEnd-look;
             wcsncpy(lookBuf, look+1, nchars);
+            canonicalize(lookBuf, lookBuf);
             lookBuf[nchars] = L'\0';
             /* Up one level to the parent */
             reduce(lookBuf);

--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -104,7 +104,9 @@
           Condition="($(Platform) == 'Win32' or $(Platform) == 'x64') and
                      $(Configuration) != 'PGInstrument' and $(Configuration) != 'PGUpdate'">
     <Message Text="Regenerate @(_TestFrozenOutputs->'%(Filename)%(Extension)', ' ')" Importance="high" />
-    <Exec Command="$(PythonExe) Programs\freeze_test_frozenmain.py Programs/test_frozenmain.h"
+    <Exec Command='setlocal
+set PYTHONPATH=$(PySourcePath)Lib
+"$(PythonExe)" Programs\freeze_test_frozenmain.py Programs\test_frozenmain.h'
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 


### PR DESCRIPTION
Also ensures that when Python is run as part of build, it can locate the library in the source tree even when built out of tree.

<!-- issue-number: [bpo-45375](https://bugs.python.org/issue45375) -->
https://bugs.python.org/issue45375
<!-- /issue-number -->
