### PR TITLE
bpo-45262: Prevent use-after-free in asyncio

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-10-07-14-04-10.bpo-45262.HqF71Z.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-07-14-04-10.bpo-45262.HqF71Z.rst
@@ -1,0 +1,1 @@
+Prevent use-after-free in asyncio. Make sure the cached running loop holder gets cleared on dealloc to prevent use-after-free in get_running_loop

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3239,6 +3239,9 @@ new_running_loop_holder(PyObject *loop)
 static void
 PyRunningLoopHolder_tp_dealloc(PyRunningLoopHolder *rl)
 {
+    if (cached_running_holder == (PyObject *)rl) {
+        cached_running_holder = NULL;
+    }
     Py_CLEAR(rl->rl_loop);
     PyObject_Free(rl);
 }


### PR DESCRIPTION
Make sure the cached running loop holder gets cleared on dealloc to prevent use-after-free in get_running_loop

<!-- issue-number: [bpo-45262](https://bugs.python.org/issue45262) -->
https://bugs.python.org/issue45262
<!-- /issue-number -->
