### PR TITLE
[3.10] bpo-20028: Keep original exception when PyUnicode_GetLength re…

### DIFF
--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -244,6 +244,9 @@ _set_char_or_none(const char *name, Py_UCS4 *target, PyObject *src, Py_UCS4 dflt
                 return -1;
             }
             Py_ssize_t len = PyUnicode_GetLength(src);
+            if (len < 0) {
+                return -1;
+            }
             if (len > 1) {
                 PyErr_Format(PyExc_TypeError,
                     "\"%s\" must be a 1-character string",
@@ -274,6 +277,9 @@ _set_char(const char *name, Py_UCS4 *target, PyObject *src, Py_UCS4 dflt)
                 return -1;
         }
         Py_ssize_t len = PyUnicode_GetLength(src);
+        if (len < 0) {
+            return -1;
+        }
         if (len > 1) {
             PyErr_Format(PyExc_TypeError,
                          "\"%s\" must be a 1-character string",


### PR DESCRIPTION
…turn -1 (GH-28832)

(cherry picked from commit ec04db74e24a5f5da441bcabbe259157b4938b9b)

Co-authored-by: Dong-hee Na <donghee.na@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-20028](https://bugs.python.org/issue20028) -->
https://bugs.python.org/issue20028
<!-- /issue-number -->
