### PR TITLE
bpo-35134: Move Include/funcobject.h to Include/cpython/

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -572,6 +572,12 @@ Porting to Python 3.11
   header provides functions like ``printf()`` and ``fopen()``.
   (Contributed by Victor Stinner in :issue:`45434`.)
 
+* The non-limited API file ``funcobject.h`` has been moved to the
+  ``Include/cpython`` directory. This file must not be included directly, as it
+  is already included in ``Python.h``: :ref:`Include Files <api-includes>`. If
+  it has been included directly, consider including ``Python.h`` instead.
+  (Contributed by Victor Stinner in :issue:`35134`.)
+
 Deprecated
 ----------
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -60,7 +60,7 @@
 #include "setobject.h"
 #include "methodobject.h"
 #include "moduleobject.h"
-#include "funcobject.h"
+#include "cpython/funcobject.h"
 #include "classobject.h"
 #include "fileobject.h"
 #include "pycapsule.h"

--- a/Include/cpython/funcobject.h
+++ b/Include/cpython/funcobject.h
@@ -1,5 +1,5 @@
-
 /* Function object interface */
+
 #ifndef Py_LIMITED_API
 #ifndef Py_FUNCOBJECT_H
 #define Py_FUNCOBJECT_H
@@ -76,7 +76,6 @@ PyAPI_FUNC(int) PyFunction_SetClosure(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) PyFunction_GetAnnotations(PyObject *);
 PyAPI_FUNC(int) PyFunction_SetAnnotations(PyObject *, PyObject *);
 
-#ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
     PyObject *func,
     PyObject *const *stack,
@@ -84,7 +83,6 @@ PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
     PyObject *kwnames);
 
 uint32_t _PyFunction_GetVersionForCurrentState(PyFunctionObject *func);
-#endif
 
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1145,7 +1145,6 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/fileutils.h \
 		$(srcdir)/Include/floatobject.h \
 		$(srcdir)/Include/frameobject.h \
-		$(srcdir)/Include/funcobject.h \
 		$(srcdir)/Include/genobject.h \
 		$(srcdir)/Include/import.h \
 		$(srcdir)/Include/interpreteridobject.h \
@@ -1210,6 +1209,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/fileutils.h \
 		$(srcdir)/Include/cpython/floatobject.h \
 		$(srcdir)/Include/cpython/frameobject.h \
+		$(srcdir)/Include/cpython/funcobject.h \
 		$(srcdir)/Include/cpython/import.h \
 		$(srcdir)/Include/cpython/initconfig.h \
 		$(srcdir)/Include/cpython/interpreteridobject.h \

--- a/Misc/NEWS.d/next/C API/2021-10-15-00-11-51.bpo-35134.eX4zqy.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-15-00-11-51.bpo-35134.eX4zqy.rst
@@ -1,0 +1,3 @@
+Move Include/funcobject.h header file to Include/cpython/funcobject.h.
+C extensions should only include the main ``<Python.h>`` header.
+Patch by Victor Stinner.

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -134,6 +134,7 @@
     <ClInclude Include="..\Include\cpython\fileutils.h" />
     <ClInclude Include="..\Include\cpython\floatobject.h" />
     <ClInclude Include="..\Include\cpython\frameobject.h" />
+    <ClInclude Include="..\Include\cpython\funcobject.h" />
     <ClInclude Include="..\Include\cpython\import.h" />
     <ClInclude Include="..\Include\cpython\initconfig.h" />
     <ClInclude Include="..\Include\cpython\interpreteridobject.h" />
@@ -169,7 +170,6 @@
     <ClInclude Include="..\Include\fileutils.h" />
     <ClInclude Include="..\Include\floatobject.h" />
     <ClInclude Include="..\Include\frameobject.h" />
-    <ClInclude Include="..\Include\funcobject.h" />
     <ClInclude Include="..\Include\genobject.h" />
     <ClInclude Include="..\Include\import.h" />
     <ClInclude Include="..\Include\internal\pycore_abstract.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -108,9 +108,6 @@
     <ClInclude Include="..\Include\frameobject.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\Include\funcobject.h">
-      <Filter>Include</Filter>
-    </ClInclude>
     <ClInclude Include="..\Include\genobject.h">
       <Filter>Include</Filter>
     </ClInclude>
@@ -454,6 +451,9 @@
       <Filter>Include\cpython</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\cpython\frameobject.h">
+      <Filter>Include\cpython</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\funcobject.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\cpython\interpreteridobject.h">

--- a/Tools/scripts/stable_abi.py
+++ b/Tools/scripts/stable_abi.py
@@ -34,7 +34,6 @@ EXCLUDED_HEADERS = {
     "datetime.h",
     "dtoa.h",
     "frameobject.h",
-    "funcobject.h",
     "genobject.h",
     "longintrepr.h",
     "parsetok.h",


### PR DESCRIPTION
Remove redundant "#ifndef Py_LIMITED_API" in funcobject.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
