### PR TITLE
Add MappingView.mapping for parity with dictview

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -849,10 +849,12 @@ Mapping.register(mappingproxy)
 
 class MappingView(Sized):
 
-    __slots__ = '_mapping',
+    __slots__ = ('_mapping', 'mapping')
 
     def __init__(self, mapping):
         self._mapping = mapping
+        from types import MappingProxyType
+        self.mapping = MappingProxyType(self._mapping)
 
     def __len__(self):
         return len(self._mapping)


### PR DESCRIPTION
As of gh-20749, built-in dictviews now have a `mapping` attribute.

This PR adds the same to `collections.abc.MappingView`, so that non-builtin mappings can get feature parity, not to mention a consistent interface, just by inheriting from `collections.abc.Mapping` (as many already do), without having to add any boilerplate code of their own.

From the associated original issue [bpo-40890](https://bugs.python.org/issue40890), it looks like this was never discussed or considered. Perhaps this would have been added at the same time as gh-20749 if it had been part of the original discussion. Submitting this (currently draft) 3-line PR as a starting point for further discussion. The changes in this PR already make the following code work:

```python
# demo.txt

>>> from collections.abc import Mapping

>>> class MyMapping(Mapping):
...     def __init__(self, source: Mapping):
...         self._source = source
... 
...     def __iter__(self):
...         return iter(self._source)
... 
...     def __len__(self):
...         return len(self._source)
... 
...     def __getitem__(self, key):
...         return self._source[key]
... 
...     def __repr__(self):
...         return f'{self.__class__.__name__}({self._source})'


>>> d = dict(one=1, two=2)
>>> d.keys().mapping
mappingproxy({'one': 1, 'two': 2})

>>> m = MyMapping(d)
>>> m.keys().mapping
mappingproxy(MyMapping({'one': 1, 'two': 2}))
```

```bash
$ ./python.exe -VV
Python 3.11.0a1+ (heads/main-dirty:7103356455, Oct 11 2021, 17:28:12) [Clang 12.0.0 (clang-1200.0.32.29)]

$ ./python.exe -m doctest demo.txt  # no output + exits zero => it works
```

If it makes sense to pursue this, I can create a proper bpo issue and put the finishing touches on this PR.

Context: I noticed this while reviewing the changes in Python 3.10 to see if they called for any corresponding changes to my [bidict](https://github.com/jab/bidict) library, which I believe is one of several libraries that would benefit from fixing this issue.

/cc @rhettinger @sweeneyde et al.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->