### PR TITLE
bpo-45410: regrtest -W leaves stdout/err FD unchanged

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import sys
-from test import support
 from test.support import os_helper
 
 

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 import warnings
 from inspect import isabstract

--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -1,4 +1,3 @@
-import collections
 import faulthandler
 import json
 import os

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -75,7 +75,7 @@ def regrtest_unraisable_hook(unraisable):
     old_stderr = sys.stderr
     try:
         support.flush_std_streams()
-        sys.stderr = sys.__stderr__
+        sys.stderr = support.print_warning.orig_stderr
         orig_unraisablehook(unraisable)
         sys.stderr.flush()
     finally:
@@ -98,7 +98,7 @@ def regrtest_threading_excepthook(args):
     old_stderr = sys.stderr
     try:
         support.flush_std_streams()
-        sys.stderr = sys.__stderr__
+        sys.stderr = support.print_warning.orig_stderr
         orig_threading_excepthook(args)
         sys.stderr.flush()
     finally:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1177,12 +1177,14 @@ def flush_std_streams():
 def print_warning(msg):
     # bpo-45410: Explicitly flush stdout to keep logs in order
     flush_std_streams()
-    # bpo-39983: Print into sys.__stderr__ to display the warning even
-    # when sys.stderr is captured temporarily by a test
-    stream = sys.__stderr__
+    stream = print_warning.orig_stderr
     for line in msg.splitlines():
         print(f"Warning -- {line}", file=stream)
     stream.flush()
+
+# bpo-39983: Store the original sys.stderr at Python startup to be able to
+# log warnings even if sys.stderr is captured temporarily by a test.
+print_warning.orig_stderr = sys.stderr
 
 
 # Flag used by saved_test_environment of test.libregrtest.save_env,

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -469,12 +469,8 @@ class TestSupport(unittest.TestCase):
                 if time.monotonic() > deadline:
                     self.fail("timeout")
 
-                old_stderr = sys.__stderr__
-                try:
-                    sys.__stderr__ = stderr
+                with support.swap_attr(support.print_warning, 'orig_stderr', stderr):
                     support.reap_children()
-                finally:
-                    sys.__stderr__ = old_stderr
 
                 # Use environment_altered to check if reap_children() found
                 # the child process
@@ -674,14 +670,8 @@ class TestSupport(unittest.TestCase):
 
     def check_print_warning(self, msg, expected):
         stderr = io.StringIO()
-
-        old_stderr = sys.__stderr__
-        try:
-            sys.__stderr__ = stderr
+        with support.swap_attr(support.print_warning, 'orig_stderr', stderr):
             support.print_warning(msg)
-        finally:
-            sys.__stderr__ = old_stderr
-
         self.assertEqual(stderr.getvalue(), expected)
 
     def test_print_warning(self):


### PR DESCRIPTION
libregrtest capture_std_streams() no longer replaces stdout and
stderr file descriptors.

libregrtest now always call faulthandler.enable() with file=2. Don't
attempt to get the file descriptor from sys.__stderr__.

Remove also a few unused imports in libregrtest.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45410](https://bugs.python.org/issue45410) -->
https://bugs.python.org/issue45410
<!-- /issue-number -->
