### PR TITLE
bpo-45416: Fix use of asyncio.Condition() with explicit Lock objects

### DIFF
--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -230,8 +230,6 @@ class Condition(_ContextManagerMixin, mixins._LoopBoundMixin):
         super().__init__(loop=loop)
         if lock is None:
             lock = Lock()
-        elif lock._loop is not self._get_loop():
-            raise ValueError("loop argument must agree with lock")
 
         self._lock = lock
         # Export the lock's locked(), acquire() and release() methods.

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -735,7 +735,9 @@ class ConditionTests(test_utils.TestCase):
             self.assertFalse(cond.locked())
             async with lock:
                 self.assertTrue(lock.locked())
+                self.assertTrue(cond.locked())
             self.assertFalse(lock.locked())
+            self.assertFalse(cond.locked())
 
         # All should work in the same way.
         self.loop.run_until_complete(f())
@@ -749,7 +751,7 @@ class ConditionTests(test_utils.TestCase):
 
         async def wrong_loop_in_lock():
             with self.assertRaises(TypeError):
-                lock = asyncio.Lock(loop=loop)  # actively disallowed since 3.10
+                asyncio.Lock(loop=loop)  # actively disallowed since 3.10
             lock = asyncio.Lock()
             lock._loop = loop  # use private API for testing
             async with lock:

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -772,7 +772,7 @@ class ConditionTests(test_utils.TestCase):
             async with lock:
                 cond = asyncio.Condition(lock)
                 with self.assertRaises(TypeError):
-                    cond = asyncio.Condition(lock, loop=loop)
+                    asyncio.Condition(lock, loop=loop)
                 cond._loop = loop
                 with self.assertRaisesRegex(
                     RuntimeError,

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -726,10 +726,12 @@ class ConditionTests(test_utils.TestCase):
             if cond is None:
                 cond = asyncio.Condition(lock)
             self.assertIs(cond._lock, lock)
-            # should work same!
+            self.assertFalse(lock.locked())
             self.assertFalse(cond.locked())
             async with cond:
+                self.assertTrue(lock.locked())
                 self.assertTrue(cond.locked())
+            self.assertFalse(lock.locked())
             self.assertFalse(cond.locked())
             async with lock:
                 self.assertTrue(lock.locked())

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -770,9 +770,9 @@ class ConditionTests(test_utils.TestCase):
             # Same analogy here with the condition's loop.
             lock = asyncio.Lock()
             async with lock:
-                cond = asyncio.Condition(lock)
                 with self.assertRaises(TypeError):
                     asyncio.Condition(lock, loop=loop)
+                cond = asyncio.Condition(lock)
                 cond._loop = loop
                 with self.assertRaisesRegex(
                     RuntimeError,

--- a/Misc/NEWS.d/next/Library/2021-10-10-09-42-34.bpo-45416.n35O0_.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-10-09-42-34.bpo-45416.n35O0_.rst
@@ -1,0 +1,2 @@
+Fix use of :class:`asyncio.Condition` with explicit :class:`asyncio.Lock` objects, which was a regression due to removal of explicit loop arguments.
+Patch by Joongi Kim.


### PR DESCRIPTION
Both `asyncio.Lock` and `asyncio.Condition` contacts the event loop in a deferred manner,
when they really need to make a future to wait on.

So the loop-match validation should be delegated to `asyncio.mixins._LoopBoundMixin._get_loop()`
and removed from the constructor of `asyncio.Condition`.

The above change requires updates on two test cases:
* `test_explicit_loop()` should not assert on the removed check in the constructor of
  `asyncio.Condition`, and it should be updated to simply test setting of the explicit lock
  instance.  I also changed it to repeat the routines of `test_context_manager()` to expose
  the symptom reported in [bpo-45416](https://bugs.python.org/issue45416) when the change of `asyncio.Condition` constructor
  is not applied.
* `test_ambiguous_loops()` must be updated accordingly to trigger actual
  waiting on the lock to happen and `_LoopBoundMixin._get_loop()` to detect
  the wrong event loop attachment.


<!-- issue-number: [bpo-45416](https://bugs.python.org/issue45416) -->
https://bugs.python.org/issue45416
<!-- /issue-number -->
