### PR TITLE
bpo-38371: Remove remaining use of tk.split from bigmem tcl test

### DIFF
--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -729,7 +729,6 @@ class BigmemTclTest(unittest.TestCase):
         self.assertRaises(OverflowError, tk.exprlong, value)
         self.assertRaises(OverflowError, tk.exprboolean, value)
         self.assertRaises(OverflowError, tk.splitlist, value)
-        self.assertRaises(OverflowError, tk.split, value)
         self.assertRaises(OverflowError, tk.createcommand, value, max)
         self.assertRaises(OverflowError, tk.deletecommand, value)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-38371](https://bugs.python.org/issue38371) -->
https://bugs.python.org/issue38371
<!-- /issue-number -->
