### PR TITLE
bpo-35134: Add Include/cpython/longobject.h

### DIFF
--- a/Include/cpython/longobject.h
+++ b/Include/cpython/longobject.h
@@ -1,0 +1,95 @@
+#ifndef Py_CPYTHON_LONGOBJECT_H
+#  error "this header file must not be included directly"
+#endif
+
+PyAPI_FUNC(int) _PyLong_AsInt(PyObject *);
+
+PyAPI_FUNC(int) _PyLong_UnsignedShort_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _PyLong_UnsignedInt_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _PyLong_UnsignedLong_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _PyLong_UnsignedLongLong_Converter(PyObject *, void *);
+PyAPI_FUNC(int) _PyLong_Size_t_Converter(PyObject *, void *);
+
+/* _PyLong_Frexp returns a double x and an exponent e such that the
+   true value is approximately equal to x * 2**e.  e is >= 0.  x is
+   0.0 if and only if the input is 0 (in which case, e and x are both
+   zeroes); otherwise, 0.5 <= abs(x) < 1.0.  On overflow, which is
+   possible if the number of bits doesn't fit into a Py_ssize_t, sets
+   OverflowError and returns -1.0 for x, 0 for e. */
+PyAPI_FUNC(double) _PyLong_Frexp(PyLongObject *a, Py_ssize_t *e);
+
+PyAPI_FUNC(PyObject *) PyLong_FromUnicodeObject(PyObject *u, int base);
+PyAPI_FUNC(PyObject *) _PyLong_FromBytes(const char *, Py_ssize_t, int);
+
+/* _PyLong_Sign.  Return 0 if v is 0, -1 if v < 0, +1 if v > 0.
+   v must not be NULL, and must be a normalized long.
+   There are no error cases.
+*/
+PyAPI_FUNC(int) _PyLong_Sign(PyObject *v);
+
+/* _PyLong_NumBits.  Return the number of bits needed to represent the
+   absolute value of a long.  For example, this returns 1 for 1 and -1, 2
+   for 2 and -2, and 2 for 3 and -3.  It returns 0 for 0.
+   v must not be NULL, and must be a normalized long.
+   (size_t)-1 is returned and OverflowError set if the true result doesn't
+   fit in a size_t.
+*/
+PyAPI_FUNC(size_t) _PyLong_NumBits(PyObject *v);
+
+/* _PyLong_DivmodNear.  Given integers a and b, compute the nearest
+   integer q to the exact quotient a / b, rounding to the nearest even integer
+   in the case of a tie.  Return (q, r), where r = a - q*b.  The remainder r
+   will satisfy abs(r) <= abs(b)/2, with equality possible only if q is
+   even.
+*/
+PyAPI_FUNC(PyObject *) _PyLong_DivmodNear(PyObject *, PyObject *);
+
+/* _PyLong_FromByteArray:  View the n unsigned bytes as a binary integer in
+   base 256, and return a Python int with the same numeric value.
+   If n is 0, the integer is 0.  Else:
+   If little_endian is 1/true, bytes[n-1] is the MSB and bytes[0] the LSB;
+   else (little_endian is 0/false) bytes[0] is the MSB and bytes[n-1] the
+   LSB.
+   If is_signed is 0/false, view the bytes as a non-negative integer.
+   If is_signed is 1/true, view the bytes as a 2's-complement integer,
+   non-negative if bit 0x80 of the MSB is clear, negative if set.
+   Error returns:
+   + Return NULL with the appropriate exception set if there's not
+     enough memory to create the Python int.
+*/
+PyAPI_FUNC(PyObject *) _PyLong_FromByteArray(
+    const unsigned char* bytes, size_t n,
+    int little_endian, int is_signed);
+
+/* _PyLong_AsByteArray: Convert the least-significant 8*n bits of long
+   v to a base-256 integer, stored in array bytes.  Normally return 0,
+   return -1 on error.
+   If little_endian is 1/true, store the MSB at bytes[n-1] and the LSB at
+   bytes[0]; else (little_endian is 0/false) store the MSB at bytes[0] and
+   the LSB at bytes[n-1].
+   If is_signed is 0/false, it's an error if v < 0; else (v >= 0) n bytes
+   are filled and there's nothing special about bit 0x80 of the MSB.
+   If is_signed is 1/true, bytes is filled with the 2's-complement
+   representation of v's value.  Bit 0x80 of the MSB is the sign bit.
+   Error returns (-1):
+   + is_signed is 0 and v < 0.  TypeError is set in this case, and bytes
+     isn't altered.
+   + n isn't big enough to hold the full mathematical value of v.  For
+     example, if is_signed is 0 and there are more digits in the v than
+     fit in n; or if is_signed is 1, v < 0, and n is just 1 bit shy of
+     being large enough to hold a sign bit.  OverflowError is set in this
+     case, but bytes holds the least-significant n bytes of the true value.
+*/
+PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
+    unsigned char* bytes, size_t n,
+    int little_endian, int is_signed);
+
+/* _PyLong_Format: Convert the long to a string object with given base,
+   appending a base prefix of 0[box] if base is 2, 8 or 16. */
+PyAPI_FUNC(PyObject *) _PyLong_Format(PyObject *obj, int base);
+
+/* For use by the gcd function in mathmodule.c */
+PyAPI_FUNC(PyObject *) _PyLong_GCD(PyObject *, PyObject *);
+
+PyAPI_FUNC(PyObject *) _PyLong_Rshift(PyObject *, size_t);
+PyAPI_FUNC(PyObject *) _PyLong_Lshift(PyObject *, size_t);

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -37,6 +37,32 @@ static inline PyObject* _PyLong_GetOne(void)
 PyObject *_PyLong_Add(PyLongObject *left, PyLongObject *right);
 PyObject *_PyLong_Multiply(PyLongObject *left, PyLongObject *right);
 
+/* Used by Python/mystrtoul.c, _PyBytes_FromHex(),
+   _PyBytes_DecodeEscape(), etc. */
+PyAPI_DATA(unsigned char) _PyLong_DigitValue[256];
+
+/* Format the object based on the format_spec, as defined in PEP 3101
+   (Advanced String Formatting). */
+PyAPI_FUNC(int) _PyLong_FormatAdvancedWriter(
+    _PyUnicodeWriter *writer,
+    PyObject *obj,
+    PyObject *format_spec,
+    Py_ssize_t start,
+    Py_ssize_t end);
+
+PyAPI_FUNC(int) _PyLong_FormatWriter(
+    _PyUnicodeWriter *writer,
+    PyObject *obj,
+    int base,
+    int alternate);
+
+PyAPI_FUNC(char*) _PyLong_FormatBytesWriter(
+    _PyBytesWriter *writer,
+    char *str,
+    PyObject *obj,
+    int base,
+    int alternate);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/longobject.h
+++ b/Include/longobject.h
@@ -26,9 +26,6 @@ PyAPI_FUNC(Py_ssize_t) PyLong_AsSsize_t(PyObject *);
 PyAPI_FUNC(size_t) PyLong_AsSize_t(PyObject *);
 PyAPI_FUNC(unsigned long) PyLong_AsUnsignedLong(PyObject *);
 PyAPI_FUNC(unsigned long) PyLong_AsUnsignedLongMask(PyObject *);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(int) _PyLong_AsInt(PyObject *);
-#endif
 PyAPI_FUNC(PyObject *) PyLong_GetInfo(void);
 
 /* It may be useful in the future. I've added it in the PyInt -> PyLong
@@ -65,30 +62,6 @@ PyAPI_FUNC(PyObject *) PyLong_GetInfo(void);
 #  error "void* different in size from int, long and long long"
 #endif /* SIZEOF_VOID_P */
 
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(int) _PyLong_UnsignedShort_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _PyLong_UnsignedInt_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _PyLong_UnsignedLong_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _PyLong_UnsignedLongLong_Converter(PyObject *, void *);
-PyAPI_FUNC(int) _PyLong_Size_t_Converter(PyObject *, void *);
-#endif
-
-/* Used by Python/mystrtoul.c, _PyBytes_FromHex(),
-   _PyBytes_DecodeEscape(), etc. */
-#ifndef Py_LIMITED_API
-PyAPI_DATA(unsigned char) _PyLong_DigitValue[256];
-#endif
-
-/* _PyLong_Frexp returns a double x and an exponent e such that the
-   true value is approximately equal to x * 2**e.  e is >= 0.  x is
-   0.0 if and only if the input is 0 (in which case, e and x are both
-   zeroes); otherwise, 0.5 <= abs(x) < 1.0.  On overflow, which is
-   possible if the number of bits doesn't fit into a Py_ssize_t, sets
-   OverflowError and returns -1.0 for x, 0 for e. */
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(double) _PyLong_Frexp(PyLongObject *a, Py_ssize_t *e);
-#endif
-
 PyAPI_FUNC(double) PyLong_AsDouble(PyObject *);
 PyAPI_FUNC(PyObject *) PyLong_FromVoidPtr(void *);
 PyAPI_FUNC(void *) PyLong_AsVoidPtr(PyObject *);
@@ -101,102 +74,6 @@ PyAPI_FUNC(unsigned long long) PyLong_AsUnsignedLongLongMask(PyObject *);
 PyAPI_FUNC(long long) PyLong_AsLongLongAndOverflow(PyObject *, int *);
 
 PyAPI_FUNC(PyObject *) PyLong_FromString(const char *, char **, int);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) PyLong_FromUnicodeObject(PyObject *u, int base);
-PyAPI_FUNC(PyObject *) _PyLong_FromBytes(const char *, Py_ssize_t, int);
-#endif
-
-#ifndef Py_LIMITED_API
-/* _PyLong_Sign.  Return 0 if v is 0, -1 if v < 0, +1 if v > 0.
-   v must not be NULL, and must be a normalized long.
-   There are no error cases.
-*/
-PyAPI_FUNC(int) _PyLong_Sign(PyObject *v);
-
-
-/* _PyLong_NumBits.  Return the number of bits needed to represent the
-   absolute value of a long.  For example, this returns 1 for 1 and -1, 2
-   for 2 and -2, and 2 for 3 and -3.  It returns 0 for 0.
-   v must not be NULL, and must be a normalized long.
-   (size_t)-1 is returned and OverflowError set if the true result doesn't
-   fit in a size_t.
-*/
-PyAPI_FUNC(size_t) _PyLong_NumBits(PyObject *v);
-
-/* _PyLong_DivmodNear.  Given integers a and b, compute the nearest
-   integer q to the exact quotient a / b, rounding to the nearest even integer
-   in the case of a tie.  Return (q, r), where r = a - q*b.  The remainder r
-   will satisfy abs(r) <= abs(b)/2, with equality possible only if q is
-   even.
-*/
-PyAPI_FUNC(PyObject *) _PyLong_DivmodNear(PyObject *, PyObject *);
-
-/* _PyLong_FromByteArray:  View the n unsigned bytes as a binary integer in
-   base 256, and return a Python int with the same numeric value.
-   If n is 0, the integer is 0.  Else:
-   If little_endian is 1/true, bytes[n-1] is the MSB and bytes[0] the LSB;
-   else (little_endian is 0/false) bytes[0] is the MSB and bytes[n-1] the
-   LSB.
-   If is_signed is 0/false, view the bytes as a non-negative integer.
-   If is_signed is 1/true, view the bytes as a 2's-complement integer,
-   non-negative if bit 0x80 of the MSB is clear, negative if set.
-   Error returns:
-   + Return NULL with the appropriate exception set if there's not
-     enough memory to create the Python int.
-*/
-PyAPI_FUNC(PyObject *) _PyLong_FromByteArray(
-    const unsigned char* bytes, size_t n,
-    int little_endian, int is_signed);
-
-/* _PyLong_AsByteArray: Convert the least-significant 8*n bits of long
-   v to a base-256 integer, stored in array bytes.  Normally return 0,
-   return -1 on error.
-   If little_endian is 1/true, store the MSB at bytes[n-1] and the LSB at
-   bytes[0]; else (little_endian is 0/false) store the MSB at bytes[0] and
-   the LSB at bytes[n-1].
-   If is_signed is 0/false, it's an error if v < 0; else (v >= 0) n bytes
-   are filled and there's nothing special about bit 0x80 of the MSB.
-   If is_signed is 1/true, bytes is filled with the 2's-complement
-   representation of v's value.  Bit 0x80 of the MSB is the sign bit.
-   Error returns (-1):
-   + is_signed is 0 and v < 0.  TypeError is set in this case, and bytes
-     isn't altered.
-   + n isn't big enough to hold the full mathematical value of v.  For
-     example, if is_signed is 0 and there are more digits in the v than
-     fit in n; or if is_signed is 1, v < 0, and n is just 1 bit shy of
-     being large enough to hold a sign bit.  OverflowError is set in this
-     case, but bytes holds the least-significant n bytes of the true value.
-*/
-PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
-    unsigned char* bytes, size_t n,
-    int little_endian, int is_signed);
-
-/* _PyLong_Format: Convert the long to a string object with given base,
-   appending a base prefix of 0[box] if base is 2, 8 or 16. */
-PyAPI_FUNC(PyObject *) _PyLong_Format(PyObject *obj, int base);
-
-PyAPI_FUNC(int) _PyLong_FormatWriter(
-    _PyUnicodeWriter *writer,
-    PyObject *obj,
-    int base,
-    int alternate);
-
-PyAPI_FUNC(char*) _PyLong_FormatBytesWriter(
-    _PyBytesWriter *writer,
-    char *str,
-    PyObject *obj,
-    int base,
-    int alternate);
-
-/* Format the object based on the format_spec, as defined in PEP 3101
-   (Advanced String Formatting). */
-PyAPI_FUNC(int) _PyLong_FormatAdvancedWriter(
-    _PyUnicodeWriter *writer,
-    PyObject *obj,
-    PyObject *format_spec,
-    Py_ssize_t start,
-    Py_ssize_t end);
-#endif /* Py_LIMITED_API */
 
 /* These aren't really part of the int object, but they're handy. The
    functions are in Python/mystrtoul.c.
@@ -205,13 +82,9 @@ PyAPI_FUNC(unsigned long) PyOS_strtoul(const char *, char **, int);
 PyAPI_FUNC(long) PyOS_strtol(const char *, char **, int);
 
 #ifndef Py_LIMITED_API
-/* For use by the gcd function in mathmodule.c */
-PyAPI_FUNC(PyObject *) _PyLong_GCD(PyObject *, PyObject *);
-#endif /* !Py_LIMITED_API */
-
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyLong_Rshift(PyObject *, size_t);
-PyAPI_FUNC(PyObject *) _PyLong_Lshift(PyObject *, size_t);
+#  define Py_CPYTHON_LONGOBJECT_H
+#  include "cpython/longobject.h"
+#  undef Py_CPYTHON_LONGOBJECT_H
 #endif
 
 #ifdef __cplusplus

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1210,6 +1210,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/initconfig.h \
 		$(srcdir)/Include/cpython/listobject.h \
 		$(srcdir)/Include/cpython/longintrepr.h \
+		$(srcdir)/Include/cpython/longobject.h \
 		$(srcdir)/Include/cpython/methodobject.h \
 		$(srcdir)/Include/cpython/object.h \
 		$(srcdir)/Include/cpython/objimpl.h \

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -56,6 +56,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
+#include "pycore_long.h"          // _PyLong_DigitValue
 #include "pycore_strhex.h"        // _Py_strhex_bytes_with_sep()
 #ifdef USE_ZLIB_CRC32
 #  include "zlib.h"

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -8,6 +8,7 @@
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_format.h"        // F_LJUST
 #include "pycore_initconfig.h"    // _PyStatus_OK()
+#include "pycore_long.h"          // _PyLong_DigitValue
 #include "pycore_object.h"        // _PyObject_GC_TRACK
 #include "pycore_pymem.h"         // PYMEM_CLEANBYTE
 #include "pycore_strhex.h"        // _Py_strhex_with_sep()

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -46,6 +46,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "pycore_format.h"        // F_LJUST
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_interp.h"        // PyInterpreterState.fs_codec
+#include "pycore_long.h"          // _PyLong_FormatWriter()
 #include "pycore_object.h"        // _PyObject_GC_TRACK()
 #include "pycore_pathconfig.h"    // _Py_DumpPathConfig()
 #include "pycore_pyerrors.h"      // _Py_FatalRefcountError()

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -140,6 +140,7 @@
     <ClInclude Include="..\Include\cpython\initconfig.h" />
     <ClInclude Include="..\Include\cpython\listobject.h" />
     <ClInclude Include="..\Include\cpython\longintrepr.h" />
+    <ClInclude Include="..\Include\cpython\longobject.h" />
     <ClInclude Include="..\Include\cpython\methodobject.h" />
     <ClInclude Include="..\Include\cpython\object.h" />
     <ClInclude Include="..\Include\cpython\objimpl.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -387,6 +387,9 @@
     <ClInclude Include="..\Include\cpython\longintrepr.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\longobject.h">
+      <Filter>Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\odictobject.h">
       <Filter>Include</Filter>
     </ClInclude>

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -3,7 +3,8 @@
    of int.__float__, etc., that take and return unicode objects */
 
 #include "Python.h"
-#include "pycore_fileutils.h"
+#include "pycore_fileutils.h"     // _Py_GetLocaleconvNumeric()
+#include "pycore_long.h"          // _PyLong_FormatWriter()
 #include <locale.h>
 
 /* Raises an exception about an unknown presentation type for this

--- a/Python/mystrtoul.c
+++ b/Python/mystrtoul.c
@@ -1,5 +1,5 @@
-
 #include "Python.h"
+#include "pycore_long.h"          // _PyLong_DigitValue
 
 #if defined(__sgi) && !defined(_SGI_MP_SOURCE)
 #define _SGI_MP_SOURCE


### PR DESCRIPTION
Move Include/longobject.h non-limited API to a new
Include/cpython/longobject.h header file.

Move the following definitions to the internal C API:

* _PyLong_DigitValue
* _PyLong_FormatAdvancedWriter()
* _PyLong_FormatWriter()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
