### PR TITLE
bpo-45434: Python.h no longer includes <stdlib.h>

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -552,6 +552,10 @@ Porting to Python 3.11
 
   (Contributed by Victor Stinner in :issue:`39573`.)
 
+* The ``<Python.h>`` header file no longer includes ``<stdlib.h>``. C
+  extensions using ``<stdlib.h>`` must now include it explicitly.
+  (Contributed by Victor Stinner in :issue:`45434`.)
+
 Deprecated
 ----------
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -25,7 +25,6 @@
 #ifdef HAVE_ERRNO_H
 #  include <errno.h>              // errno
 #endif
-#include <stdlib.h>
 #ifndef MS_WINDOWS
 #  include <unistd.h>
 #endif

--- a/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
@@ -1,0 +1,3 @@
+The ``<Python.h>`` header file no longer includes ``<stdlib.h>``. C
+extensions using ``<stdlib.h>`` must now include it explicitly. Patch by
+Victor Stinner.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
