### PR TITLE
Fix typos in the Mac and Misc directories

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -454,7 +454,7 @@ def pkg_recipes():
             source="/pydocs",
             readme="""\
                 This package installs the python documentation at a location
-                that is useable for pydoc and IDLE.
+                that is usable for pydoc and IDLE.
                 """,
             postflight="scripts/postflight.documentation",
             required=False,
@@ -1602,7 +1602,7 @@ def buildDMG():
     # instead of 11.  We should not run into that situation here.)
     # Also we should use "macos" instead of "macosx" going forward.
     #
-    # To maintain compability for legacy variants, the file name for
+    # To maintain compatibility for legacy variants, the file name for
     # builds on macOS 10.15 and earlier remains:
     #   python-3.x.y-macosx10.z.{dmg->pkg}
     #   e.g. python-3.9.4-macosx10.9.{dmg->pkg}

--- a/Mac/IDLE/IDLE.app/Contents/Resources/idlemain.py
+++ b/Mac/IDLE/IDLE.app/Contents/Resources/idlemain.py
@@ -35,7 +35,7 @@ os.chdir(os.path.expanduser('~/Documents'))
 #       idlemain.py running under the symlinked python.
 #       This is the magic step.
 # 4. During interpreter initialization, because PYTHONEXECUTABLE is defined,
-#    sys.executable may get set to an unuseful value.
+#    sys.executable may get set to an useless value.
 #
 # (Note that the IDLE script and the setting of PYTHONEXECUTABLE is
 #  generated automatically by bundlebuilder in the Python 2.x build.

--- a/Mac/PythonLauncher/MyAppDelegate.m
+++ b/Mac/PythonLauncher/MyAppDelegate.m
@@ -22,7 +22,7 @@
 {
     // Test that the file mappings are correct
     [self testFileTypeBinding];
-    // If we were opened because of a file drag or doubleclick
+    // If we were opened because of a file drag or double-click
     // we've set initial_action_done in shouldShowUI
     // Otherwise we open a preferences dialog.
     if (!initial_action_done) {

--- a/Mac/README.rst
+++ b/Mac/README.rst
@@ -296,7 +296,7 @@ How do I create a binary distribution?
 Download and unpack the source release from https://www.python.org/download/.
 Go to the directory ``Mac/BuildScript``. There you will find a script
 ``build-installer.py`` that does all the work. This will download and build
-a number of 3rd-party libaries, configures and builds a framework Python,
+a number of 3rd-party libraries, configures and builds a framework Python,
 installs it, creates the installer package files and then packs this in a
 DMG image.  The script also builds an HTML copy of the current Python
 documentation set for this release for inclusion in the framework.  The

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -178,7 +178,7 @@ Convert the :mod:`_sha256` extension module types to heap types.
 .. section: Core and Builtins
 
 Fix a possible stack overflow in the parser when parsing functions and
-classes with a huge ammount of arguments. Patch by Pablo Galindo.
+classes with a huge amount of arguments. Patch by Pablo Galindo.
 
 ..
 

--- a/Misc/NEWS.d/3.10.0a2.rst
+++ b/Misc/NEWS.d/3.10.0a2.rst
@@ -258,7 +258,7 @@ The :func:`repr` of :mod:`typing` types containing :ref:`Generic Alias Types
 .. nonce: 6aDbty
 .. section: Library
 
-``binhex.binhex()`` consisently writes macOS 9 line endings.
+``binhex.binhex()`` consistently writes macOS 9 line endings.
 
 ..
 
@@ -534,7 +534,7 @@ belong to. Patch by Batuhan Taskaya.
 .. nonce: LR4fnY
 .. section: Library
 
-Handle exceptions caused by unparseable date headers when using email
+Handle exceptions caused by unparsable date headers when using email
 "default" policy.  Patch by Tim Bell, Georges Toth
 
 ..

--- a/Misc/NEWS.d/3.10.0a3.rst
+++ b/Misc/NEWS.d/3.10.0a3.rst
@@ -949,7 +949,7 @@ branches, are now handled by docsbuild-script.
 .. nonce: W_updK
 .. section: Tests
 
-Reenable test_gdb on gdb 9.2 and newer:
+Re-enable test_gdb on gdb 9.2 and newer:
 https://bugzilla.redhat.com/show_bug.cgi?id=1866884 bug is fixed in gdb
 10.1.
 

--- a/Misc/NEWS.d/3.10.0a4.rst
+++ b/Misc/NEWS.d/3.10.0a4.rst
@@ -767,7 +767,7 @@ results. Patch by Ammar Askar.
 .. nonce: -7-XGz
 .. section: Tests
 
-Update test_nntplib to use offical group name of news.aioe.org for testing.
+Update test_nntplib to use official group name of news.aioe.org for testing.
 Patch by Dong-hee Na.
 
 ..
@@ -863,7 +863,7 @@ and Peixing Xin.
 
 Now all platforms use a value for the "EXT_SUFFIX" build variable derived
 from SOABI (for instance in freeBSD, "EXT_SUFFIX" is now ".cpython-310d.so"
-instead of ".so"). Previosuly only Linux, Mac and VxWorks were using a value
+instead of ".so"). Previously only Linux, Mac and VxWorks were using a value
 for "EXT_SUFFIX" that included "SOABI".
 
 ..

--- a/Misc/NEWS.d/3.10.0a5.rst
+++ b/Misc/NEWS.d/3.10.0a5.rst
@@ -549,7 +549,7 @@ Pass ``--timeout=$(TESTTIMEOUT)`` option to the default profile task
 .. section: Build
 
 Removed the grep -q and -E flags in the tzpath validation section of the
-configure script to better accomodate users of some platforms (specifically
+configure script to better accommodate users of some platforms (specifically
 Solaris 10).
 
 ..

--- a/Misc/NEWS.d/3.10.0a6.rst
+++ b/Misc/NEWS.d/3.10.0a6.rst
@@ -49,7 +49,7 @@ The :data:`types.FunctionType` constructor now inherits the current builtins
 if the *globals* dictionary has no ``"__builtins__"`` key, rather than using
 ``{"None": None}`` as builtins: same behavior as :func:`eval` and
 :func:`exec` functions. Defining a function with ``def function(...): ...``
-in Python is not affected, globals cannot be overriden with this syntax: it
+in Python is not affected, globals cannot be overridden with this syntax: it
 also inherits the current builtins. Patch by Victor Stinner.
 
 ..
@@ -355,7 +355,7 @@ in 4.0" to "3.12". See :pep:`623` for detail.
 .. nonce: LfTvL-
 .. section: Tests
 
-Fix test_importlib to correctly skip Unicode file tests if the fileystem
+Fix test_importlib to correctly skip Unicode file tests if the filesystem
 does not support them.
 
 ..

--- a/Misc/NEWS.d/3.10.0a7.rst
+++ b/Misc/NEWS.d/3.10.0a7.rst
@@ -195,7 +195,7 @@ decoded as Unicode characters outside the [U+0000; U+10ffff] range.
 .. nonce: lCzIg0
 .. section: Core and Builtins
 
-Fix a bug that was causing the parser to crash when emiting syntax errors
+Fix a bug that was causing the parser to crash when emitting syntax errors
 when reading input from stdin. Patch by Pablo Galindo
 
 ..

--- a/Misc/NEWS.d/3.10.0b1.rst
+++ b/Misc/NEWS.d/3.10.0b1.rst
@@ -276,7 +276,7 @@ cause any runtime effects with ``from __future__ import annotations``.
 .. nonce: 0Ik1AM
 .. section: Core and Builtins
 
-:exc:`SyntaxError` exceptions raised by the intepreter will highlight the
+:exc:`SyntaxError` exceptions raised by the interpreter will highlight the
 full error range of the expression that consistutes the syntax error itself,
 instead of just where the problem is detected. Patch by Pablo Galindo.
 
@@ -547,7 +547,7 @@ enum or one of its members' value.
 .. nonce: ejjsyR
 .. section: Library
 
-For backwards compatbility with previous minor versions of Python, if
+For backwards compatibility with previous minor versions of Python, if
 :func:`typing.get_type_hints` receives no namespace dictionary arguments,
 :func:`typing.get_type_hints` will search through the global then local
 namespaces during evaluation of stringized type annotations (string forward
@@ -720,9 +720,9 @@ now raise ``TypeError`` during substitution.
 .. nonce: xT9QjF
 .. section: Library
 
-The :mod:`multiprocessing` ``Server`` class now explicitly catchs
+The :mod:`multiprocessing` ``Server`` class now explicitly catches
 :exc:`SystemExit` and closes the client connection in this case. It happens
-when the ``Server.serve_client()`` method reachs the end of file (EOF).
+when the ``Server.serve_client()`` method reaches the end of file (EOF).
 
 ..
 
@@ -1132,7 +1132,7 @@ preferred "user", "home", and "prefix" (default) scheme names.
 .. section: Library
 
 Improve :meth:`sqlite3.Connection.backup` error handling. The error message
-for non-existant target database names is now ``unknown database <database
+for non-existent target database names is now ``unknown database <database
 name>`` instead of ``SQL logic error``. Patch by Erlend E. Aasland.
 
 ..

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -162,7 +162,7 @@ called directly or via ``super()``. Patch provided by Yurii Karabas.
 .. section: Core and Builtins
 
 The deallocator function of the :exc:`BaseException` type now uses the
-trashcan mecanism to prevent stack overflow. For example, when a
+trashcan mechanism to prevent stack overflow. For example, when a
 :exc:`RecursionError` instance is raised, it can be linked to another
 RecursionError through the ``__context__`` attribute or the
 ``__traceback__`` attribute, and then a chain of exceptions is created. When
@@ -1138,7 +1138,7 @@ blocks. Patch by Pablo Galindo.
 .. nonce: vYFPPC
 .. section: Core and Builtins
 
-Constructors of subclasses of some buitin classes (e.g. :class:`tuple`,
+Constructors of subclasses of some builtin classes (e.g. :class:`tuple`,
 :class:`list`, :class:`frozenset`) no longer accept arbitrary keyword
 arguments. Subclass of :class:`set` can now define a ``__new__()`` method
 with additional keyword parameters without overriding also ``__init__()``.
@@ -1317,7 +1317,7 @@ expressions.
 .. nonce: Kp5FxD
 .. section: Core and Builtins
 
-Corrent the syntax error message regarding multiple exception types to not
+Correct the syntax error message regarding multiple exception types to not
 refer to "exception groups". Patch by Pablo Galindo
 
 ..
@@ -3068,8 +3068,8 @@ prevented parallel computation as other :mod:`hashlib` algorithms support.
 .. section: Library
 
 It's now possible to receive the type of service (ToS), a.k.a.
-differentiated services (DS), a.k.a. differenciated services code point
-(DSCP) and excplicit congestion notification (ECN) IP header fields with
+differentiated services (DS), a.k.a. differentiated services code point
+(DSCP) and explicit congestion notification (ECN) IP header fields with
 ``socket.IP_RECVTOS``.
 
 ..
@@ -3242,7 +3242,7 @@ Patch by Erlend E. Aasland.
 
 AIX: `Lib/_aix_support.get_platform()` may fail in an AIX WPAR. The fileset
 bos.rte appears to have a builddate in both LPAR and WPAR so this fileset is
-queried rather than bos.mp64. To prevent a similiar situation (no builddate
+queried rather than bos.mp64. To prevent a similar situation (no builddate
 in ODM) a value (9988) sufficient for completing a build is provided. Patch
 by M Felt.
 
@@ -3717,7 +3717,7 @@ RFC.
 .. nonce: zMFGMV
 .. section: Documentation
 
-Replaced occurences of uppercase "Web" and "Internet" with lowercase
+Replaced occurrences of uppercase "Web" and "Internet" with lowercase
 versions per the 2016 revised Associated Press Style Book.
 
 ..

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -279,7 +279,7 @@ visited by ``tp_traverse()`` are valid.
 .. nonce: Xgc6F_
 .. section: Core and Builtins
 
-Remove unecessary intersection and update set operation in dictview with
+Remove unnecessary intersection and update set operation in dictview with
 empty set. (Contributed by Dong-hee Na in :issue:`38210`.)
 
 ..
@@ -868,7 +868,7 @@ Fix the :c:func:`PySys_Audit` call in :class:`mmap.mmap`.
 .. nonce: WJkgKV
 .. section: Core and Builtins
 
-Remove an unnecssary Py_XINCREF in classobject.c.
+Remove an unnecessary Py_XINCREF in classobject.c.
 
 ..
 
@@ -1224,7 +1224,7 @@ Anthony Sottile.
 .. nonce: cyq5nr
 .. section: Library
 
-Now :func:`~logging.config.fileConfig` correcty sets the .name of handlers
+Now :func:`~logging.config.fileConfig` correctly sets the .name of handlers
 loaded.
 
 ..
@@ -1637,7 +1637,7 @@ Preserve subclassing in inspect.Signature.from_callable.
 .. nonce: nHAbuJ
 .. section: Library
 
-Names of hashing algorithms frome OpenSSL are now normalized to follow
+Names of hashing algorithms from OpenSSL are now normalized to follow
 Python's naming conventions. For example OpenSSL uses sha3-512 instead of
 sha3_512 or blake2b512 instead of blake2b.
 
@@ -2403,7 +2403,7 @@ Fixed comparisons of :class:`datetime.timedelta` and
 .. nonce: 7UV5d0
 .. section: Library
 
-Syncronize ``importlib.metadata`` with `importlib_metadata 0.19
+Synchronize ``importlib.metadata`` with `importlib_metadata 0.19
 <https://gitlab.com/python-devs/importlib_metadata/-/milestones/20>`_,
 improving handling of EGG-INFO files and fixing a crash when entry point
 names contained colons.
@@ -3002,7 +3002,7 @@ on platforms with 16-bit :c:type:`wchar_t` (for example, Windows and AIX).
 
 In a subinterpreter, spawning a daemon thread now raises an exception.
 Daemon threads were never supported in subinterpreters. Previously, the
-subinterpreter finalization crashed with a Pyton fatal error if a daemon
+subinterpreter finalization crashed with a Python fatal error if a daemon
 thread was still running.
 
 ..
@@ -3065,7 +3065,7 @@ internal tasks weak set is changed by another thread during iteration.
 .. section: Library
 
 :class:`_pyio.IOBase` destructor now does nothing if getting the ``closed``
-attribute fails to better mimick :class:`_io.IOBase` finalizer.
+attribute fails to better mimic :class:`_io.IOBase` finalizer.
 
 ..
 
@@ -4038,7 +4038,7 @@ crypto policies. Use PKCS#8 format with AES256 encryption instead.
 .. nonce: _x-9uH
 .. section: Tests
 
-test.support now has a helper function to check for availibility of a hash
+test.support now has a helper function to check for availability of a hash
 digest function. Several tests are refactored avoid MD5 and use SHA256
 instead. Other tests are marked to use MD5 and skipped when MD5 is disabled.
 

--- a/Misc/NEWS.d/3.9.0a3.rst
+++ b/Misc/NEWS.d/3.9.0a3.rst
@@ -178,7 +178,7 @@ last iteration of asynchronous for loops. Patch by Pablo Galindo.
 .. nonce: WG9alt
 .. section: Core and Builtins
 
-Fix incorrent line execution reporting in trace functions when tracing
+Fix incorrect line execution reporting in trace functions when tracing
 exception handlers with name binding. Patch by Pablo Galindo.
 
 ..
@@ -685,7 +685,7 @@ but not required. Patch by Juergen Gmach.
 .. section: Library
 
 Fixed __subclasshook__ of :class:`os.PathLike` to return a correct result
-upon inheritence. Patch by Bar Harel.
+upon inheritance. Patch by Bar Harel.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a5.rst
+++ b/Misc/NEWS.d/3.9.0a5.rst
@@ -175,7 +175,7 @@ convention. Patch by Dong-hee Na.
 .. nonce: FE9S21
 .. section: Core and Builtins
 
-Chaged list overallocation strategy. It no longer overallocates if the new
+Changed list overallocation strategy. It no longer overallocates if the new
 size is closer to overallocated size than to the old size and adds padding.
 
 ..

--- a/Misc/stable_abi.txt
+++ b/Misc/stable_abi.txt
@@ -285,7 +285,7 @@ macro Py_UNBLOCK_THREADS
 macro Py_END_ALLOW_THREADS
     added 3.2
 
-# The following were added in PC/python3.def in the intial stable ABI commit,
+# The following were added in PC/python3.def in the initial stable ABI commit,
 # 4d0d471a8031de90a2b1ce99c4ac4780e60b3bc9,
 # and later amendments in 3.2:
 # 0d012f284be829c6217f60523db0e1671b7db9d9


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Like #28744 but for the Mac and Misc directories.  In `Misc/NEWS.d` this PR only fixes typos for Python 3.9 and later.

[skip issue] Opening a related issue is pending python/psf-infra-meta#130