### PR TITLE
Documentation: 'mapping' appears in the paragraph devoted to classes

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1017,7 +1017,7 @@ A class pattern represents a class and its positional and keyword arguments
 
 The same keyword should not be repeated in class patterns.
 
-The following is the logical flow for matching a mapping pattern against a
+The following is the logical flow for matching a class pattern against a
 subject value:
 
 #. If ``name_or_attr`` is not an instance of the builtin :class:`type` , raise


### PR DESCRIPTION
Needs backport to 3.10
