### PR TITLE
bpo-45375: Fix off by one error in buffer allocation

### DIFF
--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -266,7 +266,7 @@ canonicalize(wchar_t *buffer, const wchar_t *path)
     }
 
     if (PathIsRelativeW(path)) {
-        wchar_t buff[MAXPATHLEN];
+        wchar_t buff[MAXPATHLEN + 1];
         if (!GetCurrentDirectoryW(MAXPATHLEN, buff)) {
             return _PyStatus_ERR("unable to find current working directory");
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45375](https://bugs.python.org/issue45375) -->
https://bugs.python.org/issue45375
<!-- /issue-number -->
