### PR TITLE
bpo-45462: Speed up re.match with pre-compiled pattern

### DIFF
--- a/Lib/re.py
+++ b/Lib/re.py
@@ -265,17 +265,17 @@ _cache = {}  # ordered!
 _MAXCACHE = 512
 def _compile(pattern, flags):
     # internal: compile pattern
+    if isinstance(pattern, Pattern):
+        if flags:
+            raise ValueError(
+                "cannot process flags argument with a compiled pattern")
+        return pattern
     if isinstance(flags, RegexFlag):
         flags = flags.value
     try:
         return _cache[type(pattern), pattern, flags]
     except KeyError:
         pass
-    if isinstance(pattern, Pattern):
-        if flags:
-            raise ValueError(
-                "cannot process flags argument with a compiled pattern")
-        return pattern
     if not sre_compile.isstring(pattern):
         raise TypeError("first argument must be string or compiled pattern")
     p = sre_compile.compile(pattern, flags)

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -149,9 +149,13 @@ class ReTests(unittest.TestCase):
         # Verify that flags do not get silently ignored with compiled patterns
         pattern = re.compile('.')
         self.assertRaises(ValueError, re.match, pattern, 'A', re.I)
+        self.assertRaises(ValueError, re.match, pattern, 'A', re.I.value)
         self.assertRaises(ValueError, re.search, pattern, 'A', re.I)
+        self.assertRaises(ValueError, re.search, pattern, 'A', re.I.value)
         self.assertRaises(ValueError, re.findall, pattern, 'A', re.I)
+        self.assertRaises(ValueError, re.findall, pattern, 'A', re.I.value)
         self.assertRaises(ValueError, re.compile, pattern, re.I)
+        self.assertRaises(ValueError, re.compile, pattern, re.I.value)
 
     def test_bug_3629(self):
         # A regex that triggered a bug in the sre-code validator


### PR DESCRIPTION
Implements the speedup and also extends the tests so as to explicitly cover the `if flags` check for both `RegexFlag` and raw integer values.

<!-- issue-number: [bpo-45462](https://bugs.python.org/issue45462) -->
https://bugs.python.org/issue45462
<!-- /issue-number -->
