### PR TITLE
bpo-45434: pyport.h no longer includes <stdlib.h>

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -556,6 +556,9 @@ Porting to Python 3.11
 
 * The ``<Python.h>`` header file no longer includes ``<stdlib.h>``. C
   extensions using ``<stdlib.h>`` must now include it explicitly.
+  The system ``<stdlib.h>`` header provides functions like:
+  ``malloc()``/``free()``, ``getenv()``, ``strtol()``, ``abs()``, ``strtol()``,
+  ``exit()`` and ``abort()``.
   (Contributed by Victor Stinner in :issue:`45434`.)
 
 Deprecated

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -33,7 +33,8 @@
 #  include <stddef.h>
 #endif
 
-#include <assert.h>
+#include <assert.h>               // assert()
+#include <wchar.h>                // wchar_t
 
 #include "pyport.h"
 #include "pymacro.h"

--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -88,6 +88,9 @@ extern int _Py_add_relfile(wchar_t *dirname,
 //      ...
 //      _Py_END_SUPPRESS_IPH
 #if defined _MSC_VER && _MSC_VER >= 1900
+
+#  include <stdlib.h>   // _set_thread_local_invalid_parameter_handler()
+
    extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #  define _Py_BEGIN_SUPPRESS_IPH \
     { _invalid_parameter_handler _Py_old_handler = \

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -205,8 +205,6 @@ typedef Py_ssize_t Py_ssize_clean_t;
  * see https://bugs.python.org/issue28126 */
 #define Py_MEMCPY memcpy
 
-#include <stdlib.h>
-
 #ifdef HAVE_IEEEFP_H
 #include <ieeefp.h>  /* needed for 'finite' declaration on some platforms */
 #endif

--- a/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
@@ -1,3 +1,6 @@
 The ``<Python.h>`` header file no longer includes ``<stdlib.h>``. C
-extensions using ``<stdlib.h>`` must now include it explicitly. Patch by
-Victor Stinner.
+extensions using ``<stdlib.h>`` must now include it explicitly.
+The system ``<stdlib.h>`` header provides functions like:
+``malloc()``/``free()``, ``getenv()``, ``strtol()``, ``abs()``, ``strtol()``,
+``exit()`` and ``abort()``.
+Patch by Victor Stinner.

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -4,6 +4,8 @@
 #include <windows.h>
 #endif
 
+#include <stdlib.h>               // qsort()
+
 #define EXPORT(x) Py_EXPORTED_SYMBOL x
 
 /* some functions handy for testing */

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -5,11 +5,12 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include "gdbm.h"
+
+#include <fcntl.h>
+#include <stdlib.h>               // free()
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #if defined(WIN32) && !defined(__CYGWIN__)
 #include "gdbmerrno.h"

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -10,6 +10,7 @@
 #include "Python.h"
 #include "structmember.h"         // PyMemberDef
 
+#include <stdlib.h>               // free()
 #include <string.h>
 
 #include <lzma.h>

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -12,6 +12,8 @@
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
 #include "structmember.h"         // PyMemberDef
 
+#include <stdlib.h>               // strtol()
+
 PyDoc_STRVAR(pickle_module_doc,
 "Optimized C implementation for the Python pickle module.");
 

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -5,7 +5,10 @@
 #include "pycore_hashtable.h"
 #include <pycore_frame.h>
 
+#include <stdlib.h>               // malloc()
+
 #include "clinic/_tracemalloc.c.h"
+
 /*[clinic input]
 module _tracemalloc
 [clinic start generated code]*/

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -3,10 +3,13 @@
 #include "pycore_pyerrors.h"      // _Py_DumpExtensionModules
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads
-#include <signal.h>
+
+#include "frameobject.h"
+
 #include <object.h>
-#include <frameobject.h>
 #include <signal.h>
+#include <signal.h>
+#include <stdlib.h>               // abort()
 #if defined(HAVE_PTHREAD_SIGMASK) && !defined(HAVE_BROKEN_PTHREAD_SIGMASK)
 #  include <pthread.h>
 #endif

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -6,8 +6,9 @@
 #include "pycore_pathconfig.h"
 #include "osdefs.h"               // DELIM
 
-#include <sys/types.h>
+#include <stdlib.h>               // getenv()
 #include <string.h>
+#include <sys/types.h>
 
 #ifdef __APPLE__
 #  include <mach-o/dyld.h>

--- a/Modules/nismodule.c
+++ b/Modules/nismodule.c
@@ -12,6 +12,7 @@
 
 #include "Python.h"
 
+#include <stdlib.h>               // free()
 #include <sys/time.h>
 #include <sys/types.h>
 #include <rpc/rpc.h>

--- a/Modules/ossaudiodev.c
+++ b/Modules/ossaudiodev.c
@@ -21,6 +21,7 @@
 #include "Python.h"
 #include "structmember.h"         // PyMemberDef
 
+#include <stdlib.h>               // getenv()
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #else

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -46,7 +46,8 @@
 #  undef HAVE_FACCESSAT
 #endif
 
-#include <stdio.h>  /* needed for ctermid() */
+#include <stdio.h>                // ctermid()
+#include <stdlib.h>               // system()
 
 /*
  * A number of APIs are available on macOS from a certain macOS version.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -6,9 +6,11 @@
 
 /* Standard definitions */
 #include "Python.h"
-#include <stddef.h>
-#include <signal.h>
+
 #include <errno.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdlib.h>               // free()
 #include <sys/time.h>
 
 #if defined(HAVE_SETLOCALE)

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -13,6 +13,7 @@
 
 #include <ctype.h>
 #include <float.h>
+#include <stdlib.h>               // strtol()
 
 /*[clinic input]
 class float "PyObject *" "&PyFloat_Type"

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -10,9 +10,10 @@
 #include "pycore_pystate.h"       // _Py_IsMainInterpreter()
 #include "longintrepr.h"
 
-#include <float.h>
 #include <ctype.h>
+#include <float.h>
 #include <stddef.h>
+#include <stdlib.h>               // abs()
 
 #include "clinic/longobject.c.h"
 /*[clinic input]

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2,6 +2,7 @@
 #include "pycore_pymem.h"         // _PyTraceMalloc_Config
 
 #include <stdbool.h>
+#include <stdlib.h>               // malloc()
 
 
 /* Defined in tracemalloc.c */

--- a/PC/WinMain.c
+++ b/PC/WinMain.c
@@ -4,6 +4,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <stdlib.h>  /* __argc, __wargv */
 
 int WINAPI wWinMain(
     HINSTANCE hInstance,      /* handle to current instance */

--- a/Programs/_freeze_module.c
+++ b/Programs/_freeze_module.c
@@ -12,6 +12,7 @@
 #include <pycore_import.h>
 
 #include <stdio.h>
+#include <stdlib.h>               // malloc()
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifndef MS_WINDOWS

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -11,6 +11,7 @@
 #include <Python.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>               // putenv()
 #include <wchar.h>
 
 /*********************************************************

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -119,6 +119,7 @@
 
 #include "Python.h"
 #include "pycore_dtoa.h"
+#include <stdlib.h>               // exit()
 
 /* if PY_NO_SHORT_FLOAT_REPR is defined, then don't even try to compile
    the following code */

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -15,12 +15,13 @@ extern char *strerror(int);
 #endif
 #endif
 
+#include <ctype.h>
 #ifdef MS_WINDOWS
-#include <windows.h>
-#include <winbase.h>
+#  include <windows.h>
+#  include <winbase.h>
+#  include <stdlib.h>             // _sys_nerr
 #endif
 
-#include <ctype.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -3,6 +3,7 @@
 #include "pycore_runtime.h"       // _PyRuntime
 #include "osdefs.h"               // SEP
 #include <locale.h>
+#include <stdlib.h>               // mbstowcs()
 
 #ifdef MS_WINDOWS
 #  include <malloc.h>

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -10,7 +10,9 @@
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 
 #include "osdefs.h"               // DELIM
+
 #include <locale.h>               // setlocale()
+#include <stdlib.h>               // getenv()
 #if defined(MS_WINDOWS) || defined(__CYGWIN__)
 #  ifdef HAVE_IO_H
 #    include <io.h>

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -4,7 +4,9 @@
 #include "pycore_initconfig.h"    // _PyArgv
 #include "pycore_pymem.h"         // _PyMem_GetAllocatorName()
 #include "pycore_runtime.h"       // _PyRuntime_Initialize()
+
 #include <locale.h>               // setlocale()
+#include <stdlib.h>               // getenv()
 
 
 /* Forward declarations */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -16,6 +16,7 @@
 #include "pycore_traceback.h"     // _Py_DumpTracebackThreads()
 
 #include <locale.h>               // setlocale()
+#include <stdlib.h>               // getenv()
 
 #if defined(__APPLE__)
 #include <mach-o/loader.h>

--- a/Python/pystrhex.c
+++ b/Python/pystrhex.c
@@ -1,8 +1,8 @@
 /* Format bytes as hexadecimal */
 
 #include "Python.h"
-#include "pycore_strhex.h"       // _Py_strhex_with_sep()
-
+#include "pycore_strhex.h"        // _Py_strhex_with_sep()
+#include <stdlib.h>               // abs()
 
 static PyObject *_Py_strhex_impl(const char* argbuf, const Py_ssize_t arglen,
                                  const PyObject* sep, int bytes_per_sep_group,


### PR DESCRIPTION
Include <stdlib.h> explicitly in C files.

Python.h includes <wchar.h>.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
