### PR TITLE
Fix deprecated use of List

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -975,16 +975,16 @@ These can be used as types in annotations using ``[]``, each having a unique syn
 
       For example::
 
-         def is_str_list(val: List[object]) -> TypeGuard[List[str]]:
+         def is_str_list(val: list[object]) -> TypeGuard[list[str]]:
              '''Determines whether all objects in the list are strings'''
              return all(isinstance(x, str) for x in val)
 
-         def func1(val: List[object]):
+         def func1(val: list[object]):
              if is_str_list(val):
-                 # Type of ``val`` is narrowed to ``List[str]``.
+                 # Type of ``val`` is narrowed to ``list[str]``.
                  print(" ".join(val))
              else:
-                 # Type of ``val`` remains as ``List[object]``.
+                 # Type of ``val`` remains as ``list[object]``.
                  print("Not a list of strings!")
 
    If ``is_str_list`` is a class or instance method, then the type in
@@ -999,8 +999,8 @@ These can be used as types in annotations using ``[]``, each having a unique syn
 
       ``TypeB`` need not be a narrower form of ``TypeA`` -- it can even be a
       wider form. The main reason is to allow for things like
-      narrowing ``List[object]`` to ``List[str]`` even though the latter
-      is not a subtype of the former, since ``List`` is invariant.
+      narrowing ``list[object]`` to ``list[str]`` even though the latter
+      is not a subtype of the former, since ``list`` is invariant.
       The responsibility of writing type-safe type guards is left to the user.
 
    ``TypeGuard`` also works with type variables.  For more information, see
@@ -2065,8 +2065,8 @@ Introspection helpers
 .. class:: ForwardRef
 
    A class used for internal typing representation of string forward references.
-   For example, ``List["SomeClass"]`` is implicitly transformed into
-   ``List[ForwardRef("SomeClass")]``.  This class should not be instantiated by
+   For example, ``list["SomeClass"]`` is implicitly transformed into
+   ``list[ForwardRef("SomeClass")]``.  This class should not be instantiated by
    a user, but may be used by introspection tools.
 
    .. note::


### PR DESCRIPTION
Some typing examples were still using `List[...]` instead of `list[...]`.

https://docs.python.org/3/library/typing.html#typing.TypeGuard
https://docs.python.org/3/library/typing.html#typing.ForwardRef

> Deprecated since version 3.9: [builtins.list](https://docs.python.org/3/library/stdtypes.html#list) now supports `[]`. See [**PEP 585**](https://www.python.org/dev/peps/pep-0585) and [Generic Alias Type](https://docs.python.org/3/library/stdtypes.html#types-genericalias).
> https://docs.python.org/3/library/typing.html#typing.List

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
