### PR TITLE
Make getpath.c easier to follow.

### DIFF
--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -8,6 +8,23 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#define LOCATION_UNKNOWN 0
+#define LOCATION_EXISTS 2<<0
+#define LOCATION_FORCED 2<<1        /* trusted to exist */
+#define LOCATION_DEFAULT 2<<2       /* the default value */
+#define LOCATION_CUSTOM 2<<3        /* from a file or env var */
+/* build-defined */
+#define LOCATION_PREFIX 2<<10
+#define LOCATION_EXEC_PREFIX 2<<11
+/* build-related */
+#define LOCATION_IN_BUILD_DIR 2<<15
+#define LOCATION_IN_SOURCE_TREE 2<<16
+/* relative */
+#define LOCATION_WITH_FILE 2<<20    /* in the tree under dirname(<file>)
+                                       (combined with LOCATION_NEAR_*) */
+#define LOCATION_NEAR_ARGV0 2<<21   /* based on a parent of argv[0] */
+#define LOCATION_NEAR_LIB 2<<22     /* based on a parent of DLL/SO file */
+
 typedef struct _PyPathConfig {
     /* Full path to the Python program */
     wchar_t *program_full_path;

--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -8,22 +8,22 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#define LOCATION_UNKNOWN 0
-#define LOCATION_EXISTS 2<<0
-#define LOCATION_FORCED 2<<1        /* trusted to exist */
-#define LOCATION_DEFAULT 2<<2       /* the default value */
-#define LOCATION_CUSTOM 2<<3        /* from a file or env var */
+#define LOCATION_UNKNOWN (0)
+#define LOCATION_EXISTS (1<<0)
+#define LOCATION_FORCED (1<<1)      /* trusted to exist */
+#define LOCATION_DEFAULT (1<<2)     /* the default value */
+#define LOCATION_CUSTOM (1<<3)      /* from a file or env var */
 /* build-defined */
-#define LOCATION_PREFIX 2<<10
-#define LOCATION_EXEC_PREFIX 2<<11
+#define LOCATION_PREFIX (1<<10)
+#define LOCATION_EXEC_PREFIX (1<<11)
 /* build-related */
-#define LOCATION_IN_BUILD_DIR 2<<15
-#define LOCATION_IN_SOURCE_TREE 2<<16
+#define LOCATION_IN_BUILD_DIR (1<<15)
+#define LOCATION_IN_SOURCE_TREE (1<<16)
 /* relative */
-#define LOCATION_WITH_FILE 2<<20    /* in the tree under dirname(<file>)
+#define LOCATION_WITH_FILE (1<<20)  /* in the tree under dirname(<file>)
                                        (combined with LOCATION_NEAR_*) */
-#define LOCATION_NEAR_ARGV0 2<<21   /* based on a parent of argv[0] */
-#define LOCATION_NEAR_LIB 2<<22     /* based on a parent of DLL/SO file */
+#define LOCATION_NEAR_ARGV0 (1<<21) /* based on a parent of argv[0] */
+#define LOCATION_NEAR_LIB (1<<22)   /* based on a parent of DLL/SO file */
 
 typedef struct _PyPathConfig {
     /* Full path to the Python program */

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -1555,7 +1555,9 @@ calculate_path(PyCalculatePath *calculate, _PyPathConfig *pathconfig)
     }
 
     if (pathconfig->stdlib_dir == NULL) {
-        if (calculate->stdlib_dir != NULL) {
+        // XXX Drop the prefix_found check.  stdlib_dir_verified can be
+        // used where the distinction is needed.
+        if (calculate->stdlib_dir != NULL && calculate->prefix_found) {
             pathconfig->stdlib_dir = _PyMem_RawWcsdup(calculate->stdlib_dir);
             if (pathconfig->stdlib_dir == NULL) {
                 return _PyStatus_NO_MEMORY();


### PR DESCRIPTION
This change helps make getpath.c more understandable and easier to modify.  It involves 3 changes:

* rename some variables/functions
* calculate `stdlib_dir` separately
* track information about various filenames, especially `stdlib_dir`

I've avoided changing any behavior or exposing internal data that wasn't already.  I'm saving that for a follow-up PR.