### PR TITLE
bpo-45401: Fix ResourceWarning in test_logging

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5321,6 +5321,7 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
         # See bpo-45401. Should only ever rollover regular files
         fh = logging.handlers.TimedRotatingFileHandler(
                 os.devnull, 'S', encoding="utf-8", backupCount=1)
+        self.addCleanup(fh.close)
         time.sleep(1.1)    # a little over a second ...
         r = logging.makeLogRecord({'msg': 'testing - device file'})
         self.assertFalse(fh.shouldRollover(r))


### PR DESCRIPTION
Fix ResourceWarning in test_logging.test_should_not_rollover().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45401](https://bugs.python.org/issue45401) -->
https://bugs.python.org/issue45401
<!-- /issue-number -->
