### PR TITLE
bpo-29505: Add fuzzer for ast.literal_eval

### DIFF
--- a/Modules/_xxtestfuzz/fuzz_tests.txt
+++ b/Modules/_xxtestfuzz/fuzz_tests.txt
@@ -6,3 +6,4 @@ fuzz_sre_compile
 fuzz_sre_match
 fuzz_csv_reader
 fuzz_struct_unpack
+fuzz_ast_literal_eval


### PR DESCRIPTION
This supercedes https://github.com/python/cpython/pull/3437 and fuzzes the method we recommend for unsafe inputs, `ast.literal_eval`. This should exercise the tokenizer and parser.

<!-- issue-number: [bpo-29505](https://bugs.python.org/issue29505) -->
https://bugs.python.org/issue29505
<!-- /issue-number -->

Automerge-Triggered-By: GH:ammaraskar