### PR TITLE
bpo-45401: Fix a resource warning in test_logging

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5324,6 +5324,7 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
         time.sleep(1.1)    # a little over a second ...
         r = logging.makeLogRecord({'msg': 'testing - device file'})
         self.assertFalse(fh.shouldRollover(r))
+        fh.close()
 
     # other test methods added below
     def test_rollover(self):


### PR DESCRIPTION


<!-- issue-number: [bpo-45401](https://bugs.python.org/issue45401) -->
https://bugs.python.org/issue45401
<!-- /issue-number -->
