### PR TITLE
bpo-30570: Use Py_EnterRecursiveCall() in issubclass()

### DIFF
--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -313,6 +313,27 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
         self.assertRaises(RecursionError, issubclass, int, X())
         self.assertRaises(RecursionError, isinstance, 1, X())
 
+    def test_infinite_cycle_in_bases(self):
+        # bpo-30570
+        class X:
+            @property
+            def __bases__(self):
+                return (self, self, self)
+        self.assertRaises(RecursionError, issubclass, X(), int)
+
+    def test_infinitely_many_bases(self):
+        # bpo-30570
+        class X:
+            def __getattr__(self, attr):
+                self.assertEqual(attr, "__bases__")
+                class A:
+                    pass
+                class B:
+                    pass
+                A.__getattr__ = B.__getattr__ = X.__getattr__
+                return (A(), B())
+        self.assertRaises(RecursionError, issubclass, X(), int)
+
 
 def blowstack(fxn, arg, compare_to):
     # Make sure that calling isinstance with a deeply nested tuple for its

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -313,8 +313,17 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
         self.assertRaises(RecursionError, issubclass, int, X())
         self.assertRaises(RecursionError, isinstance, 1, X())
 
+    def test_infinite_recursion_via_bases_tuple(self):
+        """Regression test for bpo-30570."""
+        class Failure(object):
+            def __getattr__(self, attr):
+                return (self, None)
+
+        with self.assertRaises(RecursionError):
+            issubclass(Failure(), int)
+
     def test_infinite_cycle_in_bases(self):
-        # bpo-30570
+        """Regression test for bpo-30570."""
         class X:
             @property
             def __bases__(self):
@@ -322,7 +331,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
         self.assertRaises(RecursionError, issubclass, X(), int)
 
     def test_infinitely_many_bases(self):
-        # bpo-30570
+        """Regression test for bpo-30570."""
         class X:
             def __getattr__(self, attr):
                 self.assertEqual(attr, "__bases__")

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-19-01-04-08.bpo-30570._G30Ms.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-19-01-04-08.bpo-30570._G30Ms.rst
@@ -1,0 +1,1 @@
+Fixed a crash in ``issubclass()`` from infinite recursion when searching pathological ``__bases__`` tuples.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2557,14 +2557,22 @@ abstract_issubclass(PyObject *derived, PyObject *cls)
             derived = PyTuple_GET_ITEM(bases, 0);
             continue;
         }
-        for (i = 0; i < n; i++) {
-            r = abstract_issubclass(PyTuple_GET_ITEM(bases, i), cls);
-            if (r != 0)
-                break;
-        }
-        Py_DECREF(bases);
-        return r;
+        break;
     }
+    assert(n >= 2);
+    if (Py_EnterRecursiveCall(" in __issubclass__")) {
+        Py_DECREF(bases);
+        return -1;
+    }
+    for (i = 0; i < n; i++) {
+        r = abstract_issubclass(PyTuple_GET_ITEM(bases, i), cls);
+        if (r != 0) {
+            break;
+        }
+    }
+    Py_LeaveRecursiveCall();
+    Py_DECREF(bases);
+    return r;
 }
 
 static int


### PR DESCRIPTION
This is an alternative to GH-29017. This shouldn't affect performance too much because the recursion checks only occur once for each time a length>=2 `__bases__` tuple is found (i.e. for multiple inheritance). Note that if we get stuck in the `while (1) {...}` loop, as long as the pathological `__bases__` implementation is in Python, we can still interrupt with a KeyboardInterrupt.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-30570](https://bugs.python.org/issue30570) -->
https://bugs.python.org/issue30570
<!-- /issue-number -->
