### PR TITLE
bpo-45403: Fix test_sys.test_stdlib_dir()

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1001,8 +1001,8 @@ class SysModuleTest(unittest.TestCase):
         if marker and not os.path.exists(marker):
             marker = None
         expected = os.path.dirname(marker) if marker else None
-        actual = sys._stdlib_dir
-        self.assertEqual(actual, expected)
+        self.assertEqual(os.path.normpath(sys._stdlib_dir),
+                         os.path.normpath(expected))
 
 
 @test.support.cpython_only

--- a/Misc/NEWS.d/next/Tests/2021-10-07-13-27-12.bpo-45403.7QiDvw.rst
+++ b/Misc/NEWS.d/next/Tests/2021-10-07-13-27-12.bpo-45403.7QiDvw.rst
@@ -1,0 +1,2 @@
+Fix test_sys.test_stdlib_dir() when Python is built outside the source tree:
+compare normalized paths. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_sys.test_stdlib_dir() when Python is built outside the
source tree: compare normalized paths.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45403](https://bugs.python.org/issue45403) -->
https://bugs.python.org/issue45403
<!-- /issue-number -->
