### PR TITLE
bpo-45506: Normalize _PyPathConfig.stdlib_dir when calculated.

### DIFF
--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -80,6 +80,9 @@ extern int _Py_add_relfile(wchar_t *dirname,
                            const wchar_t *relfile,
                            size_t bufsize);
 extern size_t _Py_find_basename(const wchar_t *filename);
+PyAPI_FUNC(int) _Py_normalize_path(const wchar_t *path,
+                                   wchar_t *buf, const size_t buf_len);
+
 
 // Macros to protect CRT calls against instant termination when passed an
 // invalid parameter (bpo-23524). IPH stands for Invalid Parameter Handler.

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -61,7 +61,7 @@ class EmbeddingTestsMixin:
         else:
             exepath = os.path.join(builddir, 'Programs')
         self.test_exe = exe = os.path.join(exepath, exename)
-        if not os.path.exists(exe):
+        if exepath != support.REPO_ROOT or not os.path.exists(exe):
             self.skipTest("%r doesn't exist" % exe)
         # This is needed otherwise we get a fatal error:
         # "Py_Initialize: Unable to get the locale encoding

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -61,7 +61,7 @@ class EmbeddingTestsMixin:
         else:
             exepath = os.path.join(builddir, 'Programs')
         self.test_exe = exe = os.path.join(exepath, exename)
-        if exepath != support.REPO_ROOT or not os.path.exists(exe):
+        if not os.path.exists(exe):
             self.skipTest("%r doesn't exist" % exe)
         # This is needed otherwise we get a fatal error:
         # "Py_Initialize: Unable to get the locale encoding

--- a/Lib/test/test_fileutils.py
+++ b/Lib/test/test_fileutils.py
@@ -1,0 +1,32 @@
+# Run tests for functions in Python/fileutils.c.
+
+import os
+import os.path
+import unittest
+from test.support import import_helper
+from .test_posixpath import PosixPathTest as posixdata
+
+# Skip this test if the _testcapi module isn't available.
+_testcapi = import_helper.import_module('_testinternalcapi')
+
+
+class PathTests(unittest.TestCase):
+
+    if os.name == 'nt':
+        raise Unittest.SkipTest()
+    else:
+        NORMPATH_CASES = posixdata.NORMPATH_CASES
+
+    def test_normalize_path(self):
+        for filename, expected in self.NORMPATH_CASES:
+            if not os.path.isabs(filename):
+                continue
+            with self.subTest(filename):
+                result = _testcapi.test_normalize_path(filename)
+                self.assertEqual(result, expected)
+
+del posixdata
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_fileutils.py
+++ b/Lib/test/test_fileutils.py
@@ -4,7 +4,6 @@ import os
 import os.path
 import unittest
 from test.support import import_helper
-from .test_posixpath import PosixPathTest as posixdata
 
 # Skip this test if the _testcapi module isn't available.
 _testcapi = import_helper.import_module('_testinternalcapi')
@@ -12,20 +11,18 @@ _testcapi = import_helper.import_module('_testinternalcapi')
 
 class PathTests(unittest.TestCase):
 
-    if os.name == 'nt':
-        raise Unittest.SkipTest()
-    else:
-        NORMPATH_CASES = posixdata.NORMPATH_CASES
-
     def test_normalize_path(self):
-        for filename, expected in self.NORMPATH_CASES:
+        if os.name == 'nt':
+            raise unittest.SkipTest('Windows has its own helper for this')
+        else:
+            from .test_posixpath import PosixPathTest as posixdata
+            tests = posixdata.NORMPATH_CASES
+        for filename, expected in tests:
             if not os.path.isabs(filename):
                 continue
             with self.subTest(filename):
                 result = _testcapi.test_normalize_path(filename)
                 self.assertEqual(result, expected)
-
-del posixdata
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_fileutils.py
+++ b/Lib/test/test_fileutils.py
@@ -11,7 +11,7 @@ _testcapi = import_helper.import_module('_testinternalcapi')
 
 class PathTests(unittest.TestCase):
 
-    def test_normalize_path(self):
+    def test_capi_normalize_path(self):
         if os.name == 'nt':
             raise unittest.SkipTest('Windows has its own helper for this')
         else:
@@ -22,7 +22,8 @@ class PathTests(unittest.TestCase):
                 continue
             with self.subTest(filename):
                 result = _testcapi.normalize_path(filename)
-                self.assertEqual(result, expected)
+                self.assertEqual(result, expected,
+                    msg=f'input: {filename!r} expected output: {expected!r}')
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_fileutils.py
+++ b/Lib/test/test_fileutils.py
@@ -21,7 +21,7 @@ class PathTests(unittest.TestCase):
             if not os.path.isabs(filename):
                 continue
             with self.subTest(filename):
-                result = _testcapi.test_normalize_path(filename)
+                result = _testcapi.normalize_path(filename)
                 self.assertEqual(result, expected)
 
 

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -307,6 +307,9 @@ class PosixPathTest(unittest.TestCase):
     NORMPATH_CASES = [
         ("", "."),
         ("/", "/"),
+        ("/.", "/"),
+        ("/./", "/"),
+        ("/.//.", "/"),
         ("/foo", "/foo"),
         ("/foo/bar", "/foo/bar"),
         ("//", "//"),
@@ -314,6 +317,8 @@ class PosixPathTest(unittest.TestCase):
         ("///foo/.//bar//", "/foo/bar"),
         ("///foo/.//bar//.//..//.//baz///", "/foo/baz"),
         ("///..//./foo/.//bar", "/foo/bar"),
+        (".", "."),
+        (".//.", "."),
         ("..", ".."),
         ("../", ".."),
         ("../foo", "../foo"),
@@ -323,11 +328,14 @@ class PosixPathTest(unittest.TestCase):
         ("/..", "/"),
         ("/..", "/"),
         ("/../", "/"),
+        ("/..//", "/"),
+        ("//..", "//"),
         ("/../foo", "/foo"),
         ("/../../foo", "/foo"),
         ("/../foo/../", "/"),
         ("/../foo/../bar", "/bar"),
         ("/../../foo/../bar/./baz/boom/..", "/bar/baz"),
+        ("/../../foo/../bar/./baz/boom/.", "/bar/baz/boom"),
     ]
 
     def test_normpath(self):
@@ -338,7 +346,7 @@ class PosixPathTest(unittest.TestCase):
 
             path = path.encode('utf-8')
             expected = expected.encode('utf-8')
-            with self.subTest(path):
+            with self.subTest(path, type=bytes):
                 result = posixpath.normpath(path)
                 self.assertEqual(result, expected)
 

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -304,25 +304,43 @@ class PosixPathTest(unittest.TestCase):
                 for path in ('~', '~/.local', '~vstinner/'):
                     self.assertEqual(posixpath.expanduser(path), path)
 
-    def test_normpath(self):
-        self.assertEqual(posixpath.normpath(""), ".")
-        self.assertEqual(posixpath.normpath("/"), "/")
-        self.assertEqual(posixpath.normpath("//"), "//")
-        self.assertEqual(posixpath.normpath("///"), "/")
-        self.assertEqual(posixpath.normpath("///foo/.//bar//"), "/foo/bar")
-        self.assertEqual(posixpath.normpath("///foo/.//bar//.//..//.//baz"),
-                         "/foo/baz")
-        self.assertEqual(posixpath.normpath("///..//./foo/.//bar"), "/foo/bar")
+    NORMPATH_CASES = [
+        ("", "."),
+        ("/", "/"),
+        ("/foo", "/foo"),
+        ("/foo/bar", "/foo/bar"),
+        ("//", "//"),
+        ("///", "/"),
+        ("///foo/.//bar//", "/foo/bar"),
+        ("///foo/.//bar//.//..//.//baz///", "/foo/baz"),
+        ("///..//./foo/.//bar", "/foo/bar"),
+        ("..", ".."),
+        ("../", ".."),
+        ("../foo", "../foo"),
+        ("../../foo", "../../foo"),
+        ("../foo/../bar", "../bar"),
+        ("../../foo/../bar/./baz/boom/..", "../../bar/baz"),
+        ("/..", "/"),
+        ("/..", "/"),
+        ("/../", "/"),
+        ("/../foo", "/foo"),
+        ("/../../foo", "/foo"),
+        ("/../foo/../", "/"),
+        ("/../foo/../bar", "/bar"),
+        ("/../../foo/../bar/./baz/boom/..", "/bar/baz"),
+    ]
 
-        self.assertEqual(posixpath.normpath(b""), b".")
-        self.assertEqual(posixpath.normpath(b"/"), b"/")
-        self.assertEqual(posixpath.normpath(b"//"), b"//")
-        self.assertEqual(posixpath.normpath(b"///"), b"/")
-        self.assertEqual(posixpath.normpath(b"///foo/.//bar//"), b"/foo/bar")
-        self.assertEqual(posixpath.normpath(b"///foo/.//bar//.//..//.//baz"),
-                         b"/foo/baz")
-        self.assertEqual(posixpath.normpath(b"///..//./foo/.//bar"),
-                         b"/foo/bar")
+    def test_normpath(self):
+        for path, expected in self.NORMPATH_CASES:
+            with self.subTest(path):
+                result = posixpath.normpath(path)
+                self.assertEqual(result, expected)
+
+            path = path.encode('utf-8')
+            expected = expected.encode('utf-8')
+            with self.subTest(path):
+                result = posixpath.normpath(path)
+                self.assertEqual(result, expected)
 
     @skip_if_ABSTFN_contains_backslash
     def test_realpath_curdir(self):

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -371,10 +371,6 @@ test_edit_cost(PyObject *self, PyObject *Py_UNUSED(args))
 static PyObject *
 normalize_path(PyObject *self, PyObject *filename)
 {
-//    if (!PyUnicode_Check(filename)) {
-//        PyErr_SetString(PyExc_TypeError, "argument must be a string");
-//        return NULL;
-//    }
     Py_ssize_t size = -1;
     wchar_t *encoded = PyUnicode_AsWideCharString(filename, &size);
     if (encoded == NULL) {

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -369,7 +369,7 @@ test_edit_cost(PyObject *self, PyObject *Py_UNUSED(args))
 
 
 static PyObject *
-test_normalize_path(PyObject *self, PyObject *filename)
+normalize_path(PyObject *self, PyObject *filename)
 {
 //    if (!PyUnicode_Check(filename)) {
 //        PyErr_SetString(PyExc_TypeError, "argument must be a string");
@@ -404,7 +404,7 @@ static PyMethodDef TestMethods[] = {
     {"set_config", test_set_config, METH_O},
     {"test_atomic_funcs", test_atomic_funcs, METH_NOARGS},
     {"test_edit_cost", test_edit_cost, METH_NOARGS},
-    {"test_normalize_path", test_normalize_path, METH_O, NULL},
+    {"normalize_path", normalize_path, METH_O, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -14,12 +14,14 @@
 #include "Python.h"
 #include "pycore_atomic_funcs.h" // _Py_atomic_int_get()
 #include "pycore_bitutils.h"     // _Py_bswap32()
+#include "pycore_fileutils.h"    // _Py_normalize_path
 #include "pycore_gc.h"           // PyGC_Head
 #include "pycore_hashtable.h"    // _Py_hashtable_new()
 #include "pycore_initconfig.h"   // _Py_GetConfigsAsDict()
 #include "pycore_interp.h"       // _PyInterpreterState_GetConfigCopy()
 #include "pycore_pyerrors.h"     // _Py_UTF8_Edit_Cost()
 #include "pycore_pystate.h"      // _PyThreadState_GET()
+#include "osdefs.h"               // MAXPATHLEN
 
 
 static PyObject *
@@ -366,6 +368,31 @@ test_edit_cost(PyObject *self, PyObject *Py_UNUSED(args))
 }
 
 
+static PyObject *
+test_normalize_path(PyObject *self, PyObject *filename)
+{
+//    if (!PyUnicode_Check(filename)) {
+//        PyErr_SetString(PyExc_TypeError, "argument must be a string");
+//        return NULL;
+//    }
+    Py_ssize_t size = -1;
+    wchar_t *encoded = PyUnicode_AsWideCharString(filename, &size);
+    if (encoded == NULL) {
+        return NULL;
+    }
+
+    wchar_t buf[MAXPATHLEN + 1];
+    int res = _Py_normalize_path(encoded, buf, Py_ARRAY_LENGTH(buf));
+    PyMem_Free(encoded);
+    if (res != 0) {
+        PyErr_SetString(PyExc_ValueError, "string too long");
+        return NULL;
+    }
+
+    return PyUnicode_FromWideChar(buf, -1);
+}
+
+
 static PyMethodDef TestMethods[] = {
     {"get_configs", get_configs, METH_NOARGS},
     {"get_recursion_depth", get_recursion_depth, METH_NOARGS},
@@ -377,6 +404,7 @@ static PyMethodDef TestMethods[] = {
     {"set_config", test_set_config, METH_O},
     {"test_atomic_funcs", test_atomic_funcs, METH_NOARGS},
     {"test_edit_cost", test_edit_cost, METH_NOARGS},
+    {"test_normalize_path", test_normalize_path, METH_O, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -338,8 +338,8 @@ normalize(const wchar_t *orig, wchar_t *buf, const size_t buf_len)
     int dots = -1;
     wchar_t *buf_next = buf;
     // The resulting filename will never be longer than orig.
-    for (const wchar_t *unused = orig; *unused != L'\0'; unused++) {
-        wchar_t c = *unused;
+    for (const wchar_t *remainder = orig; *remainder != L'\0'; remainder++) {
+        wchar_t c = *remainder;
         buf_next[0] = c;
         buf_next++;
         if (c == SEP) {

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -365,8 +365,7 @@ normalize(const wchar_t *orig, wchar_t *buf, const size_t buf_len)
             dots = 0;
         }
         else if (dots >= 0) {
-            if (c == L'.') {
-                assert(dots <= 2);
+            if (c == L'.' && dots < 2) {
                 dots++;
             }
             else {

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -322,8 +322,9 @@ absolutize(wchar_t **path_p)
 }
 
 
-/* Remove navigation elements such as "." and "..". */
-// This is similar to canonicalize() in PC/getpathp.c.
+/* Remove navigation elements such as "." and "..".
+
+   This is essentially a C implementation of posixpath.normpath(). */
 static PyStatus
 normalize(const wchar_t *orig, wchar_t *buf, const size_t buf_len)
 {

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -584,9 +584,23 @@ calculate_set_stdlib_dir(PyCalculatePath *calculate, _PyPathConfig *pathconfig)
     if (!calculate->prefix_found) {
         return _PyStatus_OK();
     }
+    PyStatus status;
+    wchar_t *prefix = calculate->prefix;
+    if (!_Py_isabs(prefix)) {
+        prefix = _PyMem_RawWcsdup(prefix);
+        if (prefix == NULL) {
+            return _PyStatus_NO_MEMORY();
+        }
+        status = absolutize(&prefix);
+        if (_PyStatus_EXCEPTION(status)) {
+            return status;
+        }
+    }
     wchar_t buf[MAXPATHLEN + 1];
-    PyStatus status = normalize(calculate->prefix,
-                                buf, Py_ARRAY_LENGTH(buf));
+    status = normalize(prefix, buf, Py_ARRAY_LENGTH(buf));
+    if (prefix != calculate->prefix) {
+        PyMem_RawFree(prefix);
+    }
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -363,6 +363,11 @@ normalize(const wchar_t *orig, wchar_t *buf, const size_t buf_len)
                 buf_next -= 2;  // "./"
                 assert(*(buf_next - 1) == SEP);
             }
+            else if (dots == 0) {
+                // Turn "//" into "/".
+                buf_next--;
+                assert(*(buf_next - 1) == SEP);
+            }
             dots = 0;
         }
         else if (dots >= 0) {

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -323,7 +323,7 @@ absolutize(wchar_t **path_p)
 
 
 /* Remove navigation elements such as "." and "..". */
-// This is similar to canonicalize() is PC/getpathp.c.
+// This is similar to canonicalize() in PC/getpathp.c.
 static PyStatus
 normalize(const wchar_t *orig, wchar_t *buf, const size_t buf_len)
 {

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2241,12 +2241,15 @@ _Py_normalize_path(const wchar_t *path, wchar_t *buf, const size_t buf_len)
             }
             dots = 0;
         }
-        else if (dots >= 0) {
-            if (c == L'.' && dots < 2) {
-                dots++;
-            }
-            else {
-                dots = -1;
+        else {
+            check_leading = 0;
+            if (dots >= 0) {
+                if (c == L'.' && dots < 2) {
+                    dots++;
+                }
+                else {
+                    dots = -1;
+                }
             }
         }
     }

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2181,6 +2181,88 @@ _Py_find_basename(const wchar_t *filename)
 }
 
 
+/* Remove navigation elements such as "." and "..".
+
+   This is mostly a C implementation of posixpath.normpath().
+   Return 0 on success.  Return -1 if "orig" is too big for the buffer. */
+int
+_Py_normalize_path(const wchar_t *path, wchar_t *buf, const size_t buf_len)
+{
+    assert(path && *path != L'\0');
+    assert(*path == SEP);  // an absolute path
+    if (wcslen(path) + 1 >= buf_len) {
+        return -1;
+    }
+
+    int dots = -1;
+    wchar_t *buf_next = buf;
+    // The resulting filename will never be longer than path.
+    for (const wchar_t *remainder = path; *remainder != L'\0'; remainder++) {
+        wchar_t c = *remainder;
+        buf_next[0] = c;
+        buf_next++;
+        if (c == SEP) {
+            assert(dots <= 2);
+            if (dots == 2) {
+                // Turn "/x/y/../z" into "/x/z".
+                buf_next -= 4;  // "/../"
+                assert(*buf_next == SEP);
+                // We cap it off at the root, so "/../spam" becomes "/spam".
+                if (buf_next == buf) {
+                    buf_next++;
+                }
+                else {
+                    // Move to the previous SEP in the buffer.
+                    while (*(buf_next - 1) != SEP) {
+                        assert(buf_next != buf);
+                        buf_next--;
+                    }
+                }
+            }
+            else if (dots == 1) {
+                // Turn "/./" into "/".
+                buf_next -= 2;  // "./"
+                assert(*(buf_next - 1) == SEP);
+            }
+            else if (dots == 0) {
+                // Turn "//" into "/".
+                buf_next--;
+                assert(*(buf_next - 1) == SEP);
+            }
+            dots = 0;
+        }
+        else if (dots >= 0) {
+            if (c == L'.' && dots < 2) {
+                dots++;
+            }
+            else {
+                dots = -1;
+            }
+        }
+    }
+    if (dots >= 0) {
+        // Strip any trailing dots and trailing slash.
+        buf_next -= dots + 1;  // "/" or "/." or "/.."
+        assert(*buf_next == SEP);
+        if (buf_next == buf) {
+            // Leave the single slash for root.
+            buf_next++;
+        }
+        else {
+            if (dots == 2) {
+                // Move to the previous SEP in the buffer.
+                do {
+                    assert(buf_next != buf);
+                    buf_next--;
+                } while (*(buf_next) != SEP);
+            }
+        }
+    }
+    *buf_next = L'\0';
+    return 0;
+}
+
+
 /* Get the current directory. buflen is the buffer size in wide characters
    including the null character. Decode the path from the locale encoding.
 


### PR DESCRIPTION
The recently added `PyConfig.stdlib_dir` was being set with ".." entries.  When `__file__` was added for from modules this caused a problem on out-of-tree builds.  This PR fixes that by normalizing "stdlib_dir" when it is calculated in getpath.c.

<!-- issue-number: [bpo-45506](https://bugs.python.org/issue45506) -->
https://bugs.python.org/issue45506
<!-- /issue-number -->
