### PR TITLE
bpo-45434: Clean-up Python.h header file

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -1,83 +1,50 @@
+// Entry point of the Python C API.
+// C extensions should only #include <Python.h>, and not include directly
+// the other Python header files included by <Python.h>.
+
 #ifndef Py_PYTHON_H
 #define Py_PYTHON_H
-/* Since this is a "meta-include" file, no #ifdef __cplusplus / extern "C" { */
 
-/* Include nearly all Python header files */
+// Since this is a "meta-include" file, no #ifdef __cplusplus / extern "C" {
 
+// Include Python header files
 #include "patchlevel.h"
 #include "pyconfig.h"
 #include "pymacconfig.h"
 
-#include <limits.h>
-
-#ifndef UCHAR_MAX
-#error "Something's broken.  UCHAR_MAX should be defined in limits.h."
-#endif
-
-#if UCHAR_MAX != 255
-#error "Python's source code assumes C's unsigned char is an 8-bit type."
-#endif
-
 #if defined(__sgi) && !defined(_SGI_MP_SOURCE)
-#define _SGI_MP_SOURCE
+#  define _SGI_MP_SOURCE
 #endif
 
-#include <stdio.h>
+#include <stdio.h>                // NULL, FILE*
 #ifndef NULL
 #   error "Python.h requires that stdio.h define NULL."
 #endif
 
-#include <string.h>
+#include <string.h>               // memcpy()
 #ifdef HAVE_ERRNO_H
-#include <errno.h>
+#  include <errno.h>              // errno
 #endif
 #include <stdlib.h>
 #ifndef MS_WINDOWS
-#include <unistd.h>
+#  include <unistd.h>
 #endif
-
-/* For size_t? */
 #ifdef HAVE_STDDEF_H
-#include <stddef.h>
+   // For size_t
+#  include <stddef.h>
 #endif
 
-/* CAUTION:  Build setups should ensure that NDEBUG is defined on the
- * compiler command line when building Python in release mode; else
- * assert() calls won't be removed.
- */
 #include <assert.h>
 
 #include "pyport.h"
 #include "pymacro.h"
-
-/* A convenient way for code to know if sanitizers are enabled. */
-#if defined(__has_feature)
-#  if __has_feature(memory_sanitizer)
-#    if !defined(_Py_MEMORY_SANITIZER)
-#      define _Py_MEMORY_SANITIZER
-#    endif
-#  endif
-#  if __has_feature(address_sanitizer)
-#    if !defined(_Py_ADDRESS_SANITIZER)
-#      define _Py_ADDRESS_SANITIZER
-#    endif
-#  endif
-#elif defined(__GNUC__)
-#  if defined(__SANITIZE_ADDRESS__)
-#    define _Py_ADDRESS_SANITIZER
-#  endif
-#endif
-
 #include "pymath.h"
 #include "pymem.h"
-
 #include "object.h"
 #include "objimpl.h"
 #include "typeslots.h"
 #include "pyhash.h"
-
 #include "cpython/pydebug.h"
-
 #include "bytearrayobject.h"
 #include "bytesobject.h"
 #include "unicodeobject.h"
@@ -115,15 +82,12 @@
 #include "namespaceobject.h"
 #include "cpython/picklebufobject.h"
 #include "cpython/pytime.h"
-
 #include "codecs.h"
 #include "pyerrors.h"
-
 #include "cpython/initconfig.h"
 #include "pythread.h"
 #include "pystate.h"
 #include "context.h"
-
 #include "modsupport.h"
 #include "compile.h"
 #include "pythonrun.h"
@@ -133,12 +97,9 @@
 #include "osmodule.h"
 #include "intrcheck.h"
 #include "import.h"
-
 #include "abstract.h"
 #include "bltinmodule.h"
-
 #include "eval.h"
-
 #include "cpython/pyctype.h"
 #include "pystrtod.h"
 #include "pystrcmp.h"

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -5,6 +5,14 @@
 
 #include <inttypes.h>
 
+#include <limits.h>
+#ifndef UCHAR_MAX
+#  error "limits.h must define UCHAR_MAX"
+#endif
+#if UCHAR_MAX != 255
+#  error "Python's source code assumes C's unsigned char is an 8-bit type"
+#endif
+
 
 /* Defines to build Python and its standard library:
  *
@@ -850,5 +858,23 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #  define _Py__has_builtin(x) 0
 #endif
 
+
+/* A convenient way for code to know if sanitizers are enabled. */
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+#    if !defined(_Py_MEMORY_SANITIZER)
+#      define _Py_MEMORY_SANITIZER
+#    endif
+#  endif
+#  if __has_feature(address_sanitizer)
+#    if !defined(_Py_ADDRESS_SANITIZER)
+#      define _Py_ADDRESS_SANITIZER
+#    endif
+#  endif
+#elif defined(__GNUC__)
+#  if defined(__SANITIZE_ADDRESS__)
+#    define _Py_ADDRESS_SANITIZER
+#  endif
+#endif
 
 #endif /* Py_PYPORT_H */


### PR DESCRIPTION
* Move limits.h include and UCHAR_MAX checks to pyport.h
* Move sanitizers macros to pyport.h
* Remove comment about <assert.h>: C extensions are built with NDEBUG
  automatically by Python.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
