### PR TITLE
tiny speedup in shutil fast copy on Windows

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -183,6 +183,7 @@ def _copyfileobj_readinto(fsrc, fdst, length=COPY_BUFSIZE):
             elif n < length:
                 with mv[:n] as smv:
                     fdst_write(smv)
+                break
             else:
                 fdst_write(mv)
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -182,7 +182,7 @@ def _copyfileobj_readinto(fsrc, fdst, length=COPY_BUFSIZE):
                 break
             elif n < length:
                 with mv[:n] as smv:
-                    fdst.write(smv)
+                    fdst_write(smv)
             else:
                 fdst_write(mv)
 


### PR DESCRIPTION
can't see why the final write was doing a 2nd lookup of fdst.write