### PR TITLE
bpo-45436: Fix tkinter tests with Tcl/Tk 8.6.11+

### DIFF
--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -1241,8 +1241,11 @@ class MenuTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_type(self):
         widget = self.create()
-        self.checkEnumParam(widget, 'type',
-                'normal', 'tearoff', 'menubar')
+        self.checkEnumParam(
+            widget, 'type',
+            'normal', 'tearoff', 'menubar',
+            errmsg='bad type "{}": must be normal, tearoff, or menubar',
+            )
 
     def test_entryconfigure(self):
         m1 = self.create()

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -169,10 +169,13 @@ class AbstractLabelTest(AbstractWidgetTest):
                 errmsg='image "spam" doesn\'t exist')
 
     def test_configure_compound(self):
+        options = 'none text image center top bottom left right'.split()
+        errmsg = (
+            'bad compound "{}": must be'
+            f' {", ".join(options[:-1])}, or {options[-1]}'
+            )
         widget = self.create()
-        self.checkEnumParam(widget, 'compound',
-                'none', 'text', 'image', 'center',
-                'top', 'bottom', 'left', 'right')
+        self.checkEnumParam(widget, 'compound', *options, errmsg=errmsg)
 
     def test_configure_state(self):
         widget = self.create()


### PR DESCRIPTION
Since v8.6.11, a few configuration options seem to accept an empty value
where they did not previously; particularly the `type` of a `Menu`
widget, and the `compound` of an ttk widget with a label.  Providing an
explicit expected error message to `checkEnumParam` bypasses the check
of an empty value, which no longer raises `TclError`.


<!-- issue-number: [bpo-45436](https://bugs.python.org/issue45436) -->
https://bugs.python.org/issue45436
<!-- /issue-number -->
