### PR TITLE
bpo-42222: Remove deprecated support for non-integer values

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -137,7 +137,8 @@ Functions for integers
 
    .. versionchanged:: 3.11
       Automatic conversion of non-integer types is no longer supported.
-      Float arguments such as ``randrange(10.0)`` now raise a :exc:`TypeError`.
+      Calls such as ``randrange(10.0)`` and ``randrange(Fraction(10, 1))``
+      now raise a :exc:`TypeError`.
 
 .. function:: randint(a, b)
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -135,15 +135,9 @@ Functions for integers
       values.  Formerly it used a style like ``int(random()*n)`` which could produce
       slightly uneven distributions.
 
-   .. deprecated:: 3.10
-      The automatic conversion of non-integer types to equivalent integers is
-      deprecated.  Currently ``randrange(10.0)`` is losslessly converted to
-      ``randrange(10)``.  In the future, this will raise a :exc:`TypeError`.
-
-   .. deprecated:: 3.10
-      The exception raised for non-integral values such as ``randrange(10.5)``
-      or ``randrange('10')`` will be changed from :exc:`ValueError` to
-      :exc:`TypeError`.
+   .. versionchanged:: 3.11
+      Automatic conversion of non-integer types is no longer supported.
+      Float arguments such as ``randrange(10.0)`` now raise a :exc:`TypeError`.
 
 .. function:: randint(a, b)
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -313,7 +313,7 @@ class Random(_random.Random):
         if istep == 1:
             if width > 0:
                 return istart + self._randbelow(width)
-            raise ValueError("empty range for randrange() (%d, %d, %d)" % (istart, istop, width))
+            raise ValueError(f"empty range in randrange({start}, {stop}, {step})")
 
         # Non-unit step argument supplied.
         if istep > 0:
@@ -323,7 +323,7 @@ class Random(_random.Random):
         else:
             raise ValueError("zero step for randrange()")
         if n <= 0:
-            raise ValueError("empty range for randrange()")
+            raise ValueError(f"empty range in randrange({start}, {stop}, {step})")
         return istart + istep * self._randbelow(n)
 
     def randint(self, a, b):

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -288,8 +288,9 @@ class Random(_random.Random):
     def randrange(self, start, stop=None, step=_ONE):
         """Choose a random item from range(stop) or range(start, stop[, step]).
 
-        Roughly equivalent to:  choice(range(start, stop, step))
-        but runs faster and supports a larger range.
+        Roughly equivalent to ``choice(range(start, stop, step))``
+        but supports arbitrarily large ranges and is optimized
+        for common cases.
 
         """
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -286,10 +286,10 @@ class Random(_random.Random):
     ## -------------------- integer methods  -------------------
 
     def randrange(self, start, stop=None, step=_ONE):
-        """Choose a random item from range(start, stop[, step]).
+        """Choose a random item from range(stop) or range(start, stop[, step]).
 
-        This fixes the problem with randint() which includes the
-        endpoint; in Python this is usually not what you want.
+        Roughly equivalent to:  choice(range(start, stop, step))
+        but runs faster and supports a larger range.
 
         """
 

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -483,12 +483,16 @@ class SystemRandom_TestBasicOps(TestBasicOps, unittest.TestCase):
     def test_randrange_errors(self):
         raises_value_error = partial(self.assertRaises, ValueError, self.gen.randrange)
         raises_type_error = partial(self.assertRaises, TypeError, self.gen.randrange)
+
         # Empty range
         raises_value_error(3, 3)
         raises_value_error(-721)
         raises_value_error(0, 100, -12)
-        # Non-integer start/stop
 
+        # Zero step
+        raises_value_error(0, 42, 0)
+
+        # Non-integer start/stop/step
         raises_type_error(3.14159)
         raises_type_error(3.0)
         raises_type_error(Fraction(3, 1))
@@ -498,10 +502,9 @@ class SystemRandom_TestBasicOps(TestBasicOps, unittest.TestCase):
         raises_type_error(0, Fraction(2, 1))
         raises_type_error(0, '2')
 
-        # Zero and non-integer step
-        raises_value_error(0, 42, 0)
-        raises_type_error(0, 42, 0.0)
-        raises_type_error(0, 0, 0.0)
+        # Non-integer step
+        raises_type_error(0, 42, 1.0)
+        raises_type_error(0, 0, 1.0)
         raises_type_error(0, 42, 3.14159)
         raises_type_error(0, 42, 3.0)
         raises_type_error(0, 42, Fraction(3, 1))

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -481,50 +481,50 @@ class SystemRandom_TestBasicOps(TestBasicOps, unittest.TestCase):
         self.assertEqual(rint, 0)
 
     def test_randrange_errors(self):
-        raises = partial(self.assertRaises, ValueError, self.gen.randrange)
+        raises_value_error = partial(self.assertRaises, ValueError, self.gen.randrange)
+        raises_type_error = partial(self.assertRaises, TypeError, self.gen.randrange)
         # Empty range
-        raises(3, 3)
-        raises(-721)
-        raises(0, 100, -12)
+        raises_value_error(3, 3)
+        raises_value_error(-721)
+        raises_value_error(0, 100, -12)
         # Non-integer start/stop
-        self.assertWarns(DeprecationWarning, raises, 3.14159)
-        self.assertWarns(DeprecationWarning, self.gen.randrange, 3.0)
-        self.assertWarns(DeprecationWarning, self.gen.randrange, Fraction(3, 1))
-        self.assertWarns(DeprecationWarning, raises, '3')
-        self.assertWarns(DeprecationWarning, raises, 0, 2.71828)
-        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 2.0)
-        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, Fraction(2, 1))
-        self.assertWarns(DeprecationWarning, raises, 0, '2')
+
+        raises_type_error(3.14159)
+        raises_type_error(3.0)
+        raises_type_error(Fraction(3, 1))
+        raises_type_error('3')
+        raises_type_error(0, 2.71827)
+        raises_type_error(0, 2.0)
+        raises_type_error(0, Fraction(2, 1))
+        raises_type_error(0, '2')
+
         # Zero and non-integer step
-        raises(0, 42, 0)
-        self.assertWarns(DeprecationWarning, raises, 0, 42, 0.0)
-        self.assertWarns(DeprecationWarning, raises, 0, 0, 0.0)
-        self.assertWarns(DeprecationWarning, raises, 0, 42, 3.14159)
-        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 42, 3.0)
-        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 42, Fraction(3, 1))
-        self.assertWarns(DeprecationWarning, raises, 0, 42, '3')
-        self.assertWarns(DeprecationWarning, self.gen.randrange, 0, 42, 1.0)
-        self.assertWarns(DeprecationWarning, raises, 0, 0, 1.0)
+        raises_value_error(0, 42, 0)
+        raises_type_error(0, 42, 0.0)
+        raises_type_error(0, 0, 0.0)
+        raises_type_error(0, 42, 3.14159)
+        raises_type_error(0, 42, 3.0)
+        raises_type_error(0, 42, Fraction(3, 1))
+        raises_type_error(0, 42, '3')
+        raises_type_error(0, 42, 1.0)
+        raises_type_error(0, 0, 1.0)
 
     def test_randrange_argument_handling(self):
         randrange = self.gen.randrange
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(TypeError):
             randrange(10.0, 20, 2)
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(TypeError):
             randrange(10, 20.0, 2)
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(TypeError):
             randrange(10, 20, 1.0)
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(TypeError):
             randrange(10, 20, 2.0)
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(ValueError):
-                randrange(10.5)
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(ValueError):
-                randrange(10, 20.5)
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(ValueError):
-                randrange(10, 20, 1.5)
+        with self.assertRaises(TypeError):
+            randrange(10.5)
+        with self.assertRaises(TypeError):
+            randrange(10, 20.5)
+        with self.assertRaises(TypeError):
+            randrange(10, 20, 1.5)
 
     def test_randrange_step(self):
         # bpo-42772: When stop is None, the step argument was being ignored.

--- a/Misc/NEWS.d/next/Library/2021-10-15-11-30-11.bpo-42222.hdHyac.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-15-11-30-11.bpo-42222.hdHyac.rst
@@ -1,0 +1,1 @@
+Removed deprecated support for float arguments in *randrange()*.


### PR DESCRIPTION
<!-- issue-number: [bpo-42222](https://bugs.python.org/issue42222) -->
https://bugs.python.org/issue42222
<!-- /issue-number -->
