### PR TITLE
bpo-37295: Optimize math.comb() for small arguments

### DIFF
--- a/Misc/NEWS.d/next/Library/2021-10-18-16-08-55.bpo-37295.wBEWH2.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-18-16-08-55.bpo-37295.wBEWH2.rst
@@ -1,0 +1,1 @@
+Optimize :func:`math.comb` for small arguments.`


### PR DESCRIPTION
Do calculations in C unsigned long long if the result can fit in 64 bits.

Co-authored-by: Marco <cognetta.marco@gmail.com>


<!-- issue-number: [bpo-37295](https://bugs.python.org/issue37295) -->
https://bugs.python.org/issue37295
<!-- /issue-number -->
