### PR TITLE
bpo-42092: Add a comment about how to fix bogus test_host_resolution_bad_address…

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1017,8 +1017,10 @@ class GeneralModuleTests(unittest.TestCase):
 
     def test_host_resolution_bad_address(self):
         # These are all malformed IP addresses and expected not to resolve to
-        # any result.  But some ISPs, e.g. AWS, may successfully resolve these
-        # IPs.
+        # any result.  But some ISPs, e.g. AWS and AT&T, may successfully
+        # resolve these IPs. In particular, AT&T's DNS Error Assist service
+        # will break this test.  See https://bugs.python.org/issue42092 for a
+        # workaround.
         explanation = (
             "resolving an invalid IP address did not raise OSError; "
             "can be caused by a broken DNS server"


### PR DESCRIPTION
Add a comment about how to work around `test_socket` failures caused by AT&T's DNS Error Assist service.

<!-- issue-number: [bpo-42092](https://bugs.python.org/issue42092) -->
https://bugs.python.org/issue42092
<!-- /issue-number -->

Automerge-Triggered-By: GH:warsaw