### PR TITLE
bpo-35134: Split warnings.h and weakrefobject.h

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -644,3 +644,8 @@ Removed
 
   Remove also the ``Py_MARSHAL_VERSION`` macro from the limited C API.
   (Contributed by Victor Stinner in :issue:`45474`.)
+
+* Exclude :c:func:`PyWeakref_GET_OBJECT` from the limited C API. It never
+  worked since the :c:type:`PyWeakReference` structure is opaque in the
+  limited C API.
+  (Contributed by Victor Stinner in :issue:`35134`.)

--- a/Include/cpython/warnings.h
+++ b/Include/cpython/warnings.h
@@ -1,0 +1,20 @@
+#ifndef Py_CPYTHON_WARNINGS_H
+#  error "this header file must not be included directly"
+#endif
+
+PyAPI_FUNC(int) PyErr_WarnExplicitObject(
+    PyObject *category,
+    PyObject *message,
+    PyObject *filename,
+    int lineno,
+    PyObject *module,
+    PyObject *registry);
+
+PyAPI_FUNC(int) PyErr_WarnExplicitFormat(
+    PyObject *category,
+    const char *filename, int lineno,
+    const char *module, PyObject *registry,
+    const char *format, ...);
+
+// DEPRECATED: Use PyErr_WarnEx() instead.
+#define PyErr_Warn(category, msg) PyErr_WarnEx(category, msg, 1)

--- a/Include/cpython/weakrefobject.h
+++ b/Include/cpython/weakrefobject.h
@@ -1,0 +1,47 @@
+#ifndef Py_CPYTHON_WEAKREFOBJECT_H
+#  error "this header file must not be included directly"
+#endif
+
+/* PyWeakReference is the base struct for the Python ReferenceType, ProxyType,
+ * and CallableProxyType.
+ */
+struct _PyWeakReference {
+    PyObject_HEAD
+
+    /* The object to which this is a weak reference, or Py_None if none.
+     * Note that this is a stealth reference:  wr_object's refcount is
+     * not incremented to reflect this pointer.
+     */
+    PyObject *wr_object;
+
+    /* A callable to invoke when wr_object dies, or NULL if none. */
+    PyObject *wr_callback;
+
+    /* A cache for wr_object's hash code.  As usual for hashes, this is -1
+     * if the hash code isn't known yet.
+     */
+    Py_hash_t hash;
+
+    /* If wr_object is weakly referenced, wr_object has a doubly-linked NULL-
+     * terminated list of weak references to it.  These are the list pointers.
+     * If wr_object goes away, wr_object is set to Py_None, and these pointers
+     * have no meaning then.
+     */
+    PyWeakReference *wr_prev;
+    PyWeakReference *wr_next;
+};
+
+PyAPI_FUNC(Py_ssize_t) _PyWeakref_GetWeakrefCount(PyWeakReference *head);
+
+PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);
+
+/* Explanation for the Py_REFCNT() check: when a weakref's target is part
+   of a long chain of deallocations which triggers the trashcan mechanism,
+   clearing the weakrefs can be delayed long after the target's refcount
+   has dropped to zero.  In the meantime, code accessing the weakref will
+   be able to "see" the target object even though it is supposed to be
+   unreachable.  See issue #16602. */
+#define PyWeakref_GET_OBJECT(ref)                           \
+    (Py_REFCNT(((PyWeakReference *)(ref))->wr_object) > 0   \
+     ? ((PyWeakReference *)(ref))->wr_object                \
+     : Py_None)

--- a/Include/internal/pycore_warnings.h
+++ b/Include/internal/pycore_warnings.h
@@ -19,7 +19,7 @@ struct _warnings_runtime_state {
 
 extern int _PyWarnings_InitState(PyInterpreterState *interp);
 
-extern PyObject* _PyWarnings_Init(void);
+PyAPI_FUNC(PyObject*) _PyWarnings_Init(void);
 
 extern void _PyErr_WarnUnawaitedCoroutine(PyObject *coro);
 

--- a/Include/internal/pycore_warnings.h
+++ b/Include/internal/pycore_warnings.h
@@ -19,6 +19,10 @@ struct _warnings_runtime_state {
 
 extern int _PyWarnings_InitState(PyInterpreterState *interp);
 
+extern PyObject* _PyWarnings_Init(void);
+
+extern void _PyErr_WarnUnawaitedCoroutine(PyObject *coro);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/warnings.h
+++ b/Include/warnings.h
@@ -4,14 +4,11 @@
 extern "C" {
 #endif
 
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject*) _PyWarnings_Init(void);
-#endif
-
 PyAPI_FUNC(int) PyErr_WarnEx(
     PyObject *category,
     const char *message,        /* UTF-8 encoded string */
     Py_ssize_t stack_level);
+
 PyAPI_FUNC(int) PyErr_WarnFormat(
     PyObject *category,
     Py_ssize_t stack_level,
@@ -26,15 +23,7 @@ PyAPI_FUNC(int) PyErr_ResourceWarning(
     const char *format,         /* ASCII-encoded string  */
     ...);
 #endif
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(int) PyErr_WarnExplicitObject(
-    PyObject *category,
-    PyObject *message,
-    PyObject *filename,
-    int lineno,
-    PyObject *module,
-    PyObject *registry);
-#endif
+
 PyAPI_FUNC(int) PyErr_WarnExplicit(
     PyObject *category,
     const char *message,        /* UTF-8 encoded string */
@@ -44,20 +33,9 @@ PyAPI_FUNC(int) PyErr_WarnExplicit(
     PyObject *registry);
 
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(int)
-PyErr_WarnExplicitFormat(PyObject *category,
-                         const char *filename, int lineno,
-                         const char *module, PyObject *registry,
-                         const char *format, ...);
-#endif
-
-/* DEPRECATED: Use PyErr_WarnEx() instead. */
-#ifndef Py_LIMITED_API
-#define PyErr_Warn(category, msg) PyErr_WarnEx(category, msg, 1)
-#endif
-
-#ifndef Py_LIMITED_API
-void _PyErr_WarnUnawaitedCoroutine(PyObject *coro);
+#  define Py_CPYTHON_WARNINGS_H
+#  include "cpython/warnings.h"
+#  undef Py_CPYTHON_WARNINGS_H
 #endif
 
 #ifdef __cplusplus

--- a/Include/weakrefobject.h
+++ b/Include/weakrefobject.h
@@ -6,39 +6,7 @@
 extern "C" {
 #endif
 
-
 typedef struct _PyWeakReference PyWeakReference;
-
-/* PyWeakReference is the base struct for the Python ReferenceType, ProxyType,
- * and CallableProxyType.
- */
-#ifndef Py_LIMITED_API
-struct _PyWeakReference {
-    PyObject_HEAD
-
-    /* The object to which this is a weak reference, or Py_None if none.
-     * Note that this is a stealth reference:  wr_object's refcount is
-     * not incremented to reflect this pointer.
-     */
-    PyObject *wr_object;
-
-    /* A callable to invoke when wr_object dies, or NULL if none. */
-    PyObject *wr_callback;
-
-    /* A cache for wr_object's hash code.  As usual for hashes, this is -1
-     * if the hash code isn't known yet.
-     */
-    Py_hash_t hash;
-
-    /* If wr_object is weakly referenced, wr_object has a doubly-linked NULL-
-     * terminated list of weak references to it.  These are the list pointers.
-     * If wr_object goes away, wr_object is set to Py_None, and these pointers
-     * have no meaning then.
-     */
-    PyWeakReference *wr_prev;
-    PyWeakReference *wr_next;
-};
-#endif
 
 PyAPI_DATA(PyTypeObject) _PyWeakref_RefType;
 PyAPI_DATA(PyTypeObject) _PyWeakref_ProxyType;
@@ -56,29 +24,17 @@ PyAPI_DATA(PyTypeObject) _PyWeakref_CallableProxyType;
 
 
 PyAPI_FUNC(PyObject *) PyWeakref_NewRef(PyObject *ob,
-                                              PyObject *callback);
+                                        PyObject *callback);
 PyAPI_FUNC(PyObject *) PyWeakref_NewProxy(PyObject *ob,
-                                                PyObject *callback);
+                                          PyObject *callback);
 PyAPI_FUNC(PyObject *) PyWeakref_GetObject(PyObject *ref);
 
+
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(Py_ssize_t) _PyWeakref_GetWeakrefCount(PyWeakReference *head);
-
-PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference *self);
+#  define Py_CPYTHON_WEAKREFOBJECT_H
+#  include "cpython/weakrefobject.h"
+#  undef Py_CPYTHON_WEAKREFOBJECT_H
 #endif
-
-/* Explanation for the Py_REFCNT() check: when a weakref's target is part
-   of a long chain of deallocations which triggers the trashcan mechanism,
-   clearing the weakrefs can be delayed long after the target's refcount
-   has dropped to zero.  In the meantime, code accessing the weakref will
-   be able to "see" the target object even though it is supposed to be
-   unreachable.  See issue #16602. */
-
-#define PyWeakref_GET_OBJECT(ref)                           \
-    (Py_REFCNT(((PyWeakReference *)(ref))->wr_object) > 0   \
-     ? ((PyWeakReference *)(ref))->wr_object                \
-     : Py_None)
-
 
 #ifdef __cplusplus
 }

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1228,6 +1228,8 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/traceback.h \
 		$(srcdir)/Include/cpython/tupleobject.h \
 		$(srcdir)/Include/cpython/unicodeobject.h \
+		$(srcdir)/Include/cpython/warnings.h \
+		$(srcdir)/Include/cpython/weakrefobject.h \
 		\
 		$(srcdir)/Include/internal/pycore_abstract.h \
 		$(srcdir)/Include/internal/pycore_accu.h \

--- a/Misc/NEWS.d/next/C API/2021-10-19-00-20-40.bpo-35134.Z0Zk_m.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-19-00-20-40.bpo-35134.Z0Zk_m.rst
@@ -1,0 +1,3 @@
+Exclude :c:func:`PyWeakref_GET_OBJECT` from the limited C API. It never
+worked since the :c:type:`PyWeakReference` structure is opaque in the
+limited C API.

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -160,6 +160,8 @@
     <ClInclude Include="..\Include\cpython\traceback.h" />
     <ClInclude Include="..\Include\cpython\tupleobject.h" />
     <ClInclude Include="..\Include\cpython\unicodeobject.h" />
+    <ClInclude Include="..\Include\cpython\warnings.h" />
+    <ClInclude Include="..\Include\cpython\weakrefobject.h" />
     <ClInclude Include="..\Include\datetime.h" />
     <ClInclude Include="..\Include\descrobject.h" />
     <ClInclude Include="..\Include\dictobject.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -393,6 +393,12 @@
     <ClInclude Include="..\Include\cpython\unicodeobject.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\warnings.h">
+      <Filter>Include\cpython</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\weakrefobject.h">
+      <Filter>Include\cpython</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\methodobject.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>


### PR DESCRIPTION
Split header files to move the non-limited API to Include/cpython/:

* Include/warnings.h => Include/cpython/warnings.h
* Include/weakrefobject.h => Include/cpython/weakrefobject.h

Exclude PyWeakref_GET_OBJECT() from the limited C API. It never
worked since the PyWeakReference structure is opaque in the limited C
API.

Move _PyWarnings_Init() and _PyErr_WarnUnawaitedCoroutine() to the
internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
