### PR TITLE
bpo-45516: use documentation links in TraversableResources' description

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -859,10 +859,11 @@ ABC hierarchy::
 .. class:: TraversableResources
 
     An abstract base class for resource readers capable of serving
-    the ``files`` interface. Subclasses ResourceReader and provides
-    concrete implementations of the ResourceReader's abstract
-    methods. Therefore, any loader supplying TraversableReader
-    also supplies ResourceReader.
+    the :meth:`importlib.resources.files` interface. Subclasses
+    :class:`importlib.abc.ResourceReader` and provides
+    concrete implementations of the :class:`importlib.abc.ResourceReader`'s
+    abstract methods. Therefore, any loader supplying
+    :class:`importlib.abc.TraversableReader` also supplies ResourceReader.
 
     Loaders that wish to support resource reading are expected to
     implement this interface.


### PR DESCRIPTION
I think this makes the documentation much more digestible :)

Signed-off-by: Filipe Laíns <lains@riseup.net>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45516](https://bugs.python.org/issue45516) -->
https://bugs.python.org/issue45516
<!-- /issue-number -->
