### PR TITLE
bpo-42174: fallback to sane values if the columns or lines are 0 in get_terminal_size

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -804,6 +804,10 @@ Querying the size of the output terminal
 
    .. versionadded:: 3.3
 
+   .. versionchanged:: 3.11
+   The ``fallback`` values are also used if :func:`os.get_terminal_size`
+   returns zeroes.
+
 .. _`fcopyfile`:
    http://www.manpagez.com/man/3/copyfile/
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -805,8 +805,8 @@ Querying the size of the output terminal
    .. versionadded:: 3.3
 
    .. versionchanged:: 3.11
-   The ``fallback`` values are also used if :func:`os.get_terminal_size`
-   returns zeroes.
+      The ``fallback`` values are also used if :func:`os.get_terminal_size`
+      returns zeroes.
 
 .. _`fcopyfile`:
    http://www.manpagez.com/man/3/copyfile/

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1372,9 +1372,9 @@ def get_terminal_size(fallback=(80, 24)):
             # os.get_terminal_size() is unsupported
             size = os.terminal_size(fallback)
         if columns <= 0:
-            columns = size.columns
+            columns = size.columns or fallback[0]
         if lines <= 0:
-            lines = size.lines
+            lines = size.lines or fallback[1]
 
     return os.terminal_size((columns, lines))
 

--- a/Misc/NEWS.d/next/Library/2021-10-19-01-30-57.bpo-42174.O2w9bi.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-19-01-30-57.bpo-42174.O2w9bi.rst
@@ -1,0 +1,2 @@
+:meth:`shutil.get_terminal_size` now falls back to sane values if the column
+or line count are 0.


### PR DESCRIPTION
I considered only falling back when both were 0, but that still seems
wrong, and the highly popular rich[1] library does it this way, so I
thought we should probably inherit that behavior.

[1] https://github.com/willmcgugan/rich

Signed-off-by: Filipe Laíns <lains@riseup.net>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-42174](https://bugs.python.org/issue42174) -->
https://bugs.python.org/issue42174
<!-- /issue-number -->
