### PR TITLE
bpo-45474: Exclude all of marshal.h if Py_LIMITED_API is defined

### DIFF
--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -632,6 +632,8 @@ Removed
 
   * :c:func:`PyMarshal_WriteLongToFile`
   * :c:func:`PyMarshal_WriteObjectToFile`
+  * :c:func:`PyMarshal_ReadObjectFromString`
+  * :c:func:`PyMarshal_WriteObjectToString`
   * the ``Py_MARSHAL_VERSION`` macro
 
   These are not part of the :ref:`limited API <stable-abi-list>`.

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -627,14 +627,15 @@ Removed
   ``Py_IS_INFINITY()`` macro.
   (Contributed by Victor Stinner in :issue:`45440`.)
 
-* Remove two functions from the limited C API:
+* The following items are no longer available when :c:macro:`Py_LIMITED_API`
+  is defined:
 
   * :c:func:`PyMarshal_WriteLongToFile`
   * :c:func:`PyMarshal_WriteObjectToFile`
+  * the ``Py_MARSHAL_VERSION`` macro
 
-  The :pep:`384` excludes functions expecting ``FILE*`` from the stable ABI.
+  These are not part of the :ref:`limited API <stable-abi-list>`.
 
-  Remove also the ``Py_MARSHAL_VERSION`` macro from the limited C API.
   (Contributed by Victor Stinner in :issue:`45474`.)
 
 * Exclude :c:func:`PyWeakref_GET_OBJECT` from the limited C API. It never

--- a/Include/marshal.h
+++ b/Include/marshal.h
@@ -3,6 +3,8 @@
 
 #ifndef Py_MARSHAL_H
 #define Py_MARSHAL_H
+#ifndef Py_LIMITED_API
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,7 +13,6 @@ PyAPI_FUNC(PyObject *) PyMarshal_ReadObjectFromString(const char *,
                                                       Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyMarshal_WriteObjectToString(PyObject *, int);
 
-#ifndef Py_LIMITED_API
 #define Py_MARSHAL_VERSION 4
 
 PyAPI_FUNC(long) PyMarshal_ReadLongFromFile(FILE *);
@@ -21,9 +22,10 @@ PyAPI_FUNC(PyObject *) PyMarshal_ReadLastObjectFromFile(FILE *);
 
 PyAPI_FUNC(void) PyMarshal_WriteLongToFile(long, FILE *, int);
 PyAPI_FUNC(void) PyMarshal_WriteObjectToFile(PyObject *, FILE *, int);
-#endif
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* Py_LIMITED_API */
 #endif /* !Py_MARSHAL_H */

--- a/Misc/NEWS.d/next/C API/2021-10-14-22-16-56.bpo-45474.1OkJQh.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-14-22-16-56.bpo-45474.1OkJQh.rst
@@ -1,10 +1,9 @@
-Remove two functions from the limited C API:
+The following items are no longer available when ``Py_LIMITED_API`` is defined:
 
 * :c:func:`PyMarshal_WriteLongToFile`
 * :c:func:`PyMarshal_WriteObjectToFile`
+* the ``Py_MARSHAL_VERSION`` macro
 
-The :pep:`384` excludes functions expecting ``FILE*`` from the stable ABI.
-
-Remove also the ``Py_MARSHAL_VERSION`` macro from the limited C API.
+These are not part of the :ref:`limited API <stable-abi-list>`.
 
 Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2021-10-14-22-16-56.bpo-45474.1OkJQh.rst
+++ b/Misc/NEWS.d/next/C API/2021-10-14-22-16-56.bpo-45474.1OkJQh.rst
@@ -2,6 +2,8 @@ The following items are no longer available when ``Py_LIMITED_API`` is defined:
 
 * :c:func:`PyMarshal_WriteLongToFile`
 * :c:func:`PyMarshal_WriteObjectToFile`
+* :c:func:`PyMarshal_ReadObjectFromString`
+* :c:func:`PyMarshal_WriteObjectToString`
 * the ``Py_MARSHAL_VERSION`` macro
 
 These are not part of the :ref:`limited API <stable-abi-list>`.


### PR DESCRIPTION
Also, reword the What's New messages: this doesn't change the limited API, it only brings the Py_LIMITED_API macro closer to the ideal of only allowing the limited API.

<!-- issue-number: [bpo-45474](https://bugs.python.org/issue45474) -->
https://bugs.python.org/issue45474
<!-- /issue-number -->

Automerge-Triggered-By: GH:encukou