### PR TITLE
bpo-44904: Fix classmethod property bug in doctest module

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1037,7 +1037,9 @@ class DocTestFinder:
                 if isinstance(val, staticmethod):
                     val = getattr(obj, valname)
                 if isinstance(val, classmethod):
-                    val = getattr(obj, valname).__func__
+                    # Lookup via __dict__ instead of getattr
+                    # in case it is a classmethod property.
+                    val = obj.__dict__[valname].__func__
 
                 # Recurse to methods, properties, and nested classes.
                 if ((inspect.isroutine(val) or inspect.isclass(val) or

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1034,12 +1034,8 @@ class DocTestFinder:
         if inspect.isclass(obj) and self._recurse:
             for valname, val in obj.__dict__.items():
                 # Special handling for staticmethod/classmethod.
-                if isinstance(val, staticmethod):
-                    val = getattr(obj, valname)
-                if isinstance(val, classmethod):
-                    # Lookup via __dict__ instead of getattr
-                    # in case it is a classmethod property.
-                    val = obj.__dict__[valname].__func__
+                if isinstance(val, (staticmethod, classmethod)):
+                    val = val.__func__
 
                 # Recurse to methods, properties, and nested classes.
                 if ((inspect.isroutine(val) or inspect.isclass(val) or

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -96,6 +96,17 @@ class SampleClass:
         22
         """)
 
+    a_class_attribute = 42
+
+    @classmethod
+    @property
+    def a_classmethod_property(cls):
+        """
+        >>> print(SampleClass.a_classmethod_property)
+        42
+        """
+        return cls.a_class_attribute
+
     class NestedClass:
         """
         >>> x = SampleClass.NestedClass(5)
@@ -501,6 +512,7 @@ methods, classmethods, staticmethods, properties, and nested classes.
      1  SampleClass.NestedClass.__init__
      1  SampleClass.__init__
      2  SampleClass.a_classmethod
+     1  SampleClass.a_classmethod_property
      1  SampleClass.a_property
      1  SampleClass.a_staticmethod
      1  SampleClass.double
@@ -556,6 +568,7 @@ functions, classes, and the `__test__` dictionary, if it exists:
      1  some_module.SampleClass.NestedClass.__init__
      1  some_module.SampleClass.__init__
      2  some_module.SampleClass.a_classmethod
+     1  some_module.SampleClass.a_classmethod_property
      1  some_module.SampleClass.a_property
      1  some_module.SampleClass.a_staticmethod
      1  some_module.SampleClass.double
@@ -597,6 +610,7 @@ By default, an object with no doctests doesn't create any tests:
      1  SampleClass.NestedClass.__init__
      1  SampleClass.__init__
      2  SampleClass.a_classmethod
+     1  SampleClass.a_classmethod_property
      1  SampleClass.a_property
      1  SampleClass.a_staticmethod
      1  SampleClass.double
@@ -617,6 +631,7 @@ displays.
      0  SampleClass.NestedClass.square
      1  SampleClass.__init__
      2  SampleClass.a_classmethod
+     1  SampleClass.a_classmethod_property
      1  SampleClass.a_property
      1  SampleClass.a_staticmethod
      1  SampleClass.double

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1885,6 +1885,7 @@ Bob Watson
 Colin Watson
 David Watson
 Aaron Watters
+Alex Waygood
 Henrik Weber
 Leon Weber
 Steve Weber

--- a/Misc/NEWS.d/next/Library/2021-10-09-18-42-27.bpo-44904.RlW5h8.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-09-18-42-27.bpo-44904.RlW5h8.rst
@@ -1,0 +1,3 @@
+Fix bug in the :mod:`doctest` module that caused it to fail if a docstring
+included an example with a ``classmethod`` ``property``. Patch by Alex
+Waygood.


### PR DESCRIPTION
The doctest module raised an error if a docstring contained an example that
attempted to access a classmethod property. (Stacking `@classmethod` on top of
`@property` has been supported since Python 3.9; see
https://docs.python.org/3/howto/descriptor.html#class-methods.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-44904](https://bugs.python.org/issue44904) -->
https://bugs.python.org/issue44904
<!-- /issue-number -->
