### PR TITLE
bpo-45475: Revert `__iter__` optimization for GzipFile, BZ2File, and LZMAFile.

### DIFF
--- a/Lib/bz2.py
+++ b/Lib/bz2.py
@@ -197,10 +197,6 @@ class BZ2File(_compression.BaseStream):
         self._check_can_read()
         return self._buffer.readline(size)
 
-    def __iter__(self):
-        self._check_can_read()
-        return self._buffer.__iter__()
-
     def readlines(self, size=-1):
         """Read a list of lines of uncompressed bytes from the file.
 

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -398,10 +398,6 @@ class GzipFile(_compression.BaseStream):
         self._check_not_closed()
         return self._buffer.readline(size)
 
-    def __iter__(self):
-        self._check_not_closed()
-        return self._buffer.__iter__()
-
 
 def _read_exact(fp, n):
     '''Read exactly *n* bytes from `fp`

--- a/Lib/lzma.py
+++ b/Lib/lzma.py
@@ -221,10 +221,6 @@ class LZMAFile(_compression.BaseStream):
         self._check_can_read()
         return self._buffer.readline(size)
 
-    def __iter__(self):
-        self._check_can_read()
-        return self._buffer.__iter__()
-
     def write(self, data):
         """Write a bytes object to the file.
 

--- a/Misc/NEWS.d/next/Library/2021-10-18-10-46-47.bpo-45475.sb9KDF.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-18-10-46-47.bpo-45475.sb9KDF.rst
@@ -1,0 +1,4 @@
+Reverted optimization of iterating :class:`gzip.GzipFile`,
+:class:`bz2.BZ2File`, and :class:`lzma.LZMAFile` (see bpo-43787) because it
+caused regression when user iterate them without having reference of them.
+Patch by Inada Naoki.


### PR DESCRIPTION
This commit reverts GH-25353.

<!-- issue-number: [bpo-45475](https://bugs.python.org/issue45475) -->
https://bugs.python.org/issue45475
<!-- /issue-number -->
