### PR TITLE
bpo-45439: Rename _PyObject_CallNoArg() to _PyObject_CallNoArgs()

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -163,7 +163,7 @@ _PyObject_FastCall(PyObject *func, PyObject *const *args, Py_ssize_t nargs)
    Private static inline function variant of public function
    PyObject_CallNoArgs(). */
 static inline PyObject *
-_PyObject_CallNoArg(PyObject *func) {
+_PyObject_CallNoArgs(PyObject *func) {
     PyThreadState *tstate = PyThreadState_Get();
     return _PyObject_VectorcallTstate(tstate, func, NULL, 0, NULL);
 }

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -29,7 +29,7 @@ PyAPI_FUNC(PyObject *) _PyObject_Call(
     PyObject *kwargs);
 
 static inline PyObject *
-_PyObject_CallNoArgTstate(PyThreadState *tstate, PyObject *func) {
+_PyObject_CallNoArgsTstate(PyThreadState *tstate, PyObject *func) {
     return _PyObject_VectorcallTstate(tstate, func, NULL, 0, NULL);
 }
 

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2010,7 +2010,7 @@ defdict_missing(defdictobject *dd, PyObject *key)
         Py_DECREF(tup);
         return NULL;
     }
-    value = _PyObject_CallNoArg(factory);
+    value = _PyObject_CallNoArgs(factory);
     if (value == NULL)
         return value;
     if (PyObject_SetItem((PyObject *)dd, key, value) < 0) {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -216,7 +216,7 @@ PyDict_SetItemProxy(PyObject *dict, PyObject *key, PyObject *item)
     PyObject *proxy;
     int result;
 
-    obj = _PyObject_CallNoArg((PyObject *)&DictRemover_Type);
+    obj = _PyObject_CallNoArgs((PyObject *)&DictRemover_Type);
     if (obj == NULL)
         return -1;
 
@@ -506,7 +506,7 @@ StructUnionType_new(PyTypeObject *type, PyObject *args, PyObject *kwds, int isSt
         return NULL;
     }
 
-    dict = (StgDictObject *)_PyObject_CallNoArg((PyObject *)&PyCStgDict_Type);
+    dict = (StgDictObject *)_PyObject_CallNoArgs((PyObject *)&PyCStgDict_Type);
     if (!dict) {
         Py_DECREF(result);
         return NULL;
@@ -1067,7 +1067,7 @@ PyCPointerType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
   stgdict items size, align, length contain info about pointers itself,
   stgdict->proto has info about the pointed to type!
 */
-    stgdict = (StgDictObject *)_PyObject_CallNoArg(
+    stgdict = (StgDictObject *)_PyObject_CallNoArgs(
         (PyObject *)&PyCStgDict_Type);
     if (!stgdict)
         return NULL;
@@ -1550,7 +1550,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         goto error;
     }
 
-    stgdict = (StgDictObject *)_PyObject_CallNoArg(
+    stgdict = (StgDictObject *)_PyObject_CallNoArgs(
         (PyObject *)&PyCStgDict_Type);
     if (!stgdict)
         goto error;
@@ -2006,7 +2006,7 @@ static PyObject *CreateSwappedType(PyTypeObject *type, PyObject *args, PyObject 
     if (result == NULL)
         return NULL;
 
-    stgdict = (StgDictObject *)_PyObject_CallNoArg(
+    stgdict = (StgDictObject *)_PyObject_CallNoArgs(
         (PyObject *)&PyCStgDict_Type);
     if (!stgdict) {
         Py_DECREF(result);
@@ -2120,7 +2120,7 @@ PyCSimpleType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         goto error;
     }
 
-    stgdict = (StgDictObject *)_PyObject_CallNoArg(
+    stgdict = (StgDictObject *)_PyObject_CallNoArgs(
         (PyObject *)&PyCStgDict_Type);
     if (!stgdict)
         goto error;
@@ -2560,7 +2560,7 @@ PyCFuncPtrType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyTypeObject *result;
     StgDictObject *stgdict;
 
-    stgdict = (StgDictObject *)_PyObject_CallNoArg(
+    stgdict = (StgDictObject *)_PyObject_CallNoArgs(
         (PyObject *)&PyCStgDict_Type);
     if (!stgdict)
         return NULL;
@@ -3985,10 +3985,10 @@ _build_callargs(PyCFuncPtrObject *self, PyObject *argtypes,
                 goto error;
             }
             if (PyCArrayTypeObject_Check(ob))
-                ob = _PyObject_CallNoArg(ob);
+                ob = _PyObject_CallNoArgs(ob);
             else
                 /* Create an instance of the pointed-to type */
-                ob = _PyObject_CallNoArg(dict->proto);
+                ob = _PyObject_CallNoArgs(dict->proto);
             /*
                XXX Is the following correct any longer?
                We must not pass a byref() to the array then but
@@ -5596,7 +5596,7 @@ cast(void *ptr, PyObject *src, PyObject *ctype)
     CDataObject *result;
     if (0 == cast_check_pointertype(ctype))
         return NULL;
-    result = (CDataObject *)_PyObject_CallNoArg(ctype);
+    result = (CDataObject *)_PyObject_CallNoArgs(ctype);
     if (result == NULL)
         return NULL;
 

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -187,7 +187,7 @@ static void _CallPythonObject(void *mem,
             */
         } else if (dict) {
             /* Hm, shouldn't we use PyCData_AtAddress() or something like that instead? */
-            CDataObject *obj = (CDataObject *)_PyObject_CallNoArg(cnv);
+            CDataObject *obj = (CDataObject *)_PyObject_CallNoArgs(cnv);
             if (!obj) {
                 PrintError("create argument %zd:\n", i);
                 Py_DECREF(cnv);
@@ -572,7 +572,7 @@ long Call_CanUnloadNow(void)
         return E_FAIL;
     }
 
-    result = _PyObject_CallNoArg(func);
+    result = _PyObject_CallNoArgs(func);
     Py_DECREF(func);
     if (!result) {
         PyErr_WriteUnraisable(context ? context : Py_None);

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -61,7 +61,7 @@ PyCField_FromDesc(PyObject *desc, Py_ssize_t index,
 #define CONT_BITFIELD 2
 #define EXPAND_BITFIELD 3
 
-    self = (CFieldObject *)_PyObject_CallNoArg((PyObject *)&PyCField_Type);
+    self = (CFieldObject *)_PyObject_CallNoArgs((PyObject *)&PyCField_Type);
     if (self == NULL)
         return NULL;
     dict = PyType_stgdict(desc);

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -248,7 +248,7 @@ MakeFields(PyObject *type, CFieldObject *descr,
             }
             continue;
         }
-        new_descr = (CFieldObject *)_PyObject_CallNoArg((PyObject *)&PyCField_Type);
+        new_descr = (CFieldObject *)_PyObject_CallNoArgs((PyObject *)&PyCField_Type);
         if (new_descr == NULL) {
             Py_DECREF(fdescr);
             Py_DECREF(fieldlist);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1440,7 +1440,7 @@ static int
 _functools_exec(PyObject *module)
 {
     _functools_state *state = get_functools_state(module);
-    state->kwd_mark = _PyObject_CallNoArg((PyObject *)&PyBaseObject_Type);
+    state->kwd_mark = _PyObject_CallNoArgs((PyObject *)&PyBaseObject_Type);
     if (state->kwd_mark == NULL) {
         return -1;
     }

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1550,7 +1550,7 @@ _bufferedreader_read_all(buffered *self)
         goto cleanup;
     }
     if (readall) {
-        tmp = _PyObject_CallNoArg(readall);
+        tmp = _PyObject_CallNoArgs(readall);
         Py_DECREF(readall);
         if (tmp == NULL)
             goto cleanup;

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -76,7 +76,7 @@ _lsprof_get_state(PyObject *module)
 
 static _PyTime_t CallExternalTimer(ProfilerObject *pObj)
 {
-    PyObject *o = _PyObject_CallNoArg(pObj->externalTimer);
+    PyObject *o = _PyObject_CallNoArgs(pObj->externalTimer);
     if (o == NULL) {
         PyErr_WriteUnraisable(pObj->externalTimer);
         return 0;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -710,7 +710,7 @@ step_callback(sqlite3_context *context, int argc, sqlite3_value **params)
     if (*aggregate_instance == NULL) {
         callback_context *ctx = (callback_context *)sqlite3_user_data(context);
         assert(ctx != NULL);
-        *aggregate_instance = _PyObject_CallNoArg(ctx->callable);
+        *aggregate_instance = _PyObject_CallNoArgs(ctx->callable);
         if (!*aggregate_instance) {
             set_sqlite_error(context,
                     "user-defined aggregate's '__init__' method raised error");
@@ -1008,7 +1008,7 @@ progress_callback(void *ctx)
 
     assert(ctx != NULL);
     PyObject *callable = ((callback_context *)ctx)->callable;
-    ret = _PyObject_CallNoArg(callable);
+    ret = _PyObject_CallNoArgs(callable);
     if (!ret) {
         /* abort query if error occurred */
         rc = -1;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3773,7 +3773,7 @@ _password_callback(char *buf, int size, int rwflag, void *userdata)
     }
 
     if (pw_info->callable) {
-        fn_ret = _PyObject_CallNoArg(pw_info->callable);
+        fn_ret = _PyObject_CallNoArgs(pw_info->callable);
         if (!fn_ret) {
             /* TODO: It would be nice to move _ctypes_add_traceback() into the
                core python API, so we could use it to add a frame here */

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2866,7 +2866,7 @@ _make_call(void *callable)
     PyObject *rc;
     int success;
     PyGILState_STATE s = PyGILState_Ensure();
-    rc = _PyObject_CallNoArg((PyObject *)callable);
+    rc = _PyObject_CallNoArgs((PyObject *)callable);
     success = (rc != NULL);
     Py_XDECREF(rc);
     PyGILState_Release(s);
@@ -2937,7 +2937,7 @@ static int _pending_callback(void *arg)
 {
     /* we assume the argument is callable object to which we own a reference */
     PyObject *callable = (PyObject *)arg;
-    PyObject *r = _PyObject_CallNoArg(callable);
+    PyObject *r = _PyObject_CallNoArgs(callable);
     Py_DECREF(callable);
     Py_XDECREF(r);
     return r != NULL ? 0 : -1;
@@ -3729,7 +3729,7 @@ slot_tp_del(PyObject *self)
     /* Execute __del__ method, if any. */
     del = _PyObject_LookupSpecial(self, &PyId___tp_del__);
     if (del != NULL) {
-        res = _PyObject_CallNoArg(del);
+        res = _PyObject_CallNoArgs(del);
         if (res == NULL)
             PyErr_WriteUnraisable(del);
         else
@@ -4358,7 +4358,7 @@ temporary_c_thread(void *data)
     /* Allocate a Python thread state for this thread */
     state = PyGILState_Ensure();
 
-    res = _PyObject_CallNoArg(test_c_thread->callback);
+    res = _PyObject_CallNoArgs(test_c_thread->callback);
     Py_CLEAR(test_c_thread->callback);
 
     if (res == NULL) {
@@ -4893,7 +4893,7 @@ check_pyobject_freed_is_freed(PyObject *self, PyObject *Py_UNUSED(args))
 #ifdef _Py_ADDRESS_SANITIZER
     Py_RETURN_NONE;
 #else
-    PyObject *op = _PyObject_CallNoArg((PyObject *)&PyBaseObject_Type);
+    PyObject *op = _PyObject_CallNoArgs((PyObject *)&PyBaseObject_Type);
     if (op == NULL) {
         return NULL;
     }
@@ -5271,7 +5271,7 @@ bad_get(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         return NULL;
     }
 
-    PyObject *res = _PyObject_CallNoArg(cls);
+    PyObject *res = _PyObject_CallNoArgs(cls);
     if (res == NULL) {
         return NULL;
     }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1058,7 +1058,7 @@ itertools_tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n)
 
     PyTuple_SET_ITEM(result, 0, copyable);
     for (i = 1; i < n; i++) {
-        copyable = _PyObject_CallNoArg(copyfunc);
+        copyable = _PyObject_CallNoArgs(copyfunc);
         if (copyable == NULL) {
             Py_DECREF(copyfunc);
             Py_DECREF(result);

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -457,7 +457,7 @@ pymain_run_interactive_hook(int *exitcode)
         goto error;
     }
 
-    result = _PyObject_CallNoArg(hook);
+    result = _PyObject_CallNoArgs(hook);
     Py_DECREF(hook);
     if (result == NULL) {
         goto error;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1206,7 +1206,7 @@ math_ceil(PyObject *module, PyObject *number)
     if (!PyFloat_CheckExact(number)) {
         PyObject *method = _PyObject_LookupSpecial(number, &PyId___ceil__);
         if (method != NULL) {
-            PyObject *result = _PyObject_CallNoArg(method);
+            PyObject *result = _PyObject_CallNoArgs(method);
             Py_DECREF(method);
             return result;
         }
@@ -1275,7 +1275,7 @@ math_floor(PyObject *module, PyObject *number)
     {
         PyObject *method = _PyObject_LookupSpecial(number, &PyId___floor__);
         if (method != NULL) {
-            PyObject *result = _PyObject_CallNoArg(method);
+            PyObject *result = _PyObject_CallNoArgs(method);
             Py_DECREF(method);
             return result;
         }
@@ -2130,7 +2130,7 @@ math_trunc(PyObject *module, PyObject *x)
                          Py_TYPE(x)->tp_name);
         return NULL;
     }
-    result = _PyObject_CallNoArg(trunc);
+    result = _PyObject_CallNoArgs(trunc);
     Py_DECREF(trunc);
     return result;
 }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -561,7 +561,7 @@ run_at_forkers(PyObject *lst, int reverse)
             for (i = 0; i < PyList_GET_SIZE(cpy); i++) {
                 PyObject *func, *res;
                 func = PyList_GET_ITEM(cpy, i);
-                res = _PyObject_CallNoArg(func);
+                res = _PyObject_CallNoArgs(func);
                 if (res == NULL)
                     PyErr_WriteUnraisable(func);
                 else
@@ -1183,7 +1183,7 @@ path_converter(PyObject *o, void *p)
         if (NULL == func) {
             goto error_format;
         }
-        res = _PyObject_CallNoArg(func);
+        res = _PyObject_CallNoArgs(func);
         Py_DECREF(func);
         if (NULL == res) {
             goto error_exit;
@@ -14380,7 +14380,7 @@ PyOS_FSPath(PyObject *path)
                             _PyType_Name(Py_TYPE(path)));
     }
 
-    path_repr = _PyObject_CallNoArg(func);
+    path_repr = _PyObject_CallNoArgs(func);
     Py_DECREF(func);
     if (NULL == path_repr) {
         return NULL;

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -114,7 +114,7 @@ PyObject_LengthHint(PyObject *o, Py_ssize_t defaultvalue)
         }
         return defaultvalue;
     }
-    result = _PyObject_CallNoArg(hint);
+    result = _PyObject_CallNoArgs(hint);
     Py_DECREF(hint);
     if (result == NULL) {
         PyThreadState *tstate = _PyThreadState_GET();
@@ -1576,7 +1576,7 @@ PyNumber_Long(PyObject *o)
     }
     trunc_func = _PyObject_LookupSpecial(o, &PyId___trunc__);
     if (trunc_func) {
-        result = _PyObject_CallNoArg(trunc_func);
+        result = _PyObject_CallNoArgs(trunc_func);
         Py_DECREF(trunc_func);
         if (result == NULL || PyLong_CheckExact(result)) {
             return result;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -572,7 +572,7 @@ format_obj(PyObject *v, const char **pbuf, Py_ssize_t *plen)
     /* does it support __bytes__? */
     func = _PyObject_LookupSpecial(v, &PyId___bytes__);
     if (func != NULL) {
-        result = _PyObject_CallNoArg(func);
+        result = _PyObject_CallNoArgs(func);
         Py_DECREF(func);
         if (result == NULL)
             return NULL;
@@ -2622,7 +2622,7 @@ bytes_new_impl(PyTypeObject *type, PyObject *x, const char *encoding,
        integer argument before deferring to PyBytes_FromObject, something
        PyObject_Bytes doesn't do. */
     else if ((func = _PyObject_LookupSpecial(x, &PyId___bytes__)) != NULL) {
-        bytes = _PyObject_CallNoArg(func);
+        bytes = _PyObject_CallNoArgs(func);
         Py_DECREF(func);
         if (bytes == NULL)
             return NULL;

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1,5 +1,5 @@
 #include "Python.h"
-#include "pycore_call.h"          // _PyObject_CallNoArgTstate()
+#include "pycore_call.h"          // _PyObject_CallNoArgsTstate()
 #include "pycore_ceval.h"         // _PyEval_EvalFrame()
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include "pycore_pyerrors.h"      // _PyErr_Occurred()
@@ -110,7 +110,7 @@ PyObject *
 PyObject_CallNoArgs(PyObject *func)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    return _PyObject_CallNoArgTstate(tstate, func);
+    return _PyObject_CallNoArgsTstate(tstate, func);
 }
 
 
@@ -389,7 +389,7 @@ PyObject_CallObject(PyObject *callable, PyObject *args)
     PyThreadState *tstate = _PyThreadState_GET();
     assert(!_PyErr_Occurred(tstate));
     if (args == NULL) {
-        return _PyObject_CallNoArgTstate(tstate, callable);
+        return _PyObject_CallNoArgsTstate(tstate, callable);
     }
     if (!PyTuple_Check(args)) {
         _PyErr_SetString(tstate, PyExc_TypeError,
@@ -455,7 +455,7 @@ _PyObject_CallFunctionVa(PyThreadState *tstate, PyObject *callable,
     }
 
     if (!format || !*format) {
-        return _PyObject_CallNoArgTstate(tstate, callable);
+        return _PyObject_CallNoArgsTstate(tstate, callable);
     }
 
     if (is_size_t) {

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -284,7 +284,7 @@ try_complex_special_method(PyObject *op)
 
     f = _PyObject_LookupSpecial(op, &PyId___complex__);
     if (f) {
-        PyObject *res = _PyObject_CallNoArg(f);
+        PyObject *res = _PyObject_CallNoArgs(f);
         Py_DECREF(f);
         if (!res || PyComplex_CheckExact(res)) {
             return res;

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1897,7 +1897,7 @@ _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)
     PyObject *d;
     int status;
 
-    d = _PyObject_CallNoArg(cls);
+    d = _PyObject_CallNoArgs(cls);
     if (d == NULL)
         return NULL;
 

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -298,7 +298,7 @@ reversed_new_impl(PyTypeObject *type, PyObject *seq)
         return NULL;
     }
     if (reversed_meth != NULL) {
-        PyObject *res = _PyObject_CallNoArg(reversed_meth);
+        PyObject *res = _PyObject_CallNoArgs(reversed_meth);
         Py_DECREF(reversed_meth);
         return res;
     }

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -190,7 +190,7 @@ PyObject_AsFileDescriptor(PyObject *o)
         return -1;
     }
     else if (meth != NULL) {
-        PyObject *fno = _PyObject_CallNoArg(meth);
+        PyObject *fno = _PyObject_CallNoArgs(meth);
         Py_DECREF(meth);
         if (fno == NULL)
             return -1;

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -319,7 +319,7 @@ gen_close_iter(PyObject *yf)
             PyErr_WriteUnraisable(yf);
         }
         if (meth) {
-            retval = _PyObject_CallNoArg(meth);
+            retval = _PyObject_CallNoArgs(meth);
             Py_DECREF(meth);
             if (retval == NULL)
                 return -1;

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -217,7 +217,7 @@ calliter_iternext(calliterobject *it)
         return NULL;
     }
 
-    result = _PyObject_CallNoArg(it->it_callable);
+    result = _PyObject_CallNoArgs(it->it_callable);
     if (result != NULL) {
         int ok;
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -866,7 +866,7 @@ module_dir(PyObject *self, PyObject *args)
         if (PyDict_Check(dict)) {
             PyObject *dirfunc = _PyDict_GetItemIdWithError(dict, &PyId___dir__);
             if (dirfunc) {
-                result = _PyObject_CallNoArg(dirfunc);
+                result = _PyObject_CallNoArgs(dirfunc);
             }
             else if (!PyErr_Occurred()) {
                 result = PyDict_Keys(dict);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -560,7 +560,7 @@ PyObject_Bytes(PyObject *v)
 
     func = _PyObject_LookupSpecial(v, &PyId___bytes__);
     if (func != NULL) {
-        result = _PyObject_CallNoArg(func);
+        result = _PyObject_CallNoArgs(func);
         Py_DECREF(func);
         if (result == NULL)
             return NULL;
@@ -1521,7 +1521,7 @@ _dir_object(PyObject *obj)
         return NULL;
     }
     /* use __dir__ */
-    result = _PyObject_CallNoArg(dirfunc);
+    result = _PyObject_CallNoArgs(dirfunc);
     Py_DECREF(dirfunc);
     if (result == NULL)
         return NULL;

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1203,7 +1203,7 @@ odict_copy(register PyODictObject *od, PyObject *Py_UNUSED(ignored))
     if (PyODict_CheckExact(od))
         od_copy = PyODict_New();
     else
-        od_copy = _PyObject_CallNoArg((PyObject *)Py_TYPE(od));
+        od_copy = _PyObject_CallNoArgs((PyObject *)Py_TYPE(od));
     if (od_copy == NULL)
         return NULL;
 
@@ -2221,7 +2221,7 @@ mutablemapping_update_arg(PyObject *self, PyObject *arg)
         return -1;
     }
     if (func != NULL) {
-        PyObject *keys = _PyObject_CallNoArg(func);
+        PyObject *keys = _PyObject_CallNoArgs(func);
         Py_DECREF(func);
         if (keys == NULL) {
             return -1;
@@ -2253,7 +2253,7 @@ mutablemapping_update_arg(PyObject *self, PyObject *arg)
         return -1;
     }
     if (func != NULL) {
-        PyObject *items = _PyObject_CallNoArg(func);
+        PyObject *items = _PyObject_CallNoArgs(func);
         Py_DECREF(func);
         if (items == NULL) {
             return -1;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1640,7 +1640,7 @@ call_unbound_noarg(int unbound, PyObject *func, PyObject *self)
         return PyObject_CallOneArg(func, self);
     }
     else {
-        return _PyObject_CallNoArg(func);
+        return _PyObject_CallNoArgs(func);
     }
 }
 
@@ -5019,7 +5019,7 @@ _PyObject_GetState(PyObject *obj, int required)
         Py_DECREF(slotnames);
     }
     else { /* getstate != NULL */
-        state = _PyObject_CallNoArg(getstate);
+        state = _PyObject_CallNoArgs(getstate);
         Py_DECREF(getstate);
         if (state == NULL)
             return NULL;
@@ -5044,7 +5044,7 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
        __getnewargs_ex__ on the object. */
     getnewargs_ex = _PyObject_LookupSpecial(obj, &PyId___getnewargs_ex__);
     if (getnewargs_ex != NULL) {
-        PyObject *newargs = _PyObject_CallNoArg(getnewargs_ex);
+        PyObject *newargs = _PyObject_CallNoArgs(getnewargs_ex);
         Py_DECREF(getnewargs_ex);
         if (newargs == NULL) {
             return -1;
@@ -5097,7 +5097,7 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
        __getnewargs__ instead. */
     getnewargs = _PyObject_LookupSpecial(obj, &PyId___getnewargs__);
     if (getnewargs != NULL) {
-        *args = _PyObject_CallNoArg(getnewargs);
+        *args = _PyObject_CallNoArgs(getnewargs);
         Py_DECREF(getnewargs);
         if (*args == NULL) {
             return -1;
@@ -5358,7 +5358,7 @@ object___reduce_ex___impl(PyObject *self, int protocol)
         override = (clsreduce != objreduce);
         Py_DECREF(clsreduce);
         if (override) {
-            res = _PyObject_CallNoArg(reduce);
+            res = _PyObject_CallNoArgs(reduce);
             Py_DECREF(reduce);
             return res;
         }

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -477,7 +477,7 @@ fp_setreadl(struct tok_state *tok, const char* enc)
     Py_XSETREF(tok->decoding_readline, readline);
 
     if (pos > 0) {
-        PyObject *bufobj = _PyObject_CallNoArg(readline);
+        PyObject *bufobj = _PyObject_CallNoArgs(readline);
         if (bufobj == NULL)
             return 0;
         Py_DECREF(bufobj);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2305,7 +2305,7 @@ builtin_round_impl(PyObject *module, PyObject *number, PyObject *ndigits)
     }
 
     if (ndigits == Py_None)
-        result = _PyObject_CallNoArg(round);
+        result = _PyObject_CallNoArgs(round);
     else
         result = PyObject_CallOneArg(round, ndigits);
     Py_DECREF(round);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -867,7 +867,7 @@ match_keys(PyThreadState *tstate, PyObject *map, PyObject *keys)
         goto fail;
     }
     // dummy = object()
-    dummy = _PyObject_CallNoArg((PyObject *)&PyBaseObject_Type);
+    dummy = _PyObject_CallNoArgs((PyObject *)&PyBaseObject_Type);
     if (dummy == NULL) {
         goto fail;
     }
@@ -4295,7 +4295,7 @@ check_eval_breaker:
             }
             SET_TOP(exit);
             Py_DECREF(mgr);
-            res = _PyObject_CallNoArg(enter);
+            res = _PyObject_CallNoArgs(enter);
             Py_DECREF(enter);
             if (res == NULL)
                 goto error;
@@ -4333,7 +4333,7 @@ check_eval_breaker:
             }
             SET_TOP(exit);
             Py_DECREF(mgr);
-            res = _PyObject_CallNoArg(enter);
+            res = _PyObject_CallNoArgs(enter);
             Py_DECREF(enter);
             if (res == NULL) {
                 goto error;
@@ -5859,7 +5859,7 @@ do_raise(PyThreadState *tstate, PyObject *exc, PyObject *cause)
 
     if (PyExceptionClass_Check(exc)) {
         type = exc;
-        value = _PyObject_CallNoArg(exc);
+        value = _PyObject_CallNoArgs(exc);
         if (value == NULL)
             goto raise_error;
         if (!PyExceptionInstance_Check(value)) {
@@ -5890,7 +5890,7 @@ do_raise(PyThreadState *tstate, PyObject *exc, PyObject *cause)
     if (cause) {
         PyObject *fixed_cause;
         if (PyExceptionClass_Check(cause)) {
-            fixed_cause = _PyObject_CallNoArg(cause);
+            fixed_cause = _PyObject_CallNoArgs(cause);
             if (fixed_cause == NULL)
                 goto raise_error;
             Py_DECREF(cause);

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -280,7 +280,7 @@ PyObject *codec_makeincrementalcodec(PyObject *codec_info,
     if (errors)
         ret = PyObject_CallFunction(inccodec, "s", errors);
     else
-        ret = _PyObject_CallNoArg(inccodec);
+        ret = _PyObject_CallNoArgs(inccodec);
     Py_DECREF(inccodec);
     return ret;
 }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -91,7 +91,7 @@ _PyErr_CreateException(PyObject *exception_type, PyObject *value)
     PyObject *exc;
 
     if (value == NULL || value == Py_None) {
-        exc = _PyObject_CallNoArg(exception_type);
+        exc = _PyObject_CallNoArgs(exception_type);
     }
     else if (PyTuple_Check(value)) {
         exc = PyObject_Call(exception_type, value, NULL);

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1292,7 +1292,7 @@ r_object(RFILE *p)
 
         if (n == 0 && type == TYPE_FROZENSET) {
             /* call frozenset() to get the empty frozenset singleton */
-            v = _PyObject_CallNoArg((PyObject*)&PyFrozenSet_Type);
+            v = _PyObject_CallNoArgs((PyObject*)&PyFrozenSet_Type);
             if (v == NULL)
                 break;
             R_REF(v);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1676,7 +1676,7 @@ _PySys_GetSizeOf(PyObject *o)
         }
     }
     else {
-        res = _PyObject_CallNoArg(method);
+        res = _PyObject_CallNoArgs(method);
         Py_DECREF(method);
     }
 


### PR DESCRIPTION
Fix typo in the private _PyObject_CallNoArg() function name: rename
it to _PyObject_CallNoArgs() to be consistent with the public
function PyObject_CallNoArgs().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45439](https://bugs.python.org/issue45439) -->
https://bugs.python.org/issue45439
<!-- /issue-number -->
