### PR TITLE
[3.10] bpo-45239: Fix parsedate_tz when time has more than 2 dots in it (GH-28452)

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -128,6 +128,8 @@ def _parsedate_tz(data):
             tss = 0
         elif len(tm) == 3:
             [thh, tmm, tss] = tm
+        else:
+            return None
     else:
         return None
     try:

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3009,6 +3009,7 @@ class TestMiscellaneous(TestEmailBase):
         self.assertIsNone(utils.parsedate_tz('0'))
         self.assertIsNone(utils.parsedate('A Complete Waste of Time'))
         self.assertIsNone(utils.parsedate_tz('A Complete Waste of Time'))
+        self.assertIsNone(utils.parsedate_tz('Wed, 3 Apr 2002 12.34.56.78+0800'))
         # Not a part of the spec but, but this has historically worked:
         self.assertIsNone(utils.parsedate(None))
         self.assertIsNone(utils.parsedate_tz(None))

--- a/Misc/NEWS.d/next/Library/2021-10-13-17-52-48.bpo-45239.7li1_0.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-13-17-52-48.bpo-45239.7li1_0.rst
@@ -1,0 +1,3 @@
+Fixed :func:`email.utils.parsedate_tz` crashing with
+:exc:`UnboundLocalError` on certain invalid input instead of returning
+``None``. Patch by Ben Hoyt.


### PR DESCRIPTION
Co-authored-by: Łukasz Langa <lukasz@langa.pl>
(cherry picked from commit b9e687618d3489944f29adbd2be50b46940c9e70)

Co-authored-by: Ben Hoyt <benhoyt@gmail.com>


<!-- issue-number: [bpo-45239](https://bugs.python.org/issue45239) -->
https://bugs.python.org/issue45239
<!-- /issue-number -->
