### PR TITLE
bpo-45391: mark UnionType as a class in documentation

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -312,7 +312,7 @@ Standard names are defined for the following types:
       This type can now be subclassed.
 
 
-.. data:: UnionType
+.. class:: UnionType
 
    The type of :ref:`union type expressions<types-union>`.
 


### PR DESCRIPTION
```
❯ sphobjinv suggest ./build/html/objects.inv UnionType
:py:class:`types.UnionType`
```
Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>


<!-- issue-number: [bpo-45391](https://bugs.python.org/issue45391) -->
https://bugs.python.org/issue45391
<!-- /issue-number -->

Things to consider the type does show up as class now in documentation:
<img width="831" alt="Screenshot 2021-10-06 at 13 43 14" src="https://user-images.githubusercontent.com/690238/136204526-931c0f63-a60f-4069-b4f4-616e53ffbbe2.png">
vs before
<img width="824" alt="Screenshot 2021-10-06 at 13 44 36" src="https://user-images.githubusercontent.com/690238/136204632-47b5d25a-e74d-4dc4-8fd2-3add92c781b8.png">


This PR only addresses the instance in the issue report, but we should discuss if we should change all such instances in this file (there are quite a few others suffering from the same problem).
