### PR TITLE
[3.9] Fix typos in the Tools directory (GH-28769)

### DIFF
--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -685,7 +685,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             self.print(
                 f'D(fprintf(stderr, "%*c+ {rulename}[%d-%d]: %s succeeded!\\n", p->level, \' \', _mark, p->mark, "{node_str}"));'
             )
-            # Prepare to emmit the rule action and do so
+            # Prepare to emit the rule action and do so
             if node.action and "EXTRA" in node.action:
                 self._set_up_token_end_metadata_extraction()
             if self.skip_actions:

--- a/Tools/peg_generator/pegen/first_sets.py
+++ b/Tools/peg_generator/pegen/first_sets.py
@@ -59,7 +59,7 @@ class FirstSetCalculator(GrammarVisitor):
                 result -= to_remove
 
             # If the set of new terminals can start with the empty string,
-            # it means that the item is completelly nullable and we should
+            # it means that the item is completely nullable and we should
             # also considering at least the next item in case the current
             # one fails to parse.
 

--- a/Tools/peg_generator/scripts/download_pypi_packages.py
+++ b/Tools/peg_generator/scripts/download_pypi_packages.py
@@ -72,7 +72,7 @@ def main() -> None:
 
         package_json = load_json(package_name)
         try:
-            print(f"Dowloading and compressing package {package_name} ... ", end="")
+            print(f"Downloading and compressing package {package_name} ... ", end="")
             download_package_code(package_name, package_json)
             print("Done")
         except (IndexError, KeyError):

--- a/Tools/pynche/ColorDB.py
+++ b/Tools/pynche/ColorDB.py
@@ -9,7 +9,7 @@ format of the file is.  If it can't figure out the file format, or it has
 trouble reading the file, None is returned.  You can pass get_colordb() an
 optional filetype argument.
 
-Supporte file types are:
+Supported file types are:
 
     X_RGB_TXT -- X Consortium rgb.txt format files.  Three columns of numbers
                  from 0 .. 255 separated by whitespace.  Arbitrary trailing

--- a/Tools/scripts/dutree.doc
+++ b/Tools/scripts/dutree.doc
@@ -15,7 +15,7 @@ From the keyboard of flee@cs.psu.edu (Felix Lee):
 :And Perl is definitely awkward with data types.  I haven't yet found a
 :pleasant way of shoving non-trivial data types into Perl's grammar.
 
-Yes, it's pretty aweful at that, alright.  Sometimes I write perl programs
+Yes, it's pretty awful at that, alright.  Sometimes I write perl programs
 that need them, and sometimes it just takes a little creativity.  But
 sometimes it's not worth it.  I actually wrote a C program the other day
 (gasp) because I didn't want to deal with a game matrix with six links per node.


### PR DESCRIPTION
Like #28744 but for the Tools directory.

[skip issue] Opening a related issue is pending python/psf-infra-meta#130

Automerge-Triggered-By: GH:pablogsal
(cherry picked from commit 682aecfdeba481c876bfc9f3796c635bd5b5df50)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
