### PR TITLE
bpo-45457: Minor fix to documentation for SSLContext.load_default_certs.

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1576,7 +1576,7 @@ to speed up repeated connections from the same clients.
 
    Load a set of default "certification authority" (CA) certificates from
    default locations. On Windows it loads CA certs from the ``CA`` and
-   ``ROOT`` system stores. On other systems it calls
+   ``ROOT`` system stores. On all systems it calls
    :meth:`SSLContext.set_default_verify_paths`. In the future the method may
    load CA certificates from other locations, too.
 


### PR DESCRIPTION
Specify that SSLContext.set_default_verify_paths is called on ALL systems.

The code of SSLContext.load_default_certs was changed in [bpo-22449](https://bugs.python.org/issue22449) to do this,
this fix corrects the documentation to match that change.

<!-- issue-number: [bpo-45457](https://bugs.python.org/issue45457) -->
https://bugs.python.org/issue45457
<!-- /issue-number -->
