### PR TITLE
bpo-45400: Fix suggestion test of test_exceptions

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1840,7 +1840,7 @@ class NameErrorTests(unittest.TestCase):
             with support.captured_stderr() as err:
                 sys.__excepthook__(*sys.exc_info())
 
-        self.assertNotIn("a1", err.getvalue())
+        self.assertNotRegex(err.getvalue(), r"NameError.*a1")
 
     def test_name_error_with_custom_exceptions(self):
         def f():

--- a/Misc/NEWS.d/next/Tests/2021-10-07-13-11-45.bpo-45400.h3iT7V.rst
+++ b/Misc/NEWS.d/next/Tests/2021-10-07-13-11-45.bpo-45400.h3iT7V.rst
@@ -1,0 +1,3 @@
+Fix test_name_error_suggestions_do_not_trigger_for_too_many_locals() of
+test_exceptions if a directory name contains "a1" (like "Python-3.11.0a1"):
+use a stricter regular expression. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_name_error_suggestions_do_not_trigger_for_too_many_locals()
of test_exceptions if a directory name contains "a1" (like
"Python-3.11.0a1"): use a stricter regular expression.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45400](https://bugs.python.org/issue45400) -->
https://bugs.python.org/issue45400
<!-- /issue-number -->
