### PR TITLE
Fix typo in email id in HOWTO's.

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -5,7 +5,7 @@ Descriptor HowTo Guide
 ======================
 
 :Author: Raymond Hettinger
-:Contact: <python at rcn dot com>
+:Contact: <python@rcn.com>
 
 .. Contents::
 

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -2,7 +2,7 @@
 Enum HOWTO
 ==========
 
-:Author: Ethan Furman <ethan at stoneleaf dot us>
+:Author: Ethan Furman <ethan@stoneleaf.us>
 
 .. _enum-basic-tutorial:
 


### PR DESCRIPTION
Minor edit of email id in author details.