### PR TITLE
bpo-40360: Make the 2to3 deprecation more obvious.

### DIFF
--- a/Doc/library/2to3.rst
+++ b/Doc/library/2to3.rst
@@ -11,6 +11,11 @@ contains a rich set of fixers that will handle almost all code.  2to3 supporting
 library :mod:`lib2to3` is, however, a flexible and generic library, so it is
 possible to write your own fixers for 2to3.
 
+.. deprecated-removed:: 3.11 3.13
+   The ``lib2to3`` module was marked pending for deprecation in Python 3.9
+   (raising :exc:`PendingDeprecationWarning` on import) and fully deprecated
+   in Python 3.11 (raising :exc:`DeprecationWarning`).  The ``2to3`` tool is
+   part of that.  It will be removed in Python 3.13.
 
 .. _2to3-using:
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -308,9 +308,9 @@ CPython bytecode changes
 Deprecated
 ==========
 
-* The :mod:`lib2to3` package is now deprecated and may not be able to parse
-  Python 3.10 or newer. See the :pep:`617` (New PEG parser for CPython).
-  (Contributed by Victor Stinner in :issue:`40360`.)
+* The :mod:`lib2to3` package and ``2to3`` tool are now deprecated and may not
+  be able to parse Python 3.10 or newer. See the :pep:`617` (New PEG parser for
+  CPython).  (Contributed by Victor Stinner in :issue:`40360`.)
 
 * :class:`webbrowser.MacOSX` is deprecated and will be removed in Python 3.13.
   It is untested and undocumented and also not used by webbrowser itself.


### PR DESCRIPTION
The deprecation text was way at the bottom of the doc.  This includes a more obvious note up top.

<!-- issue-number: [bpo-40360](https://bugs.python.org/issue40360) -->
https://bugs.python.org/issue40360
<!-- /issue-number -->

Automerge-Triggered-By: GH:gpshead