### PR TITLE
bpo-45410: regrtest replaces print_warning.orig_stderr

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -196,10 +196,18 @@ def _runtest(ns: Namespace, test_name: str) -> TestResult:
             stream = io.StringIO()
             orig_stdout = sys.stdout
             orig_stderr = sys.stderr
+            print_warning = support.print_warning
+            orig_print_warnings_stderr = print_warning.orig_stderr
+
             output = None
             try:
                 sys.stdout = stream
                 sys.stderr = stream
+                # print_warning() writes into the temporary stream to preserve
+                # messages order. If support.environment_altered becomes true,
+                # warnings will be written to sys.stderr below.
+                print_warning.orig_stderr = stream
+
                 result = _runtest_inner(ns, test_name,
                                         display_failure=False)
                 if not isinstance(result, Passed):
@@ -207,6 +215,7 @@ def _runtest(ns: Namespace, test_name: str) -> TestResult:
             finally:
                 sys.stdout = orig_stdout
                 sys.stderr = orig_stderr
+                print_warning.orig_stderr = orig_print_warnings_stderr
 
             if output is not None:
                 sys.stderr.write(output)

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -320,7 +320,8 @@ class saved_test_environment:
                 support.environment_altered = True
                 restore(original)
                 if not self.quiet and not self.pgo:
-                    print_warning(f"{name} was modified by {self.testname}")
-                    print(f"  Before: {original}\n  After:  {current} ",
-                          file=sys.stderr, flush=True)
+                    print_warning(
+                        f"{name} was modified by {self.testname}\n"
+                        f"  Before: {original}\n"
+                        f"  After:  {current} ")
         return False


### PR DESCRIPTION
When running Python tests with -W, runtest() now replaces
support.print_warning.orig_stderr to preserve the messages order.

Add an unit test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45410](https://bugs.python.org/issue45410) -->
https://bugs.python.org/issue45410
<!-- /issue-number -->
