### PR TITLE
bpo-45434: Limited Python.h no longer includes stdio.h

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -565,6 +565,13 @@ Porting to Python 3.11
   ``exit()`` and ``abort()``.
   (Contributed by Victor Stinner in :issue:`45434`.)
 
+* The ``<Python.h>`` header file no longer includes ``<stdio.h>`` if the
+  ``Py_LIMITED_API`` macro is defined. Functions expecting ``FILE*`` are
+  excluded from the limited C API (:pep:`384`). C extensions using
+  ``<stdio.h>`` must now include it explicitly.  The system ``<stdio.h>``
+  header provides functions like ``printf()`` and ``fopen()``.
+  (Contributed by Victor Stinner in :issue:`45434`.)
+
 Deprecated
 ----------
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -16,12 +16,10 @@
 #  define _SGI_MP_SOURCE
 #endif
 
-#include <stdio.h>                // NULL, FILE*
-#ifndef NULL
-#   error "Python.h requires that stdio.h define NULL."
-#endif
-
 #include <string.h>               // memcpy()
+#ifndef Py_LIMITED_API
+#  include <stdio.h>              // FILE*
+#endif
 #ifdef HAVE_ERRNO_H
 #  include <errno.h>              // errno
 #endif
@@ -29,8 +27,7 @@
 #  include <unistd.h>
 #endif
 #ifdef HAVE_STDDEF_H
-   // For size_t
-#  include <stddef.h>
+#  include <stddef.h>             // size_t
 #endif
 
 #include <assert.h>               // assert()

--- a/Misc/NEWS.d/next/C API/2021-10-15-00-30-45.bpo-45434.XLtsbK.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-15-00-30-45.bpo-45434.XLtsbK.rst
@@ -1,0 +1,5 @@
+The ``<Python.h>`` header file no longer includes ``<stdio.h>`` if the
+``Py_LIMITED_API`` macro is defined. Functions expecting ``FILE*`` are excluded
+from the limited C API (:pep:`384`). C extensions using ``<stdio.h>`` must now
+include it explicitly.
+Patch by Victor Stinner.


### PR DESCRIPTION
The <Python.h> header file no longer includes <stdio.h> if the
Py_LIMITED_API macro is defined.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
