### PR TITLE
no-issue: Make silence about  warning '_POSIX_C_SOURCE redefined'

### DIFF
--- a/Modules/expat/xmltok.c
+++ b/Modules/expat/xmltok.c
@@ -42,15 +42,15 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <stddef.h>
-#include <string.h> /* memcpy */
-#include <stdbool.h>
-
 #ifdef _WIN32
 #  include "winconfig.h"
 #endif
 
 #include <expat_config.h>
+
+#include <stddef.h>
+#include <string.h> /* memcpy */
+#include <stdbool.h>
 
 #include "expat_external.h"
 #include "internal.h"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
````
In file included from /home/corona10/cpython/Modules/expat/expat_config.h:8,
                 from /home/corona10/cpython/Modules/expat/xmltok.c:53:
./pyconfig.h:1628: warning: "_POSIX_C_SOURCE" redefined
 #define _POSIX_C_SOURCE 200809L

In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/string.h:26,
                 from /home/corona10/cpython/Modules/expat/xmltok.c:46:
/usr/include/features.h:294: note: this is the location of the previous definition
 # define _POSIX_C_SOURCE 199506L

````