### PR TITLE
[3.9] bpo-39679: Fix `singledispatchmethod` `classmethod`/`staticmethod` bug

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -906,6 +906,11 @@ class singledispatchmethod:
 
         Registers a new implementation for the given *cls* on a *generic_method*.
         """
+        # In Python <=3 .9, classmethods and staticmethods
+        # don't have the annotations of the function they wrap
+        # So we add them manually
+        if isinstance(cls, (staticmethod, classmethod)):
+            cls.__annotations__ = getattr(cls.__func__, '__annotations__', {})
         return self.dispatcher.register(cls, func=method)
 
     def __get__(self, obj, cls=None):

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -906,9 +906,10 @@ class singledispatchmethod:
 
         Registers a new implementation for the given *cls* on a *generic_method*.
         """
-        # In Python <=3 .9, classmethods and staticmethods
-        # don't have the annotations of the function they wrap
-        # So we add them manually
+        # bpo-39679: in Python <= 3.9, classmethods and staticmethods don't
+        # inherit __annotations__ of the wrapped function (fixed in 3.10+ as
+        # a side-effect of bpo-43682) but we need that for annotation-derived
+        # singledispatches. So we add that just-in-time here.
         if isinstance(cls, (staticmethod, classmethod)):
             cls.__annotations__ = getattr(cls.__func__, '__annotations__', {})
         return self.dispatcher.register(cls, func=method)

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2427,6 +2427,48 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(a.t(''), "str")
         self.assertEqual(a.t(0.0), "base")
 
+    def test_staticmethod_type_ann_register(self):
+        class A:
+            @functools.singledispatchmethod
+            @staticmethod
+            def t(arg):
+                return arg
+            @t.register
+            @staticmethod
+            def _(arg: int):
+                return isinstance(arg, int)
+            @t.register
+            @staticmethod
+            def _(arg: str):
+                return isinstance(arg, str)
+        a = A()
+
+        self.assertTrue(A.t(0))
+        self.assertTrue(A.t(''))
+        self.assertEqual(A.t(0.0), 0.0)
+
+    def test_classmethod_type_ann_register(self):
+        class A:
+            def __init__(self, arg):
+                self.arg = arg
+
+            @functools.singledispatchmethod
+            @classmethod
+            def t(cls, arg):
+                return cls("base")
+            @t.register
+            @classmethod
+            def _(cls, arg: int):
+                return cls("int")
+            @t.register
+            @classmethod
+            def _(cls, arg: str):
+                return cls("str")
+
+        self.assertEqual(A.t(0).arg, "int")
+        self.assertEqual(A.t('').arg, "str")
+        self.assertEqual(A.t(0.0).arg, "base")
+
     def test_invalid_registrations(self):
         msg_prefix = "Invalid first argument to `register()`: "
         msg_suffix = (

--- a/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
@@ -1,3 +1,3 @@
 Fix bug in :class:`functools.singledispatchmethod` that caused it to fail
-when attempting to register :func:`classmethod`s or :func:`staticmethod`s
+when attempting to register :func:`classmethod` or :func:`staticmethod`
 using type annotations. Patch contributed by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
@@ -1,3 +1,3 @@
 Fix bug in :class:`functools.singledispatchmethod` that caused it to fail
-when attempting to register classmethods or staticmethods using type
+when attempting to register `classmethod`s or `staticmethod`s using type
 annotations. Patch contributed by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
@@ -1,0 +1,3 @@
+Fix bug in :class:`functools.singledispatchmethod` that caused it to fail
+when attempting to register classmethods or staticmethods using type
+annotations. Patch contributed by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
@@ -1,3 +1,3 @@
 Fix bug in :class:`functools.singledispatchmethod` that caused it to fail
-when attempting to register :func:`classmethod` or :func:`staticmethod`
+when attempting to register a :func:`classmethod` or :func:`staticmethod`
 using type annotations. Patch contributed by Alex Waygood.

--- a/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
+++ b/Misc/NEWS.d/next/Library/2021-10-20-10-07-44.bpo-39679.nVYJJ3.rst
@@ -1,3 +1,3 @@
 Fix bug in :class:`functools.singledispatchmethod` that caused it to fail
-when attempting to register `classmethod`s or `staticmethod`s using type
-annotations. Patch contributed by Alex Waygood.
+when attempting to register :func:`classmethod`s or :func:`staticmethod`s
+using type annotations. Patch contributed by Alex Waygood.


### PR DESCRIPTION
This commit fixes a bug in the 3.9 branch where stacking
`@functools.singledispatchmethod` on top of `@classmethod` or `@staticmethod`
caused an exception to be raised if the method was registered using
type-annotations rather than `@method.register(int)`. Tests for this scenario
were added to the 3.11 and 3.10 branches in #29034 and #29072; this commit
also backports those tests to the 3.9 branch.

The solution proposed in this commit partially derives from ideas suggested by Karthikeyan Singaravelan and Dmitry Kulazhenko in the thread on bugs.python.org.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- issue-number: [bpo-39679](https://bugs.python.org/issue39679) -->
https://bugs.python.org/issue39679
<!-- /issue-number -->
