### PR TITLE
bpo-37295: Add fast path for small `n` in `math.comb`

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -503,7 +503,7 @@ between the effects of a drug versus a placebo::
 
 Simulation of arrival times and service deliveries for a multiserver queue::
 
-    from heapq import heappush, heappop
+    from heapq import heapify, heapreplace
     from random import expovariate, gauss
     from statistics import mean, quantiles
 
@@ -515,14 +515,15 @@ Simulation of arrival times and service deliveries for a multiserver queue::
     waits = []
     arrival_time = 0.0
     servers = [0.0] * num_servers  # time when each server becomes available
-    for i in range(100_000):
+    heapify(servers)
+    for i in range(1_000_000):
         arrival_time += expovariate(1.0 / average_arrival_interval)
-        next_server_available = heappop(servers)
+        next_server_available = servers[0]
         wait = max(0.0, next_server_available - arrival_time)
         waits.append(wait)
-        service_duration = gauss(average_service_time, stdev_service_time)
+        service_duration = max(0.0, gauss(average_service_time, stdev_service_time))
         service_completed = arrival_time + wait + service_duration
-        heappush(servers, service_completed)
+        heapreplace(servers, service_completed)
 
     print(f'Mean wait: {mean(waits):.1f}   Max wait: {max(waits):.1f}')
     print('Quartiles:', [round(q, 1) for q in quantiles(waits)])


### PR DESCRIPTION
This adds a fast path for `n <= 62` in `math.comb`, as there the result of `math.comb(n, k)` is guaranteed to fit into a `uint64_t`. A small benchmark shows a ~3x performance gain (which is unfortunately not as large of a speedup as hoped for in the [original issue](https://bugs.python.org/issue37295)).

This is my first PR to the CPython codebase. Any advice is appreciated.

-------------------

```python
import math
def test():
    x = 0
    for i in range(2, 60):
        for j in range(i+1):
            math.comb(i, j)
if __name__ == '__main__':
    import timeit
    print(timeit.timeit("test()", globals=locals(), number=10000))
```

```
mc@boss:~/github/cpython$ ./python ~/Desktop/comb_time.py 
4.041443197998888
mc@boss:~/github/cpython$ python3 ~/Desktop/comb_time.py 
12.292179312000371
```

<!-- issue-number: [bpo-37295](https://bugs.python.org/issue37295) -->
https://bugs.python.org/issue37295
<!-- /issue-number -->
