### PR TITLE
bpo-45439: _PyObject_Call() only checks tp_vectorcall_offset once

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -71,6 +71,7 @@ PyVectorcall_Function(PyObject *callable)
         return NULL;
     }
     assert(PyCallable_Check(callable));
+
     offset = tp->tp_vectorcall_offset;
     assert(offset > 0);
     memcpy(&ptr, (char *) callable + offset, sizeof(ptr));


### PR DESCRIPTION
Add _PyVectorcall_Call() helper function.

Add "assert(PyCallable_Check(callable));" to PyVectorcall_Call(),
similar check than PyVectorcall_Function().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45439](https://bugs.python.org/issue45439) -->
https://bugs.python.org/issue45439
<!-- /issue-number -->
