### PR TITLE
Fix typos in the Lib directory

### DIFF
--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -479,7 +479,7 @@ class AbstractEventLoop:
         # The reason to accept file-like object instead of just file descriptor
         # is: we need to own pipe and close it at transport finishing
         # Can got complicated errors if pass f.fileno(),
-        # close fd in pipe transport then close f and vise versa.
+        # close fd in pipe transport then close f and vice versa.
         raise NotImplementedError
 
     async def connect_write_pipe(self, protocol_factory, pipe):
@@ -492,7 +492,7 @@ class AbstractEventLoop:
         # The reason to accept file-like object instead of just file descriptor
         # is: we need to own pipe and close it at transport finishing
         # Can got complicated errors if pass f.fileno(),
-        # close fd in pipe transport then close f and vise versa.
+        # close fd in pipe transport then close f and vice versa.
         raise NotImplementedError
 
     async def subprocess_shell(self, protocol_factory, cmd, *,

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1379,7 +1379,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
     def remove_child_handler(self, pid):
         # asyncio never calls remove_child_handler() !!!
         # The method is no-op but is implemented because
-        # abstract base classe requires it
+        # abstract base classes requires it
         return True
 
     def attach_loop(self, loop):

--- a/Lib/ctypes/_aix.py
+++ b/Lib/ctypes/_aix.py
@@ -163,7 +163,7 @@ def get_legacy(members):
             return member
     else:
         # 32-bit legacy names - both shr.o and shr4.o exist.
-        # shr.o is the preffered name so we look for shr.o first
+        # shr.o is the preferred name so we look for shr.o first
         #  i.e., shr4.o is returned only when shr.o does not exist
         for name in ['shr.o', 'shr4.o']:
             member = get_one_match(re.escape(name), members)

--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -443,7 +443,7 @@ class StructureTestCase(unittest.TestCase):
 
         s = Test(1, 2, 3)
         # Test the StructUnionType_paramfunc() code path which copies the
-        # structure: if the stucture is larger than sizeof(void*).
+        # structure: if the structure is larger than sizeof(void*).
         self.assertGreater(sizeof(s), sizeof(c_void_p))
 
         dll = CDLL(_ctypes_test.__file__)
@@ -451,7 +451,7 @@ class StructureTestCase(unittest.TestCase):
         func.argtypes = (Test,)
         func.restype = None
         func(s)
-        # bpo-37140: Passing the structure by refrence must not call
+        # bpo-37140: Passing the structure by reference must not call
         # its finalizer!
         self.assertEqual(finalizer_calls, [])
         self.assertEqual(s.first, 1)

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -62,7 +62,7 @@ class SequenceMatcher:
     notion, pairing up elements that appear uniquely in each sequence.
     That, and the method here, appear to yield more intuitive difference
     reports than does diff.  This method appears to be the least vulnerable
-    to synching up on blocks of "junk lines", though (like blank lines in
+    to syncing up on blocks of "junk lines", though (like blank lines in
     ordinary text files, or maybe "<P>" lines in HTML files).  That may be
     because this is the only method of the 3 that has a *concept* of
     "junk" <wink>.

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -392,7 +392,7 @@ class CCompiler:
         return output_dir, macros, include_dirs
 
     def _prep_compile(self, sources, output_dir, depends=None):
-        """Decide which souce files must be recompiled.
+        """Decide which source files must be recompiled.
 
         Determine the list of object files corresponding to 'sources',
         and figure out which ones really need to be recompiled.

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -31,7 +31,7 @@ SCHEME_KEYS = ('purelib', 'platlib', 'headers', 'scripts', 'data')
 # while making the sysconfig module the single point of truth.
 # This makes it easier for OS distributions where they need to
 # alter locations for packages installations in a single place.
-# Note that this module is depracated (PEP 632); all consumers
+# Note that this module is deprecated (PEP 632); all consumers
 # of this information should switch to using sysconfig directly.
 INSTALL_SCHEMES = {"unix_prefix": {}, "unix_home": {}, "nt": {}}
 
@@ -43,7 +43,7 @@ for key in SCHEME_KEYS:
         sys_key = key
         sys_scheme = sysconfig._INSTALL_SCHEMES[sys_scheme_name]
         if key == "headers" and key not in sys_scheme:
-            # On POSIX-y platofrms, Python will:
+            # On POSIX-y platforms, Python will:
             # - Build from .h files in 'headers' (only there when
             #   building CPython)
             # - Install .h files to 'include'

--- a/Lib/email/errors.py
+++ b/Lib/email/errors.py
@@ -110,4 +110,4 @@ class NonASCIILocalPartDefect(HeaderDefect):
     # parsing messages decoded from binary.
 
 class InvalidDateDefect(HeaderDefect):
-    """Header has unparseable or invalid date"""
+    """Header has unparsable or invalid date"""

--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -405,7 +405,7 @@ class HTMLParser(_markupbase.ParserBase):
             tagname = namematch.group(1).lower()
             # consume and ignore other stuff between the name and the >
             # Note: this is not 100% correct, since we might have things like
-            # </tag attr=">">, but looking for > after tha name should cover
+            # </tag attr=">">, but looking for > after the name should cover
             # most of the cases and is much simpler
             gtpos = rawdata.find('>', namematch.end())
             self.handle_endtag(tagname)

--- a/Lib/idlelib/ChangeLog
+++ b/Lib/idlelib/ChangeLog
@@ -1175,7 +1175,7 @@ Wed Mar 10 05:18:02 1999  Guido van Rossum  <guido@cnri.reston.va.us>
 	    classes in selected module
 	    methods of selected class
 
-	Sinlge clicking in a directory, module or class item updates the next
+	Single clicking in a directory, module or class item updates the next
 	column with info about the selected item.  Double clicking in a
 	module, class or method item opens the file (and selects the clicked
 	item if it is a class or method).

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -246,7 +246,7 @@ _multistatus_bar_spec = {
 _object_browser_spec = {
     'file': 'debugobj',
     'kwds': {},
-    'msg': "Double click on items upto the lowest level.\n"
+    'msg': "Double click on items up to the lowest level.\n"
            "Attributes of the objects and related information "
            "will be displayed side-by-side at each level."
     }
@@ -255,7 +255,7 @@ _path_browser_spec = {
     'file': 'pathbrowser',
     'kwds': {},
     'msg': "Test for correct display of all paths in sys.path.\n"
-           "Toggle nested items upto the lowest level.\n"
+           "Toggle nested items up to the lowest level.\n"
            "Double clicking on an item prints a traceback\n"
            "for an exception that is ignored."
     }
@@ -341,7 +341,7 @@ _tree_widget_spec = {
     'file': 'tree',
     'kwds': {},
     'msg': "The canvas is scrollable.\n"
-           "Click on folders upto to the lowest level."
+           "Click on folders up to to the lowest level."
     }
 
 _undo_delegator_spec = {

--- a/Lib/idlelib/idle_test/mock_tk.py
+++ b/Lib/idlelib/idle_test/mock_tk.py
@@ -79,7 +79,7 @@ class Test(unittest.TestCase):
     ---
     For 'ask' functions, set func.result return value before calling the method
     that uses the message function. When messagebox functions are the
-    only gui calls in a method, this replacement makes the method gui-free,
+    only GUI calls in a method, this replacement makes the method GUI-free,
     """
     askokcancel = Mbox_func()     # True or False
     askquestion = Mbox_func()     # 'yes' or 'no'

--- a/Lib/idlelib/idle_test/mock_tk.py
+++ b/Lib/idlelib/idle_test/mock_tk.py
@@ -79,7 +79,7 @@ class Test(unittest.TestCase):
     ---
     For 'ask' functions, set func.result return value before calling the method
     that uses the message function. When messagebox functions are the
-    only gui alls in a method, this replacement makes the method gui-free,
+    only gui calls in a method, this replacement makes the method gui-free,
     """
     askokcancel = Mbox_func()     # True or False
     askquestion = Mbox_func()     # 'yes' or 'no'

--- a/Lib/idlelib/idle_test/test_multicall.py
+++ b/Lib/idlelib/idle_test/test_multicall.py
@@ -37,7 +37,7 @@ class MultiCallTest(unittest.TestCase):
 
     def test_yview(self):
         # Added for tree.wheel_event
-        # (it depends on yview to not be overriden)
+        # (it depends on yview to not be overridden)
         mc = self.mc
         self.assertIs(mc.yview, Text.yview)
         mctext = self.mc(self.root)

--- a/Lib/idlelib/idle_test/test_pyparse.py
+++ b/Lib/idlelib/idle_test/test_pyparse.py
@@ -284,7 +284,7 @@ class PyParseTest(unittest.TestCase):
         tests = (
             TestInfo('[x for x in a]\n', 1),      # Closed on one line.
             TestInfo('[x\nfor x in a\n', 2),      # Not closed.
-            TestInfo('[x\\\nfor x in a\\\n', 2),  # "", uneeded backslashes.
+            TestInfo('[x\\\nfor x in a\\\n', 2),  # "", unneeded backslashes.
             TestInfo('[x\nfor x in a\n]\n', 3),   # Closed on multi-line.
             TestInfo('\n"""Docstring comment L1"""\nL2\nL3\nL4\n', 1),
             TestInfo('\n"""Docstring comment L1\nL2"""\nL3\nL4\n', 1),

--- a/Lib/importlib/_adapters.py
+++ b/Lib/importlib/_adapters.py
@@ -41,8 +41,8 @@ def _io_wrapper(file, mode='r', *args, **kwargs):
 
 class CompatibilityFiles:
     """
-    Adapter for an existing or non-existant resource reader
-    to provide a compability .files().
+    Adapter for an existing or non-existent resource reader
+    to provide a compatibility .files().
     """
 
     class SpecPath(abc.Traversable):
@@ -83,7 +83,7 @@ class CompatibilityFiles:
     class ChildPath(abc.Traversable):
         """
         Path tied to a resource reader child.
-        Can be read but doesn't expose any meaningfull children.
+        Can be read but doesn't expose any meaningful children.
         """
 
         def __init__(self, reader, name):

--- a/Lib/lib2to3/fixes/fix_metaclass.py
+++ b/Lib/lib2to3/fixes/fix_metaclass.py
@@ -51,7 +51,7 @@ def fixup_parse_tree(cls_node):
             # already in the preferred format, do nothing
             return
 
-    # !%@#! oneliners have no suite node, we have to fake one up
+    # !%@#! one-liners have no suite node, we have to fake one up
     for i, node in enumerate(cls_node.children):
         if node.type == token.COLON:
             break

--- a/Lib/lib2to3/fixes/fix_paren.py
+++ b/Lib/lib2to3/fixes/fix_paren.py
@@ -1,4 +1,4 @@
-"""Fixer that addes parentheses where they are required
+"""Fixer that adds parentheses where they are required
 
 This converts ``[x for x in 1, 2]`` to ``[x for x in (1, 2)]``."""
 

--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -154,7 +154,7 @@ def lazycache(filename, module_globals):
 
     :return: True if a lazy load is registered in the cache,
         otherwise False. To register such a load a module loader with a
-        get_source method must be found, the filename must be a cachable
+        get_source method must be found, the filename must be a cacheable
         filename, and the filename must not be already cached.
     """
     if filename in cache:

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1173,7 +1173,7 @@ class _Unpickler:
         used in Python 3.  The *encoding* and *errors* tell pickle how
         to decode 8-bit string instances pickled by Python 2; these
         default to 'ASCII' and 'strict', respectively. *encoding* can be
-        'bytes' to read theses 8-bit string instances as bytes objects.
+        'bytes' to read these 8-bit string instances as bytes objects.
         """
         self._buffers = iter(buffers) if buffers is not None else None
         self._file_readline = file.readline

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -1261,7 +1261,7 @@ _os_release_cache = None
 
 def _parse_os_release(lines):
     # These fields are mandatory fields with well-known defaults
-    # in pratice all Linux distributions override NAME, ID, and PRETTY_NAME.
+    # in practice all Linux distributions override NAME, ID, and PRETTY_NAME.
     info = {
         "NAME": "Linux",
         "ID": "linux",

--- a/Lib/sqlite3/test/test_dbapi.py
+++ b/Lib/sqlite3/test/test_dbapi.py
@@ -616,7 +616,7 @@ class CursorTests(unittest.TestCase):
         self.assertEqual(row, None)
 
     def test_array_size(self):
-        # must default ot 1
+        # must default to 1
         self.assertEqual(self.cu.arraysize, 1)
 
         # now set to 2

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -184,7 +184,7 @@ _PYTHON_BUILD = is_python_build(True)
 
 if _PYTHON_BUILD:
     for scheme in ('posix_prefix', 'posix_home'):
-        # On POSIX-y platofrms, Python will:
+        # On POSIX-y platforms, Python will:
         # - Build from .h files in 'headers' (which is only added to the
         #   scheme when building CPython)
         # - Install .h files to 'include'

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4064,7 +4064,7 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
         self.assertEqual(t1, t1)
         self.assertEqual(t2, t2)
 
-        # Equal afer adjustment.
+        # Equal after adjustment.
         t1 = self.theclass(1, 12, 31, 23, 59, tzinfo=FixedOffset(1, ""))
         t2 = self.theclass(2, 1, 1, 3, 13, tzinfo=FixedOffset(3*60+13+2, ""))
         self.assertEqual(t1, t2)
@@ -4903,7 +4903,7 @@ class TestTimezoneConversions(unittest.TestCase):
         # OTOH, these fail!  Don't enable them.  The difficulty is that
         # the edge case tests assume that every hour is representable in
         # the "utc" class.  This is always true for a fixed-offset tzinfo
-        # class (lke utc_real and utc_fake), but not for Eastern or Central.
+        # class (like utc_real and utc_fake), but not for Eastern or Central.
         # For these adjacent DST-aware time zones, the range of time offsets
         # tested ends up creating hours in the one that aren't representable
         # in the other.  For the same reason, we would see failures in the

--- a/Lib/test/decimaltestdata/abs.decTest
+++ b/Lib/test/decimaltestdata/abs.decTest
@@ -20,7 +20,7 @@
 version: 2.59
 
 -- This set of tests primarily tests the existence of the operator.
--- Additon, subtraction, rounding, and more overflows are tested
+-- Addition, subtraction, rounding, and more overflows are tested
 -- elsewhere.
 
 precision:   9

--- a/Lib/test/decimaltestdata/extra.decTest
+++ b/Lib/test/decimaltestdata/extra.decTest
@@ -156,7 +156,7 @@ extr1302 fma -Inf 0E-456 sNaN148 -> NaN Invalid_operation
 
 -- max/min/max_mag/min_mag bug in 2.5.2/2.6/3.0: max(NaN, finite) gave
 -- incorrect answers when the finite number required rounding; similarly
--- for the other thre functions
+-- for the other three functions
 maxexponent: 999
 minexponent: -999
 precision: 6

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -114,7 +114,7 @@ def dash_R(ns, test_name, test_func):
 
     # These checkers return False on success, True on failure
     def check_rc_deltas(deltas):
-        # Checker for reference counters and memomry blocks.
+        # Checker for reference counters and memory blocks.
         #
         # bpo-30776: Try to ignore false positives:
         #

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3723,7 +3723,7 @@ class AbstractHookTests:
 
                 self.assertEqual(new_f, 5)
                 self.assertEqual(some_str, 'some str')
-                # math.log does not have its usual reducer overriden, so the
+                # math.log does not have its usual reducer overridden, so the
                 # custom reduction callback should silently direct the pickler
                 # to the default pickling by attribute, by returning
                 # NotImplemented
@@ -3740,7 +3740,7 @@ class AbstractHookTests:
     def test_reducer_override_no_reference_cycle(self):
         # bpo-39492: reducer_override used to induce a spurious reference cycle
         # inside the Pickler object, that could prevent all serialized objects
-        # from being garbage-collected without explicity invoking gc.collect.
+        # from being garbage-collected without explicitly invoking gc.collect.
 
         for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
             with self.subTest(proto=proto):

--- a/Lib/test/support/threading_helper.py
+++ b/Lib/test/support/threading_helper.py
@@ -157,7 +157,7 @@ class catch_threading_exception:
     Context manager catching threading.Thread exception using
     threading.excepthook.
 
-    Attributes set when an exception is catched:
+    Attributes set when an exception is caught:
 
     * exc_type
     * exc_value

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -1221,7 +1221,7 @@ class ChannelTests(TestBase):
             import _xxsubinterpreters as _interpreters
             obj = _interpreters.channel_recv({cid})
             """))
-        # Test for channel that has boths ends associated to an interpreter.
+        # Test for channel that has both ends associated to an interpreter.
         send_interps = interpreters.channel_list_interpreters(cid, send=True)
         recv_interps = interpreters.channel_list_interpreters(cid, send=False)
         self.assertEqual(send_interps, [interp0])

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -711,7 +711,7 @@ class StreamTests(test_utils.TestCase):
         # See asyncio issue 168.  This test is derived from the example
         # subprocess_attach_read_pipe.py, but we configure the
         # StreamReader's limit so that twice it is less than the size
-        # of the data writter.  Also we must explicitly attach a child
+        # of the data writer.  Also we must explicitly attach a child
         # watcher to the event loop.
 
         code = """\

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -228,7 +228,7 @@ class SubprocessMixin:
         # buffer large enough to feed the whole pipe buffer
         large_data = b'x' * support.PIPE_MAX_SIZE
 
-        # the program ends before the stdin can be feeded
+        # the program ends before the stdin can be fed
         proc = self.loop.run_until_complete(
             asyncio.create_subprocess_exec(
                 sys.executable, '-c', 'pass',

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3269,7 +3269,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
             self.assertTrue(task.done())
 
     def test_run_coroutine_threadsafe_task_cancelled(self):
-        """Test coroutine submission from a tread to an event loop
+        """Test coroutine submission from a thread to an event loop
         when the task is cancelled."""
         callback = lambda: self.target(cancel=True)
         future = self.loop.run_in_executor(None, callback)
@@ -3277,7 +3277,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
             self.loop.run_until_complete(future)
 
     def test_run_coroutine_threadsafe_task_factory_exception(self):
-        """Test coroutine submission from a tread to an event loop
+        """Test coroutine submission from a thread to an event loop
         when the task factory raise an exception."""
 
         def task_factory(loop, coro):

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -264,7 +264,7 @@ class CAPITest(unittest.TestCase):
 
     def test_getitem_with_error(self):
         # Test _Py_CheckSlotResult(). Raise an exception and then calls
-        # PyObject_GetItem(): check that the assertion catchs the bug.
+        # PyObject_GetItem(): check that the assertion catches the bug.
         # PyObject_GetItem() must not be called with an exception set.
         code = textwrap.dedent("""
             import _testcapi

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1594,7 +1594,7 @@ class TestCollectionABCs(ABCTestCase):
         self.assertSetEqual(set(s1), set(s2))
 
     def test_Set_from_iterable(self):
-        """Verify _from_iterable overriden to an instance method works."""
+        """Verify _from_iterable overridden to an instance method works."""
         class SetUsingInstanceFromIterable(MutableSet):
             def __init__(self, values, created_by):
                 if not created_by:

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3695,7 +3695,7 @@ class TestKeywordArgs(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, msg):
             B(3, 4, 5)
 
-        # Explicitely make a field that follows KW_ONLY be non-keyword-only.
+        # Explicitly make a field that follows KW_ONLY be non-keyword-only.
         @dataclass
         class C:
             a: int

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -5723,7 +5723,7 @@ class MroTest(unittest.TestCase):
 
     def test_incomplete_super(self):
         """
-        Attrubute lookup on a super object must be aware that
+        Attribute lookup on a super object must be aware that
         its target type can be uninitialized (type->tp_mro == NULL).
         """
         class M(DebugHelperMeta):

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1046,7 +1046,7 @@ class DictTest(unittest.TestCase):
 
     @support.cpython_only
     def test_splittable_pop_pending(self):
-        """pop a pending key in a splitted table should not crash"""
+        """pop a pending key in a split table should not crash"""
         a, b = self.make_shared_key_dict(2)
 
         a['a'] = 4
@@ -1363,7 +1363,7 @@ class DictTest(unittest.TestCase):
         self.assertRaises(StopIteration, next, r)
 
     def test_reverse_iterator_for_empty_dict(self):
-        # bpo-38525: revered iterator should work properly
+        # bpo-38525: reversed iterator should work properly
 
         # empty dict is directly used for reference count test
         self.assertEqual(list(reversed({})), [])

--- a/Lib/test/test_dict_version.py
+++ b/Lib/test/test_dict_version.py
@@ -1,5 +1,5 @@
 """
-Test implementation of the PEP 509: dictionary versionning.
+Test implementation of the PEP 509: dictionary versioning.
 """
 import unittest
 from test.support import import_helper

--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -34,7 +34,7 @@ def normalize_trace_output(output):
         return "\n".join(result)
     except (IndexError, ValueError):
         raise AssertionError(
-            "tracer produced unparseable output:\n{}".format(output)
+            "tracer produced unparsable output:\n{}".format(output)
         )
 
 

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -433,7 +433,7 @@ class TestEmailMessageBase:
                 --===
                 Content-Type: text/plain
 
-                Your message has bounced, ser.
+                Your message has bounced, sir.
 
                 --===
                 Content-Type: message/rfc822

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -250,7 +250,7 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_pre_initialization_api(self):
         """
-        Checks some key parts of the C-API that need to work before the runtine
+        Checks some key parts of the C-API that need to work before the runtime
         is initialized (via Py_Initialize()).
         """
         env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
@@ -1170,7 +1170,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
              # The current getpath.c doesn't determine the stdlib dir
              # in this case.
             'stdlib_dir': '',
-            # overriden by PyConfig
+            # overridden by PyConfig
             'program_name': 'conf_program_name',
             'base_executable': 'conf_executable',
             'executable': 'conf_executable',

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2281,7 +2281,7 @@ class SyntaxErrorTests(unittest.TestCase):
                  abcdefg
              SyntaxError: bad bad
              """)),
-            # End offset pass the source lenght
+            # End offset pass the source length
             (("bad.py", 1, 2, "abcdefg", 1, 100),
              dedent(
              """

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -329,7 +329,7 @@ class AnnotationsFutureTestCase(unittest.TestCase):
 
     def test_fstring_debug_annotations(self):
         # f-strings with '=' don't round trip very well, so set the expected
-        # result explicitely.
+        # result explicitly.
         self.assertAnnotationEqual("f'{x=!r}'", expected="f'x={x!r}'")
         self.assertAnnotationEqual("f'{x=:}'", expected="f'x={x:}'")
         self.assertAnnotationEqual("f'{x=:.2f}'", expected="f'x={x:.2f}'")

--- a/Lib/test/test_lltrace.py
+++ b/Lib/test/test_lltrace.py
@@ -12,7 +12,7 @@ class TestLLTrace(unittest.TestCase):
         # If this test fails, it will reproduce a crash reported as
         # bpo-34113. The crash happened at the command line console of
         # debug Python builds with __ltrace__ enabled (only possible in console),
-        # when the interal Python stack was negatively adjusted
+        # when the internal Python stack was negatively adjusted
         with open(os_helper.TESTFN, 'w', encoding='utf-8') as fd:
             self.addCleanup(os_helper.unlink, os_helper.TESTFN)
             fd.write(textwrap.dedent("""\

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -496,7 +496,7 @@ class NormalizeTest(unittest.TestCase):
 class TestMiscellaneous(unittest.TestCase):
     def test_defaults_UTF8(self):
         # Issue #18378: on (at least) macOS setting LC_CTYPE to "UTF-8" is
-        # valid. Futhermore LC_CTYPE=UTF is used by the UTF-8 locale coercing
+        # valid. Furthermore LC_CTYPE=UTF is used by the UTF-8 locale coercing
         # during interpreter startup (on macOS).
         import _locale
         import os

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1260,7 +1260,7 @@ class LongTest(unittest.TestCase):
                             expected)
                     except Exception as err:
                         raise AssertionError(
-                            "failed to convert {} with default arugments"
+                            "failed to convert {} with default arguments"
                             .format(test)) from err
 
                 try:

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -324,7 +324,7 @@ class _BasePurePathTest(object):
         self.assertFalse(P('b/py').match('b.py'))
         self.assertFalse(P('/a.py').match('b.py'))
         self.assertFalse(P('b.py/c').match('b.py'))
-        # Wilcard relative pattern.
+        # Wildcard relative pattern.
         self.assertTrue(P('b.py').match('*.py'))
         self.assertTrue(P('a/b.py').match('*.py'))
         self.assertTrue(P('/a/b.py').match('*.py'))
@@ -1284,7 +1284,7 @@ class PureWindowsPathTest(_BasePurePathTest, unittest.TestCase):
         self.assertIs(False, P('/foo/bar').is_reserved())
         # UNC paths are never reserved.
         self.assertIs(False, P('//my/share/nul/con/aux').is_reserved())
-        # Case-insenstive DOS-device names are reserved.
+        # Case-insensitive DOS-device names are reserved.
         self.assertIs(True, P('nul').is_reserved())
         self.assertIs(True, P('aux').is_reserved())
         self.assertIs(True, P('prn').is_reserved())

--- a/Lib/test/test_strftime.py
+++ b/Lib/test/test_strftime.py
@@ -114,7 +114,7 @@ class StrftimeTest(unittest.TestCase):
         )
 
         for e in expectations:
-            # musn't raise a value error
+            # mustn't raise a value error
             try:
                 result = time.strftime(e[0], now)
             except ValueError as error:

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -381,7 +381,7 @@ class SysModuleTest(unittest.TestCase):
         self.assertTrue(frame is sys._getframe())
 
         # Verify that the captured thread frame is blocked in g456, called
-        # from f123.  This is a litte tricky, since various bits of
+        # from f123.  This is a little tricky, since various bits of
         # threading.py are also in the thread's call stack.
         frame = d.pop(thread_id)
         stack = traceback.extract_stack(frame)
@@ -448,7 +448,7 @@ class SysModuleTest(unittest.TestCase):
         self.assertEqual((None, None, None), d.pop(main_id))
 
         # Verify that the captured thread frame is blocked in g456, called
-        # from f123.  This is a litte tricky, since various bits of
+        # from f123.  This is a little tricky, since various bits of
         # threading.py are also in the thread's call stack.
         exc_type, exc_value, exc_tb = d.pop(thread_id)
         stack = traceback.extract_stack(exc_tb.tb_frame)

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1435,7 +1435,7 @@ class TestTemporaryDirectory(BaseTestCase):
             self.assertEqual(
                 temp_path.exists(),
                 sys.platform.startswith("win"),
-                f"TemporaryDirectory {temp_path!s} existance state unexpected")
+                f"TemporaryDirectory {temp_path!s} existence state unexpected")
             temp_dir.cleanup()
             self.assertFalse(
                 temp_path.exists(),
@@ -1494,7 +1494,7 @@ class TestTemporaryDirectory(BaseTestCase):
             self.assertEqual(
                 temp_path.exists(),
                 sys.platform.startswith("win"),
-                f"TemporaryDirectory {temp_path!s} existance state unexpected")
+                f"TemporaryDirectory {temp_path!s} existence state unexpected")
 
     def test_del_on_shutdown(self):
         # A TemporaryDirectory may be cleaned up during shutdown
@@ -1559,7 +1559,7 @@ class TestTemporaryDirectory(BaseTestCase):
             self.assertEqual(
                 temp_path.exists(),
                 sys.platform.startswith("win"),
-                f"TemporaryDirectory {temp_path!s} existance state unexpected")
+                f"TemporaryDirectory {temp_path!s} existence state unexpected")
             err = err.decode('utf-8', 'backslashreplace')
             self.assertNotIn("Exception", err)
             self.assertNotIn("Error", err)

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -441,7 +441,7 @@ class TimeTestCase(unittest.TestCase):
                          "disabled because of a bug in glibc. Issue #13309")
     def test_mktime_error(self):
         # It may not be possible to reliably make mktime return error
-        # on all platfom.  This will make sure that no other exception
+        # on all platform.  This will make sure that no other exception
         # than OverflowError is raised for an extreme value.
         tt = time.gmtime(self.t)
         tzname = time.strftime('%Z', tt)

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -440,8 +440,8 @@ class TimeTestCase(unittest.TestCase):
     @unittest.skipUnless(platform.libc_ver()[0] != 'glibc',
                          "disabled because of a bug in glibc. Issue #13309")
     def test_mktime_error(self):
-        # It may not be possible to reliably make mktime return error
-        # on all platform.  This will make sure that no other exception
+        # It may not be possible to reliably make mktime return an error
+        # on all platforms.  This will make sure that no other exception
         # than OverflowError is raised for an extreme value.
         tt = time.gmtime(self.t)
         tzname = time.strftime('%Z', tt)

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -427,7 +427,7 @@ class UnparseTestCase(ASTTestCase):
 
 
 class CosmeticTestCase(ASTTestCase):
-    """Test if there are cosmetic issues caused by unnecesary additions"""
+    """Test if there are cosmetic issues caused by unnecessary additions"""
 
     def test_simple_expressions_parens(self):
         self.check_src_roundtrip("(a := b)")

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1473,7 +1473,7 @@ class MappingTestCase(TestBase):
         o = Object(123456)
         with testcontext():
             n = len(dict)
-            # Since underlaying dict is ordered, first item is popped
+            # Since underlying dict is ordered, first item is popped
             dict.pop(next(dict.keys()))
             self.assertEqual(len(dict), n - 1)
             dict[o] = o

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -556,7 +556,7 @@ class HandlerTests(TestCase):
         # Test handler.environ as a dict
         expected = {}
         setup_testing_defaults(expected)
-        # Handler inherits os_environ variables which are not overriden
+        # Handler inherits os_environ variables which are not overridden
         # by SimpleHandler.add_cgi_vars() (SimpleHandler.base_env)
         for key, value in os_environ.items():
             if key not in expected:

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -3331,7 +3331,7 @@ class TreeBuilderTest(unittest.TestCase):
         self._check_element_factory_class(MyElement)
 
     def test_element_factory_pure_python_subclass(self):
-        # Mimick SimpleTAL's behaviour (issue #16089): both versions of
+        # Mimic SimpleTAL's behaviour (issue #16089): both versions of
         # TreeBuilder should be able to cope with a subclass of the
         # pure Python Element class.
         base = ET._Element_Py

--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -561,7 +561,7 @@ class DateTimeTestCase(unittest.TestCase):
 
 class BinaryTestCase(unittest.TestCase):
 
-    # XXX What should str(Binary(b"\xff")) return?  I'm chosing "\xff"
+    # XXX What should str(Binary(b"\xff")) return?  I'm choosing "\xff"
     # for now (i.e. interpreting the binary data as Latin-1-encoded
     # text).  But this feels very unsatisfactory.  Perhaps we should
     # only define repr(), and return r"Binary(b'\xff')" instead?

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1572,7 +1572,7 @@ def _shutdown():
             break
 
         for lock in locks:
-            # mimick Thread.join()
+            # mimic Thread.join()
             lock.acquire()
             lock.release()
 

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2735,7 +2735,7 @@ class Canvas(Widget, XView, YView):
         """Add tag NEWTAG to item which is closest to pixel at X, Y.
         If several match take the top-most.
         All items closer than HALO are considered overlapping (all are
-        closests). If START is specified the next below this tag is taken."""
+        closest). If START is specified the next below this tag is taken."""
         self.addtag(newtag, 'closest', x, y, halo, start)
 
     def addtag_enclosed(self, newtag, x1, y1, x2, y2):
@@ -3330,7 +3330,7 @@ class Menu(Widget):
         self.add('command', cnf or kw)
 
     def add_radiobutton(self, cnf={}, **kw):
-        """Addd radio menu item."""
+        """Add radio menu item."""
         self.add('radiobutton', cnf or kw)
 
     def add_separator(self, cnf={}, **kw):
@@ -3355,7 +3355,7 @@ class Menu(Widget):
         self.insert(index, 'command', cnf or kw)
 
     def insert_radiobutton(self, index, cnf={}, **kw):
-        """Addd radio menu item at INDEX."""
+        """Add radio menu item at INDEX."""
         self.insert(index, 'radiobutton', cnf or kw)
 
     def insert_separator(self, index, cnf={}, **kw):

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -968,7 +968,7 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
         tabs = self.nb.tabs()
 
         curr = self.nb.index('current')
-        # verify that the tab gets readded at its previous position
+        # verify that the tab gets read at its previous position
         child2_index = self.nb.index(self.child2)
         self.nb.hide(self.child2)
         self.nb.add(self.child2)

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -53,7 +53,7 @@ class IsolatedAsyncioTestCase(TestCase):
         # We intentionally don't add inspect.iscoroutinefunction() check
         # for func argument because there is no way
         # to check for async function reliably:
-        # 1. It can be "async def func()" iself
+        # 1. It can be "async def func()" itself
         # 2. Class can implement "async def __call__()" method
         # 3. Regular "def func()" that returns awaitable object
         self.addCleanup(*(func, *args), **kwargs)

--- a/Lib/unittest/test/testmock/testsealable.py
+++ b/Lib/unittest/test/testmock/testsealable.py
@@ -128,7 +128,7 @@ class TestSealable(unittest.TestCase):
             m.attr_sample2
 
     def test_integration_with_spec_method_definition(self):
-        """You need to defin the methods, even if they are in the spec"""
+        """You need to define the methods, even if they are in the spec"""
         m = mock.Mock(SampleObject)
 
         m.method_sample1.return_value = 1

--- a/Lib/venv/scripts/common/Activate.ps1
+++ b/Lib/venv/scripts/common/Activate.ps1
@@ -202,7 +202,7 @@ else {
         $Prompt = $pyvenvCfg['prompt'];
     }
     else {
-        Write-Verbose "  Setting prompt based on parent's directory's name. (Is the directory name passed to venv module when creating the virutal environment)"
+        Write-Verbose "  Setting prompt based on parent's directory's name. (Is the directory name passed to venv module when creating the virtual environment)"
         Write-Verbose "  Got leaf-name of $VenvDir='$(Split-Path -Path $venvDir -Leaf)'"
         $Prompt = Split-Path -Path $venvDir -Leaf
     }

--- a/Lib/wsgiref/validate.py
+++ b/Lib/wsgiref/validate.py
@@ -137,7 +137,7 @@ def validator(application):
 
     """
     When applied between a WSGI server and a WSGI application, this
-    middleware will check for WSGI compliancy on a number of levels.
+    middleware will check for WSGI compliance on a number of levels.
     This middleware does not modify the request or response in any
     way, but will raise an AssertionError if anything seems off
     (except for a failure to close the application iterator, which

--- a/Lib/zoneinfo/_zoneinfo.py
+++ b/Lib/zoneinfo/_zoneinfo.py
@@ -338,7 +338,7 @@ class ZoneInfo(tzinfo):
                 comp_idx = trans_idx[i + 1]
 
                 # If the following transition is also DST and we couldn't
-                # find the DST offset by this point, we're going ot have to
+                # find the DST offset by this point, we're going to have to
                 # skip it and hope this transition gets assigned later
                 if isdsts[comp_idx]:
                     continue


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Like #28744 but for the Lib directory.

[skip issue] Opening a related issue is pending python/psf-infra-meta#130

codespell --ignore-words-list=aline,alo,ans,asend,atleast,ba,bloc,browseable,cant,crasher,crashers,commen,datas,datea,doesnot,donn,ende,filetest,filetests,fiter,fo,hda,hel,hellow,henc,hist,infinit,inout,interruptable,invokations,ist,ket,lable,larg,leapyear,mye,nams,nd,ned,nin,notmutch,nwe,oder,oll,parm,raison,responsable,seh,simeple,squirl,spawnve,sur,tbe,te,teh,tey,thow,timere,tre,trough,tthe,ue,upto,wile,wont --skip="*.decTest,*.txt,*.types" Lib