### PR TITLE
gh-89691: list mmap constants in documentation

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -41,9 +41,6 @@ memory map raises a :exc:`TypeError` exception.  Assignment to an
 Assignment to an :const:`ACCESS_COPY` memory map affects memory but does not
 update the underlying file.
 
-.. versionchanged:: 3.7
-   Added :const:`ACCESS_DEFAULT` constant.
-
 To map anonymous memory, -1 should be passed as the fileno along with the length.
 
 .. class:: mmap(fileno, length, tagname=None, access=ACCESS_DEFAULT[, offset])
@@ -310,6 +307,25 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
       the mmap was created with :const:`ACCESS_READ`, then writing to it will
       raise a :exc:`TypeError` exception.
 
+.. data:: ALLOCATIONGRANULARITY
+.. data:: PAGESIZE
+
+
+.. _access-constants:
+
+ACCESS_* Constants
+++++++++++++++++++
+
+.. data:: ACCESS_READ
+	  ACCESS_WRITE
+	  ACCESS_COPY
+	  ACCESS_DEFAULT
+
+   These access types can be passed to :meth:`mmap.mmap`.
+
+   .. versionchanged:: 3.7
+      Added :const:`ACCESS_DEFAULT` constant.
+
 .. _madvise-constants:
 
 MADV_* Constants
@@ -364,3 +380,16 @@ MAP_* Constants
 
     .. versionchanged:: 3.10
        Added MAP_POPULATE constant.
+
+.. _prot-constants:
+
+PROT_* Constants
+++++++++++++++++
+
+.. data:: PROT_READ
+	  PROT_WRITE
+	  PROT_EXEC
+
+   These memory-protection options may be passed to :meth:`mmap.mmap` on Unix systems.
+
+   Availability: Unix.

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -317,9 +317,9 @@ ACCESS_* Constants
 ++++++++++++++++++
 
 .. data:: ACCESS_READ
-	  ACCESS_WRITE
-	  ACCESS_COPY
-	  ACCESS_DEFAULT
+          ACCESS_WRITE
+          ACCESS_COPY
+          ACCESS_DEFAULT
 
    These access types can be passed to :meth:`mmap.mmap`.
 
@@ -387,9 +387,9 @@ PROT_* Constants
 ++++++++++++++++
 
 .. data:: PROT_READ
-	  PROT_WRITE
-	  PROT_EXEC
+          PROT_WRITE
+          PROT_EXEC
 
-   These memory-protection options may be passed to :meth:`mmap.mmap` on Unix systems.
+   These memory-protection options can be passed to :meth:`mmap.mmap` on Unix systems.
 
    Availability: Unix.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -631,6 +631,7 @@ Tiago Gonçalves
 Chris Gonnerman
 Shelley Gooch
 David Goodger
+Michael Wayne Goodman
 Elliot Gorokhovsky
 Hans de Graaff
 Tim Graham


### PR DESCRIPTION
This adds some constants in the mmap module to the documentation. Previously they were (mostly) mentioned but not listed as part of the module contents.

The first commit only adds the lists of constants with some notes about applicability and availability. Prior to merging, there are a few things that could be improved:
- [ ] Update the prose is the relevant method descriptions (e.g., create links to the constant sections)
- [ ] Verify the availability of the constants (e.g., that PROT_* are only available on Unix)
- [ ] Provide descriptions, and possibly a section header, for `ALLOCATIONGRANULARITY` and `PAGESIZE`

Also, this PR also adds my name to Misc/ACKS, although it is my third contribution.

<!-- issue-number: [bpo-45528](https://bugs.python.org/issue45528) -->
https://bugs.python.org/issue45528
<!-- /issue-number -->

<!-- gh-issue-number: gh-89691 -->
* Issue: gh-89691
<!-- /gh-issue-number -->
