### PR TITLE
bpo-45020: Add tests for the -X "frozen_modules" option.

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -123,6 +123,21 @@ class CmdLineTest(unittest.TestCase):
         else:
             self.assertEqual(err, b'')
 
+    def test_xoption_frozen_modules(self):
+        tests = {
+            ('=on', 'FrozenImporter'),
+            ('=off', 'SourceFileLoader'),
+            ('=', 'FrozenImporter'),
+            ('', 'FrozenImporter'),
+        }
+        for raw, expected in tests:
+            cmd = ['-X', f'frozen_modules{raw}',
+                   #'-c', 'import os; print(os.__spec__.loader.__name__, end="")']
+                   '-c', 'import os; print(os.__spec__.loader, end="")']
+            with self.subTest(raw):
+                res = assert_python_ok(*cmd)
+                self.assertRegex(res.out.decode('utf-8'), expected)
+
     def test_run_module(self):
         # Test expected operation of the '-m' switch
         # Switch needs an argument

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1458,6 +1458,30 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         self.run_embedded_interpreter("test_get_argc_argv")
         # ignore output
 
+    def test_init_use_frozen_modules(self):
+        tests = {
+            ('=on', 1),
+            ('=off', 0),
+            ('=', 1),
+            ('', 1),
+        }
+        for raw, expected in tests:
+            optval = f'frozen_modules{raw}'
+            config = {
+                'parse_argv': 2,
+                'argv': ['-c'],
+                'orig_argv': ['./argv0', '-X', optval, '-c', 'pass'],
+                'program_name': './argv0',
+                'run_command': 'pass\n',
+                'use_environment': 1,
+                'xoptions': [optval],
+                'use_frozen_modules': expected,
+            }
+            with self.subTest(raw):
+                self.check_all_configs("test_init_use_frozen_modules",
+                                       config, api=API_PYTHON,
+                                       env={'TESTFROZEN': raw})
+
 
 class SetConfigTests(unittest.TestCase):
     def test_set_config(self):

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1477,10 +1477,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 'xoptions': [optval],
                 'use_frozen_modules': expected,
             }
-            with self.subTest(raw):
-                self.check_all_configs("test_init_use_frozen_modules",
-                                       config, api=API_PYTHON,
-                                       env={'TESTFROZEN': raw})
+            env = {'TESTFROZEN': raw[1:]} if raw else None
+            with self.subTest(repr(raw)):
+                self.check_all_configs("test_init_use_frozen_modules", config,
+                                       api=API_PYTHON, env=env)
 
 
 class SetConfigTests(unittest.TestCase):

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1726,6 +1726,45 @@ static int test_get_argc_argv(void)
 }
 
 
+static int check_use_frozen_modules(const char *rawval)
+{
+    wchar_t optval[100];
+    if (swprintf(optval, 100, L"frozen_modules%s", rawval) < 0) {
+        error("rawval is too long");
+        return -1;
+    }
+
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+
+    config.parse_argv = 1;
+
+    wchar_t* argv[] = {
+        L"./argv0",
+        L"-X",
+        optval,
+        L"-c",
+        L"pass",
+    };
+    config_set_argv(&config, Py_ARRAY_LENGTH(argv), argv);
+    init_from_config_clear(&config);
+
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+static int test_init_use_frozen_modules(void)
+{
+    const char *envvar = getenv("TESTFROZEN");
+    if (envvar == NULL) {
+        error("missing TESTFROZEN env var");
+        return 1;
+    }
+    return check_use_frozen_modules(envvar);
+}
+
+
 static int test_unicode_id_init(void)
 {
     // bpo-42882: Test that _PyUnicode_FromId() works
@@ -1912,6 +1951,7 @@ static struct TestCase TestCases[] = {
     {"test_run_main", test_run_main},
     {"test_run_main_loop", test_run_main_loop},
     {"test_get_argc_argv", test_get_argc_argv},
+    {"test_init_use_frozen_modules", test_init_use_frozen_modules},
 
     // Audit
     {"test_open_code_hook", test_open_code_hook},

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1729,7 +1729,10 @@ static int test_get_argc_argv(void)
 static int check_use_frozen_modules(const char *rawval)
 {
     wchar_t optval[100];
-    if (swprintf(optval, 100, L"frozen_modules%s", rawval) < 0) {
+    if (rawval == NULL) {
+        wcscpy(optval, L"frozen_modules");
+    }
+    else if (swprintf(optval, 100, L"frozen_modules=%s", rawval) < 0) {
         error("rawval is too long");
         return -1;
     }
@@ -1757,10 +1760,6 @@ static int check_use_frozen_modules(const char *rawval)
 static int test_init_use_frozen_modules(void)
 {
     const char *envvar = getenv("TESTFROZEN");
-    if (envvar == NULL) {
-        error("missing TESTFROZEN env var");
-        return 1;
-    }
     return check_use_frozen_modules(envvar);
 }
 


### PR DESCRIPTION
We hadn't explicitly added any tests for this, so here they are.

<!-- issue-number: [bpo-45020](https://bugs.python.org/issue45020) -->
https://bugs.python.org/issue45020
<!-- /issue-number -->
