### PR TITLE
bpo-45530: speed listobject.c's unsafe_tuple_compare()

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1424,6 +1424,8 @@ Note that ``a op1 b op2 c`` doesn't imply any kind of comparison between *a* and
 *c*, so that, e.g., ``x < y > z`` is perfectly legal (though perhaps not
 pretty).
 
+.. _expressions-value-comparisons:
+
 Value comparisons
 -----------------
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -450,6 +450,13 @@ Changes in the Python API
   the ``'utf-8'`` encoding.
   (Contributed by Srinivas Reddy Thatiparthy (శ్రీనివాస్  రెడ్డి తాటిపర్తి) in :issue:`41137`.)
 
+* When sorting using tuples as keys, the order of the result may differ
+  from earlier releases if the tuple elements don't define a total
+  ordering (see :ref:`expressions-value-comparisons` for
+  information on total ordering).  It's generally true that the result
+  of sorting simply isn't well-defined in the absence of a total ordering
+  on list elements.
+
 
 Build Changes
 =============

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-20-01-28-26.bpo-45530.5r7n4m.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-20-01-28-26.bpo-45530.5r7n4m.rst
@@ -3,6 +3,6 @@ in some cases. Patch by Tim Peters.
 
 The order of the result may differ from earlier releases if the tuple
 elements don't define a total ordering (see
-:ref:`reference/expressions:value-comparisons` for information on
+:ref:`expressions-value-comparisons` for information on
 total ordering).  It's generally true that the result of sorting simply
 isn't well-defined in the absence of a total ordering on list elements.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-20-01-28-26.bpo-45530.5r7n4m.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-20-01-28-26.bpo-45530.5r7n4m.rst
@@ -1,0 +1,6 @@
+Cases of sorting using tuples as keys may be significantly faster
+in some cases. This is worth mentioning because, if the tuple
+elements don't define a total ordering, the order of the result
+may differ from earlier releases. It's generally true that the
+result of sorting simply isn't well-defined in the absence of a
+total ordering on list elements.

--- a/Misc/NEWS.d/next/Core and Builtins/2021-10-20-01-28-26.bpo-45530.5r7n4m.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-10-20-01-28-26.bpo-45530.5r7n4m.rst
@@ -1,6 +1,8 @@
-Cases of sorting using tuples as keys may be significantly faster
-in some cases. This is worth mentioning because, if the tuple
-elements don't define a total ordering, the order of the result
-may differ from earlier releases. It's generally true that the
-result of sorting simply isn't well-defined in the absence of a
-total ordering on list elements.
+Cases of sorting using tuples as keys may now be significantly faster
+in some cases. Patch by Tim Peters.
+
+The order of the result may differ from earlier releases if the tuple
+elements don't define a total ordering (see
+:ref:`reference/expressions:value-comparisons` for information on
+total ordering).  It's generally true that the result of sorting simply
+isn't well-defined in the absence of a total ordering on list elements.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2237,6 +2237,10 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
         firsti = 1;
         ms->first_tuple_items_resolved_it = 0;
     }
+    /* Now first_tuple_items_resolved_it was 0 on entry, or was forced to 0
+     * at the end of the `if` block just above.
+     */
+    assert(! ms->first_tuple_items_resolved_it);
 
     vlen = Py_SIZE(vt);
     wlen = Py_SIZE(wt);
@@ -2245,14 +2249,14 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
         if (k < 0)
             return -1;
         if (!k) { /* not equal */
-            if (!i) {
+            if (i) {
+                return PyObject_RichCompareBool(vt->ob_item[i], wt->ob_item[i],
+                                                Py_LT);
+            }
+            else {
                 ms->first_tuple_items_resolved_it = 1;
                 return ms->tuple_elem_compare(vt->ob_item[0], wt->ob_item[0],
                                               ms);
-            }
-            else {
-                return PyObject_RichCompareBool(vt->ob_item[i], wt->ob_item[i],
-                                                Py_LT);
             }
         }
     }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2225,10 +2225,10 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
         if (k) /* error, or v < w */
             return k;
         k = ms->tuple_elem_compare(wt->ob_item[0], vt->ob_item[0], ms);
-        if (k < 0) /* error */
-            return -1;
         if (k > 0) /* w < v */
             return 0;
+        if (k < 0) /* error */
+            return -1;
         /* We have
          *     not (v[0] < w[0]) and not (w[0] < v[0])
          * which implies, for a total order, that the first elements are
@@ -2246,8 +2246,6 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
     wlen = Py_SIZE(wt);
     for (; i < vlen && i < wlen; i++) {
         k = PyObject_RichCompareBool(vt->ob_item[i], wt->ob_item[i], Py_EQ);
-        if (k < 0)
-            return -1;
         if (!k) { /* not equal */
             if (i) {
                 return PyObject_RichCompareBool(vt->ob_item[i], wt->ob_item[i],
@@ -2259,6 +2257,8 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
                                               ms);
             }
         }
+        if (k < 0)
+            return -1;
     }
     /* all equal until we fell off the end */
     return vlen < wlen;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2207,7 +2207,7 @@ static int
 unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
 {
     PyTupleObject *vt, *wt;
-    Py_ssize_t i, vlen, wlen, firsti;
+    Py_ssize_t i, vlen, wlen;
     int k;
 
     /* Modified from Objects/tupleobject.c:tuplerichcompare, assuming: */
@@ -2218,7 +2218,7 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
 
     vt = (PyTupleObject *)v;
     wt = (PyTupleObject *)w;
-    firsti = 0;
+    i = 0;
     if (ms->first_tuple_items_resolved_it) {
         /* See whether fast compares of the first elements settle it. */
         k = ms->tuple_elem_compare(vt->ob_item[0], wt->ob_item[0], ms);
@@ -2234,7 +2234,7 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
          * which implies, for a total order, that the first elements are
          * equal. So skip them in the loop.
          */
-        firsti = 1;
+        i = 1;
         ms->first_tuple_items_resolved_it = 0;
     }
     /* Now first_tuple_items_resolved_it was 0 on entry, or was forced to 0
@@ -2244,7 +2244,7 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
 
     vlen = Py_SIZE(vt);
     wlen = Py_SIZE(wt);
-    for (i = firsti; i < vlen && i < wlen; i++) {
+    for (; i < vlen && i < wlen; i++) {
         k = PyObject_RichCompareBool(vt->ob_item[i], wt->ob_item[i], Py_EQ);
         if (k < 0)
             return -1;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
[bpo-45530](https://bugs.python.org/issue45530): speed listobject.c's unsafe_tuple_compare()


<!-- issue-number: [bpo-45530](https://bugs.python.org/issue45530) -->
https://bugs.python.org/issue45530
<!-- /issue-number -->
