### PR TITLE
bpo-45434: Include stdlib.h for specialize stat

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1,4 +1,3 @@
-
 #include "Python.h"
 #include "pycore_code.h"
 #include "pycore_dict.h"
@@ -7,6 +6,8 @@
 #include "pycore_object.h"
 #include "opcode.h"
 #include "structmember.h"         // struct PyMemberDef, T_OFFSET_EX
+
+#include <stdlib.h> // rand()
 
 /* For guidance on adding or extending families of instructions see
  * ./adaptive.md


### PR DESCRIPTION
`````

Python/specialize.c:172:71: error: implicit declaration of function 'rand' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    sprintf(buf, "%s%u_%u.txt", dirname, (unsigned)clock(), (unsigned)rand());
`````

<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
