### PR TITLE
bpo-45506: Go back to not running most of test_embed in out-of-tree builds.

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -61,7 +61,7 @@ class EmbeddingTestsMixin:
         else:
             exepath = os.path.join(builddir, 'Programs')
         self.test_exe = exe = os.path.join(exepath, exename)
-        if not os.path.exists(exe):
+        if exepath != support.REPO_ROOT or not os.path.exists(exe):
             self.skipTest("%r doesn't exist" % exe)
         # This is needed otherwise we get a fatal error:
         # "Py_Initialize: Unable to get the locale encoding


### PR DESCRIPTION
In gh-28954 I adjusted how test_embed determines if it should be skipped.  That broke out-of-tree builds.  This change fixes them.

<!-- issue-number: [bpo-45506](https://bugs.python.org/issue45506) -->
https://bugs.python.org/issue45506
<!-- /issue-number -->
