### PR TITLE
bpo-45474: Fix the limited C API of marshal.h

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -613,3 +613,13 @@ Removed
 * Remove the ``Py_FORCE_DOUBLE()`` macro. It was used by the
   ``Py_IS_INFINITY()`` macro.
   (Contributed by Victor Stinner in :issue:`45440`.)
+
+* Remove two functions from the limited C API:
+
+  * :c:func:`PyMarshal_WriteLongToFile`
+  * :c:func:`PyMarshal_WriteObjectToFile`
+
+  The :pep:`384` excludes functions expecting ``FILE*`` from the stable ABI.
+
+  Remove also the ``Py_MARSHAL_VERSION`` macro from the limited C API.
+  (Contributed by Victor Stinner in :issue:`45474`.)

--- a/Include/marshal.h
+++ b/Include/marshal.h
@@ -7,20 +7,21 @@
 extern "C" {
 #endif
 
-#define Py_MARSHAL_VERSION 4
-
-PyAPI_FUNC(void) PyMarshal_WriteLongToFile(long, FILE *, int);
-PyAPI_FUNC(void) PyMarshal_WriteObjectToFile(PyObject *, FILE *, int);
+PyAPI_FUNC(PyObject *) PyMarshal_ReadObjectFromString(const char *,
+                                                      Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyMarshal_WriteObjectToString(PyObject *, int);
 
 #ifndef Py_LIMITED_API
+#define Py_MARSHAL_VERSION 4
+
 PyAPI_FUNC(long) PyMarshal_ReadLongFromFile(FILE *);
 PyAPI_FUNC(int) PyMarshal_ReadShortFromFile(FILE *);
 PyAPI_FUNC(PyObject *) PyMarshal_ReadObjectFromFile(FILE *);
 PyAPI_FUNC(PyObject *) PyMarshal_ReadLastObjectFromFile(FILE *);
+
+PyAPI_FUNC(void) PyMarshal_WriteLongToFile(long, FILE *, int);
+PyAPI_FUNC(void) PyMarshal_WriteObjectToFile(PyObject *, FILE *, int);
 #endif
-PyAPI_FUNC(PyObject *) PyMarshal_ReadObjectFromString(const char *,
-                                                      Py_ssize_t);
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/C API/2021-10-14-22-16-56.bpo-45474.1OkJQh.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-14-22-16-56.bpo-45474.1OkJQh.rst
@@ -1,0 +1,10 @@
+Remove two functions from the limited C API:
+
+* :c:func:`PyMarshal_WriteLongToFile`
+* :c:func:`PyMarshal_WriteObjectToFile`
+
+The :pep:`384` excludes functions expecting ``FILE*`` from the stable ABI.
+
+Remove also the ``Py_MARSHAL_VERSION`` macro from the limited C API.
+
+Patch by Victor Stinner.


### PR DESCRIPTION
Remove two functions from the limited C API:

* PyMarshal_WriteLongToFile()
* PyMarshal_WriteObjectToFile()

The PEP 384 excludes functions expecting "FILE*" from the stable ABI.

Remove also the Py_MARSHAL_VERSION macro from the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45474](https://bugs.python.org/issue45474) -->
https://bugs.python.org/issue45474
<!-- /issue-number -->
