### PR TITLE
bpo-45471: Do not set _Py_path_config.stdlib_dir in Py_SetPythonHome().

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1247,6 +1247,11 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             self.fail(f"Unable to find home in {paths!r}")
 
         prefix = exec_prefix = home
+        if MS_WINDOWS:
+            stdlib = os.path.join(home, sys.platlibdir)
+        else:
+            version = f'{sys.version_info.major}.{sys.version_info.minor}'
+            stdlib = os.path.join(home, sys.platlibdir, f'python{version}')
         expected_paths = self.module_search_paths(prefix=home, exec_prefix=home)
 
         config = {
@@ -1257,7 +1262,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'exec_prefix': exec_prefix,
             'base_exec_prefix': exec_prefix,
             'pythonpath_env': paths_str,
-            'stdlib_dir': home,
+            'stdlib_dir': stdlib,
         }
         self.default_program_name(config)
         env = {'TESTHOME': home, 'PYTHONPATH': paths_str}

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -530,13 +530,10 @@ Py_SetPythonHome(const wchar_t *home)
 
     PyMem_RawFree(_Py_path_config.home);
     _Py_path_config.home = _PyMem_RawWcsdup(home);
-    if (_Py_path_config.home != NULL) {
-        _Py_path_config.stdlib_dir = _PyMem_RawWcsdup(home);
-    }
 
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
-    if (_Py_path_config.home == NULL || _Py_path_config.stdlib_dir == NULL) {
+    if (_Py_path_config.home == NULL) {
         path_out_of_memory(__func__);
     }
 }


### PR DESCRIPTION
The change in gh-28586 ([bpo-45211](https://bugs.python.org/issue45211)) should not have included code to set _Py_path_config.stdlib_dir in Py_SetPythonHome().  We fix that here.

<!-- issue-number: [bpo-45471](https://bugs.python.org/issue45471) -->
https://bugs.python.org/issue45471
<!-- /issue-number -->
