### PR TITLE
[3.9] bpo-45449: add note about PEP 585 in collections.abc's documentation (GH-29047)

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -24,6 +24,9 @@ This module provides :term:`abstract base classes <abstract base class>` that
 can be used to test whether a class provides a particular interface; for
 example, whether it is hashable or whether it is a mapping.
 
+.. versionadded:: 3.9
+   These abstract classes now support ``[]``. See :ref:`types-genericalias`
+   and :pep:`585`.
 
 .. _collections-abstract-base-classes:
 

--- a/Misc/NEWS.d/next/Documentation/2021-10-19-01-41-40.bpo-45449.fjHZJc.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-10-19-01-41-40.bpo-45449.fjHZJc.rst
@@ -1,0 +1,1 @@
+Add note about :pep:`585` in :mod:`collections.abc`.


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>

Co-authored-by: Łukasz Langa <lukasz@langa.pl>.
(cherry picked from commit 7bafa0cf586227987d3d662264d491e3780024b7)

Co-authored-by: Filipe Laíns <lains@riseup.net>


<!-- issue-number: [bpo-45449](https://bugs.python.org/issue45449) -->
https://bugs.python.org/issue45449
<!-- /issue-number -->
