### PR TITLE
bpo-45521: Fix a bug in the obmalloc radix tree code.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-18-22-40-33.bpo-45521.GdMiuW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-18-22-40-33.bpo-45521.GdMiuW.rst
@@ -1,0 +1,3 @@
+Fix a bug in the obmalloc radix tree code.  On 64-bit machines, the bug
+causes the tree to hold 46-bits of virtual addresses, rather than the
+intended 48-bits.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1341,7 +1341,7 @@ _Py_GetAllocatedBlocks(void)
 
 #define MAP_TOP_BITS INTERIOR_BITS
 #define MAP_TOP_LENGTH (1 << MAP_TOP_BITS)
-#define MAP_TOP_MASK (MAP_BOT_LENGTH - 1)
+#define MAP_TOP_MASK (MAP_TOP_LENGTH - 1)
 
 #define MAP_MID_BITS INTERIOR_BITS
 #define MAP_MID_LENGTH (1 << MAP_MID_BITS)


### PR DESCRIPTION
MAP_BOT_LENGTH was incorrectly used to compute MAP_TOP_MASK instead of MAP_TOP_LENGTH. On 64-bit machines, the error causes the tree to hold 46-bits of virtual addresses, rather than the intended 48-bits.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-45521](https://bugs.python.org/issue45521) -->
https://bugs.python.org/issue45521
<!-- /issue-number -->
