### PR TITLE
bpo-45434: Only exclude <stdlib.h> in Python 3.11 limited C API

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -564,18 +564,9 @@ Porting to Python 3.11
 
   (Contributed by Victor Stinner in :issue:`39573`.)
 
-* The ``<Python.h>`` header file no longer includes ``<stdlib.h>``. C
-  extensions using ``<stdlib.h>`` must now include it explicitly.
-  The system ``<stdlib.h>`` header provides functions like:
-  ``malloc()``/``free()``, ``getenv()``, ``strtol()``, ``abs()``, ``strtol()``,
-  ``exit()`` and ``abort()``.
-  (Contributed by Victor Stinner in :issue:`45434`.)
-
-* The ``<Python.h>`` header file no longer includes ``<stdio.h>`` if the
-  ``Py_LIMITED_API`` macro is defined. Functions expecting ``FILE*`` are
-  excluded from the limited C API (:pep:`384`). C extensions using
-  ``<stdio.h>`` must now include it explicitly.  The system ``<stdio.h>``
-  header provides functions like ``printf()`` and ``fopen()``.
+* The Python 3.11 limited C API no longer includes ``<stdlib.h>``,
+  ``<stdio.h>``, ``<errno.h>`` and ``<string.h>``. C extensions using these
+  headers must now include them explicitly.
   (Contributed by Victor Stinner in :issue:`45434`.)
 
 * The non-limited API files ``cellobject.h``, ``classobject.h``, ``context.h``,

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -565,8 +565,9 @@ Porting to Python 3.11
   (Contributed by Victor Stinner in :issue:`39573`.)
 
 * The Python 3.11 limited C API no longer includes ``<stdlib.h>``,
-  ``<stdio.h>``, ``<errno.h>`` and ``<string.h>``. C extensions using these
-  headers must now include them explicitly.
+  ``<stdio.h>``, ``<errno.h>`` and ``<string.h>``:
+  if ``Py_LIMITED_API >= 0x030b0000``. C extensions using these headers must
+  now include them explicitly.
   (Contributed by Victor Stinner in :issue:`45434`.)
 
 * The non-limited API files ``cellobject.h``, ``classobject.h``, ``context.h``,

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -564,10 +564,10 @@ Porting to Python 3.11
 
   (Contributed by Victor Stinner in :issue:`39573`.)
 
-* The Python 3.11 limited C API no longer includes ``<stdlib.h>``,
-  ``<stdio.h>``, ``<errno.h>`` and ``<string.h>``:
-  if ``Py_LIMITED_API >= 0x030b0000``. C extensions using these headers must
-  now include them explicitly.
+* ``<Python.h>`` no longer includes the header files ``<stdlib.h>``,
+  ``<stdio.h>``, ``<errno.h>`` and ``<string.h>`` when the ``Py_LIMITED_API``
+  macro is set to ``0x030b0000`` (Python 3.11) or higher. C extensions should
+  explicitly include the header files after ``#include <Python.h>``.
   (Contributed by Victor Stinner in :issue:`45434`.)
 
 * The non-limited API files ``cellobject.h``, ``classobject.h``, ``context.h``,

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -16,12 +16,14 @@
 #  define _SGI_MP_SOURCE
 #endif
 
-#include <string.h>               // memcpy()
-#ifndef Py_LIMITED_API
+// stdlib.h, stdio.h, errno.h and string.h headers are not used by Python
+// headers, but kept for backward compatibility. They are excluded from the
+// limited C API of Python 3.11.
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
+#  include <stdlib.h>
 #  include <stdio.h>              // FILE*
-#endif
-#ifdef HAVE_ERRNO_H
 #  include <errno.h>              // errno
+#  include <string.h>             // memcpy()
 #endif
 #ifndef MS_WINDOWS
 #  include <unistd.h>

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -201,9 +201,8 @@ typedef Py_ssize_t Py_ssize_clean_t;
 #  define Py_LOCAL_INLINE(type) static inline type
 #endif
 
-/* Py_MEMCPY is kept for backwards compatibility,
- * see https://bugs.python.org/issue28126 */
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030b0000
+// bpo-28126: Py_MEMCPY is kept for backwards compatibility,
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #  define Py_MEMCPY memcpy
 #endif
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -203,7 +203,9 @@ typedef Py_ssize_t Py_ssize_clean_t;
 
 /* Py_MEMCPY is kept for backwards compatibility,
  * see https://bugs.python.org/issue28126 */
-#define Py_MEMCPY memcpy
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030b0000
+#  define Py_MEMCPY memcpy
+#endif
 
 #ifdef HAVE_IEEEFP_H
 #include <ieeefp.h>  /* needed for 'finite' declaration on some platforms */

--- a/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
@@ -1,4 +1,5 @@
-The Python 3.11 limited C API no longer includes ``<stdlib.h>``, ``<stdio.h>``,
-``<errno.h>`` and ``<string.h>``: if ``Py_LIMITED_API >= 0x030b0000``.
-C extensions using these headers must now include them explicitly.
+``<Python.h>`` no longer includes the header files ``<stdlib.h>``,
+``<stdio.h>``, ``<errno.h>`` and ``<string.h>`` when the ``Py_LIMITED_API``
+macro is set to ``0x030b0000`` (Python 3.11) or higher. C extensions should
+explicitly include the header files after ``#include <Python.h>``.
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
@@ -1,6 +1,4 @@
-The ``<Python.h>`` header file no longer includes ``<stdlib.h>``. C
-extensions using ``<stdlib.h>`` must now include it explicitly.
-The system ``<stdlib.h>`` header provides functions like:
-``malloc()``/``free()``, ``getenv()``, ``strtol()``, ``abs()``, ``strtol()``,
-``exit()`` and ``abort()``.
+The Python 3.11 limited C API no longer includes ``<stdlib.h>``, ``<stdio.h>``,
+``<errno.h>`` and ``<string.h>``. C extensions using these headers must now
+include them explicitly.
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-11-23-03-49.bpo-45434.tsS8I_.rst
@@ -1,4 +1,4 @@
 The Python 3.11 limited C API no longer includes ``<stdlib.h>``, ``<stdio.h>``,
-``<errno.h>`` and ``<string.h>``. C extensions using these headers must now
-include them explicitly.
+``<errno.h>`` and ``<string.h>``: if ``Py_LIMITED_API >= 0x030b0000``.
+C extensions using these headers must now include them explicitly.
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2021-10-15-00-30-45.bpo-45434.XLtsbK.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-15-00-30-45.bpo-45434.XLtsbK.rst
@@ -1,5 +1,0 @@
-The ``<Python.h>`` header file no longer includes ``<stdio.h>`` if the
-``Py_LIMITED_API`` macro is defined. Functions expecting ``FILE*`` are excluded
-from the limited C API (:pep:`384`). C extensions using ``<stdio.h>`` must now
-include it explicitly.
-Patch by Victor Stinner.

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -1,4 +1,3 @@
-
 /* Use this file as a template to start implementing a module that
    also declares object types. All occurrences of 'Xxo' should be changed
    to something reasonable for your objects. After that, all other
@@ -55,7 +54,7 @@
           pass
    */
 
-#define Py_LIMITED_API 0x030a0000
+#define Py_LIMITED_API 0x030b0000
 
 #include "Python.h"
 


### PR DESCRIPTION
The Python 3.11 limited C API no longer includes stdlib.h, stdio.h,
string.h and errno.h.

* Exclude Py_MEMCPY() from Python 3.11 limited C API.
* xxlimited C extension is now built with Python 3.11 limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45434](https://bugs.python.org/issue45434) -->
https://bugs.python.org/issue45434
<!-- /issue-number -->
