### PR TITLE
bpo-30459: Use (void) in macros setting variables

### DIFF
--- a/Include/internal/pycore_asdl.h
+++ b/Include/internal/pycore_asdl.h
@@ -91,7 +91,7 @@ asdl_ ## NAME ## _seq *_Py_asdl_ ## NAME ## _seq_new(Py_ssize_t size, PyArena *a
         (S)->typed_elements[_asdl_i] = (V); \
     } while (0)
 #else
-#  define asdl_seq_SET(S, I, V) (S)->typed_elements[I] = (V)
+#  define asdl_seq_SET(S, I, V) ((void)((S)->typed_elements[I] = (V)))
 #endif
 
 #ifdef Py_DEBUG
@@ -103,7 +103,7 @@ asdl_ ## NAME ## _seq *_Py_asdl_ ## NAME ## _seq_new(Py_ssize_t size, PyArena *a
         (S)->elements[_asdl_i] = (V); \
     } while (0)
 #else
-#  define asdl_seq_SET_UNTYPED(S, I, V) (S)->elements[I] = (V)
+#  define asdl_seq_SET_UNTYPED(S, I, V) ((void)((S)->elements[I] = (V)))
 #endif
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -43,7 +43,7 @@ typedef struct {
 // Lowest bit of _gc_next is used for flags only in GC.
 // But it is always 0 for normal code.
 #define _PyGCHead_NEXT(g)        ((PyGC_Head*)(g)->_gc_next)
-#define _PyGCHead_SET_NEXT(g, p) ((g)->_gc_next = (uintptr_t)(p))
+#define _PyGCHead_SET_NEXT(g, p) ((void)((g)->_gc_next = (uintptr_t)(p)))
 
 // Lowest two bits of _gc_prev is used for _PyGC_PREV_MASK_* flags.
 #define _PyGCHead_PREV(g) ((PyGC_Head*)((g)->_gc_prev & _PyGC_PREV_MASK))
@@ -56,7 +56,7 @@ typedef struct {
 #define _PyGCHead_FINALIZED(g) \
     (((g)->_gc_prev & _PyGC_PREV_MASK_FINALIZED) != 0)
 #define _PyGCHead_SET_FINALIZED(g) \
-    ((g)->_gc_prev |= _PyGC_PREV_MASK_FINALIZED)
+    ((void)((g)->_gc_prev |= _PyGC_PREV_MASK_FINALIZED))
 
 #define _PyGC_FINALIZED(o) \
     _PyGCHead_FINALIZED(_Py_AS_GC(o))


### PR DESCRIPTION
Convert the result of macros setting variables to void to avoid risks
of misusing them:

* _PyGCHead_SET_NEXT()
* asdl_seq_SET()
* asdl_seq_SET_UNTYPED()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-30459](https://bugs.python.org/issue30459) -->
https://bugs.python.org/issue30459
<!-- /issue-number -->
