### PR TITLE
bpo-45507: EOFErrors should be thrown for truncated gzip members

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -607,6 +607,9 @@ def decompress(data):
         do = zlib.decompressobj(wbits=-zlib.MAX_WBITS)
         # Read all the data except the header
         decompressed = do.decompress(data[fp.tell():])
+        if not do.eof or len(do.unused_data) < 8:
+            raise EOFError("Compressed file ended before the end-of-stream "
+                           "marker was reached")
         crc, length = struct.unpack("<II", do.unused_data[:8])
         if crc != zlib.crc32(decompressed):
             raise BadGzipFile("CRC check failed")

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -562,6 +562,14 @@ class TestGzip(BaseTest):
             datac = gzip.compress(data)
             self.assertEqual(gzip.decompress(datac), data)
 
+    def test_decompress_truncated_trailer(self):
+        compressed_data = gzip.compress(data1)
+        self.assertRaises(EOFError, gzip.decompress, compressed_data[:-4])
+
+    def test_decompress_missing_trailer(self):
+        compressed_data = gzip.compress(data1)
+        self.assertRaises(EOFError, gzip.decompress, compressed_data[:-8])
+
     def test_read_truncated(self):
         data = data1*50
         # Drop the CRC (4 bytes) and file size (4 bytes).

--- a/Misc/NEWS.d/next/Library/2021-10-18-14-00-01.bpo-45507.lDotNV.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-18-14-00-01.bpo-45507.lDotNV.rst
@@ -1,0 +1,1 @@
+Add tests for truncated/missing trailers in gzip.decompress implementation.


### PR DESCRIPTION
This is to keep error compatibility with 3.10 and lower.

It was missed in my last PR #27941. When the gzip member contains an incomplete trailer (less than 8 bytes) the GzipFile-based implementation of 3.10 and below would throuw an EOF error, so the newer in-memory implementation should do the same.
Currently it throws 'struct.error: unpack requires a buffer of 8 bytes' when the trailer is truncated.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45507](https://bugs.python.org/issue45507) -->
https://bugs.python.org/issue45507
<!-- /issue-number -->
