### PR TITLE
bpo-45400: Fix test_name_error_suggestions_do_not_trigger_for_too_many_locals on a1 releases

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1840,7 +1840,13 @@ class NameErrorTests(unittest.TestCase):
             with support.captured_stderr() as err:
                 sys.__excepthook__(*sys.exc_info())
 
-        self.assertNotIn("a1", err.getvalue())
+        traceback = err.getvalue()
+
+        # remvoe the source path from the traceback, it could contain "a1" in it
+        # https://bugs.python.org/issue45400
+        traceback = traceback.replace(__file__, os.path.basename(__file__))
+
+        self.assertNotIn("a1", traceback)
 
     def test_name_error_with_custom_exceptions(self):
         def f():

--- a/Misc/NEWS.d/next/Tests/2021-10-07-13-17-42.bpo-45400.oHgprZ.rst
+++ b/Misc/NEWS.d/next/Tests/2021-10-07-13-17-42.bpo-45400.oHgprZ.rst
@@ -1,0 +1,4 @@
+The ``test_name_error_suggestions_do_not_trigger_for_too_many_locals`` will
+no longer fail when run from a directory that contains ``a1`` in the path,
+which is likely to happen when building from unpacked sources of a first
+alpha release.


### PR DESCRIPTION
When test_name_error_suggestions_do_not_trigger_for_too_many_locals
run from a directory that contained "a1" somewhere in the path,
which was likely to happen when building from unpacked sources of a first
alpha release, it failed, as it asserts the string "a1" is nowhere in the traceback.

Now, we replace the full path in the traceback with basename to prevent this.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45400](https://bugs.python.org/issue45400) -->
https://bugs.python.org/issue45400
<!-- /issue-number -->
