### PR TITLE
bpo-45221: Fix handling of LDFLAGS and CPPFLAGS in setup.py

### DIFF
--- a/Misc/NEWS.d/next/Build/2021-10-18-10-25-56.bpo-45221.rnulhf.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-18-10-25-56.bpo-45221.rnulhf.rst
@@ -1,0 +1,3 @@
+Fixed regression in handling of ``LDFLAGS`` options where
+:meth:`argparse.parse_known_args` could interpret an option as one of the
+built-in command line argument, for example ``-h`` for help.

--- a/Misc/NEWS.d/next/Build/2021-10-18-10-25-56.bpo-45221.rnulhf.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-18-10-25-56.bpo-45221.rnulhf.rst
@@ -1,3 +1,3 @@
-Fixed regression in handling of ``LDFLAGS`` options where
-:meth:`argparse.parse_known_args` could interpret an option as one of the
-built-in command line argument, for example ``-h`` for help.
+Fixed regression in handling of ``LDFLAGS`` and ``CPPFLAGS`` options
+where :meth:`argparse.parse_known_args` could interpret an option as 
+one of the built-in command line argument, for example ``-h`` for help.

--- a/Misc/NEWS.d/next/Build/2021-10-18-10-25-56.bpo-45221.rnulhf.rst
+++ b/Misc/NEWS.d/next/Build/2021-10-18-10-25-56.bpo-45221.rnulhf.rst
@@ -1,3 +1,3 @@
 Fixed regression in handling of ``LDFLAGS`` and ``CPPFLAGS`` options
-where :meth:`argparse.parse_known_args` could interpret an option as 
+where :meth:`argparse.parse_known_args` could interpret an option as
 one of the built-in command line argument, for example ``-h`` for help.

--- a/setup.py
+++ b/setup.py
@@ -801,6 +801,16 @@ class PyBuildExt(build_ext):
             if env_val:
                 parser = argparse.ArgumentParser()
                 parser.add_argument(arg_name, dest="dirs", action="append")
+
+                # To prevent argparse from raising an exception about any
+                # options in env_val that it mistakes for known option, we
+                # strip out all double dashes and any dashes followed by a
+                # character that is not for the option we are dealing with.
+                #
+                # Please note that order of the regex is important!  We must
+                # strip out double-dashes first so that we don't end up with
+                # substituting "--Long" to "-Long" and thus lead to "ong" being
+                # used for a library directory.
                 env_val = re.sub(r'(^|\s+)-(-|(?!%s))' % arg_name[1],
                                  ' ', env_val)
                 options, _ = parser.parse_known_args(env_val.split())

--- a/setup.py
+++ b/setup.py
@@ -801,6 +801,8 @@ class PyBuildExt(build_ext):
             if env_val:
                 parser = argparse.ArgumentParser()
                 parser.add_argument(arg_name, dest="dirs", action="append")
+                env_val = re.sub(r'(^|\s+)-(-|(?!%s))' % arg_name[1],
+                                 ' ', env_val)
                 options, _ = parser.parse_known_args(env_val.split())
                 if options.dirs:
                     for directory in reversed(options.dirs):


### PR DESCRIPTION
This processing was removed in https://github.com/python/cpython/commit/09b2bece78f  when replacing optparse with argparse, because argparse will already ignore unknown arguments here; but the line is still useful to avoid mistakenly parsing known args.

I couldn't find any tests for setup.py, I can work on a test if someone can point me to where they are located..

<!-- issue-number: [bpo-45221](https://bugs.python.org/issue45221) -->
https://bugs.python.org/issue45221
<!-- /issue-number -->
