### PR TITLE
Fix docs source link for importlib.metadata

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -11,7 +11,7 @@
 .. versionchanged:: 3.10
    ``importlib.metadata`` is no longer provisional.
 
-**Source code:** :source:`Lib/importlib/metadata.py`
+**Source code:** :source:`Lib/importlib/metadata/__init__.py`
 
 ``importlib.metadata`` is a library that provides for access to installed
 package metadata.  Built in part on Python's import system, this library


### PR DESCRIPTION
The link broke for Python 3.10 since importlib.metadata was made from a module into a package

I think this is trivial enough to not need a bpo issue.

Automerge-Triggered-By: GH:jaraco