### PR TITLE
bpo-45507: Throw EOF error when gzip headers or trailers are truncated

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -607,6 +607,9 @@ def decompress(data):
         do = zlib.decompressobj(wbits=-zlib.MAX_WBITS)
         # Read all the data except the header
         decompressed = do.decompress(data[fp.tell():])
+        if not do.eof or len(do.unused_data) < 8:
+            raise EOFError("Compressed file ended before the end-of-stream "
+                           "marker was reached")
         crc, length = struct.unpack("<II", do.unused_data[:8])
         if crc != zlib.crc32(decompressed):
             raise BadGzipFile("CRC check failed")

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -442,14 +442,14 @@ def _read_gzip_header(fp):
     if flag & FNAME:
         # Read and discard a null-terminated string containing the filename
         while True:
-            s = fp.read(1)
-            if not s or s==b'\000':
+            s = _read_exact(fp, 1)
+            if s == b'\000':
                 break
     if flag & FCOMMENT:
         # Read and discard a null-terminated string containing a comment
         while True:
-            s = fp.read(1)
-            if not s or s==b'\000':
+            s = _read_exact(fp, 1)
+            if s == b'\000':
                 break
     if flag & FHCRC:
         _read_exact(fp, 2)     # Read & discard the 16-bit header CRC

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -562,7 +562,7 @@ class TestGzip(BaseTest):
             datac = gzip.compress(data)
             self.assertEqual(gzip.decompress(datac), data)
 
-    def test_decompress_uncompressed_header(self):
+    def test_truncated_header(self):
         truncated_headers = [
             b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00",             # Missing OS byte
             b"\x1f\x8b\x08\x02\x00\x00\x00\x00\x00\xff",         # FHRC, but no checksum
@@ -573,7 +573,8 @@ class TestGzip(BaseTest):
         ]
         for header in truncated_headers:
             with self.subTest(header=header):
-                self.assertRaises(EOFError, gzip.decompress, header)
+                self.assertRaises(EOFError, gzip._read_gzip_header,
+                                  io.BytesIO(header))
 
     def test_read_truncated(self):
         data = data1*50

--- a/Misc/NEWS.d/next/Library/2021-10-18-11-20-24.bpo-45507.vWx2yS.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-18-11-20-24.bpo-45507.vWx2yS.rst
@@ -1,0 +1,2 @@
+Add regression tests for errors that are thrown when decompressing with the
+``gzip`` module to ensure backwards-compatibility between Python versions.

--- a/Misc/NEWS.d/next/Library/2021-10-18-11-20-24.bpo-45507.vWx2yS.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-18-11-20-24.bpo-45507.vWx2yS.rst
@@ -1,2 +1,3 @@
-Add regression tests for errors that are thrown when decompressing with the
-``gzip`` module to ensure backwards-compatibility between Python versions.
+Make sure EOFerror is thrown when gzip headers have missing or truncated 
+NAME or COMMENT fields when FNAME or FCOMMENT flags are set.
+


### PR DESCRIPTION
This is to keep error compatibility with 3.10 and lower.

It was missed in my last PR #27941. When the gzip member contains an incomplete trailer (less than 8 bytes) the GzipFile-based implementation of 3.10 and below would throuw an EOF error, so the newer in-memory implementation should do the same.
Currently it throws 'struct.error: unpack requires a buffer of 8 bytes' when the trailer is truncated.

<!-- issue-number: [bpo-45507](https://bugs.python.org/issue45507) -->
https://bugs.python.org/issue45507
<!-- /issue-number -->
