### PR TITLE
bpo-45421: Remove dead code from html.parser

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -328,13 +328,6 @@ class HTMLParser(_markupbase.ParserBase):
 
         end = rawdata[k:endpos].strip()
         if end not in (">", "/>"):
-            lineno, offset = self.getpos()
-            if "\n" in self.__starttag_text:
-                lineno = lineno + self.__starttag_text.count("\n")
-                offset = len(self.__starttag_text) \
-                         - self.__starttag_text.rfind("\n")
-            else:
-                offset = offset + len(self.__starttag_text)
             self.handle_data(rawdata[i:endpos])
             return endpos
         if end.endswith('/>'):


### PR DESCRIPTION
Support for HtmlParserError was removed back in 2014 with commit
73a4359eb0eb624c588c5d52083ea4944f9787ea, however this small block was
missed.


<!-- issue-number: [bpo-45421](https://bugs.python.org/issue45421) -->
https://bugs.python.org/issue45421
<!-- /issue-number -->
