### PR TITLE
bpo-35970: Add help flag to base64 module

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -567,15 +567,17 @@ def decodebytes(s):
 def main():
     """Small main program"""
     import sys, getopt
+    usage = """usage: %s [-h|-d|-e|-u|-t] [file|-]
+        -h: print this help message and exit
+        -d, -u: decode
+        -e: encode (default)
+        -t: encode and decode string 'Aladdin:open sesame'"""%sys.argv[0]
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'deut')
+        opts, args = getopt.getopt(sys.argv[1:], 'hdeut')
     except getopt.error as msg:
         sys.stdout = sys.stderr
         print(msg)
-        print("""usage: %s [-d|-e|-u|-t] [file|-]
-        -d, -u: decode
-        -e: encode (default)
-        -t: encode and decode string 'Aladdin:open sesame'"""%sys.argv[0])
+        print(usage)
         sys.exit(2)
     func = encode
     for o, a in opts:
@@ -583,6 +585,7 @@ def main():
         if o == '-d': func = decode
         if o == '-u': func = decode
         if o == '-t': test(); return
+        if o == '-h': print(usage); return
     if args and args[0] != '-':
         with open(args[0], 'rb') as f:
             func(f, sys.stdout.buffer)

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -788,5 +788,15 @@ class TestMain(unittest.TestCase):
         output = self.get_output('-d', os_helper.TESTFN)
         self.assertEqual(output.rstrip(), b'a\xffb')
 
+    def test_prints_usage_with_help_flag(self):
+        output = self.get_output('-h')
+        self.assertIn(b'usage: ', output)
+        self.assertIn(b'-d, -u: decode', output)
+
+    def test_prints_usage_with_invalid_flag(self):
+        output = script_helper.assert_python_failure('-m', 'base64', '-x').err
+        self.assertIn(b'usage: ', output)
+        self.assertIn(b'-d, -u: decode', output)
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2019-02-11-19-06-10.bpo-35970.ZRvh51.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-11-19-06-10.bpo-35970.ZRvh51.rst
@@ -1,0 +1,2 @@
+Add help flag to the base64's module command line interface. Patch contributed
+by Robert Kuska.

--- a/Misc/NEWS.d/next/Library/2019-02-11-19-06-10.bpo-35970.ZRvh51.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-11-19-06-10.bpo-35970.ZRvh51.rst
@@ -1,2 +1,2 @@
-Add help flag to the base64's module command line interface. Patch contributed
+Add help flag to the base64 module's command line interface. Patch contributed
 by Robert Kuska.


### PR DESCRIPTION
This continues off rkuska's work from https://github.com/python/cpython/pull/11789 seeing as the patch wasn't updated to add tests.

<!-- issue-number: [bpo-35970](https://bugs.python.org/issue35970) -->
https://bugs.python.org/issue35970
<!-- /issue-number -->

Automerge-Triggered-By: GH:ammaraskar