### PR TITLE
bpo-45353: Remind sys.modules users to copy when iterating.

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1073,7 +1073,11 @@ always available.
    This is a dictionary that maps module names to modules which have already been
    loaded.  This can be manipulated to force reloading of modules and other tricks.
    However, replacing the dictionary will not necessarily work as expected and
-   deleting essential items from the dictionary may cause Python to fail.
+   deleting essential items from the dictionary may cause Python to fail.  If
+   you want to iterate over this global dictionary always use
+   ``sys.modules.copy()`` or ``tuple(sys.modules)`` to avoid exceptions as its
+   size may change during iteration as a side effect of code or activity in
+   other threads.
 
 
 .. data:: orig_argv


### PR DESCRIPTION
This is true of all dictionaries in Python, but this one tends to
catch people off guard as they don't realize when sys.modules might
change out from underneath them as a hidden side effect of their
code.  Copying it first avoids the RuntimeError.  An example when
this happens in single threaded code are codecs being loaded which
are an implicit time of use import that most need not think about.

<!-- issue-number: [bpo-45353](https://bugs.python.org/issue45353) -->
https://bugs.python.org/issue45353
<!-- /issue-number -->
