### PR TITLE
bpo-45434: bytearrayobject.h no longer includes <stdarg.h>

### DIFF
--- a/Include/bytearrayobject.h
+++ b/Include/bytearrayobject.h
@@ -6,8 +6,6 @@
 extern "C" {
 #endif
 
-#include <stdarg.h>
-
 /* Type PyByteArrayObject represents a mutable array of bytes.
  * The Python API is that of a sequence;
  * the bytes are mapped to ints in [0, 256).

--- a/Include/bytesobject.h
+++ b/Include/bytesobject.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-#include <stdarg.h>
+#include <stdarg.h>               // va_list
 
 /*
 Type PyBytesObject represents a byte string.  An extra zero byte is

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -7,7 +7,7 @@ extern "C" {
 
 /* Module support interface */
 
-#include <stdarg.h>
+#include <stdarg.h>               // va_list
 
 /* If PY_SSIZE_T_CLEAN is defined, each functions treats #-specifier
    to mean Py_ssize_t */

--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -1,7 +1,7 @@
 #ifndef Py_UNICODEOBJECT_H
 #define Py_UNICODEOBJECT_H
 
-#include <stdarg.h>
+#include <stdarg.h>               // va_list
 
 /*
 

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -10,7 +10,6 @@
 #include "Python.h"
 #include "structmember.h"         // PyMemberDef
 
-#include <stdarg.h>
 #include <string.h>
 
 #include <lzma.h>


### PR DESCRIPTION
bytearrayobject.h and _lzmamodule.c don't use va_list and so don't
need to include <stdarg.h>.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
