### PR TITLE
bpo-45407: Remove outdated XXX comment from Struct___init___impl

### DIFF
--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1475,7 +1475,6 @@ Struct___init___impl(PyStructObject *self, PyObject *format)
         if (format == NULL)
             return -1;
     }
-    /* XXX support buffer interface, too */
     else {
         Py_INCREF(format);
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

`Struct___init___impl` had `XXX` comment to use buffer protocol for there.
~This patch it by falling back to buffer protocol when the given object is neither unicode nor bytes.~
remove only comment by following the comment of [bpo-45407](https://bugs.python.org/issue45407)

<!-- issue-number: [bpo-45407](https://bugs.python.org/issue45407) -->
https://bugs.python.org/issue45407
<!-- /issue-number -->
