### PR TITLE
Remove test_nntplib from quicktest

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1320,7 +1320,7 @@ QUICKTESTOPTS=	$(TESTOPTS) -x test_subprocess test_io test_lib2to3 \
 		test_multibytecodec test_urllib2_localnet test_itertools \
 		test_multiprocessing_fork test_multiprocessing_spawn \
 		test_multiprocessing_forkserver \
-		test_mailbox test_socket test_poll \
+		test_mailbox test_nntplib test_socket test_poll \
 		test_select test_zipfile test_concurrent_futures
 quicktest:	@DEF_MAKE_RULE@ platform
 		$(TESTRUNNER) $(QUICKTESTOPTS)


### PR DESCRIPTION
`test_nntplib` depends on network service so it is slow sometime.

```
0:02:09 load avg: 1.00 [412/412/4] test_nntplib passed (2 min 1 sec)
Resource 'news.trigofacile.com' is not available
Resource 'nntp.aioe.org' is not available
```