### PR TITLE
bpo-45464: Add a warning about subclassing built-in exceptions

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -66,6 +66,8 @@ In either case, the exception itself is always shown after any chained
 exceptions so that the final line of the traceback always shows the last
 exception that was raised.
 
+.. warning:: Creating a subclass that inherits from multiple exceptions may not
+   work and the potential conflicts may change in new versions.
 
 Base classes
 ------------


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45464](https://bugs.python.org/issue45464) -->
https://bugs.python.org/issue45464
<!-- /issue-number -->

Automerge-Triggered-By: GH:pablogsal