### PR TITLE
bpo-45434: Convert Py_GETENV() macro to a function

### DIFF
--- a/Include/cpython/pydebug.h
+++ b/Include/cpython/pydebug.h
@@ -29,7 +29,7 @@ PyAPI_DATA(int) Py_LegacyWindowsStdioFlag;
 /* this is a wrapper around getenv() that pays attention to
    Py_IgnoreEnvironmentFlag.  It should be used for getting variables like
    PYTHONPATH and PYTHONHOME from the environment */
-#define Py_GETENV(s) (Py_IgnoreEnvironmentFlag ? NULL : getenv(s))
+PyAPI_DATA(char*) Py_GETENV(const char *name);
 
 #ifdef __cplusplus
 }

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -249,6 +249,14 @@ fail:
 #undef SET_ITEM_STR
 }
 
+char*
+Py_GETENV(const char *name)
+{
+    if (Py_IgnoreEnvironmentFlag) {
+        return NULL;
+    }
+    return getenv(name);
+}
 
 /* --- PyStatus ----------------------------------------------- */
 


### PR DESCRIPTION
Avoid calling directly getenv() in the header file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
