### PR TITLE
bpo-30570: fix an issubclass infinite recursion crash

### DIFF
--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -313,6 +313,14 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
         self.assertRaises(RecursionError, issubclass, int, X())
         self.assertRaises(RecursionError, isinstance, 1, X())
 
+    def test_infinite_recursion_via_bases_tuple(self):
+        """Regression test for bpo-30570."""
+        class Failure(object):
+            def __getattr__(self, attr):
+                return (self, None)
+
+        self.assertFalse(issubclass(Failure(), int))
+
 
 def blowstack(fxn, arg, compare_to):
     # Make sure that calling isinstance with a deeply nested tuple for its


### PR DESCRIPTION
`issubclass()` could crash due to infinite recursion on the values user supplied code emits for `__bases__`.

<!-- issue-number: [bpo-30570](https://bugs.python.org/issue30570) -->
https://bugs.python.org/issue30570
<!-- /issue-number -->
