### PR TITLE
Improve multiserver queue recipe

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -503,7 +503,7 @@ between the effects of a drug versus a placebo::
 
 Simulation of arrival times and service deliveries for a multiserver queue::
 
-    from heapq import heapreplace
+    from heapq import heapify, heapreplace
     from random import expovariate, gauss
     from statistics import mean, quantiles
 
@@ -515,6 +515,7 @@ Simulation of arrival times and service deliveries for a multiserver queue::
     waits = []
     arrival_time = 0.0
     servers = [0.0] * num_servers  # time when each server becomes available
+    heapify(servers)
     for i in range(1_000_000):
         arrival_time += expovariate(1.0 / average_arrival_interval)
         next_server_available = servers[0]

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -503,7 +503,7 @@ between the effects of a drug versus a placebo::
 
 Simulation of arrival times and service deliveries for a multiserver queue::
 
-    from heapq import heappush, heappop
+    from heapq import heapreplace
     from random import expovariate, gauss
     from statistics import mean, quantiles
 
@@ -515,14 +515,14 @@ Simulation of arrival times and service deliveries for a multiserver queue::
     waits = []
     arrival_time = 0.0
     servers = [0.0] * num_servers  # time when each server becomes available
-    for i in range(100_000):
+    for i in range(1_000_000):
         arrival_time += expovariate(1.0 / average_arrival_interval)
-        next_server_available = heappop(servers)
+        next_server_available = servers[0]
         wait = max(0.0, next_server_available - arrival_time)
         waits.append(wait)
-        service_duration = gauss(average_service_time, stdev_service_time)
+        service_duration = max(0.0, gauss(average_service_time, stdev_service_time))
         service_completed = arrival_time + wait + service_duration
-        heappush(servers, service_completed)
+        heapreplace(servers, service_completed)
 
     print(f'Mean wait: {mean(waits):.1f}   Max wait: {max(waits):.1f}')
     print('Quartiles:', [round(q, 1) for q in quantiles(waits)])


### PR DESCRIPTION
* A million iterations is reasonably fast but gives more consistent simulation results than a shorter run.
* The *heapreplace()* function does less work than a *heappop()* followed by a *heappush()*.
* The service duration is normally distributed but can never be negative.
* The initial *servers* list must be arranged as a heap.