### PR TITLE
bpo-45428: Strip trailing '\n' from filename

### DIFF
--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -194,6 +194,7 @@ def main():
     else:
         filenames = args.filenames
     for filename in filenames:
+        filename = filename.rstrip('\n')
         try:
             compile(filename, doraise=True)
         except PyCompileError as error:

--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -190,11 +190,10 @@ def main():
     )
     args = parser.parse_args()
     if args.filenames == ['-']:
-        filenames = sys.stdin.readlines()
+        filenames = [filename.rstrip('\n') for filename in sys.stdin.readlines()]
     else:
         filenames = args.filenames
     for filename in filenames:
-        filename = filename.rstrip('\n')
         try:
             compile(filename, doraise=True)
         except PyCompileError as error:

--- a/Misc/NEWS.d/next/Library/2021-10-14-18-04-17.bpo-45428.mM2War.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-14-18-04-17.bpo-45428.mM2War.rst
@@ -1,0 +1,1 @@
+Fix a regression in py_compile when reading filenames from standard input.


### PR DESCRIPTION
This was dropped in daff390 and breaks reading the list of files to compile from stdin


<!-- issue-number: [bpo-45428](https://bugs.python.org/issue45428) -->
https://bugs.python.org/issue45428
<!-- /issue-number -->
