### PR TITLE
bpo-45417: fix quadratic behaviour when creating an enum

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -237,7 +237,7 @@ class _proto_member:
         # new member becomes an alias to the existing one.
         try:
             try:
-                # try to do a fast lookup to avoid the quadratip loop
+                # try to do a fast lookup to avoid the quadratic loop
                 enum_member = enum_class._value2member_map_[value]
             except TypeError:
                 for name, canonical_member in enum_class._member_map_.items():

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -235,11 +235,18 @@ class _proto_member:
         enum_member._sort_order_ = len(enum_class._member_names_)
         # If another member with the same value was already defined, the
         # new member becomes an alias to the existing one.
-        for name, canonical_member in enum_class._member_map_.items():
-            if canonical_member._value_ == enum_member._value_:
-                enum_member = canonical_member
-                break
-        else:
+        try:
+            try:
+                # try to do a fast lookup to avoid the quadratip loop
+                enum_member = enum_class._value2member_map_[value]
+            except TypeError:
+                for name, canonical_member in enum_class._member_map_.items():
+                    if canonical_member._value_ == value:
+                        enum_member = canonical_member
+                        break
+                else:
+                    raise KeyError
+        except KeyError:
             # this could still be an alias if the value is multi-bit and the
             # class is a flag class
             if (
@@ -301,7 +308,7 @@ class _EnumDict(dict):
     """
     def __init__(self):
         super().__init__()
-        self._member_names = []
+        self._member_names = {} # use a dict to keep insertion order
         self._last_values = []
         self._ignore = []
         self._auto_called = False
@@ -365,7 +372,7 @@ class _EnumDict(dict):
                             )
                     self._auto_called = True
                 value = value.value
-            self._member_names.append(key)
+            self._member_names[key] = None
             self._last_values.append(value)
         super().__setitem__(key, value)
 

--- a/Misc/NEWS.d/next/Library/2021-10-12-20-35-06.bpo-45417.gQM-O7.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-12-20-35-06.bpo-45417.gQM-O7.rst
@@ -1,0 +1,2 @@
+Fix quadratic behaviour in the enum module: Creation of enum classes with a
+lot of entries was quadratic.


### PR DESCRIPTION
We got a [bug report](https://foss.heptapod.net/pypy/pypy/-/issues/3571) in PyPy that creating really big enums was slow, and worse, the performance was growing quadratically in the number of fields. We actually even found two places with quadratic behavior. Both are fixed in this PR:

- in the `_EnumDict` class, the `_member_names` attribute was a list that was continually growing, and every new field was checked for existance using "in" in that list. Replace it with a dict (with None keys) to get both insertion order tracking as well as O(1) lookup.
- When setting the name of a `_proto_member`, there was code that goes through all members to find something. Use the existing dictionary for that lookup if possible.

I am open to ideas how I would test that the slow behavior is fixed without relying on brittle timing checks.

(there is also a *third* place that behaves quadratically: When using `auto()`, the growing `_EnumDict._last_values` list is continually copied for every auto member. Removing that copy fixes the slowness (and tests pass), but I don't understand why it is there in the first place, so I am bit wary of touching it.)

<!-- issue-number: [bpo-45417](https://bugs.python.org/issue45417) -->
https://bugs.python.org/issue45417
<!-- /issue-number -->
