### PR TITLE
bpo-45410: Add test.support.flush_std_streams()

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -607,6 +607,15 @@ The :mod:`test.support` module defines the following functions:
    target of the "as" clause, if there is one.
 
 
+.. function:: flush_std_streams()
+
+   Call the ``flush()`` method on :data:`sys.stdout` and then on
+   :data:`sys.stderr`. It can be used to make sure that the logs order is
+   consistent before writing into stderr.
+
+   .. versionadded:: 3.11
+
+
 .. function:: print_warning(msg)
 
    Print a warning into :data:`sys.__stderr__`. Format the message as:

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -68,20 +68,13 @@ def print_warning(msg):
 orig_unraisablehook = None
 
 
-def flush_std_streams():
-    if sys.stdout is not None:
-        sys.stdout.flush()
-    if sys.stderr is not None:
-        sys.stderr.flush()
-
-
 def regrtest_unraisable_hook(unraisable):
     global orig_unraisablehook
     support.environment_altered = True
     print_warning("Unraisable exception")
     old_stderr = sys.stderr
     try:
-        flush_std_streams()
+        support.flush_std_streams()
         sys.stderr = sys.__stderr__
         orig_unraisablehook(unraisable)
         sys.stderr.flush()
@@ -104,7 +97,7 @@ def regrtest_threading_excepthook(args):
     print_warning(f"Uncaught thread exception: {args.exc_type.__name__}")
     old_stderr = sys.stderr
     try:
-        flush_std_streams()
+        support.flush_std_streams()
         sys.stderr = sys.__stderr__
         orig_threading_excepthook(args)
         sys.stderr.flush()

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1167,7 +1167,16 @@ def run_doctest(module, verbosity=None, optionflags=0):
 #=======================================================================
 # Support for saving and restoring the imported modules.
 
+def flush_std_streams():
+    if sys.stdout is not None:
+        sys.stdout.flush()
+    if sys.stderr is not None:
+        sys.stderr.flush()
+
+
 def print_warning(msg):
+    # bpo-45410: Explicitly flush stdout to keep logs in order
+    flush_std_streams()
     # bpo-39983: Print into sys.__stderr__ to display the warning even
     # when sys.stderr is captured temporarily by a test
     for line in msg.splitlines():


### PR DESCRIPTION
support.print_warning() now flushs sys.stdout.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45410](https://bugs.python.org/issue45410) -->
https://bugs.python.org/issue45410
<!-- /issue-number -->
